### PR TITLE
Timeout http requests after 5 minutes.

### DIFF
--- a/pkg/uhttp/client.go
+++ b/pkg/uhttp/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"net/http"
+	"time"
 
 	"go.uber.org/zap"
 )
@@ -61,11 +62,13 @@ type Option interface {
 
 // NewClient creates a new HTTP client that uses the given context and options to create a new transport layer.
 func NewClient(ctx context.Context, options ...Option) (*http.Client, error) {
+	httpClient := &http.Client{
+		Timeout: 300 * time.Second, // 5 minutes
+	}
 	t, err := NewTransport(ctx, options...)
 	if err != nil {
 		return nil, err
 	}
-	return &http.Client{
-		Transport: t,
-	}, nil
+	httpClient.Transport = t
+	return httpClient, nil
 }


### PR DESCRIPTION
We do have timeouts for parts of the http request, but we didn't set an overall timeout, making it possible for some requests to hang indefinitely. I think 5 minutes is fine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a default timeout setting of 5 minutes for the HTTP client, enhancing robustness against long-running requests.
	- Improved error handling to provide clearer feedback for request timeouts, enhancing error reporting consistency.
- **Bug Fixes**
	- Resolved potential indefinite blocking issue by ensuring HTTP requests time out if no response is received within the specified duration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->