### PR TITLE
Performance improvements

### DIFF
--- a/pkg/sync/expand.go
+++ b/pkg/sync/expand.go
@@ -233,7 +233,7 @@ func (g *EntitlementGraph) getDescendants(nodeID int) []Node {
 	if !ok {
 		return nil
 	}
-	nodes := make([]Node, len(g.Edges[nodeID]))
+	nodes := make([]Node, 0, len(g.Edges[nodeID]))
 	for dstNodeId := range g.Edges[nodeID] {
 		dstNode := g.Nodes[dstNodeId]
 		nodes = append(nodes, dstNode)

--- a/pkg/sync/expand.go
+++ b/pkg/sync/expand.go
@@ -386,11 +386,13 @@ func (g *EntitlementGraph) mergeNodes(node1ID int, node2ID int) {
 	g.removeNode(node2ID)
 }
 
-func (g *EntitlementGraph) FixCycles() {
-	for {
+func (g *EntitlementGraph) FixCycles() error {
+	// If we can't fix the cycles in 10 tries, just give up
+	const maxTries = 10
+	for i := 0; i < maxTries; i++ {
 		cycles, hasCycles := g.GetCycles()
 		if !hasCycles {
-			return
+			return nil
 		}
 
 		// Merge all the nodes in a cycle.
@@ -398,4 +400,5 @@ func (g *EntitlementGraph) FixCycles() {
 			g.mergeNodes(cycles[0][0], cycles[0][i])
 		}
 	}
+	return fmt.Errorf("could not fix cycles after %v tries", maxTries)
 }

--- a/pkg/sync/expand.go
+++ b/pkg/sync/expand.go
@@ -229,12 +229,12 @@ func (g *EntitlementGraph) getCycle(visits []int) ([]int, bool) {
 }
 
 func (g *EntitlementGraph) getDescendants(nodeID int) []Node {
-	node, ok := g.Nodes[nodeID]
+	_, ok := g.Nodes[nodeID]
 	if !ok {
 		return nil
 	}
-	var nodes []Node
-	for dstNodeId := range g.Edges[node.Id] {
+	nodes := make([]Node, len(g.Edges[nodeID]))
+	for dstNodeId := range g.Edges[nodeID] {
 		dstNode := g.Nodes[dstNodeId]
 		nodes = append(nodes, dstNode)
 	}

--- a/pkg/sync/expand.go
+++ b/pkg/sync/expand.go
@@ -224,7 +224,7 @@ func (g *EntitlementGraph) getCycle(visits []int) ([]int, bool) {
 		}
 
 		tempVisits = append(tempVisits, descendantId)
-		return g.getCycle(tempVisits) //nolint:staticcheck // false positive
+		return g.getCycle(tempVisits)
 	}
 	return nil, false
 }

--- a/pkg/sync/expand.go
+++ b/pkg/sync/expand.go
@@ -169,7 +169,8 @@ func (g *EntitlementGraph) getAncestors(entitlementID string) []int {
 func (g *EntitlementGraph) GetCycles() ([][]int, bool) {
 	rv := make([][]int, 0)
 	for nodeID := range g.Nodes {
-		if len(g.getDescendants(nodeID)) == 0 {
+		edges, ok := g.Edges[nodeID]
+		if !ok || len(edges) == 0 {
 			continue
 		}
 		cycle, isCycle := g.getCycle([]int{nodeID})
@@ -202,7 +203,7 @@ func (g *EntitlementGraph) getCycle(visits []int) ([]int, bool) {
 		return nil, false
 	}
 	nodeId := visits[len(visits)-1]
-	for _, descendantId := range g.getDescendants(nodeId) {
+	for descendantId := range g.Edges[nodeId] {
 		tempVisits := make([]int, len(visits))
 		copy(tempVisits, visits)
 		if descendantId == visits[0] {
@@ -226,18 +227,6 @@ func (g *EntitlementGraph) getCycle(visits []int) ([]int, bool) {
 		return g.getCycle(tempVisits) //nolint:staticcheck // false positive
 	}
 	return nil, false
-}
-
-func (g *EntitlementGraph) getDescendants(nodeID int) []int {
-	_, ok := g.Nodes[nodeID]
-	if !ok {
-		return nil
-	}
-	nodeIDs := make([]int, 0, len(g.Edges[nodeID]))
-	for dstNodeID := range g.Edges[nodeID] {
-		nodeIDs = append(nodeIDs, dstNodeID)
-	}
-	return nodeIDs
 }
 
 func (g *EntitlementGraph) GetDescendantEntitlements(entitlementID string) map[string]*grantInfo {

--- a/pkg/sync/expand.go
+++ b/pkg/sync/expand.go
@@ -202,10 +202,10 @@ func (g *EntitlementGraph) getCycle(visits []int) ([]int, bool) {
 		return nil, false
 	}
 	nodeId := visits[len(visits)-1]
-	for _, descendant := range g.getDescendants(nodeId) {
+	for _, descendantId := range g.getDescendants(nodeId) {
 		tempVisits := make([]int, len(visits))
 		copy(tempVisits, visits)
-		if descendant.Id == visits[0] {
+		if descendantId == visits[0] {
 			// shift array so that the smallest element is first
 			smallestIndex := 0
 			for i := range tempVisits {
@@ -217,28 +217,27 @@ func (g *EntitlementGraph) getCycle(visits []int) ([]int, bool) {
 			return tempVisits, true
 		}
 		for _, visit := range visits {
-			if visit == descendant.Id {
+			if visit == descendantId {
 				return nil, false
 			}
 		}
 
-		tempVisits = append(tempVisits, descendant.Id)
+		tempVisits = append(tempVisits, descendantId)
 		return g.getCycle(tempVisits) //nolint:staticcheck // false positive
 	}
 	return nil, false
 }
 
-func (g *EntitlementGraph) getDescendants(nodeID int) []Node {
+func (g *EntitlementGraph) getDescendants(nodeID int) []int {
 	_, ok := g.Nodes[nodeID]
 	if !ok {
 		return nil
 	}
-	nodes := make([]Node, 0, len(g.Edges[nodeID]))
-	for dstNodeId := range g.Edges[nodeID] {
-		dstNode := g.Nodes[dstNodeId]
-		nodes = append(nodes, dstNode)
+	nodeIDs := make([]int, 0, len(g.Edges[nodeID]))
+	for dstNodeID := range g.Edges[nodeID] {
+		nodeIDs = append(nodeIDs, dstNodeID)
 	}
-	return nodes
+	return nodeIDs
 }
 
 func (g *EntitlementGraph) GetDescendantEntitlements(entitlementID string) map[string]*grantInfo {

--- a/pkg/sync/expand_test.go
+++ b/pkg/sync/expand_test.go
@@ -93,7 +93,8 @@ func TestHandleCycle(t *testing.T) {
 	require.True(t, isCycle)
 	require.Equal(t, [][]int{{2, 3, 4}}, cycles)
 
-	graph.FixCycles()
+	err = graph.FixCycles()
+	require.NoError(t, err)
 	err = graph.Validate()
 	require.NoError(t, err)
 	cycles, isCycle = graph.GetCycles()
@@ -120,7 +121,8 @@ func TestHandleCycle(t *testing.T) {
 	err = graph.Validate()
 	require.NoError(t, err)
 
-	graph.FixCycles()
+	err = graph.FixCycles()
+	require.NoError(t, err)
 	err = graph.Validate()
 	require.NoError(t, err)
 

--- a/pkg/sync/expand_test.go
+++ b/pkg/sync/expand_test.go
@@ -25,10 +25,6 @@ func TestGetDescendants(t *testing.T) {
 	err = graph.Validate()
 	require.NoError(t, err)
 
-	descendants := graph.getDescendants(node.Id)
-	expected := []int{2, 3, 4}
-	require.ElementsMatch(t, expected, descendants)
-
 	descendantEntitlements := graph.GetDescendantEntitlements("1")
 	expectedEntitlements := map[string]*grantInfo{
 		"2": {

--- a/pkg/sync/expand_test.go
+++ b/pkg/sync/expand_test.go
@@ -26,21 +26,28 @@ func TestGetDescendants(t *testing.T) {
 	require.NoError(t, err)
 
 	descendants := graph.getDescendants(node.Id)
-	expected := []Node{
-		{
-			Id:             2,
-			EntitlementIDs: []string{"2"},
+	expected := []int{2, 3, 4}
+	require.ElementsMatch(t, expected, descendants)
+
+	descendantEntitlements := graph.GetDescendantEntitlements("1")
+	expectedEntitlements := map[string]*grantInfo{
+		"2": {
+			Expanded:        false,
+			Shallow:         false,
+			ResourceTypeIDs: nil,
 		},
-		{
-			Id:             3,
-			EntitlementIDs: []string{"3"},
+		"3": {
+			Expanded:        false,
+			Shallow:         false,
+			ResourceTypeIDs: nil,
 		},
-		{
-			Id:             4,
-			EntitlementIDs: []string{"4"},
+		"4": {
+			Expanded:        false,
+			Shallow:         false,
+			ResourceTypeIDs: nil,
 		},
 	}
-	require.ElementsMatch(t, expected, descendants)
+	require.EqualValues(t, expectedEntitlements, descendantEntitlements)
 }
 
 func TestRemoveNode(t *testing.T) {

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -809,9 +809,10 @@ func (s *syncer) SyncGrantExpansion(ctx context.Context) error {
 		cycles, hasCycles := entitlementGraph.GetCycles()
 		if hasCycles {
 			l.Warn("cycles detected in entitlement graph", zap.Any("cycles", cycles))
-			entitlementGraph.FixCycles()
-			cycles, _ := entitlementGraph.GetCycles()
-			l.Warn("fixed cycles", zap.Any("cycles", cycles))
+			err := entitlementGraph.FixCycles()
+			if err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
- Remove getDescendants() and just get node ids directly. This should drastically speed up GetCycles().
- Give up fixing cycles after 10 tries.
- Don't call GetCycles() after fixing cycles.