### PR TITLE
Remove index on grant entitlement id.

### DIFF
--- a/pkg/dotc1z/grants.go
+++ b/pkg/dotc1z/grants.go
@@ -27,7 +27,6 @@ create table if not exists %s (
     discovered_at datetime not null
 );
 create index if not exists %s on %s (resource_type_id, resource_id);
-create index if not exists %s on %s (entitlement_id);
 create index if not exists %s on %s (principal_resource_type_id, principal_resource_id);
 create index if not exists %s on %s (entitlement_id, principal_resource_type_id, principal_resource_id);
 create unique index if not exists %s on %s (external_id, sync_id);`
@@ -48,8 +47,6 @@ func (r *grantsTable) Schema() (string, []interface{}) {
 	return grantsTableSchema, []interface{}{
 		r.Name(),
 		fmt.Sprintf("idx_resource_types_external_sync_v%s", r.Version()),
-		r.Name(),
-		fmt.Sprintf("idx_grants_entitlement_id_v%s", r.Version()),
 		r.Name(),
 		fmt.Sprintf("idx_grants_principal_id_v%s", r.Version()),
 		r.Name(),


### PR DESCRIPTION
According to the SQLite docs, any queries for grants with a specific entitlement id will be handled by the index on (entitlement_id, principal_resource_type_id, principal_resource_id). In my testing, sync times and grant expansion performance are the same without this index.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the SQL schema by removing the index creation on the `entitlement_id` column in the grants table. 

*Note: This change may impact performance for related queries but does not affect existing functionality.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->