### PR TITLE
Add Interactive Credentials Setup for Windows Service

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -78,7 +78,7 @@ func DefineConfiguration[T field.Configurable](
 		return nil, nil, err
 	}
 
-	mainCMD.AddCommand(cli.AdditionalCommands(connectorName, schema.Fields)...)
+	mainCMD.AddCommand(cli.AdditionalCommands(connectorName, confschema.Fields)...)
 	cli.VisitFlags(mainCMD, v)
 
 	err = cli.OptionallyAddLambdaCommand(ctx, connectorName, v, connector, confschema, mainCMD)


### PR DESCRIPTION
Include all (including default) fields when calling `cli.AdditionalCommands()`. This will ensure that the user is prompted to enter the `client-id` and `client-secret` during interactive setup of a Windows Service and added to `config.yaml`. All other default fields are ignored during the setup.

If `client-id` and `client-secret` are missing from `config.yaml`, the Windows Service will fail to start.

Context:
When deciding which fields to prompt for, we filter out all default fields except `client-id` and `client-secret`. But we don't send the default fields, so they are never included.
https://github.com/ConductorOne/baton-sdk/blob/20f8c9acd100494063faa85c0704f35c810cc944/pkg/cli/service_windows.go#L282-L285

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated CLI command registration to ensure that only unique, properly filtered configuration fields are applied, contributing to a more consistent and streamlined command-line experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->