### PR TITLE
[Performance]: Basic Benchmark & Multi-Put objects

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -138,6 +138,7 @@ github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0V
 github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-sqlite3 v1.14.7 h1:fxWBnXkxfM6sRiuH3bqJ4CfzZojMOLVc0UTsTglEghA=
 github.com/mattn/go-sqlite3 v1.14.7/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=

--- a/pkg/connectorstore/connectorstore.go
+++ b/pkg/connectorstore/connectorstore.go
@@ -47,4 +47,7 @@ type Writer interface {
 type BulkWriter interface {
 	Writer
 	PutGrants(ctx context.Context, grants ...*v2.Grant) error
+	PutResourceTypes(ctx context.Context, resourceTypes ...*v2.ResourceType) error
+	PutResources(ctx context.Context, resources ...*v2.Resource) error
+	PutEntitlements(ctx context.Context, entitlements ...*v2.Entitlement) error
 }

--- a/pkg/connectorstore/connectorstore.go
+++ b/pkg/connectorstore/connectorstore.go
@@ -43,3 +43,8 @@ type Writer interface {
 	PutAsset(ctx context.Context, assetRef *v2.AssetRef, contentType string, data []byte) error
 	Cleanup(ctx context.Context) error
 }
+
+type BulkWriter interface {
+	Writer
+	PutGrants(ctx context.Context, grants ...*v2.Grant) error
+}

--- a/pkg/connectorstore/connectorstore.go
+++ b/pkg/connectorstore/connectorstore.go
@@ -36,16 +36,9 @@ type Writer interface {
 	CurrentSyncStep(ctx context.Context) (string, error)
 	CheckpointSync(ctx context.Context, syncToken string) error
 	EndSync(ctx context.Context) error
-	PutResourceType(ctx context.Context, resourceType *v2.ResourceType) error
-	PutResource(ctx context.Context, resource *v2.Resource) error
-	PutEntitlement(ctx context.Context, entitlement *v2.Entitlement) error
-	PutGrant(ctx context.Context, grant *v2.Grant) error
 	PutAsset(ctx context.Context, assetRef *v2.AssetRef, contentType string, data []byte) error
 	Cleanup(ctx context.Context) error
-}
 
-type BulkWriter interface {
-	Writer
 	PutGrants(ctx context.Context, grants ...*v2.Grant) error
 	PutResourceTypes(ctx context.Context, resourceTypes ...*v2.ResourceType) error
 	PutResources(ctx context.Context, resources ...*v2.Resource) error

--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -33,7 +33,7 @@ type C1File struct {
 	pragmas        []pragma
 }
 
-var _ connectorstore.BulkWriter = (*C1File)(nil)
+var _ connectorstore.Writer = (*C1File)(nil)
 
 type C1FOption func(*C1File)
 

--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -8,8 +8,13 @@ import (
 	"path/filepath"
 
 	"github.com/doug-martin/goqu/v9"
-	// NOTE: required to register the dialect for goqu
+	// NOTE: required to register the dialect for goqu.
+	//
+	// If you remove this import, goqu.Dialect("sqlite3") will
+	// return a copy of the default dialect, which is not what we want,
+	// and allocates a ton of memory.
 	_ "github.com/doug-martin/goqu/v9/dialect/sqlite3"
+
 	_ "github.com/glebarez/go-sqlite"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"

--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -8,9 +8,12 @@ import (
 	"path/filepath"
 
 	"github.com/doug-martin/goqu/v9"
+	// NOTE: required to register the dialect for goqu
+	_ "github.com/doug-martin/goqu/v9/dialect/sqlite3"
 	_ "github.com/glebarez/go-sqlite"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
 )
 
 type pragma struct {
@@ -29,6 +32,8 @@ type C1File struct {
 	tempDir        string
 	pragmas        []pragma
 }
+
+var _ connectorstore.BulkWriter = (*C1File)(nil)
 
 type C1FOption func(*C1File)
 
@@ -50,6 +55,7 @@ func NewC1File(ctx context.Context, dbFilePath string, opts ...C1FOption) (*C1Fi
 	if err != nil {
 		return nil, err
 	}
+
 	db := goqu.New("sqlite3", rawDB)
 
 	c1File := &C1File{

--- a/pkg/dotc1z/c1file_test.go
+++ b/pkg/dotc1z/c1file_test.go
@@ -114,7 +114,7 @@ func TestC1Z(t *testing.T) {
 	require.Equal(t, syncID, syncID2)
 
 	resourceTypeID := "test-resource-type"
-	err = f.PutResourceType(ctx, &v2.ResourceType{Id: resourceTypeID})
+	err = f.PutResourceTypes(ctx, &v2.ResourceType{Id: resourceTypeID})
 	require.NoError(t, err)
 
 	// Fetch the resource type we just saved
@@ -167,7 +167,7 @@ func TestC1ZDecoder(t *testing.T) {
 	require.True(t, newSync)
 
 	resourceTypeID := "test-resource-type"
-	err = f.PutResourceType(ctx, &v2.ResourceType{Id: resourceTypeID})
+	err = f.PutResourceTypes(ctx, &v2.ResourceType{Id: resourceTypeID})
 	require.NoError(t, err)
 
 	dbFile, err := os.ReadFile(f.dbFilePath)

--- a/pkg/dotc1z/c1file_test.go
+++ b/pkg/dotc1z/c1file_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/doug-martin/goqu/v9"
 	"github.com/stretchr/testify/require"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
@@ -17,6 +18,14 @@ import (
 
 var c1zTests struct {
 	workingDir string
+}
+
+func TestSQLiteDialectRegistered(t *testing.T) {
+	require.Equal(
+		t,
+		"sqlite3",
+		goqu.GetDialect("sqlite3").Dialect(),
+	)
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/dotc1z/entitlements.go
+++ b/pkg/dotc1z/entitlements.go
@@ -84,7 +84,6 @@ func (c *C1File) GetEntitlement(ctx context.Context, request *reader_v2.Entitlem
 }
 
 func (c *C1File) PutEntitlements(ctx context.Context, entitlementObjs ...*v2.Entitlement) error {
-
 	err := c.db.WithTx(func(tx *goqu.TxDatabase) error {
 		err := bulkPutConnectorObjectTx(ctx, c, tx, entitlements.Name(),
 			func(entitlement *v2.Entitlement) (goqu.Record, error) {

--- a/pkg/dotc1z/entitlements.go
+++ b/pkg/dotc1z/entitlements.go
@@ -83,6 +83,33 @@ func (c *C1File) GetEntitlement(ctx context.Context, request *reader_v2.Entitlem
 	}, nil
 }
 
+func (c *C1File) PutEntitlements(ctx context.Context, entitlementObjs ...*v2.Entitlement) error {
+	pairs := make([]*messageFieldsPair, 0, len(entitlementObjs))
+	for _, entitlement := range entitlementObjs {
+		fields := goqu.Record{
+			"resource_id":      entitlement.Resource.Id.Resource,
+			"resource_type_id": entitlement.Resource.Id.ResourceType,
+		}
+		pairs = append(pairs, &messageFieldsPair{
+			m:      entitlement,
+			fields: fields,
+		})
+	}
+
+	err := c.db.WithTx(func(tx *goqu.TxDatabase) error {
+		err := c.bulkPutConnectorObjectQuery(ctx, tx, entitlements.Name(), pairs...)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	c.dbUpdated = true
+	return nil
+}
+
 func (c *C1File) PutEntitlement(ctx context.Context, entitlement *v2.Entitlement) error {
 	if entitlement.Resource == nil && entitlement.Resource.Id == nil {
 		return fmt.Errorf("entitlements must have a non-nil resource")

--- a/pkg/dotc1z/grants.go
+++ b/pkg/dotc1z/grants.go
@@ -167,6 +167,35 @@ func (c *C1File) ListGrantsForResourceType(
 	}, nil
 }
 
+func (c *C1File) PutGrants(ctx context.Context, bulkGrants ...*v2.Grant) error {
+	pairs := make([]*messageFieldsPair, 0, len(bulkGrants))
+	for _, grant := range bulkGrants {
+		pairs = append(pairs, &messageFieldsPair{
+			m: grant,
+			fields: goqu.Record{
+				"resource_type_id":           grant.Entitlement.Resource.Id.ResourceType,
+				"resource_id":                grant.Entitlement.Resource.Id.Resource,
+				"entitlement_id":             grant.Entitlement.Id,
+				"principal_resource_type_id": grant.Principal.Id.ResourceType,
+				"principal_resource_id":      grant.Principal.Id.Resource,
+			},
+		})
+
+	}
+	err := c.db.WithTx(func(tx *goqu.TxDatabase) error {
+		err := c.bulkPutConnectorObjectQuery(ctx, tx, grants.Name(), pairs...)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	c.dbUpdated = true
+	return nil
+}
+
 func (c *C1File) PutGrant(ctx context.Context, grant *v2.Grant) error {
 	query, args, err := c.putConnectorObjectQuery(ctx, grants.Name(), grant, goqu.Record{
 		"resource_type_id":           grant.Entitlement.Resource.Id.ResourceType,

--- a/pkg/sync/syncer_test.go
+++ b/pkg/sync/syncer_test.go
@@ -1,0 +1,173 @@
+package sync
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	et "github.com/conductorone/baton-sdk/pkg/types/entitlement"
+	gt "github.com/conductorone/baton-sdk/pkg/types/grant"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+func BenchmarkExpandCircle(b *testing.B) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// create a loop of N entitlements
+	circleSize := 9
+	// with different principal + grants at each layer
+	usersPerLayer := 100
+
+	mc := newMockConnector()
+
+	groupResourceType := &v2.ResourceType{
+		Id:          "group",
+		DisplayName: "Group",
+		Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_GROUP},
+	}
+	userResourceType := &v2.ResourceType{
+		Id:          "user",
+		DisplayName: "User",
+		Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_USER},
+		Annotations: annotations.New(&v2.SkipEntitlementsAndGrants{}),
+	}
+	mc.rtDB = append(mc.rtDB, groupResourceType, userResourceType)
+
+	for i := 0; i < circleSize; i++ {
+		resoruceId := "g_" + strconv.Itoa(i)
+		resoruce, err := rs.NewGroupResource(
+			resoruceId,
+			groupResourceType,
+			resoruceId,
+			[]rs.GroupTraitOption{},
+		)
+		require.NoError(b, err)
+
+		mc.resourceDB = append(mc.resourceDB, resoruce)
+
+		ent := et.NewAssignmentEntitlement(
+			resoruce,
+			"member",
+			et.WithGrantableTo(groupResourceType, userResourceType),
+		)
+		ent.Slug = "member"
+
+		mc.entDB = append(mc.entDB, ent)
+		for j := 0; j < usersPerLayer; j++ {
+			pid := "u_" + strconv.Itoa(i*usersPerLayer+j)
+			principal, err := rs.NewUserResource(
+				pid,
+				userResourceType,
+				pid,
+				[]rs.UserTraitOption{},
+				rs.WithAnnotation(&v2.SkipEntitlementsAndGrants{}),
+			)
+			require.NoError(b, err)
+			mc.userDB = append(mc.userDB, principal)
+
+			grant := gt.NewGrant(
+				resoruce,
+				"member",
+				principal,
+			)
+			mc.grantDB = append(mc.grantDB, grant)
+		}
+	}
+
+	// create the circle
+	for i := 0; i < circleSize; i++ {
+		currentEnt := mc.entDB[i]
+		nextEnt := mc.entDB[(i+1)%circleSize] // Wrap around to the start for the last element
+
+		grant := gt.NewGrant(
+			nextEnt.Resource,
+			"member",
+			currentEnt.Resource,
+			gt.WithAnnotation(&v2.GrantExpandable{
+				EntitlementIds: []string{
+					currentEnt.Id,
+				},
+			}),
+		)
+
+		mc.grantDB = append(mc.grantDB, grant)
+	}
+
+	tempDir, err := os.MkdirTemp("", "baton-benchmark-expand-circle")
+	require.NoError(b, err)
+	defer os.RemoveAll(tempDir)
+	c1zpath := filepath.Join(tempDir, "expand-circle.c1z")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		syncer, err := NewSyncer(ctx, mc, WithC1ZPath(c1zpath), WithTmpDir(tempDir))
+		require.NoError(b, err)
+		err = syncer.Sync(ctx)
+		require.NoError(b, err)
+		err = syncer.Close(ctx)
+		require.NoError(b, err)
+		os.Remove(c1zpath)
+	}
+}
+
+func newMockConnector() *mockConnector {
+	mc := &mockConnector{
+		rtDB:       make([]*v2.ResourceType, 0),
+		resourceDB: make([]*v2.Resource, 0),
+		entDB:      make([]*v2.Entitlement, 0),
+		userDB:     make([]*v2.Resource, 0),
+		grantDB:    make([]*v2.Grant, 0),
+	}
+	return mc
+}
+
+type mockConnector struct {
+	metadata   *v2.ConnectorMetadata
+	rtDB       []*v2.ResourceType
+	resourceDB []*v2.Resource
+	entDB      []*v2.Entitlement
+	userDB     []*v2.Resource
+	grantDB    []*v2.Grant
+	v2.AssetServiceClient
+	v2.GrantManagerServiceClient
+	v2.ResourceManagerServiceClient
+	v2.AccountManagerServiceClient
+	v2.CredentialManagerServiceClient
+	v2.EventServiceClient
+	v2.TicketsServiceClient
+}
+
+func (mc *mockConnector) ListResourceTypes(context.Context, *v2.ResourceTypesServiceListResourceTypesRequest, ...grpc.CallOption) (*v2.ResourceTypesServiceListResourceTypesResponse, error) {
+	return &v2.ResourceTypesServiceListResourceTypesResponse{List: mc.rtDB}, nil
+}
+
+func (mc *mockConnector) ListResources(ctx context.Context, in *v2.ResourcesServiceListResourcesRequest, opts ...grpc.CallOption) (*v2.ResourcesServiceListResourcesResponse, error) {
+	all := make([]*v2.Resource, 0, len(mc.resourceDB)+len(mc.userDB))
+	all = append(all, mc.resourceDB...)
+	all = append(all, mc.userDB...)
+	return &v2.ResourcesServiceListResourcesResponse{List: all}, nil
+}
+
+func (mc *mockConnector) ListEntitlements(ctx context.Context, in *v2.EntitlementsServiceListEntitlementsRequest, opts ...grpc.CallOption) (*v2.EntitlementsServiceListEntitlementsResponse, error) {
+	return &v2.EntitlementsServiceListEntitlementsResponse{List: mc.entDB}, nil
+}
+
+func (mc *mockConnector) ListGrants(ctx context.Context, in *v2.GrantsServiceListGrantsRequest, opts ...grpc.CallOption) (*v2.GrantsServiceListGrantsResponse, error) {
+	return &v2.GrantsServiceListGrantsResponse{List: mc.grantDB}, nil
+}
+
+func (mc *mockConnector) GetMetadata(ctx context.Context, in *v2.ConnectorServiceGetMetadataRequest, opts ...grpc.CallOption) (*v2.ConnectorServiceGetMetadataResponse, error) {
+	return &v2.ConnectorServiceGetMetadataResponse{
+		Metadata: mc.metadata,
+	}, nil
+}
+
+func (mc *mockConnector) Validate(ctx context.Context, in *v2.ConnectorServiceValidateRequest, opts ...grpc.CallOption) (*v2.ConnectorServiceValidateResponse, error) {
+	return &v2.ConnectorServiceValidateResponse{}, nil
+}

--- a/pkg/sync/syncer_test.go
+++ b/pkg/sync/syncer_test.go
@@ -112,7 +112,7 @@ func BenchmarkExpandCircle(b *testing.B) {
 		require.NoError(b, err)
 		err = syncer.Close(ctx)
 		require.NoError(b, err)
-		os.Remove(c1zpath)
+		_ = os.Remove(c1zpath)
 	}
 }
 

--- a/vendor/github.com/doug-martin/goqu/v9/dialect/sqlite3/sqlite3.go
+++ b/vendor/github.com/doug-martin/goqu/v9/dialect/sqlite3/sqlite3.go
@@ -1,0 +1,76 @@
+package sqlite3
+
+import (
+	"time"
+
+	"github.com/doug-martin/goqu/v9"
+	"github.com/doug-martin/goqu/v9/exp"
+)
+
+func DialectOptions() *goqu.SQLDialectOptions {
+	opts := goqu.DefaultDialectOptions()
+
+	opts.SupportsReturn = false
+	opts.SupportsOrderByOnUpdate = true
+	opts.SupportsLimitOnUpdate = true
+	opts.SupportsOrderByOnDelete = true
+	opts.SupportsLimitOnDelete = true
+	opts.SupportsConflictUpdateWhere = false
+	opts.SupportsInsertIgnoreSyntax = true
+	opts.SupportsConflictTarget = true
+	opts.SupportsMultipleUpdateTables = false
+	opts.WrapCompoundsInParens = false
+	opts.SupportsDistinctOn = false
+	opts.SupportsWindowFunction = false
+	opts.SupportsLateral = false
+
+	opts.PlaceHolderFragment = []byte("?")
+	opts.IncludePlaceholderNum = false
+	opts.QuoteRune = '`'
+	opts.DefaultValuesFragment = []byte("")
+	opts.True = []byte("1")
+	opts.False = []byte("0")
+	opts.TimeFormat = time.RFC3339Nano
+	opts.BooleanOperatorLookup = map[exp.BooleanOperation][]byte{
+		exp.EqOp:             []byte("="),
+		exp.NeqOp:            []byte("!="),
+		exp.GtOp:             []byte(">"),
+		exp.GteOp:            []byte(">="),
+		exp.LtOp:             []byte("<"),
+		exp.LteOp:            []byte("<="),
+		exp.InOp:             []byte("IN"),
+		exp.NotInOp:          []byte("NOT IN"),
+		exp.IsOp:             []byte("IS"),
+		exp.IsNotOp:          []byte("IS NOT"),
+		exp.LikeOp:           []byte("LIKE"),
+		exp.NotLikeOp:        []byte("NOT LIKE"),
+		exp.ILikeOp:          []byte("LIKE"),
+		exp.NotILikeOp:       []byte("NOT LIKE"),
+		exp.RegexpLikeOp:     []byte("REGEXP"),
+		exp.RegexpNotLikeOp:  []byte("NOT REGEXP"),
+		exp.RegexpILikeOp:    []byte("REGEXP"),
+		exp.RegexpNotILikeOp: []byte("NOT REGEXP"),
+	}
+	opts.UseLiteralIsBools = false
+	opts.BitwiseOperatorLookup = map[exp.BitwiseOperation][]byte{
+		exp.BitwiseOrOp:         []byte("|"),
+		exp.BitwiseAndOp:        []byte("&"),
+		exp.BitwiseLeftShiftOp:  []byte("<<"),
+		exp.BitwiseRightShiftOp: []byte(">>"),
+	}
+	opts.EscapedRunes = map[rune][]byte{
+		'\'': []byte("''"),
+	}
+	opts.InsertIgnoreClause = []byte("INSERT OR IGNORE INTO ")
+	opts.ConflictFragment = []byte(" ON CONFLICT ")
+	opts.ConflictDoUpdateFragment = []byte(" DO UPDATE SET ")
+	opts.ConflictDoNothingFragment = []byte(" DO NOTHING ")
+	opts.ForUpdateFragment = []byte("")
+	opts.OfFragment = []byte("")
+	opts.NowaitFragment = []byte("")
+	return opts
+}
+
+func init() {
+	goqu.RegisterDialect("sqlite3", DialectOptions())
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -149,6 +149,7 @@ github.com/deckarep/golang-set/v2
 # github.com/doug-martin/goqu/v9 v9.19.0
 ## explicit; go 1.12
 github.com/doug-martin/goqu/v9
+github.com/doug-martin/goqu/v9/dialect/sqlite3
 github.com/doug-martin/goqu/v9/exec
 github.com/doug-martin/goqu/v9/exp
 github.com/doug-martin/goqu/v9/internal/errors


### PR DESCRIPTION
- Adds a basic full Sync() benchmark.
- Based on early profiling of this, add a Multi-Write / Bulk `PutGrants()` function as an interface upgrade to Writer.  Just this change has a ~67.33% reduction in sync time for the basic benchmark.
- Also fix an issue with `goqu` Dialect;  We were trying to use `goqu.Dialect("sqlite3")`.  But if this Dialect isn't loaded, goqu makes a duplicate of the default... which is a huge memory allocation.  So... by using an underscore import of the dialect module, we cut memory allocations by ~16%.

```
goos: linux
goarch: amd64
pkg: github.com/conductorone/baton-sdk/pkg/sync
cpu: Intel(R) Xeon(R) E-2274G CPU @ 4.00GHz
               │   old.text   │              new.text               │
               │    sec/op    │   sec/op     vs base                │
ExpandCircle-8   1644.0m ± 1%   537.1m ± 2%  -67.33% (p=0.000 n=50)
```