### PR TITLE
If cycles are detected, only log the whole entitlement graph if we're debug logging.

### DIFF
--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -84,12 +84,22 @@ func (p *ProgressCounts) LogResourcesProgress(ctx context.Context, resourceType 
 func (p *ProgressCounts) LogEntitlementsProgress(ctx context.Context, resourceType string) {
 	entitlementsProgress := p.EntitlementsProgress[resourceType]
 	resources := p.Resources[resourceType]
-	if resources == 0 {
-		return
-	}
-	percentComplete := (entitlementsProgress * 100) / resources
 
 	l := ctxzap.Extract(ctx)
+	if resources == 0 {
+		// if resuming sync, resource counts will be zero, so don't calculate percentage. just log every 10 seconds.
+		if time.Since(p.LastEntitlementLog[resourceType]) > maxLogFrequency {
+			l.Info("Syncing entitlements",
+				zap.String("resource_type_id", resourceType),
+				zap.Int("synced", entitlementsProgress),
+			)
+			p.LastEntitlementLog[resourceType] = time.Now()
+		}
+		return
+	}
+
+	percentComplete := (entitlementsProgress * 100) / resources
+
 	switch {
 	case entitlementsProgress > resources:
 		l.Error("more entitlement resources than resources",
@@ -118,12 +128,22 @@ func (p *ProgressCounts) LogEntitlementsProgress(ctx context.Context, resourceTy
 func (p *ProgressCounts) LogGrantsProgress(ctx context.Context, resourceType string) {
 	grantsProgress := p.GrantsProgress[resourceType]
 	resources := p.Resources[resourceType]
-	if resources == 0 {
-		return
-	}
-	percentComplete := (grantsProgress * 100) / resources
 
 	l := ctxzap.Extract(ctx)
+	if resources == 0 {
+		// if resuming sync, resource counts will be zero, so don't calculate percentage. just log every 10 seconds.
+		if time.Since(p.LastGrantLog[resourceType]) > maxLogFrequency {
+			l.Info("Syncing grants",
+				zap.String("resource_type_id", resourceType),
+				zap.Int("synced", grantsProgress),
+			)
+			p.LastGrantLog[resourceType] = time.Now()
+		}
+		return
+	}
+
+	percentComplete := (grantsProgress * 100) / resources
+
 	switch {
 	case grantsProgress > resources:
 		l.Error("more grant resources than resources",

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -1132,8 +1132,8 @@ func (s *syncer) SyncGrantExpansion(ctx context.Context) error {
 			l.Warn(
 				"cycle detected in entitlement graph",
 				zap.Any("cycle", cycle),
-				zap.Any("initial graph", entitlementGraph),
 			)
+			l.Debug("initial graph", zap.Any("initial graph", entitlementGraph))
 			if dontFixCycles {
 				return fmt.Errorf("cycles detected in entitlement graph")
 			}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Enhanced logging functionality for syncing entitlements and grants, providing detailed information when resource counts are zero.
  - Adjusted logging level for the initial state of the entitlement graph from warning to debug, improving diagnostic clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->