### PR TITLE
use ctx when init otel

### DIFF
--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -327,7 +327,7 @@ func initOtel(ctx context.Context, name string, v *viper.Viper, initialLogFields
 		otelOpts = append(otelOpts, uotel.WithOtelEndpoint(otelEndpoint, otelTLSCertPath, otelTLSCert))
 	}
 
-	return uotel.InitOtel(context.Background(), otelOpts...)
+	return uotel.InitOtel(ctx, otelOpts...)
 }
 
 func MakeGRPCServerCommand[T field.Configurable](

--- a/pkg/cli/lambda_server__added.go
+++ b/pkg/cli/lambda_server__added.go
@@ -74,7 +74,7 @@ func OptionallyAddLambdaCommand[T field.Configurable](
 			return err
 		}
 
-		runCtx, otelShutdown, err := initOtel(context.Background(), name, v, initalLogFields)
+		runCtx, otelShutdown, err := initOtel(runCtx, name, v, initalLogFields)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Use the ctx for init logging 
Confirmed debug logs show up in cloudwatch for lambda connectors with this change 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved context propagation for OpenTelemetry initialization to ensure consistent use of the caller's context throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->