### PR TITLE
Tiny: We don't need to Close() the underlying reader if we never initialized it by calling Read().

### DIFF
--- a/pkg/dotc1z/decoder.go
+++ b/pkg/dotc1z/decoder.go
@@ -179,7 +179,9 @@ func (d *decoder) Read(p []byte) (int, error) {
 }
 
 func (d *decoder) Close() error {
-	d.zd.Close()
+	if d.zd != nil {
+		d.zd.Close()
+	}
 	return nil
 }
 


### PR DESCRIPTION
We don't initialize underlying decoder until we call `Read()` the first time, so don't try to close a nil decoder if we never `Read()` from one. 