### PR TITLE
Add index on entitlement + principal to speed up grant expansion.

### DIFF
--- a/pkg/dotc1z/grants.go
+++ b/pkg/dotc1z/grants.go
@@ -29,6 +29,7 @@ create table if not exists %s (
 create index if not exists %s on %s (resource_type_id, resource_id);
 create index if not exists %s on %s (entitlement_id);
 create index if not exists %s on %s (principal_resource_type_id, principal_resource_id);
+create index if not exists %s on %s (entitlement_id, principal_resource_type_id, principal_resource_id);
 create unique index if not exists %s on %s (external_id, sync_id);`
 
 var grants = (*grantsTable)(nil)
@@ -51,6 +52,8 @@ func (r *grantsTable) Schema() (string, []interface{}) {
 		fmt.Sprintf("idx_grants_entitlement_id_v%s", r.Version()),
 		r.Name(),
 		fmt.Sprintf("idx_grants_principal_id_v%s", r.Version()),
+		r.Name(),
+		fmt.Sprintf("idx_grants_entitlement_id_principal_id_v%s", r.Version()),
 		r.Name(),
 		fmt.Sprintf("idx_grants_external_sync_v%s", r.Version()),
 		r.Name(),


### PR DESCRIPTION
In grant expansion, [we call ListGrantsForEntitlement() in a loop](https://github.com/ConductorOne/baton-sdk/blob/1b38020fbc69b6a324b44b36ff4609def0ff9fe3/pkg/sync/syncer.go#L1297). There is no index on entitlement id + principal id + principal resource type, so we do a table scan each time. In my test case with 3,000 resources that had a group grant on each one that needed to be expanded (and the group had 2,000 users), we ended up doing 6,000,000 scans on the grants table, taking 6 hours. Adding this index brings it down to 15 minutes.

I played around with adding some caching too, but that only got the time down to 10 minutes so I don't think it's worth the added complexity. Also it doubled memory usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved database indexing for grants, enhancing performance in data retrieval.

- **Bug Fixes**
	- Ensured that existing functionality for listing and retrieving grants remains unchanged and error handling is consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->