### PR TITLE
Convert more HTTP statuses to GRPC statuses.

### DIFF
--- a/pkg/uhttp/wrapper.go
+++ b/pkg/uhttp/wrapper.go
@@ -361,7 +361,7 @@ func (c *BaseHttpClient) Do(req *http.Request, options ...DoOption) (*http.Respo
 	switch resp.StatusCode {
 	case http.StatusRequestTimeout:
 		return resp, WrapErrorsWithRateLimitInfo(codes.DeadlineExceeded, resp, optErrs...)
-	case http.StatusTooManyRequests, http.StatusServiceUnavailable:
+	case http.StatusTooManyRequests, http.StatusBadGateway, http.StatusServiceUnavailable:
 		return resp, WrapErrorsWithRateLimitInfo(codes.Unavailable, resp, optErrs...)
 	case http.StatusNotFound:
 		return resp, WrapErrorsWithRateLimitInfo(codes.NotFound, resp, optErrs...)
@@ -369,6 +369,8 @@ func (c *BaseHttpClient) Do(req *http.Request, options ...DoOption) (*http.Respo
 		return resp, WrapErrorsWithRateLimitInfo(codes.Unauthenticated, resp, optErrs...)
 	case http.StatusForbidden:
 		return resp, WrapErrorsWithRateLimitInfo(codes.PermissionDenied, resp, optErrs...)
+	case http.StatusConflict:
+		return resp, WrapErrorsWithRateLimitInfo(codes.AlreadyExists, resp, optErrs...)
 	case http.StatusNotImplemented:
 		return resp, WrapErrorsWithRateLimitInfo(codes.Unimplemented, resp, optErrs...)
 	}


### PR DESCRIPTION
409 conflict should be GRPC status already exists.

502 bad gateway should be GRPC status unavailable so that we retry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for HTTP requests to better manage rate limiting and conflict scenarios.
	- Enhanced response to specific HTTP status codes like Too Many Requests, Bad Gateway, and Conflict.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->