### PR TITLE
Service improvements.

### DIFF
--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -56,6 +56,7 @@ func MakeMainCommand(
 		l := ctxzap.Extract(runCtx)
 
 		if isService() {
+			l.Debug("running as service", zap.String("name", name))
 			runCtx, err = runService(runCtx, name)
 			if err != nil {
 				l.Error("error running service", zap.Error(err))


### PR DESCRIPTION
Add more/better logging to services, especially on windows. Increase timeout to 1 second. Some machines are busy enough that we can sometimes hit the 300ms timeout. Add the service name to service logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced logging capabilities for better context during service execution.
	- Improved error handling with service name included in logs.

- **Bug Fixes**
	- Increased timeout for service stop command to improve responsiveness.

- **Chores**
	- General code cleanup and formatting adjustments for better organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->