### PR TITLE
Add uhttp.WithBearerToken method

### DIFF
--- a/pkg/uhttp/wrapper.go
+++ b/pkg/uhttp/wrapper.go
@@ -30,6 +30,7 @@ const (
 	applicationFormUrlencoded = "application/x-www-form-urlencoded"
 	applicationVndApiJSON     = "application/vnd.api+json"
 	acceptHeader              = "Accept"
+	authorizationHeader       = "Authorization"
 )
 
 const maxBodySize = 4096
@@ -462,6 +463,10 @@ func WithContentType(ctype string) RequestOption {
 
 func WithAccept(value string) RequestOption {
 	return WithHeader(acceptHeader, value)
+}
+
+func WithBearerToken(token string) RequestOption {
+	return WithHeader(authorizationHeader, fmt.Sprintf("Bearer %s", token))
 }
 
 func (c *BaseHttpClient) NewRequest(ctx context.Context, method string, url *url.URL, options ...RequestOption) (*http.Request, error) {


### PR DESCRIPTION
Add simple helper method for connectors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method to easily include Bearer tokens in HTTP request headers for improved API authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->