### PR TITLE
Fix error if we bulk insert resources where some have parent ids and some don't.

### DIFF
--- a/pkg/dotc1z/resources.go
+++ b/pkg/dotc1z/resources.go
@@ -114,7 +114,11 @@ func (c *C1File) PutResources(ctx context.Context, resourceObjs ...*v2.Resource)
 				"external_id":      fmt.Sprintf("%s:%s", resource.Id.ResourceType, resource.Id.Resource),
 			}
 
-			if resource.ParentResourceId != nil {
+			// If we bulk insert some resources with parent ids and some without, goqu errors because of the different number of fields.
+			if resource.ParentResourceId == nil {
+				fields["parent_resource_type_id"] = nil
+				fields["parent_resource_id"] = nil
+			} else {
 				fields["parent_resource_type_id"] = resource.ParentResourceId.ResourceType
 				fields["parent_resource_id"] = resource.ParentResourceId.Resource
 			}


### PR DESCRIPTION
Fixes an error syncing baton-slack: https://github.com/ConductorOne/baton-slack/actions/runs/13532534365/job/37817773032

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the bulk resource insertion process by ensuring consistent handling of records with or without parent association data. This refinement prevents errors due to mismatched record structures during bulk operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->