### PR TITLE
Return partial body.

### DIFF
--- a/pkg/uhttp/wrapper.go
+++ b/pkg/uhttp/wrapper.go
@@ -290,7 +290,10 @@ func (c *BaseHttpClient) Do(req *http.Request, options ...DoOption) (*http.Respo
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, err
+		if len(body) > 0 {
+			resp.Body = io.NopCloser(bytes.NewBuffer(body))
+		}
+		return resp, err
 	}
 
 	// Replace resp.Body with a no-op closer so nobody has to worry about closing the reader.


### PR DESCRIPTION
If there's an error reading the response but we got some data, set it so the caller can read it.

This is needed to work around a bug in Percipio's API. If the response is large enough, it returns an incorrect content length and closes the connection unexpectedly. The response contains the full JSON payload... most of the time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for response bodies, ensuring that the body is preserved even when reading errors occur. 

These changes enhance the reliability of the HTTP client, providing a more robust experience for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->