### PR TITLE
Allow config to set log level on windows services.

### DIFF
--- a/pkg/cli/service_windows.go
+++ b/pkg/cli/service_windows.go
@@ -93,11 +93,12 @@ func getExePath() (string, error) {
 
 func initLogger(ctx context.Context, name string, loggingOpts ...logging.Option) (context.Context, error) {
 	if isService() {
-		loggingOpts = []logging.Option{
+		defaultLoggingOpts := []logging.Option{
 			logging.WithLogFormat(logging.LogFormatJSON),
 			logging.WithLogLevel("info"),
 			logging.WithOutputPaths([]string{filepath.Join(getConfigDir(name), "baton.log")}),
 		}
+		loggingOpts = append(defaultLoggingOpts, loggingOpts...)
 	}
 
 	return logging.Init(ctx, loggingOpts...)

--- a/pkg/field/field_options.go
+++ b/pkg/field/field_options.go
@@ -14,7 +14,9 @@ func WithRequired(required bool) fieldOption {
 
 		switch o.Variant {
 		case BoolVariant:
-			panic(fmt.Sprintf("required cannot be set on bool field: %s", o.FieldName))
+			if required {
+				panic(fmt.Sprintf("required cannot be set on bool field: %s", o.FieldName))
+			}
 		case IntVariant:
 			if o.Rules.i == nil {
 				o.Rules.i = &v1_conf.Int64Rules{}


### PR DESCRIPTION
Don't panic if bool field has WithRequired(false), as that's a no-op.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the logging setup in service mode, ensuring default settings are consistently merged with additional options.
- **Bug Fixes**
	- Adjusted error handling for boolean configuration so that errors occur only when an invalid 'required' flag is set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->