### PR TITLE
add benchmark for large scale cycles

### DIFF
--- a/pkg/sync/expand/cycle.go
+++ b/pkg/sync/expand/cycle.go
@@ -3,114 +3,68 @@ package expand
 import (
 	"context"
 
+	"github.com/conductorone/baton-sdk/pkg/sync/expand/scc"
 	mapset "github.com/deckarep/golang-set/v2"
 )
-
-const (
-	colorWhite uint8 = iota
-	colorGray
-	colorBlack
-)
-
-// cycleDetector encapsulates coloring state for cycle detection on an
-// EntitlementGraph. Node IDs are dense (1..NextNodeID), so slices are used for
-// O(1) access and zero per-op allocations.
-type cycleDetector struct {
-	g      *EntitlementGraph
-	state  []uint8
-	parent []int
-}
-
-func newCycleDetector(g *EntitlementGraph) *cycleDetector {
-	cd := &cycleDetector{
-		g:      g,
-		state:  make([]uint8, g.NextNodeID+1),
-		parent: make([]int, g.NextNodeID+1),
-	}
-	for i := range cd.parent {
-		cd.parent[i] = -1
-	}
-	return cd
-}
-
-// dfs performs a coloring-based DFS from u, returning the first detected cycle
-// as a slice of node IDs or nil if no cycle is reachable from u.
-func (cd *cycleDetector) dfs(u int) ([]int, bool) {
-	// Self-loop fast path.
-	if nbrs, ok := cd.g.SourcesToDestinations[u]; ok {
-		if _, ok := nbrs[u]; ok {
-			return []int{u}, true
-		}
-	}
-
-	cd.state[u] = colorGray
-	if nbrs, ok := cd.g.SourcesToDestinations[u]; ok {
-		for v := range nbrs {
-			switch cd.state[v] {
-			case colorWhite:
-				cd.parent[v] = u
-				if cyc, ok := cd.dfs(v); ok {
-					return cyc, true
-				}
-			case colorGray:
-				// Back-edge to a node on the current recursion stack.
-				// Reconstruct cycle by walking parents from u back to v (inclusive), then reverse.
-				cycle := make([]int, 0, 8)
-				for x := u; ; x = cd.parent[x] {
-					cycle = append(cycle, x)
-					if x == v || cd.parent[x] == -1 {
-						break
-					}
-				}
-				for i, j := 0, len(cycle)-1; i < j; i, j = i+1, j-1 {
-					cycle[i], cycle[j] = cycle[j], cycle[i]
-				}
-				return cycle, true
-			}
-		}
-	}
-	cd.state[u] = colorBlack
-	return nil, false
-}
-
-// FindAny scans all nodes and returns the first detected cycle or nil if none exist.
-func (cd *cycleDetector) FindAny() []int {
-	for nodeID := range cd.g.Nodes {
-		if cd.state[nodeID] != colorWhite {
-			continue
-		}
-		if cyc, ok := cd.dfs(nodeID); ok {
-			return cyc
-		}
-	}
-	return nil
-}
-
-// FindFrom starts cycle detection from a specific node and returns the first
-// cycle reachable from that node, or nil,false if none.
-func (cd *cycleDetector) FindFrom(start int) ([]int, bool) {
-	return cd.dfs(start)
-}
 
 // GetFirstCycle given an entitlements graph, return a cycle by node ID if it
 // exists. Returns nil if no cycle exists. If there is a single
 // node pointing to itself, that will count as a cycle.
-func (g *EntitlementGraph) GetFirstCycle() []int {
+func (g *EntitlementGraph) GetFirstCycle(ctx context.Context) []int {
 	if g.HasNoCycles {
 		return nil
 	}
-	cd := newCycleDetector(g)
-	return cd.FindAny()
+	comps := g.ComputeCyclicComponents(ctx)
+	if len(comps) == 0 {
+		return nil
+	}
+	return comps[0]
+}
+
+// HasCycles returns true if the graph contains any cycle.
+func (g *EntitlementGraph) HasCycles(ctx context.Context) bool {
+	if g.HasNoCycles {
+		return false
+	}
+	return len(g.ComputeCyclicComponents(ctx)) > 0
 }
 
 func (g *EntitlementGraph) cycleDetectionHelper(
 	nodeID int,
 ) ([]int, bool) {
-	// Thin wrapper around the coloring-based DFS, starting from a specific node.
-	// The provided visited/currentCycle are ignored here; coloring provides the
-	// necessary state for correctness and performance.
-	cd := newCycleDetector(g)
-	return cd.FindFrom(nodeID)
+	reach := g.reachableFrom(nodeID)
+	if len(reach) == 0 {
+		return nil, false
+	}
+	adj := g.toAdjacency(reach)
+	groups := scc.CondenseFWBWGroupsFromAdj(context.Background(), adj, scc.DefaultOptions())
+	for _, comp := range groups {
+		if len(comp) > 1 || (len(comp) == 1 && adj[comp[0]][comp[0]] != 0) {
+			return comp, true
+		}
+	}
+	return nil, false
+}
+
+func (g *EntitlementGraph) FixCycles(ctx context.Context) error {
+	return g.FixCyclesFromComponents(ctx, g.ComputeCyclicComponents(ctx))
+}
+
+// ComputeCyclicComponents runs SCC once and returns only cyclic components.
+// A component is cyclic if len>1 or a singleton with a self-loop.
+func (g *EntitlementGraph) ComputeCyclicComponents(ctx context.Context) [][]int {
+	if g.HasNoCycles {
+		return nil
+	}
+	adj := g.toAdjacency(nil)
+	groups := scc.CondenseFWBWGroupsFromAdj(ctx, adj, scc.DefaultOptions())
+	cyclic := make([][]int, 0)
+	for _, comp := range groups {
+		if len(comp) > 1 || (len(comp) == 1 && adj[comp[0]][comp[0]] != 0) {
+			cyclic = append(cyclic, comp)
+		}
+	}
+	return cyclic
 }
 
 // removeNode obliterates a node and all incoming/outgoing edges.
@@ -147,34 +101,33 @@ func (g *EntitlementGraph) removeNode(nodeID int) {
 	delete(g.SourcesToDestinations, nodeID)
 }
 
-// FixCycles if any cycles of nodes exist, merge all nodes in that cycle into a
-// single node and then repeat. Iteration ends when there are no more cycles.
-func (g *EntitlementGraph) FixCycles(ctx context.Context) error {
+// FixCyclesFromComponents merges all provided cyclic components in one pass.
+func (g *EntitlementGraph) FixCyclesFromComponents(ctx context.Context, cyclic [][]int) error {
 	if g.HasNoCycles {
 		return nil
 	}
-	for {
+	if len(cyclic) == 0 {
+		g.HasNoCycles = true
+		return nil
+	}
+	for _, comp := range cyclic {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
 		}
-		cycle := g.GetFirstCycle()
-		if cycle == nil {
-			g.HasNoCycles = true
-			return nil
-		}
-
-		if err := g.fixCycle(cycle); err != nil {
+		if err := g.fixCycle(comp); err != nil {
 			return err
 		}
 	}
+	g.HasNoCycles = true
+	return nil
 }
 
 // fixCycle takes a list of Node IDs that form a cycle and merges them into a
 // single, new node.
 func (g *EntitlementGraph) fixCycle(nodeIDs []int) error {
-	entitlementIDs := mapset.NewSet[string]()
+	entitlementIDs := mapset.NewThreadUnsafeSet[string]()
 	outgoingEdgesToResourceTypeIDs := map[int]mapset.Set[string]{}
 	incomingEdgesToResourceTypeIDs := map[int]mapset.Set[string]{}
 	for _, nodeID := range nodeIDs {
@@ -190,7 +143,7 @@ func (g *EntitlementGraph) fixCycle(nodeIDs []int) error {
 					if edge, ok := g.Edges[edgeID]; ok {
 						resourceTypeIDs, ok := incomingEdgesToResourceTypeIDs[sourceNodeID]
 						if !ok {
-							resourceTypeIDs = mapset.NewSet[string]()
+							resourceTypeIDs = mapset.NewThreadUnsafeSet[string]()
 						}
 						for _, resourceTypeID := range edge.ResourceTypeIDs {
 							resourceTypeIDs.Add(resourceTypeID)
@@ -206,7 +159,7 @@ func (g *EntitlementGraph) fixCycle(nodeIDs []int) error {
 					if edge, ok := g.Edges[edgeID]; ok {
 						resourceTypeIDs, ok := outgoingEdgesToResourceTypeIDs[destinationNodeID]
 						if !ok {
-							resourceTypeIDs = mapset.NewSet[string]()
+							resourceTypeIDs = mapset.NewThreadUnsafeSet[string]()
 						}
 						for _, resourceTypeID := range edge.ResourceTypeIDs {
 							resourceTypeIDs.Add(resourceTypeID)

--- a/pkg/sync/expand/cycle_benchmark_test.go
+++ b/pkg/sync/expand/cycle_benchmark_test.go
@@ -151,6 +151,8 @@ func BenchmarkCycleDetectionHelper(b *testing.B) {
 }
 
 func BenchmarkGetFirstCycle(b *testing.B) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	sizes := []int{100, 1000}
 
 	for _, n := range sizes {
@@ -158,7 +160,7 @@ func BenchmarkGetFirstCycle(b *testing.B) {
 			g := buildRing(b, n)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				_ = g.GetFirstCycle()
+				_ = g.GetFirstCycle(ctx)
 			}
 		})
 	}
@@ -168,7 +170,7 @@ func BenchmarkGetFirstCycle(b *testing.B) {
 			g := buildChain(b, n)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				_ = g.GetFirstCycle()
+				_ = g.GetFirstCycle(ctx)
 			}
 		})
 	}

--- a/pkg/sync/expand/graph_test.go
+++ b/pkg/sync/expand/graph_test.go
@@ -160,7 +160,7 @@ func TestGetFirstCycle(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.message, func(t *testing.T) {
 			graph := parseExpression(t, ctx, testCase.expression)
-			cycle := graph.GetFirstCycle()
+			cycle := graph.GetFirstCycle(ctx)
 			if testCase.expectedCycleSize == 0 {
 				require.Nil(t, cycle)
 			} else {
@@ -189,7 +189,7 @@ func TestHandleCycle(t *testing.T) {
 
 			graph := parseExpression(t, ctx, testCase.expression)
 
-			cycle := graph.GetFirstCycle()
+			cycle := graph.GetFirstCycle(ctx)
 			expectedCycles := createNodeIDList(testCase.expectedCycles)
 			require.NotNil(t, cycle)
 			found := false
@@ -205,7 +205,7 @@ func TestHandleCycle(t *testing.T) {
 			require.NoError(t, err, graph.Str())
 			err = graph.Validate()
 			require.NoError(t, err)
-			cycle = graph.GetFirstCycle()
+			cycle = graph.GetFirstCycle(ctx)
 			require.Nil(t, cycle)
 		})
 	}
@@ -230,7 +230,7 @@ func TestHandleComplexCycle(t *testing.T) {
 	require.Equal(t, 0, len(graph.Edges))
 	require.Equal(t, 3, len(graph.GetEntitlements()))
 
-	cycle := graph.GetFirstCycle()
+	cycle := graph.GetFirstCycle(ctx)
 	require.Nil(t, cycle)
 }
 
@@ -257,7 +257,7 @@ func TestHandleCliqueCycle(t *testing.T) {
 		require.Equal(t, 0, len(graph.Edges))
 		require.Equal(t, 3, len(graph.GetEntitlements()))
 
-		cycle := graph.GetFirstCycle()
+		cycle := graph.GetFirstCycle(ctx)
 		require.Nil(t, cycle)
 	}
 }

--- a/pkg/sync/expand/graph_test.go
+++ b/pkg/sync/expand/graph_test.go
@@ -201,7 +201,7 @@ func TestHandleCycle(t *testing.T) {
 			}
 			require.True(t, found)
 
-			err := graph.FixCycles()
+			err := graph.FixCycles(ctx)
 			require.NoError(t, err, graph.Str())
 			err = graph.Validate()
 			require.NoError(t, err)
@@ -221,7 +221,7 @@ func TestHandleComplexCycle(t *testing.T) {
 	require.Equal(t, 4, len(graph.Edges))
 	require.Equal(t, 3, len(graph.GetEntitlements()))
 
-	err := graph.FixCycles()
+	err := graph.FixCycles(ctx)
 	require.NoError(t, err, graph.Str())
 	err = graph.Validate()
 	require.NoError(t, err)
@@ -248,7 +248,7 @@ func TestHandleCliqueCycle(t *testing.T) {
 		require.Equal(t, 6, len(graph.Edges))
 		require.Equal(t, 3, len(graph.GetEntitlements()))
 
-		err := graph.FixCycles()
+		err := graph.FixCycles(ctx)
 		require.NoError(t, err, graph.Str())
 		err = graph.Validate()
 		require.NoError(t, err)

--- a/pkg/sync/expand/large_scc_benchmark_test.go
+++ b/pkg/sync/expand/large_scc_benchmark_test.go
@@ -9,9 +9,9 @@ import (
 
 // generateEdges constructs a deterministic set of edges for N nodes, aiming for ~M unique edges.
 // It embeds numCycles rings of length cycleLen, and fills the rest randomly using seed.
-func generateEdges(N, M, cycleLen, numCycles int, seed int64) [][2]int {
-	rng := rand.New(rand.NewSource(seed))
-	edgeSet := make(map[[2]int]struct{}, M)
+func generateEdges(n, m, cycleLen, numCycles int, seed int64) [][2]int {
+	rng := rand.New(rand.NewSource(seed)) //nolint:gosec // Deterministic seed is fine for testing/benchmarking.
+	edgeSet := make(map[[2]int]struct{}, m)
 	add := func(u, v int) {
 		if u == v {
 			return
@@ -21,27 +21,27 @@ func generateEdges(N, M, cycleLen, numCycles int, seed int64) [][2]int {
 	}
 	// embed cycles
 	if cycleLen > 1 && numCycles > 0 {
-		stride := N / (numCycles + 1)
+		stride := n / (numCycles + 1)
 		idx := 1
 		for c := 0; c < numCycles; c++ {
 			start := idx
-			for k := 0; k < cycleLen-1 && idx < N; k++ {
+			for k := 0; k < cycleLen-1 && idx < n; k++ {
 				add(idx, idx+1)
 				idx++
 			}
-			if idx <= N {
+			if idx <= n {
 				add(idx, start)
 			}
 			idx += stride
-			if idx > N {
-				idx = N
+			if idx > n {
+				idx = n
 			}
 		}
 	}
 	// fill random until ~M
-	for len(edgeSet) < M {
-		u := 1 + rng.Intn(N)
-		v := 1 + rng.Intn(N)
+	for len(edgeSet) < m {
+		u := 1 + rng.Intn(n)
+		v := 1 + rng.Intn(n)
 		add(u, v)
 	}
 	edges := make([][2]int, 0, len(edgeSet))
@@ -52,17 +52,17 @@ func generateEdges(N, M, cycleLen, numCycles int, seed int64) [][2]int {
 }
 
 // buildGraphFromEdges creates an EntitlementGraph populated only with fields required by FixCycles.
-func buildGraphFromEdges(N int, edges [][2]int) *EntitlementGraph {
+func buildGraphFromEdges(n int, edges [][2]int) *EntitlementGraph {
 	g := &EntitlementGraph{
-		NextNodeID:            N,
+		NextNodeID:            n,
 		NextEdgeID:            0,
-		Nodes:                 make(map[int]Node, N),
+		Nodes:                 make(map[int]Node, n),
 		EntitlementsToNodes:   make(map[string]int),
-		SourcesToDestinations: make(map[int]map[int]int, N),
-		DestinationsToSources: make(map[int]map[int]int, N),
+		SourcesToDestinations: make(map[int]map[int]int, n),
+		DestinationsToSources: make(map[int]map[int]int, n),
 		Edges:                 make(map[int]Edge, len(edges)),
 	}
-	for i := 1; i <= N; i++ {
+	for i := 1; i <= n; i++ {
 		g.Nodes[i] = Node{Id: i}
 	}
 	for _, e := range edges {
@@ -92,14 +92,14 @@ func buildGraphFromEdges(N int, edges [][2]int) *EntitlementGraph {
 	return g
 }
 
-func benchmarkFixCycles(b *testing.B, N, M, cycleLen, numCycles int) {
+func benchmarkFixCycles(b *testing.B, n, m, cycleLen, numCycles int) {
 	b.Helper()
-	edges := generateEdges(N, M, cycleLen, numCycles, 1)
+	edges := generateEdges(n, m, cycleLen, numCycles, 1)
 	ctx := context.Background()
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		g := buildGraphFromEdges(N, edges)
+		g := buildGraphFromEdges(n, edges)
 		if err := g.FixCycles(ctx); err != nil {
 			b.Fatalf("FixCycles error: %v", err)
 		}

--- a/pkg/sync/expand/large_scc_benchmark_test.go
+++ b/pkg/sync/expand/large_scc_benchmark_test.go
@@ -1,0 +1,132 @@
+package expand
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+)
+
+// generateEdges constructs a deterministic set of edges for N nodes, aiming for ~M unique edges.
+// It embeds numCycles rings of length cycleLen, and fills the rest randomly using seed.
+func generateEdges(N, M, cycleLen, numCycles int, seed int64) [][2]int {
+	rng := rand.New(rand.NewSource(seed))
+	edgeSet := make(map[[2]int]struct{}, M)
+	add := func(u, v int) {
+		if u == v {
+			return
+		}
+		key := [2]int{u, v}
+		edgeSet[key] = struct{}{}
+	}
+	// embed cycles
+	if cycleLen > 1 && numCycles > 0 {
+		stride := N / (numCycles + 1)
+		idx := 1
+		for c := 0; c < numCycles; c++ {
+			start := idx
+			for k := 0; k < cycleLen-1 && idx < N; k++ {
+				add(idx, idx+1)
+				idx++
+			}
+			if idx <= N {
+				add(idx, start)
+			}
+			idx += stride
+			if idx > N {
+				idx = N
+			}
+		}
+	}
+	// fill random until ~M
+	for len(edgeSet) < M {
+		u := 1 + rng.Intn(N)
+		v := 1 + rng.Intn(N)
+		add(u, v)
+	}
+	edges := make([][2]int, 0, len(edgeSet))
+	for e := range edgeSet {
+		edges = append(edges, e)
+	}
+	return edges
+}
+
+// buildGraphFromEdges creates an EntitlementGraph populated only with fields required by FixCycles.
+func buildGraphFromEdges(N int, edges [][2]int) *EntitlementGraph {
+	g := &EntitlementGraph{
+		NextNodeID:            N,
+		NextEdgeID:            0,
+		Nodes:                 make(map[int]Node, N),
+		EntitlementsToNodes:   make(map[string]int),
+		SourcesToDestinations: make(map[int]map[int]int, N),
+		DestinationsToSources: make(map[int]map[int]int, N),
+		Edges:                 make(map[int]Edge, len(edges)),
+	}
+	for i := 1; i <= N; i++ {
+		g.Nodes[i] = Node{Id: i}
+	}
+	for _, e := range edges {
+		src, dst := e[0], e[1]
+		if src == dst {
+			continue
+		}
+		row := g.SourcesToDestinations[src]
+		if row == nil {
+			row = make(map[int]int)
+			g.SourcesToDestinations[src] = row
+		}
+		if _, ok := row[dst]; ok {
+			continue
+		}
+		g.NextEdgeID++
+		ed := Edge{EdgeID: g.NextEdgeID, SourceID: src, DestinationID: dst}
+		g.Edges[ed.EdgeID] = ed
+		row[dst] = ed.EdgeID
+		col := g.DestinationsToSources[dst]
+		if col == nil {
+			col = make(map[int]int)
+			g.DestinationsToSources[dst] = col
+		}
+		col[src] = ed.EdgeID
+	}
+	return g
+}
+
+func benchmarkFixCycles(b *testing.B, N, M, cycleLen, numCycles int) {
+	b.Helper()
+	edges := generateEdges(N, M, cycleLen, numCycles, 1)
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		g := buildGraphFromEdges(N, edges)
+		if err := g.FixCycles(ctx); err != nil {
+			b.Fatalf("FixCycles error: %v", err)
+		}
+	}
+}
+
+const enableLongTests = false
+
+func BenchmarkSCC_FixCycles_Large(b *testing.B) {
+	shortCases := []struct{ N, M int }{
+		{N: 10000, M: 100000},
+		{N: 20000, M: 200000},
+	}
+	fullCases := []struct{ N, M int }{
+		{N: 50000, M: 500000},
+		{N: 100000, M: 1000000},
+	}
+	cases := shortCases
+	if !testing.Short() && enableLongTests {
+		cases = append(cases, fullCases...)
+	}
+	for _, c := range cases {
+		name := fmt.Sprintf("N=%d_M=%d", c.N, c.M)
+		b.Run(name, func(b *testing.B) {
+			cycleLen := 16
+			numCycles := c.N / 2048
+			benchmarkFixCycles(b, c.N, c.M, cycleLen, numCycles)
+		})
+	}
+}

--- a/pkg/sync/expand/scc/scc.go
+++ b/pkg/sync/expand/scc/scc.go
@@ -214,6 +214,9 @@ func newBitset(n int) *bitset {
 // test reads a bit without synchronization. Do not call concurrently with any
 // writer to the same bitset.
 func (b *bitset) test(i int) bool {
+	if i < 0 {
+		return false
+	}
 	w := i >> 6
 	return (b.w[w] & (1 << (uint(i) & 63))) != 0
 }
@@ -221,6 +224,9 @@ func (b *bitset) test(i int) bool {
 // set writes a bit without synchronization. Not safe to race with other
 // accesses (reads or writes) to the same bitset.
 func (b *bitset) set(i int) {
+	if i < 0 {
+		return
+	}
 	w := i >> 6
 	b.w[w] |= 1 << (uint(i) & 63)
 }
@@ -228,6 +234,9 @@ func (b *bitset) set(i int) {
 // testAndSetAtomic atomically sets bit i and returns true if it was already
 // set. Safe for concurrent use by multiple goroutines.
 func (b *bitset) testAndSetAtomic(i int) bool {
+	if i < 0 {
+		return false
+	}
 	w := i >> 6
 	mask := uint64(1) << (uint(i) & 63)
 	addr := &b.w[w]
@@ -245,6 +254,9 @@ func (b *bitset) testAndSetAtomic(i int) bool {
 // clearAtomic atomically clears bit i. Safe for concurrent use by multiple
 // goroutines.
 func (b *bitset) clearAtomic(i int) {
+	if i < 0 {
+		return
+	}
 	w := i >> 6
 	mask := ^(uint64(1) << (uint(i) & 63))
 	addr := &b.w[w]
@@ -306,7 +318,7 @@ func (b *bitset) forEachSet(fn func(i int)) {
 			tz := bits.TrailingZeros64(w)
 			i := (wi << 6) + tz
 			fn(i)
-			w &^= 1 << uint(tz)
+			w &^= 1 << uint(tz) //nolint:gosec //bits.TrailingZeros64 never returns negative.
 		}
 	}
 }

--- a/pkg/sync/expand/scc/scc.go
+++ b/pkg/sync/expand/scc/scc.go
@@ -1,0 +1,781 @@
+// Package scc provides a parallel FW–BW SCC condensation for directed graphs,
+// adapted for Baton’s entitlement graph. It builds an immutable CSR + transpose,
+// runs reachability-based SCC (with parallel BFS and parallel recursion), and
+// returns components as groups of your original node IDs.
+package scc
+
+import (
+	"context"
+	"math/bits"
+	"runtime"
+	"sort"
+	"sync"
+	"sync/atomic"
+)
+
+// Lightweight pools to reduce transient allocations in hot paths.
+var (
+	intSlicePool    sync.Pool // *([]int)
+	bucketSlicePool sync.Pool // *([]int)
+)
+
+func getIntSlice(n int) []int {
+	p, _ := intSlicePool.Get().(*[]int)
+	if p == nil || cap(*p) < n {
+		return make([]int, n)
+	}
+	s := (*p)[:n]
+	return s
+}
+
+func putIntSlice(s []int) {
+	intSlicePool.Put(&s)
+}
+
+func getBucketSlice() []int {
+	p, _ := bucketSlicePool.Get().(*[]int)
+	if p == nil {
+		return make([]int, 0, 256)
+	}
+	return (*p)[:0]
+}
+
+func putBucketSlice(s []int) {
+	bucketSlicePool.Put(&s)
+}
+
+// Options controls parallel SCC execution.
+type Options struct {
+	// MaxWorkers bounds concurrency for BFS/recursion. Defaults to GOMAXPROCS.
+	MaxWorkers int
+	// EnableTrim peels vertices with min(in,out)==0 before FW–BW (usually beneficial).
+	EnableTrim bool
+	// SmallCutoff size below which we switch to a simpler (sequential) routine.
+	// You can later swap this to Tarjan for tiny subgraphs.
+	SmallCutoff int
+	// Deterministic maps node IDs to CSR indices in sorted order (recommended).
+	Deterministic bool
+}
+
+// DefaultOptions returns a sensible baseline.
+func DefaultOptions() Options {
+	return Options{
+		MaxWorkers:    runtime.GOMAXPROCS(0),
+		EnableTrim:    false,
+		SmallCutoff:   8192,
+		Deterministic: false,
+	}
+}
+
+// CSR is a compact adjacency for G and its transpose Gᵗ.
+// Indices are 0..N-1; IdxToNodeID maps back to the original node IDs.
+type CSR struct {
+	N           int
+	Row         []int // len N+1
+	Col         []int // len = m
+	TRow        []int // len N+1
+	TCol        []int // len = m
+	IdxToNodeID []int
+	NodeIDToIdx map[int]int
+}
+
+// BuildCSRFromAdj constructs CSR/transpose from adjacency map[int]map[int]int.
+// If opts.Deterministic, node IDs are sorted before assigning indices.
+// Isolated nodes must appear as keys in adj (with empty inner map).
+func BuildCSRFromAdj(adj map[int]map[int]int, opts Options) *CSR {
+	nodes := make([]int, 0, len(adj)*2)
+	seen := make(map[int]struct{}, len(adj)*2)
+	for u, nbrs := range adj {
+		if _, ok := seen[u]; !ok {
+			seen[u] = struct{}{}
+			nodes = append(nodes, u)
+		}
+		for v := range nbrs {
+			if _, ok := seen[v]; !ok {
+				seen[v] = struct{}{}
+				nodes = append(nodes, v)
+			}
+		}
+	}
+	if opts.Deterministic {
+		sort.Ints(nodes)
+	}
+	id2idx := make(map[int]int, len(nodes))
+	for i, id := range nodes {
+		id2idx[id] = i
+	}
+	n := len(nodes)
+
+	// Count edges per row.
+	outDeg := make([]int, n)
+	m := 0
+	for uID, nbrs := range adj {
+		u := id2idx[uID]
+		deg := len(nbrs)
+		outDeg[u] += deg
+		m += deg
+	}
+
+	row := make([]int, n+1)
+	for i := 0; i < n; i++ {
+		row[i+1] = row[i] + outDeg[i]
+	}
+	col := make([]int, m)
+
+	// Fill CSR.
+	cur := make([]int, n)
+	copy(cur, row)
+	for uID, nbrs := range adj {
+		u := id2idx[uID]
+		if opts.Deterministic {
+			vs := make([]int, 0, len(nbrs))
+			for vID := range nbrs {
+				vs = append(vs, vID)
+			}
+			sort.Ints(vs)
+			for _, vID := range vs {
+				v := id2idx[vID]
+				pos := cur[u]
+				col[pos] = v
+				cur[u]++
+			}
+		} else {
+			for vID := range nbrs {
+				v := id2idx[vID]
+				pos := cur[u]
+				col[pos] = v
+				cur[u]++
+			}
+		}
+	}
+
+	// Transpose.
+	inDeg := make([]int, n)
+	for _, v := range col {
+		inDeg[v]++
+	}
+	trow := make([]int, n+1)
+	for i := 0; i < n; i++ {
+		trow[i+1] = trow[i] + inDeg[i]
+	}
+	tcol := make([]int, m)
+	tcur := make([]int, n)
+	copy(tcur, trow)
+	for u := 0; u < n; u++ {
+		start, end := row[u], row[u+1]
+		for p := start; p < end; p++ {
+			v := col[p]
+			pos := tcur[v]
+			tcol[pos] = u
+			tcur[v]++
+		}
+	}
+
+	return &CSR{
+		N:           n,
+		Row:         row,
+		Col:         col,
+		TRow:        trow,
+		TCol:        tcol,
+		IdxToNodeID: nodes,
+		NodeIDToIdx: id2idx,
+	}
+}
+
+// bitset is a packed, atomically updatable bitset.
+//
+// Concurrency notes for callers:
+//   - Only testAndSetAtomic and clearAtomic are safe for concurrent use on the
+//     same bitset value. They perform CAS loops on 64-bit words.
+//   - All other methods (test, set, clone, and, or, andNot, isEmpty, count,
+//     forEachSet) are NOT safe to call concurrently with writers and must not
+//     race with any mutation of the same bitset.
+//   - Concurrent calls to test are fine only if no goroutine may write to that
+//     bitset at the same time (including via atomic methods), otherwise it is a
+//     data race by the Go memory model and race detector.
+//   - Slice storage for []uint64 is 64-bit aligned, satisfying atomic.*Uint64
+//     alignment requirements across architectures.
+//
+// Package usage:
+//   - In BFS, multiple workers set bits in the per-search "visited" bitset via
+//     testAndSetAtomic only; there are no concurrent non-atomic reads/writes.
+//   - The shared "active" mask is only modified outside an in-flight BFS; BFS
+//     reads it (test) while no goroutine mutates it, and recursive calls operate
+//     on disjoint cloned masks.
+type bitset struct{ w []uint64 }
+
+func newBitset(n int) *bitset {
+	if n <= 0 {
+		return &bitset{}
+	}
+	return &bitset{w: make([]uint64, (n+63)>>6)}
+}
+
+// test reads a bit without synchronization. Do not call concurrently with any
+// writer to the same bitset.
+func (b *bitset) test(i int) bool {
+	w := i >> 6
+	return (b.w[w] & (1 << (uint(i) & 63))) != 0
+}
+
+// set writes a bit without synchronization. Not safe to race with other
+// accesses (reads or writes) to the same bitset.
+func (b *bitset) set(i int) {
+	w := i >> 6
+	b.w[w] |= 1 << (uint(i) & 63)
+}
+
+// testAndSetAtomic atomically sets bit i and returns true if it was already
+// set. Safe for concurrent use by multiple goroutines.
+func (b *bitset) testAndSetAtomic(i int) bool {
+	w := i >> 6
+	mask := uint64(1) << (uint(i) & 63)
+	addr := &b.w[w]
+	for {
+		old := atomic.LoadUint64(addr)
+		if old&mask != 0 {
+			return true
+		}
+		if atomic.CompareAndSwapUint64(addr, old, old|mask) {
+			return false
+		}
+	}
+}
+
+// clearAtomic atomically clears bit i. Safe for concurrent use by multiple
+// goroutines.
+func (b *bitset) clearAtomic(i int) {
+	w := i >> 6
+	mask := ^(uint64(1) << (uint(i) & 63))
+	addr := &b.w[w]
+	for {
+		old := atomic.LoadUint64(addr)
+		if atomic.CompareAndSwapUint64(addr, old, old&mask) {
+			return
+		}
+	}
+}
+
+func (b *bitset) clone() *bitset {
+	cp := &bitset{w: make([]uint64, len(b.w))}
+	copy(cp.w, b.w)
+	return cp
+}
+
+func (b *bitset) and(x *bitset) *bitset {
+	for i := range b.w {
+		b.w[i] &= x.w[i]
+	}
+	return b
+}
+
+func (b *bitset) or(x *bitset) *bitset {
+	for i := range b.w {
+		b.w[i] |= x.w[i]
+	}
+	return b
+}
+
+func (b *bitset) andNot(x *bitset) *bitset {
+	for i := range b.w {
+		b.w[i] &^= x.w[i]
+	}
+	return b
+}
+
+func (b *bitset) isEmpty() bool {
+	for _, w := range b.w {
+		if w != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func (b *bitset) count() int {
+	total := 0
+	for _, w := range b.w {
+		total += bits.OnesCount64(w)
+	}
+	return total
+}
+
+func (b *bitset) forEachSet(fn func(i int)) {
+	for wi, w := range b.w {
+		for w != 0 {
+			tz := bits.TrailingZeros64(w)
+			i := (wi << 6) + tz
+			fn(i)
+			w &^= 1 << uint(tz)
+		}
+	}
+}
+
+// CondenseFWBWGroupsFromAdj runs parallel FW–BW SCC on adj and returns only
+// the component groups as slices of original node IDs. This avoids building the
+// idToComp map when callers don't need it.
+func CondenseFWBWGroupsFromAdj(ctx context.Context, adj map[int]map[int]int, opts Options) [][]int {
+	if opts.MaxWorkers <= 0 {
+		opts.MaxWorkers = runtime.GOMAXPROCS(0)
+	}
+	csr := BuildCSRFromAdj(adj, opts)
+	// Small graphs: use low-overhead Tarjan SCC
+	if csr.N <= opts.SmallCutoff {
+		comp := tarjanSCC(csr)
+		maxID := -1
+		for _, c := range comp {
+			if c > maxID {
+				maxID = c
+			}
+		}
+		groups := make([][]int, maxID+1)
+		for idx := 0; idx < csr.N; idx++ {
+			cid := comp[idx]
+			groups[cid] = append(groups[cid], csr.IdxToNodeID[idx])
+		}
+		return groups
+	}
+	comp := make([]int, csr.N)
+	for i := range comp {
+		comp[i] = -1
+	}
+	active := newBitset(csr.N)
+	for i := 0; i < csr.N; i++ {
+		active.set(i)
+	}
+	nextID := 0
+	sccFWBW(ctx, csr, active, comp, &nextID, opts)
+
+	groups := make([][]int, nextID)
+	for idx := 0; idx < csr.N; idx++ {
+		cid := comp[idx]
+		if cid < 0 {
+			// Defensive: assign singleton if anything slipped through
+			cid = nextID
+			nextID++
+			comp[idx] = cid
+			if cid >= len(groups) {
+				tmp := make([][]int, cid+1)
+				copy(tmp, groups)
+				groups = tmp
+			}
+		}
+		groups[cid] = append(groups[cid], csr.IdxToNodeID[idx])
+	}
+	return groups
+}
+
+func sccFWBW(ctx context.Context, csr *CSR, active *bitset, comp []int, nextID *int, opts Options) {
+	// Optional trimming loop.
+	if opts.EnableTrim {
+		for {
+			if n := trimSingletons(csr, active, comp, nextID); n == 0 {
+				break
+			}
+			if active.isEmpty() {
+				return
+			}
+		}
+	}
+
+	// Base case: small subgraph — do simple repeated FW–BW (Tarjan hook point).
+	if active.count() <= opts.SmallCutoff {
+		for !active.isEmpty() {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			pivot := firstActive(active)
+			f := bfsMultiSource(ctx, csr, []int{pivot}, active, false, opts.MaxWorkers)
+			b := bfsMultiSource(ctx, csr, []int{pivot}, active, true, opts.MaxWorkers)
+			c := f.clone().and(b)
+			assignComponent(c, comp, nextID, active)
+
+			// Partitions
+			fNotC := f.clone().andNot(c)
+			bNotC := b.clone().andNot(c)
+			fOrB := f.clone().or(b)
+			u := active.clone().andNot(fOrB)
+
+			if !fNotC.isEmpty() {
+				sccFWBW(ctx, csr, fNotC, comp, nextID, opts)
+				active.andNot(fNotC)
+			}
+			if !bNotC.isEmpty() {
+				sccFWBW(ctx, csr, bNotC, comp, nextID, opts)
+				active.andNot(bNotC)
+			}
+			if !u.isEmpty() {
+				sccFWBW(ctx, csr, u, comp, nextID, opts)
+				active.andNot(u)
+			}
+		}
+		return
+	}
+
+	// General case: one pivot; add pivot batching later for extra speed.
+	pivot := firstActive(active)
+	f := bfsMultiSource(ctx, csr, []int{pivot}, active, false, opts.MaxWorkers)
+	b := bfsMultiSource(ctx, csr, []int{pivot}, active, true, opts.MaxWorkers)
+	c := f.clone().and(b)
+	assignComponent(c, comp, nextID, active)
+
+	// F\C, B\C, and U = active \ (F ∪ B)
+	fNotC := f.clone().andNot(c)
+	bNotC := b.clone().andNot(c)
+	fOrB := f.clone().or(b)
+	u := active.clone().andNot(fOrB)
+
+	type sub struct{ mask *bitset }
+	var subs []sub
+	if !fNotC.isEmpty() {
+		subs = append(subs, sub{fNotC})
+	}
+	if !bNotC.isEmpty() {
+		subs = append(subs, sub{bNotC})
+	}
+	if !u.isEmpty() {
+		subs = append(subs, sub{u})
+	}
+	if len(subs) == 0 {
+		return
+	}
+
+	if len(subs) == 1 || opts.MaxWorkers <= 1 {
+		for _, s := range subs {
+			sccFWBW(ctx, csr, s.mask, comp, nextID, opts)
+			active.andNot(s.mask)
+		}
+		return
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(len(subs))
+	for _, s := range subs {
+		mask := s.mask
+		go func() {
+			defer wg.Done()
+			sccFWBW(ctx, csr, mask, comp, nextID, opts)
+		}()
+	}
+	wg.Wait()
+	for _, s := range subs {
+		active.andNot(s.mask)
+	}
+}
+
+// bfsMultiSource runs a parallel BFS from sources over csr.
+// If useTranspose is true, traverses csr.T* arrays.
+// Traversal respects 'active' mask; returns visited including sources.
+// Cancellation: checks ctx between levels.
+func bfsMultiSource(ctx context.Context, csr *CSR, sources []int, active *bitset, useTranspose bool, maxWorkers int) *bitset {
+	if maxWorkers <= 0 {
+		maxWorkers = runtime.GOMAXPROCS(0)
+	}
+	visited := newBitset(csr.N)
+	frontier := frontierSeed(sources, active, visited)
+	if len(frontier) == 0 {
+		return visited
+	}
+
+	getRow := func(u int) (int, int) {
+		if useTranspose {
+			return csr.TRow[u], csr.TRow[u+1]
+		}
+		return csr.Row[u], csr.Row[u+1]
+	}
+	getCol := func(p int) int {
+		if useTranspose {
+			return csr.TCol[p]
+		}
+		return csr.Col[p]
+	}
+
+	for len(frontier) > 0 {
+		select {
+		case <-ctx.Done():
+			return visited
+		default:
+		}
+
+		// Gate parallelism: if frontier small, do sequential step to avoid overhead
+		if len(frontier) <= 64 || maxWorkers == 1 {
+			next := make([]int, 0, len(frontier))
+			for i := 0; i < len(frontier); i++ {
+				u := frontier[i]
+				rs, re := getRow(u)
+				for p := rs; p < re; p++ {
+					v := getCol(p)
+					if !active.test(v) {
+						continue
+					}
+					// Non-atomic is safe because we are single-threaded on this step
+					w := v >> 6
+					mask := uint64(1) << (uint(v) & 63)
+					if (visited.w[w] & mask) == 0 {
+						visited.w[w] |= mask
+						next = append(next, v)
+					}
+				}
+			}
+			frontier = next
+			continue
+		}
+
+		workers := maxWorkers
+		if workers > len(frontier) {
+			workers = len(frontier)
+		}
+		var wg sync.WaitGroup
+		wg.Add(workers)
+
+		chunkSize := (len(frontier) + workers - 1) / workers
+		nextBuckets := make([][]int, workers)
+
+		for w := 0; w < workers; w++ {
+			start := w * chunkSize
+			end := start + chunkSize
+			if start >= len(frontier) {
+				wg.Done()
+				continue
+			}
+			if end > len(frontier) {
+				end = len(frontier)
+			}
+
+			w := w // capture
+			go func(start, end int) {
+				defer wg.Done()
+				local := getBucketSlice()
+				for i := start; i < end; i++ {
+					u := frontier[i]
+					rs, re := getRow(u)
+					for p := rs; p < re; p++ {
+						v := getCol(p)
+						if !active.test(v) {
+							continue
+						}
+						if !visited.testAndSetAtomic(v) {
+							local = append(local, v)
+						}
+					}
+				}
+				nextBuckets[w] = local
+			}(start, end)
+		}
+		wg.Wait()
+
+		// Flatten next frontier and return bucket buffers to pool.
+		total := 0
+		for _, b := range nextBuckets {
+			total += len(b)
+		}
+		next := make([]int, total)
+		off := 0
+		for _, b := range nextBuckets {
+			copy(next[off:], b)
+			off += len(b)
+			putBucketSlice(b)
+		}
+		frontier = next
+	}
+
+	return visited
+}
+
+func frontierSeed(sources []int, active, visited *bitset) []int {
+	out := make([]int, 0, len(sources))
+	for _, s := range sources {
+		if s < 0 {
+			continue
+		}
+		if !active.test(s) {
+			continue
+		}
+		if visited.testAndSetAtomic(s) {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+func firstActive(active *bitset) int {
+	var pivot = -1
+	active.forEachSet(func(i int) {
+		if pivot == -1 {
+			pivot = i
+		}
+	})
+	return pivot
+}
+
+// assignComponent writes comp ids for cMask, and clears those vertices from 'active'.
+func assignComponent(cMask *bitset, comp []int, nextID *int, active *bitset) {
+	if cMask.isEmpty() {
+		return
+	}
+	cid := *nextID
+	*nextID++
+
+	cMask.forEachSet(func(i int) {
+		comp[i] = cid
+		active.clearAtomic(i)
+	})
+}
+
+// trimSingletons peels vertices with restricted in/out degree within 'active'.
+// Each peeled vertex becomes its own SCC id. Returns count peeled.
+func trimSingletons(csr *CSR, active *bitset, comp []int, nextID *int) int {
+	n := csr.N
+	inDeg := getIntSlice(n)
+	outDeg := getIntSlice(n)
+	defer func() {
+		putIntSlice(inDeg)
+		putIntSlice(outDeg)
+	}()
+
+	// Initialize degrees within active and queue zeros
+	queue := getIntSlice(0)
+	defer putIntSlice(queue)
+	// Out-degree within active.
+	for u := 0; u < n; u++ {
+		if !active.test(u) {
+			continue
+		}
+		rs, re := csr.Row[u], csr.Row[u+1]
+		d := 0
+		for p := rs; p < re; p++ {
+			v := csr.Col[p]
+			if active.test(v) {
+				d++
+			}
+		}
+		outDeg[u] = d
+	}
+	// In-degree within active (via transpose).
+	for v := 0; v < n; v++ {
+		if !active.test(v) {
+			continue
+		}
+		rs, re := csr.TRow[v], csr.TRow[v+1]
+		d := 0
+		for p := rs; p < re; p++ {
+			u := csr.TCol[p]
+			if active.test(u) {
+				d++
+			}
+		}
+		inDeg[v] = d
+	}
+	for i := 0; i < n; i++ {
+		if !active.test(i) {
+			continue
+		}
+		if inDeg[i] == 0 || outDeg[i] == 0 {
+			queue = append(queue, i)
+		}
+	}
+
+	peeled := 0
+	for len(queue) > 0 {
+		u := queue[len(queue)-1]
+		queue = queue[:len(queue)-1]
+		if !active.test(u) {
+			continue
+		}
+		if inDeg[u] > 0 && outDeg[u] > 0 {
+			continue
+		}
+		// assign and remove u
+		comp[u] = *nextID
+		*nextID++
+		active.clearAtomic(u)
+		peeled++
+		// Decrement out-neighbors' inDeg
+		rs, re := csr.Row[u], csr.Row[u+1]
+		for p := rs; p < re; p++ {
+			v := csr.Col[p]
+			if !active.test(v) {
+				continue
+			}
+			if inDeg[v] > 0 {
+				inDeg[v]--
+				if inDeg[v] == 0 {
+					queue = append(queue, v)
+				}
+			}
+		}
+		// Decrement in-neighbors' outDeg
+		rs, re = csr.TRow[u], csr.TRow[u+1]
+		for p := rs; p < re; p++ {
+			w := csr.TCol[p]
+			if !active.test(w) {
+				continue
+			}
+			if outDeg[w] > 0 {
+				outDeg[w]--
+				if outDeg[w] == 0 {
+					queue = append(queue, w)
+				}
+			}
+		}
+	}
+	return peeled
+}
+
+// Add a simple sequential Tarjan SCC for small graphs.
+func tarjanSCC(csr *CSR) []int {
+	n := csr.N
+	index := 0
+	indices := make([]int, n)
+	lowlink := make([]int, n)
+	onstack := make([]bool, n)
+	stack := make([]int, 0, n)
+	comp := make([]int, n)
+	for i := 0; i < n; i++ {
+		indices[i] = -1
+		comp[i] = -1
+	}
+	compID := 0
+	var strongConnect func(v int)
+	strongConnect = func(v int) {
+		indices[v] = index
+		lowlink[v] = index
+		index++
+		stack = append(stack, v)
+		onstack[v] = true
+		for p := csr.Row[v]; p < csr.Row[v+1]; p++ {
+			w := csr.Col[p]
+			if indices[w] == -1 {
+				strongConnect(w)
+				if lowlink[w] < lowlink[v] {
+					lowlink[v] = lowlink[w]
+				}
+			} else if onstack[w] {
+				if indices[w] < lowlink[v] {
+					lowlink[v] = indices[w]
+				}
+			}
+		}
+		if lowlink[v] == indices[v] {
+			for {
+				w := stack[len(stack)-1]
+				stack = stack[:len(stack)-1]
+				onstack[w] = false
+				comp[w] = compID
+				if w == v {
+					break
+				}
+			}
+			compID++
+		}
+	}
+	for v := 0; v < n; v++ {
+		if indices[v] == -1 {
+			strongConnect(v)
+		}
+	}
+	return comp
+}

--- a/pkg/sync/expand/scc/scc.go
+++ b/pkg/sync/expand/scc/scc.go
@@ -523,7 +523,7 @@ func bfsMultiSource(ctx context.Context, csr *CSR, sources []int, active *bitset
 					}
 					// Non-atomic is safe because we are single-threaded on this step
 					w := v >> 6
-					mask := uint64(1) << (uint(v) & 63)
+					mask := uint64(1) << (uint(v) & 63) //nolint:gosec //active.test returns false for negative values.
 					if (visited.w[w] & mask) == 0 {
 						visited.w[w] |= mask
 						next = append(next, v)

--- a/pkg/sync/expand/scc/scc_test.go
+++ b/pkg/sync/expand/scc/scc_test.go
@@ -1,0 +1,239 @@
+package scc
+
+import (
+	"context"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// makeAdj creates an adjacency map ensuring every node appears as a key.
+func makeAdj(nodes []int, edges [][2]int) map[int]map[int]int {
+	adj := make(map[int]map[int]int, len(nodes))
+	for _, u := range nodes {
+		adj[u] = make(map[int]int)
+	}
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		adj[u][v] = 1
+	}
+	return adj
+}
+
+// normalizeGroups sorts nodes within each group and sorts groups by lexicographic order.
+func normalizeGroups(groups [][]int) [][]int {
+	out := make([][]int, len(groups))
+	for i := range groups {
+		g := append([]int(nil), groups[i]...)
+		sort.Ints(g)
+		out[i] = g
+	}
+	sort.Slice(out, func(i, j int) bool {
+		a, b := out[i], out[j]
+		for k := 0; k < len(a) && k < len(b); k++ {
+			if a[k] != b[k] {
+				return a[k] < b[k]
+			}
+		}
+		return len(a) < len(b)
+	})
+	return out
+}
+
+func defaultOpts() Options {
+	o := DefaultOptions()
+	o.Deterministic = true
+	o.MaxWorkers = 1 // ensure deterministic exploration in tests
+	return o
+}
+
+func TestRingSingleComponent(t *testing.T) {
+	n := 6
+	nodes := make([]int, n)
+	for i := 0; i < n; i++ {
+		nodes[i] = i
+	}
+	var edges [][2]int
+	for i := 0; i < n; i++ {
+		edges = append(edges, [2]int{i, (i + 1) % n})
+	}
+	adj := makeAdj(nodes, edges)
+
+	groups := CondenseFWBWGroupsFromAdj(context.Background(), adj, defaultOpts())
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 component, got %d: %+v", len(groups), groups)
+	}
+	if len(groups[0]) != n {
+		t.Fatalf("expected ring size %d, got %d", n, len(groups[0]))
+	}
+}
+
+func TestChainAllSingletons(t *testing.T) {
+	n := 7
+	nodes := make([]int, n)
+	for i := 0; i < n; i++ {
+		nodes[i] = i
+	}
+	var edges [][2]int
+	for i := 0; i+1 < n; i++ {
+		edges = append(edges, [2]int{i, i + 1})
+	}
+	adj := makeAdj(nodes, edges)
+
+	groups := CondenseFWBWGroupsFromAdj(context.Background(), adj, defaultOpts())
+	if len(groups) != n {
+		t.Fatalf("expected %d singleton components, got %d", n, len(groups))
+	}
+	for idx, g := range groups {
+		if len(g) != 1 {
+			t.Fatalf("expected singleton at comp %d, got size %d", idx, len(g))
+		}
+	}
+}
+
+func TestSelfLoopIsolatedCyclicSingleton(t *testing.T) {
+	nodes := []int{1, 2}
+	edges := [][2]int{{1, 1}, {1, 2}}
+	adj := makeAdj(nodes, edges)
+
+	groups := CondenseFWBWGroupsFromAdj(context.Background(), adj, defaultOpts())
+	// Expect two components: {1} and {2}
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 components, got %d: %+v", len(groups), groups)
+	}
+	// Determine which comp has node 1
+	var comp1 []int
+	for _, g := range groups {
+		for _, id := range g {
+			if id == 1 {
+				comp1 = g
+				break
+			}
+		}
+	}
+	if len(comp1) != 1 {
+		t.Fatalf("node 1 should be singleton SCC, got %v", comp1)
+	}
+	// Verify self-loop classification logic: len==1 but adj[1][1] exists
+	if adj[1][1] == 0 {
+		t.Fatalf("expected self-loop for node 1 in adjacency")
+	}
+}
+
+func TestCliqueSingleComponent(t *testing.T) {
+	n := 5
+	nodes := make([]int, n)
+	for i := 0; i < n; i++ {
+		nodes[i] = 100 + i
+	}
+	var edges [][2]int
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if i == j {
+				continue
+			}
+			edges = append(edges, [2]int{nodes[i], nodes[j]})
+		}
+	}
+	adj := makeAdj(nodes, edges)
+	groups := CondenseFWBWGroupsFromAdj(context.Background(), adj, defaultOpts())
+	if len(groups) != 1 || len(groups[0]) != n {
+		t.Fatalf("expected one SCC of size %d, got %+v", n, groups)
+	}
+}
+
+func TestTailIntoRing(t *testing.T) {
+	ringN := 4
+	tail := []int{900, 901, 902}
+	var nodes []int
+	for i := 0; i < ringN; i++ {
+		nodes = append(nodes, i)
+	}
+	nodes = append(nodes, tail...)
+	var edges [][2]int
+	// ring
+	for i := 0; i < ringN; i++ {
+		edges = append(edges, [2]int{i, (i + 1) % ringN})
+	}
+	// tail into ring start (0)
+	edges = append(edges, [2]int{tail[0], tail[1]}, [2]int{tail[1], tail[2]}, [2]int{tail[2], 0})
+	adj := makeAdj(nodes, edges)
+
+	groups := CondenseFWBWGroupsFromAdj(context.Background(), adj, defaultOpts())
+	// Expect: 1 SCC of size ringN, plus len(tail) singletons
+	if len(groups) != 1+len(tail) {
+		t.Fatalf("expected %d components, got %d: %+v", 1+len(tail), len(groups), groups)
+	}
+	sizes := make([]int, 0, len(groups))
+	for _, g := range groups {
+		sizes = append(sizes, len(g))
+	}
+	sort.Ints(sizes)
+	want := append(make([]int, len(tail)), 0)
+	for i := 0; i < len(tail); i++ {
+		want[i] = 1
+	}
+	want[len(want)-1] = ringN
+	sort.Ints(want)
+	if !reflect.DeepEqual(sizes, want) {
+		t.Fatalf("component sizes mismatch: got %v want %v", sizes, want)
+	}
+}
+
+func TestMultipleDisjointSCCs(t *testing.T) {
+	// Ring A: 0-1-2-0 (size 3)
+	// Ring B: 10-11-12-13-10 (size 4)
+	// Singletons: 100, 101
+	nodes := []int{0, 1, 2, 10, 11, 12, 13, 100, 101}
+	edges := [][2]int{{0, 1}, {1, 2}, {2, 0}, {10, 11}, {11, 12}, {12, 13}, {13, 10}}
+	adj := makeAdj(nodes, edges)
+
+	groups := CondenseFWBWGroupsFromAdj(context.Background(), adj, defaultOpts())
+	// Filter out any empty groups (should not occur logically, but tolerate
+	// preallocated empty slots when packing components).
+	sizes := make([]int, 0, len(groups))
+	for _, g := range groups {
+		if len(g) == 0 {
+			continue
+		}
+		sizes = append(sizes, len(g))
+	}
+	sort.Ints(sizes)
+	want := []int{1, 1, 3, 4}
+	if !reflect.DeepEqual(sizes, want) {
+		t.Fatalf("component sizes mismatch: got %v want %v", sizes, want)
+	}
+	// Ensure partition covers all nodes
+	seen := make(map[int]bool, len(nodes))
+	for _, g := range groups {
+		for _, id := range g {
+			seen[id] = true
+		}
+	}
+	for _, id := range nodes {
+		if !seen[id] {
+			t.Fatalf("node %d missing from partition", id)
+		}
+	}
+}
+
+func TestDeterminismWithSingleWorker(t *testing.T) {
+	// Graph with two SCCs and two singletons
+	nodes := []int{1, 2, 3, 4, 5, 6}
+	edges := [][2]int{{1, 2}, {2, 1}, {3, 4}, {4, 3}}
+	adj := makeAdj(nodes, edges)
+	opts := defaultOpts()
+
+	var ref [][]int
+	for i := 0; i < 5; i++ {
+		groups := CondenseFWBWGroupsFromAdj(context.Background(), adj, opts)
+		ng := normalizeGroups(groups)
+		if i == 0 {
+			ref = ng
+			continue
+		}
+		if !reflect.DeepEqual(ng, ref) {
+			t.Fatalf("non-deterministic groups across runs: got %v want %v", ng, ref)
+		}
+	}
+}

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -1362,18 +1362,18 @@ func (s *syncer) SyncGrantExpansion(ctx context.Context) error {
 	}
 
 	if entitlementGraph.Loaded {
-		cycle := entitlementGraph.GetFirstCycle()
-		if cycle != nil {
+		comps := entitlementGraph.ComputeCyclicComponents(ctx)
+		if len(comps) > 0 {
+			// Log a sample cycle
 			l.Warn(
 				"cycle detected in entitlement graph",
-				zap.Any("cycle", cycle),
+				zap.Any("cycle", comps[0]),
 			)
 			l.Debug("initial graph", zap.Any("initial graph", entitlementGraph))
 			if dontFixCycles {
 				return fmt.Errorf("cycles detected in entitlement graph")
 			}
-
-			err := entitlementGraph.FixCycles(ctx)
+			err := entitlementGraph.FixCyclesFromComponents(ctx, comps)
 			if err != nil {
 				return err
 			}

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -1373,7 +1373,7 @@ func (s *syncer) SyncGrantExpansion(ctx context.Context) error {
 				return fmt.Errorf("cycles detected in entitlement graph")
 			}
 
-			err := entitlementGraph.FixCycles()
+			err := entitlementGraph.FixCycles(ctx)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
```
benchmark                                           old ns/op        new ns/op     delta
BenchmarkSCC_FixCycles_Large/N=10000_M=100000-8     29685173578      304004762     -98.98%
BenchmarkSCC_FixCycles_Large/N=20000_M=200000-8     137692330860     702017885     -99.49%

benchmark                                           old allocs     new allocs     delta
BenchmarkSCC_FixCycles_Large/N=10000_M=100000-8     44297909       175621         -99.60%
BenchmarkSCC_FixCycles_Large/N=20000_M=200000-8     176603238      350899         -99.80%

benchmark                                           old bytes       new bytes     delta
BenchmarkSCC_FixCycles_Large/N=10000_M=100000-8     3627974760      53200072      -98.53%
BenchmarkSCC_FixCycles_Large/N=20000_M=200000-8     14439696344     106345592     -99.26%
```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Cycle detection now uses SCC-based component analysis and supports context-aware, cancellable operations for more responsive syncs.

- **Refactor**
  - Cycle handling rewritten to iterate over computed components (instead of recursive/coloring), improving scalability, determinism, and concurrency friendliness.

- **Tests**
  - Tests and benchmarks updated for context-aware APIs, deterministic SCC validation, and added large-scale SCC benchmarks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->