### PR TITLE
Fix flaky test.

### DIFF
--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"strings"
 	"sync"
 	"time"
 
@@ -362,7 +361,7 @@ func (cw *wrapper) Close() error {
 
 	if cw.serverStdin != nil {
 		err = cw.serverStdin.Close()
-		if err != nil && !strings.Contains(err.Error(), "already closed") {
+		if err != nil && errors.Is(err, os.ErrClosed) {
 			return fmt.Errorf("error closing connector service stdin: %w", err)
 		}
 	}

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strings"
 	"sync"
 	"time"
 
@@ -361,7 +362,7 @@ func (cw *wrapper) Close() error {
 
 	if cw.serverStdin != nil {
 		err = cw.serverStdin.Close()
-		if err != nil {
+		if err != nil && !strings.Contains(err.Error(), "already closed") {
 			return fmt.Errorf("error closing connector service stdin: %w", err)
 		}
 	}

--- a/internal/tests/notrequireargsinsubcommands_test.go
+++ b/internal/tests/notrequireargsinsubcommands_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestCallSubCommand(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), timeoutIn)
+	ctx, cancel := context.WithTimeout(context.Background(), 0)
 	defer cancel()
 
 	requiredField := field.StringField("name", field.WithRequired(true))

--- a/internal/tests/passingvalues_test.go
+++ b/internal/tests/passingvalues_test.go
@@ -3,16 +3,14 @@ package tests
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/conductorone/baton-sdk/pkg/field"
 	"github.com/stretchr/testify/require"
 )
 
-const timeoutIn = time.Microsecond * 1
-
 func TestEntryPoint(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), timeoutIn)
+	// We want a context that is already DeadlineExceeded so that entrypoint() doesn't hang
+	ctx, cancel := context.WithTimeout(context.Background(), 0)
 	defer cancel()
 
 	stringRequiredField := field.StringField(


### PR DESCRIPTION
- Don't try to release a semaphore if acquire errors, as the error might be context deadline exceeded in a test.
- Squelch error closing serverStdin if the error is that it's already closed.
- Make timeout in passingvalues_test 0 so that context is always deadline exceeded, preventing flakes and preventing entrypoint() from running forever.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Refined error handling in connector and runner components to better manage context cancellation and input stream closure scenarios.

- **Tests**
	- Updated test configurations to modify timeout behaviors in test contexts, ensuring immediate expiration.
	- Removed specific timeout constant in test files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->