### PR TITLE
Log bad XML response better.

### DIFF
--- a/pkg/uhttp/wrapper.go
+++ b/pkg/uhttp/wrapper.go
@@ -231,7 +231,7 @@ func WithXMLResponse(response interface{}) DoOption {
 		}
 		err := xml.Unmarshal(resp.Body, response)
 		if err != nil {
-			return fmt.Errorf("failed to unmarshal xml response: %w. body %v", err, resp.Body)
+			return fmt.Errorf("failed to unmarshal xml response: %w. body %s", err, string(resp.Body))
 		}
 		return nil
 	}


### PR DESCRIPTION
This logs the response body as a string instead of a slice of integers that correspond to the bytes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved formatting of error messages for XML response handling to display response content as readable text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->