### PR TITLE
[BB-700] Just log a warning if connector can't create debug.log

### DIFF
--- a/pkg/connectorrunner/runner.go
+++ b/pkg/connectorrunner/runner.go
@@ -53,7 +53,6 @@ func (c *connectorRunner) Run(ctx context.Context) error {
 		var err error
 		tempDir := c.tasks.GetTempDir()
 		if tempDir == "" {
-			// Obtener el directorio de trabajo actual
 			wd, err := os.Getwd()
 			if err != nil {
 				l.Info("unable to get the current working directory")

--- a/pkg/connectorrunner/runner.go
+++ b/pkg/connectorrunner/runner.go
@@ -45,20 +45,25 @@ var ErrSigTerm = errors.New("context cancelled by process shutdown")
 
 // Run starts a connector and creates a new C1Z file.
 func (c *connectorRunner) Run(ctx context.Context) error {
+	l := ctxzap.Extract(ctx)
 	ctx, cancel := context.WithCancelCause(ctx)
 	defer cancel(ErrSigTerm)
 
 	if c.tasks.ShouldDebug() && c.debugFile == nil {
 		var err error
-		c.debugFile, err = os.Create(filepath.Join(c.tasks.GetTempDir(), "debug.log"))
+		tempDir := c.tasks.GetTempDir()
+		if tempDir == "" {
+			l.Warn("no temporal folder found on this system according to our task manager")
+		}
+		debugFile := filepath.Join(tempDir, "debug.log")
+		c.debugFile, err = os.Create(debugFile)
 		if err != nil {
-			return err
+			l.Warn("cannot create file", zap.String("full file path", debugFile))
 		}
 	}
 
 	// modify the context to insert a logger directed to a file
 	if c.debugFile != nil {
-		l := ctxzap.Extract(ctx)
 		writeSyncer := zapcore.AddSync(c.debugFile)
 		encoder := zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig())
 		core := zapcore.NewCore(encoder, writeSyncer, zapcore.DebugLevel)
@@ -102,6 +107,7 @@ func (c *connectorRunner) handleContextCancel(ctx context.Context) error {
 	l.Debug("runner: unexpected context cancellation", zap.Error(err))
 	return err
 }
+
 func (c *connectorRunner) processTask(ctx context.Context, task *v1.Task) error {
 	cc, err := c.cw.C(ctx)
 	if err != nil {
@@ -280,8 +286,7 @@ type rotateCredentialsConfig struct {
 	resourceType string
 }
 
-type eventStreamConfig struct {
-}
+type eventStreamConfig struct{}
 
 type syncDifferConfig struct {
 	baseSyncID    string
@@ -410,6 +415,7 @@ func WithOnDemandGrant(c1zPath string, entitlementID string, principalID string,
 		return nil
 	}
 }
+
 func WithClientCredentials(clientID string, clientSecret string) Option {
 	return func(ctx context.Context, cfg *runnerConfig) error {
 		cfg.clientID = clientID
@@ -474,6 +480,7 @@ func WithOnDemandSync(c1zPath string) Option {
 		return nil
 	}
 }
+
 func WithOnDemandEventStream() Option {
 	return func(ctx context.Context, cfg *runnerConfig) error {
 		cfg.onDemand = true

--- a/pkg/connectorrunner/runner.go
+++ b/pkg/connectorrunner/runner.go
@@ -55,8 +55,9 @@ func (c *connectorRunner) Run(ctx context.Context) error {
 		if tempDir == "" {
 			wd, err := os.Getwd()
 			if err != nil {
-				l.Info("unable to get the current working directory")
+				l.Warn("unable to get the current working directory", zap.Error(err))
 			}
+
 			if wd != "" {
 				l.Warn("no temporal folder found on this system according to our task manager,"+
 					" we may create files in the current working directory by mistake as a result",
@@ -68,7 +69,7 @@ func (c *connectorRunner) Run(ctx context.Context) error {
 		debugFile := filepath.Join(tempDir, "debug.log")
 		c.debugFile, err = os.Create(debugFile)
 		if err != nil {
-			l.Warn("cannot create file", zap.String("full file path", debugFile))
+			l.Warn("cannot create file", zap.String("full file path", debugFile), zap.Error(err))
 		}
 	}
 

--- a/pkg/connectorrunner/runner.go
+++ b/pkg/connectorrunner/runner.go
@@ -53,7 +53,18 @@ func (c *connectorRunner) Run(ctx context.Context) error {
 		var err error
 		tempDir := c.tasks.GetTempDir()
 		if tempDir == "" {
-			l.Warn("no temporal folder found on this system according to our task manager")
+			// Obtener el directorio de trabajo actual
+			wd, err := os.Getwd()
+			if err != nil {
+				l.Info("unable to get the current working directory")
+			}
+			if wd != "" {
+				l.Warn("no temporal folder found on this system according to our task manager,"+
+					" we may create files in the current working directory by mistake as a result",
+					zap.String("current working directory", wd))
+			} else {
+				l.Warn("no temporal folder found on this system according to our task manager")
+			}
 		}
 		debugFile := filepath.Join(tempDir, "debug.log")
 		c.debugFile, err = os.Create(debugFile)

--- a/pkg/tasks/c1api/full_sync.go
+++ b/pkg/tasks/c1api/full_sync.go
@@ -206,14 +206,12 @@ func uploadDebugLogs(ctx context.Context, helper fullSyncHelpers) error {
 		switch {
 		case errors.Is(err, os.ErrNotExist):
 			l.Warn("debug log file does not exists", zap.Error(err))
-			return nil
 		case errors.Is(err, os.ErrPermission):
 			l.Warn("debug log file cannot be stat'd due to lack of permissions", zap.Error(err))
-			return nil
 		default:
 			l.Warn("cannot stat debug log file", zap.Error(err))
-			return nil
 		}
+		return nil
 	} else {
 		debugfile, err := os.Open(debugfilelocation)
 		if err != nil {

--- a/pkg/tasks/c1api/full_sync.go
+++ b/pkg/tasks/c1api/full_sync.go
@@ -189,7 +189,7 @@ func uploadDebugLogs(ctx context.Context, helper fullSyncHelpers) error {
 	if tempDir == "" {
 		wd, err := os.Getwd()
 		if err != nil {
-			l.Info("unable to get the current working directory")
+			l.Warn("unable to get the current working directory", zap.Error(err))
 		}
 		if wd != "" {
 			l.Warn("no temporal folder found on this system according to our sync helper,"+

--- a/pkg/tasks/c1api/full_sync.go
+++ b/pkg/tasks/c1api/full_sync.go
@@ -185,15 +185,35 @@ func uploadDebugLogs(ctx context.Context, helper fullSyncHelpers) error {
 
 	l := ctxzap.Extract(ctx)
 
-	debugfilelocation := filepath.Join(helper.TempDir(), "debug.log")
+	tempDir := helper.TempDir()
+	if tempDir == "" {
+		wd, err := os.Getwd()
+		if err != nil {
+			l.Info("unable to get the current working directory")
+		}
+		if wd != "" {
+			l.Warn("no temporal folder found on this system according to our sync helper,"+
+				" we may create files in the current working directory by mistake as a result",
+				zap.String("current working directory", wd))
+		} else {
+			l.Warn("no temporal folder found on this system according to our sync helper")
+		}
+	}
+	debugfilelocation := filepath.Join(tempDir, "debug.log")
 
 	_, err := os.Stat(debugfilelocation)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
+		switch {
+		case errors.Is(err, os.ErrNotExist):
 			l.Warn("debug log file does not exists", zap.Error(err))
 			return nil
+		case errors.Is(err, os.ErrPermission):
+			l.Warn("debug log file cannot be stat'd due to lack of permissions", zap.Error(err))
+			return nil
+		default:
+			l.Warn("cannot stat debug log file", zap.Error(err))
+			return nil
 		}
-		return err
 	} else {
 		debugfile, err := os.Open(debugfilelocation)
 		if err != nil {
@@ -203,7 +223,6 @@ func uploadDebugLogs(ctx context.Context, helper fullSyncHelpers) error {
 
 		l.Info("uploading debug logs", zap.String("file", debugfilelocation))
 		err = helper.Upload(ctx, debugfile)
-
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR should stop connectors from failing if the file to output debugging information cannot be created. Also, some information about the system is collected (the current working directory) because the connector may be looking to create it somewhere where it should

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of debug log file creation and upload with fallback to the current directory and clearer warnings when the temporary directory is unavailable.

- **Style**
  - Enhanced code formatting for consistency, including blank lines and struct declaration style.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->