### PR TITLE
Don't require ticket status and type

### DIFF
--- a/pkg/tasks/local/ticket.go
+++ b/pkg/tasks/local/ticket.go
@@ -78,10 +78,13 @@ func (m *localCreateTicket) Process(ctx context.Context, task *v1.Task, cc types
 	ticketRequestBody := &v2.TicketRequest{
 		DisplayName: template.DisplayName,
 		Description: template.Description,
-		Type: &v2.TicketType{
+		Labels:      template.Labels,
+	}
+
+	if template.TypeId != "" {
+		ticketRequestBody.Type = &v2.TicketType{
 			Id: template.TypeId,
-		},
-		Labels: template.Labels,
+		}
 	}
 
 	if template.StatusId != "" {

--- a/pkg/types/ticket/custom_fields.go
+++ b/pkg/types/ticket/custom_fields.go
@@ -244,40 +244,36 @@ func GetCustomFieldValue(field *v2.TicketCustomField) (interface{}, error) {
 func ValidateTicket(ctx context.Context, schema *v2.TicketSchema, ticket *v2.Ticket) (bool, error) {
 	l := ctxzap.Extract(ctx)
 
-	// Look for a matching status
-	foundMatch := ticket.Status == nil
-	for _, status := range schema.GetStatuses() {
-		// Status is not required
-		if ticket.Status == nil {
-			foundMatch = true
-			break
-		}
-
-		if ticket.Status.GetId() == status.GetId() {
-			foundMatch = true
-			break
+	// Validate the ticket status is one defined in the schema
+	// Ticket status is not required so if a ticket doesn't have a status
+	// we don't need to validate, skip the loop in this case
+	validTicketStatus := ticket.Status == nil
+	if !validTicketStatus {
+		for _, status := range schema.GetStatuses() {
+			if ticket.Status.GetId() == status.GetId() {
+				validTicketStatus = true
+				break
+			}
 		}
 	}
-
-	if !foundMatch {
+	if !validTicketStatus {
 		l.Debug("error: invalid ticket: could not find status", zap.String("status_id", ticket.Status.GetId()))
 		return false, nil
 	}
 
-	// Look for a matching ticket type
-	foundMatch = ticket.Type == nil
-	for _, tType := range schema.GetTypes() {
-		if ticket.Type == nil {
-			foundMatch = true
-			break
-		}
-		if ticket.Type.GetId() == tType.GetId() {
-			foundMatch = true
-			break
+	// Validate the ticket type is one defined in the schema
+	// Ticket type is not required so if a ticket doesn't have a type
+	// we don't need to validate, skip the loop in this case
+	validTicketType := ticket.Type == nil
+	if !validTicketType {
+		for _, tType := range schema.GetTypes() {
+			if ticket.Type.GetId() == tType.GetId() {
+				validTicketType = true
+				break
+			}
 		}
 	}
-
-	if !foundMatch {
+	if !validTicketType {
 		l.Debug("error: invalid ticket: could not find ticket type", zap.String("ticket_type_id", ticket.Type.GetId()))
 		return false, nil
 	}
@@ -361,7 +357,7 @@ func ValidateTicket(ctx context.Context, schema *v2.TicketSchema, ticket *v2.Tic
 				return false, nil
 			}
 
-			foundMatch = false
+			foundMatch := false
 			for _, m := range allowedValues {
 				if m == ticketValue {
 					foundMatch = true
@@ -436,7 +432,7 @@ func ValidateTicket(ctx context.Context, schema *v2.TicketSchema, ticket *v2.Tic
 				return false, nil
 			}
 
-			foundMatch = false
+			foundMatch := false
 			for _, m := range allowedValues {
 				if m.GetId() == ticketValue.GetId() {
 					foundMatch = true

--- a/pkg/types/ticket/custom_fields.go
+++ b/pkg/types/ticket/custom_fields.go
@@ -245,7 +245,7 @@ func ValidateTicket(ctx context.Context, schema *v2.TicketSchema, ticket *v2.Tic
 	l := ctxzap.Extract(ctx)
 
 	// Look for a matching status
-	foundMatch := false
+	foundMatch := ticket.Status == nil
 	for _, status := range schema.GetStatuses() {
 		// Status is not required
 		if ticket.Status == nil {
@@ -265,10 +265,11 @@ func ValidateTicket(ctx context.Context, schema *v2.TicketSchema, ticket *v2.Tic
 	}
 
 	// Look for a matching ticket type
-	foundMatch = false
+	foundMatch = ticket.Type == nil
 	for _, tType := range schema.GetTypes() {
 		if ticket.Type == nil {
-			return false, nil
+			foundMatch = true
+			break
 		}
 		if ticket.Type.GetId() == tType.GetId() {
 			foundMatch = true


### PR DESCRIPTION
- We don't require status but if the schema didn't include status we were still erroring 
- Change ticket type to not be required since not all ticket systems require type 