### PR TITLE
New Incremental Sync Grant Options

### DIFF
--- a/pkg/sync/state.go
+++ b/pkg/sync/state.go
@@ -57,6 +57,8 @@ func (s ActionOp) String() string {
 		return "grant-expansion"
 	case SyncTargetedResourceOp:
 		return "targeted-resource-sync"
+	case SyncExternalGrantsOp:
+		return "list-external-grants"
 	default:
 		return "unknown"
 	}
@@ -100,6 +102,8 @@ func newActionOp(str string) ActionOp {
 		return SyncExternalResourcesOp
 	case SyncTargetedResourceOp.String():
 		return SyncTargetedResourceOp
+	case SyncExternalGrantsOp.String():
+		return SyncExternalGrantsOp
 	default:
 		return UnknownOp
 	}
@@ -117,6 +121,7 @@ const (
 	SyncAssetsOp
 	SyncGrantExpansionOp
 	SyncTargetedResourceOp
+	SyncExternalGrantsOp
 )
 
 // Action stores the current operation, page token, and optional fields for which resource is being worked with.


### PR DESCRIPTION
Adds New functionality designed for incremental sync. 
First is a simple option `WithSkipSyncGrants` which makes a sync skip syncing grants entirely. 
The second is a new option `WithExternalGrants` which takes in grants we have heard exist, we sync the resources involved via targeted sync, and then insert the grants directly into the db.

TODO:
- [ ] Do we actually want to make targeted resource syncs for grants?
- [ ] Are we missing any fields on these grants? they have no source or annotations
- [ ] is adding the DB check to targeted syncs ok to do? it will help us avoid double getting a principal in multiple grants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for syncing external grants, processed before standard entitlement/grant syncing.
  - Introduced options to provide external grants for syncing.
  - Added an option to skip per-resource grant syncing.
- Bug Fixes
  - Prevents re-processing of resources that already exist, reducing redundant work during targeted resource syncs.
- Chores
  - Extended internal action set to include external-grants processing, with full serialization support for the new operation type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->