### PR TITLE
Limit ticket schemas to 100

### DIFF
--- a/pkg/tasks/c1api/list_ticket_schemas.go
+++ b/pkg/tasks/c1api/list_ticket_schemas.go
@@ -15,6 +15,8 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/types"
 )
 
+const maxTicketSchemas = 100
+
 type listTicketSchemasTaskHelpers interface {
 	ConnectorClient() types.ConnectorClient
 	FinishTask(ctx context.Context, resp proto.Message, annos annotations.Annotations, err error) error
@@ -48,9 +50,16 @@ func (c *listTicketSchemasTaskHandler) HandleTask(ctx context.Context) error {
 
 		ticketSchemas = append(ticketSchemas, schemas.GetList()...)
 
+		// Only return first 100 elements
+		if len(ticketSchemas) >= maxTicketSchemas {
+			ticketSchemas = ticketSchemas[:maxTicketSchemas]
+			break
+		}
+
 		if schemas.GetNextPageToken() == "" {
 			break
 		}
+
 		pageToken = schemas.GetNextPageToken()
 	}
 

--- a/pkg/tasks/c1api/list_ticket_schemas.go
+++ b/pkg/tasks/c1api/list_ticket_schemas.go
@@ -59,7 +59,6 @@ func (c *listTicketSchemasTaskHandler) HandleTask(ctx context.Context) error {
 			l.Info("list ticket schemas was greater than or equal to max of 100",
 				zap.Int("ignoredCount", ignoreCount),
 				zap.Bool("hasAdditionalPages", hasAdditionalPages))
-			
 			break
 		}
 

--- a/pkg/tasks/c1api/list_ticket_schemas.go
+++ b/pkg/tasks/c1api/list_ticket_schemas.go
@@ -52,7 +52,14 @@ func (c *listTicketSchemasTaskHandler) HandleTask(ctx context.Context) error {
 
 		// Only return first 100 elements
 		if len(ticketSchemas) >= maxTicketSchemas {
+			ignoreCount := len(ticketSchemas) - maxTicketSchemas
 			ticketSchemas = ticketSchemas[:maxTicketSchemas]
+			hasAdditionalPages := schemas.GetNextPageToken() != ""
+
+			l.Info("list ticket schemas was greater than or equal to max of 100",
+				zap.Int("ignoredCount", ignoreCount),
+				zap.Bool("hasAdditionalPages", hasAdditionalPages))
+			
 			break
 		}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Implemented a limit on the number of ticket schemas returned, enhancing efficiency and performance by ensuring only the first 100 schemas are processed.
  
- **Bug Fixes**
	- Improved control flow in the task handling to prevent excessive data accumulation, resulting in better usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->