### PR TITLE
Show the body regardless of what's the Content Type

### DIFF
--- a/pkg/uhttp/contenttype.go
+++ b/pkg/uhttp/contenttype.go
@@ -1,6 +1,8 @@
 package uhttp
 
-import "strings"
+import (
+	"strings"
+)
 
 var xmlContentTypes []string = []string{
 	"text/xml",
@@ -8,6 +10,7 @@ var xmlContentTypes []string = []string{
 }
 
 func IsJSONContentType(contentType string) bool {
+	contentType = strings.TrimSpace(strings.ToLower(contentType))
 	return strings.HasPrefix(contentType, "application") &&
 		strings.Contains(contentType, "json")
 }

--- a/pkg/uhttp/wrapper.go
+++ b/pkg/uhttp/wrapper.go
@@ -181,10 +181,6 @@ func NewBaseHttpClientWithContext(ctx context.Context, httpClient *http.Client, 
 func WithJSONResponse(response interface{}) DoOption {
 	return func(resp *WrapperResponse) error {
 		contentHeader := resp.Header.Get(ContentType)
-		if contentHeader == "" {
-			// for some reason there was no header for content-type
-			contentHeader = "custom-mime/empty"
-		}
 
 		if !IsJSONContentType(contentHeader) {
 			if len(resp.Body) != 0 {


### PR DESCRIPTION
Show the body of the response, even if we expected it to be JSON, for error reporting and debugging purposes.

Example output:

```
{"level":"error","ts":1730327736.9045234,"caller":"connectorrunner/runner.go:182","msg":"runner: error processing on-demand task","error":"runner: error processing task: rpc error: code = NotFound desc = error: listing resources failed: rpc error: code = NotFound desc = 404 Not Found\nunexpected content type for JSON response: custom-mime/empty. body: « \" Not Available \" »","task_id":"","task_type":"sync_full"}
{"level":"error","ts":1730327736.9045494,"caller":"cli/commands.go:178","msg":"error running connector","error":"runner: error processing task: rpc error: code = NotFound desc = error: listing resources failed: rpc error: code = NotFound desc = 404 Not Found\nunexpected content type for JSON response: custom-mime/empty. body: « \" Not Available \" »"}
runner: error processing task: rpc error: code = NotFound desc = error: listing resources failed: rpc error: code = NotFound desc = 404 Not Found
unexpected content type for JSON response: custom-mime/empty. body: « " Not Available " »
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for non-JSON HTTP responses, providing clearer error messages that include response body content when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->