### PR TITLE
Return annotations for failed ticket tasks 

### DIFF
--- a/pkg/tasks/c1api/create_ticket.go
+++ b/pkg/tasks/c1api/create_ticket.go
@@ -30,7 +30,7 @@ func (c *createTicketTaskHandler) HandleTask(ctx context.Context) error {
 	t := c.task.GetCreateTicketTask()
 	if t == nil || t.GetTicketRequest() == nil {
 		l.Error("create ticket task was nil or missing ticket request", zap.Any("create_ticket_task", t))
-		return c.helpers.FinishTask(ctx, nil, nil, errors.Join(errors.New("malformed create ticket task"), ErrTaskNonRetryable))
+		return c.helpers.FinishTask(ctx, nil, t.GetAnnotations(), errors.Join(errors.New("malformed create ticket task"), ErrTaskNonRetryable))
 	}
 
 	cc := c.helpers.ConnectorClient()
@@ -41,7 +41,7 @@ func (c *createTicketTaskHandler) HandleTask(ctx context.Context) error {
 	})
 	if err != nil {
 		l.Error("failed creating ticket", zap.Error(err))
-		return c.helpers.FinishTask(ctx, nil, nil, errors.Join(err, ErrTaskNonRetryable))
+		return c.helpers.FinishTask(ctx, nil, t.GetAnnotations(), err)
 	}
 
 	respAnnos := annotations.Annotations(resp.GetAnnotations())

--- a/pkg/tasks/c1api/get_ticket.go
+++ b/pkg/tasks/c1api/get_ticket.go
@@ -3,7 +3,6 @@ package c1api
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	v1 "github.com/conductorone/baton-sdk/pb/c1/connectorapi/baton/v1"
@@ -43,8 +42,7 @@ func (c *getTicketTaskHandler) HandleTask(ctx context.Context) error {
 	}
 
 	if ticket.GetTicket() == nil {
-		// TODO(lauren) should this use finish task? 
-		return fmt.Errorf("connector returned empty ticket")
+		return c.helpers.FinishTask(ctx, nil, t.GetAnnotations(), errors.Join(errors.New("connector returned empty ticket"), ErrTaskNonRetryable))
 	}
 
 	resp := &v2.TicketsServiceGetTicketResponse{

--- a/pkg/tasks/c1api/get_ticket.go
+++ b/pkg/tasks/c1api/get_ticket.go
@@ -39,10 +39,11 @@ func (c *getTicketTaskHandler) HandleTask(ctx context.Context) error {
 		Id: t.GetTicketId(),
 	})
 	if err != nil {
-		return err
+		return c.helpers.FinishTask(ctx, nil, t.GetAnnotations(), err)
 	}
 
 	if ticket.GetTicket() == nil {
+		// TODO(lauren) should this use finish task? 
 		return fmt.Errorf("connector returned empty ticket")
 	}
 

--- a/pkg/tasks/c1api/list_ticket_schemas.go
+++ b/pkg/tasks/c1api/list_ticket_schemas.go
@@ -60,6 +60,7 @@ func (c *listTicketSchemasTaskHandler) HandleTask(ctx context.Context) error {
 
 	if err != nil {
 		l.Error("failed listing ticket schemas", zap.Error(err))
+		// TODO(lauren) should this be retryable?
 		return c.helpers.FinishTask(ctx, nil, nil, errors.Join(err, ErrTaskNonRetryable))
 	}
 

--- a/pkg/tasks/c1api/list_ticket_schemas.go
+++ b/pkg/tasks/c1api/list_ticket_schemas.go
@@ -60,8 +60,7 @@ func (c *listTicketSchemasTaskHandler) HandleTask(ctx context.Context) error {
 
 	if err != nil {
 		l.Error("failed listing ticket schemas", zap.Error(err))
-		// TODO(lauren) should this be retryable?
-		return c.helpers.FinishTask(ctx, nil, nil, errors.Join(err, ErrTaskNonRetryable))
+		return c.helpers.FinishTask(ctx, nil, nil, err)
 	}
 
 	resp := &v2.TicketsServiceListTicketSchemasResponse{


### PR DESCRIPTION
- We need the external ticket annotation to record retry attempts 
- Makes create ticket failure retryable 