### PR TITLE
Add env vars to configure cache max size and TTL.

### DIFF
--- a/pkg/uhttp/wrapper.go
+++ b/pkg/uhttp/wrapper.go
@@ -74,12 +74,20 @@ func NewBaseHttpClientWithContext(ctx context.Context, httpClient *http.Client) 
 	if err != nil {
 		disableCache = false
 	}
+	cacheMaxSize, err := strconv.ParseInt(os.Getenv("BATON_HTTP_CACHE_MAX_SIZE"), 10, 64)
+	if err != nil {
+		cacheMaxSize = 128 // MB
+	}
+	cacheTTL, err := strconv.ParseInt(os.Getenv("BATON_HTTP_CACHE_TTL"), 10, 64)
+	if err != nil {
+		cacheTTL = 3600 // seconds
+	}
 
 	var (
 		config = CacheConfig{
 			LogDebug:     l.Level().Enabled(zap.DebugLevel),
-			CacheTTL:     int32(3600), // seconds
-			CacheMaxSize: int(2048),   // MB
+			CacheTTL:     int32(cacheTTL),   // seconds
+			CacheMaxSize: int(cacheMaxSize), // MB
 			DisableCache: disableCache,
 		}
 		ok bool


### PR DESCRIPTION
Also default the cache max size to 128MB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced support for dynamic cache configuration through environment variables.
	- Enhanced flexibility of the HTTP client by allowing runtime adjustments to cache settings without code changes.

- **Improvements**
	- Replaced hardcoded cache values with environment variable-driven configurations for better adaptability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->