### PR TITLE
Return nil if no values for PickMultipleObjectValues custom field

### DIFF
--- a/pkg/types/ticket/custom_fields.go
+++ b/pkg/types/ticket/custom_fields.go
@@ -276,7 +276,7 @@ func GetCustomFieldValue(field *v2.TicketCustomField) (interface{}, error) {
 	case *v2.TicketCustomField_PickMultipleObjectValues:
 		objVals := v.PickMultipleObjectValues.GetValues()
 		if len(objVals) == 0 {
-			return objVals, nil
+			return nil, nil
 		}
 		return objVals, nil
 
@@ -337,7 +337,7 @@ func GetDefaultCustomFieldValue(field *v2.TicketCustomField) (interface{}, error
 	case *v2.TicketCustomField_PickMultipleObjectValues:
 		objVals := v.PickMultipleObjectValues.GetDefaultValues()
 		if len(objVals) == 0 {
-			return objVals, nil
+			return nil, nil
 		}
 		return objVals, nil
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of return values for custom field functions when no values are present, ensuring a `nil` response instead of an empty slice.
  
- **Refactor**
	- Streamlined return behavior for functions related to custom field values, enhancing consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->