### PR TITLE
Drop dotc1z debug logs

### DIFF
--- a/pkg/dotc1z/assets.go
+++ b/pkg/dotc1z/assets.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/doug-martin/goqu/v9"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
-	"go.uber.org/zap"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 )
@@ -64,8 +63,6 @@ func (c *C1File) PutAsset(ctx context.Context, assetRef *v2.AssetRef, contentTyp
 		contentType = "unknown"
 	}
 
-	l.Debug("syncing asset", zap.String("content_type", contentType), zap.Int("asset_size", len(data)))
-
 	err := c.validateSyncDb(ctx)
 	if err != nil {
 		return err
@@ -101,8 +98,6 @@ func (c *C1File) PutAsset(ctx context.Context, assetRef *v2.AssetRef, contentTyp
 // GetAsset fetches the specified asset from the database, and returns the content type and an io.Reader for the caller to
 // read the asset from.
 func (c *C1File) GetAsset(ctx context.Context, request *v2.AssetServiceGetAssetRequest) (string, io.Reader, error) {
-	ctxzap.Extract(ctx).Debug("fetching asset", zap.String("id", request.Asset.Id))
-
 	err := c.validateDb(ctx)
 	if err != nil {
 		return "", nil, err

--- a/pkg/dotc1z/entitlements.go
+++ b/pkg/dotc1z/entitlements.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 
 	"github.com/doug-martin/goqu/v9"
-	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
-	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
@@ -51,7 +49,6 @@ func (r *entitlementsTable) Schema() (string, []interface{}) {
 }
 
 func (c *C1File) ListEntitlements(ctx context.Context, request *v2.EntitlementsServiceListEntitlementsRequest) (*v2.EntitlementsServiceListEntitlementsResponse, error) {
-	ctxzap.Extract(ctx).Debug("listing entitlements")
 	objs, nextPageToken, err := c.listConnectorObjects(ctx, entitlements.Name(), request)
 	if err != nil {
 		return nil, fmt.Errorf("error listing entitlements: %w", err)
@@ -74,8 +71,6 @@ func (c *C1File) ListEntitlements(ctx context.Context, request *v2.EntitlementsS
 }
 
 func (c *C1File) GetEntitlement(ctx context.Context, request *reader_v2.EntitlementsReaderServiceGetEntitlementRequest) (*reader_v2.EntitlementsReaderServiceGetEntitlementResponse, error) {
-	ctxzap.Extract(ctx).Debug("fetching entitlement", zap.String("entitlement_id", request.EntitlementId))
-
 	ret := &v2.Entitlement{}
 
 	err := c.getConnectorObject(ctx, entitlements.Name(), request.EntitlementId, ret)
@@ -89,8 +84,6 @@ func (c *C1File) GetEntitlement(ctx context.Context, request *reader_v2.Entitlem
 }
 
 func (c *C1File) PutEntitlement(ctx context.Context, entitlement *v2.Entitlement) error {
-	ctxzap.Extract(ctx).Debug("syncing entitlement", zap.String("entitlement_id", entitlement.Id))
-
 	if entitlement.Resource == nil && entitlement.Resource.Id == nil {
 		return fmt.Errorf("entitlements must have a non-nil resource")
 	}

--- a/pkg/dotc1z/grants.go
+++ b/pkg/dotc1z/grants.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 
 	"github.com/doug-martin/goqu/v9"
-	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
-	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
@@ -60,8 +58,6 @@ func (r *grantsTable) Schema() (string, []interface{}) {
 }
 
 func (c *C1File) ListGrants(ctx context.Context, request *v2.GrantsServiceListGrantsRequest) (*v2.GrantsServiceListGrantsResponse, error) {
-	ctxzap.Extract(ctx).Debug("listing grants")
-
 	objs, nextPageToken, err := c.listConnectorObjects(ctx, grants.Name(), request)
 	if err != nil {
 		return nil, fmt.Errorf("error listing grants: %w", err)
@@ -84,8 +80,6 @@ func (c *C1File) ListGrants(ctx context.Context, request *v2.GrantsServiceListGr
 }
 
 func (c *C1File) GetGrant(ctx context.Context, request *reader_v2.GrantsReaderServiceGetGrantRequest) (*reader_v2.GrantsReaderServiceGetGrantResponse, error) {
-	ctxzap.Extract(ctx).Debug("fetching grant", zap.String("grant_id", request.GrantId))
-
 	ret := &v2.Grant{}
 
 	err := c.getConnectorObject(ctx, grants.Name(), request.GrantId, ret)
@@ -102,8 +96,6 @@ func (c *C1File) ListGrantsForEntitlement(
 	ctx context.Context,
 	request *reader_v2.GrantsReaderServiceListGrantsForEntitlementRequest,
 ) (*reader_v2.GrantsReaderServiceListGrantsForEntitlementResponse, error) {
-	ctxzap.Extract(ctx).Debug("listing grants for entitlement", zap.Any("entitlement", request.Entitlement))
-
 	objs, nextPageToken, err := c.listConnectorObjects(ctx, grants.Name(), request)
 	if err != nil {
 		return nil, fmt.Errorf("error listing grants for entitlement '%s': %w", request.GetEntitlement().GetId(), err)
@@ -129,8 +121,6 @@ func (c *C1File) ListGrantsForPrincipal(
 	ctx context.Context,
 	request *reader_v2.GrantsReaderServiceListGrantsForEntitlementRequest,
 ) (*reader_v2.GrantsReaderServiceListGrantsForEntitlementResponse, error) {
-	ctxzap.Extract(ctx).Debug("listing grants for principal", zap.Any("principal", request.GetPrincipalId()))
-
 	objs, nextPageToken, err := c.listConnectorObjects(ctx, grants.Name(), request)
 	if err != nil {
 		return nil, fmt.Errorf("error listing grants for principal '%s': %w", request.GetPrincipalId(), err)
@@ -156,8 +146,6 @@ func (c *C1File) ListGrantsForResourceType(
 	ctx context.Context,
 	request *reader_v2.GrantsReaderServiceListGrantsForResourceTypeRequest,
 ) (*reader_v2.GrantsReaderServiceListGrantsForResourceTypeResponse, error) {
-	ctxzap.Extract(ctx).Debug("listing grants for resource type", zap.String("resource_type_id", request.GetResourceTypeId()))
-
 	objs, nextPageToken, err := c.listConnectorObjects(ctx, grants.Name(), request)
 	if err != nil {
 		return nil, fmt.Errorf("error listing grants for resource type '%s': %w", request.GetResourceTypeId(), err)
@@ -180,8 +168,6 @@ func (c *C1File) ListGrantsForResourceType(
 }
 
 func (c *C1File) PutGrant(ctx context.Context, grant *v2.Grant) error {
-	ctxzap.Extract(ctx).Debug("syncing grant", zap.String("grant_id", grant.Id))
-
 	query, args, err := c.putConnectorObjectQuery(ctx, grants.Name(), grant, goqu.Record{
 		"resource_type_id":           grant.Entitlement.Resource.Id.ResourceType,
 		"resource_id":                grant.Entitlement.Resource.Id.Resource,

--- a/pkg/dotc1z/resouce_types.go
+++ b/pkg/dotc1z/resouce_types.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
-	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
@@ -45,8 +43,6 @@ func (r *resourceTypesTable) Schema() (string, []interface{}) {
 }
 
 func (c *C1File) ListResourceTypes(ctx context.Context, request *v2.ResourceTypesServiceListResourceTypesRequest) (*v2.ResourceTypesServiceListResourceTypesResponse, error) {
-	ctxzap.Extract(ctx).Debug("listing resource types")
-
 	objs, nextPageToken, err := c.listConnectorObjects(ctx, resourceTypes.Name(), request)
 	if err != nil {
 		return nil, fmt.Errorf("error listing resource types: %w", err)
@@ -69,8 +65,6 @@ func (c *C1File) ListResourceTypes(ctx context.Context, request *v2.ResourceType
 }
 
 func (c *C1File) GetResourceType(ctx context.Context, request *reader_v2.ResourceTypesReaderServiceGetResourceTypeRequest) (*reader_v2.ResourceTypesReaderServiceGetResourceTypeResponse, error) {
-	ctxzap.Extract(ctx).Debug("fetching resource type", zap.String("resource_type_id", request.ResourceTypeId))
-
 	ret := &v2.ResourceType{}
 
 	err := c.getConnectorObject(ctx, resourceTypes.Name(), request.ResourceTypeId, ret)
@@ -84,8 +78,6 @@ func (c *C1File) GetResourceType(ctx context.Context, request *reader_v2.Resourc
 }
 
 func (c *C1File) PutResourceType(ctx context.Context, resourceType *v2.ResourceType) error {
-	ctxzap.Extract(ctx).Debug("syncing resource type", zap.String("resource_type_id", resourceType.Id))
-
 	query, args, err := c.putConnectorObjectQuery(ctx, resourceTypes.Name(), resourceType, nil)
 	if err != nil {
 		return err

--- a/pkg/dotc1z/resources.go
+++ b/pkg/dotc1z/resources.go
@@ -4,12 +4,11 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/doug-martin/goqu/v9"
+	"google.golang.org/protobuf/proto"
+
 	c1zpb "github.com/conductorone/baton-sdk/pb/c1/c1z/v1"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
-	"github.com/doug-martin/goqu/v9"
-	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
-	"go.uber.org/zap"
-	"google.golang.org/protobuf/proto"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	reader_v2 "github.com/conductorone/baton-sdk/pb/c1/reader/v2"
@@ -57,8 +56,6 @@ func (r *resourcesTable) Schema() (string, []interface{}) {
 }
 
 func (c *C1File) ListResources(ctx context.Context, request *v2.ResourcesServiceListResourcesRequest) (*v2.ResourcesServiceListResourcesResponse, error) {
-	ctxzap.Extract(ctx).Debug("listing resources")
-
 	objs, nextPageToken, err := c.listConnectorObjects(ctx, resources.Name(), request)
 	if err != nil {
 		return nil, fmt.Errorf("error listing resources: %w", err)
@@ -81,12 +78,6 @@ func (c *C1File) ListResources(ctx context.Context, request *v2.ResourcesService
 }
 
 func (c *C1File) GetResource(ctx context.Context, request *reader_v2.ResourcesReaderServiceGetResourceRequest) (*reader_v2.ResourcesReaderServiceGetResourceResponse, error) {
-	ctxzap.Extract(ctx).Debug(
-		"fetching resource",
-		zap.String("resource_id", request.ResourceId.Resource),
-		zap.String("resource_type_id", request.ResourceId.ResourceType),
-	)
-
 	ret := &v2.Resource{}
 	annos := annotations.Annotations(request.GetAnnotations())
 	syncDetails := &c1zpb.SyncDetails{}
@@ -107,12 +98,6 @@ func (c *C1File) GetResource(ctx context.Context, request *reader_v2.ResourcesRe
 }
 
 func (c *C1File) PutResource(ctx context.Context, resource *v2.Resource) error {
-	ctxzap.Extract(ctx).Debug(
-		"syncing resource",
-		zap.String("resource_id", resource.Id.Resource),
-		zap.String("resource_type_id", resource.Id.ResourceType),
-	)
-
 	updateRecord := goqu.Record{
 		"resource_type_id": resource.Id.ResourceType,
 		"external_id":      fmt.Sprintf("%s:%s", resource.Id.ResourceType, resource.Id.Resource),


### PR DESCRIPTION
These logs produce a lot of noise while using the debug log level. The are useful for tracing execution, but there are better methods for using that. 

This PR removes these logs, as they are more suited for a TRACE log level that is unavailable to us.