### PR TITLE
General retry logic in syncing

### DIFF
--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -82,10 +82,15 @@ func shouldWaitAndRetry(ctx context.Context, err error) bool {
 	l := ctxzap.Extract(ctx)
 	l.Error("retrying operation", zap.Error(err))
 
-	// TODO: this should back off based on error counts
-	time.Sleep(1 * time.Second)
-
-	return true
+	for {
+		select {
+		// TODO: this should back off based on error counts
+		case <-time.After(1 * time.Second):
+			return true
+		case <-ctx.Done():
+			return false
+		}
+	}
 }
 
 // Sync starts the syncing process. The sync process is driven by the action stack that is part of the state object.

--- a/pkg/uhttp/wrapper.go
+++ b/pkg/uhttp/wrapper.go
@@ -90,6 +90,7 @@ func WithRatelimitData(resource *v2.RateLimitDescription) DoOption {
 		resource.Limit = rl.Limit
 		resource.Remaining = rl.Remaining
 		resource.ResetAt = rl.ResetAt
+		resource.Status = rl.Status
 
 		return nil
 	}

--- a/pkg/uhttp/wrapper.go
+++ b/pkg/uhttp/wrapper.go
@@ -148,8 +148,21 @@ func (c *BaseHttpClient) Do(req *http.Request, options ...DoOption) (*http.Respo
 		}
 	}
 
+	switch resp.StatusCode {
+	case http.StatusTooManyRequests:
+		return resp, status.Error(codes.Unavailable, resp.Status)
+	case http.StatusNotFound:
+		return resp, status.Error(codes.NotFound, resp.Status)
+	case http.StatusUnauthorized:
+		return resp, status.Error(codes.Unauthenticated, resp.Status)
+	case http.StatusForbidden:
+		return resp, status.Error(codes.PermissionDenied, resp.Status)
+	case http.StatusNotImplemented:
+		return resp, status.Error(codes.Unimplemented, resp.Status)
+	}
+
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return resp, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		return resp, status.Error(codes.Unknown, fmt.Sprintf("unexpected status code: %d", resp.StatusCode))
 	}
 
 	return resp, err

--- a/pkg/uhttp/wrapper_test.go
+++ b/pkg/uhttp/wrapper_test.go
@@ -105,6 +105,15 @@ func TestWrapper_WithJSONResponse(t *testing.T) {
 
 	require.Nil(t, err)
 	require.Equal(t, exampleResponse, responseBody)
+
+	wrapperResp.Header = map[string][]string{
+		"Content-Type": {"application/xml"},
+	}
+	responseBody = example{}
+	option = WithJSONResponse(&responseBody)
+	err = option(&wrapperResp)
+
+	require.NotNil(t, err)
 }
 
 func TestWrapper_WithXMLResponse(t *testing.T) {
@@ -216,6 +225,10 @@ func TestWrapper_WithErrorResponse(t *testing.T) {
 	require.NotNil(t, err)
 	require.Contains(t, errResp.Message(), "not found")
 	require.Contains(t, err.Error(), "not found")
+
+	resp.StatusCode = http.StatusOK
+	err = WithErrorResponse(&errResp)(&resp)
+	require.Nil(t, err)
 }
 
 func TestWrapper_WithRateLimitData(t *testing.T) {


### PR DESCRIPTION
This changes the http client and the syncer so that individual connectors don't have to handle every recoverable http error. If the error status is something we can retry or recover from, we do so. For example, 429 (too many requests) caused connectors to error out. This PR fixes that.

TODO:
- [ ] Handle "skippable errors", such as a 404 for a specific resource. We need to advance the syncer state in that case.
- [ ] Backoff behavior (right now we always wait exactly one second)
- [x] Use something smarter than time.sleep() to wait.

If this works, we can simplify connector code and avoid an entire class of bugs.