### PR TITLE
Treat errors syncing grants as warnings. Fail if we hit too many warnings.

### DIFF
--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -158,8 +158,6 @@ func isWarning(ctx context.Context, err error) bool {
 	return false
 }
 
-var warnings []error
-
 // Sync starts the syncing process. The sync process is driven by the action stack that is part of the state object.
 // For each page of data that is required to be fetched from the connector, a new action is pushed on to the stack. Once
 // an action is completed, it is popped off of the queue. Before processing each action, we checkpoint the state object
@@ -213,6 +211,7 @@ func (s *syncer) Sync(ctx context.Context) error {
 	}
 	s.state = state
 
+	var warnings []error
 	for s.state.Current() != nil {
 		err = s.Checkpoint(ctx)
 		if err != nil {

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -273,7 +273,7 @@ func (s *syncer) Sync(ctx context.Context) error {
 		case SyncEntitlementsOp:
 			err = s.SyncEntitlements(ctx)
 			if isWarning(ctx, err) {
-				l.Error("skipping entitlement", zap.Any("state", s.state.Current()), zap.Error(err))
+				l.Warn("skipping sync entitlement action", zap.Any("stateAction", stateAction), zap.Error(err))
 				warnings = append(warnings, err)
 				s.state.FinishAction(ctx)
 				continue
@@ -286,7 +286,7 @@ func (s *syncer) Sync(ctx context.Context) error {
 		case SyncGrantsOp:
 			err = s.SyncGrants(ctx)
 			if isWarning(ctx, err) {
-				l.Error("skipping grant", zap.Any("state", s.state.Current()), zap.Error(err))
+				l.Warn("skipping sync grant action", zap.Any("stateAction", stateAction), zap.Error(err))
 				warnings = append(warnings, err)
 				s.state.FinishAction(ctx)
 				continue

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -337,6 +337,9 @@ func (s *syncer) Sync(ctx context.Context) error {
 		l.Error("error clearing connector caches", zap.Error(err))
 	}
 
+	if len(warnings) > 0 {
+		l.Warn("sync completed with warnings", zap.Int("warning_count", len(warnings)), zap.Any("warnings", warnings))
+	}
 	return nil
 }
 


### PR DESCRIPTION
Continue after a 404 for syncing grants/entitlements for a resource. If we get too many (currently 10), error the sync.

The advantage of this approach is that anyone using the uhttp wrapper will get this behavior for free (since wrapper converts http statuses to grpc statuses).

A later PR will keep a ratio of ops to warnings and error if the fraction becomes too high.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced improved warning handling during the sync process, allowing the operation to continue despite non-critical errors.
	- Added a mechanism to track and log warnings encountered during synchronization.
- **Bug Fixes**
	- Enhanced error handling to prevent sync termination when encountering warnings, with a limit on the number of warnings allowed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->