### PR TITLE
Log the response body if we fail to unmarshal it.

### DIFF
--- a/pkg/uhttp/wrapper.go
+++ b/pkg/uhttp/wrapper.go
@@ -63,7 +63,11 @@ func WithJSONResponse(response interface{}) DoOption {
 		if response == nil && len(resp.Body) == 0 {
 			return nil
 		}
-		return json.Unmarshal(resp.Body, response)
+		err := json.Unmarshal(resp.Body, response)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal json response: %w. body %v", err, resp.Body)
+		}
+		return nil
 	}
 }
 
@@ -117,7 +121,11 @@ func WithXMLResponse(response interface{}) DoOption {
 		if response == nil && len(resp.Body) == 0 {
 			return nil
 		}
-		return xml.Unmarshal(resp.Body, response)
+		err := xml.Unmarshal(resp.Body, response)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal xml response: %w. body %v", err, resp.Body)
+		}
+		return nil
 	}
 }
 


### PR DESCRIPTION
I've seen this error in logs before and it would really help debugging if we knew what the response body was.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for JSON and XML response processing.
	- Improved error reporting for unmarshalling failures, providing context for easier debugging.
  
- **Bug Fixes**
	- Addressed potential silent failures due to lack of error handling in response unmarshalling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->