### PR TITLE
Use correct name for additional commands.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -184,7 +184,7 @@ func DefineConfiguration(
 	}
 	mainCMD.AddCommand(capabilitiesCmd)
 
-	mainCMD.AddCommand(cli.AdditionalCommands(name, schema.Fields)...)
+	mainCMD.AddCommand(cli.AdditionalCommands(connectorName, schema.Fields)...)
 
 	// NOTE (shackra): we don't check subcommands (i.e.: grpcServerCmd and capabilitiesCmd)
 	mainCMD.PersistentFlags().VisitAll(func(f *pflag.Flag) {


### PR DESCRIPTION
Fixes an issue where we installed a service named ".baton" instead of the actual connector name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved command structure in the CLI configuration for better clarity and specificity.
  
- **Bug Fixes**
	- Enhanced the semantic meaning of command identifiers to align with specific connectors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->