### PR TITLE
upgrade to 1.25

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.x
+          go-version: 1.25.x
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Run linters
@@ -18,7 +18,7 @@ jobs:
   go-test:
     strategy:
       matrix:
-        go-version: [1.23.x]
+        go-version: [1.25.x]
         platform: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.x
+          go-version: 1.25.x
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Run linters
@@ -37,7 +37,7 @@ jobs:
   go-test:
     strategy:
       matrix:
-        go-version: [ 1.23.x ]
+        go-version: [ 1.25.x ]
         platform: [ ubuntu-latest, windows-latest ]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/conductorone/baton-sdk
 
-go 1.23.4
+go 1.25
 
 require (
 	filippo.io/age v1.2.1


### PR DESCRIPTION
I pulled this into C1 without issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded the underlying Go runtime to version 1.25 for improved compatibility, security updates, and potential performance enhancements.
  * CI and build workflows updated to use Go 1.25 to ensure consistency across testing and releases.
  * No changes to features, UI, or public APIs; application behavior remains the same.
  * No action required from users; infrastructure-focused update to improve stability and toolchain alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->