### PR TITLE
A little bit of cleanup in compactor land.

### DIFF
--- a/pkg/synccompactor/attached/attached_test.go
+++ b/pkg/synccompactor/attached/attached_test.go
@@ -18,8 +18,13 @@ func TestAttachedCompactor(t *testing.T) {
 	appliedFile := filepath.Join(tmpDir, "applied.c1z")
 	destFile := filepath.Join(tmpDir, "dest.c1z")
 
+	opts := []dotc1z.C1ZOption{
+		dotc1z.WithPragma("journal_mode", "WAL"),
+		dotc1z.WithTmpDir(tmpDir),
+	}
+
 	// Create base database with some test data
-	baseDB, err := dotc1z.NewC1ZFile(ctx, baseFile, dotc1z.WithTmpDir(tmpDir))
+	baseDB, err := dotc1z.NewC1ZFile(ctx, baseFile, opts...)
 	require.NoError(t, err)
 	defer baseDB.Close()
 
@@ -31,7 +36,7 @@ func TestAttachedCompactor(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create applied database with some test data
-	appliedDB, err := dotc1z.NewC1ZFile(ctx, appliedFile, dotc1z.WithTmpDir(tmpDir))
+	appliedDB, err := dotc1z.NewC1ZFile(ctx, appliedFile, opts...)
 	require.NoError(t, err)
 	defer appliedDB.Close()
 
@@ -43,7 +48,7 @@ func TestAttachedCompactor(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create destination database
-	destDB, err := dotc1z.NewC1ZFile(ctx, destFile, dotc1z.WithTmpDir(tmpDir))
+	destDB, err := dotc1z.NewC1ZFile(ctx, destFile, opts...)
 	require.NoError(t, err)
 	defer destDB.Close()
 
@@ -72,7 +77,10 @@ func TestAttachedCompactorMixedSyncTypes(t *testing.T) {
 	appliedFile := filepath.Join(tmpDir, "applied.c1z")
 	destFile := filepath.Join(tmpDir, "dest.c1z")
 
-	opts := []dotc1z.C1ZOption{dotc1z.WithTmpDir(tmpDir)}
+	opts := []dotc1z.C1ZOption{
+		dotc1z.WithPragma("journal_mode", "WAL"),
+		dotc1z.WithTmpDir(tmpDir),
+	}
 
 	// Create base database with a full sync
 	baseDB, err := dotc1z.NewC1ZFile(ctx, baseFile, opts...)
@@ -132,7 +140,10 @@ func TestAttachedCompactorFailsWithNoFullSyncInBase(t *testing.T) {
 	appliedFile := filepath.Join(tmpDir, "applied.c1z")
 	destFile := filepath.Join(tmpDir, "dest.c1z")
 
-	opts := []dotc1z.C1ZOption{dotc1z.WithTmpDir(tmpDir)}
+	opts := []dotc1z.C1ZOption{
+		dotc1z.WithPragma("journal_mode", "WAL"),
+		dotc1z.WithTmpDir(tmpDir),
+	}
 
 	// Create base database with only an incremental sync (no full sync)
 	baseDB, err := dotc1z.NewC1ZFile(ctx, baseFile, opts...)
@@ -186,7 +197,10 @@ func TestAttachedCompactorUsesLatestAppliedSyncOfAnyType(t *testing.T) {
 	appliedFile := filepath.Join(tmpDir, "applied.c1z")
 	destFile := filepath.Join(tmpDir, "dest.c1z")
 
-	opts := []dotc1z.C1ZOption{dotc1z.WithTmpDir(tmpDir)}
+	opts := []dotc1z.C1ZOption{
+		dotc1z.WithPragma("journal_mode", "WAL"),
+		dotc1z.WithTmpDir(tmpDir),
+	}
 
 	// Create base database with a full sync
 	baseDB, err := dotc1z.NewC1ZFile(ctx, baseFile, opts...)

--- a/pkg/synccompactor/benchmark_test.go
+++ b/pkg/synccompactor/benchmark_test.go
@@ -227,17 +227,25 @@ func benchmarkNaiveCompactor(b *testing.B, dataset BenchmarkData) {
 		// Generate test data
 		baseFile, _, appliedFile, _ := generateTestData(ctx, b, tmpDir, dataset)
 
+		opts := []dotc1z.C1ZOption{
+			dotc1z.WithPragma("journal_mode", "WAL"),
+		}
+
 		// Use naive compactor
-		baseC1Z, err := dotc1z.NewC1ZFile(ctx, baseFile)
+		baseC1Z, err := dotc1z.NewC1ZFile(ctx, baseFile, opts...)
 		require.NoError(b, err)
 		defer baseC1Z.Close()
 
-		appliedC1Z, err := dotc1z.NewC1ZFile(ctx, appliedFile)
+		appliedC1Z, err := dotc1z.NewC1ZFile(ctx, appliedFile, opts...)
 		require.NoError(b, err)
 		defer appliedC1Z.Close()
 
 		destFile := filepath.Join(tmpDir, "naive-dest.c1z")
-		destC1Z, err := dotc1z.NewC1ZFile(ctx, destFile, dotc1z.WithTmpDir(tmpDir))
+		destOpts := []dotc1z.C1ZOption{
+			dotc1z.WithTmpDir(tmpDir),
+		}
+		destOpts = append(destOpts, opts...)
+		destC1Z, err := dotc1z.NewC1ZFile(ctx, destFile, destOpts...)
 		require.NoError(b, err)
 		defer destC1Z.Close()
 
@@ -264,6 +272,10 @@ func benchmarkNaiveCompactor(b *testing.B, dataset BenchmarkData) {
 func benchmarkAttachedCompactor(b *testing.B, dataset BenchmarkData) {
 	ctx := context.Background()
 
+	opts := []dotc1z.C1ZOption{
+		dotc1z.WithPragma("journal_mode", "WAL"),
+	}
+
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()
 
@@ -280,16 +292,20 @@ func benchmarkAttachedCompactor(b *testing.B, dataset BenchmarkData) {
 		baseFile, _, appliedFile, _ := generateTestData(ctx, b, tmpDir, dataset)
 
 		// Use attached compactor
-		baseC1Z, err := dotc1z.NewC1ZFile(ctx, baseFile)
+		baseC1Z, err := dotc1z.NewC1ZFile(ctx, baseFile, opts...)
 		require.NoError(b, err)
 		defer baseC1Z.Close()
 
-		appliedC1Z, err := dotc1z.NewC1ZFile(ctx, appliedFile)
+		appliedC1Z, err := dotc1z.NewC1ZFile(ctx, appliedFile, opts...)
 		require.NoError(b, err)
 		defer appliedC1Z.Close()
 
 		destFile := filepath.Join(tmpDir, "attached-dest.c1z")
-		destC1Z, err := dotc1z.NewC1ZFile(ctx, destFile, dotc1z.WithTmpDir(tmpDir))
+		destOpts := []dotc1z.C1ZOption{
+			dotc1z.WithTmpDir(tmpDir),
+		}
+		destOpts = append(destOpts, opts...)
+		destC1Z, err := dotc1z.NewC1ZFile(ctx, destFile, destOpts...)
 		require.NoError(b, err)
 		defer destC1Z.Close()
 

--- a/pkg/synccompactor/compactor.go
+++ b/pkg/synccompactor/compactor.go
@@ -268,6 +268,9 @@ func (c *Compactor) doOneCompaction(ctx context.Context, base *CompactableSync, 
 			l.Error("error running compaction", zap.Error(err))
 			return nil, err
 		}
+	default:
+		// c.compactorType defaults to attached, so this should never happen.
+		return nil, fmt.Errorf("invalid compactor type: %s", c.compactorType)
 	}
 
 	if err := newFile.EndSync(ctx); err != nil {

--- a/pkg/synccompactor/compactor_test.go
+++ b/pkg/synccompactor/compactor_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCompactorWithTmpDir(t *testing.T) {
+func TestAttachedCompactorWithTmpDir(t *testing.T) {
 	ctx := context.Background()
 
 	inputSyncsDir, err := os.MkdirTemp("", "compactor-test")
@@ -29,7 +29,28 @@ func TestCompactorWithTmpDir(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	runCompactorTest(t, ctx, inputSyncsDir, func(compactableSyncs []*CompactableSync) (*Compactor, func() error, error) {
-		return NewCompactor(ctx, outputDir, compactableSyncs, WithTmpDir(tmpDir))
+		return NewCompactor(ctx, outputDir, compactableSyncs, WithTmpDir(tmpDir), WithCompactorType(CompactorTypeAttached))
+	})
+}
+
+func TestNaiveCompactorWithTmpDir(t *testing.T) {
+	ctx := context.Background()
+
+	inputSyncsDir, err := os.MkdirTemp("", "compactor-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(inputSyncsDir)
+
+	outputDir, err := os.MkdirTemp("", "compactor-output")
+	require.NoError(t, err)
+	defer os.RemoveAll(outputDir)
+
+	// Create temporary directory for intermediate files
+	tmpDir, err := os.MkdirTemp("", "compactor-tmp")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	runCompactorTest(t, ctx, inputSyncsDir, func(compactableSyncs []*CompactableSync) (*Compactor, func() error, error) {
+		return NewCompactor(ctx, outputDir, compactableSyncs, WithTmpDir(tmpDir), WithCompactorType(CompactorTypeNaive))
 	})
 }
 
@@ -300,6 +321,136 @@ func runCompactorTest(t *testing.T, ctx context.Context, inputSyncsDir string, c
 	err = secondSync.Close()
 	require.NoError(t, err)
 
+	// Create the third sync file
+	thirdSyncPath := filepath.Join(inputSyncsDir, "third-sync.c1z")
+	thirdSync, err := dotc1z.NewC1ZFile(ctx, thirdSyncPath, opts...)
+	require.NoError(t, err)
+
+	// Start a new sync
+	thirdSyncID, isNewSync, err := thirdSync.StartSync(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, thirdSyncID)
+	require.True(t, isNewSync)
+
+	// Create the same resource types
+	err = thirdSync.PutResourceTypes(ctx, &v2.ResourceType{
+		Id:          userResourceTypeID,
+		DisplayName: "User",
+	})
+	require.NoError(t, err)
+
+	err = thirdSync.PutResourceTypes(ctx, &v2.ResourceType{
+		Id:          groupResourceTypeID,
+		DisplayName: "Group",
+	})
+	require.NoError(t, err)
+
+	err = thirdSync.PutResourceTypes(ctx, &v2.ResourceType{
+		Id:          roleResourceTypeID,
+		DisplayName: "Role",
+	})
+	require.NoError(t, err)
+
+	// Create resources for the third sync
+	// Users - only in third sync
+	onlyInThirdUser := &v2.Resource{
+		Id: &v2.ResourceId{
+			ResourceType: userResourceTypeID,
+			Resource:     "user-only-third",
+		},
+		DisplayName: "User Only Third",
+	}
+	err = thirdSync.PutResources(ctx, onlyInThirdUser)
+	require.NoError(t, err)
+
+	// Users - in all syncs (same as first and second)
+	inAllUserInThird := &v2.Resource{
+		Id: &v2.ResourceId{
+			ResourceType: userResourceTypeID,
+			Resource:     "user-in-both",
+		},
+		DisplayName: "User In Both",
+	}
+	err = thirdSync.PutResources(ctx, inAllUserInThird)
+	require.NoError(t, err)
+
+	// Groups - only in third sync
+	onlyInThirdGroup := &v2.Resource{
+		Id: &v2.ResourceId{
+			ResourceType: groupResourceTypeID,
+			Resource:     "group-only-third",
+		},
+		DisplayName: "Group Only Third",
+	}
+	err = thirdSync.PutResources(ctx, onlyInThirdGroup)
+	require.NoError(t, err)
+
+	// Groups - in all syncs (same as first and second)
+	inAllGroupInThird := &v2.Resource{
+		Id: &v2.ResourceId{
+			ResourceType: groupResourceTypeID,
+			Resource:     "group-in-both",
+		},
+		DisplayName: "Group In Both",
+	}
+	err = thirdSync.PutResources(ctx, inAllGroupInThird)
+	require.NoError(t, err)
+
+	// Roles - moderator role only in third sync
+	moderatorRole := &v2.Resource{
+		Id: &v2.ResourceId{
+			ResourceType: roleResourceTypeID,
+			Resource:     "moderator",
+		},
+		DisplayName: "Moderator Role",
+	}
+	err = thirdSync.PutResources(ctx, moderatorRole)
+	require.NoError(t, err)
+
+	// Create entitlements for the third sync
+	memberEntitlementThird := &v2.Entitlement{
+		Id:          "member",
+		DisplayName: "Member",
+		Resource:    inAllGroupInThird,
+		Purpose:     v2.Entitlement_PURPOSE_VALUE_ASSIGNMENT,
+	}
+	err = thirdSync.PutEntitlements(ctx, memberEntitlementThird)
+	require.NoError(t, err)
+
+	moderatorEntitlement := &v2.Entitlement{
+		Id:          "moderator",
+		DisplayName: "Moderator",
+		Resource:    moderatorRole,
+		Purpose:     v2.Entitlement_PURPOSE_VALUE_ASSIGNMENT,
+	}
+	err = thirdSync.PutEntitlements(ctx, moderatorEntitlement)
+	require.NoError(t, err)
+
+	// Create grants for the third sync
+	// Grant new user membership to group
+	thirdUserGroupGrant := &v2.Grant{
+		Id:          "third-user-group-grant",
+		Principal:   onlyInThirdUser,
+		Entitlement: memberEntitlementThird,
+	}
+	err = thirdSync.PutGrants(ctx, thirdUserGroupGrant)
+	require.NoError(t, err)
+
+	// Grant user moderator role
+	userModeratorGrant := &v2.Grant{
+		Id:          "user-moderator-grant",
+		Principal:   inAllUserInThird,
+		Entitlement: moderatorEntitlement,
+	}
+	err = thirdSync.PutGrants(ctx, userModeratorGrant)
+	require.NoError(t, err)
+
+	// End the third sync
+	err = thirdSync.EndSync(ctx)
+	require.NoError(t, err)
+	err = thirdSync.Close()
+	require.NoError(t, err)
+
 	// Create compactable syncs
 	firstCompactableSync := &CompactableSync{
 		FilePath: firstSyncPath,
@@ -309,9 +460,13 @@ func runCompactorTest(t *testing.T, ctx context.Context, inputSyncsDir string, c
 		FilePath: secondSyncPath,
 		SyncID:   secondSyncID,
 	}
+	thirdCompactableSync := &CompactableSync{
+		FilePath: thirdSyncPath,
+		SyncID:   thirdSyncID,
+	}
 
 	// Create compactor
-	compactableSyncs := []*CompactableSync{firstCompactableSync, secondCompactableSync}
+	compactableSyncs := []*CompactableSync{firstCompactableSync, secondCompactableSync, thirdCompactableSync}
 	compactor, cleanup, err := createCompactor(compactableSyncs)
 	require.NoError(t, err)
 	defer func() {
@@ -414,6 +569,28 @@ func runCompactorTest(t *testing.T, ctx context.Context, inputSyncsDir string, c
 	require.Equal(t, adminRole.Id.Resource, adminRoleResp.Resource.Id.Resource)
 	require.Equal(t, "Admin Role", adminRoleResp.Resource.DisplayName)
 
+	// Resources from third sync only
+	onlyThirdUserResp, err := compactedFile.GetResource(ctx, &reader_v2.ResourcesReaderServiceGetResourceRequest{
+		ResourceId: onlyInThirdUser.Id,
+	})
+	require.NoError(t, err)
+	require.Equal(t, onlyInThirdUser.Id.Resource, onlyThirdUserResp.Resource.Id.Resource)
+	require.Equal(t, "User Only Third", onlyThirdUserResp.Resource.DisplayName)
+
+	onlyThirdGroupResp, err := compactedFile.GetResource(ctx, &reader_v2.ResourcesReaderServiceGetResourceRequest{
+		ResourceId: onlyInThirdGroup.Id,
+	})
+	require.NoError(t, err)
+	require.Equal(t, onlyInThirdGroup.Id.Resource, onlyThirdGroupResp.Resource.Id.Resource)
+	require.Equal(t, "Group Only Third", onlyThirdGroupResp.Resource.DisplayName)
+
+	moderatorRoleResp, err := compactedFile.GetResource(ctx, &reader_v2.ResourcesReaderServiceGetResourceRequest{
+		ResourceId: moderatorRole.Id,
+	})
+	require.NoError(t, err)
+	require.Equal(t, moderatorRole.Id.Resource, moderatorRoleResp.Resource.Id.Resource)
+	require.Equal(t, "Moderator Role", moderatorRoleResp.Resource.DisplayName)
+
 	// ========= Entitlements Verification =========
 	// Entitlements from first sync
 	memberEntitlementResp, err := compactedFile.GetEntitlement(ctx, &reader_v2.EntitlementsReaderServiceGetEntitlementRequest{
@@ -437,6 +614,21 @@ func runCompactorTest(t *testing.T, ctx context.Context, inputSyncsDir string, c
 	require.NoError(t, err)
 	require.Equal(t, viewerEntitlement.Id, viewerEntitlementResp.Entitlement.Id)
 	require.Equal(t, "Viewer", viewerEntitlementResp.Entitlement.DisplayName)
+
+	// Entitlements from third sync
+	memberEntitlementThirdResp, err := compactedFile.GetEntitlement(ctx, &reader_v2.EntitlementsReaderServiceGetEntitlementRequest{
+		EntitlementId: memberEntitlementThird.Id,
+	})
+	require.NoError(t, err)
+	require.Equal(t, memberEntitlementThird.Id, memberEntitlementThirdResp.Entitlement.Id)
+	require.Equal(t, "Member", memberEntitlementThirdResp.Entitlement.DisplayName)
+
+	moderatorEntitlementResp, err := compactedFile.GetEntitlement(ctx, &reader_v2.EntitlementsReaderServiceGetEntitlementRequest{
+		EntitlementId: moderatorEntitlement.Id,
+	})
+	require.NoError(t, err)
+	require.Equal(t, moderatorEntitlement.Id, moderatorEntitlementResp.Entitlement.Id)
+	require.Equal(t, "Moderator", moderatorEntitlementResp.Entitlement.DisplayName)
 
 	// ========= Grants Verification =========
 	// Grants from first sync
@@ -464,4 +656,17 @@ func runCompactorTest(t *testing.T, ctx context.Context, inputSyncsDir string, c
 	})
 	require.NoError(t, err)
 	require.Equal(t, userViewerGrant.Id, userViewerGrantResp.Grant.Id)
+
+	// Grants from third sync
+	thirdUserGroupGrantResp, err := compactedFile.GetGrant(ctx, &reader_v2.GrantsReaderServiceGetGrantRequest{
+		GrantId: thirdUserGroupGrant.Id,
+	})
+	require.NoError(t, err)
+	require.Equal(t, thirdUserGroupGrant.Id, thirdUserGroupGrantResp.Grant.Id)
+
+	userModeratorGrantResp, err := compactedFile.GetGrant(ctx, &reader_v2.GrantsReaderServiceGetGrantRequest{
+		GrantId: userModeratorGrant.Id,
+	})
+	require.NoError(t, err)
+	require.Equal(t, userModeratorGrant.Id, userModeratorGrantResp.Grant.Id)
 }


### PR DESCRIPTION
- Compactor tests: Use WAL in new syncs, since that's what we do in real life. Remove unused variables. Check error on compactor cleanup.
- Simplify compaction code. This applies compacitons in reverse order instead of applying incremental syncs in order, then applying the base.
- Add compactor option to choose naive or attached. Test both.
- Add a third sync in compactor tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added selectable compaction strategies: choose between naive and attached compactor modes.

- Refactor
  - Compaction simplified to a single-pass reverse-apply approach, streamlining processing and error handling.

- Tests
  - Standardized tests/benchmarks to enable journaling and consistent temp-dir handling; added broader coverage (including the naive path and multi-sync scenarios) and stricter cleanup/assertions.

- Benchmarks
  - Aligned benchmark setup with tests for consistent results and data generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->