### PR TITLE
Log grant expansion progress.

### DIFF
--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -872,6 +872,7 @@ func (s *syncer) SyncGrantExpansion(ctx context.Context) error {
 				return err
 			}
 		} else {
+			l.Info("Finished loading entitlement graph", zap.Int("edges", len(entitlementGraph.Edges)))
 			entitlementGraph.Loaded = true
 		}
 
@@ -1426,6 +1427,11 @@ func (s *syncer) expandGrantsForEntitlements(ctx context.Context) error {
 	graph := s.state.EntitlementGraph(ctx)
 	l = l.With(zap.Int("depth", graph.Depth))
 	l.Debug("expandGrantsForEntitlements: start", zap.Any("graph", graph))
+
+	actions := len(graph.Actions)
+	if actions%250 == 0 || actions < 10 {
+		l.Info("Expanding grants", zap.Int("actions", actions))
+	}
 
 	actionsDone, err := s.runGrantExpandActions(ctx)
 	if err != nil {


### PR DESCRIPTION
On my laptop, this logs about once every 10 seconds.
```
{"level":"info","ts":1734487902.506569,"caller":"sync/syncer.go:859","msg":"Expanding grants..."}
{"level":"info","ts":1734487902.74467,"caller":"sync/syncer.go:875","msg":"Finished loading entitlement graph","edges":6582}
{"level":"info","ts":1734487902.811059,"caller":"sync/syncer.go:1433","msg":"Expanding grants","depth":0,"actions":0}
{"level":"info","ts":1734487902.956737,"caller":"sync/syncer.go:1433","msg":"Expanding grants","depth":1,"actions":10000}
{"level":"info","ts":1734487906.959425,"caller":"sync/syncer.go:1433","msg":"Expanding grants","depth":1,"actions":9750}
...
```