### PR TITLE
Add sorting and pretty printing to config schema command

### DIFF
--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -562,30 +562,6 @@ func MakeConfigSchemaCommand[T field.Configurable](
 			return confschema.Fields[i].FieldName < confschema.Fields[j].FieldName
 		})
 
-		// Sort fields within each relationship
-		for i := range confschema.Constraints {
-			// Sort Fields
-			sort.Slice(confschema.Constraints[i].Fields, func(x, y int) bool {
-				return confschema.Constraints[i].Fields[x].FieldName < confschema.Constraints[i].Fields[y].FieldName
-			})
-			// Sort ExpectedFields
-			sort.Slice(confschema.Constraints[i].ExpectedFields, func(x, y int) bool {
-				return confschema.Constraints[i].ExpectedFields[x].FieldName < confschema.Constraints[i].ExpectedFields[y].FieldName
-			})
-		}
-
-		// Sort constraints by Kind by their enum values, then by first field name if available
-		sort.Slice(confschema.Constraints, func(i, j int) bool {
-			if confschema.Constraints[i].Kind != confschema.Constraints[j].Kind {
-				return confschema.Constraints[i].Kind < confschema.Constraints[j].Kind
-			}
-			// If same kind, sort by first field name if available
-			if len(confschema.Constraints[i].Fields) > 0 && len(confschema.Constraints[j].Fields) > 0 {
-				return confschema.Constraints[i].Fields[0].FieldName < confschema.Constraints[j].Fields[0].FieldName
-			}
-			return false
-		})
-
 		// Use MarshalIndent for pretty printing
 		pb, err := json.MarshalIndent(&confschema, "", "  ")
 		if err != nil {

--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"time"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
@@ -556,7 +557,37 @@ func MakeConfigSchemaCommand[T field.Configurable](
 	getconnector GetConnectorFunc[T],
 ) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		pb, err := json.Marshal(&confschema)
+		// Sort fields by FieldName
+		sort.Slice(confschema.Fields, func(i, j int) bool {
+			return confschema.Fields[i].FieldName < confschema.Fields[j].FieldName
+		})
+
+		// Sort fields within each relationship
+		for i := range confschema.Constraints {
+			// Sort Fields
+			sort.Slice(confschema.Constraints[i].Fields, func(x, y int) bool {
+				return confschema.Constraints[i].Fields[x].FieldName < confschema.Constraints[i].Fields[y].FieldName
+			})
+			// Sort ExpectedFields
+			sort.Slice(confschema.Constraints[i].ExpectedFields, func(x, y int) bool {
+				return confschema.Constraints[i].ExpectedFields[x].FieldName < confschema.Constraints[i].ExpectedFields[y].FieldName
+			})
+		}
+
+		// Sort constraints by Kind by their enum values, then by first field name if available
+		sort.Slice(confschema.Constraints, func(i, j int) bool {
+			if confschema.Constraints[i].Kind != confschema.Constraints[j].Kind {
+				return confschema.Constraints[i].Kind < confschema.Constraints[j].Kind
+			}
+			// If same kind, sort by first field name if available
+			if len(confschema.Constraints[i].Fields) > 0 && len(confschema.Constraints[j].Fields) > 0 {
+				return confschema.Constraints[i].Fields[0].FieldName < confschema.Constraints[j].Fields[0].FieldName
+			}
+			return false
+		})
+
+		// Use MarshalIndent for pretty printing
+		pb, err := json.MarshalIndent(&confschema, "", "  ")
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Configuration schema JSON output is now sorted and formatted for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->