### PR TITLE
Performance: Improve cycle detection by using DFS Coloring

### DIFF
--- a/pkg/sync/expand/cycle.go
+++ b/pkg/sync/expand/cycle.go
@@ -103,8 +103,6 @@ func (g *EntitlementGraph) GetFirstCycle() []int {
 
 func (g *EntitlementGraph) cycleDetectionHelper(
 	nodeID int,
-	visited map[int]bool,
-	currentCycle []int,
 ) ([]int, bool) {
 	// Thin wrapper around the coloring-based DFS, starting from a specific node.
 	// The provided visited/currentCycle are ignored here; coloring provides the

--- a/pkg/sync/expand/cycle_benchmark_test.go
+++ b/pkg/sync/expand/cycle_benchmark_test.go
@@ -115,8 +115,7 @@ func BenchmarkCycleDetectionHelper(b *testing.B) {
 			start := g.EntitlementsToNodes["1"]
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				visited := make(map[int]bool)
-				_, _ = g.cycleDetectionHelper(start, visited, []int{})
+				_, _ = g.cycleDetectionHelper(start)
 			}
 		})
 	}
@@ -127,8 +126,7 @@ func BenchmarkCycleDetectionHelper(b *testing.B) {
 			start := g.EntitlementsToNodes["1"]
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				visited := make(map[int]bool)
-				_, _ = g.cycleDetectionHelper(start, visited, []int{})
+				_, _ = g.cycleDetectionHelper(start)
 			}
 		})
 	}
@@ -138,8 +136,7 @@ func BenchmarkCycleDetectionHelper(b *testing.B) {
 		start := g.EntitlementsToNodes["1"]
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			visited := make(map[int]bool)
-			_, _ = g.cycleDetectionHelper(start, visited, []int{})
+			_, _ = g.cycleDetectionHelper(start)
 		}
 	})
 
@@ -148,8 +145,7 @@ func BenchmarkCycleDetectionHelper(b *testing.B) {
 		start := g.EntitlementsToNodes["1"]
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			visited := make(map[int]bool)
-			_, _ = g.cycleDetectionHelper(start, visited, []int{})
+			_, _ = g.cycleDetectionHelper(start)
 		}
 	})
 }

--- a/pkg/sync/expand/cycle_test.go
+++ b/pkg/sync/expand/cycle_test.go
@@ -59,8 +59,7 @@ func TestCycleDetectionHelper_BasicScenarios(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := parseExpression(t, ctx, tc.expr)
 			startNodeID := g.EntitlementsToNodes[tc.start]
-			visited := make(map[int]bool)
-			cycle, ok := g.cycleDetectionHelper(startNodeID, visited, []int{})
+			cycle, ok := g.cycleDetectionHelper(startNodeID)
 
 			if !tc.has {
 				require.False(t, ok)
@@ -82,8 +81,7 @@ func TestCycleDetectionHelper_MultipleCyclesDifferentStarts(t *testing.T) {
 	// Start at 1 -> should find cycle {1,2}
 	{
 		startNodeID := g.EntitlementsToNodes["1"]
-		visited := make(map[int]bool)
-		cycle, ok := g.cycleDetectionHelper(startNodeID, visited, []int{})
+		cycle, ok := g.cycleDetectionHelper(startNodeID)
 		require.True(t, ok)
 		require.NotNil(t, cycle)
 		require.True(t, elementsMatch([]int{1, 2}, cycle))
@@ -92,8 +90,7 @@ func TestCycleDetectionHelper_MultipleCyclesDifferentStarts(t *testing.T) {
 	// Start at 3 -> should find cycle {3,4}
 	{
 		startNodeID := g.EntitlementsToNodes["3"]
-		visited := make(map[int]bool)
-		cycle, ok := g.cycleDetectionHelper(startNodeID, visited, []int{})
+		cycle, ok := g.cycleDetectionHelper(startNodeID)
 		require.True(t, ok)
 		require.NotNil(t, cycle)
 		require.True(t, elementsMatch([]int{3, 4}, cycle))
@@ -119,8 +116,7 @@ func TestCycleDetectionHelper_LargeRing(t *testing.T) {
 
 	g := parseExpression(t, ctx, expr)
 	startNodeID := g.EntitlementsToNodes["1"]
-	visited := make(map[int]bool)
-	cycle, ok := g.cycleDetectionHelper(startNodeID, visited, []int{})
+	cycle, ok := g.cycleDetectionHelper(startNodeID)
 	require.True(t, ok)
 	require.NotNil(t, cycle)
 	require.Len(t, cycle, n)


### PR DESCRIPTION
Noticed some memory profiles in production-like data, that we were allocating a TON of memory in this function, took a deep dive on improving it.  Ended up using using a DFS coloring
```
❯ benchcmp baseline.out dfs-color.out
benchmark                                         old ns/op     new ns/op     delta
BenchmarkCycleDetectionHelper/ring-100-8          75073         8553          -88.61%
BenchmarkCycleDetectionHelper/ring-1000-8         3505307       93744         -97.33%
BenchmarkCycleDetectionHelper/chain-100-8         75483         9240          -87.76%
BenchmarkCycleDetectionHelper/chain-1000-8        3479840       98271         -97.18%
BenchmarkCycleDetectionHelper/clique-5-8          562           282           -49.73%
BenchmarkCycleDetectionHelper/tail10-ring20-8     11942         2436          -79.60%
BenchmarkGetFirstCycle/ring-100-8                 76989         8215          -89.33%
BenchmarkGetFirstCycle/ring-1000-8                3506584       90427         -97.42%
BenchmarkGetFirstCycle/chain-100-8                74474         10094         -86.45%
BenchmarkGetFirstCycle/chain-1000-8               3033203       110031        -96.37%

benchmark                                         old allocs     new allocs     delta
BenchmarkCycleDetectionHelper/ring-100-8          319            7              -97.81%
BenchmarkCycleDetectionHelper/ring-1000-8         3038           11             -99.64%
BenchmarkCycleDetectionHelper/chain-100-8         308            2              -99.35%
BenchmarkCycleDetectionHelper/chain-1000-8        3023           2              -99.93%
BenchmarkCycleDetectionHelper/clique-5-8          11             3              -72.73%
BenchmarkCycleDetectionHelper/tail10-ring20-8     105            5              -95.24%
BenchmarkGetFirstCycle/ring-100-8                 319            7              -97.81%
BenchmarkGetFirstCycle/ring-1000-8                3038           11             -99.64%
BenchmarkGetFirstCycle/chain-100-8                600            2              -99.67%
BenchmarkGetFirstCycle/chain-1000-8               6020           2              -99.97%

benchmark                                         old bytes     new bytes     delta
BenchmarkCycleDetectionHelper/ring-100-8          131908        2992          -97.73%
BenchmarkCycleDetectionHelper/ring-1000-8         11088055      34369         -99.69%
BenchmarkCycleDetectionHelper/chain-100-8         127172        1008          -99.21%
BenchmarkCycleDetectionHelper/chain-1000-8        11042372      9216          -99.92%
BenchmarkCycleDetectionHelper/clique-5-8          312           120           -61.54%
BenchmarkCycleDetectionHelper/tail10-ring20-8     13728         736           -94.64%
BenchmarkGetFirstCycle/ring-100-8                 131909        2992          -97.73%
BenchmarkGetFirstCycle/ring-1000-8                11088083      34369         -99.69%
BenchmarkGetFirstCycle/chain-100-8                82474         1008          -98.78%
BenchmarkGetFirstCycle/chain-1000-8               7237852       9216          -99.87%
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved cycle detection in entitlement graphs with a more efficient and reliable algorithm for identifying cycles.

* **Tests**
  * Added comprehensive unit tests to verify correct cycle detection across various graph scenarios.
  * Introduced benchmark tests to measure and compare the performance of cycle detection on different graph topologies and sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->