### PR TITLE
Rate limit support

### DIFF
--- a/pkg/connectorbuilder/connectorbuilder.go
+++ b/pkg/connectorbuilder/connectorbuilder.go
@@ -373,21 +373,22 @@ func (b *builderImpl) ListResources(ctx context.Context, request *v2.ResourcesSe
 		Size:  int(request.PageSize),
 		Token: request.PageToken,
 	})
-	if err != nil {
-		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start))
-		return nil, fmt.Errorf("error: listing resources failed: %w", err)
-	}
-	if request.PageToken != "" && request.PageToken == nextPageToken {
-		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start))
-		return nil, fmt.Errorf("error: listing resources failed: next page token is the same as the current page token. this is most likely a connector bug")
-	}
-
-	b.m.RecordTaskSuccess(ctx, tt, b.nowFunc().Sub(start))
-	return &v2.ResourcesServiceListResourcesResponse{
+	resp := &v2.ResourcesServiceListResourcesResponse{
 		List:          out,
 		NextPageToken: nextPageToken,
 		Annotations:   annos,
-	}, nil
+	}
+	if err != nil {
+		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start))
+		return resp, fmt.Errorf("error: listing resources failed: %w", err)
+	}
+	if request.PageToken != "" && request.PageToken == nextPageToken {
+		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start))
+		return resp, fmt.Errorf("error: listing resources failed: next page token is the same as the current page token. this is most likely a connector bug")
+	}
+
+	b.m.RecordTaskSuccess(ctx, tt, b.nowFunc().Sub(start))
+	return resp, nil
 }
 
 // ListEntitlements returns all the entitlements for a given resource.
@@ -404,21 +405,22 @@ func (b *builderImpl) ListEntitlements(ctx context.Context, request *v2.Entitlem
 		Size:  int(request.PageSize),
 		Token: request.PageToken,
 	})
-	if err != nil {
-		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start))
-		return nil, fmt.Errorf("error: listing entitlements failed: %w", err)
-	}
-	if request.PageToken != "" && request.PageToken == nextPageToken {
-		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start))
-		return nil, fmt.Errorf("error: listing entitlements failed: next page token is the same as the current page token. this is most likely a connector bug")
-	}
-
-	b.m.RecordTaskSuccess(ctx, tt, b.nowFunc().Sub(start))
-	return &v2.EntitlementsServiceListEntitlementsResponse{
+	resp := &v2.EntitlementsServiceListEntitlementsResponse{
 		List:          out,
 		NextPageToken: nextPageToken,
 		Annotations:   annos,
-	}, nil
+	}
+	if err != nil {
+		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start))
+		return resp, fmt.Errorf("error: listing entitlements failed: %w", err)
+	}
+	if request.PageToken != "" && request.PageToken == nextPageToken {
+		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start))
+		return resp, fmt.Errorf("error: listing entitlements failed: next page token is the same as the current page token. this is most likely a connector bug")
+	}
+
+	b.m.RecordTaskSuccess(ctx, tt, b.nowFunc().Sub(start))
+	return resp, nil
 }
 
 // ListGrants lists all the grants for a given resource.
@@ -436,23 +438,24 @@ func (b *builderImpl) ListGrants(ctx context.Context, request *v2.GrantsServiceL
 		Size:  int(request.PageSize),
 		Token: request.PageToken,
 	})
+	resp := &v2.GrantsServiceListGrantsResponse{
+		List:          out,
+		NextPageToken: nextPageToken,
+		Annotations:   annos,
+	}
 	if err != nil {
 		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start))
-		return nil, fmt.Errorf("error: listing grants for resource %s/%s failed: %w", rid.ResourceType, rid.Resource, err)
+		return resp, fmt.Errorf("error: listing grants for resource %s/%s failed: %w", rid.ResourceType, rid.Resource, err)
 	}
 	if request.PageToken != "" && request.PageToken == nextPageToken {
 		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start))
-		return nil, fmt.Errorf("error: listing grants for resource %s/%s failed: next page token is the same as the current page token. this is most likely a connector bug",
+		return resp, fmt.Errorf("error: listing grants for resource %s/%s failed: next page token is the same as the current page token. this is most likely a connector bug",
 			rid.ResourceType,
 			rid.Resource)
 	}
 
 	b.m.RecordTaskSuccess(ctx, tt, b.nowFunc().Sub(start))
-	return &v2.GrantsServiceListGrantsResponse{
-		List:          out,
-		NextPageToken: nextPageToken,
-		Annotations:   annos,
-	}, nil
+	return resp, nil
 }
 
 // GetMetadata gets all metadata for a connector.

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -92,7 +92,7 @@ func shouldWaitAndRetry(ctx context.Context, annos annotations.Annotations, err 
 		attempts = 0
 		return true
 	}
-	if status.Code(err) != codes.Unavailable {
+	if status.Code(err) != codes.Unavailable && status.Code(err) != codes.DeadlineExceeded {
 		return false
 	}
 

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -114,8 +114,6 @@ func shouldWaitAndRetry(ctx context.Context, err error) bool {
 				wait = time.Duration(math.Ceil(wait.Seconds())) * time.Second
 			}
 		}
-	} else {
-		l.Debug("unable to parse rate limit description from error", zap.Error(err), zap.Any("status", st))
 	}
 
 	l.Warn("retrying operation", zap.Error(err), zap.Duration("wait", wait))

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -109,6 +109,17 @@ func shouldWaitAndRetry(ctx context.Context, annos annotations.Annotations, err 
 			wait = time.Until(rlData.ResetAt.AsTime())
 		}
 	}
+	if st, ok := status.FromError(err); annos == nil && ok {
+		details := st.Details()
+		for _, detail := range details {
+			if rlData, ok := detail.(*v2.RateLimitDescription); ok {
+				wait = time.Until(rlData.ResetAt.AsTime())
+			}
+		}
+		l.Debug("details from status error", zap.Any("details", details), zap.Int("len of details", len(details)), zap.Error(err))
+	} else {
+		l.Debug("unable to parse rate limit description from error", zap.Error(err), zap.Any("status", st))
+	}
 
 	l.Warn("retrying operation", zap.Error(err), zap.Duration("wait", wait))
 

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -264,7 +264,7 @@ func (s *syncer) Sync(ctx context.Context) error {
 				continue
 			}
 
-			err := s.SyncGrantExpansion(ctx)
+			err = s.SyncGrantExpansion(ctx)
 			if !shouldWaitAndRetry(ctx, err) {
 				return err
 			}

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -99,8 +99,10 @@ func shouldWaitAndRetry(ctx context.Context, err error) bool {
 	attempts++
 	l := ctxzap.Extract(ctx)
 
-	// use lineal time by default
+	// use linear time by default
 	var wait time.Duration = time.Duration(attempts) * time.Second
+
+	// If error contains rate limit data, use that instead
 	if st, ok := status.FromError(err); ok {
 		details := st.Details()
 		for _, detail := range details {

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -99,11 +99,13 @@ func shouldWaitAndRetry(ctx context.Context, annos annotations.Annotations, err 
 	attempts++
 	l := ctxzap.Extract(ctx)
 
+	// use lineal time by default
 	var wait time.Duration = time.Duration(attempts) * time.Second
 	rlData := &v2.RateLimitDescription{}
 	if annos != nil {
 		ok, err := annos.Pick(rlData)
 		if ok && err == nil {
+			// or use time provided in the annotations
 			wait = time.Until(rlData.ResetAt.AsTime())
 		}
 	}

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"strconv"
 	"time"
@@ -108,9 +109,11 @@ func shouldWaitAndRetry(ctx context.Context, err error) bool {
 		for _, detail := range details {
 			if rlData, ok := detail.(*v2.RateLimitDescription); ok {
 				wait = time.Until(rlData.ResetAt.AsTime())
+				wait /= time.Duration(rlData.Limit)
+				// Round up to the nearest second to make sure we don't hit the rate limit again
+				wait = time.Duration(math.Ceil(wait.Seconds())) * time.Second
 			}
 		}
-		l.Debug("details from status error", zap.Any("details", details), zap.Int("len of details", len(details)), zap.Error(err))
 	} else {
 		l.Debug("unable to parse rate limit description from error", zap.Error(err), zap.Any("status", st))
 	}

--- a/pkg/uhttp/transport.go
+++ b/pkg/uhttp/transport.go
@@ -85,7 +85,7 @@ func (uat *userAgentTripper) RoundTrip(req *http.Request) (*http.Response, error
 	return uat.next.RoundTrip(req)
 }
 
-func (t *Transport) make(ctx context.Context) (http.RoundTripper, error) {
+func (t *Transport) make(_ context.Context) (http.RoundTripper, error) {
 	// based on http.DefaultTransport
 	baseTransport := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,

--- a/pkg/uhttp/wrapper.go
+++ b/pkg/uhttp/wrapper.go
@@ -213,7 +213,7 @@ func WithResponse(response interface{}) DoOption {
 	}
 }
 
-func wrapErrors(preferredCode codes.Code, resp *http.Response, errs ...error) error {
+func WrapErrors(preferredCode codes.Code, resp *http.Response, errs ...error) error {
 	description, err := ratelimit.ExtractRateLimitData(resp.StatusCode, &resp.Header)
 	if err != nil {
 		return err
@@ -297,26 +297,26 @@ func (c *BaseHttpClient) Do(req *http.Request, options ...DoOption) (*http.Respo
 
 	switch resp.StatusCode {
 	case http.StatusRequestTimeout:
-		return resp, wrapErrors(codes.DeadlineExceeded, resp, optErrs...)
+		return resp, WrapErrors(codes.DeadlineExceeded, resp, optErrs...)
 	case http.StatusTooManyRequests, http.StatusServiceUnavailable:
-		return resp, wrapErrors(codes.Unavailable, resp, optErrs...)
+		return resp, WrapErrors(codes.Unavailable, resp, optErrs...)
 	case http.StatusNotFound:
-		return resp, wrapErrors(codes.NotFound, resp, optErrs...)
+		return resp, WrapErrors(codes.NotFound, resp, optErrs...)
 	case http.StatusUnauthorized:
-		return resp, wrapErrors(codes.Unauthenticated, resp, optErrs...)
+		return resp, WrapErrors(codes.Unauthenticated, resp, optErrs...)
 	case http.StatusForbidden:
-		return resp, wrapErrors(codes.PermissionDenied, resp, optErrs...)
+		return resp, WrapErrors(codes.PermissionDenied, resp, optErrs...)
 	case http.StatusNotImplemented:
-		return resp, wrapErrors(codes.Unimplemented, resp, optErrs...)
+		return resp, WrapErrors(codes.Unimplemented, resp, optErrs...)
 	}
 
 	if resp.StatusCode >= 500 && resp.StatusCode <= 599 {
-		return resp, wrapErrors(codes.Unavailable, resp, optErrs...)
+		return resp, WrapErrors(codes.Unavailable, resp, optErrs...)
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		// TODO: add opterrs here
-		return resp, wrapErrors(codes.Unknown, resp, fmt.Errorf("unexpected status code: %d", resp.StatusCode))
+		return resp, WrapErrors(codes.Unknown, resp, fmt.Errorf("unexpected status code: %d", resp.StatusCode))
 	}
 
 	if req.Method == http.MethodGet && resp.StatusCode == http.StatusOK {

--- a/pkg/uhttp/wrapper.go
+++ b/pkg/uhttp/wrapper.go
@@ -84,6 +84,7 @@ func getCacheTTL() int32 {
 
 	cacheTTL = min(cacheTTLMaximum, max(0, cacheTTL))
 
+	//nolint:gosec // No risk of overflow because we have a low maximum.
 	return int32(cacheTTL)
 }
 

--- a/pkg/uhttp/wrapper.go
+++ b/pkg/uhttp/wrapper.go
@@ -333,6 +333,8 @@ func (c *BaseHttpClient) Do(req *http.Request, options ...DoOption) (*http.Respo
 				return resp, err
 			}
 			return resp, st.Err()
+		} else {
+			l.Warn("retry-after header not found or impossible to parse", zap.Error(err), zap.String("retry-after", retryAfter))
 		}
 		return resp, status.Error(codes.Unavailable, resp.Status)
 	}

--- a/pkg/uhttp/wrapper.go
+++ b/pkg/uhttp/wrapper.go
@@ -84,7 +84,6 @@ func getCacheTTL() int32 {
 
 	cacheTTL = min(cacheTTLMaximum, max(0, cacheTTL))
 
-	//nolint:gosec // No risk of overflow because we have a low maximum.
 	return int32(cacheTTL)
 }
 

--- a/pkg/uhttp/wrapper.go
+++ b/pkg/uhttp/wrapper.go
@@ -307,6 +307,8 @@ func (c *BaseHttpClient) Do(req *http.Request, options ...DoOption) (*http.Respo
 				return resp, err
 			}
 			return resp, st.Err()
+		} else {
+			l.Warn("retry-after header not found or impossible to parse", zap.Error(err), zap.String("retry-after", retryAfter))
 		}
 		return resp, status.Error(codes.Unavailable, resp.Status)
 	case http.StatusNotFound:

--- a/pkg/uhttp/wrapper.go
+++ b/pkg/uhttp/wrapper.go
@@ -293,6 +293,9 @@ func (c *BaseHttpClient) Do(req *http.Request, options ...DoOption) (*http.Respo
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return resp, status.Error(codes.Unknown, fmt.Sprintf("unexpected status code: %d", resp.StatusCode))
 	}
+	if resp.StatusCode >= 500 && resp.StatusCode <= 599 {
+		return resp, status.Error(codes.Unavailable, resp.Status)
+	}
 
 	if req.Method == http.MethodGet && resp.StatusCode == http.StatusOK {
 		err := c.baseHttpCache.Set(cacheKey, resp)

--- a/pkg/uhttp/wrapper.go
+++ b/pkg/uhttp/wrapper.go
@@ -213,6 +213,20 @@ func WithResponse(response interface{}) DoOption {
 	}
 }
 
+func wrapRetryAfterInStatus(httpStatus int, headers *http.Header, preferredCode codes.Code) (*status.Status, error) {
+	description, err := ratelimit.ExtractRateLimitData(httpStatus, headers)
+	if err != nil {
+		return nil, err
+	}
+
+	st := status.New(preferredCode, http.StatusText(httpStatus))
+	st, err = st.WithDetails(description)
+	if err != nil {
+		return nil, err
+	}
+	return st, nil
+}
+
 func (c *BaseHttpClient) Do(req *http.Request, options ...DoOption) (*http.Response, error) {
 	var (
 		cacheKey string
@@ -279,16 +293,11 @@ func (c *BaseHttpClient) Do(req *http.Request, options ...DoOption) (*http.Respo
 	case http.StatusRequestTimeout:
 		return resp, status.Error(codes.DeadlineExceeded, resp.Status)
 	case http.StatusTooManyRequests:
-		description, err := ratelimit.ExtractRateLimitData(http.StatusTooManyRequests, &resp.Header)
-		if err == nil {
-			st := status.New(codes.Unavailable, resp.Status)
-			st, err = st.WithDetails(description)
-			if err != nil {
-				return resp, err
-			}
-			return resp, st.Err()
+		st, err := wrapRetryAfterInStatus(http.StatusTooManyRequests, &resp.Header, codes.Unavailable)
+		if err != nil {
+			return resp, status.Error(codes.Unavailable, resp.Status)
 		}
-		return resp, status.Error(codes.Unavailable, resp.Status)
+		return resp, st.Err()
 	case http.StatusNotFound:
 		return resp, status.Error(codes.NotFound, resp.Status)
 	case http.StatusUnauthorized:
@@ -298,16 +307,11 @@ func (c *BaseHttpClient) Do(req *http.Request, options ...DoOption) (*http.Respo
 	case http.StatusNotImplemented:
 		return resp, status.Error(codes.Unimplemented, resp.Status)
 	case http.StatusServiceUnavailable:
-		description, err := ratelimit.ExtractRateLimitData(http.StatusTooManyRequests, &resp.Header)
-		if err == nil {
-			st := status.New(codes.Unavailable, resp.Status)
-			st, err = st.WithDetails(description)
-			if err != nil {
-				return resp, err
-			}
-			return resp, st.Err()
+		st, err := wrapRetryAfterInStatus(http.StatusServiceUnavailable, &resp.Header, codes.Unavailable)
+		if err != nil {
+			return resp, status.Error(codes.Unavailable, resp.Status)
 		}
-		return resp, status.Error(codes.Unavailable, resp.Status)
+		return resp, st.Err()
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {

--- a/pkg/uhttp/wrapper.go
+++ b/pkg/uhttp/wrapper.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"time"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/ratelimit"
@@ -318,6 +319,36 @@ func (c *BaseHttpClient) Do(req *http.Request, options ...DoOption) (*http.Respo
 
 	if resp.StatusCode >= 500 && resp.StatusCode <= 599 {
 		return resp, errors.Join(status.Error(codes.Unavailable, resp.Status), optErr, stErr)
+	}
+
+	allErrs := errors.Join(stErr, err, optErr)
+	l.Error("allErrs", zap.Error(allErrs))
+	type grpcstatus interface{ GRPCStatus() *status.Status }
+
+	var grpcStatus grpcstatus
+	ok := errors.As(allErrs, &grpcStatus)
+	if ok {
+		realStatus := grpcStatus.GRPCStatus()
+		l.Error("GRPC_STATUS", zap.Any("grpcStatus", realStatus), zap.Any("details", realStatus.Details()))
+	} else {
+		l.Error("NO_GRPC_STATUS", zap.Error(allErrs))
+	}
+	if stfe, ok := status.FromError(allErrs); ok {
+		details := stfe.Details()
+		if len(details) == 0 {
+			l.Error("OMG NO DETAILS", zap.Any("stfe", stfe))
+			if allErrs == nil {
+				l.Error("ALL ERRS IS NIL")
+			}
+		}
+		for _, detail := range details {
+			if rlData, ok := detail.(*v2.RateLimitDescription); ok {
+				wait := time.Until(rlData.ResetAt.AsTime())
+				l.Debug("RL_DATA_SUCCESS", zap.Duration("reset_at", wait))
+			} else {
+				l.Debug("RL_DATA_FAIL", zap.Any("detail", detail))
+			}
+		}
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {

--- a/pkg/uhttp/wrapper.go
+++ b/pkg/uhttp/wrapper.go
@@ -315,8 +315,7 @@ func (c *BaseHttpClient) Do(req *http.Request, options ...DoOption) (*http.Respo
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		// TODO: add opterrs here
-		return resp, WrapErrors(codes.Unknown, resp, fmt.Errorf("unexpected status code: %d", resp.StatusCode))
+		return resp, WrapErrors(codes.Unknown, resp, append(optErrs, fmt.Errorf("unexpected status code: %d", resp.StatusCode))...)
 	}
 
 	if req.Method == http.MethodGet && resp.StatusCode == http.StatusOK {


### PR DESCRIPTION
The current behavior is to retry recoverable errors every second and linearly backoff. This adds backoff that respects rate limit annotations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced response handling across resource and entitlement listing methods, ensuring structured responses are returned even in error scenarios.
	- Improved synchronization error handling by integrating annotations into retry logic, providing better context during operations.
	- Added granular error reporting for server errors in the HTTP client, improving clarity in error responses.
	- Introduced detailed error reporting for rate limiting and service unavailability in the HTTP client, enhancing user awareness of retry conditions.

- **Bug Fixes**
	- Adjusted error handling to return additional context alongside errors, facilitating better debugging and operational insights.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->