### PR TITLE
Automatically cleanup old sync data in the c1z after a sync

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,7 @@ jobs:
         uses: bufbuild/buf-setup-action@v0.5.0
         with:
           version: '1.7.0'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Lint
         uses: bufbuild/buf-lint-action@v1
       - name: Breaking change detection against `main`

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,6 +13,7 @@ jobs:
         uses: bufbuild/buf-setup-action@v0.5.0
         with:
           version: '1.7.0'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Lint
         uses: bufbuild/buf-lint-action@v1
       - name: Breaking change detection against `main`

--- a/internal/dotc1z/dotc1z.go
+++ b/internal/dotc1z/dotc1z.go
@@ -68,8 +68,10 @@ func NewC1ZFile(ctx context.Context, outputFilePath string) (*C1File, error) {
 // Close ensures that the sqlite database is flushed to disk, and if any changes were made we update the original database
 // with our changes.
 func (c *C1File) Close() error {
+	var err error
+
 	if c.rawDb != nil {
-		err := c.rawDb.Close()
+		err = c.rawDb.Close()
 		if err != nil {
 			return err
 		}
@@ -79,7 +81,7 @@ func (c *C1File) Close() error {
 
 	// We only want to save the file if we've made any changes
 	if c.dbUpdated {
-		err := saveC1z(c.dbFilePath, c.outputFilePath)
+		err = saveC1z(c.dbFilePath, c.outputFilePath)
 		if err != nil {
 			return err
 		}

--- a/pkg/connectorstore/connectorstore.go
+++ b/pkg/connectorstore/connectorstore.go
@@ -26,10 +26,6 @@ type Reader interface {
 	// the GRPC api, but because this is defined as a streaming RPC, it isn't trivial to implement grpc streaming as part of the c1z format.
 	GetAsset(ctx context.Context, req *v2.AssetServiceGetAssetRequest) (string, io.Reader, error)
 
-	// ViewSync uses the provided syncID to change which sync generation is used for fetching results.
-	// If this is not called, the latest complete sync will be used.
-	ViewSync(ctx context.Context, syncID string) error
-
 	Close() error
 }
 
@@ -45,4 +41,5 @@ type Writer interface {
 	PutEntitlement(ctx context.Context, entitlement *v2.Entitlement) error
 	PutGrant(ctx context.Context, grant *v2.Grant) error
 	PutAsset(ctx context.Context, assetRef *v2.AssetRef, contentType string, data []byte) error
+	Cleanup(ctx context.Context) error
 }

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -183,6 +183,11 @@ func (s *syncer) Sync(ctx context.Context) error {
 
 	l.Info("Sync complete.")
 
+	err = s.store.Cleanup(ctx)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
In order to prevent c1z files from growing unbounded, this change will perform automatic cleanup on the contents of the local db after a sync.

By default it will keep the last sync performed, and the previous sync if available. This allows diffing to continue to work without storing all of the data.

In order to disable the automatic cleanup, the user can set `BATON_SKIP_CLEANUP=1` in the environment, and cleanup will not happen. Users can also set `BATON_KEEP_SYNC_COUNT=5` in order to increase the number of syncs from the default 2. Sync count is clamped to 1 as a minimum. 