### PR TITLE
HTTP helper improvements

### DIFF
--- a/pkg/uhttp/wrapper.go
+++ b/pkg/uhttp/wrapper.go
@@ -45,6 +45,9 @@ func NewBaseHttpClient(httpClient *http.Client) *BaseHttpClient {
 
 func WithJSONResponse(response interface{}) DoOption {
 	return func(resp *WrapperResponse) error {
+		if !helpers.IsJSONContentType(resp.Header.Get("Content-Type")) {
+			return fmt.Errorf("unexpected content type for json response: %s", resp.Header.Get("Content-Type"))
+		}
 		return json.Unmarshal(resp.Body, response)
 	}
 }
@@ -77,7 +80,7 @@ func WithErrorResponse(resource ErrorResponse) DoOption {
 
 func WithRatelimitData(resource *v2.RateLimitDescription) DoOption {
 	return func(resp *WrapperResponse) error {
-		rl, err := helpers.ExtractRateLimitData(&resp.Header)
+		rl, err := helpers.ExtractRateLimitData(resp.StatusCode, &resp.Header)
 		if err != nil {
 			return err
 		}
@@ -92,6 +95,9 @@ func WithRatelimitData(resource *v2.RateLimitDescription) DoOption {
 
 func WithXMLResponse(response interface{}) DoOption {
 	return func(resp *WrapperResponse) error {
+		if !helpers.IsXMLContentType(resp.Header.Get("Content-Type")) {
+			return fmt.Errorf("unexpected content type for xml response: %s", resp.Header.Get("Content-Type"))
+		}
 		return xml.Unmarshal(resp.Body, response)
 	}
 }

--- a/pkg/uhttp/wrapper.go
+++ b/pkg/uhttp/wrapper.go
@@ -104,6 +104,19 @@ func WithXMLResponse(response interface{}) DoOption {
 	}
 }
 
+func WithResponse(response interface{}) DoOption {
+	return func(resp *WrapperResponse) error {
+		if helpers.IsJSONContentType(resp.Header.Get(ContentType)) {
+			return WithJSONResponse(response)(resp)
+		}
+		if helpers.IsXMLContentType(resp.Header.Get(ContentType)) {
+			return WithXMLResponse(response)(resp)
+		}
+
+		return status.Error(codes.Unknown, "unsupported content type")
+	}
+}
+
 func (c *BaseHttpClient) Do(req *http.Request, options ...DoOption) (*http.Response, error) {
 	resp, err := c.HttpClient.Do(req)
 	if err != nil {

--- a/pkg/uhttp/wrapper.go
+++ b/pkg/uhttp/wrapper.go
@@ -16,6 +16,8 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+const ContentType = "Content-Type"
+
 type WrapperResponse struct {
 	Header     http.Header
 	Body       []byte
@@ -45,8 +47,8 @@ func NewBaseHttpClient(httpClient *http.Client) *BaseHttpClient {
 
 func WithJSONResponse(response interface{}) DoOption {
 	return func(resp *WrapperResponse) error {
-		if !helpers.IsJSONContentType(resp.Header.Get("Content-Type")) {
-			return fmt.Errorf("unexpected content type for json response: %s", resp.Header.Get("Content-Type"))
+		if !helpers.IsJSONContentType(resp.Header.Get(ContentType)) {
+			return fmt.Errorf("unexpected content type for json response: %s", resp.Header.Get(ContentType))
 		}
 		return json.Unmarshal(resp.Body, response)
 	}
@@ -62,7 +64,7 @@ func WithErrorResponse(resource ErrorResponse) DoOption {
 			return nil
 		}
 
-		if !helpers.IsJSONContentType(resp.Header.Get("Content-Type")) {
+		if !helpers.IsJSONContentType(resp.Header.Get(ContentType)) {
 			return fmt.Errorf("%v", string(resp.Body))
 		}
 
@@ -95,8 +97,8 @@ func WithRatelimitData(resource *v2.RateLimitDescription) DoOption {
 
 func WithXMLResponse(response interface{}) DoOption {
 	return func(resp *WrapperResponse) error {
-		if !helpers.IsXMLContentType(resp.Header.Get("Content-Type")) {
-			return fmt.Errorf("unexpected content type for xml response: %s", resp.Header.Get("Content-Type"))
+		if !helpers.IsXMLContentType(resp.Header.Get(ContentType)) {
+			return fmt.Errorf("unexpected content type for xml response: %s", resp.Header.Get(ContentType))
 		}
 		return xml.Unmarshal(resp.Body, response)
 	}
@@ -168,7 +170,7 @@ func WithAcceptJSONHeader() RequestOption {
 func WithContentTypeJSONHeader() RequestOption {
 	return func() (io.ReadWriter, map[string]string, error) {
 		return nil, map[string]string{
-			"Content-Type": "application/json",
+			ContentType: "application/json",
 		}, nil
 	}
 }

--- a/pkg/uhttp/wrapper_test.go
+++ b/pkg/uhttp/wrapper_test.go
@@ -138,6 +138,60 @@ func TestWrapper_WithXMLResponse(t *testing.T) {
 	require.Equal(t, exampleResponse, responseBody)
 }
 
+func TestWrapper_WithResponse(t *testing.T) {
+	exampleResponse := example{
+		Name: "John",
+		Age:  30,
+	}
+	exampleResponseBuffer := new(bytes.Buffer)
+	err := xml.NewEncoder(exampleResponseBuffer).Encode(exampleResponse)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp := http.Response{
+		Header: map[string][]string{
+			"Content-Type": {"application/xml"},
+		},
+	}
+
+	responseBody := example{}
+	option := WithResponse(&responseBody)
+	wrapperResp := WrapperResponse{
+		Header:     resp.Header,
+		Body:       exampleResponseBuffer.Bytes(),
+		StatusCode: 200,
+		Status:     "200 OK",
+	}
+	err = option(&wrapperResp)
+
+	require.Nil(t, err)
+	require.Equal(t, exampleResponse, responseBody)
+
+	exampleResponseBuffer = new(bytes.Buffer)
+	err = json.NewEncoder(exampleResponseBuffer).Encode(exampleResponse)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp.Header = map[string][]string{
+		"Content-Type": {"application/json"},
+	}
+
+	responseBody = example{}
+	option = WithResponse(&responseBody)
+	wrapperResp = WrapperResponse{
+		Header:     resp.Header,
+		Body:       exampleResponseBuffer.Bytes(),
+		StatusCode: 200,
+		Status:     "200 OK",
+	}
+	err = option(&wrapperResp)
+
+	require.Nil(t, err)
+	require.Equal(t, exampleResponse, responseBody)
+}
+
 type ErrResponse struct {
 	Title  string `json:"title"`
 	Detail string `json:"detail"`

--- a/pkg/uhttp/wrapper_test.go
+++ b/pkg/uhttp/wrapper_test.go
@@ -87,7 +87,11 @@ func TestWrapper_WithJSONResponse(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resp := http.Response{}
+	resp := http.Response{
+		Header: map[string][]string{
+			"Content-Type": {"application/json"},
+		},
+	}
 
 	responseBody := example{}
 	option := WithJSONResponse(&responseBody)
@@ -114,7 +118,11 @@ func TestWrapper_WithXMLResponse(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resp := http.Response{}
+	resp := http.Response{
+		Header: map[string][]string{
+			"Content-Type": {"application/xml"},
+		},
+	}
 
 	responseBody := example{}
 	option := WithXMLResponse(&responseBody)


### PR DESCRIPTION
- Check content type of JSON and XML responses before trying to parse the body.
- Add HTTP status 429 handling to helpers.ExtractRateLimitData().