### PR TITLE
Refactor c1z decoder options

### DIFF
--- a/pkg/dotc1z/decoder.go
+++ b/pkg/dotc1z/decoder.go
@@ -6,13 +6,19 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"strconv"
 	"sync"
 
 	"github.com/klauspost/compress/zstd"
 )
 
-const defaultDecoderMaxMemory = 32 * 1024 * 1024     // 32MiB
-const defaultMaxDecodedSize = 1 * 1024 * 1024 * 1024 // 1GiB
+const (
+	defaultMaxDecodedSize   = 2 * 1024 * 1024 * 1024 // 2GiB
+	defaultDecoderMaxMemory = 32 * 1024 * 1024       // 32MiB
+	maxDecodedSizeEnvVar    = "BATON_DECODER_MAX_DECODED_SIZE_MB"
+	maxDecoderMemorySizeEnv = "BATON_DECODER_MAX_MEMORY_MB"
+)
 
 var C1ZFileHeader = []byte("C1ZF\x00")
 
@@ -179,6 +185,24 @@ func (d *decoder) Close() error {
 
 // NewDecoder wraps a given .c1z file io.Reader and returns an io.Reader for the underlying decoded/uncompressed file.
 func NewDecoder(f io.Reader, opts ...DecoderOption) (*decoder, error) {
+	// We want these options to be configurable via the environment. They are appended to the end of opts so they will take
+	// precedence over any other options of the same type.
+	maxDecodedSizeVar := os.Getenv(maxDecodedSizeEnvVar)
+	if maxDecodedSizeVar != "" {
+		maxDecodedSize, err := strconv.ParseUint(maxDecodedSizeVar, 10, 64)
+		if err == nil {
+			opts = append(opts, WithDecoderMaxDecodedSize(maxDecodedSize*1024*1024))
+		}
+	}
+
+	maxDecoderMemorySizeVar := os.Getenv(maxDecoderMemorySizeEnv)
+	if maxDecoderMemorySizeVar != "" {
+		maxDecoderMemorySize, err := strconv.ParseUint(maxDecoderMemorySizeVar, 10, 64)
+		if err == nil {
+			opts = append(opts, WithDecoderMaxMemory(maxDecoderMemorySize*1024*1024))
+		}
+	}
+
 	o := &decoderOptions{}
 	for _, opt := range opts {
 		err := opt(o)

--- a/pkg/dotc1z/file.go
+++ b/pkg/dotc1z/file.go
@@ -5,15 +5,9 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strconv"
 	"syscall"
 
 	"github.com/klauspost/compress/zstd"
-)
-
-const (
-	maxDecodedSizeEnvVar    = "BATON_DECODER_MAX_DECODED_SIZE_MB"
-	maxDecoderMemorySizeEnv = "BATON_DECODER_MAX_MEMORY_MB"
 )
 
 func loadC1z(filePath string) (string, error) {
@@ -35,25 +29,7 @@ func loadC1z(filePath string) (string, error) {
 		}
 		defer c1zFile.Close()
 
-		var opts []DecoderOption
-
-		maxDecodedSizeVar := os.Getenv(maxDecodedSizeEnvVar)
-		if maxDecodedSizeVar != "" {
-			maxDecodedSize, err := strconv.ParseUint(maxDecodedSizeVar, 10, 64)
-			if err == nil {
-				opts = append(opts, WithDecoderMaxDecodedSize(maxDecodedSize*1024*1024))
-			}
-		}
-
-		maxDecoderMemorySizeVar := os.Getenv(maxDecoderMemorySizeEnv)
-		if maxDecoderMemorySizeVar != "" {
-			maxDecoderMemorySize, err := strconv.ParseUint(maxDecoderMemorySizeVar, 10, 64)
-			if err == nil {
-				opts = append(opts, WithDecoderMaxMemory(maxDecoderMemorySize*1024*1024))
-			}
-		}
-
-		r, err := NewDecoder(c1zFile, opts...)
+		r, err := NewDecoder(c1zFile)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/dotc1z/manager/local/local.go
+++ b/pkg/dotc1z/manager/local/local.go
@@ -1,7 +1,6 @@
 package local
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -47,18 +46,18 @@ func (l *localManager) copyFileToTmp(ctx context.Context) error {
 }
 
 // LoadRaw returns an io.Reader of the bytes in the c1z file.
-func (l *localManager) LoadRaw(ctx context.Context) (io.Reader, error) {
+func (l *localManager) LoadRaw(ctx context.Context) (io.ReadCloser, error) {
 	err := l.copyFileToTmp(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	fBytes, err := os.ReadFile(l.tmpPath)
+	f, err := os.Open(l.tmpPath)
 	if err != nil {
 		return nil, err
 	}
 
-	return bytes.NewBuffer(fBytes), nil
+	return f, nil
 }
 
 // LoadC1Z loads the C1Z file from the local file system.

--- a/pkg/dotc1z/manager/manager.go
+++ b/pkg/dotc1z/manager/manager.go
@@ -11,7 +11,7 @@ import (
 )
 
 type Manager interface {
-	LoadRaw(ctx context.Context) (io.Reader, error)
+	LoadRaw(ctx context.Context) (io.ReadCloser, error)
 	LoadC1Z(ctx context.Context) (*dotc1z.C1File, error)
 	SaveC1Z(ctx context.Context) error
 	Close(ctx context.Context) error

--- a/pkg/dotc1z/manager/s3/s3.go
+++ b/pkg/dotc1z/manager/s3/s3.go
@@ -1,7 +1,6 @@
 package s3
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -42,7 +41,7 @@ func (s *s3Manager) copyToTempFile(ctx context.Context, r io.Reader) error {
 }
 
 // LoadRaw loads the file from S3 and returns an io.Reader for the contents.
-func (s *s3Manager) LoadRaw(ctx context.Context) (io.Reader, error) {
+func (s *s3Manager) LoadRaw(ctx context.Context) (io.ReadCloser, error) {
 	out, err := s.client.Get(ctx, s.fileName)
 	if err != nil {
 		var ae smithy.APIError
@@ -63,12 +62,12 @@ func (s *s3Manager) LoadRaw(ctx context.Context) (io.Reader, error) {
 		return nil, err
 	}
 
-	fBytes, err := os.ReadFile(s.tmpFile)
+	f, err := os.Open(s.tmpFile)
 	if err != nil {
 		return nil, err
 	}
 
-	return bytes.NewBuffer(fBytes), nil
+	return f, nil
 }
 
 // LoadC1Z gets a file from the AWS S3 bucket and copies it to a temp file.


### PR DESCRIPTION
Check the environment later on to ensure it always happens.

I also realized that the `LoadRaw()` method on the c1z manager was loading the entire file into memory instead of serving it from disk. 