### PR TITLE
Ignore errors when parsing bad datetimes in rate limit headers.

### DIFF
--- a/pkg/ratelimit/http.go
+++ b/pkg/ratelimit/http.go
@@ -104,7 +104,7 @@ func ExtractRateLimitData(statusCode int, header *http.Header) (*v2.RateLimitDes
 		if resetAtStr != "" {
 			resetAt, err = parseTime(resetAtStr)
 			if err != nil {
-				return nil, err
+				continue
 			}
 			break
 		}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed rate limit reset time headers to ensure the application continues processing other available headers without interruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->