### PR TITLE
dont retry ListTicketSchemas forever

### DIFF
--- a/pkg/connectorbuilder/connectorbuilder.go
+++ b/pkg/connectorbuilder/connectorbuilder.go
@@ -326,7 +326,7 @@ func (b *builderImpl) ListTicketSchemas(ctx context.Context, request *v2.Tickets
 	}
 
 	retryer := retry.NewRetryer(ctx, retry.RetryConfig{
-		MaxAttempts:  0,
+		MaxAttempts:  10,
 		InitialDelay: 15 * time.Second,
 		MaxDelay:     0,
 	})


### PR DESCRIPTION
This will retry for a few minutes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Limited the number of retry attempts to 10 when listing ticket schemas, improving reliability and preventing potential infinite retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->