### PR TITLE
Daemon Refactoring

### DIFF
--- a/pkg/cli/config.go
+++ b/pkg/cli/config.go
@@ -1,0 +1,40 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// loadConfig sets viper up to parse the config into the provided configuration object.
+func loadConfig[T any, PtrT *T](name string, cmd *cobra.Command, cfg PtrT) (*viper.Viper, error) {
+	v := viper.New()
+	v.SetConfigType("yaml")
+	v.SetConfigName(fmt.Sprintf(defaultConfigFilename, name))
+	v.AddConfigPath(".")
+
+	if err := v.ReadInConfig(); err != nil {
+		if ok := !errors.Is(err, viper.ConfigFileNotFoundError{}); !ok {
+			return nil, err
+		}
+	}
+
+	v.SetEnvPrefix(envPrefix)
+	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	v.AutomaticEnv()
+	if err := v.BindPFlags(cmd.PersistentFlags()); err != nil {
+		return nil, err
+	}
+	if err := v.BindPFlags(cmd.Flags()); err != nil {
+		return nil, err
+	}
+
+	if err := v.Unmarshal(cfg); err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}

--- a/pkg/connectorrunner/runner.go
+++ b/pkg/connectorrunner/runner.go
@@ -1,73 +1,52 @@
-package sdk
+package connectorrunner
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"os/signal"
 	"time"
 
 	ratelimitV1 "github.com/conductorone/baton-sdk/pb/c1/ratelimit/v1"
-	"github.com/conductorone/baton-sdk/pkg/dotc1z/manager"
-	"github.com/conductorone/baton-sdk/pkg/sync"
+	"github.com/conductorone/baton-sdk/pkg/connectorrunner/tasks"
+	sdkSync "github.com/conductorone/baton-sdk/pkg/sync"
 	"github.com/conductorone/baton-sdk/pkg/types"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/conductorone/baton-sdk/internal/connector"
-	"github.com/conductorone/baton-sdk/pkg/connectorstore"
 )
 
 type connectorRunner struct {
-	syncer  sync.Syncer
-	store   connectorstore.Writer
-	manager manager.Manager
+	cw           types.ClientWrapper
+	dbPath       string
+	onDemandMode bool
+	tasks        tasks.Manager
 }
 
-func (c *connectorRunner) shutdown(ctx context.Context) error {
-	logger := ctxzap.Extract(ctx)
-
-	err := c.Close()
-	if err != nil {
-		// Explicitly ignoring the error here as it is possible that things have already been closed.
-		logger.Error("error closing connector runner", zap.Error(err))
-	}
-
-	err = c.manager.SaveC1Z(ctx)
-	if err != nil {
-		logger.Error("error saving c1z", zap.Error(err))
-		return err
-	}
-
-	err = c.manager.Close(ctx)
-	if err != nil {
-		logger.Error("error closing c1z manager", zap.Error(err))
-		return err
-	}
-
-	return nil
-}
+var ErrSigTerm = errors.New("context cancelled by process shutdown")
 
 // Run starts a connector and creates a new C1Z file.
 func (c *connectorRunner) Run(ctx context.Context) error {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	defer func(c *connectorRunner, ctx context.Context) {
-		err := c.shutdown(ctx)
-		if err != nil {
-			ctxzap.Extract(ctx).Error("error shutting down", zap.Error(err))
-		}
-	}(c, ctx)
+	ctx, cancel := context.WithCancelCause(ctx)
+	defer cancel(ErrSigTerm)
 
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt)
 	go func() {
 		for range sigChan {
-			cancel()
+			cancel(ErrSigTerm)
 		}
 	}()
 
-	err := c.syncer.Sync(ctx)
+	err := c.run(ctx)
+	if err != nil {
+		return err
+	}
+
+	err = c.Close(ctx)
 	if err != nil {
 		return err
 	}
@@ -75,12 +54,105 @@ func (c *connectorRunner) Run(ctx context.Context) error {
 	return nil
 }
 
-func (c *connectorRunner) Close() error {
-	err := c.syncer.Close()
-	if err != nil {
-		return err
+func (c *connectorRunner) handleContextCancel(ctx context.Context) error {
+	l := ctxzap.Extract(ctx)
+
+	err := context.Cause(ctx)
+	if err == nil {
+		return nil
 	}
 
+	// The context was cancelled due to an expected end of the process. Swallow the error.
+	if errors.Is(err, ErrSigTerm) {
+		return nil
+	}
+
+	l.Debug("unexpected context cancellation", zap.Error(err))
+	return err
+}
+
+func (c *connectorRunner) run(ctx context.Context) error {
+	l := ctxzap.Extract(ctx)
+
+	l.Info("waiting for work....")
+
+	var done bool
+
+	for !done {
+		select {
+		case <-ctx.Done():
+			return c.handleContextCancel(ctx)
+		default:
+		}
+
+		nextTask, err := c.tasks.Next(ctx)
+		if err != nil {
+			l.Error("error getting next task", zap.Error(err))
+			continue
+		}
+
+		// No work for us to do, go to sleep for a bit and try again
+		if nextTask == nil {
+			l.Debug("no available tasks, going to sleep for 5 seconds")
+			select {
+			case <-ctx.Done():
+				return c.handleContextCancel(ctx)
+			case <-time.After(time.Second * 5):
+			}
+			continue
+		}
+
+		switch nextTask.(type) {
+		case *tasks.SyncTask:
+			client, err := c.cw.C(ctx)
+			if err != nil {
+				return err
+			}
+
+			syncer, err := sdkSync.NewSyncer(ctx, client, c.dbPath)
+			if err != nil {
+				return err
+			}
+
+			err = syncer.Sync(ctx)
+			if err != nil {
+				return err
+			}
+
+			err = syncer.Close(ctx)
+			if err != nil {
+				return err
+			}
+
+			err = c.tasks.Finish(ctx, nextTask.GetTaskId())
+			if err != nil {
+				return err
+			}
+
+			if c.onDemandMode {
+				done = true
+			}
+
+			err = c.cw.Close()
+			if err != nil {
+				return err
+			}
+
+		default:
+			l.Debug("unknown task type, going to sleep for 10 seconds")
+			select {
+			case <-ctx.Done():
+				return c.handleContextCancel(ctx)
+			case <-time.After(time.Second * 10):
+			}
+			continue
+		}
+	}
+
+	return nil
+}
+
+func (c *connectorRunner) Close(ctx context.Context) error {
 	return nil
 }
 
@@ -166,7 +238,7 @@ func WithRateLimitDescriptor(entry *ratelimitV1.RateLimitDescriptors_Entry) Opti
 }
 
 // NewConnectorRunner creates a new connector runner.
-func NewConnectorRunner(ctx context.Context, c types.ConnectorServer, dbPath string, opts ...Option) (*connectorRunner, error) {
+func NewConnectorRunner(ctx context.Context, c1zPath string, onDemandSync bool, c types.ConnectorServer, opts ...Option) (*connectorRunner, error) {
 	runner := &connectorRunner{}
 	cfg := &runnerConfig{}
 
@@ -177,17 +249,24 @@ func NewConnectorRunner(ctx context.Context, c types.ConnectorServer, dbPath str
 		}
 	}
 
-	m, err := manager.New(ctx, dbPath)
+	tm, err := tasks.NewNaiveManager(ctx)
 	if err != nil {
 		return nil, err
 	}
-	runner.manager = m
+	runner.tasks = tm
 
-	store, err := runner.manager.LoadC1Z(ctx)
-	if err != nil {
-		return nil, err
+	if c1zPath == "" {
+		return nil, fmt.Errorf("connector-runner: must provide a c1z path to sync with")
 	}
-	runner.store = store
+	runner.dbPath = c1zPath
+
+	if onDemandSync {
+		runner.onDemandMode = true
+		err = runner.tasks.Add(ctx, tasks.NewSyncTask())
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	wrapperOpts := []connector.Option{}
 	wrapperOpts = append(wrapperOpts, connector.WithRateLimiterConfig(cfg.rlCfg))
@@ -201,7 +280,7 @@ func NewConnectorRunner(ctx context.Context, c types.ConnectorServer, dbPath str
 		return nil, err
 	}
 
-	runner.syncer = sync.NewSyncer(store, cw)
+	runner.cw = cw
 
 	return runner, nil
 }

--- a/pkg/connectorrunner/tasks/naive.go
+++ b/pkg/connectorrunner/tasks/naive.go
@@ -1,0 +1,73 @@
+package tasks
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+type naiveManager struct {
+	tasks      []Task
+	nextTaskID int
+}
+
+func (m *naiveManager) Next(ctx context.Context) (Task, error) {
+	if len(m.tasks) == 0 {
+		return nil, nil
+	}
+
+	ret := m.tasks[m.nextTaskID]
+
+	return ret, nil
+}
+
+func (m *naiveManager) Add(ctx context.Context, tsk Task) error {
+	m.tasks = append(m.tasks, tsk)
+
+	return nil
+}
+
+func (m *naiveManager) Finish(ctx context.Context, taskID string) error {
+	idx := -1
+
+	for ii, t := range m.tasks {
+		if t.GetTaskId() == taskID {
+			idx = ii
+			break
+		}
+	}
+
+	if idx == -1 {
+		return fmt.Errorf("unexpected task ID was provided: %s", taskID)
+	}
+
+	newTasks := m.tasks[:idx]
+	// If this wasn't the last index in the slice, include everything after the idx that matches our task ID
+	if idx != len(m.tasks)-1 {
+		newTasks = append(newTasks, m.tasks[idx:]...)
+	}
+
+	m.tasks = newTasks
+
+	return nil
+}
+
+// NewNaiveManager returns a task manager that queues a sync task.
+func NewNaiveManager(ctx context.Context) (*naiveManager, error) {
+	nm := &naiveManager{}
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGUSR1)
+	go func() {
+		for range sigChan {
+			err := nm.Add(ctx, NewSyncTask())
+			if err != nil {
+				panic(err)
+			}
+		}
+	}()
+
+	return nm, nil
+}

--- a/pkg/connectorrunner/tasks/tasks.go
+++ b/pkg/connectorrunner/tasks/tasks.go
@@ -1,0 +1,35 @@
+package tasks
+
+import (
+	"context"
+
+	"github.com/segmentio/ksuid"
+)
+
+type Task interface {
+	GetTaskType() string
+	GetTaskId() string
+}
+
+type Manager interface {
+	Next(ctx context.Context) (Task, error)
+	Finish(ctx context.Context, taskID string) error
+	Add(ctx context.Context, task Task) error
+}
+
+type SyncTask struct {
+	taskID string
+}
+
+func (s SyncTask) GetTaskType() string {
+	return "sync"
+}
+
+func (s SyncTask) GetTaskId() string {
+	return s.taskID
+}
+
+func NewSyncTask() *SyncTask {
+	id := ksuid.New().String()
+	return &SyncTask{taskID: id}
+}


### PR DESCRIPTION
The goal of this change is to refactor the CLI harness to take ownership of the process and introduce the idea of a 'daemon' mode for connectors. The SDK takes over the main run loop of the connector, working off of a serial work queue. Today this includes a single task type for Syncs, but you can imagine adding `Grant` and `Revoke` tasks as well. 

This is the first step on the path to allowing connectors to run in "service mode" where they will communicate with an upstream API in order to get work to do and submit the results of each task.

This is a breaking change for connectors consuming the SDK. They will be required to make updates to begin using this version of the SDK. 

## main loop changes
The primary change here is that the SDK cli package takes control of running the connector implementation instead of the connector implementation itself. Before this change, when using the `NewCmd()`, SDK users would pass a run function defined by the connector. This function looked something like this:
```
// run is where the process of syncing with the connector is implemented.
func run(ctx context.Context, cfg *config) error {
	l := ctxzap.Extract(ctx)

	c, err := getConnector(ctx, cfg)
	if err != nil {
		return err
	}

	r, err := sdk.NewConnectorRunner(ctx, c, cfg.C1zPath)
	if err != nil {
		l.Error("error creating connector runner", zap.Error(err))
		return err
	}
	defer r.Close()

	err = r.Run(ctx)
	if err != nil {
		l.Error("error running connector", zap.Error(err))
		return err
	}

	return nil
}
```

With this change, the SDK is in charge of the run command for the 'main loop' of the connector process, meaning that implementors only need to provide a factory method.

## on demand mode
in order to keep the existing functionality(running without the new `-d` flag), this also implements 'on-demand' mode. If we don't have the daemonize flag set, we will still bring up the connector as if we were daemonized, but we manually push a sync task into the work queue, and then explicitly quit after running the single task. 

## naive task manager
For testing and debugging, I've implemented a 'naive' task manager. It is very basic and implements the work queue as an in-memory slice. It also supports injecting a single sync task into its queue by signalling the process with `USR1`. Clearly not for production use, and will be removed eventually.

## connector lifecycle
Previous to this change, when the connector was run it would immediately spin up the connector server as a child process, run a sync, and then shut everything down. Now the connector server is only spun up to perform a task, and then is shutdown. A new process will be spun up to process each task.