### PR TITLE
Jirwin/docker issues

### DIFF
--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -213,7 +213,6 @@ func (cw *wrapper) runServer(ctx context.Context, serverCred *tlsV1.Credential) 
 		waitErr := cmd.Wait()
 		if waitErr != nil {
 			l.Error("connector service quit unexpectedly", zap.Error(waitErr))
-
 			waitErr = cw.Close()
 			if waitErr != nil {
 				l.Error("error closing connector wrapper", zap.Error(waitErr))
@@ -303,7 +302,6 @@ func (cw *wrapper) C(ctx context.Context) (types.ConnectorClient, error) {
 func (cw *wrapper) Close() error {
 	var err error
 	if cw.conn != nil {
-		fmt.Println("Closing client")
 		err = cw.conn.Close()
 		if err != nil {
 			return fmt.Errorf("error closing client connection: %w", err)
@@ -311,7 +309,6 @@ func (cw *wrapper) Close() error {
 	}
 
 	if cw.serverStdin != nil {
-		fmt.Println("Closing server stdin")
 		err = cw.serverStdin.Close()
 		if err != nil {
 			return fmt.Errorf("error closing connector service stdin: %w", err)

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -92,14 +92,6 @@ func NewCmd[T any, PtrT *T](
 				return err
 			}
 
-			stdin, err := os.Stdin.Stat()
-			if err != nil {
-				return err
-			}
-			if stdin.Size() == 0 {
-				return fmt.Errorf("unexpected end of input")
-			}
-
 			var cfgStr string
 			scn := bufio.NewScanner(os.Stdin)
 			for scn.Scan() {


### PR DESCRIPTION
Stdin doesn't have a valid size when running in docker, so dropping the check and just attempting to read from stdin instead.