### PR TITLE
Add log-level debug expires at field

### DIFF
--- a/pkg/cli/lambda_server__added.go
+++ b/pkg/cli/lambda_server__added.go
@@ -55,6 +55,13 @@ func OptionallyAddLambdaCommand[T field.Configurable](
 			return err
 		}
 
+		logLevel := v.GetString("log-level")
+		// Downgrade log level to "info" if debug mode has expired
+		debugModeExpiresAt := v.GetTime("log-level-debug-expires-at")
+		if logLevel == "debug" && !debugModeExpiresAt.IsZero() && time.Now().After(debugModeExpiresAt) {
+			logLevel = "info"
+		}
+
 		initalLogFields := map[string]interface{}{
 			"tenant":       os.Getenv("tenant"),
 			"connector":    os.Getenv("connector"),
@@ -67,7 +74,7 @@ func OptionallyAddLambdaCommand[T field.Configurable](
 			ctx,
 			name,
 			logging.WithLogFormat(v.GetString("log-format")),
-			logging.WithLogLevel(v.GetString("log-level")),
+			logging.WithLogLevel(logLevel),
 			logging.WithInitialFields(initalLogFields),
 		)
 		if err != nil {

--- a/pkg/field/defaults.go
+++ b/pkg/field/defaults.go
@@ -79,6 +79,10 @@ var (
 		WithPersistent(true), WithExportTarget(ExportTargetNone))
 	logLevelField = StringField("log-level", WithDefaultValue("info"), WithDescription("The log level: debug, info, warn, error"), WithPersistent(true),
 		WithExportTarget(ExportTargetOps))
+	logLevelDebugExpiresAtField = StringField("log-level-debug-expires-at",
+		WithDescription("The timestamp indicating when debug-level logging should expire"),
+		WithPersistent(true),
+		WithExportTarget(ExportTargetOps))
 	skipFullSync            = BoolField("skip-full-sync", WithDescription("This must be set to skip a full sync"), WithPersistent(true), WithExportTarget(ExportTargetNone))
 	targetedSyncResourceIDs = StringSliceField("sync-resources", WithDescription("The resource IDs to sync"), WithPersistent(true), WithExportTarget(ExportTargetNone))
 	diffSyncsField          = BoolField(
@@ -245,6 +249,7 @@ var DefaultFields = []SchemaField{
 	ticketIDField,
 	ticketTemplatePathField,
 	logLevelField,
+	logLevelDebugExpiresAtField,
 	skipFullSync,
 	targetedSyncResourceIDs,
 	externalResourceC1ZField,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for automatically downgrading log level from "debug" to "info" after a specified expiration time.
  * Introduced a new configuration field to set the expiration timestamp for debug-level logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->