### PR TITLE
Increase default decoder limits to allow baton to list resources with big c1zs.

### DIFF
--- a/pkg/dotc1z/decoder.go
+++ b/pkg/dotc1z/decoder.go
@@ -14,8 +14,8 @@ import (
 )
 
 const (
-	defaultMaxDecodedSize   = 2 * 1024 * 1024 * 1024 // 2GiB
-	defaultDecoderMaxMemory = 32 * 1024 * 1024       // 32MiB
+	defaultMaxDecodedSize   = 3 * 1024 * 1024 * 1024 // 3GiB
+	defaultDecoderMaxMemory = 128 * 1024 * 1024      // 128MiB
 	maxDecodedSizeEnvVar    = "BATON_DECODER_MAX_DECODED_SIZE_MB"
 	maxDecoderMemorySizeEnv = "BATON_DECODER_MAX_MEMORY_MB"
 )
@@ -24,8 +24,8 @@ var C1ZFileHeader = []byte("C1ZF\x00")
 
 var (
 	ErrInvalidFile        = fmt.Errorf("c1z: invalid file")
-	ErrMaxSizeExceeded    = errors.New("c1z: max decoded size exceeded, increase DecoderMaxDecodedSize")
-	ErrWindowSizeExceeded = errors.New("c1z: window size exceeded, increase DecoderMaxMemory")
+	ErrMaxSizeExceeded    = fmt.Errorf("c1z: max decoded size exceeded, increase DecoderMaxDecodedSize using %v environment variable", maxDecodedSizeEnvVar)
+	ErrWindowSizeExceeded = fmt.Errorf("c1z: window size exceeded, increase DecoderMaxMemory using %v  environment variable", maxDecoderMemorySizeEnv)
 )
 
 // ReadHeader reads len(C1ZFileHeader) bytes from the given io.Reader and compares them to C1ZFileHeader, returning an error if they don't match.


### PR DESCRIPTION
Also print the env vars that are needed to change the limits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Increased the maximum size for decoding operations from 2 GiB to 3 GiB.
	- Expanded the memory allocated for the decoder from 32 MiB to 128 MiB.
  
- **Improvements**
	- Updated error messages for better clarity, providing users with specific instructions on adjusting decoder settings using environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->