### PR TITLE
Fetch related resources for grants.

### DIFF
--- a/pkg/connectorbuilder/connectorbuilder.go
+++ b/pkg/connectorbuilder/connectorbuilder.go
@@ -650,7 +650,7 @@ func (b *builderImpl) GetResource(ctx context.Context, request *v2.ResourceGette
 	rb, ok := b.resourceTargetedSyncers[resourceType]
 	if !ok {
 		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start))
-		return nil, fmt.Errorf("error: get resource with unknown resource type %s", resourceType)
+		return nil, status.Errorf(codes.Unimplemented, "error: get resource with unknown resource type %s", resourceType)
 	}
 
 	resource, annos, err := rb.Get(ctx, request.GetResourceId(), request.GetParentResourceId())

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -409,6 +409,7 @@ func (s *syncer) Sync(ctx context.Context) error {
 						ParentResourceTypeID: r.GetParentResourceId().GetResourceType(),
 					})
 				}
+				s.state.SetShouldFetchRelatedResources()
 				s.state.PushAction(ctx, Action{Op: SyncResourceTypesOp})
 				err = s.Checkpoint(ctx, true)
 				if err != nil {
@@ -1522,6 +1523,10 @@ func (s *syncer) syncGrantsForResource(ctx context.Context, resourceID *v2.Resou
 		}
 		if grantAnnos.ContainsAny(&v2.ExternalResourceMatchAll{}, &v2.ExternalResourceMatch{}, &v2.ExternalResourceMatchID{}) {
 			s.state.SetHasExternalResourcesGrants()
+		}
+
+		if !s.state.ShouldFetchRelatedResources() {
+			continue
 		}
 		// Some connectors emit grants for other resources. If we're doing a partial sync, check if it exists and queue a fetch if not.
 		entitlementResource := grant.GetEntitlement().GetResource()

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -661,7 +661,7 @@ func (s *syncer) getSubResources(ctx context.Context, parent *v2.Resource) error
 	return nil
 }
 
-func (s *syncer) getResource(ctx context.Context, resourceID *v2.ResourceId, parentResourceID *v2.ResourceId) (*v2.Resource, error) {
+func (s *syncer) getResourceFromConnector(ctx context.Context, resourceID *v2.ResourceId, parentResourceID *v2.ResourceId) (*v2.Resource, error) {
 	ctx, span := tracer.Start(ctx, "syncer.getResource")
 	defer span.End()
 
@@ -706,7 +706,7 @@ func (s *syncer) SyncTargetedResource(ctx context.Context) error {
 		}
 	}
 
-	resource, err := s.getResource(ctx, &v2.ResourceId{
+	resource, err := s.getResourceFromConnector(ctx, &v2.ResourceId{
 		ResourceType: resourceTypeID,
 		Resource:     resourceID,
 	}, prID)
@@ -1567,7 +1567,7 @@ func (s *syncer) syncGrantsForResource(ctx context.Context, resourceID *v2.Resou
 
 			erId := entitlementResource.GetId()
 			prId := entitlementResource.GetParentResourceId()
-			resource, err := s.getResource(ctx, erId, prId)
+			resource, err := s.getResourceFromConnector(ctx, erId, prId)
 			if err != nil {
 				l.Error("error fetching entitlement resource", zap.Error(err))
 				return err
@@ -1590,7 +1590,7 @@ func (s *syncer) syncGrantsForResource(ctx context.Context, resourceID *v2.Resou
 			}
 
 			// Principal resource is not in the DB, so try to fetch it from the connector.
-			resource, err := s.getResource(ctx, principalResource.GetId(), principalResource.GetParentResourceId())
+			resource, err := s.getResourceFromConnector(ctx, principalResource.GetId(), principalResource.GetParentResourceId())
 			if err != nil {
 				l.Error("error fetching principal resource", zap.Error(err))
 				return err


### PR DESCRIPTION
TODO:

- [x] Only do this for partial syncs.
~- [ ] Maybe cache notfounds so we're not constantly calling GetResource for the same resource over and over?~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of partial syncs by ensuring related resources referenced by grants are present or queued for syncing.
  - Enhanced handling of missing or unsupported resources during synchronization to prevent interruptions.
  - Standardized error reporting for unsupported resource types to improve client error interpretation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->