### PR TITLE
When putting and fetching resources, include resource type in the ext…

### DIFF
--- a/internal/dotc1z/resources.go
+++ b/internal/dotc1z/resources.go
@@ -104,7 +104,7 @@ func (c *C1File) PutResource(ctx context.Context, resource *v2.Resource) error {
 
 	updateRecord := goqu.Record{
 		"resource_type_id": resource.Id.ResourceType,
-		"external_id":      resource.Id.Resource,
+		"external_id":      fmt.Sprintf("%s:%s", resource.Id.ResourceType, resource.Id.Resource),
 	}
 
 	if resource.ParentResourceId != nil {

--- a/internal/dotc1z/sql_helpers.go
+++ b/internal/dotc1z/sql_helpers.go
@@ -215,7 +215,7 @@ func (c *C1File) getResourceObject(ctx context.Context, resourceID *v2.ResourceI
 	q := c.db.From(resources.Name()).Prepared(true)
 	q = q.Select("data")
 	q = q.Where(goqu.C("resource_type_id").Eq(resourceID.ResourceType))
-	q = q.Where(goqu.C("external_id").Eq(resourceID.Resource))
+	q = q.Where(goqu.C("external_id").Eq(fmt.Sprintf("%s:%s", resourceID.ResourceType, resourceID.Resource)))
 
 	if c.currentSyncID != "" {
 		q = q.Where(goqu.C("sync_id").Eq(c.currentSyncID))


### PR DESCRIPTION
…ernal ID. This allows for different resources to have the same external ID without collisions