### PR TITLE
Enable http caching by default.

### DIFF
--- a/pkg/uhttp/wrapper.go
+++ b/pkg/uhttp/wrapper.go
@@ -57,9 +57,9 @@ type (
 )
 
 func NewBaseHttpClient(httpClient *http.Client) *BaseHttpClient {
-	return &BaseHttpClient{
-		HttpClient: httpClient,
-	}
+	ctx := context.Background()
+	client, _ := NewBaseHttpClientWithContext(ctx, httpClient)
+	return client
 }
 
 func NewBaseHttpClientWithContext(ctx context.Context, httpClient *http.Client) (*BaseHttpClient, error) {

--- a/pkg/uhttp/wrapper.go
+++ b/pkg/uhttp/wrapper.go
@@ -57,8 +57,11 @@ type (
 )
 
 func NewBaseHttpClient(httpClient *http.Client) *BaseHttpClient {
-	ctx := context.Background()
-	client, _ := NewBaseHttpClientWithContext(ctx, httpClient)
+	ctx := context.TODO()
+	client, err := NewBaseHttpClientWithContext(ctx, httpClient)
+	if err != nil {
+		return nil
+	}
 	return client
 }
 


### PR DESCRIPTION
We have to create a new context and ignore the error, but I think enabling caching everywhere is better than doing it piecemeal per connector.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced HTTP client handling with improved context management for better control over timeouts and cancellations.
  
- **Bug Fixes**
	- Addressed potential issues with request handling by implementing context-aware operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->