### PR TITLE
aws lambda start with context 

### DIFF
--- a/pkg/cli/lambda_server__added.go
+++ b/pkg/cli/lambda_server__added.go
@@ -95,7 +95,7 @@ func OptionallyAddLambdaCommand[T field.Configurable](
 		}
 
 		client, webKey, err := c1_lambda_config.GetConnectorConfigServiceClient(
-			ctx,
+			runCtx,
 			v.GetString(field.LambdaServerClientIDField.GetName()),
 			v.GetString(field.LambdaServerClientSecretField.GetName()),
 		)
@@ -104,7 +104,7 @@ func OptionallyAddLambdaCommand[T field.Configurable](
 		}
 
 		// Get configuration, convert it to viper flag values, then proceed.
-		config, err := client.GetConnectorConfig(ctx, &pb_connector_api.GetConnectorConfigRequest{})
+		config, err := client.GetConnectorConfig(runCtx, &pb_connector_api.GetConnectorConfigRequest{})
 		if err != nil {
 			return fmt.Errorf("lambda-run: failed to get connector config: %w", err)
 		}
@@ -178,9 +178,9 @@ func OptionallyAddLambdaCommand[T field.Configurable](
 		}
 
 		s := c1_lambda_grpc.NewServer(authOpt)
-		connector.Register(ctx, s, c, opts)
+		connector.Register(runCtx, s, c, opts)
 
-		aws_lambda.Start(s.Handler)
+		aws_lambda.StartWithOptions(s.Handler, aws_lambda.WithContext(runCtx))
 		return nil
 	}
 	return nil


### PR DESCRIPTION
use context with aws lambda start options for ctx logger 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved consistency by ensuring enhanced logging and telemetry context is used throughout the Lambda server command lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->