### PR TITLE
ref: Silence gosec G115

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Run linters
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
           version: latest
           args: --timeout=3m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -73,7 +73,6 @@ linters:
     # https://github.com/1uf3/execinquery is archived so golangci-lint warns/errors about it
     # - execinquery # execinquery is a linter about query string checker in Query function which reads your Go src files and warning it finds
     - exhaustive # check exhaustiveness of enum switch statements
-    - exportloopref # checks for pointers to enclosing loop variables
     - forbidigo # Forbids identifiers
     - gochecknoinits # Checks that no init functions are present in Go code
     - goconst # Finds repeated strings that could be replaced by a constant

--- a/internal/connector/connector_server_unix.go
+++ b/internal/connector/connector_server_unix.go
@@ -14,6 +14,11 @@ import (
 	"go.uber.org/zap"
 )
 
+func getPort(listener net.Listener) uint32 {
+	//nolint:gosec // No risk of overflow because `Port` is 16-bit.
+	return uint32(listener.Addr().(*net.TCPAddr).Port)
+}
+
 func (cw *wrapper) setupListener(ctx context.Context) (uint32, *os.File, error) {
 	l := ctxzap.Extract(ctx)
 
@@ -25,7 +30,7 @@ func (cw *wrapper) setupListener(ctx context.Context) (uint32, *os.File, error) 
 	if err != nil {
 		return 0, nil, err
 	}
-	listenPort := uint32(listener.Addr().(*net.TCPAddr).Port)
+	listenPort := getPort(listener)
 	listenerFile, err := listener.File()
 	if err != nil {
 		return 0, nil, err
@@ -58,7 +63,7 @@ func (cw *wrapper) getListener(ctx context.Context, serverCfg *connectorwrapperV
 		return nil, err
 	}
 
-	listenPort := uint32(listener.Addr().(*net.TCPAddr).Port)
+	listenPort := getPort(listener)
 	if listenPort != serverCfg.ListenPort {
 		return nil, fmt.Errorf("listen port mismatch: %d != %d", listenPort, serverCfg.ListenPort)
 	}

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -79,7 +79,9 @@ func (s *syncer) handleInitialActionForStep(ctx context.Context, a Action) {
 
 func (s *syncer) handleProgress(ctx context.Context, a *Action, c int) {
 	if s.progressHandler != nil {
-		s.progressHandler(NewProgress(a, uint32(c)))
+		//nolint:gosec // No risk of overflow because `c` is a slice length.
+		count := uint32(c)
+		s.progressHandler(NewProgress(a, count))
 	}
 }
 

--- a/pkg/tasks/c1api/manager.go
+++ b/pkg/tasks/c1api/manager.go
@@ -178,6 +178,7 @@ func (c *c1ApiTaskManager) finishTask(ctx context.Context, task *v1.Task, resp p
 	_, rpcErr := c.serviceClient.FinishTask(finishCtx, &v1.BatonServiceFinishTaskRequest{
 		TaskId: task.GetId(),
 		Status: &pbstatus.Status{
+			//nolint:gosec // No risk of overflow because `Code` is a small enum.
 			Code:    int32(statusErr.Code()),
 			Message: statusErr.Message(),
 		},
@@ -233,25 +234,18 @@ func (c *c1ApiTaskManager) Process(ctx context.Context, task *v1.Task, cc types.
 	switch tasks.GetType(task) {
 	case taskTypes.FullSyncType:
 		handler = newFullSyncTaskHandler(task, tHelpers, c.skipFullSync)
-
 	case taskTypes.HelloType:
 		handler = newHelloTaskHandler(task, tHelpers)
-
 	case taskTypes.GrantType:
 		handler = newGrantTaskHandler(task, tHelpers)
-
 	case taskTypes.RevokeType:
 		handler = newRevokeTaskHandler(task, tHelpers)
-
 	case taskTypes.CreateAccountType:
 		handler = newCreateAccountTaskHandler(task, tHelpers)
-
 	case taskTypes.CreateResourceType:
 		handler = newCreateResourceTaskHandler(task, tHelpers)
-
 	case taskTypes.DeleteResourceType:
 		handler = newDeleteResourceTaskHandler(task, tHelpers)
-
 	case taskTypes.RotateCredentialsType:
 		handler = newRotateCredentialsTaskHandler(task, tHelpers)
 	case taskTypes.CreateTicketType:

--- a/pkg/tasks/c1api/service_client.go
+++ b/pkg/tasks/c1api/service_client.go
@@ -171,13 +171,17 @@ func (c *c1ServiceClient) Upload(ctx context.Context, task *v1.Task, r io.ReadSe
 		return err
 	}
 
-	chunkCount := uint64(math.Ceil(float64(rLen) / float64(fileChunkSize)))
-	for i := uint64(0); i < chunkCount; i++ {
-		l.Debug("sending upload chunk", zap.Uint64("chunk", i), zap.Uint64("total_chunks", chunkCount))
+	chunkCount := int(math.Ceil(float64(rLen) / float64(fileChunkSize)))
+	for i := 0; i < chunkCount; i++ {
+		l.Debug(
+			"sending upload chunk",
+			zap.Int("chunk", i),
+			zap.Int("total_chunks", chunkCount),
+		)
 
 		chunkSize := fileChunkSize
 		if i == chunkCount-1 {
-			chunkSize = int(rLen) - int(i)*fileChunkSize
+			chunkSize = int(rLen) - i*fileChunkSize
 		}
 
 		chunk := make([]byte, chunkSize)

--- a/pkg/uhttp/wrapper.go
+++ b/pkg/uhttp/wrapper.go
@@ -28,6 +28,8 @@ const (
 	applicationFormUrlencoded = "application/x-www-form-urlencoded"
 	applicationVndApiJSON     = "application/vnd.api+json"
 	acceptHeader              = "Accept"
+	cacheTTLMaximum           = 31536000 // 31536000 seconds = one year
+	cacheTTLDefault           = 3600     // 3600 seconds = one hour
 )
 
 type WrapperResponse struct {
@@ -68,6 +70,22 @@ func NewBaseHttpClient(httpClient *http.Client) *BaseHttpClient {
 	return client
 }
 
+// getCacheTTL read the `BATON_HTTP_CACHE_TTL` environment variable and return
+// the value as a number of seconds between 0 and an arbitrary maximum. Note:
+// this means that passing a value of `-1` will set the TTL to zero rather than
+// infinity.
+func getCacheTTL() int32 {
+	cacheTTL, err := strconv.ParseInt(os.Getenv("BATON_HTTP_CACHE_TTL"), 10, 64)
+	if err != nil {
+		cacheTTL = cacheTTLDefault // seconds
+	}
+
+	cacheTTL = min(cacheTTLMaximum, max(0, cacheTTL))
+
+	//nolint:gosec // No risk of overflow because we have a low maximum.
+	return int32(cacheTTL)
+}
+
 func NewBaseHttpClientWithContext(ctx context.Context, httpClient *http.Client) (*BaseHttpClient, error) {
 	l := ctxzap.Extract(ctx)
 	disableCache, err := strconv.ParseBool(os.Getenv("BATON_DISABLE_HTTP_CACHE"))
@@ -78,15 +96,10 @@ func NewBaseHttpClientWithContext(ctx context.Context, httpClient *http.Client) 
 	if err != nil {
 		cacheMaxSize = 128 // MB
 	}
-	cacheTTL, err := strconv.ParseInt(os.Getenv("BATON_HTTP_CACHE_TTL"), 10, 64)
-	if err != nil {
-		cacheTTL = 3600 // seconds
-	}
-
 	var (
 		config = CacheConfig{
 			LogDebug:     l.Level().Enabled(zap.DebugLevel),
-			CacheTTL:     int32(cacheTTL),   // seconds
+			CacheTTL:     getCacheTTL(),     // seconds
 			CacheMaxSize: int(cacheMaxSize), // MB
 			DisableCache: disableCache,
 		}


### PR DESCRIPTION
## Description

The linter that we run in CI was updated to include new checks. 
The new check G115 errors when converting between signed and unsigned integers.
This PR marks all of the cases in this repo as safe and adds comments specific to each case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced caching mechanism in the HTTP wrapper, allowing configuration of cache TTL based on environment variables.
	- Introduced a new function to determine cache TTL dynamically.
	
- **Improvements**
	- Upgraded the CI workflow to use a newer version of the linting tool, potentially improving linting results.
	- Simplified chunk counting in the upload process for clearer handling and logging.
	
- **Bug Fixes**
	- Improved type safety with explicit type conversions to prevent potential overflow issues in progress handling.
	
- **Documentation**
	- Added comments for clarity regarding overflow risks and code logic in various methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->