### PR TITLE
Cleanup the create account arguments so only including a profile is a valid path

### DIFF
--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -312,6 +312,8 @@ func MakeGRPCServerCommand(
 			copts = append(copts, connector.WithProvisioningEnabled())
 		case v.GetString("revoke-grant") != "":
 			copts = append(copts, connector.WithProvisioningEnabled())
+		case v.GetString("create-account-profile") != "":
+			copts = append(copts, connector.WithProvisioningEnabled())
 		case v.GetString("create-account-login") != "" || v.GetString("create-account-email") != "":
 			copts = append(copts, connector.WithProvisioningEnabled())
 		case v.GetString("delete-resource") != "" || v.GetString("delete-resource-type") != "":

--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -143,10 +143,14 @@ func MakeMainCommand(
 				}
 				login, email := "", ""
 				if l, ok := profileMap["login"]; ok {
-					login = l.(string)
+					if l, ok := l.(string); ok {
+						login = l
+					}
 				}
 				if e, ok := profileMap["email"]; ok {
-					email = e.(string)
+					if e, ok := e.(string); ok {
+						email = e
+					}
 				}
 				profile, err := structpb.NewStruct(profileMap)
 				if err != nil {


### PR DESCRIPTION
We now check the profile first, we merge the extra login/email args into it if provided, and get login/email from there directly.
This lets us totally ignore the login/email args on the cli if desired.
We also create a profile from the email/login provided for the old flow. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the CLI account creation process by allowing users to supply a structured profile with login and email details, ensuring more streamlined inputs.
- **Bug Fixes**
	- Improved error handling for empty or incorrectly formatted profile data during account creation.
- **Refactor**
	- Updated validations and error feedback to ensure the profile data is correctly formatted, while maintaining support for existing input methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->