### PR TITLE
Reduce cancel time to fix flaky test.

### DIFF
--- a/internal/tests/passingvalues_test.go
+++ b/internal/tests/passingvalues_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const timeoutIn = time.Millisecond * 1
+const timeoutIn = time.Microsecond * 1
 
 func TestEntryPoint(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeoutIn)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated timeout duration in a test case from milliseconds to microseconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->