### PR TITLE
Add bounds check to bitset set()

### DIFF
--- a/pkg/sync/expand/scc/bitset.go
+++ b/pkg/sync/expand/scc/bitset.go
@@ -31,14 +31,19 @@ func (b *bitset) test(i int) bool {
 	return (b.w[w] & (1 << (uint(i) & 63))) != 0
 }
 
+// set sets the bit at index i.
 func (b *bitset) set(i int) {
 	if i < 0 {
 		return
 	}
 	w := i >> 6
+	if w >= len(b.w) {
+		return
+	}
 	b.w[w] |= 1 << (uint(i) & 63)
 }
 
+// testAndSetAtomic sets the bit at index i and returns true if the bit was already set, false otherwise.
 func (b *bitset) testAndSetAtomic(i int) bool {
 	if i < 0 {
 		return false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Improved stability by adding bounds checks to prevent rare out-of-bounds access during bit operations, avoiding potential crashes in edge cases.

- Documentation
  - Clarified internal comments for better code readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->