### PR TITLE
Include ratelimit headers in debug logs

### DIFF
--- a/pkg/uhttp/transport.go
+++ b/pkg/uhttp/transport.go
@@ -15,6 +15,27 @@ import (
 	"golang.org/x/net/http2"
 )
 
+var loggedResponseHeaders = []string{
+	// Limit headers
+	"X-Ratelimit-Limit",
+	"Ratelimit-Limit",
+	"X-RateLimit-Requests-Limit", // Linear uses a non-standard header
+	"X-Rate-Limit-Limit",         // Okta uses a non-standard header
+
+	// Remaining headers
+	"X-Ratelimit-Remaining",
+	"Ratelimit-Remaining",
+	"X-RateLimit-Requests-Remaining", // Linear uses a non-standard header
+	"X-Rate-Limit-Remaining",         // Okta uses a non-standard header
+
+	// Reset headers
+	"X-Ratelimit-Reset",
+	"Ratelimit-Reset",
+	"X-RateLimit-Requests-Reset", // Linear uses a non-standard header
+	"X-Rate-Limit-Reset",         // Okta uses a non-standard header
+	"Retry-After",                // Often returned with 429
+}
+
 // NewTransport creates a new Transport, applies the options, and then cycles the transport.
 func NewTransport(ctx context.Context, options ...Option) (*Transport, error) {
 	t := newTransport()
@@ -136,6 +157,15 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 		if resp != nil {
 			fields = append(fields, zap.Int("http.status_code", resp.StatusCode))
+
+			headers := make(map[string][]string, len(resp.Header))
+			for _, header := range loggedResponseHeaders {
+				if v := resp.Header.Values(header); len(v) > 0 {
+					headers[header] = v
+				}
+			}
+
+			fields = append(fields, zap.Any("http.headers", headers))
 		}
 
 		t.l(ctx).Debug("Request complete", fields...)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced HTTP logging to include key response headers related to rate limiting and retry information for improved visibility during requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->