### PR TITLE
Don't fetch principals when syncing targeted resources

### DIFF
--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -1600,29 +1600,6 @@ func (s *syncer) syncGrantsForResource(ctx context.Context, resourceID *v2.Resou
 				return err
 			}
 		}
-
-		principalResource := grant.GetPrincipal()
-		_, err = s.store.GetResource(ctx, &reader_v2.ResourcesReaderServiceGetResourceRequest{
-			ResourceId: principalResource.GetId(),
-		})
-		if err != nil {
-			if !errors.Is(err, sql.ErrNoRows) {
-				return err
-			}
-
-			// Principal resource is not in the DB, so try to fetch it from the connector.
-			resource, err := s.getResourceFromConnector(ctx, principalResource.GetId(), principalResource.GetParentResourceId())
-			if err != nil {
-				l.Error("error fetching principal resource", zap.Error(err))
-				return err
-			}
-			if resource == nil {
-				continue
-			}
-			if err := s.store.PutResources(ctx, resource); err != nil {
-				return err
-			}
-		}
 	}
 	err = s.store.PutGrants(ctx, grants...)
 	if err != nil {


### PR DESCRIPTION
Skipping principals is safe because future full sync will bring them in, and it's even possible/likely that previous inc syncs will have them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed automatic fetching and creation of missing principal resources during sync.
  * Grants are still processed, but principals not already present will no longer be backfilled.
  * Reduces external calls during sync, improving predictability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->