### PR TITLE
fix typo for role trait

### DIFF
--- a/pkg/types/resource/role_trait.go
+++ b/pkg/types/resource/role_trait.go
@@ -46,7 +46,7 @@ func GetRoleTrait(resource *v2.Resource) (*v2.RoleTrait, error) {
 		return nil, err
 	}
 	if !ok {
-		return nil, fmt.Errorf("group trait was not found on resource")
+		return nil, fmt.Errorf("role trait was not found on resource")
 	}
 
 	return ret, nil


### PR DESCRIPTION
Fix typo for rule trait error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected an error message to accurately state when a role trait is not found on a resource.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->