### PR TITLE
Use JSON for invoke-action-args, like the description says.

### DIFF
--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -189,7 +189,14 @@ func MakeMainCommand[T field.Configurable](
 						profile,
 					))
 			case v.GetString("invoke-action") != "":
-				invokeActionArgs := v.GetStringMap("invoke-action-args")
+				invokeActionArgsStr := v.GetString("invoke-action-args")
+				invokeActionArgs := map[string]any{}
+				if invokeActionArgsStr != "" {
+					err := json.Unmarshal([]byte(invokeActionArgsStr), &invokeActionArgs)
+					if err != nil {
+						return fmt.Errorf("failed to parse invoke-action-args: %w", err)
+					}
+				}
 				invokeActionArgsStruct, err := structpb.NewStruct(invokeActionArgs)
 				if err != nil {
 					return fmt.Errorf("failed to parse invoke-action-args: %w", err)

--- a/pkg/field/defaults.go
+++ b/pkg/field/defaults.go
@@ -136,10 +136,10 @@ var (
 		WithPersistent(true),
 		WithExportTarget(ExportTargetNone),
 	)
-	invokeActionArgsField = StringMapField("invoke-action-args",
+	invokeActionArgsField = StringField("invoke-action-args",
 		WithHidden(true),
 		WithDescription("JSON-formatted object of map keys and values like '{ 'key': 'value' }'"),
-		WithDefaultValue(map[string]any{}),
+		WithDefaultValue("{}"),
 		WithPersistent(true),
 		WithExportTarget(ExportTargetNone),
 	)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Clearer validation and error messaging when providing action arguments via CLI.

- Refactor
  - CLI option for action arguments now accepts a JSON string instead of a map-style input.
  - Default value updated to "{}" for a more consistent experience.

- Bug Fixes
  - Invalid JSON in action arguments now surfaces a descriptive parse error to help users correct input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->