### PR TITLE
Large file upload support

### DIFF
--- a/pkg/dotc1z/decoder.go
+++ b/pkg/dotc1z/decoder.go
@@ -83,7 +83,7 @@ func WithDecoderMaxMemory(n uint64) DecoderOption {
 
 // WithDecoderMaxDecodedSize sets the maximum size of the decoded stream.
 // This can be used to cap the resulting decoded stream size.
-// Maximum is 1 << 63 bytes. Default is 2GiB.
+// Maximum is 1 << 63 bytes. Default is 1GiB.
 func WithDecoderMaxDecodedSize(n uint64) DecoderOption {
 	return func(o *decoderOptions) error {
 		if n == 0 {


### PR DESCRIPTION
* Let the aws SDK calculate sha256 checksums on upload for better multipart support
* Add support for configuring decoder limits via the environment.

`BATON_DECODER_MAX_DECODED_SIZE_MB` can be set to limit the maximum size of a decoded/uncompressed c1z in megabytes. This currently defaults to 1GB.

`BATON_DECODER_MAX_MEMORY_MB` can be set to limit the maximum amount of memory to use while decoding a c1z. This currently defaults to 32MB.