### PR TITLE
Add generic pagination helper

### DIFF
--- a/pkg/pagination/generic_bag.go
+++ b/pkg/pagination/generic_bag.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 )
 
+var ErrNoToken = fmt.Errorf("pagination token cannot be nil")
+
 type genericSerializedPaginationBag[T any] struct {
 	States       []T `json:"states"`
 	CurrentState *T  `json:"current_state"`
@@ -19,6 +21,10 @@ type GenBag[T any] struct {
 }
 
 func GenBagFromToken[T any](pToken *Token) (*GenBag[T], error) {
+	if pToken == nil {
+		return nil, ErrNoToken
+	}
+
 	bag := &GenBag[T]{}
 	err := bag.Unmarshal(pToken.Token)
 	if err != nil {

--- a/pkg/pagination/generic_bag.go
+++ b/pkg/pagination/generic_bag.go
@@ -1,0 +1,112 @@
+package pagination
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type genericSerializedPaginationBag[T any] struct {
+	States       []T `json:"states"`
+	CurrentState *T  `json:"current_state"`
+}
+
+// GenBag holds pagination states that can be serialized for use as page tokens. It acts as a stack that you can push and pop
+// pagination operations from.
+// This is a generic version of the Bag struct.
+type GenBag[T any] struct {
+	states       []T
+	currentState *T
+}
+
+func GenBagFromToken[T any](pToken Token) (*GenBag[T], error) {
+	bag := &GenBag[T]{}
+	err := bag.Unmarshal(pToken.Token)
+	if err != nil {
+		return nil, err
+	}
+	return bag, nil
+}
+
+func (pb *GenBag[T]) push(s T) {
+	if pb.currentState == nil {
+		pb.currentState = &s
+		return
+	}
+
+	pb.states = append(pb.states, *pb.currentState)
+	pb.currentState = &s
+}
+
+func (pb *GenBag[T]) pop() *T {
+	if pb.currentState == nil {
+		return nil
+	}
+
+	ret := *pb.currentState
+
+	if len(pb.states) > 0 {
+		pb.currentState = &pb.states[len(pb.states)-1]
+		pb.states = pb.states[:len(pb.states)-1]
+	} else {
+		pb.currentState = nil
+	}
+
+	return &ret
+}
+
+// Push pushes a new page state onto the stack.
+func (pb *GenBag[T]) Push(state T) {
+	pb.push(state)
+}
+
+// Pop returns the current page action, and makes the top of the stack the current.
+func (pb *GenBag[T]) Pop() *T {
+	return pb.pop()
+}
+
+// Current returns the current page state for the bag.
+func (pb *GenBag[T]) Current() *T {
+	if pb.currentState == nil {
+		return nil
+	}
+
+	current := *pb.currentState
+	return &current
+}
+
+// Unmarshal takes an input string and unmarshals it onto the state object.
+func (pb *GenBag[T]) Unmarshal(input string) error {
+	var target genericSerializedPaginationBag[T]
+
+	if input != "" {
+		err := json.Unmarshal([]byte(input), &target)
+		if err != nil {
+			return fmt.Errorf("page token corrupt: %w", err)
+		}
+
+		pb.states = target.States
+		pb.currentState = target.CurrentState
+	} else {
+		pb.states = nil
+		pb.currentState = nil
+	}
+
+	return nil
+}
+
+// Marshal returns a string encoding of the state object.
+func (pb *GenBag[T]) Marshal() (string, error) {
+	if pb.currentState == nil {
+		return "", nil
+	}
+
+	data, err := json.Marshal(genericSerializedPaginationBag[T]{
+		States:       pb.states,
+		CurrentState: pb.currentState,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return string(data), nil
+}

--- a/pkg/pagination/generic_bag.go
+++ b/pkg/pagination/generic_bag.go
@@ -18,7 +18,7 @@ type GenBag[T any] struct {
 	currentState *T
 }
 
-func GenBagFromToken[T any](pToken Token) (*GenBag[T], error) {
+func GenBagFromToken[T any](pToken *Token) (*GenBag[T], error) {
 	bag := &GenBag[T]{}
 	err := bag.Unmarshal(pToken.Token)
 	if err != nil {

--- a/pkg/pagination/generic_bag_test.go
+++ b/pkg/pagination/generic_bag_test.go
@@ -1,0 +1,109 @@
+package pagination
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenBagMarshalling(t *testing.T) {
+	type innerStruct struct {
+		Age  int
+		Name string
+	}
+
+	var bag GenBag[innerStruct]
+
+	bag.Push(innerStruct{Age: 10, Name: "John"})
+	bag.Push(innerStruct{Age: 20, Name: "Doe"})
+
+	// Marshal
+	marshalled, err := bag.Marshal()
+	require.NoError(t, err)
+
+	// Unmarshal
+	err = bag.Unmarshal(marshalled)
+	require.NoError(t, err)
+}
+
+func TestGenBagFromToken(t *testing.T) {
+	type innerStruct struct {
+		Age  int
+		Name string
+	}
+
+	var bag GenBag[innerStruct]
+
+	bag.Push(innerStruct{Age: 10, Name: "John"})
+	bag.Push(innerStruct{Age: 20, Name: "Doe"})
+
+	// Marshal
+	marshalled, err := bag.Marshal()
+	require.NoError(t, err)
+
+	token := Token{Token: marshalled}
+
+	// Unmarshal
+	bagFromToken, err := GenBagFromToken[innerStruct](token)
+	require.NoError(t, err)
+
+	require.Equal(t, &bag, bagFromToken)
+}
+
+func TestGenBagUnmarshal(t *testing.T) {
+	type innerStruct struct {
+		Age  int
+		Name string
+	}
+
+	var bag GenBag[innerStruct]
+
+	err := bag.Unmarshal("{invalid")
+	require.Error(t, err)
+
+	err = bag.Unmarshal("")
+
+	require.NoError(t, err)
+	require.Nil(t, bag.states)
+	require.Nil(t, bag.currentState)
+
+	marshal, err := bag.Marshal()
+	require.NoError(t, err)
+	require.Equal(t, "", marshal)
+
+	temp := bag.Current()
+	require.Nil(t, temp)
+
+	{
+		compare := innerStruct{Age: 10, Name: "John"}
+
+		bag.Push(compare)
+
+		current := bag.Current()
+		require.Equal(t, &compare, current)
+	}
+
+	{
+		first := innerStruct{Age: 10, Name: "John"}
+		second := innerStruct{Age: 15, Name: "Wick"}
+
+		bag.Push(first)
+		bag.Push(second)
+
+		current := bag.Current()
+		require.Equal(t, &second, current)
+	}
+
+	{
+		first := innerStruct{Age: 10, Name: "John"}
+		second := innerStruct{Age: 15, Name: "Wick"}
+
+		bag.Push(first)
+		bag.Push(second)
+		pop := bag.Pop()
+		require.Equal(t, pop, &second)
+
+		current := bag.Current()
+		require.Equal(t, &first, current)
+	}
+}

--- a/pkg/pagination/generic_bag_test.go
+++ b/pkg/pagination/generic_bag_test.go
@@ -41,7 +41,7 @@ func TestGenBagFromToken(t *testing.T) {
 	marshalled, err := bag.Marshal()
 	require.NoError(t, err)
 
-	token := Token{Token: marshalled}
+	token := &Token{Token: marshalled}
 
 	// Unmarshal
 	bagFromToken, err := GenBagFromToken[innerStruct](token)


### PR DESCRIPTION
Add Generic pagination helper

Helper to avoid explicit conversion on strings in scenarios where the token or id needs to be converted to another type, also can hold any kind of data.

We can think a better name instead of `GenBag`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a generic pagination bag implementation in Go.
	- Added methods for managing pagination states, including push, pop, and current state retrieval.
	- Implemented marshaling and unmarshaling functionality for pagination states from tokens, with error handling for invalid input.

- **Tests**
	- Added comprehensive test coverage for pagination bag functionality.
	- Verified marshaling, unmarshaling, and state management behaviors, ensuring correct handling of various input scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->