### PR TITLE
External resource support in compactor

### DIFF
--- a/pkg/connectorrunner/runner.go
+++ b/pkg/connectorrunner/runner.go
@@ -738,7 +738,7 @@ func NewConnectorRunner(ctx context.Context, c types.ConnectorServer, opts ...Op
 					SyncID:   c.syncIDs[i],
 				})
 			}
-			tm = local.NewLocalCompactor(ctx, cfg.syncCompactorConfig.outputPath, configs)
+			tm = local.NewLocalCompactor(ctx, cfg.syncCompactorConfig.outputPath, configs, cfg.externalResourceC1Z)
 		default:
 			tm, err = local.NewSyncer(ctx, cfg.c1zPath,
 				local.WithTmpDir(cfg.tempDir),


### PR DESCRIPTION
- **REVERT: Compaction test cursor generated external resource sync tests**
- **first pass at external resource wireup**
