### PR TITLE
Add transaction to batch insert

### DIFF
--- a/pkg/dotc1z/sql_helpers.go
+++ b/pkg/dotc1z/sql_helpers.go
@@ -2,6 +2,7 @@ package dotc1z
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -356,7 +357,7 @@ func executeChunkedInsert(
 
 	if txError != nil {
 		if rollbackErr := tx.Rollback(); rollbackErr != nil {
-			return fmt.Errorf("error rolling back transaction after error: %w, original error: %w", rollbackErr, txError)
+			return errors.Join(rollbackErr, txError)
 		}
 
 		return fmt.Errorf("error executing chunked insert: %w", txError)

--- a/pkg/dotc1z/sql_helpers.go
+++ b/pkg/dotc1z/sql_helpers.go
@@ -314,6 +314,13 @@ func executeChunkedInsert(
 		chunks++
 	}
 
+	tx, err := c.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	var txError error
+
 	for i := 0; i < chunks; i++ {
 		start := i * chunkSize
 		end := (i + 1) * chunkSize
@@ -323,28 +330,39 @@ func executeChunkedInsert(
 		chunkedRows := rows[start:end]
 
 		// Create the base insert dataset
-		insertDs := c.db.Insert(tableName)
+		insertDs := tx.Insert(tableName)
 
 		// Apply the custom query building function
-		insertDs, err := buildQueryFn(insertDs, chunkedRows)
+		insertDs, err = buildQueryFn(insertDs, chunkedRows)
 		if err != nil {
-			return err
+			txError = err
+			break
 		}
 
 		// Generate the SQL
 		query, args, err := insertDs.ToSQL()
 		if err != nil {
-			return err
+			txError = err
+			break
 		}
 
 		// Execute the query
-		_, err = c.db.Exec(query, args...)
+		_, err = tx.ExecContext(ctx, query, args...)
 		if err != nil {
-			return err
+			txError = err
+			break
 		}
 	}
 
-	return nil
+	if txError != nil {
+		if rollbackErr := tx.Rollback(); rollbackErr != nil {
+			return fmt.Errorf("error rolling back transaction after error: %w, original error: %v", rollbackErr, txError)
+		}
+
+		return fmt.Errorf("error executing chunked insert: %w", txError)
+	}
+
+	return tx.Commit()
 }
 
 func bulkPutConnectorObject[T proto.Message](

--- a/pkg/dotc1z/sql_helpers.go
+++ b/pkg/dotc1z/sql_helpers.go
@@ -356,7 +356,7 @@ func executeChunkedInsert(
 
 	if txError != nil {
 		if rollbackErr := tx.Rollback(); rollbackErr != nil {
-			return fmt.Errorf("error rolling back transaction after error: %w, original error: %v", rollbackErr, txError)
+			return fmt.Errorf("error rolling back transaction after error: %w, original error: %w", rollbackErr, txError)
 		}
 
 		return fmt.Errorf("error executing chunked insert: %w", txError)

--- a/pkg/dotc1z/sql_helpers_test.go
+++ b/pkg/dotc1z/sql_helpers_test.go
@@ -62,7 +62,7 @@ func TestPutResources(t *testing.T) {
 	stats, err := c1zFile.Stats(ctx)
 	require.NoError(t, err)
 
-	require.Equal(t, int64(10_000), stats["test_resource_type"])
+	require.Equal(t, int64(10_000), stats[resourceType.Id])
 
 	err = c1zFile.Close()
 	require.NoError(t, err)

--- a/pkg/dotc1z/sql_helpers_test.go
+++ b/pkg/dotc1z/sql_helpers_test.go
@@ -2,12 +2,13 @@ package dotc1z
 
 import (
 	"context"
+	"path/filepath"
+	"testing"
+
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/segmentio/ksuid"
 	"github.com/stretchr/testify/require"
-	"path/filepath"
-	"testing"
 )
 
 func generateResources(count int, resourceType *v2.ResourceType) []*v2.Resource {

--- a/pkg/dotc1z/sql_helpers_test.go
+++ b/pkg/dotc1z/sql_helpers_test.go
@@ -1,0 +1,102 @@
+package dotc1z
+
+import (
+	"context"
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/types/resource"
+	"github.com/segmentio/ksuid"
+	"github.com/stretchr/testify/require"
+	"path/filepath"
+	"testing"
+)
+
+func generateResources(count int, resourceType *v2.ResourceType) []*v2.Resource {
+	if count < 1 {
+		return nil
+	}
+
+	response := make([]*v2.Resource, count)
+
+	for i := range count {
+		id := ksuid.New().String()
+
+		newResource, err := resource.NewResource(id, resourceType, id)
+		if err != nil {
+			panic(err)
+		}
+
+		response[i] = newResource
+	}
+
+	return response
+}
+
+func TestPutResources(t *testing.T) {
+	ctx := context.Background()
+
+	tempDir := filepath.Join(t.TempDir(), "test.c1z")
+
+	c1zFile, err := NewC1ZFile(ctx, tempDir, WithPragma("journal_mode", "WAL"))
+	require.NoError(t, err)
+
+	_, err = c1zFile.StartNewSync(ctx)
+	require.NoError(t, err)
+
+	err = c1zFile.PutResources(
+		ctx,
+		generateResources(10_000, &v2.ResourceType{
+			Id:          "test_resource_type",
+			DisplayName: "Test Resource Type",
+		})...,
+	)
+	require.NoError(t, err)
+
+	err = c1zFile.Close()
+	require.NoError(t, err)
+}
+
+func BenchmarkPutResources(b *testing.B) {
+	cases := []struct {
+		name           string
+		resourcesCount int
+	}{
+		{"500", 500},
+		{"1k", 1_000},
+		{"10k", 10_000},
+		{"50k", 50_000},
+	}
+
+	for _, c := range cases {
+		b.Run(c.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				ctx := context.Background()
+
+				tempDir := filepath.Join(b.TempDir(), "test.c1z")
+
+				c1zFile, err := NewC1ZFile(ctx, tempDir, WithPragma("journal_mode", "WAL"))
+				require.NoError(b, err)
+
+				_, err = c1zFile.StartNewSync(ctx)
+				require.NoError(b, err)
+
+				generatedData := generateResources(c.resourcesCount, &v2.ResourceType{
+					Id:          "test_resource_type",
+					DisplayName: "Test Resource Type",
+				})
+
+				b.StartTimer()
+
+				err = c1zFile.PutResources(
+					ctx,
+					generatedData...,
+				)
+				require.NoError(b, err)
+
+				err = c1zFile.Close()
+				require.NoError(b, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add a transaction to execute the batch

Before
```
goos: darwin
goarch: arm64
pkg: github.com/conductorone/baton-sdk/pkg/dotc1z
cpu: Apple M1 Max
BenchmarkName
BenchmarkName/500
BenchmarkName/500-10         	     159	   7944809 ns/op	20500388 B/op	   26861 allocs/op
BenchmarkName/1k
BenchmarkName/1k-10          	      80	  13110462 ns/op	21841604 B/op	   53592 allocs/op
BenchmarkName/10k
BenchmarkName/10k-10         	       7	 153204155 ns/op	43281107 B/op	  534727 allocs/op
BenchmarkName/50k
BenchmarkName/50k-10         	       1	1117222750 ns/op	138147560 B/op	 2673078 allocs/op
PASS
```

After
```
goos: darwin
goarch: arm64
pkg: github.com/conductorone/baton-sdk/pkg/dotc1z
cpu: Apple M1 Max
BenchmarkName
BenchmarkName/500
BenchmarkName/500-10         	     160	   8204915 ns/op	20502633 B/op	   26908 allocs/op
BenchmarkName/1k
BenchmarkName/1k-10          	      88	  12675455 ns/op	21831980 B/op	   53644 allocs/op
BenchmarkName/10k
BenchmarkName/10k-10         	       9	 119945125 ns/op	43285008 B/op	  534870 allocs/op
BenchmarkName/50k
BenchmarkName/50k-10         	       2	 734946604 ns/op	138147168 B/op	 2673599 allocs/op
PASS
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Chunked inserts now run inside a single database transaction for atomic, all-or-nothing imports; error handling consolidated so failures trigger a unified rollback and successful runs commit once.

- Tests
  - Added end-to-end tests and benchmarks exercising large-scale resource imports (500–50,000 items), validating correctness, measuring performance, and reporting allocations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->