### PR TITLE
Allow specifying a user profile on the command line for account creation

### DIFF
--- a/pkg/field/defaults.go
+++ b/pkg/field/defaults.go
@@ -12,11 +12,14 @@ var (
 	TicketingField              = BoolField("ticketing", WithDescription("This must be set to enable ticketing support"), WithPersistent(true))
 	c1zTmpDirField              = StringField("c1z-temp-dir", WithHidden(true), WithDescription("The directory to store temporary files in. It must exist, "+
 		"and write access is required. Defaults to the OS temporary directory."), WithPersistent(true))
-	clientIDField              = StringField("client-id", WithDescription("The client ID used to authenticate with ConductorOne"), WithPersistent(true))
-	clientSecretField          = StringField("client-secret", WithDescription("The client secret used to authenticate with ConductorOne"), WithPersistent(true))
-	createAccountEmailField    = StringField("create-account-email", WithHidden(true), WithDescription("The email of the account to create"), WithPersistent(true))
-	createAccountLoginField    = StringField("create-account-login", WithHidden(true), WithDescription("The login of the account to create"), WithPersistent(true))
-	createAccountProfileField  = StringField("create-account-profile", WithHidden(true), WithDescription("The profile map of the account to create"), WithPersistent(true))
+	clientIDField             = StringField("client-id", WithDescription("The client ID used to authenticate with ConductorOne"), WithPersistent(true))
+	clientSecretField         = StringField("client-secret", WithDescription("The client secret used to authenticate with ConductorOne"), WithPersistent(true))
+	createAccountEmailField   = StringField("create-account-email", WithHidden(true), WithDescription("The email of the account to create"), WithPersistent(true))
+	createAccountLoginField   = StringField("create-account-login", WithHidden(true), WithDescription("The login of the account to create"), WithPersistent(true))
+	createAccountProfileField = StringField("create-account-profile",
+		WithHidden(true),
+		WithDescription("JSON-formatted object of map keys and values like '{ 'key': 'value' }'"),
+		WithPersistent(true))
 	deleteResourceField        = StringField("delete-resource", WithHidden(true), WithDescription("The id of the resource to delete"), WithPersistent(true))
 	deleteResourceTypeField    = StringField("delete-resource-type", WithHidden(true), WithDescription("The type of the resource to delete"), WithPersistent(true))
 	eventFeedField             = StringField("event-feed", WithHidden(true), WithDescription("Read feed events to stdout"), WithPersistent(true))

--- a/pkg/field/defaults.go
+++ b/pkg/field/defaults.go
@@ -16,6 +16,7 @@ var (
 	clientSecretField          = StringField("client-secret", WithDescription("The client secret used to authenticate with ConductorOne"), WithPersistent(true))
 	createAccountEmailField    = StringField("create-account-email", WithHidden(true), WithDescription("The email of the account to create"), WithPersistent(true))
 	createAccountLoginField    = StringField("create-account-login", WithHidden(true), WithDescription("The login of the account to create"), WithPersistent(true))
+	createAccountProfileField  = StringField("create-account-profile", WithHidden(true), WithDescription("The profile map of the account to create"), WithPersistent(true))
 	deleteResourceField        = StringField("delete-resource", WithHidden(true), WithDescription("The id of the resource to delete"), WithPersistent(true))
 	deleteResourceTypeField    = StringField("delete-resource-type", WithHidden(true), WithDescription("The type of the resource to delete"), WithPersistent(true))
 	eventFeedField             = StringField("event-feed", WithHidden(true), WithDescription("Read feed events to stdout"), WithPersistent(true))
@@ -47,6 +48,7 @@ var DefaultFields = []SchemaField{
 	clientSecretField,
 	createAccountEmailField,
 	createAccountLoginField,
+	createAccountProfileField,
 	deleteResourceField,
 	deleteResourceTypeField,
 	eventFeedField,

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	reader_v2 "github.com/conductorone/baton-sdk/pb/c1/reader/v2"
@@ -29,8 +30,9 @@ type Provisioner struct {
 
 	revokeGrantID string
 
-	createAccountLogin string
-	createAccountEmail string
+	createAccountLogin   string
+	createAccountEmail   string
+	createAccountProfile *structpb.Struct
 
 	deleteResourceID   string
 	deleteResourceType string
@@ -319,12 +321,13 @@ func NewResourceDeleter(c types.ConnectorClient, dbPath string, resourceId strin
 	}
 }
 
-func NewCreateAccountManager(c types.ConnectorClient, dbPath string, login string, email string) *Provisioner {
+func NewCreateAccountManager(c types.ConnectorClient, dbPath string, login string, email string, profile *structpb.Struct) *Provisioner {
 	return &Provisioner{
-		dbPath:             dbPath,
-		connector:          c,
-		createAccountLogin: login,
-		createAccountEmail: email,
+		dbPath:               dbPath,
+		connector:            c,
+		createAccountLogin:   login,
+		createAccountEmail:   email,
+		createAccountProfile: profile,
 	}
 }
 

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -241,8 +241,9 @@ func (p *Provisioner) createAccount(ctx context.Context) error {
 
 	_, err = p.connector.CreateAccount(ctx, &v2.CreateAccountRequest{
 		AccountInfo: &v2.AccountInfo{
-			Emails: emails,
-			Login:  p.createAccountLogin,
+			Emails:  emails,
+			Login:   p.createAccountLogin,
+			Profile: p.createAccountProfile,
 		},
 		CredentialOptions: opts,
 		EncryptionConfigs: config,

--- a/pkg/tasks/local/accounter.go
+++ b/pkg/tasks/local/accounter.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"time"
 
+	"google.golang.org/protobuf/types/known/structpb"
+
 	v1 "github.com/conductorone/baton-sdk/pb/c1/connectorapi/baton/v1"
 	"github.com/conductorone/baton-sdk/pkg/provisioner"
 	"github.com/conductorone/baton-sdk/pkg/tasks"
@@ -15,8 +17,9 @@ type localAccountManager struct {
 	dbPath string
 	o      sync.Once
 
-	login string
-	email string
+	login   string
+	email   string
+	profile *structpb.Struct
 }
 
 func (m *localAccountManager) GetTempDir() string {
@@ -38,7 +41,7 @@ func (m *localAccountManager) Next(ctx context.Context) (*v1.Task, time.Duration
 }
 
 func (m *localAccountManager) Process(ctx context.Context, task *v1.Task, cc types.ConnectorClient) error {
-	accountManager := provisioner.NewCreateAccountManager(cc, m.dbPath, m.login, m.email)
+	accountManager := provisioner.NewCreateAccountManager(cc, m.dbPath, m.login, m.email, m.profile)
 
 	err := accountManager.Run(ctx)
 	if err != nil {
@@ -54,10 +57,11 @@ func (m *localAccountManager) Process(ctx context.Context, task *v1.Task, cc typ
 }
 
 // NewGranter returns a task manager that queues a sync task.
-func NewCreateAccountManager(ctx context.Context, dbPath string, login string, email string) tasks.Manager {
+func NewCreateAccountManager(ctx context.Context, dbPath string, login string, email string, profile *structpb.Struct) tasks.Manager {
 	return &localAccountManager{
-		dbPath: dbPath,
-		login:  login,
-		email:  email,
+		dbPath:  dbPath,
+		login:   login,
+		email:   email,
+		profile: profile,
 	}
 }


### PR DESCRIPTION
Example call:

`
./dist/darwin_arm64/baton-okta --domain REDACTED --api-token REDACTED -p --create-account-login 'logan.saso+clitest3@conductorone.com' --create-account-email 'logan.saso+clitest3@conductorone.com' --create-account-profile '{"first name": "Logan", "last name": "CLITest3", "email": "logan.saso+clitest3@conductorone.com"}'
`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for creating accounts with profile information
	- Introduced a new profile field for account creation process

- **Refactor**
	- Updated account creation methods to include profile data
	- Modified structs and functions to accommodate profile information

- **Chores**
	- Reorganized import statements in various files
	- Added new import for protocol buffer structures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->