### PR TITLE
Add const for unknown grant id.

### DIFF
--- a/pkg/dotc1z/c1file_test.go
+++ b/pkg/dotc1z/c1file_test.go
@@ -192,7 +192,7 @@ func TestC1ZDecoder(t *testing.T) {
 	require.Equal(t, dbFile, b.Bytes())
 	b.Reset()
 
-	require.GreaterOrEqual(t, n, 0)
+	require.GreaterOrEqual(t, n, int64(0))
 
 	// Test max size exact
 	//nolint:gosec // No risk of overflow because n is always >= 0.
@@ -206,7 +206,7 @@ func TestC1ZDecoder(t *testing.T) {
 	b.Reset()
 
 	// Test max size - 1
-	require.GreaterOrEqual(t, n, 1)
+	require.GreaterOrEqual(t, n, int64(1))
 	//nolint:gosec // No risk of overflow because n is always > 0.
 	d, err = NewDecoder(c1zf, WithDecoderMaxDecodedSize(uint64(n-1)))
 	require.NoError(t, err)

--- a/pkg/dotc1z/c1file_test.go
+++ b/pkg/dotc1z/c1file_test.go
@@ -192,7 +192,10 @@ func TestC1ZDecoder(t *testing.T) {
 	require.Equal(t, dbFile, b.Bytes())
 	b.Reset()
 
+	require.GreaterOrEqual(t, n, 0)
+
 	// Test max size exact
+	//nolint:gosec // No risk of overflow because n is always >= 0.
 	d, err = NewDecoder(c1zf, WithDecoderMaxDecodedSize(uint64(n)))
 	require.NoError(t, err)
 	_, err = io.Copy(b, d)
@@ -203,6 +206,8 @@ func TestC1ZDecoder(t *testing.T) {
 	b.Reset()
 
 	// Test max size - 1
+	require.GreaterOrEqual(t, n, 1)
+	//nolint:gosec // No risk of overflow because n is always > 0.
 	d, err = NewDecoder(c1zf, WithDecoderMaxDecodedSize(uint64(n-1)))
 	require.NoError(t, err)
 	_, err = io.Copy(io.Discard, d)

--- a/pkg/dotc1z/decoder.go
+++ b/pkg/dotc1z/decoder.go
@@ -167,6 +167,7 @@ func (d *decoder) Read(p []byte) (int, error) {
 
 	// Do underlying read
 	n, err := d.zd.Read(p)
+	//nolint:gosec // No risk of overflow/underflow because n is always >= 0.
 	d.decodedBytes += uint64(n)
 	if err != nil {
 		// NOTE(morgabra) This happens if you set a small DecoderMaxMemory

--- a/pkg/dotc1z/sql_helpers.go
+++ b/pkg/dotc1z/sql_helpers.go
@@ -183,7 +183,7 @@ func (c *C1File) listConnectorObjects(ctx context.Context, tableName string, req
 	}
 
 	// Clamp the page size
-	pageSize := int(listReq.GetPageSize())
+	pageSize := listReq.GetPageSize()
 	if pageSize > maxPageSize || pageSize == 0 {
 		pageSize = maxPageSize
 	}
@@ -206,7 +206,7 @@ func (c *C1File) listConnectorObjects(ctx context.Context, tableName string, req
 	}
 	defer rows.Close()
 
-	count := 0
+	var count uint32 = 0
 	lastRow := 0
 	for rows.Next() {
 		count++

--- a/pkg/dotc1z/sync_runs.go
+++ b/pkg/dotc1z/sync_runs.go
@@ -120,7 +120,7 @@ func (c *C1File) getFinishedSync(ctx context.Context, offset uint) (*syncRun, er
 	return ret, nil
 }
 
-func (c *C1File) ListSyncRuns(ctx context.Context, pageToken string, pageSize int) ([]*syncRun, string, error) {
+func (c *C1File) ListSyncRuns(ctx context.Context, pageToken string, pageSize uint) ([]*syncRun, string, error) {
 	err := c.validateDb(ctx)
 	if err != nil {
 		return nil, "", err
@@ -138,7 +138,7 @@ func (c *C1File) ListSyncRuns(ctx context.Context, pageToken string, pageSize in
 	}
 
 	q = q.Order(goqu.C("id").Asc())
-	q = q.Limit(uint(pageSize + 1))
+	q = q.Limit(pageSize + 1)
 
 	var ret []*syncRun
 
@@ -153,7 +153,7 @@ func (c *C1File) ListSyncRuns(ctx context.Context, pageToken string, pageSize in
 	}
 	defer rows.Close()
 
-	count := 0
+	var count uint = 0
 	lastRow := 0
 	for rows.Next() {
 		count++

--- a/pkg/types/grant/grant.go
+++ b/pkg/types/grant/grant.go
@@ -17,6 +17,9 @@ type GrantPrincipal interface {
 	GetBatonResource() bool
 }
 
+// Sometimes C1 doesn't have the grant ID, but does have the principal and entitlement
+const UnknownGrantId string = "🧸_UNKNOWN_GRANT_ID"
+
 func WithGrantMetadata(metadata map[string]interface{}) GrantOption {
 	return func(g *v2.Grant) error {
 		md, err := structpb.NewStruct(metadata)

--- a/pkg/types/grant/grant.go
+++ b/pkg/types/grant/grant.go
@@ -17,7 +17,7 @@ type GrantPrincipal interface {
 	GetBatonResource() bool
 }
 
-// Sometimes C1 doesn't have the grant ID, but does have the principal and entitlement
+// Sometimes C1 doesn't have the grant ID, but does have the principal and entitlement.
 const UnknownGrantId string = "🧸_UNKNOWN_GRANT_ID"
 
 func WithGrantMetadata(metadata map[string]interface{}) GrantOption {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new constant `UnknownGrantId` to improve handling of scenarios where the grant ID is not available, enhancing semantic clarity in the application.
- **Bug Fixes**
	- Enhanced input validation in the decoder tests to ensure that size parameters meet expected conditions, improving robustness.
- **Documentation**
	- Added comments to clarify safety regarding potential overflow or underflow in the decoder methods, improving code readability.
- **Refactor**
	- Simplified the handling of the `pageSize` variable in the `listConnectorObjects` method for better clarity and type safety.
	- Updated the `ListSyncRuns` method to improve type consistency by changing the `pageSize` parameter from `int` to `uint`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->