### PR TITLE
Fix log line with multiple attempts.

### DIFF
--- a/pkg/tasks/c1api/task_helpers.go
+++ b/pkg/tasks/c1api/task_helpers.go
@@ -93,9 +93,9 @@ func (t *taskHelpers) HeartbeatTask(ctx context.Context, annos annotations.Annot
 
 	go func() {
 		attempts := 0
+		l = l.With(zap.Int("attempts", attempts))
 		for {
 			attempts++
-			l = l.With(zap.Int("attempts", attempts))
 
 			if attempts >= taskMaximumHeartbeatFailures {
 				l.Error("heartbeat: failed after 10 attempts")


### PR DESCRIPTION
Pull the l.With() out of the loop so we don't log attempts multiple times.

Previously the log would look like:

```..."task_type":"sync_full","attempts":1,"attempts":1,"attempts":1,"attempts":1,"attempts":1,"attempts":1,"attempts":1,"attempts":1,"attempts":1,"attempts":1,"attempts":1,"attempts":1,"attempts":1,"attempts":1,"attempts":1,"attempts":1,"attempts":1,"attempts":1,"attempts":1,"attempts":1,"attempts":1,"attempts":1,"attempts":1,"attempts":1,"attempts":1,"attempts":1,"attempts":1,"attempts":1,"attempts":1,"attempts":1,"attempts":1,"attempts":1,"attempts":1,"next_heartbeat":73.278338931}```