### PR TITLE
Place pagination Bag in a good state when calling NextToken

### DIFF
--- a/pkg/pagination/pagination.go
+++ b/pkg/pagination/pagination.go
@@ -93,6 +93,14 @@ func (pb *Bag) Next(pageToken string) error {
 
 // Next pops the current token, and pushes a copy of it with an updated page token.
 func (pb *Bag) NextToken(pageToken string) (string, error) {
+	// assume that `pb` was passed an empty token
+	if pb.currentState == nil {
+		pb.currentState = &PageState{
+			Token: pageToken,
+		}
+		return pb.Marshal()
+	}
+
 	st := pb.pop()
 	if st == nil {
 		return "", fmt.Errorf("no active page state")

--- a/pkg/pagination/pagination_test.go
+++ b/pkg/pagination/pagination_test.go
@@ -138,3 +138,17 @@ func TestPaginationBagNextPage(t *testing.T) {
 	require.Len(t, bag.states, 0)
 	comparePageState(t, ps2, *bag.Current())
 }
+
+func TestPaginationBagNextPageWithoutActivePageState(t *testing.T) {
+	bag := &Bag{}
+
+	// try to unmarshal an empty string
+	err := bag.Unmarshal("")
+	// passing an empty string SHOULD NOT return error
+	require.NoError(t, err)
+
+	updatedToken, err := bag.NextToken("<valid token from third-party service>")
+	require.NoError(t, err)
+	require.NotEmpty(t, updatedToken)
+	require.NotNil(t, bag.currentState)
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method, `NextToken`, for improved pagination state management.
  
- **Bug Fixes**
	- Enhanced handling of empty page states to ensure valid token retrieval without errors.

- **Tests**
	- Added a new test to validate the behavior of `NextToken` with no active page state.
	- Updated existing tests for consistency with method naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->