### PR TITLE
Add an optional callback to the syncer that reports progress.

### DIFF
--- a/pkg/sync/progress.go
+++ b/pkg/sync/progress.go
@@ -1,0 +1,24 @@
+package sync
+
+type Progress struct {
+	Action         string
+	ResourceTypeID string
+	ResourceID     string
+	Count uint32
+}
+
+func NewProgress(a *Action, c uint32) *Progress {
+	p := &Progress{}
+	if a == nil {
+		return p
+	}
+
+	if a != nil {
+		p.Count = c
+		p.Action = a.Op.String()
+		p.ResourceTypeID = a.ResourceTypeID
+		p.ResourceID = a.ResourceID
+	}
+
+	return p
+}

--- a/pkg/sync/progress.go
+++ b/pkg/sync/progress.go
@@ -4,21 +4,18 @@ type Progress struct {
 	Action         string
 	ResourceTypeID string
 	ResourceID     string
-	Count uint32
+	Count          uint32
 }
 
 func NewProgress(a *Action, c uint32) *Progress {
-	p := &Progress{}
 	if a == nil {
-		return p
+		return &Progress{}
 	}
 
-	if a != nil {
-		p.Count = c
-		p.Action = a.Op.String()
-		p.ResourceTypeID = a.ResourceTypeID
-		p.ResourceID = a.ResourceID
+	return &Progress{
+		Action:         a.Op.String(),
+		ResourceTypeID: a.ResourceTypeID,
+		ResourceID:     a.ResourceID,
+		Count:          c,
 	}
-
-	return p
 }

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -39,7 +39,7 @@ type syncer struct {
 }
 
 // Checkpoint marshals the current state and stores it.
-func (s *syncer) Checkpoint(ctx context.Context, lastAction Action) error {
+func (s *syncer) Checkpoint(ctx context.Context) error {
 	checkpoint, err := s.state.Marshal()
 	if err != nil {
 		return err
@@ -114,7 +114,7 @@ func (s *syncer) Sync(ctx context.Context) error {
 	s.state = state
 
 	for s.state.Current() != nil {
-		err = s.Checkpoint(ctx, *s.state.Current())
+		err = s.Checkpoint(ctx)
 		if err != nil {
 			return err
 		}
@@ -145,7 +145,7 @@ func (s *syncer) Sync(ctx context.Context) error {
 			s.state.PushAction(ctx, Action{Op: SyncResourcesOp})
 			s.state.PushAction(ctx, Action{Op: SyncResourceTypesOp})
 
-			err = s.Checkpoint(ctx, *s.state.Current())
+			err = s.Checkpoint(ctx)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Add an optional callback to the syncer that reports progress while running the current sync.

Currently it reports the current action, resource (if available), and count of objects processed. The work is not done in this PR, but this could be reasonably combined with the `Stats()` capability of a c1z to fetch object counts from the previous sync and be able estimate sync progress.

Additionally, if the sync context is cancelled with cause, return that error. 

