### PR TITLE
Always clean up files

### DIFF
--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -154,6 +154,11 @@ func NewC1ZFile(ctx context.Context, outputFilePath string, opts ...C1ZOption) (
 func (c *C1File) Close() error {
 	var err error
 
+	defer func() {
+		// Cleanup the database filepath. This should always be a file within a temp directory, so we remove the entire dir.
+		_ = os.RemoveAll(filepath.Dir(c.dbFilePath))
+	}()
+
 	if c.rawDb != nil {
 		err = c.rawDb.Close()
 		if err != nil {
@@ -169,12 +174,6 @@ func (c *C1File) Close() error {
 		if err != nil {
 			return err
 		}
-	}
-
-	// Cleanup the database filepath. This should always be a file within a temp directory, so we remove the entire dir.
-	err = os.RemoveAll(filepath.Dir(c.dbFilePath))
-	if err != nil {
-		return err
 	}
 
 	return nil

--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -3,6 +3,7 @@ package dotc1z
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -149,20 +150,23 @@ func NewC1ZFile(ctx context.Context, outputFilePath string, opts ...C1ZOption) (
 	return c1File, nil
 }
 
+func cleanupDbDir(dbFilePath string, err error) error {
+	cleanupErr := os.RemoveAll(filepath.Dir(dbFilePath))
+	if cleanupErr != nil {
+		err = errors.Join(err, cleanupErr)
+	}
+	return err
+}
+
 // Close ensures that the sqlite database is flushed to disk, and if any changes were made we update the original database
 // with our changes.
 func (c *C1File) Close() error {
 	var err error
 
-	defer func() {
-		// Cleanup the database filepath. This should always be a file within a temp directory, so we remove the entire dir.
-		_ = os.RemoveAll(filepath.Dir(c.dbFilePath))
-	}()
-
 	if c.rawDb != nil {
 		err = c.rawDb.Close()
 		if err != nil {
-			return err
+			return cleanupDbDir(c.dbFilePath, err)
 		}
 	}
 	c.rawDb = nil
@@ -172,11 +176,11 @@ func (c *C1File) Close() error {
 	if c.dbUpdated {
 		err = saveC1z(c.dbFilePath, c.outputFilePath)
 		if err != nil {
-			return err
+			return cleanupDbDir(c.dbFilePath, err)
 		}
 	}
 
-	return nil
+	return cleanupDbDir(c.dbFilePath, err)
 }
 
 // init ensures that the database has all of the required schema.


### PR DESCRIPTION
We suspect that these might be leaking. Always ensure that we remove these files.

Side note: Is there a preferred way to log/track errors in here so we can gauge whether we're hitting the error cases in here?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable cleanup of temporary files/directories when closing data files; cleanup now runs on all exit paths and surfaces combined errors when cleanup and close/save both fail.
  * Prevents leftover temp folders and reduces disk usage.
  * No changes to public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->