### PR TITLE
wal is durable enough, better concurrency for sqlite journal

### DIFF
--- a/pkg/dotc1z/manager/local/local.go
+++ b/pkg/dotc1z/manager/local/local.go
@@ -97,7 +97,7 @@ func (l *localManager) LoadC1Z(ctx context.Context) (*dotc1z.C1File, error) {
 		zap.String("temp_path", l.tmpPath),
 	)
 
-	return dotc1z.NewC1ZFile(ctx, l.tmpPath, dotc1z.WithTmpDir(l.tmpDir), dotc1z.WithPragma("journal_mode", "WAL"))
+	return dotc1z.NewC1ZFile(ctx, l.tmpPath, dotc1z.WithTmpDir(l.tmpDir), dotc1z.WithPragma("journal_mode", "WAL"), dotc1z.WithPragma("synchronous", "NORMAL"))
 }
 
 // SaveC1Z saves the C1Z file to the local file system.

--- a/pkg/dotc1z/manager/s3/s3.go
+++ b/pkg/dotc1z/manager/s3/s3.go
@@ -116,7 +116,7 @@ func (s *s3Manager) LoadC1Z(ctx context.Context) (*dotc1z.C1File, error) {
 		return nil, err
 	}
 
-	return dotc1z.NewC1ZFile(ctx, s.tmpFile, dotc1z.WithTmpDir(s.tmpDir))
+	return dotc1z.NewC1ZFile(ctx, s.tmpFile, dotc1z.WithTmpDir(s.tmpDir), dotc1z.WithPragma("journal_mode", "WAL"))
 }
 
 // SaveC1Z saves a file to the AWS S3 bucket.

--- a/pkg/dotc1z/manager/s3/s3.go
+++ b/pkg/dotc1z/manager/s3/s3.go
@@ -116,7 +116,7 @@ func (s *s3Manager) LoadC1Z(ctx context.Context) (*dotc1z.C1File, error) {
 		return nil, err
 	}
 
-	return dotc1z.NewC1ZFile(ctx, s.tmpFile, dotc1z.WithTmpDir(s.tmpDir), dotc1z.WithPragma("journal_mode", "WAL"))
+	return dotc1z.NewC1ZFile(ctx, s.tmpFile, dotc1z.WithTmpDir(s.tmpDir), dotc1z.WithPragma("journal_mode", "WAL"), dotc1z.WithPragma("synchronous", "NORMAL"))
 }
 
 // SaveC1Z saves a file to the AWS S3 bucket.


### PR DESCRIPTION
For SQLITE.  Enable WAL Journal (and sync NORMAL( When you enable WAL journal.  Which allows some concurrency and will reduce time waiting on locks while maintaining a very safe level of durability.  Conservative estimate is we'll spend half as much time waiting on locks. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated internal database settings to improve performance and reliability. No changes to user-facing features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->