### PR TITLE
make NewConnectorClient public

### DIFF
--- a/pkg/connectorclient/connectorclient.go
+++ b/pkg/connectorclient/connectorclient.go
@@ -1,0 +1,15 @@
+package connectorclient
+
+import (
+	"context"
+
+	"github.com/conductorone/baton-sdk/internal/connector"
+	"github.com/conductorone/baton-sdk/pkg/types"
+	"google.golang.org/grpc"
+)
+
+// NewConnectorClient takes a grpc.ClientConnInterface and returns an implementation of the ConnectorClient interface.
+// Note: lambda functions directly instantiate the connector client, so this function is not used in this package.
+func NewConnectorClient(ctx context.Context, cc grpc.ClientConnInterface) types.ConnectorClient {
+	return connector.NewConnectorClient(ctx, cc)
+}


### PR DESCRIPTION
for the lambda invoker, which directly makes a grpc client, and is currently copy pasting this code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new mechanism for initializing the connector client, enabling direct instantiation to streamline connectivity processes for enhanced integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->