### PR TITLE
Only append client credentials if they exist, not if stdin isn't a tty.

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -83,6 +83,12 @@ func NewCmd[T any, PtrT *T](
 
 			daemonMode := v.GetString("client-id") != "" || isService()
 			if daemonMode {
+				if v.GetString("client-id") == "" {
+					return fmt.Errorf("client-id is required in service mode")
+				}
+				if v.GetString("client-secret") == "" {
+					return fmt.Errorf("client-secret is required in service mode")
+				}
 				opts = append(opts, connectorrunner.WithClientCredentials(v.GetString("client-id"), v.GetString("client-secret")))
 			} else {
 				switch {

--- a/pkg/cli/service_unix.go
+++ b/pkg/cli/service_unix.go
@@ -4,15 +4,13 @@ package cli
 
 import (
 	"context"
-	"os"
 
 	"github.com/conductorone/baton-sdk/pkg/logging"
 	"github.com/spf13/cobra"
-	"golang.org/x/term"
 )
 
 func isService() bool {
-	return !term.IsTerminal(int(os.Stdin.Fd()))
+	return false
 }
 
 func setupService(name string) error {


### PR DESCRIPTION
This fixes a bug that happens when testing baton cli tools in CI (where stdin isn't a tty).

Needed so that CI passes on https://github.com/ConductorOne/baton-ldap/pull/10