### PR TITLE
Unconditionally remove the temp dir backing the C1File implementation on Close().

### DIFF
--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/doug-martin/goqu/v9"
 	_ "github.com/glebarez/go-sqlite"
@@ -85,6 +87,12 @@ func (c *C1File) Close() error {
 		if err != nil {
 			return err
 		}
+	}
+
+	// Cleanup the database filepath. This should always be a file within a temp directory, so we remove the entire dir.
+	err = os.RemoveAll(filepath.Dir(c.dbFilePath))
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/dotc1z/file.go
+++ b/pkg/dotc1z/file.go
@@ -33,6 +33,7 @@ func loadC1z(filePath string) (string, error) {
 		if err != nil {
 			return "", err
 		}
+		defer c1zFile.Close()
 
 		var opts []DecoderOption
 
@@ -57,6 +58,10 @@ func loadC1z(filePath string) (string, error) {
 			return "", err
 		}
 		_, err = io.Copy(dbFile, r)
+		if err != nil {
+			return "", err
+		}
+		err = r.Close()
 		if err != nil {
 			return "", err
 		}
@@ -95,7 +100,6 @@ func saveC1z(dbFilePath string, outputFilePath string) error {
 
 	_, err = io.Copy(c1z, dbFile)
 	if err != nil {
-		c1z.Close()
 		return err
 	}
 
@@ -104,12 +108,6 @@ func saveC1z(dbFilePath string, outputFilePath string) error {
 		return err
 	}
 	err = c1z.Close()
-	if err != nil {
-		return err
-	}
-
-	// Cleanup the databaase filepath. This shoould always be a file within a temp directory, so we remove the entire dir.
-	err = os.RemoveAll(filepath.Dir(dbFilePath))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Unconditionally remove the temp dir backing the C1File implementation on Close().

This avoids orphaning a tempdir if you open a C1File but make no changes that need written back out.

Also other small cleanup. 