### PR TITLE
Fix sync error if a connector provides bad grant IDs for grant expansion.

### DIFF
--- a/pkg/sync/expand/graph.go
+++ b/pkg/sync/expand/graph.go
@@ -288,3 +288,24 @@ func (g *EntitlementGraph) AddEdge(
 	g.DestinationsToSources[dstNode.Id][srcNode.Id] = edge.EdgeID
 	return nil
 }
+
+func (g *EntitlementGraph) DeleteEdge(ctx context.Context, srcEntitlementID string, dstEntitlementID string) error {
+	srcNode := g.GetNode(srcEntitlementID)
+	if srcNode == nil {
+		return ErrNoEntitlement
+	}
+	dstNode := g.GetNode(dstEntitlementID)
+	if dstNode == nil {
+		return ErrNoEntitlement
+	}
+
+	if destinations, ok := g.SourcesToDestinations[srcNode.Id]; ok {
+		if edgeID, ok := destinations[dstNode.Id]; ok {
+			delete(destinations, dstNode.Id)
+			delete(g.DestinationsToSources[dstNode.Id], srcNode.Id)
+			delete(g.Edges, edgeID)
+			return nil
+		}
+	}
+	return nil
+}

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -1563,8 +1563,15 @@ func (s *syncer) expandGrantsForEntitlements(ctx context.Context) error {
 
 	actionsDone, err := s.runGrantExpandActions(ctx)
 	if err != nil {
-		l.Error("expandGrantsForEntitlements: error running graph actions", zap.Error(err))
-		return fmt.Errorf("expandGrantsForEntitlements: error running graph actions: %w", err)
+		// Skip action and delete the edge that caused the error.
+		erroredAction := graph.Actions[0]
+		l.Error("expandGrantsForEntitlements: error running graph action", zap.Error(err), zap.Any("action", erroredAction))
+		_ = graph.DeleteEdge(ctx, erroredAction.SourceEntitlementID, erroredAction.DescendantEntitlementID)
+		graph.Actions = graph.Actions[1:]
+		if len(graph.Actions) == 0 {
+			actionsDone = true
+		}
+		// TODO: return a warning
 	}
 	if !actionsDone {
 		return nil


### PR DESCRIPTION
Also added a failing test case for a connector that creates a grant but doesn't create the entitlement for that grant. This broke grant expansion in a way that caused sync to fail.

This fixes the issue by skipping the action that caused the error in grant expansion and deleting the graph edge that was responsible for the error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added ability to delete edges in the entitlement graph
  - Enhanced error handling during grant synchronization

- **Bug Fixes**
  - Improved resilience in sync process by skipping problematic actions

- **Tests**
  - Added new test case for handling incorrect entitlement IDs
  - Updated resource management in mock connector for more robust testing

The changes focus on improving the reliability and flexibility of the synchronization system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->