### PR TITLE
Fix IsXMLContentType

### DIFF
--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -103,7 +103,7 @@ func IsXMLContentType(contentType string) bool {
 	normalizedContentType := strings.TrimSpace(strings.ToLower(contentType))
 
 	for _, xmlContentType := range xmlContentTypes {
-		if normalizedContentType == xmlContentType {
+		if strings.HasPrefix(normalizedContentType, xmlContentType) {
 			return true
 		}
 	}


### PR DESCRIPTION
Content type headers can have a charset, so check the prefix instead of directly comparing.