### PR TITLE
If there's an error in WithJSONResponse, log the status code.

### DIFF
--- a/pkg/uhttp/wrapper.go
+++ b/pkg/uhttp/wrapper.go
@@ -185,16 +185,16 @@ func WithJSONResponse(response interface{}) DoOption {
 		if !IsJSONContentType(contentHeader) {
 			if len(resp.Body) != 0 {
 				// we want to see the body regardless
-				return fmt.Errorf("unexpected content type for JSON response: %s. body: «%s»", contentHeader, logBody(resp.Body, 4096))
+				return fmt.Errorf("unexpected content type for JSON response: %s. status code: %d. body: «%s»", contentHeader, resp.StatusCode, logBody(resp.Body, 4096))
 			}
-			return fmt.Errorf("unexpected content type for JSON response: %s", contentHeader)
+			return fmt.Errorf("unexpected content type for JSON response: %s. status code: %d", contentHeader, resp.StatusCode)
 		}
 		if response == nil && len(resp.Body) == 0 {
 			return nil
 		}
 		err := json.Unmarshal(resp.Body, response)
 		if err != nil {
-			return fmt.Errorf("failed to unmarshal json response: %w. body %v", err, logBody(resp.Body, 4096))
+			return fmt.Errorf("failed to unmarshal json response: %w. status code: %d. body %v", err, resp.StatusCode, logBody(resp.Body, 4096))
 		}
 		return nil
 	}


### PR DESCRIPTION
This should help us figure out what's going wrong with the Jamf connector.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error messages for non-JSON responses to include HTTP status codes, improving clarity in error reporting.
	- Improved handling of response bodies to allow for multiple reads without issues.

- **Bug Fixes**
	- Adjusted error handling for reading response bodies to ensure availability for logging even when errors occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->