### PR TITLE
feat: "Grant already exists" annotation

### DIFF
--- a/pb/c1/connector/v2/annotation_grant.pb.go
+++ b/pb/c1/connector/v2/annotation_grant.pb.go
@@ -131,6 +131,7 @@ func (x *GrantExpandable) GetResourceTypeIds() []string {
 	return nil
 }
 
+// Grant cannot be updated or revoked. For example, membership in an "all users" group.
 type GrantImmutable struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -186,6 +187,45 @@ func (x *GrantImmutable) GetMetadata() *structpb.Struct {
 	return nil
 }
 
+// Grant was not create because the entitlement already existed.
+type GrantAlreadyExists struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+}
+
+func (x *GrantAlreadyExists) Reset() {
+	*x = GrantAlreadyExists{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_c1_connector_v2_annotation_grant_proto_msgTypes[3]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *GrantAlreadyExists) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GrantAlreadyExists) ProtoMessage() {}
+
+func (x *GrantAlreadyExists) ProtoReflect() protoreflect.Message {
+	mi := &file_c1_connector_v2_annotation_grant_proto_msgTypes[3]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GrantAlreadyExists.ProtoReflect.Descriptor instead.
+func (*GrantAlreadyExists) Descriptor() ([]byte, []int) {
+	return file_c1_connector_v2_annotation_grant_proto_rawDescGZIP(), []int{3}
+}
+
 var File_c1_connector_v2_annotation_grant_proto protoreflect.FileDescriptor
 
 var file_c1_connector_v2_annotation_grant_proto_rawDesc = []byte{
@@ -213,11 +253,12 @@ var file_c1_connector_v2_annotation_grant_proto_rawDesc = []byte{
 	0x33, 0x0a, 0x08, 0x6d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x18, 0x02, 0x20, 0x01, 0x28,
 	0x0b, 0x32, 0x17, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f,
 	0x62, 0x75, 0x66, 0x2e, 0x53, 0x74, 0x72, 0x75, 0x63, 0x74, 0x52, 0x08, 0x6d, 0x65, 0x74, 0x61,
-	0x64, 0x61, 0x74, 0x61, 0x42, 0x36, 0x5a, 0x34, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63,
-	0x6f, 0x6d, 0x2f, 0x63, 0x6f, 0x6e, 0x64, 0x75, 0x63, 0x74, 0x6f, 0x72, 0x6f, 0x6e, 0x65, 0x2f,
-	0x62, 0x61, 0x74, 0x6f, 0x6e, 0x2d, 0x73, 0x64, 0x6b, 0x2f, 0x70, 0x62, 0x2f, 0x63, 0x31, 0x2f,
-	0x63, 0x6f, 0x6e, 0x6e, 0x65, 0x63, 0x74, 0x6f, 0x72, 0x2f, 0x76, 0x32, 0x62, 0x06, 0x70, 0x72,
-	0x6f, 0x74, 0x6f, 0x33,
+	0x64, 0x61, 0x74, 0x61, 0x22, 0x14, 0x0a, 0x12, 0x47, 0x72, 0x61, 0x6e, 0x74, 0x41, 0x6c, 0x72,
+	0x65, 0x61, 0x64, 0x79, 0x45, 0x78, 0x69, 0x73, 0x74, 0x73, 0x42, 0x36, 0x5a, 0x34, 0x67, 0x69,
+	0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x63, 0x6f, 0x6e, 0x64, 0x75, 0x63, 0x74,
+	0x6f, 0x72, 0x6f, 0x6e, 0x65, 0x2f, 0x62, 0x61, 0x74, 0x6f, 0x6e, 0x2d, 0x73, 0x64, 0x6b, 0x2f,
+	0x70, 0x62, 0x2f, 0x63, 0x31, 0x2f, 0x63, 0x6f, 0x6e, 0x6e, 0x65, 0x63, 0x74, 0x6f, 0x72, 0x2f,
+	0x76, 0x32, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -232,16 +273,17 @@ func file_c1_connector_v2_annotation_grant_proto_rawDescGZIP() []byte {
 	return file_c1_connector_v2_annotation_grant_proto_rawDescData
 }
 
-var file_c1_connector_v2_annotation_grant_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_c1_connector_v2_annotation_grant_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_c1_connector_v2_annotation_grant_proto_goTypes = []interface{}{
-	(*GrantMetadata)(nil),   // 0: c1.connector.v2.GrantMetadata
-	(*GrantExpandable)(nil), // 1: c1.connector.v2.GrantExpandable
-	(*GrantImmutable)(nil),  // 2: c1.connector.v2.GrantImmutable
-	(*structpb.Struct)(nil), // 3: google.protobuf.Struct
+	(*GrantMetadata)(nil),      // 0: c1.connector.v2.GrantMetadata
+	(*GrantExpandable)(nil),    // 1: c1.connector.v2.GrantExpandable
+	(*GrantImmutable)(nil),     // 2: c1.connector.v2.GrantImmutable
+	(*GrantAlreadyExists)(nil), // 3: c1.connector.v2.GrantAlreadyExists
+	(*structpb.Struct)(nil),    // 4: google.protobuf.Struct
 }
 var file_c1_connector_v2_annotation_grant_proto_depIdxs = []int32{
-	3, // 0: c1.connector.v2.GrantMetadata.metadata:type_name -> google.protobuf.Struct
-	3, // 1: c1.connector.v2.GrantImmutable.metadata:type_name -> google.protobuf.Struct
+	4, // 0: c1.connector.v2.GrantMetadata.metadata:type_name -> google.protobuf.Struct
+	4, // 1: c1.connector.v2.GrantImmutable.metadata:type_name -> google.protobuf.Struct
 	2, // [2:2] is the sub-list for method output_type
 	2, // [2:2] is the sub-list for method input_type
 	2, // [2:2] is the sub-list for extension type_name
@@ -291,6 +333,18 @@ func file_c1_connector_v2_annotation_grant_proto_init() {
 				return nil
 			}
 		}
+		file_c1_connector_v2_annotation_grant_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*GrantAlreadyExists); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -298,7 +352,7 @@ func file_c1_connector_v2_annotation_grant_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_c1_connector_v2_annotation_grant_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   3,
+			NumMessages:   4,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pb/c1/connector/v2/annotation_grant.pb.go
+++ b/pb/c1/connector/v2/annotation_grant.pb.go
@@ -187,7 +187,7 @@ func (x *GrantImmutable) GetMetadata() *structpb.Struct {
 	return nil
 }
 
-// Grant was not create because the entitlement already existed.
+// Grant was not created because the entitlement already existed.
 type GrantAlreadyExists struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -226,6 +226,45 @@ func (*GrantAlreadyExists) Descriptor() ([]byte, []int) {
 	return file_c1_connector_v2_annotation_grant_proto_rawDescGZIP(), []int{3}
 }
 
+// Grant was not revoked because the entitlement does not exist.
+type GrantAlreadyRevoked struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+}
+
+func (x *GrantAlreadyRevoked) Reset() {
+	*x = GrantAlreadyRevoked{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_c1_connector_v2_annotation_grant_proto_msgTypes[4]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *GrantAlreadyRevoked) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GrantAlreadyRevoked) ProtoMessage() {}
+
+func (x *GrantAlreadyRevoked) ProtoReflect() protoreflect.Message {
+	mi := &file_c1_connector_v2_annotation_grant_proto_msgTypes[4]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GrantAlreadyRevoked.ProtoReflect.Descriptor instead.
+func (*GrantAlreadyRevoked) Descriptor() ([]byte, []int) {
+	return file_c1_connector_v2_annotation_grant_proto_rawDescGZIP(), []int{4}
+}
+
 var File_c1_connector_v2_annotation_grant_proto protoreflect.FileDescriptor
 
 var file_c1_connector_v2_annotation_grant_proto_rawDesc = []byte{
@@ -254,11 +293,13 @@ var file_c1_connector_v2_annotation_grant_proto_rawDesc = []byte{
 	0x0b, 0x32, 0x17, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f,
 	0x62, 0x75, 0x66, 0x2e, 0x53, 0x74, 0x72, 0x75, 0x63, 0x74, 0x52, 0x08, 0x6d, 0x65, 0x74, 0x61,
 	0x64, 0x61, 0x74, 0x61, 0x22, 0x14, 0x0a, 0x12, 0x47, 0x72, 0x61, 0x6e, 0x74, 0x41, 0x6c, 0x72,
-	0x65, 0x61, 0x64, 0x79, 0x45, 0x78, 0x69, 0x73, 0x74, 0x73, 0x42, 0x36, 0x5a, 0x34, 0x67, 0x69,
-	0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x63, 0x6f, 0x6e, 0x64, 0x75, 0x63, 0x74,
-	0x6f, 0x72, 0x6f, 0x6e, 0x65, 0x2f, 0x62, 0x61, 0x74, 0x6f, 0x6e, 0x2d, 0x73, 0x64, 0x6b, 0x2f,
-	0x70, 0x62, 0x2f, 0x63, 0x31, 0x2f, 0x63, 0x6f, 0x6e, 0x6e, 0x65, 0x63, 0x74, 0x6f, 0x72, 0x2f,
-	0x76, 0x32, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x65, 0x61, 0x64, 0x79, 0x45, 0x78, 0x69, 0x73, 0x74, 0x73, 0x22, 0x15, 0x0a, 0x13, 0x47, 0x72,
+	0x61, 0x6e, 0x74, 0x41, 0x6c, 0x72, 0x65, 0x61, 0x64, 0x79, 0x52, 0x65, 0x76, 0x6f, 0x6b, 0x65,
+	0x64, 0x42, 0x36, 0x5a, 0x34, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f,
+	0x63, 0x6f, 0x6e, 0x64, 0x75, 0x63, 0x74, 0x6f, 0x72, 0x6f, 0x6e, 0x65, 0x2f, 0x62, 0x61, 0x74,
+	0x6f, 0x6e, 0x2d, 0x73, 0x64, 0x6b, 0x2f, 0x70, 0x62, 0x2f, 0x63, 0x31, 0x2f, 0x63, 0x6f, 0x6e,
+	0x6e, 0x65, 0x63, 0x74, 0x6f, 0x72, 0x2f, 0x76, 0x32, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f,
+	0x33,
 }
 
 var (
@@ -273,17 +314,18 @@ func file_c1_connector_v2_annotation_grant_proto_rawDescGZIP() []byte {
 	return file_c1_connector_v2_annotation_grant_proto_rawDescData
 }
 
-var file_c1_connector_v2_annotation_grant_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_c1_connector_v2_annotation_grant_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
 var file_c1_connector_v2_annotation_grant_proto_goTypes = []interface{}{
-	(*GrantMetadata)(nil),      // 0: c1.connector.v2.GrantMetadata
-	(*GrantExpandable)(nil),    // 1: c1.connector.v2.GrantExpandable
-	(*GrantImmutable)(nil),     // 2: c1.connector.v2.GrantImmutable
-	(*GrantAlreadyExists)(nil), // 3: c1.connector.v2.GrantAlreadyExists
-	(*structpb.Struct)(nil),    // 4: google.protobuf.Struct
+	(*GrantMetadata)(nil),       // 0: c1.connector.v2.GrantMetadata
+	(*GrantExpandable)(nil),     // 1: c1.connector.v2.GrantExpandable
+	(*GrantImmutable)(nil),      // 2: c1.connector.v2.GrantImmutable
+	(*GrantAlreadyExists)(nil),  // 3: c1.connector.v2.GrantAlreadyExists
+	(*GrantAlreadyRevoked)(nil), // 4: c1.connector.v2.GrantAlreadyRevoked
+	(*structpb.Struct)(nil),     // 5: google.protobuf.Struct
 }
 var file_c1_connector_v2_annotation_grant_proto_depIdxs = []int32{
-	4, // 0: c1.connector.v2.GrantMetadata.metadata:type_name -> google.protobuf.Struct
-	4, // 1: c1.connector.v2.GrantImmutable.metadata:type_name -> google.protobuf.Struct
+	5, // 0: c1.connector.v2.GrantMetadata.metadata:type_name -> google.protobuf.Struct
+	5, // 1: c1.connector.v2.GrantImmutable.metadata:type_name -> google.protobuf.Struct
 	2, // [2:2] is the sub-list for method output_type
 	2, // [2:2] is the sub-list for method input_type
 	2, // [2:2] is the sub-list for extension type_name
@@ -345,6 +387,18 @@ func file_c1_connector_v2_annotation_grant_proto_init() {
 				return nil
 			}
 		}
+		file_c1_connector_v2_annotation_grant_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*GrantAlreadyRevoked); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -352,7 +406,7 @@ func file_c1_connector_v2_annotation_grant_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_c1_connector_v2_annotation_grant_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   4,
+			NumMessages:   5,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pb/c1/connector/v2/annotation_grant.pb.validate.go
+++ b/pb/c1/connector/v2/annotation_grant.pb.validate.go
@@ -396,3 +396,105 @@ var _ interface {
 	Cause() error
 	ErrorName() string
 } = GrantImmutableValidationError{}
+
+// Validate checks the field values on GrantAlreadyExists with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the first error encountered is returned, or nil if there are no violations.
+func (m *GrantAlreadyExists) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on GrantAlreadyExists with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// GrantAlreadyExistsMultiError, or nil if none found.
+func (m *GrantAlreadyExists) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *GrantAlreadyExists) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	if len(errors) > 0 {
+		return GrantAlreadyExistsMultiError(errors)
+	}
+
+	return nil
+}
+
+// GrantAlreadyExistsMultiError is an error wrapping multiple validation errors
+// returned by GrantAlreadyExists.ValidateAll() if the designated constraints
+// aren't met.
+type GrantAlreadyExistsMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m GrantAlreadyExistsMultiError) Error() string {
+	var msgs []string
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m GrantAlreadyExistsMultiError) AllErrors() []error { return m }
+
+// GrantAlreadyExistsValidationError is the validation error returned by
+// GrantAlreadyExists.Validate if the designated constraints aren't met.
+type GrantAlreadyExistsValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e GrantAlreadyExistsValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e GrantAlreadyExistsValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e GrantAlreadyExistsValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e GrantAlreadyExistsValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e GrantAlreadyExistsValidationError) ErrorName() string {
+	return "GrantAlreadyExistsValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e GrantAlreadyExistsValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sGrantAlreadyExists.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = GrantAlreadyExistsValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = GrantAlreadyExistsValidationError{}

--- a/pb/c1/connector/v2/annotation_grant.pb.validate.go
+++ b/pb/c1/connector/v2/annotation_grant.pb.validate.go
@@ -498,3 +498,105 @@ var _ interface {
 	Cause() error
 	ErrorName() string
 } = GrantAlreadyExistsValidationError{}
+
+// Validate checks the field values on GrantAlreadyRevoked with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the first error encountered is returned, or nil if there are no violations.
+func (m *GrantAlreadyRevoked) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on GrantAlreadyRevoked with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// GrantAlreadyRevokedMultiError, or nil if none found.
+func (m *GrantAlreadyRevoked) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *GrantAlreadyRevoked) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	if len(errors) > 0 {
+		return GrantAlreadyRevokedMultiError(errors)
+	}
+
+	return nil
+}
+
+// GrantAlreadyRevokedMultiError is an error wrapping multiple validation
+// errors returned by GrantAlreadyRevoked.ValidateAll() if the designated
+// constraints aren't met.
+type GrantAlreadyRevokedMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m GrantAlreadyRevokedMultiError) Error() string {
+	var msgs []string
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m GrantAlreadyRevokedMultiError) AllErrors() []error { return m }
+
+// GrantAlreadyRevokedValidationError is the validation error returned by
+// GrantAlreadyRevoked.Validate if the designated constraints aren't met.
+type GrantAlreadyRevokedValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e GrantAlreadyRevokedValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e GrantAlreadyRevokedValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e GrantAlreadyRevokedValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e GrantAlreadyRevokedValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e GrantAlreadyRevokedValidationError) ErrorName() string {
+	return "GrantAlreadyRevokedValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e GrantAlreadyRevokedValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sGrantAlreadyRevoked.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = GrantAlreadyRevokedValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = GrantAlreadyRevokedValidationError{}

--- a/proto/c1/connector/v2/annotation_grant.proto
+++ b/proto/c1/connector/v2/annotation_grant.proto
@@ -16,7 +16,11 @@ message GrantExpandable {
   repeated string resource_type_ids = 3;
 }
 
+// Grant cannot be updated or revoked. For example, membership in an "all users" group.
 message GrantImmutable {
   string source_id = 1;
   google.protobuf.Struct metadata = 2;
 }
+
+// Grant was not create because the entitlement already existed.
+message GrantAlreadyExists {}

--- a/proto/c1/connector/v2/annotation_grant.proto
+++ b/proto/c1/connector/v2/annotation_grant.proto
@@ -22,5 +22,8 @@ message GrantImmutable {
   google.protobuf.Struct metadata = 2;
 }
 
-// Grant was not create because the entitlement already existed.
+// Grant was not created because the entitlement already existed.
 message GrantAlreadyExists {}
+
+// Grant was not revoked because the entitlement does not exist.
+message GrantAlreadyRevoked {}


### PR DESCRIPTION
## Description

Create a new annotation for when Grant is called, but the grant already exists.

## TODO
- [ ] I'm not confident about my descriptions of the existing messages
- [ ] Should there be a fields on the message?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Added validation capabilities for the `GrantAlreadyExists` structure, improving error handling for grant-related operations.
  - Introduced new messages `GrantAlreadyExists` and `GrantAlreadyRevoked` to clarify situations regarding existing and revoked entitlements.

- **Documentation**
  - Enhanced comments in the `annotation_grant.proto` file to provide better context on the `GrantImmutable` message and its implications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->