### PR TITLE
Don't rebuild user agent on every reuse of a roundtripper.

### DIFF
--- a/pkg/sdk/version.go
+++ b/pkg/sdk/version.go
@@ -1,4 +1,4 @@
 package sdk
 
 // Version is the current version of the baton SDK.
-const Version = "0.1.30"
+const Version = "0.2.8"

--- a/pkg/uhttp/transport.go
+++ b/pkg/uhttp/transport.go
@@ -21,6 +21,8 @@ func NewTransport(ctx context.Context, options ...Option) (*Transport, error) {
 	for _, opt := range options {
 		opt.Apply(t)
 	}
+	t.userAgent = t.userAgent + " baton-sdk/" + sdk.Version
+
 	_, err := t.cycle(ctx)
 	if err != nil {
 		return nil, err
@@ -104,7 +106,6 @@ func (t *Transport) make(ctx context.Context) (http.RoundTripper, error) {
 		return nil, err
 	}
 	var rv http.RoundTripper = baseTransport
-	t.userAgent = t.userAgent + " baton-sdk/" + sdk.Version
 	rv = &userAgentTripper{next: rv, userAgent: t.userAgent}
 	return rv, nil
 }


### PR DESCRIPTION
Fixes an issue where reusing it too many times would result in a ridiculously long user agent.

Also update the sdk version to be closer to accurate.