### PR TITLE
Use opinionated developer encoder config for console logging.

### DIFF
--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -30,6 +30,7 @@ func WithLogFormat(format string) Option {
 			c.Encoding = LogFormatJSON
 		case LogFormatConsole:
 			c.Encoding = LogFormatConsole
+			c.EncoderConfig = zap.NewDevelopmentEncoderConfig()
 		default:
 			c.Encoding = LogFormatJSON
 		}


### PR DESCRIPTION
This fixes the exponential notation of timestamps and shows human readable ones. Also it capitalizes the log level and a few other things.

Before:
<img width="970" alt="Screenshot 2024-05-29 at 10 37 10" src="https://github.com/ConductorOne/baton-sdk/assets/200121/9c7e4e8b-14b6-4bdc-8504-6c0bc5d83453">

After:
<img width="1065" alt="Screenshot 2024-05-29 at 10 37 00" src="https://github.com/ConductorOne/baton-sdk/assets/200121/bb6f2317-3592-4d0a-9a79-cebe085ffe35">

