### PR TITLE
Allow running actions from the CLI.

### DIFF
--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -195,7 +195,7 @@ func MakeMainCommand[T field.Configurable](
 				}
 				invokeActionArgsStruct, err := structpb.NewStruct(invokeActionArgs)
 				if err != nil {
-					return err
+					return fmt.Errorf("failed to parse invoke-action-args: %w", err)
 				}
 				opts = append(opts,
 					connectorrunner.WithActionsEnabled(),

--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -190,9 +190,6 @@ func MakeMainCommand[T field.Configurable](
 					))
 			case v.GetString("invoke-action") != "":
 				invokeActionArgs := v.GetStringMap("invoke-action-args")
-				if invokeActionArgs == nil {
-					return fmt.Errorf("invoke-action-args is empty or incorrectly formatted: %v", v.GetString("invoke-action-args"))
-				}
 				invokeActionArgsStruct, err := structpb.NewStruct(invokeActionArgs)
 				if err != nil {
 					return fmt.Errorf("failed to parse invoke-action-args: %w", err)

--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -188,6 +188,22 @@ func MakeMainCommand[T field.Configurable](
 						v.GetString("create-account-email"),
 						profile,
 					))
+			case v.GetString("invoke-action") != "":
+				invokeActionArgs := v.GetStringMap("invoke-action-args")
+				if invokeActionArgs == nil {
+					return fmt.Errorf("invoke-action-args is empty or incorrectly formatted: %v", v.GetString("invoke-action-args"))
+				}
+				invokeActionArgsStruct, err := structpb.NewStruct(invokeActionArgs)
+				if err != nil {
+					return err
+				}
+				opts = append(opts,
+					connectorrunner.WithActionsEnabled(),
+					connectorrunner.WithOnDemandInvokeAction(
+						v.GetString("file"),
+						v.GetString("invoke-action"),
+						invokeActionArgsStruct,
+					))
 			case v.GetString("delete-resource") != "":
 				opts = append(opts,
 					connectorrunner.WithProvisioningEnabled(),

--- a/pkg/field/defaults.go
+++ b/pkg/field/defaults.go
@@ -132,7 +132,7 @@ var (
 		WithPersistent(true),
 		WithExportTarget(ExportTargetNone),
 	)
-	invokeActionArgsField = StringField("invoke-action-args",
+	invokeActionArgsField = StringMapField("invoke-action-args",
 		WithHidden(true),
 		WithDescription("JSON-formatted object of map keys and values like '{ 'key': 'value' }'"),
 		WithDefaultValue(map[string]any{}),

--- a/pkg/field/defaults.go
+++ b/pkg/field/defaults.go
@@ -126,6 +126,17 @@ var (
 		WithExportTarget(ExportTargetNone),
 	)
 
+	invokeActionField = StringField("invoke-action",
+		WithDescription("The name of the custom action to invoke"),
+		WithHidden(true),
+		WithPersistent(true),
+		WithExportTarget(ExportTargetNone),
+	)
+	invokeActionArgsField = StringField("invoke-action-args",
+		WithHidden(true),
+		WithDescription("JSON-formatted object of map keys and values like '{ 'key': 'value' }'"),
+		WithPersistent(true), WithExportTarget(ExportTargetNone))
+
 	otelCollectorEndpoint = StringField(OtelCollectorEndpointFieldName,
 		WithDescription("The endpoint of the OpenTelemetry collector to send observability data to (used for both tracing and logging if specific endpoints are not provided)"),
 		WithPersistent(true), WithExportTarget(ExportTargetOps))
@@ -242,6 +253,8 @@ var DefaultFields = []SchemaField{
 	compactFilePathsField,
 	compactOutputDirectoryField,
 	compactSyncsField,
+	invokeActionField,
+	invokeActionArgsField,
 
 	otelCollectorEndpoint,
 	otelCollectorEndpointTLSCertPath,

--- a/pkg/field/defaults.go
+++ b/pkg/field/defaults.go
@@ -135,7 +135,10 @@ var (
 	invokeActionArgsField = StringField("invoke-action-args",
 		WithHidden(true),
 		WithDescription("JSON-formatted object of map keys and values like '{ 'key': 'value' }'"),
-		WithPersistent(true), WithExportTarget(ExportTargetNone))
+		WithDefaultValue(map[string]any{}),
+		WithPersistent(true),
+		WithExportTarget(ExportTargetNone),
+	)
 
 	otelCollectorEndpoint = StringField(OtelCollectorEndpointFieldName,
 		WithDescription("The endpoint of the OpenTelemetry collector to send observability data to (used for both tracing and logging if specific endpoints are not provided)"),

--- a/pkg/field/fields.go
+++ b/pkg/field/fields.go
@@ -8,7 +8,7 @@ import (
 	v1_conf "github.com/conductorone/baton-sdk/pb/c1/config/v1"
 )
 
-var WrongValueTypeErr = errors.New("unable to cast any to concrete type")
+var ErrWrongValueType = errors.New("unable to cast any to concrete type")
 
 type Variant string
 
@@ -128,31 +128,31 @@ func (s SchemaField) validate(value any) (bool, error) {
 	case StringVariant:
 		v, ok := value.(string)
 		if !ok {
-			return false, WrongValueTypeErr
+			return false, ErrWrongValueType
 		}
 		return v != "", ValidateStringRules(s.Rules.s, v, s.FieldName)
 	case BoolVariant:
 		v, ok := value.(bool)
 		if !ok {
-			return false, WrongValueTypeErr
+			return false, ErrWrongValueType
 		}
 		return v, ValidateBoolRules(s.Rules.b, v, s.FieldName)
 	case IntVariant:
 		v, ok := value.(int)
 		if !ok {
-			return false, WrongValueTypeErr
+			return false, ErrWrongValueType
 		}
 		return v != 0, ValidateIntRules(s.Rules.i, v, s.FieldName)
 	case StringSliceVariant:
 		v, ok := value.([]string)
 		if !ok {
-			return false, WrongValueTypeErr
+			return false, ErrWrongValueType
 		}
 		return len(v) != 0, ValidateRepeatedStringRules(s.Rules.ss, v, s.FieldName)
 	case StringMapVariant:
 		v, ok := value.(map[string]any)
 		if !ok {
-			return false, WrongValueTypeErr
+			return false, ErrWrongValueType
 		}
 		return len(v) != 0, ValidateStringMapRules(s.Rules.sm, v, s.FieldName)
 	default:
@@ -168,7 +168,7 @@ func toUpperCase(i string) string {
 func GetDefaultValue[T SchemaTypes](s SchemaField) (*T, error) {
 	value, ok := s.DefaultValue.(T)
 	if !ok {
-		return nil, WrongValueTypeErr
+		return nil, ErrWrongValueType
 	}
 	return &value, nil
 }

--- a/pkg/field/struct_test.go
+++ b/pkg/field/struct_test.go
@@ -82,7 +82,10 @@ func TestConfiguration_MarshalJSON(t *testing.T) {
 				"description": "Field 5",
 				"stringMapField": {
 					"defaultValue": {
-						"key": "value"
+						"key": {
+							"@type": "type.googleapis.com/google.protobuf.Value",
+							"value": "value"
+						}
 					}
 				}
 			}

--- a/pkg/field/struct_test.go
+++ b/pkg/field/struct_test.go
@@ -24,8 +24,9 @@ func TestConfiguration_MarshalJSON(t *testing.T) {
 	intF := IntField("if", WithDescription("Field 2"), WithDefaultValue(42))
 	bf := BoolField("bf", WithDescription("Field 3"))
 	ssf := StringSliceField("ssf", WithDescription("Field 4"), WithDefaultValue([]string{"default"}))
+	smf := StringMapField("smf", WithDescription("Field 5"), WithDefaultValue(map[string]any{"key": "value"}))
 
-	fields := []SchemaField{ss, intF, bf, ssf}
+	fields := []SchemaField{ss, intF, bf, ssf, smf}
 	constraints := []SchemaFieldRelationship{
 		FieldsMutuallyExclusive(ss, intF),
 		FieldsRequiredTogether(bf, ssf),
@@ -74,6 +75,15 @@ func TestConfiguration_MarshalJSON(t *testing.T) {
 					"defaultValue": [
 						"default"
 					]
+				}
+			},
+			{
+				"name": "smf",
+				"description": "Field 5",
+				"stringMapField": {
+					"defaultValue": {
+						"key": "value"
+					}
 				}
 			}
 		],

--- a/pkg/tasks/local/action_invoker.go
+++ b/pkg/tasks/local/action_invoker.go
@@ -1,0 +1,82 @@
+package local
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	v1 "github.com/conductorone/baton-sdk/pb/c1/connectorapi/baton/v1"
+	"github.com/conductorone/baton-sdk/pkg/tasks"
+	"github.com/conductorone/baton-sdk/pkg/types"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+)
+
+type localActionInvoker struct {
+	dbPath string
+	o      sync.Once
+
+	action string
+	args   *structpb.Struct
+}
+
+func (m *localActionInvoker) GetTempDir() string {
+	return ""
+}
+
+func (m *localActionInvoker) ShouldDebug() bool {
+	return false
+}
+
+func (m *localActionInvoker) Next(ctx context.Context) (*v1.Task, time.Duration, error) {
+	var task *v1.Task
+	m.o.Do(func() {
+		task = &v1.Task{
+			TaskType: &v1.Task_ActionInvoke{
+				ActionInvoke: &v1.Task_ActionInvokeTask{
+					Name: m.action,
+					Args: m.args,
+				},
+			},
+		}
+	})
+	return task, 0, nil
+}
+
+func (m *localActionInvoker) Process(ctx context.Context, task *v1.Task, cc types.ConnectorClient) error {
+	l := ctxzap.Extract(ctx)
+	ctx, span := tracer.Start(ctx, "localActionInvoker.Process", trace.WithNewRoot())
+	defer span.End()
+
+	t := task.GetActionInvoke()
+	resp, err := cc.InvokeAction(ctx, &v2.InvokeActionRequest{
+		Name:        t.GetName(),
+		Args:        t.GetArgs(),
+		Annotations: t.GetAnnotations(),
+	})
+	if err != nil {
+		return err
+	}
+
+	l.Info("ActionInvoke response", zap.Any("resp", resp))
+
+	if resp.GetStatus() == v2.BatonActionStatus_BATON_ACTION_STATUS_FAILED {
+		return fmt.Errorf("action invoke failed: %v", resp.GetResponse())
+	}
+
+	return nil
+}
+
+// NewActionInvoker returns a task manager that queues an action invoke task.
+func NewActionInvoker(ctx context.Context, dbPath string, action string, args *structpb.Struct) tasks.Manager {
+	return &localActionInvoker{
+		dbPath: dbPath,
+		action: action,
+		args:   args,
+	}
+}


### PR DESCRIPTION
This will mostly be used to test custom actions in connectors.

To run a custom action, run with `--invoke-action=action_name --invoke-action-args='{...}'` (where action args are json).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for on-demand invocation of custom connector actions from the CLI, including the ability to pass arguments.
  * Introduced new CLI options and configuration fields to specify the action name and arguments in JSON format.
  * Enhanced task management to handle single-action invocation workflows with improved logging and tracing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->