### PR TITLE
Use unique name for resource type and resource ID in grants table.

### DIFF
--- a/pkg/dotc1z/grants.go
+++ b/pkg/dotc1z/grants.go
@@ -46,7 +46,7 @@ func (r *grantsTable) Name() string {
 func (r *grantsTable) Schema() (string, []interface{}) {
 	return grantsTableSchema, []interface{}{
 		r.Name(),
-		fmt.Sprintf("idx_resource_types_external_sync_v%s", r.Version()),
+		fmt.Sprintf("idx_grants_resource_type_id_resource_id_v%s", r.Version()),
 		r.Name(),
 		fmt.Sprintf("idx_grants_principal_id_v%s", r.Version()),
 		r.Name(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the internal naming convention for database indexes to enhance consistency without affecting the overall functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->