### PR TITLE
Expand grants faster.

### DIFF
--- a/pkg/dotc1z/manager/local/local.go
+++ b/pkg/dotc1z/manager/local/local.go
@@ -84,7 +84,7 @@ func (l *localManager) LoadC1Z(ctx context.Context) (*dotc1z.C1File, error) {
 		zap.String("temp_path", l.tmpPath),
 	)
 
-	return dotc1z.NewC1ZFile(ctx, l.tmpPath, dotc1z.WithTmpDir(l.tmpDir))
+	return dotc1z.NewC1ZFile(ctx, l.tmpPath, dotc1z.WithTmpDir(l.tmpDir), dotc1z.WithPragma("journal_mode", "WAL"))
 }
 
 // SaveC1Z saves the C1Z file to the local file system.

--- a/pkg/sync/expand/cycle.go
+++ b/pkg/sync/expand/cycle.go
@@ -8,6 +8,9 @@ import (
 // exists. Returns nil if no cycle exists. If there is a single
 // node pointing to itself, that will count as a cycle.
 func (g *EntitlementGraph) GetFirstCycle() []int {
+	if g.HasNoCycles {
+		return nil
+	}
 	visited := mapset.NewSet[int]()
 	for nodeID := range g.Nodes {
 		cycle, hasCycle := g.cycleDetectionHelper(nodeID, visited, []int{})
@@ -87,8 +90,12 @@ func (g *EntitlementGraph) removeNode(nodeID int) {
 // FixCycles if any cycles of nodes exist, merge all nodes in that cycle into a
 // single node and then repeat. Iteration ends when there are no more cycles.
 func (g *EntitlementGraph) FixCycles() error {
+	if g.HasNoCycles {
+		return nil
+	}
 	cycle := g.GetFirstCycle()
 	if cycle == nil {
+		g.HasNoCycles = true
 		return nil
 	}
 

--- a/pkg/sync/expand/graph.go
+++ b/pkg/sync/expand/graph.go
@@ -8,27 +8,29 @@ import (
 	"go.uber.org/zap"
 )
 
+// JSON tags for actions, edges, and nodes are short to minimize size of serialized data when checkpointing
+
 type EntitlementGraphAction struct {
-	SourceEntitlementID     string   `json:"source_entitlement_id"`
-	DescendantEntitlementID string   `json:"descendant_entitlement_id"`
-	Shallow                 bool     `json:"shallow"`
-	ResourceTypeIDs         []string `json:"resource_types_ids"`
-	PageToken               string   `json:"page_token"`
+	SourceEntitlementID     string   `json:"sid"`
+	DescendantEntitlementID string   `json:"did"`
+	Shallow                 bool     `json:"s"`
+	ResourceTypeIDs         []string `json:"rtids"`
+	PageToken               string   `json:"pt"`
 }
 
 type Edge struct {
-	EdgeID          int      `json:"edge_id"`
-	SourceID        int      `json:"source_id"`
-	DestinationID   int      `json:"destination_id"`
-	IsExpanded      bool     `json:"expanded"`
-	IsShallow       bool     `json:"shallow"`
-	ResourceTypeIDs []string `json:"resource_type_ids"`
+	EdgeID          int      `json:"id"`
+	SourceID        int      `json:"sid"`
+	DestinationID   int      `json:"did"`
+	IsExpanded      bool     `json:"e"`
+	IsShallow       bool     `json:"s"`
+	ResourceTypeIDs []string `json:"rtids"`
 }
 
 // Node represents a list of entitlements. It is the base element of the graph.
 type Node struct {
 	Id             int      `json:"id"`
-	EntitlementIDs []string `json:"entitlementIds"` // List of entitlements.
+	EntitlementIDs []string `json:"eids"` // List of entitlements.
 }
 
 // EntitlementGraph - a directed graph representing the relationships between

--- a/pkg/sync/expand/graph.go
+++ b/pkg/sync/expand/graph.go
@@ -49,6 +49,7 @@ type EntitlementGraph struct {
 	Loaded                bool                     `json:"loaded"`
 	Depth                 int                      `json:"depth"`
 	Actions               []EntitlementGraphAction `json:"actions"`
+	HasNoCycles           bool                     `json:"has_no_cycles"`
 }
 
 func NewEntitlementGraph(_ context.Context) *EntitlementGraph {
@@ -58,6 +59,7 @@ func NewEntitlementGraph(_ context.Context) *EntitlementGraph {
 		EntitlementsToNodes:   make(map[string]int),
 		Nodes:                 make(map[int]Node),
 		SourcesToDestinations: make(map[int]map[int]int),
+		HasNoCycles:           false,
 	}
 }
 
@@ -157,6 +159,7 @@ func (g *EntitlementGraph) AddEntitlement(entitlement *v2.Entitlement) {
 	if found != nil {
 		return
 	}
+	g.HasNoCycles = false // Reset this since we're changing the graph.
 
 	// Start at 1 in case we don't initialize something and try to get node 0.
 	g.NextNodeID++
@@ -266,6 +269,8 @@ func (g *EntitlementGraph) AddEdge(
 	} else {
 		g.DestinationsToSources[dstNode.Id] = make(map[int]int)
 	}
+
+	g.HasNoCycles = false // Reset this since we're changing the graph.
 
 	// Start at 1 in case we don't initialize something and try to get edge 0.
 	g.NextEdgeID++

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -63,7 +63,7 @@ const minCheckpointInterval = 10 * time.Second
 
 // Checkpoint marshals the current state and stores it.
 func (s *syncer) Checkpoint(ctx context.Context) error {
-	if time.Since(s.lastCheckPointTime) < minCheckpointInterval {
+	if !s.lastCheckPointTime.IsZero() && time.Since(s.lastCheckPointTime) < minCheckpointInterval {
 		return nil
 	}
 	s.lastCheckPointTime = time.Now()

--- a/pkg/sync/syncer_test.go
+++ b/pkg/sync/syncer_test.go
@@ -21,7 +21,7 @@ func BenchmarkExpandCircle(b *testing.B) {
 	defer cancel()
 
 	// create a loop of N entitlements
-	circleSize := 9
+	circleSize := 10
 	// with different principal + grants at each layer
 	usersPerLayer := 100
 	groupCount := 100

--- a/pkg/sync/syncer_test.go
+++ b/pkg/sync/syncer_test.go
@@ -189,10 +189,13 @@ func (mc *mockConnector) ListResourceTypes(context.Context, *v2.ResourceTypesSer
 }
 
 func (mc *mockConnector) ListResources(ctx context.Context, in *v2.ResourcesServiceListResourcesRequest, opts ...grpc.CallOption) (*v2.ResourcesServiceListResourcesResponse, error) {
-	all := make([]*v2.Resource, 0, len(mc.resourceDB)+len(mc.userDB))
-	all = append(all, mc.resourceDB...)
-	all = append(all, mc.userDB...)
-	return &v2.ResourcesServiceListResourcesResponse{List: all}, nil
+	if in.ResourceTypeId == "group" {
+		return &v2.ResourcesServiceListResourcesResponse{List: mc.resourceDB}, nil
+	}
+	if in.ResourceTypeId == "user" {
+		return &v2.ResourcesServiceListResourcesResponse{List: mc.userDB}, nil
+	}
+	return nil, fmt.Errorf("unknown resource type %s", in.ResourceTypeId)
 }
 
 func (mc *mockConnector) ListEntitlements(ctx context.Context, in *v2.EntitlementsServiceListEntitlementsRequest, opts ...grpc.CallOption) (*v2.EntitlementsServiceListEntitlementsResponse, error) {


### PR DESCRIPTION
Improve syncing and grant expansion performance.

- Add more expandable grants to the syncer benchmark (which aren't cycles, just group->group->user). Increase the cycle depth.
- Fix behavior of mock connector in syncer benchmark. Instead of Entitlements() returning all entitlements, we return the entitlements for that specific resource. Same for Grants().
- Never checkpoint more often than once every 10 seconds. Previously we were checkpointing after every action was completed, which hurt performance since we were serializing the syncer state and saving it.
- Use shorter JSON tags so that we're serializing less data every time we checkpoint.
- Optimize GetFirstCycle() and FixCycles() to not iterate over every edge every time. If we called FixCycles() previously and the graph hasn't been modified, then we know there are still no cycles.

After these changes, we spend almost all of our time saving grants instead of checkpointing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `HasNoCycles` property to streamline cycle detection in the entitlement graph.
	- Enhanced checkpointing mechanism with a minimum interval for creating checkpoints.

- **Bug Fixes**
	- Improved error handling in resource listing methods.

- **Refactor**
	- Updated JSON serialization tags for better efficiency in the entitlement graph structures.
	- Enhanced test code organization and resource management in the mock connector.
	- Modified the `LoadC1Z` method to include additional parameters for improved functionality.

- **Tests**
	- Added new methods for managing groups and users in the mock connector for improved benchmarking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->