### PR TITLE
Add retries to ListTicketSchemas

### DIFF
--- a/pkg/connectorbuilder/connectorbuilder.go
+++ b/pkg/connectorbuilder/connectorbuilder.go
@@ -325,25 +325,36 @@ func (b *builderImpl) ListTicketSchemas(ctx context.Context, request *v2.Tickets
 		return nil, fmt.Errorf("error: ticket manager not implemented")
 	}
 
-	out, nextPageToken, annos, err := b.ticketManager.ListTicketSchemas(ctx, &pagination.Token{
-		Size:  int(request.PageSize),
-		Token: request.PageToken,
+	retryer := retry.NewRetryer(ctx, retry.RetryConfig{
+		MaxAttempts:  3,
+		InitialDelay: 15 * time.Second,
+		MaxDelay:     60 * time.Second,
 	})
-	if err != nil {
+
+	for {
+		out, nextPageToken, annos, err := b.ticketManager.ListTicketSchemas(ctx, &pagination.Token{
+			Size:  int(request.PageSize),
+			Token: request.PageToken,
+		})
+		if err == nil {
+			if request.PageToken != "" && request.PageToken == nextPageToken {
+				b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start))
+				return nil, fmt.Errorf("error: listing ticket schemas failed: next page token is the same as the current page token. this is most likely a connector bug")
+			}
+
+			b.m.RecordTaskSuccess(ctx, tt, b.nowFunc().Sub(start))
+			return &v2.TicketsServiceListTicketSchemasResponse{
+				List:          out,
+				NextPageToken: nextPageToken,
+				Annotations:   annos,
+			}, nil
+		}
+		if retryer.ShouldWaitAndRetry(ctx, err) {
+			continue
+		}
 		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start))
 		return nil, fmt.Errorf("error: listing ticket schemas failed: %w", err)
 	}
-	if request.PageToken != "" && request.PageToken == nextPageToken {
-		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start))
-		return nil, fmt.Errorf("error: listing ticket schemas failed: next page token is the same as the current page token. this is most likely a connector bug")
-	}
-
-	b.m.RecordTaskSuccess(ctx, tt, b.nowFunc().Sub(start))
-	return &v2.TicketsServiceListTicketSchemasResponse{
-		List:          out,
-		NextPageToken: nextPageToken,
-		Annotations:   annos,
-	}, nil
 }
 
 func (b *builderImpl) CreateTicket(ctx context.Context, request *v2.TicketsServiceCreateTicketRequest) (*v2.TicketsServiceCreateTicketResponse, error) {

--- a/pkg/connectorbuilder/connectorbuilder.go
+++ b/pkg/connectorbuilder/connectorbuilder.go
@@ -326,9 +326,9 @@ func (b *builderImpl) ListTicketSchemas(ctx context.Context, request *v2.Tickets
 	}
 
 	retryer := retry.NewRetryer(ctx, retry.RetryConfig{
-		MaxAttempts:  3,
+		MaxAttempts:  0,
 		InitialDelay: 15 * time.Second,
-		MaxDelay:     60 * time.Second,
+		MaxDelay:     0,
 	})
 
 	for {

--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -52,23 +52,7 @@ func (r *Retryer) ShouldWaitAndRetry(ctx context.Context, err error) bool {
 		r.attempts = 0
 		return true
 	}
-
-	// Check if error contains rate limit data
-	hasRateLimitData := false
-	if st, ok := status.FromError(err); ok {
-		details := st.Details()
-		for _, detail := range details {
-			if _, ok := detail.(*v2.RateLimitDescription); ok {
-				hasRateLimitData = true
-				break
-			}
-		}
-	}
-
-	// Retry on Unavailable, DeadlineExceeded, ResourceExhausted, or Unknown with rate limit data
-	if status.Code(err) != codes.Unavailable && status.Code(err) != codes.DeadlineExceeded &&
-		status.Code(err) != codes.ResourceExhausted &&
-		!(status.Code(err) == codes.Unknown && hasRateLimitData) {
+	if status.Code(err) != codes.Unavailable && status.Code(err) != codes.DeadlineExceeded {
 		return false
 	}
 

--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -52,7 +52,23 @@ func (r *Retryer) ShouldWaitAndRetry(ctx context.Context, err error) bool {
 		r.attempts = 0
 		return true
 	}
-	if status.Code(err) != codes.Unavailable && status.Code(err) != codes.DeadlineExceeded {
+
+	// Check if error contains rate limit data
+	hasRateLimitData := false
+	if st, ok := status.FromError(err); ok {
+		details := st.Details()
+		for _, detail := range details {
+			if _, ok := detail.(*v2.RateLimitDescription); ok {
+				hasRateLimitData = true
+				break
+			}
+		}
+	}
+
+	// Retry on Unavailable, DeadlineExceeded, ResourceExhausted, or Unknown with rate limit data
+	if status.Code(err) != codes.Unavailable && status.Code(err) != codes.DeadlineExceeded &&
+		status.Code(err) != codes.ResourceExhausted &&
+		!(status.Code(err) == codes.Unknown && hasRateLimitData) {
 		return false
 	}
 


### PR DESCRIPTION
This PR adds support for handling rate limits occurring when attempting to get ticket schemas. Making this change in the sdk supports [this ticket](https://conductorone.atlassian.net/browse/BB-1129) for Linear.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of ticket schema listing by adding automatic retry logic for failed attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->