### PR TITLE
Upgrade golangci v2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Run linters
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
           version: latest
           args: --timeout=3m

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Run linters
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
           version: latest
           args: --timeout=3m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,104 +1,111 @@
-linters-settings:
-  exhaustive:
-    default-signifies-exhaustive: true
-
-  gocritic:
-    # The list of supported checkers can be find in https://go-critic.github.io/overview.
-    settings:
-      underef:
-        # Whether to skip (*x).method() calls where x is a pointer receiver.
-        skipRecvDeref: false
-
-  govet:
-    enable-all: true
-    disable:
-      - fieldalignment # too strict
-      - shadow # complains too much about shadowing errors. All research points to this being fine.
-
-  nakedret:
-    max-func-lines: 0
-
-  nolintlint:
-    allow-no-explanation: [ forbidigo, tracecheck, gomnd, gochecknoinits, makezero ]
-    require-explanation: true
-    require-specific: true
-
-  revive:
-    ignore-generated-header: true
-    severity: error
-    rules:
-      - name: atomic
-      - name: line-length-limit
-        arguments: [ 200 ]
-      # These are functions that we use without checking the errors often. Most of these can't return an error even
-      # though they implement an interface that can.
-      - name: unhandled-error
-        arguments:
-          - fmt.Printf
-          - fmt.Println
-          - fmt.Fprint
-          - fmt.Fprintf
-          - fmt.Fprintln
-          - os.Stderr.Sync
-          - sb.WriteString
-          - buf.WriteString
-          - hasher.Write
-          - os.Setenv
-          - os.RemoveAll
-      - name: var-naming
-        arguments: [["ID", "URL", "HTTP", "API"], []]
-
-  tenv:
-    all: true
-
-
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
-    - errcheck # Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases
-    - gosimple # Linter for Go source code that specializes in simplifying a code
-    - govet # Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
-    - ineffassign # Detects when assignments to existing variables are not used
-    - staticcheck # Staticcheck is a go vet on steroids, applying a ton of static analysis checks
-    - typecheck # Like the front-end of a Go compiler, parses and type-checks Go code
-    - unused # Checks Go code for unused constants, variables, functions and types
-    - asasalint # Check for pass []any as any in variadic func(...any)
-    - asciicheck # Simple linter to check that your code does not contain non-ASCII identifiers
-    - bidichk # Checks for dangerous unicode character sequences
-    - bodyclose # checks whether HTTP response body is closed successfully
-    - durationcheck # check for two durations multiplied together
-    - errorlint # errorlint is a linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.
-    # https://github.com/1uf3/execinquery is archived so golangci-lint warns/errors about it
-    # - execinquery # execinquery is a linter about query string checker in Query function which reads your Go src files and warning it finds
-    - exhaustive # check exhaustiveness of enum switch statements
-    - forbidigo # Forbids identifiers
-    - gochecknoinits # Checks that no init functions are present in Go code
-    - goconst # Finds repeated strings that could be replaced by a constant
-    - gocritic # Provides diagnostics that check for bugs, performance and style issues.
-    - godot # Check if comments end in a period
-    - goimports # In addition to fixing imports, goimports also formats your code in the same style as gofmt.
-#    Need this disabled for now, we need to have a replace
-#    - gomoddirectives # Manage the use of 'replace', 'retract', and 'excludes' directives in go.mod.
-    - goprintffuncname # Checks that printf-like functions are named with f at the end
-    - gosec # Inspects source code for security problems
-    - nakedret # Finds naked returns in functions greater than a specified function length
-    - nilerr # Finds the code that returns nil even if it checks that the error is not nil.
-    - noctx # noctx finds sending http request without context.Context
-    - nolintlint # Reports ill-formed or insufficient nolint directives
-    - nonamedreturns # Reports all named returns
-    - nosprintfhostport # Checks for misuse of Sprintf to construct a host with port in a URL.
-    - predeclared # find code that shadows one of Go's predeclared identifiers
-    - revive # Fast, configurable, extensible, flexible, and beautiful linter for Go. Drop-in replacement of golint.
-    - tenv # tenv is analyzer that detects using os.Setenv instead of t.Setenv since Go1.17
-    - tparallel # tparallel detects inappropriate usage of t.Parallel() method in your Go test codes
-    - unconvert # Remove unnecessary type conversions
-    - usestdlibvars # detect the possibility to use variables/constants from the Go standard library
-    - whitespace # Tool for detection of leading and trailing whitespace
-
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - durationcheck
+    - errcheck
+    - errorlint
+    - exhaustive
+    - forbidigo
+    - gochecknoinits
+    - goconst
+    - gocritic
+    - godot
+    - goprintffuncname
+    - gosec
+    - govet
+    - ineffassign
+    - nakedret
+    - nilerr
+    - noctx
+    - nolintlint
+    - nonamedreturns
+    - nosprintfhostport
+    - predeclared
+    - revive
+    - staticcheck
+    - tparallel
+    - unconvert
+    - unused
+    - usestdlibvars
+    - whitespace
+  settings:
+    exhaustive:
+      default-signifies-exhaustive: true
+    gocritic:
+      settings:
+        underef:
+          skipRecvDeref: false
+    govet:
+      disable:
+        - fieldalignment
+        - shadow
+      enable-all: true
+    nakedret:
+      max-func-lines: 0
+    nolintlint:
+      require-explanation: true
+      require-specific: true
+      allow-no-explanation:
+        - forbidigo
+        - tracecheck
+        - gomnd
+        - gochecknoinits
+        - makezero
+    revive:
+      severity: error
+      rules:
+        - name: atomic
+        - name: line-length-limit
+          arguments:
+            - 200
+        - name: unhandled-error
+          arguments:
+            - fmt.Printf
+            - fmt.Println
+            - fmt.Fprint
+            - fmt.Fprintf
+            - fmt.Fprintln
+            - os.Stderr.Sync
+            - sb.WriteString
+            - buf.WriteString
+            - hasher.Write
+            - os.Setenv
+            - os.RemoveAll
+        - name: var-naming
+          arguments:
+            - - ID
+              - URL
+              - HTTP
+              - API
+            - []
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - godot
+        source: (TODO)
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
   max-same-issues: 50
-
-  exclude-rules:
-    # Don't require TODO comments to end in a period
-    - source: "(TODO)"
-      linters: [ godot ]
+formatters:
+  enable:
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/pkg/actions/actions.go
+++ b/pkg/actions/actions.go
@@ -41,8 +41,8 @@ func NewOutstandingAction(id, name string) *OutstandingAction {
 }
 
 func (oa *OutstandingAction) SetStatus(ctx context.Context, status v2.BatonActionStatus) {
-	oa.Mutex.Lock()
-	defer oa.Mutex.Unlock()
+	oa.Lock()
+	defer oa.Unlock()
 	l := ctxzap.Extract(ctx).With(
 		zap.String("action_id", oa.Id),
 		zap.String("action_name", oa.Name),
@@ -59,8 +59,8 @@ func (oa *OutstandingAction) SetStatus(ctx context.Context, status v2.BatonActio
 }
 
 func (oa *OutstandingAction) setError(_ context.Context, err error) {
-	oa.Mutex.Lock()
-	defer oa.Mutex.Unlock()
+	oa.Lock()
+	defer oa.Unlock()
 	if oa.Rv == nil {
 		oa.Rv = &structpb.Struct{}
 	}

--- a/pkg/actions/actions_test.go
+++ b/pkg/actions/actions_test.go
@@ -41,7 +41,7 @@ func testActionHandler(ctx context.Context, args *structpb.Struct) (*structpb.St
 		return nil, nil, fmt.Errorf("missing dn")
 	}
 
-	var userStruct structpb.Struct = structpb.Struct{
+	var userStruct = structpb.Struct{
 		Fields: map[string]*structpb.Value{
 			"success": {
 				Kind: &structpb.Value_BoolValue{BoolValue: true},
@@ -66,7 +66,7 @@ func testAsyncActionHandler(ctx context.Context, args *structpb.Struct) (*struct
 		}
 	}
 
-	var userStruct structpb.Struct = structpb.Struct{
+	var userStruct = structpb.Struct{
 		Fields: map[string]*structpb.Value{
 			"success": {
 				Kind: &structpb.Value_BoolValue{BoolValue: true},
@@ -109,7 +109,7 @@ func testAsyncCancelActionHandler(ctx context.Context, args *structpb.Struct) (*
 		}
 	}
 
-	var userStruct structpb.Struct = structpb.Struct{
+	var userStruct = structpb.Struct{
 		Fields: map[string]*structpb.Value{
 			"success": {
 				Kind: &structpb.Value_BoolValue{BoolValue: true},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -52,7 +52,7 @@ func DefineConfiguration[T field.Configurable](
 	uniqueFields := make(map[string]field.SchemaField)
 	for _, f := range confschema.Fields {
 		if s, ok := uniqueFields[f.FieldName]; ok {
-			if !(f.WasReExported || s.WasReExported) {
+			if !f.WasReExported && !s.WasReExported {
 				return nil, nil, fmt.Errorf("multiple fields with the same name: %s.If you want to use a default field in the SDK, use ExportAs on the connector schema field", f.FieldName)
 			}
 		}
@@ -140,7 +140,7 @@ func verifyStructFields[T field.Configurable](schema field.Configuration) error 
 		configType = configType.Elem()
 	}
 	if configType.Kind() != reflect.Struct {
-		return fmt.Errorf("T must be a struct type, got %v", configType.Kind())
+		return fmt.Errorf("T must be a struct type, got %v", configType.Kind()) //nolint:staticcheck // we want to capital letter here
 	}
 	for _, field := range schema.Fields {
 		fieldFound := false

--- a/pkg/connectorrunner/runner.go
+++ b/pkg/connectorrunner/runner.go
@@ -228,7 +228,7 @@ func (c *connectorRunner) run(ctx context.Context) error {
 	}
 
 	if stopForLoop {
-		return fmt.Errorf("Unable to communicate with gRPC server")
+		return fmt.Errorf("unable to communicate with gRPC server")
 	}
 
 	return nil

--- a/pkg/crypto/providers/registry.go
+++ b/pkg/crypto/providers/registry.go
@@ -9,7 +9,7 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/crypto/providers/jwk"
 )
 
-var EncryptionProviderNotRegisteredError = fmt.Errorf("crypto/providers: encryption provider not registered")
+var ErrEncryptionProviderNotRegistered = fmt.Errorf("crypto/providers: encryption provider not registered")
 
 type EncryptionProvider interface {
 	Encrypt(ctx context.Context, conf *v2.EncryptionConfig, plainText *v2.PlaintextData) (*v2.EncryptedData, error)
@@ -29,7 +29,7 @@ func normalizeProviderName(name string) string {
 func GetEncryptionProvider(name string) (EncryptionProvider, error) {
 	provider, ok := providerRegistry[normalizeProviderName(name)]
 	if !ok {
-		return nil, fmt.Errorf("%w (%s)", EncryptionProviderNotRegisteredError, name)
+		return nil, fmt.Errorf("%w (%s)", ErrEncryptionProviderNotRegistered, name)
 	}
 	return provider, nil
 }
@@ -37,7 +37,7 @@ func GetEncryptionProvider(name string) (EncryptionProvider, error) {
 // GetEncryptionProviderForConfig returns the encryption provider for the given config.
 // If the config specifies a provider, we will fetch it directly by name and return an error if it's not found.
 // If the config contains a non-nil well-known configuration (like JWKPublicKeyConfig), we will return the provider for that by name.
-// If we can't find a provider, we return an EncryptionProviderNotRegisteredError.
+// If we can't find a provider, we return an ErrEncryptionProviderNotRegistered.
 func GetEncryptionProviderForConfig(ctx context.Context, conf *v2.EncryptionConfig) (EncryptionProvider, error) {
 	providerName := normalizeProviderName(conf.GetProvider())
 
@@ -51,7 +51,7 @@ func GetEncryptionProviderForConfig(ctx context.Context, conf *v2.EncryptionConf
 
 	// If we don't have a provider by now, bail.
 	if providerName == "" {
-		return nil, EncryptionProviderNotRegisteredError
+		return nil, ErrEncryptionProviderNotRegistered
 	}
 
 	return GetEncryptionProvider(providerName)

--- a/pkg/field/validation.go
+++ b/pkg/field/validation.go
@@ -115,7 +115,7 @@ func isValidDomain(hostname string) bool {
 
 		// Labels can only contain letters, digits, or hyphens
 		for i := range label {
-			if !(isAlphaNumeric(label[i]) || label[i] == '-') {
+			if !isAlphaNumeric(label[i]) && label[i] != '-' {
 				return false
 			}
 		}

--- a/pkg/metrics/otel_test.go
+++ b/pkg/metrics/otel_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	_ "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"go.opentelemetry.io/otel/exporters/stdout/stdoutmetric"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"

--- a/pkg/ratelimit/mem_ratelimiter.go
+++ b/pkg/ratelimit/mem_ratelimiter.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	ratelimitV1 "github.com/conductorone/baton-sdk/pb/c1/ratelimit/v1"
-	v1 "github.com/conductorone/baton-sdk/pb/c1/ratelimit/v1"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	rl "go.uber.org/ratelimit"
 	"go.uber.org/zap"
@@ -22,20 +21,20 @@ type MemRateLimiter struct {
 // TODO
 func (m *MemRateLimiter) Do(ctx context.Context, req *ratelimitV1.DoRequest) (*ratelimitV1.DoResponse, error) {
 	if m.limiter == nil {
-		return &v1.DoResponse{
+		return &ratelimitV1.DoResponse{
 			RequestToken: req.RequestToken,
-			Description: &v1.RateLimitDescription{
-				Status: v1.RateLimitDescription_STATUS_EMPTY,
+			Description: &ratelimitV1.RateLimitDescription{
+				Status: ratelimitV1.RateLimitDescription_STATUS_EMPTY,
 			},
 		}, nil
 	}
 
 	m.limiter.Take()
 
-	return &v1.DoResponse{
+	return &ratelimitV1.DoResponse{
 		RequestToken: req.RequestToken,
-		Description: &v1.RateLimitDescription{
-			Status: v1.RateLimitDescription_STATUS_EMPTY,
+		Description: &ratelimitV1.RateLimitDescription{
+			Status: ratelimitV1.RateLimitDescription_STATUS_EMPTY,
 		},
 	}, nil
 }

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -2411,7 +2411,7 @@ func (s *syncer) runGrantExpandActions(ctx context.Context) (bool, error) {
 		return false, fmt.Errorf("runGrantExpandActions: error fetching source grants: %w", err)
 	}
 
-	var newGrants []*v2.Grant = make([]*v2.Grant, 0)
+	var newGrants = make([]*v2.Grant, 0)
 	for _, sourceGrant := range sourceGrants.List {
 		// Skip this grant if it is not for a resource type we care about
 		if len(action.ResourceTypeIDs) > 0 {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1,4 +1,4 @@
-package types
+package types //nolint:revive // we want this to be "types"
 
 import (
 	"context"

--- a/pkg/uhttp/dbcache.go
+++ b/pkg/uhttp/dbcache.go
@@ -192,7 +192,7 @@ func (d *DBCache) removeDB(ctx context.Context) error {
 // Get returns cached response (if exists).
 func (d *DBCache) Get(req *http.Request) (*http.Response, error) {
 	var (
-		isFound bool = false
+		isFound = false
 		resp    *http.Response
 	)
 	key, err := CreateCacheKey(req)

--- a/pkg/uhttp/wrapper.go
+++ b/pkg/uhttp/wrapper.go
@@ -598,7 +598,7 @@ func WithBearerToken(token string) RequestOption {
 
 func (c *BaseHttpClient) NewRequest(ctx context.Context, method string, url *url.URL, options ...RequestOption) (*http.Request, error) {
 	var buffer io.ReadWriter
-	var headers map[string]string = make(map[string]string)
+	var headers = make(map[string]string)
 	for _, option := range options {
 		buf, h, err := option()
 		if err != nil {

--- a/pkg/us3/s3.go
+++ b/pkg/us3/s3.go
@@ -15,7 +15,6 @@ import (
 
 	awsSdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
-	_ "github.com/aws/aws-sdk-go-v2/aws/arn"
 	awsConfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"


### PR DESCRIPTION
Upgrade golangci to v2

also ran `golangci-lint run --fix`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None.

- Chores
  - CI linting updated to a newer lint action and lint configuration overhauled with formatter integration.

- Refactor
  - Minor code cleanups: type inference, import tidy-ups, condition simplifications, and consistent error text—no behavior changes.

- Breaking Change
  - Renamed exported error to ErrEncryptionProviderNotRegistered; update external references.

- Tests
  - Small test simplifications with no behavioral impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->