### PR TITLE
Don't double remove dbFilePath.

### DIFF
--- a/pkg/dotc1z/file.go
+++ b/pkg/dotc1z/file.go
@@ -69,12 +69,6 @@ func saveC1z(dbFilePath string, outputFilePath string) error {
 		if err != nil {
 			zap.L().Error("failed to close db file", zap.Error(err))
 		}
-
-		// Cleanup the database filepath. This should always be a file within a temp directory, so we remove the entire dir.
-		err = os.RemoveAll(filepath.Dir(dbFilePath))
-		if err != nil {
-			zap.L().Error("failed to remove db dir", zap.Error(err))
-		}
 	}()
 
 	outFile, err := os.OpenFile(outputFilePath, os.O_RDWR|os.O_CREATE|syscall.O_TRUNC, 0644)


### PR DESCRIPTION
saveC1z is only called by Close(), which always removes the db directory. Double removing it just causes confusion about which part of the code is responsible for what.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents unintended removal of directories during save operations, preserving temporary files and avoiding potential data loss.
  * Streamlines cleanup to close file handles only, reducing spurious cleanup errors and improving reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->