### PR TITLE
Call init in NewC1File, as we always want to run migrations.

### DIFF
--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -93,6 +93,11 @@ func NewC1File(ctx context.Context, dbFilePath string, opts ...C1FOption) (*C1Fi
 		return nil, err
 	}
 
+	err = c1File.init(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	return c1File, nil
 }
 
@@ -140,11 +145,6 @@ func NewC1ZFile(ctx context.Context, outputFilePath string, opts ...C1ZOption) (
 	}
 
 	c1File.outputFilePath = outputFilePath
-
-	err = c1File.init(ctx)
-	if err != nil {
-		return nil, err
-	}
 
 	return c1File, nil
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved consistency and reliability of database initialization during file creation. Initialization logic is now always executed when creating new files, ensuring proper setup and reducing redundancy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->