### PR TITLE
Return a different error message if --provisioning flag is not set

### DIFF
--- a/internal/connector/noop_provisioner.go
+++ b/internal/connector/noop_provisioner.go
@@ -11,25 +11,25 @@ import (
 type noopProvisioner struct{}
 
 func (n *noopProvisioner) Grant(ctx context.Context, req *v2.GrantManagerServiceGrantRequest) (*v2.GrantManagerServiceGrantResponse, error) {
-	return nil, status.Error(codes.FailedPrecondition, "provisioning is not enabled")
+	return nil, status.Error(codes.FailedPrecondition, "error: provisioning is not enabled. try running with --provisioning")
 }
 
 func (n *noopProvisioner) Revoke(ctx context.Context, req *v2.GrantManagerServiceRevokeRequest) (*v2.GrantManagerServiceRevokeResponse, error) {
-	return nil, status.Error(codes.FailedPrecondition, "provisioning is not enabled")
+	return nil, status.Error(codes.FailedPrecondition, "error: provisioning is not enabled. try running with --provisioning")
 }
 
 func (n *noopProvisioner) CreateResource(ctx context.Context, request *v2.CreateResourceRequest) (*v2.CreateResourceResponse, error) {
-	return nil, status.Error(codes.FailedPrecondition, "provisioning is not enabled")
+	return nil, status.Error(codes.FailedPrecondition, "error: provisioning is not enabled. try running with --provisioning")
 }
 
 func (n *noopProvisioner) DeleteResource(ctx context.Context, request *v2.DeleteResourceRequest) (*v2.DeleteResourceResponse, error) {
-	return nil, status.Error(codes.FailedPrecondition, "provisioning is not enabled")
+	return nil, status.Error(codes.FailedPrecondition, "error: provisioning is not enabled. try running with --provisioning")
 }
 
 func (n *noopProvisioner) RotateCredential(ctx context.Context, request *v2.RotateCredentialRequest) (*v2.RotateCredentialResponse, error) {
-	return nil, status.Error(codes.FailedPrecondition, "provisioning is not enabled")
+	return nil, status.Error(codes.FailedPrecondition, "error: provisioning is not enabled. try running with --provisioning")
 }
 
 func (n *noopProvisioner) CreateAccount(ctx context.Context, request *v2.CreateAccountRequest) (*v2.CreateAccountResponse, error) {
-	return nil, status.Error(codes.FailedPrecondition, "provisioning is not enabled")
+	return nil, status.Error(codes.FailedPrecondition, "error: provisioning is not enabled. try running with --provisioning")
 }

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -110,7 +110,6 @@ func NewCmd[T any, PtrT *T](
 							v.GetString("grant-principal-type"),
 						))
 				case v.GetString("revoke-grant") != "":
-					l.Error("revoke-grant running service xxx-xx-xxx")
 					opts = append(opts,
 						connectorrunner.WithProvisioningEnabled(),
 						connectorrunner.WithOnDemandRevoke(

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -4,13 +4,14 @@ import (
 	"bufio"
 	"context"
 	"encoding/base64"
-	"errors"
 	"fmt"
 	"os"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -96,7 +97,7 @@ func NewCmd[T any, PtrT *T](
 				opts = append(opts, connectorrunner.WithClientCredentials(v.GetString("client-id"), v.GetString("client-secret")))
 			} else {
 				if isProvisioning && !v.GetBool("provisioning") {
-					return errors.New("error: provisioning is not enabled. try running with --provisioning")
+					return status.Error(codes.Unimplemented, "provisioning is not enabled. try running with --provisioning")
 				}
 				switch {
 				case v.GetString("grant-entitlement") != "":

--- a/pkg/connectorbuilder/connectorbuilder.go
+++ b/pkg/connectorbuilder/connectorbuilder.go
@@ -317,8 +317,8 @@ func (b *builderImpl) Grant(ctx context.Context, request *v2.GrantManagerService
 		return &v2.GrantManagerServiceGrantResponse{Annotations: annos, Grants: grants}, nil
 	}
 
-	l.Error("error: resource type does not have provisioner configured", zap.String("resource_type", rt))
-	return nil, fmt.Errorf("error: resource type does not have provisioner configured")
+	l.Error("error: provisioning is not enabled. try running with --provisioning", zap.String("resource_type", rt))
+	return nil, fmt.Errorf("error: provisioning is not enabled. try running with --provisioning")
 }
 
 func (b *builderImpl) Revoke(ctx context.Context, request *v2.GrantManagerServiceRevokeRequest) (*v2.GrantManagerServiceRevokeResponse, error) {
@@ -345,8 +345,8 @@ func (b *builderImpl) Revoke(ctx context.Context, request *v2.GrantManagerServic
 		return &v2.GrantManagerServiceRevokeResponse{Annotations: annos}, nil
 	}
 
-	l.Error("error: resource type does not have provisioner configured", zap.String("resource_type", rt))
-	return nil, status.Error(codes.Unimplemented, "resource type does not have provisioner configured")
+	l.Error("error: provisioning is not enabled. try running with --provisioning", zap.String("resource_type", rt))
+	return nil, status.Error(codes.Unimplemented, "provisioning is not enabled. try running with --provisioning")
 }
 
 // GetAsset streams the asset to the client.

--- a/pkg/connectorbuilder/connectorbuilder.go
+++ b/pkg/connectorbuilder/connectorbuilder.go
@@ -295,8 +295,7 @@ func (b *builderImpl) Grant(ctx context.Context, request *v2.GrantManagerService
 	l := ctxzap.Extract(ctx)
 
 	rt := request.Entitlement.Resource.Id.ResourceType
-	provisioner, ok := b.resourceProvisioners[rt]
-	if ok {
+	if provisioner, ok := b.resourceProvisioners[rt]; ok {
 		annos, err := provisioner.Grant(ctx, request.Principal, request.Entitlement)
 		if err != nil {
 			l.Error("error: grant failed", zap.Error(err))
@@ -306,8 +305,7 @@ func (b *builderImpl) Grant(ctx context.Context, request *v2.GrantManagerService
 		return &v2.GrantManagerServiceGrantResponse{Annotations: annos}, nil
 	}
 
-	provisionerV2, ok := b.resourceProvisionersV2[rt]
-	if ok {
+	if provisionerV2, ok := b.resourceProvisionersV2[rt]; ok {
 		grants, annos, err := provisionerV2.Grant(ctx, request.Principal, request.Entitlement)
 		if err != nil {
 			l.Error("error: grant failed", zap.Error(err))
@@ -325,8 +323,7 @@ func (b *builderImpl) Revoke(ctx context.Context, request *v2.GrantManagerServic
 	l := ctxzap.Extract(ctx)
 
 	rt := request.Grant.Entitlement.Resource.Id.ResourceType
-	provisioner, ok := b.resourceProvisioners[rt]
-	if ok {
+	if provisioner, ok := b.resourceProvisioners[rt]; ok {
 		annos, err := provisioner.Revoke(ctx, request.Grant)
 		if err != nil {
 			l.Error("error: revoke failed", zap.Error(err))
@@ -335,8 +332,7 @@ func (b *builderImpl) Revoke(ctx context.Context, request *v2.GrantManagerServic
 		return &v2.GrantManagerServiceRevokeResponse{Annotations: annos}, nil
 	}
 
-	provisionerV2, ok := b.resourceProvisionersV2[rt]
-	if ok {
+	if provisionerV2, ok := b.resourceProvisionersV2[rt]; ok {
 		annos, err := provisionerV2.Revoke(ctx, request.Grant)
 		if err != nil {
 			l.Error("error: revoke failed", zap.Error(err))
@@ -377,15 +373,16 @@ func (b *builderImpl) ListEvents(ctx context.Context, request *v2.ListEventsRequ
 func (b *builderImpl) CreateResource(ctx context.Context, request *v2.CreateResourceRequest) (*v2.CreateResourceResponse, error) {
 	l := ctxzap.Extract(ctx)
 	rt := request.GetResource().GetId().GetResourceType()
-	manager, ok := b.resourceManagers[rt]
-	if ok {
+	if manager, ok := b.resourceManagers[rt]; ok {
 		resource, annos, err := manager.Create(ctx, request.Resource)
 		if err != nil {
 			l.Error("error: create resource failed", zap.Error(err))
 			return nil, fmt.Errorf("error: create resource failed: %w", err)
 		}
+
 		return &v2.CreateResourceResponse{Created: resource, Annotations: annos}, nil
 	}
+
 	l.Error("error: resource type does not have resource manager configured", zap.String("resource_type", rt))
 	return nil, status.Error(codes.Unimplemented, "resource type does not have resource manager configured")
 }
@@ -393,15 +390,16 @@ func (b *builderImpl) CreateResource(ctx context.Context, request *v2.CreateReso
 func (b *builderImpl) DeleteResource(ctx context.Context, request *v2.DeleteResourceRequest) (*v2.DeleteResourceResponse, error) {
 	l := ctxzap.Extract(ctx)
 	rt := request.GetResourceId().GetResourceType()
-	manager, ok := b.resourceManagers[rt]
-	if ok {
+	if manager, ok := b.resourceManagers[rt]; ok {
 		annos, err := manager.Delete(ctx, request.GetResourceId())
 		if err != nil {
 			l.Error("error: delete resource failed", zap.Error(err))
 			return nil, fmt.Errorf("error: delete resource failed: %w", err)
 		}
+
 		return &v2.DeleteResourceResponse{Annotations: annos}, nil
 	}
+
 	l.Error("error: resource type does not have resource manager configured", zap.String("resource_type", rt))
 	return nil, status.Error(codes.Unimplemented, "resource type does not have resource manager configured")
 }


### PR DESCRIPTION
- Right now if you try to provision something without the --provisioning flag, we error with "resource type does not have provisioner configured".  This error message should be something like "provisioning is not enabled. try running with --provisioning".

Fixes https://github.com/ConductorOne/baton-sdk/issues/114.