### PR TITLE
Remove client id/file mutually exclusive relationship

### DIFF
--- a/pkg/field/default_relationships.go
+++ b/pkg/field/default_relationships.go
@@ -5,7 +5,6 @@ var defaultRelationship = []SchemaFieldRelationship{
 	FieldsRequiredTogether(clientIDField, clientSecretField),
 	FieldsRequiredTogether(createTicketField, ticketTemplatePathField),
 	FieldsRequiredTogether(getTicketField, ticketIDField),
-	FieldsMutuallyExclusive(fileField, clientIDField),
 	FieldsMutuallyExclusive(
 		grantEntitlementField,
 		revokeGrantField,


### PR DESCRIPTION
Remove client id/file mutually exclusive relationship

Because of the default value set for file, setting client-id gives the error `fields marked as mutually exclusive were set: file, client-id`