### PR TITLE
Return a different error message if --provisioning flag is not set

### DIFF
--- a/internal/connector/noop_provisioner.go
+++ b/internal/connector/noop_provisioner.go
@@ -10,26 +10,28 @@ import (
 
 type noopProvisioner struct{}
 
+const ProvisioningNotEnabledMsg = "error: provisioning is not enabled. try running with --provisioning"
+
 func (n *noopProvisioner) Grant(ctx context.Context, req *v2.GrantManagerServiceGrantRequest) (*v2.GrantManagerServiceGrantResponse, error) {
-	return nil, status.Error(codes.FailedPrecondition, "provisioning is not enabled")
+	return nil, status.Error(codes.FailedPrecondition, ProvisioningNotEnabledMsg)
 }
 
 func (n *noopProvisioner) Revoke(ctx context.Context, req *v2.GrantManagerServiceRevokeRequest) (*v2.GrantManagerServiceRevokeResponse, error) {
-	return nil, status.Error(codes.FailedPrecondition, "provisioning is not enabled")
+	return nil, status.Error(codes.FailedPrecondition, ProvisioningNotEnabledMsg)
 }
 
 func (n *noopProvisioner) CreateResource(ctx context.Context, request *v2.CreateResourceRequest) (*v2.CreateResourceResponse, error) {
-	return nil, status.Error(codes.FailedPrecondition, "provisioning is not enabled")
+	return nil, status.Error(codes.FailedPrecondition, ProvisioningNotEnabledMsg)
 }
 
 func (n *noopProvisioner) DeleteResource(ctx context.Context, request *v2.DeleteResourceRequest) (*v2.DeleteResourceResponse, error) {
-	return nil, status.Error(codes.FailedPrecondition, "provisioning is not enabled")
+	return nil, status.Error(codes.FailedPrecondition, ProvisioningNotEnabledMsg)
 }
 
 func (n *noopProvisioner) RotateCredential(ctx context.Context, request *v2.RotateCredentialRequest) (*v2.RotateCredentialResponse, error) {
-	return nil, status.Error(codes.FailedPrecondition, "provisioning is not enabled")
+	return nil, status.Error(codes.FailedPrecondition, ProvisioningNotEnabledMsg)
 }
 
 func (n *noopProvisioner) CreateAccount(ctx context.Context, request *v2.CreateAccountRequest) (*v2.CreateAccountResponse, error) {
-	return nil, status.Error(codes.FailedPrecondition, "provisioning is not enabled")
+	return nil, status.Error(codes.FailedPrecondition, ProvisioningNotEnabledMsg)
 }


### PR DESCRIPTION
- Return a different error message if --provisioning flag is not set
Right now if you try to provision something without the --provisioning flag, we error with "resource type does not have provisioner configured". This error message should be something like "provisioning is not enabled. try running with --provisioning".

Fixes https://github.com/ConductorOne/baton-sdk/issues/114.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new validation step for provisioning configuration, enhancing error handling for entitlement grants.
  
- **Bug Fixes**
	- Improved error messaging consistency by using a centralized constant for provisioning-related errors.

- **Refactor**
	- Streamlined logic in the `Grant` and `Revoke` methods for improved readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->