### PR TITLE
Add some better error messages and logs to c1z functions.

### DIFF
--- a/pkg/dotc1z/entitlements.go
+++ b/pkg/dotc1z/entitlements.go
@@ -54,7 +54,7 @@ func (c *C1File) ListEntitlements(ctx context.Context, request *v2.EntitlementsS
 	ctxzap.Extract(ctx).Debug("listing entitlements")
 	objs, nextPageToken, err := c.listConnectorObjects(ctx, entitlements.Name(), request)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error listing entitlements: %w", err)
 	}
 
 	ret := make([]*v2.Entitlement, 0, len(objs))
@@ -80,7 +80,7 @@ func (c *C1File) GetEntitlement(ctx context.Context, request *reader_v2.Entitlem
 
 	err := c.getConnectorObject(ctx, entitlements.Name(), request.EntitlementId, ret)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error fetching entitlement '%s': %w", request.EntitlementId, err)
 	}
 
 	return &reader_v2.EntitlementsReaderServiceGetEntitlementResponse{

--- a/pkg/dotc1z/grants.go
+++ b/pkg/dotc1z/grants.go
@@ -64,7 +64,7 @@ func (c *C1File) ListGrants(ctx context.Context, request *v2.GrantsServiceListGr
 
 	objs, nextPageToken, err := c.listConnectorObjects(ctx, grants.Name(), request)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error listing grants: %w", err)
 	}
 
 	ret := make([]*v2.Grant, 0, len(objs))
@@ -90,7 +90,7 @@ func (c *C1File) GetGrant(ctx context.Context, request *reader_v2.GrantsReaderSe
 
 	err := c.getConnectorObject(ctx, grants.Name(), request.GrantId, ret)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error fetching grant '%s': %w", request.GetGrantId(), err)
 	}
 
 	return &reader_v2.GrantsReaderServiceGetGrantResponse{
@@ -102,11 +102,11 @@ func (c *C1File) ListGrantsForEntitlement(
 	ctx context.Context,
 	request *reader_v2.GrantsReaderServiceListGrantsForEntitlementRequest,
 ) (*reader_v2.GrantsReaderServiceListGrantsForEntitlementResponse, error) {
-	ctxzap.Extract(ctx).Debug("listing grants for entitlement")
+	ctxzap.Extract(ctx).Debug("listing grants for entitlement", zap.Any("entitlement", request.Entitlement))
 
 	objs, nextPageToken, err := c.listConnectorObjects(ctx, grants.Name(), request)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error listing grants for entitlement '%s': %w", request.GetEntitlement().GetId(), err)
 	}
 
 	ret := make([]*v2.Grant, 0, len(objs))
@@ -129,11 +129,11 @@ func (c *C1File) ListGrantsForPrincipal(
 	ctx context.Context,
 	request *reader_v2.GrantsReaderServiceListGrantsForEntitlementRequest,
 ) (*reader_v2.GrantsReaderServiceListGrantsForEntitlementResponse, error) {
-	ctxzap.Extract(ctx).Debug("listing grants for entitlement")
+	ctxzap.Extract(ctx).Debug("listing grants for principal", zap.Any("principal", request.GetPrincipalId()))
 
 	objs, nextPageToken, err := c.listConnectorObjects(ctx, grants.Name(), request)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error listing grants for principal '%s': %w", request.GetPrincipalId(), err)
 	}
 
 	ret := make([]*v2.Grant, 0, len(objs))
@@ -156,11 +156,11 @@ func (c *C1File) ListGrantsForResourceType(
 	ctx context.Context,
 	request *reader_v2.GrantsReaderServiceListGrantsForResourceTypeRequest,
 ) (*reader_v2.GrantsReaderServiceListGrantsForResourceTypeResponse, error) {
-	ctxzap.Extract(ctx).Debug("listing grants for resource type")
+	ctxzap.Extract(ctx).Debug("listing grants for resource type", zap.String("resource_type_id", request.GetResourceTypeId()))
 
 	objs, nextPageToken, err := c.listConnectorObjects(ctx, grants.Name(), request)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error listing grants for resource type '%s': %w", request.GetResourceTypeId(), err)
 	}
 
 	ret := make([]*v2.Grant, 0, len(objs))

--- a/pkg/dotc1z/resouce_types.go
+++ b/pkg/dotc1z/resouce_types.go
@@ -49,7 +49,7 @@ func (c *C1File) ListResourceTypes(ctx context.Context, request *v2.ResourceType
 
 	objs, nextPageToken, err := c.listConnectorObjects(ctx, resourceTypes.Name(), request)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error listing resource types: %w", err)
 	}
 
 	ret := make([]*v2.ResourceType, 0, len(objs))
@@ -75,7 +75,7 @@ func (c *C1File) GetResourceType(ctx context.Context, request *reader_v2.Resourc
 
 	err := c.getConnectorObject(ctx, resourceTypes.Name(), request.ResourceTypeId, ret)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error fetching resource type '%s': %w", request.ResourceTypeId, err)
 	}
 
 	return &reader_v2.ResourceTypesReaderServiceGetResourceTypeResponse{

--- a/pkg/dotc1z/resources.go
+++ b/pkg/dotc1z/resources.go
@@ -61,7 +61,7 @@ func (c *C1File) ListResources(ctx context.Context, request *v2.ResourcesService
 
 	objs, nextPageToken, err := c.listConnectorObjects(ctx, resources.Name(), request)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error listing resources: %w", err)
 	}
 
 	ret := make([]*v2.Resource, 0, len(objs))
@@ -98,7 +98,7 @@ func (c *C1File) GetResource(ctx context.Context, request *reader_v2.ResourcesRe
 
 	err := c.getResourceObject(ctx, request.ResourceId, ret, syncID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error fetching resource '%s': %w", request.ResourceId, err)
 	}
 
 	return &reader_v2.ResourcesReaderServiceGetResourceResponse{


### PR DESCRIPTION
Previously, if you tried to run a provision command with a bad grant/resource/whatever ID, you'd see an error like this:

```
{
  "level": "error",
  "ts": 1717434766.783422,
  "caller": "cli/cli.go:173",
  "msg": "error running connector",
  "error": "runner: error processing task: sql: no rows in result set"
}
```

Now it says what went wrong:
```
{
  "level": "error",
  "ts": 1717436325.934488,
  "caller": "cli/cli.go:173",
  "msg": "error running connector",
  "error": "runner: error processing task: error fetching grant 'group:cn=testgroup00001,dc=example,dc=org:member:user:cn=testuser00000,dc=example,dc=org': sql: no rows in result set"
}
```
