### PR TITLE
retries should be logged as warnings, errors on final failure

### DIFF
--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -101,7 +101,7 @@ func shouldWaitAndRetry(ctx context.Context, err error) bool {
 
 	var wait time.Duration = time.Duration(attempts) * time.Second
 
-	l.Error("retrying operation", zap.Error(err), zap.Duration("wait", wait))
+	l.Warn("retrying operation", zap.Error(err), zap.Duration("wait", wait))
 
 	for {
 		select {


### PR DESCRIPTION
Might be better to log this as a Warn and only Error on final failure. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted logging level for retry operations from error to warning, improving clarity on application behavior during retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->