### PR TITLE
Enable journal_mode=WAL in tests and s3 manager.

### DIFF
--- a/pkg/dotc1z/manager/s3/s3.go
+++ b/pkg/dotc1z/manager/s3/s3.go
@@ -116,7 +116,7 @@ func (s *s3Manager) LoadC1Z(ctx context.Context) (*dotc1z.C1File, error) {
 		return nil, err
 	}
 
-	return dotc1z.NewC1ZFile(ctx, s.tmpFile, dotc1z.WithTmpDir(s.tmpDir))
+	return dotc1z.NewC1ZFile(ctx, s.tmpFile, dotc1z.WithTmpDir(s.tmpDir), dotc1z.WithPragma("journal_mode", "WAL"))
 }
 
 // SaveC1Z saves a file to the AWS S3 bucket.

--- a/pkg/synccompactor/compactor_test.go
+++ b/pkg/synccompactor/compactor_test.go
@@ -36,9 +36,13 @@ func TestCompactorWithTmpDir(t *testing.T) {
 }
 
 func runCompactorTest(t *testing.T, ctx context.Context, tempDir, outputDir, tmpDir string, createCompactor func([]*CompactableSync) (*Compactor, func() error, error)) {
+	opts := []dotc1z.C1ZOption{
+		dotc1z.WithPragma("journal_mode", "WAL"),
+	}
+
 	// Create the first sync file
 	firstSyncPath := filepath.Join(tempDir, "first-sync.c1z")
-	firstSync, err := dotc1z.NewC1ZFile(ctx, firstSyncPath)
+	firstSync, err := dotc1z.NewC1ZFile(ctx, firstSyncPath, opts...)
 	require.NoError(t, err)
 
 	// Start a new sync
@@ -90,7 +94,7 @@ func runCompactorTest(t *testing.T, ctx context.Context, tempDir, outputDir, tmp
 
 	// Create the second sync file
 	secondSyncPath := filepath.Join(tempDir, "second-sync.c1z")
-	secondSync, err := dotc1z.NewC1ZFile(ctx, secondSyncPath)
+	secondSync, err := dotc1z.NewC1ZFile(ctx, secondSyncPath, opts...)
 	require.NoError(t, err)
 
 	// Start a new sync
@@ -163,7 +167,7 @@ func runCompactorTest(t *testing.T, ctx context.Context, tempDir, outputDir, tmp
 	require.NotNil(t, compactedSync)
 
 	// Open the compacted file
-	compactedFile, err := dotc1z.NewC1ZFile(ctx, compactedSync.FilePath)
+	compactedFile, err := dotc1z.NewC1ZFile(ctx, compactedSync.FilePath, opts...)
 	require.NoError(t, err)
 	defer compactedFile.Close()
 


### PR DESCRIPTION
We want to test C1File the same way we run it in real life, and that means turning on the write ahead log.

Also s3 manager didn't use WAL, and we probably want to do that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - C1Z files loaded from S3 now use WAL journaling, improving stability under concurrent access and reducing lock contention during reads/writes.

- Tests
  - Updated all relevant test suites to use WAL mode for C1Z files, aligning tests with runtime behavior and ensuring more consistent, realistic execution.
  - Added explicit database close/checkpoint steps in decoding tests to validate behavior under WAL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->