### PR TITLE
feat: Allow `WithJSONResponse()` and `WithXMLResponse()` to work with empty response bodies

### DIFF
--- a/pkg/uhttp/wrapper.go
+++ b/pkg/uhttp/wrapper.go
@@ -107,6 +107,9 @@ func WithXMLResponse(response interface{}) DoOption {
 		if !helpers.IsXMLContentType(resp.Header.Get(ContentType)) {
 			return fmt.Errorf("unexpected content type for xml response: %s", resp.Header.Get(ContentType))
 		}
+		if response == nil && len(resp.Body) == 0 {
+			return nil
+		}
 		return xml.Unmarshal(resp.Body, response)
 	}
 }

--- a/pkg/uhttp/wrapper.go
+++ b/pkg/uhttp/wrapper.go
@@ -45,10 +45,16 @@ func NewBaseHttpClient(httpClient *http.Client) *BaseHttpClient {
 	}
 }
 
+// WithJSONResponse is a wrapper that marshals the returned response body into
+// the provided shape. If the API should return an empty JSON body (i.e. HTTP
+// status code 204 No Content), then pass a `nil` to `response`.
 func WithJSONResponse(response interface{}) DoOption {
 	return func(resp *WrapperResponse) error {
 		if !helpers.IsJSONContentType(resp.Header.Get(ContentType)) {
 			return fmt.Errorf("unexpected content type for json response: %s", resp.Header.Get(ContentType))
+		}
+		if response == nil && len(resp.Body) == 0 {
+			return nil
 		}
 		return json.Unmarshal(resp.Body, response)
 	}

--- a/pkg/uhttp/wrapper_test.go
+++ b/pkg/uhttp/wrapper_test.go
@@ -87,33 +87,77 @@ func TestWrapper_WithJSONResponse(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resp := http.Response{
-		Header: map[string][]string{
-			"Content-Type": {"application/json"},
-		},
-	}
-
 	responseBody := example{}
 	option := WithJSONResponse(&responseBody)
-	wrapperResp := WrapperResponse{
-		Header:     resp.Header,
-		Body:       exampleResponseBuffer.Bytes(),
-		StatusCode: 200,
-		Status:     "200 OK",
-	}
-	err = option(&wrapperResp)
 
-	require.Nil(t, err)
-	require.Equal(t, exampleResponse, responseBody)
+	t.Run("should marshal a JSON response", func(t *testing.T) {
+		resp := http.Response{
+			Header: map[string][]string{
+				"Content-Type": {"application/json"},
+			},
+		}
 
-	wrapperResp.Header = map[string][]string{
-		"Content-Type": {"application/xml"},
-	}
-	responseBody = example{}
-	option = WithJSONResponse(&responseBody)
-	err = option(&wrapperResp)
+		wrapperResp := WrapperResponse{
+			Header:     resp.Header,
+			Body:       exampleResponseBuffer.Bytes(),
+			StatusCode: 200,
+			Status:     "200 OK",
+		}
+		err = option(&wrapperResp)
 
-	require.NotNil(t, err)
+		require.Nil(t, err)
+		require.Equal(t, exampleResponse, responseBody)
+	})
+
+	t.Run("should return an error when the response is not JSON", func(t *testing.T) {
+		resp := http.Response{
+			Header: map[string][]string{
+				"Content-Type": {"application/xml"},
+			},
+		}
+
+		wrapperResp := WrapperResponse{
+			Header:     resp.Header,
+			Body:       exampleResponseBuffer.Bytes(),
+			StatusCode: 200,
+			Status:     "200 OK",
+		}
+		err = option(&wrapperResp)
+
+		require.NotNil(t, err)
+	})
+
+	t.Run("should not marshal when the JSON response is empty (HTTP 204)", func(t *testing.T) {
+		wrapperResp := WrapperResponse{
+			Header: map[string][]string{
+				"Content-Type": {"application/json"},
+			},
+			Body:       []byte(""),
+			StatusCode: 204,
+			Status:     "204 No Content",
+		}
+		err = WithJSONResponse(nil)(&wrapperResp)
+
+		require.Nil(t, err)
+	})
+
+	t.Run("should marshal an empty JSON response (\"{}\")", func(t *testing.T) {
+		type empty struct{}
+
+		wrapperResp := WrapperResponse{
+			Header: map[string][]string{
+				"Content-Type": {"application/json"},
+			},
+			Body:       []byte("{}"),
+			StatusCode: 204,
+			Status:     "204 No Content",
+		}
+		responseBody := empty{}
+		err = WithJSONResponse(&responseBody)(&wrapperResp)
+
+		require.Nil(t, err)
+		require.Equal(t, empty{}, responseBody)
+	})
 }
 
 func TestWrapper_WithXMLResponse(t *testing.T) {

--- a/pkg/uhttp/wrapper_test.go
+++ b/pkg/uhttp/wrapper_test.go
@@ -177,18 +177,51 @@ func TestWrapper_WithXMLResponse(t *testing.T) {
 		},
 	}
 
-	responseBody := example{}
-	option := WithXMLResponse(&responseBody)
-	wrapperResp := WrapperResponse{
-		Header:     resp.Header,
-		Body:       exampleResponseBuffer.Bytes(),
-		StatusCode: 200,
-		Status:     "200 OK",
-	}
-	err = option(&wrapperResp)
+	t.Run("should marshal an XML response", func(t *testing.T) {
+		responseBody := example{}
+		option := WithXMLResponse(&responseBody)
+		wrapperResp := WrapperResponse{
+			Header:     resp.Header,
+			Body:       exampleResponseBuffer.Bytes(),
+			StatusCode: 200,
+			Status:     "200 OK",
+		}
+		err = option(&wrapperResp)
 
-	require.Nil(t, err)
-	require.Equal(t, exampleResponse, responseBody)
+		require.Nil(t, err)
+		require.Equal(t, exampleResponse, responseBody)
+
+	})
+
+	t.Run("should return an error when the response is not XML", func(t *testing.T) {
+		responseBody := example{}
+		option := WithXMLResponse(&responseBody)
+		wrapperResp := WrapperResponse{
+			Header: map[string][]string{
+				"Content-Type": {"application/json"},
+			},
+			Body:       exampleResponseBuffer.Bytes(),
+			StatusCode: 200,
+			Status:     "200 OK",
+		}
+		err = option(&wrapperResp)
+
+		require.NotNil(t, err)
+	})
+
+	t.Run("should not marshal when the XML response is empty (HTTP 204)", func(t *testing.T) {
+		wrapperResp := WrapperResponse{
+			Header: map[string][]string{
+				"Content-Type": {"application/xml"},
+			},
+			Body:       []byte(""),
+			StatusCode: 204,
+			Status:     "204 No Content",
+		}
+		err = WithXMLResponse(nil)(&wrapperResp)
+
+		require.Nil(t, err)
+	})
 }
 
 func TestWrapper_WithResponse(t *testing.T) {

--- a/pkg/uhttp/wrapper_test.go
+++ b/pkg/uhttp/wrapper_test.go
@@ -190,7 +190,6 @@ func TestWrapper_WithXMLResponse(t *testing.T) {
 
 		require.Nil(t, err)
 		require.Equal(t, exampleResponse, responseBody)
-
 	})
 
 	t.Run("should return an error when the response is not XML", func(t *testing.T) {


### PR DESCRIPTION
A common pattern in connectors is to create a helper function like `makeRequest()` that calls `client.wrapper.Do()`. When dealing with a JSON API, most of the client methods expect a response body. However, some APIs respond with an empty body when they `204`. To handle this we have to do something a little janky: 
```go
doOptions := []uhttp.DoOption{
  WithConfluenceRatelimitData(&ratelimitData),
}
if target != nil {
  doOptions = append(doOptions, uhttp.WithJSONResponse(target))
}
response, err := c.wrapper.Do(request, doOptions...)
```

I want to change `WithJSONResponse()` to take `nil` to mean that we expect the body to be empty and that there is no JSON.

I think it's also totally reasonable to not do this and just make sure not to call `WithJSONResponse()` when we're expecting a `204`.