### PR TITLE
fix: detect cycles better

### DIFF
--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -813,9 +813,9 @@ func (s *syncer) SyncGrantExpansion(ctx context.Context) error {
 	}
 
 	if entitlementGraph.Loaded {
-		cycles, hasCycles := entitlementGraph.GetCycles()
-		if hasCycles {
-			l.Warn("cycles detected in entitlement graph", zap.Any("cycles", cycles))
+		cycle := entitlementGraph.GetFirstCycle()
+		if cycle != nil {
+			l.Warn("cycle detected in entitlement graph", zap.Any("cycle", cycle))
 			if dontFixCycles {
 				return fmt.Errorf("cycles detected in entitlement graph")
 			}


### PR DESCRIPTION
The previous method of detecting cycles had a bug. We learned about this from what we thought was a flaky test.

This new method just finds the _first_ cycle because we just eliminate one cycle at time.