### PR TITLE
Checkpoint more often while syncing resources and their children types

### DIFF
--- a/pkg/sync/progress.go
+++ b/pkg/sync/progress.go
@@ -1,10 +1,12 @@
 package sync
 
 type Progress struct {
-	Action         string
-	ResourceTypeID string
-	ResourceID     string
-	Count          uint32
+	Action               string
+	ResourceTypeID       string
+	ResourceID           string
+	ParentResourceTypeID string
+	ParentResourceID     string
+	Count                uint32
 }
 
 func NewProgress(a *Action, c uint32) *Progress {
@@ -13,9 +15,11 @@ func NewProgress(a *Action, c uint32) *Progress {
 	}
 
 	return &Progress{
-		Action:         a.Op.String(),
-		ResourceTypeID: a.ResourceTypeID,
-		ResourceID:     a.ResourceID,
-		Count:          c,
+		Action:               a.Op.String(),
+		ResourceTypeID:       a.ResourceTypeID,
+		ResourceID:           a.ResourceID,
+		ParentResourceTypeID: a.ParentResourceTypeID,
+		ParentResourceID:     a.ParentResourceID,
+		Count:                c,
 	}
 }

--- a/pkg/sync/state.go
+++ b/pkg/sync/state.go
@@ -16,6 +16,8 @@ type State interface {
 	NextPage(ctx context.Context, pageToken string) error
 	ResourceTypeID(ctx context.Context) string
 	ResourceID(ctx context.Context) string
+	ParentResourceID(ctx context.Context) string
+	ParentResourceTypeID(ctx context.Context) string
 	PageToken(ctx context.Context) string
 	Current() *Action
 	Marshal() (string, error)
@@ -95,10 +97,12 @@ const (
 
 // Action stores the current operation, page token, and optional fields for which resource is being worked with.
 type Action struct {
-	Op             ActionOp `json:"operation"`
-	PageToken      string   `json:"page_token"`
-	ResourceTypeID string   `json:"resource_type_id"`
-	ResourceID     string   `json:"resource_id"`
+	Op                   ActionOp `json:"operation,omitempty"`
+	PageToken            string   `json:"page_token,omitempty"`
+	ResourceTypeID       string   `json:"resource_type_id,omitempty"`
+	ResourceID           string   `json:"resource_id,omitempty"`
+	ParentResourceTypeID string   `json:"parent_resource_type_id,omitempty"`
+	ParentResourceID     string   `json:"parent_resource_id,omitempty"`
 }
 
 // state is an object used for tracking the current status of a connector sync. It operates like a stack.
@@ -260,4 +264,22 @@ func (st *state) ResourceID(ctx context.Context) string {
 	}
 
 	return c.ResourceID
+}
+
+func (st *state) ParentResourceID(ctx context.Context) string {
+	c := st.Current()
+	if c == nil {
+		panic("no current state")
+	}
+
+	return c.ParentResourceID
+}
+
+func (st *state) ParentResourceTypeID(ctx context.Context) string {
+	c := st.Current()
+	if c == nil {
+		panic("no current state")
+	}
+
+	return c.ParentResourceTypeID
 }

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -327,6 +327,8 @@ func (s *syncer) syncResources(ctx context.Context) error {
 		return err
 	}
 
+	s.handleProgress(ctx, s.state.Current(), len(resp.List))
+
 	if resp.NextPageToken == "" {
 		s.state.FinishAction(ctx)
 	} else {
@@ -339,7 +341,7 @@ func (s *syncer) syncResources(ctx context.Context) error {
 	for _, r := range resp.List {
 		// Check if we've already synced this resource, skip it if we have
 		_, err = s.store.GetResource(ctx, &reader_v2.ResourceTypesReaderServiceGetResourceRequest{
-			ResourceId: &v2.ResourceId{ResourceType: "foo", Resource: "bar"},
+			ResourceId: &v2.ResourceId{ResourceType: r.Id.ResourceType, Resource: r.Id.Resource},
 		})
 		if err == nil {
 			continue
@@ -364,8 +366,6 @@ func (s *syncer) syncResources(ctx context.Context) error {
 			return err
 		}
 	}
-
-	s.handleProgress(ctx, s.state.Current(), len(resp.List))
 
 	return nil
 }

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -3,6 +3,7 @@ package sync
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"io"
@@ -247,38 +248,31 @@ func (s *syncer) SyncResourceTypes(ctx context.Context) error {
 	return nil
 }
 
-// subResource is used to track the specific resources that have been visited to avoid infinite loops.
-type subResource struct {
-	resourceTypeId   string
-	parentResourceId *v2.ResourceId
-}
-
 // getSubResources fetches the sub resource types from a resources' annotations.
-func (s *syncer) getSubResources(ctx context.Context, parent *v2.Resource) ([]subResource, error) {
-	var subResources []subResource
-
+func (s *syncer) getSubResources(ctx context.Context, parent *v2.Resource) error {
 	for _, a := range parent.Annotations {
 		if a.MessageIs((*v2.ChildResourceType)(nil)) {
 			crt := &v2.ChildResourceType{}
 			err := a.UnmarshalTo(crt)
 			if err != nil {
-				return nil, err
+				return err
 			}
 
-			subResources = append(subResources, subResource{
-				parentResourceId: parent.Id,
-				resourceTypeId:   crt.ResourceTypeId,
-			})
+			childAction := Action{
+				Op:                   SyncResourcesOp,
+				ResourceTypeID:       crt.ResourceTypeId,
+				ParentResourceID:     parent.Id.Resource,
+				ParentResourceTypeID: parent.Id.ResourceType,
+			}
+			s.state.PushAction(ctx, childAction)
 		}
 	}
 
-	return subResources, nil
+	return nil
 }
 
 // SyncResources handles fetching all of the resources from the connector given the provided resource types. For each
-// resource, we gather any child resource types it may emit, and traverse the resource tree. Currently this will checkpoint
-// for each root resource type. Additional work to track the history across actions is required for more fine grained
-// checkpointing.
+// resource, we gather any child resource types it may emit, and traverse the resource tree.
 func (s *syncer) SyncResources(ctx context.Context) error {
 	if s.state.Current().ResourceTypeID == "" {
 		ctxzap.Extract(ctx).Info("Syncing resources...")
@@ -307,86 +301,69 @@ func (s *syncer) SyncResources(ctx context.Context) error {
 		return nil
 	}
 
-	visited := make(map[subResource]struct{})
-	subResources := []subResource{{resourceTypeId: s.state.Current().ResourceTypeID}}
+	return s.syncResources(ctx)
+}
 
-	for len(subResources) > 0 {
-		// If the context is cancelled, bail from the loop
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
+// syncResources fetches a given resource from the connector, and returns a slice of new child resources to fetch.
+func (s *syncer) syncResources(ctx context.Context) error {
+	req := &v2.ResourcesServiceListResourcesRequest{
+		ResourceTypeId: s.state.ResourceTypeID(ctx),
+		PageToken:      s.state.PageToken(ctx),
+	}
+	if s.state.ParentResourceTypeID(ctx) != "" && s.state.ParentResourceID(ctx) != "" {
+		req.ParentResourceId = &v2.ResourceId{
+			ResourceType: s.state.ParentResourceTypeID(ctx),
+			Resource:     s.state.ParentResourceID(ctx),
 		}
+	}
 
-		subR := subResources[0]
-		subResources = subResources[1:]
-		// If we've seen this subresource before, skip it
-		if _, ok := visited[subR]; ok {
+	c, err := s.connector.C(ctx)
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.ListResources(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	if resp.NextPageToken == "" {
+		s.state.FinishAction(ctx)
+	} else {
+		err = s.state.NextPage(ctx, resp.NextPageToken)
+		if err != nil {
+			return err
+		}
+	}
+
+	for _, r := range resp.List {
+		// Check if we've already synced this resource, skip it if we have
+		_, err = s.store.GetResource(ctx, &reader_v2.ResourceTypesReaderServiceGetResourceRequest{
+			ResourceId: &v2.ResourceId{ResourceType: "foo", Resource: "bar"},
+		})
+		if err == nil || !errors.Is(err, sql.ErrNoRows) {
 			continue
 		}
 
-		nested, err := s.syncResources(ctx, subR.resourceTypeId, subR.parentResourceId)
+		err = s.validateResourceTraits(ctx, r)
 		if err != nil {
 			return err
 		}
 
-		visited[subR] = struct{}{}
-		subResources = append(subResources, nested...)
+		err = s.store.PutResource(ctx, r)
+		if err != nil {
+			return err
+		}
+
+		err = s.getSubResources(ctx, r)
+		if err != nil {
+			return err
+		}
 	}
 
-	s.state.FinishAction(ctx)
+	s.handleProgress(ctx, s.state.Current(), len(resp.List))
 
 	return nil
-}
-
-// syncResources fetches a given resource from the connector, and returns a slice of new child resources to fetch.
-func (s *syncer) syncResources(ctx context.Context, resourceTypeID string, parentResourceID *v2.ResourceId) ([]subResource, error) {
-	var ret []subResource
-
-	pageToken := ""
-	for {
-		req := &v2.ResourcesServiceListResourcesRequest{
-			ResourceTypeId:   resourceTypeID,
-			ParentResourceId: parentResourceID,
-			PageToken:        pageToken,
-		}
-
-		c, err := s.connector.C(ctx)
-		if err != nil {
-			return nil, err
-		}
-
-		resp, err := c.ListResources(ctx, req)
-		if err != nil {
-			return nil, err
-		}
-
-		for _, r := range resp.List {
-			err = s.validateResourceTraits(ctx, r)
-			if err != nil {
-				return nil, err
-			}
-
-			err = s.store.PutResource(ctx, r)
-			if err != nil {
-				return nil, err
-			}
-			subResources, err := s.getSubResources(ctx, r)
-			if err != nil {
-				return nil, err
-			}
-			ret = append(ret, subResources...)
-		}
-
-		s.handleProgress(ctx, s.state.Current(), len(resp.List))
-
-		if resp.NextPageToken == "" {
-			break
-		}
-		pageToken = resp.NextPageToken
-	}
-
-	return ret, nil
 }
 
 func (s *syncer) validateResourceTraits(ctx context.Context, r *v2.Resource) error {

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -341,8 +341,12 @@ func (s *syncer) syncResources(ctx context.Context) error {
 		_, err = s.store.GetResource(ctx, &reader_v2.ResourceTypesReaderServiceGetResourceRequest{
 			ResourceId: &v2.ResourceId{ResourceType: "foo", Resource: "bar"},
 		})
-		if err == nil || !errors.Is(err, sql.ErrNoRows) {
+		if err == nil {
 			continue
+		}
+
+		if !errors.Is(err, sql.ErrNoRows) {
+			return err
 		}
 
 		err = s.validateResourceTraits(ctx, r)


### PR DESCRIPTION
Before this change, we would sync all resources(and their children types) of a given resource type in a single sync run without checkpointing. This means that if the sync failed in the middle of syncing some resource type, the sync would have to begin again at the first page of resources for that type.

After this change, the syncer will checkpoint after each page of resources processed so that we can resume without having to repeat a large amount of work.

This is accomplished by refactoring how resources are synced. Now we will push individual state actions onto the sync stack as we discover pages and child resource types.

Previously we kept a slice of the resources we've seen so that we wouldn't find ourselves in an infinite loop of syncing resources. Because we are calling `SyncResources` many more times now, we don't have state for which resources we've visited across invocations. To get around this before processing a resource, we actually check the store to see if we've synced the resource already. If we have, we skip it and move onto the next one. 