### PR TITLE
Add option for configuring initial fields on the logger

### DIFF
--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -43,6 +43,8 @@ func WithOutputPaths(paths []string) Option {
 	}
 }
 
+// WithInitialFields allows the logger to be configured with static fields at creation time.
+// This is useful for setting fields that are constant across all log messages.
 func WithInitialFields(fields map[string]interface{}) Option {
 	return func(c *zap.Config) {
 		c.InitialFields = fields

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -43,6 +43,12 @@ func WithOutputPaths(paths []string) Option {
 	}
 }
 
+func WithInitialFields(fields map[string]interface{}) Option {
+	return func(c *zap.Config) {
+		c.InitialFields = fields
+	}
+}
+
 // Init creates a new zap logger and attaches it to the provided context.
 func Init(ctx context.Context, opts ...Option) (context.Context, error) {
 	zc := zap.NewProductionConfig()


### PR DESCRIPTION
calling something like:
```go
sdkLogging.WithInitialFields(map[string]interface{}{
			"tenant_id":    p.TenantId,
			"connector_id": connector.Id,
			"app_id":       connector.AppId,
		}),
```

wil be sure that the logger we create for the connector has static values included on logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the ability to specify initial fields for logger configuration, enhancing logging customization.
  
- **Bug Fixes**
	- No bug fixes were included in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->