### PR TITLE
Print the response's body on demand for debugging purposes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,6 +36,7 @@ linters-settings:
         arguments:
           - fmt.Printf
           - fmt.Println
+          - fmt.Fprint
           - fmt.Fprintf
           - fmt.Fprintln
           - os.Stderr.Sync

--- a/flake.lock
+++ b/flake.lock
@@ -18,12 +18,12 @@
     },
     "flake-schemas": {
       "locked": {
-        "lastModified": 1697467827,
-        "narHash": "sha256-j8SR19V1SRysyJwpOBF4TLuAvAjF5t+gMiboN4gYQDU=",
-        "rev": "764932025c817d4e500a8d2a4d8c565563923d29",
-        "revCount": 29,
+        "lastModified": 1721999734,
+        "narHash": "sha256-G5CxYeJVm4lcEtaO87LKzOsVnWeTcHGKbKxNamNWgOw=",
+        "rev": "0a5c42297d870156d9c57d8f99e476b738dcd982",
+        "revCount": 75,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/flake-schemas/0.1.2/018b3da8-4cc3-7fbb-8ff7-1588413c53e2/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/flake-schemas/0.1.5/0190ef2f-61e0-794b-ba14-e82f225e55e6/source.tar.gz?rev=0a5c42297d870156d9c57d8f99e476b738dcd982&revCount=75"
       },
       "original": {
         "type": "tarball",
@@ -53,12 +53,12 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1717952948,
-        "narHash": "sha256-mJi4/gjiwQlSaxjA6AusXBN/6rQRaPCycR7bd8fydnQ=",
-        "rev": "2819fffa7fa42156680f0d282c60d81e8fb185b7",
-        "revCount": 631440,
+        "lastModified": 1735669367,
+        "narHash": "sha256-tfYRbFhMOnYaM4ippqqid3BaLOXoFNdImrfBfCp4zn0=",
+        "rev": "edf04b75c13c2ac0e54df5ec5c543e300f76f1c9",
+        "revCount": 712148,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2405.631440%2Brev-2819fffa7fa42156680f0d282c60d81e8fb185b7/0190034c-678d-7039-b45c-fa38168f2500/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2411.712148%2Brev-edf04b75c13c2ac0e54df5ec5c543e300f76f1c9/0194235a-7100-7180-896b-1aa5e516625b/source.tar.gz?rev=edf04b75c13c2ac0e54df5ec5c543e300f76f1c9&revCount=712148"
       },
       "original": {
         "type": "tarball",
@@ -67,27 +67,27 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1718811006,
-        "narHash": "sha256-0Y8IrGhRmBmT7HHXlxxepg2t8j1X90++qRN3lukGaIk=",
+        "lastModified": 1730741070,
+        "narHash": "sha256-edm8WG19kWozJ/GqyYx2VjW99EdhjKwbY3ZwdlPAAlo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "03d771e513ce90147b65fe922d87d3a0356fc125",
+        "rev": "d063c1dd113c91ab27959ba540c0d9753409edf3",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.11",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1719082008,
-        "narHash": "sha256-jHJSUH619zBQ6WdC21fFAlDxHErKVDJ5fpN0Hgx4sjs=",
+        "lastModified": 1730768919,
+        "narHash": "sha256-8AKquNnnSaJRXZxc5YmF/WfmxiHX6MMZZasRP6RRQkE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9693852a2070b398ee123a329e68f0dab5526681",
+        "rev": "a04d33c0c3f1a59a2c1cb0c6e34cd24500e5a1dc",
         "type": "github"
       },
       "original": {
@@ -105,11 +105,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1719259945,
-        "narHash": "sha256-F1h+XIsGKT9TkGO3omxDLEb/9jOOsI6NnzsXFsZhry4=",
+        "lastModified": 1734797603,
+        "narHash": "sha256-ulZN7ps8nBV31SE+dwkDvKIzvN6hroRY8sYOT0w+E28=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "0ff4381bbb8f7a52ca4a851660fc7a437a4c6e07",
+        "rev": "f0f0dc4920a903c3e08f5bdb9246bb572fcae498",
         "type": "github"
       },
       "original": {

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -33,9 +33,7 @@ const maxDepth = 8
 
 var dontFixCycles, _ = strconv.ParseBool(os.Getenv("BATON_DONT_FIX_CYCLES"))
 
-var (
-	ErrSyncNotComplete = fmt.Errorf("sync exited without finishing")
-)
+var ErrSyncNotComplete = fmt.Errorf("sync exited without finishing")
 
 type Syncer interface {
 	Sync(context.Context) error
@@ -972,7 +970,7 @@ func (s *syncer) SyncAssets(ctx context.Context) error {
 }
 
 // SyncGrantExpansion
-// TODO(morgabra) Docs.
+// TODO(morgabra) Docs
 func (s *syncer) SyncGrantExpansion(ctx context.Context) error {
 	l := ctxzap.Extract(ctx)
 	entitlementGraph := s.state.EntitlementGraph(ctx)

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -970,7 +970,6 @@ func (s *syncer) SyncAssets(ctx context.Context) error {
 }
 
 // SyncGrantExpansion documentation pending.
-// TODO(morgabra) Docs
 func (s *syncer) SyncGrantExpansion(ctx context.Context) error {
 	l := ctxzap.Extract(ctx)
 	entitlementGraph := s.state.EntitlementGraph(ctx)

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -969,8 +969,6 @@ func (s *syncer) SyncAssets(ctx context.Context) error {
 	return nil
 }
 
-// SyncGrantExpansion
-// TODO(morgabra) Docs
 func (s *syncer) SyncGrantExpansion(ctx context.Context) error {
 	l := ctxzap.Extract(ctx)
 	entitlementGraph := s.state.EntitlementGraph(ctx)

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -969,6 +969,8 @@ func (s *syncer) SyncAssets(ctx context.Context) error {
 	return nil
 }
 
+// SyncGrantExpansion documentation pending.
+// TODO(morgabra) Docs
 func (s *syncer) SyncGrantExpansion(ctx context.Context) error {
 	l := ctxzap.Extract(ctx)
 	entitlementGraph := s.state.EntitlementGraph(ctx)

--- a/pkg/uhttp/body_print.go
+++ b/pkg/uhttp/body_print.go
@@ -2,9 +2,6 @@ package uhttp
 
 // Implements a debugging facility for request responses. This changes
 // the behavior of `BaseHttpClient` with an unexported flag.
-//
-// If you always wanted to see the actual body of your response, now
-// you can 👁️👄👁️undress it🫦 to uncover all its... data!
 
 import (
 	"io"
@@ -24,18 +21,18 @@ func (pr *printReader) Read(p []byte) (int, error) {
 	return n, err
 }
 
-func wrapBodyToUndress(body io.Reader) io.Reader {
+func wrapPrintBody(body io.Reader) io.Reader {
 	return &printReader{reader: body}
 }
 
-type undressOption struct {
-	undress bool
+type printBodyOption struct {
+	debugPrintBody bool
 }
 
-func (o undressOption) Apply(c *BaseHttpClient) {
-	c.debugPrintBody = o.undress
+func (o printBodyOption) Apply(c *BaseHttpClient) {
+	c.debugPrintBody = o.debugPrintBody
 }
 
-func WithUndressBody(undress bool) WrapperOption {
-	return undressOption{undress: undress}
+func WithPrintBody(shouldPrint bool) WrapperOption {
+	return printBodyOption{debugPrintBody: shouldPrint}
 }

--- a/pkg/uhttp/body_print.go
+++ b/pkg/uhttp/body_print.go
@@ -4,8 +4,10 @@ package uhttp
 // the behavior of `BaseHttpClient` with an unexported flag.
 
 import (
+	"errors"
+	"fmt"
 	"io"
-	"log"
+	"os"
 )
 
 type printReader struct {
@@ -15,7 +17,10 @@ type printReader struct {
 func (pr *printReader) Read(p []byte) (int, error) {
 	n, err := pr.reader.Read(p)
 	if n > 0 {
-		log.Print(string(p[:n]))
+		_, merr := fmt.Fprint(os.Stdout, string(p[:n]))
+		if merr != nil {
+			return -1, errors.Join(err, merr)
+		}
 	}
 
 	return n, err

--- a/pkg/uhttp/body_print.go
+++ b/pkg/uhttp/body_print.go
@@ -38,15 +38,3 @@ func (pr *printReader) Read(p []byte) (int, error) {
 func wrapPrintBody(body io.Reader) io.Reader {
 	return &printReader{reader: body}
 }
-
-type printBodyOption struct {
-	debugPrintBody bool
-}
-
-func (o printBodyOption) Apply(c *BaseHttpClient) {
-	c.debugPrintBody = o.debugPrintBody
-}
-
-func WithPrintBody(shouldPrint bool) WrapperOption {
-	return printBodyOption{debugPrintBody: shouldPrint}
-}

--- a/pkg/uhttp/body_print.go
+++ b/pkg/uhttp/body_print.go
@@ -2,6 +2,15 @@ package uhttp
 
 // Implements a debugging facility for request responses. This changes
 // the behavior of `BaseHttpClient` with an unexported flag.
+//
+// IMPORTANT: This feature is intended for development and debugging purposes only.
+// Do not enable in production as it may expose sensitive information in logs.
+//
+// Usage:
+//   client := uhttp.NewBaseHttpClient(
+//     httpClient,
+//     uhttp.WithPrintBody(true), // Enable response body printing
+//   )
 
 import (
 	"errors"

--- a/pkg/uhttp/body_print.go
+++ b/pkg/uhttp/body_print.go
@@ -1,0 +1,41 @@
+package uhttp
+
+// Implements a debugging facility for request responses. This changes
+// the behavior of `BaseHttpClient` with an unexported flag.
+//
+// If you always wanted to see the actual body of your response, now
+// you can 👁️👄👁️undress it🫦 to uncover all its... data!
+
+import (
+	"io"
+	"log"
+)
+
+type printReader struct {
+	reader io.Reader
+}
+
+func (pr *printReader) Read(p []byte) (int, error) {
+	n, err := pr.reader.Read(p)
+	if n > 0 {
+		log.Print(string(p[:n]))
+	}
+
+	return n, err
+}
+
+func wrapBodyToUndress(body io.Reader) io.Reader {
+	return &printReader{reader: body}
+}
+
+type undressOption struct {
+	undress bool
+}
+
+func (o undressOption) Apply(c *BaseHttpClient) {
+	c.debugPrintBody = o.undress
+}
+
+func WithUndressBody(undress bool) WrapperOption {
+	return undressOption{undress: undress}
+}

--- a/pkg/uhttp/wrapper.go
+++ b/pkg/uhttp/wrapper.go
@@ -343,7 +343,7 @@ func (c *BaseHttpClient) Do(req *http.Request, options ...DoOption) (*http.Respo
 
 	// Replace resp.Body with a no-op closer so nobody has to worry about closing the reader.
 	if c.debugPrintBody {
-		resp.Body = io.NopCloser(wrapBodyToUndress(bytes.NewBuffer(body)))
+		resp.Body = io.NopCloser(wrapPrintBody(bytes.NewBuffer(body)))
 	} else {
 		resp.Body = io.NopCloser(bytes.NewBuffer(body))
 	}

--- a/pkg/uhttp/wrapper.go
+++ b/pkg/uhttp/wrapper.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"syscall"
 	"time"
 
@@ -91,10 +92,9 @@ type (
 		NewRequest(ctx context.Context, method string, url *url.URL, options ...RequestOption) (*http.Request, error)
 	}
 	BaseHttpClient struct {
-		HttpClient     *http.Client
-		rateLimiter    uRateLimit.Limiter
-		baseHttpCache  icache
-		debugPrintBody bool
+		HttpClient    *http.Client
+		rateLimiter   uRateLimit.Limiter
+		baseHttpCache icache
 	}
 
 	DoOption      func(resp *WrapperResponse) error
@@ -342,7 +342,8 @@ func (c *BaseHttpClient) Do(req *http.Request, options ...DoOption) (*http.Respo
 	}
 
 	// Replace resp.Body with a no-op closer so nobody has to worry about closing the reader.
-	if c.debugPrintBody {
+	shouldPrint := os.Getenv("BATON_DEBUG_PRINT_RESPONSE_BODY")
+	if shouldPrint != "" {
 		resp.Body = io.NopCloser(wrapPrintBody(bytes.NewBuffer(body)))
 	} else {
 		resp.Body = io.NopCloser(bytes.NewBuffer(body))

--- a/pkg/uhttp/wrapper.go
+++ b/pkg/uhttp/wrapper.go
@@ -91,9 +91,10 @@ type (
 		NewRequest(ctx context.Context, method string, url *url.URL, options ...RequestOption) (*http.Request, error)
 	}
 	BaseHttpClient struct {
-		HttpClient    *http.Client
-		rateLimiter   uRateLimit.Limiter
-		baseHttpCache icache
+		HttpClient     *http.Client
+		rateLimiter    uRateLimit.Limiter
+		baseHttpCache  icache
+		debugPrintBody bool
 	}
 
 	DoOption      func(resp *WrapperResponse) error
@@ -341,7 +342,11 @@ func (c *BaseHttpClient) Do(req *http.Request, options ...DoOption) (*http.Respo
 	}
 
 	// Replace resp.Body with a no-op closer so nobody has to worry about closing the reader.
-	resp.Body = io.NopCloser(bytes.NewBuffer(body))
+	if c.debugPrintBody {
+		resp.Body = io.NopCloser(wrapBodyToUndress(bytes.NewBuffer(body)))
+	} else {
+		resp.Body = io.NopCloser(bytes.NewBuffer(body))
+	}
 
 	wresp := WrapperResponse{
 		Header:     resp.Header,


### PR DESCRIPTION
This PR adds debugging functionality that displays the response's body as it arrives to us, not immediately, but when reading it.

Example:

```shell
# assume baton-random-connector is a connector that expects a JSON response
BATON_DEBUG_PRINT_RESPONSE_BODY=yes baton-random-connector
# * prints out the response body when read *
```

The `uhttp.WithJSONResponse(&target)` option on `.Do` would trigger a read, and we would see what was read on the console.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a debugging option to log HTTP response bodies.
- **Improvements**
  - Enhanced HTTP client with configurable response body logging via environment variable.
  - Provides a flexible way to enable/disable response body debugging.
- **Debugging**
  - New capability to inspect HTTP response contents during development.
- **Documentation**
  - Updated linter settings to improve error handling practices.
  - Added requirements for explanations on `nolint` directives.
- **Code Organization**
  - Simplified visibility of the `ErrSyncNotComplete` variable.
  - Updated comments for clarity in the `SyncGrantExpansion` method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->