### PR TITLE
Clean up APIs to specify sync type and sync ID in more places.

### DIFF
--- a/pkg/connectorstore/connectorstore.go
+++ b/pkg/connectorstore/connectorstore.go
@@ -50,9 +50,9 @@ type Reader interface {
 // ConnectorStoreWriter defines an implementation for a connector v2 datasource writer. This is used to store sync data from an upstream provider.
 type Writer interface {
 	Reader
-	StartOrResumeSync(ctx context.Context, syncType SyncType) (string, bool, error)
-	StartNewSync(ctx context.Context, syncType SyncType) (string, error)
-	StartNewSyncV2(ctx context.Context, syncType SyncType, parentSyncID string) (string, error)
+	ResumeSync(ctx context.Context, syncType SyncType, syncID string) (string, error)
+	StartOrResumeSync(ctx context.Context, syncType SyncType, syncID string) (string, bool, error)
+	StartNewSync(ctx context.Context, syncType SyncType, parentSyncID string) (string, error)
 	SetCurrentSync(ctx context.Context, syncID string) error
 	CurrentSyncStep(ctx context.Context) (string, error)
 	CheckpointSync(ctx context.Context, syncToken string) error

--- a/pkg/dotc1z/c1file_test.go
+++ b/pkg/dotc1z/c1file_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/doug-martin/goqu/v9"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	reader_v2 "github.com/conductorone/baton-sdk/pb/c1/reader/v2"
@@ -275,4 +277,103 @@ func TestC1ZInvalidFile(t *testing.T) {
 
 	_, err = NewC1ZFile(ctx, testFilePath, WithPragma("journal_mode", "WAL"))
 	require.ErrorIs(t, err, ErrInvalidFile)
+}
+
+func TestC1ZStats(t *testing.T) {
+	ctx := context.Background()
+	testFilePath := filepath.Join(c1zTests.workingDir, "test-stats.c1z")
+
+	f, err := NewC1ZFile(ctx, testFilePath, WithPragma("journal_mode", "WAL"))
+	require.NoError(t, err)
+
+	syncID, err := f.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NotEmpty(t, syncID)
+
+	err = f.PutResourceTypes(ctx, &v2.ResourceType{Id: testResourceType})
+	require.NoError(t, err)
+
+	err = f.PutResources(ctx, &v2.Resource{
+		Id: &v2.ResourceId{
+			ResourceType: testResourceType,
+			Resource:     "test-resource",
+		},
+	})
+	require.NoError(t, err)
+
+	err = f.EndSync(ctx)
+	require.NoError(t, err)
+
+	expectedStats := map[string]int64{
+		"resource_types": 1,
+		testResourceType: 1,
+		"entitlements":   0,
+		"grants":         0,
+	}
+
+	stats, err := f.Stats(ctx, connectorstore.SyncTypeFull, syncID)
+	require.NoError(t, err)
+	for k, v := range expectedStats {
+		require.Equal(t, v, stats[k])
+	}
+
+	_, err = f.Stats(ctx, connectorstore.SyncTypePartial, syncID)
+	require.ErrorIs(t, err, status.Errorf(codes.InvalidArgument, "sync '%s' is not of type '%s'", syncID, connectorstore.SyncTypePartial))
+
+	_, err = f.Stats(ctx, connectorstore.SyncTypeAny, syncID)
+	require.NoError(t, err)
+	for k, v := range expectedStats {
+		require.Equal(t, v, stats[k])
+	}
+
+	stats, err = f.Stats(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	for k, v := range expectedStats {
+		require.Equal(t, v, stats[k])
+	}
+
+	err = f.Close()
+	require.NoError(t, err)
+}
+
+func TestC1ZStatsPartialSync(t *testing.T) {
+	ctx := context.Background()
+	testFilePath := filepath.Join(c1zTests.workingDir, "test-stats-partial-sync.c1z")
+
+	f, err := NewC1ZFile(ctx, testFilePath, WithPragma("journal_mode", "WAL"))
+	require.NoError(t, err)
+
+	syncID, err := f.StartNewSync(ctx, connectorstore.SyncTypePartial, "")
+	require.NoError(t, err)
+	require.NotEmpty(t, syncID)
+
+	err = f.PutResourceTypes(ctx, &v2.ResourceType{Id: testResourceType})
+	require.NoError(t, err)
+
+	err = f.PutResources(ctx, &v2.Resource{
+		Id: &v2.ResourceId{
+			ResourceType: testResourceType,
+			Resource:     "test-resource",
+		},
+	})
+	require.NoError(t, err)
+
+	err = f.EndSync(ctx)
+	require.NoError(t, err)
+
+	expectedStats := map[string]int64{
+		"resource_types": 1,
+		testResourceType: 1,
+		"entitlements":   0,
+		"grants":         0,
+	}
+
+	stats, err := f.Stats(ctx, connectorstore.SyncTypePartial, syncID)
+	require.NoError(t, err)
+	for k, v := range expectedStats {
+		require.Equal(t, v, stats[k])
+	}
+
+	err = f.Close()
+	require.NoError(t, err)
 }

--- a/pkg/dotc1z/c1file_test.go
+++ b/pkg/dotc1z/c1file_test.go
@@ -92,7 +92,7 @@ func TestC1Z(t *testing.T) {
 	require.NoError(t, err)
 
 	// Start a new sync
-	syncID, newSync, err := f.StartOrResumeSync(ctx, connectorstore.SyncTypeFull)
+	syncID, newSync, err := f.StartOrResumeSync(ctx, connectorstore.SyncTypeFull, "")
 	require.NoError(t, err)
 	require.True(t, newSync)
 	require.NotEmpty(t, syncID)
@@ -111,7 +111,7 @@ func TestC1Z(t *testing.T) {
 
 	var syncID2 string
 	// Resume the previous sync
-	syncID2, newSync, err = f.StartOrResumeSync(ctx, connectorstore.SyncTypeFull)
+	syncID2, newSync, err = f.StartOrResumeSync(ctx, connectorstore.SyncTypeFull, "")
 	require.NoError(t, err)
 	require.False(t, newSync)
 	require.Equal(t, syncID, syncID2)
@@ -165,7 +165,7 @@ func TestC1ZDecoder(t *testing.T) {
 	require.NoError(t, err)
 
 	// Start a new sync
-	_, err = f.StartNewSync(ctx, connectorstore.SyncTypeFull)
+	_, err = f.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
 	require.NoError(t, err)
 
 	resourceTypeID := testResourceType

--- a/pkg/dotc1z/clone_sync.go
+++ b/pkg/dotc1z/clone_sync.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
 )
 
 func cloneTableQuery(tableName string) (string, error) {
@@ -84,7 +86,7 @@ func (c *C1File) CloneSync(ctx context.Context, outPath string, syncID string) (
 	}
 
 	if syncID == "" {
-		syncID, err = c.LatestSyncID(ctx)
+		syncID, err = c.LatestSyncID(ctx, connectorstore.SyncTypeFull)
 		if err != nil {
 			return err
 		}

--- a/pkg/dotc1z/diff_test.go
+++ b/pkg/dotc1z/diff_test.go
@@ -22,7 +22,7 @@ func TestGenerateSyncDiff(t *testing.T) {
 	defer syncFile.Close()
 
 	// Start a sync in the base file
-	baseSyncID, err := syncFile.StartNewSyncV2(ctx, connectorstore.SyncTypeFull, "")
+	baseSyncID, err := syncFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
 	require.NoError(t, err)
 	require.NotEmpty(t, baseSyncID)
 
@@ -46,7 +46,7 @@ func TestGenerateSyncDiff(t *testing.T) {
 	require.NoError(t, err)
 
 	// Start a sync in the new file
-	newSyncID, err := syncFile.StartNewSyncV2(ctx, connectorstore.SyncTypeFull, "")
+	newSyncID, err := syncFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
 	require.NoError(t, err)
 	require.NotEmpty(t, newSyncID)
 

--- a/pkg/dotc1z/sql_helpers_test.go
+++ b/pkg/dotc1z/sql_helpers_test.go
@@ -41,7 +41,7 @@ func TestPutResources(t *testing.T) {
 	c1zFile, err := NewC1ZFile(ctx, tempDir, WithPragma("journal_mode", "WAL"))
 	require.NoError(t, err)
 
-	_, err = c1zFile.StartNewSync(ctx, connectorstore.SyncTypeFull)
+	syncId, err := c1zFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
 	require.NoError(t, err)
 
 	resourceType := &v2.ResourceType{
@@ -60,7 +60,7 @@ func TestPutResources(t *testing.T) {
 	err = c1zFile.EndSync(ctx)
 	require.NoError(t, err)
 
-	stats, err := c1zFile.Stats(ctx)
+	stats, err := c1zFile.Stats(ctx, connectorstore.SyncTypeFull, syncId)
 	require.NoError(t, err)
 
 	require.Equal(t, int64(10_000), stats[resourceType.Id])
@@ -92,7 +92,7 @@ func BenchmarkPutResources(b *testing.B) {
 				c1zFile, err := NewC1ZFile(ctx, tempDir, WithPragma("journal_mode", "WAL"))
 				require.NoError(b, err)
 
-				_, err = c1zFile.StartNewSync(ctx, connectorstore.SyncTypeFull)
+				_, err = c1zFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
 				require.NoError(b, err)
 
 				resourceType := &v2.ResourceType{

--- a/pkg/dotc1z/sync_runs.go
+++ b/pkg/dotc1z/sync_runs.go
@@ -401,7 +401,7 @@ func (c *C1File) ResumeSync(ctx context.Context, syncType connectorstore.SyncTyp
 		if err != nil {
 			return "", err
 		}
-		if syncRun.Type != syncType {
+		if syncType != connectorstore.SyncTypeAny && syncRun.Type != syncType {
 			return "", status.Errorf(codes.FailedPrecondition, "cannot resume sync (%s) when a different sync type (%s) is running", syncRun.Type, syncType)
 		}
 		if syncRun.EndedAt != nil {

--- a/pkg/dotc1z/sync_runs.go
+++ b/pkg/dotc1z/sync_runs.go
@@ -287,23 +287,7 @@ func (c *C1File) PreviousSyncID(ctx context.Context, syncType connectorstore.Syn
 	return s.ID, nil
 }
 
-func (c *C1File) LatestFinishedSyncType(ctx context.Context) (connectorstore.SyncType, error) {
-	ctx, span := tracer.Start(ctx, "C1File.LatestFinishedSyncType")
-	defer span.End()
-
-	s, err := c.getFinishedSync(ctx, 0, connectorstore.SyncTypeAny)
-	if err != nil {
-		return "", err
-	}
-
-	if s == nil {
-		return "", nil
-	}
-
-	return s.Type, nil
-}
-
-func (c *C1File) LatestFinishedSync(ctx context.Context, syncType connectorstore.SyncType) (string, error) {
+func (c *C1File) LatestFinishedSyncID(ctx context.Context, syncType connectorstore.SyncType) (string, error) {
 	ctx, span := tracer.Start(ctx, "C1File.LatestFinishedSync")
 	defer span.End()
 

--- a/pkg/dotc1z/sync_runs.go
+++ b/pkg/dotc1z/sync_runs.go
@@ -135,54 +135,6 @@ func (c *C1File) getLatestUnfinishedSync(ctx context.Context, syncType connector
 	return ret, nil
 }
 
-func (c *C1File) getLatestUnfinishedSyncs(ctx context.Context, syncType connectorstore.SyncType) ([]*syncRun, error) {
-	ctx, span := tracer.Start(ctx, "C1File.getLatestUnfinishedSyncs")
-	defer span.End()
-
-	err := c.validateDb(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	// Don't resume syncs that started over a week ago
-	oneWeekAgo := time.Now().AddDate(0, 0, -7)
-	ret := []*syncRun{}
-	q := c.db.From(syncRuns.Name())
-	q = q.Select("sync_id", "started_at", "ended_at", "sync_token", "sync_type", "parent_sync_id")
-	q = q.Where(goqu.C("ended_at").IsNull())
-	q = q.Where(goqu.C("started_at").Gte(oneWeekAgo))
-	q = q.Order(goqu.C("started_at").Desc())
-	if syncType != connectorstore.SyncTypeAny {
-		q = q.Where(goqu.C("sync_type").Eq(syncType))
-	}
-	q = q.Limit(100)
-
-	query, args, err := q.ToSQL()
-	if err != nil {
-		return nil, err
-	}
-
-	rows, err := c.db.QueryContext(ctx, query, args...)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	for rows.Next() {
-		row := &syncRun{}
-		err = rows.Scan(&row.ID, &row.StartedAt, &row.EndedAt, &row.SyncToken, &row.Type, &row.ParentSyncID)
-		if err != nil {
-			return nil, err
-		}
-		ret = append(ret, row)
-	}
-	if rows.Err() != nil {
-		return nil, rows.Err()
-	}
-
-	return ret, nil
-}
-
 func (c *C1File) getFinishedSync(ctx context.Context, offset uint, syncType connectorstore.SyncType) (*syncRun, error) {
 	ctx, span := tracer.Start(ctx, "C1File.getFinishedSync")
 	defer span.End()
@@ -293,11 +245,11 @@ func (c *C1File) ListSyncRuns(ctx context.Context, pageToken string, pageSize ui
 	return ret, nextPageToken, nil
 }
 
-func (c *C1File) LatestSyncID(ctx context.Context) (string, error) {
+func (c *C1File) LatestSyncID(ctx context.Context, syncType connectorstore.SyncType) (string, error) {
 	ctx, span := tracer.Start(ctx, "C1File.LatestSyncID")
 	defer span.End()
 
-	s, err := c.getFinishedSync(ctx, 0, connectorstore.SyncTypeFull)
+	s, err := c.getFinishedSync(ctx, 0, syncType)
 	if err != nil {
 		return "", err
 	}
@@ -319,11 +271,11 @@ func (c *C1File) ViewSync(ctx context.Context, syncID string) error {
 	return nil
 }
 
-func (c *C1File) PreviousSyncID(ctx context.Context) (string, error) {
+func (c *C1File) PreviousSyncID(ctx context.Context, syncType connectorstore.SyncType) (string, error) {
 	ctx, span := tracer.Start(ctx, "C1File.PreviousSyncID")
 	defer span.End()
 
-	s, err := c.getFinishedSync(ctx, 1, connectorstore.SyncTypeFull)
+	s, err := c.getFinishedSync(ctx, 1, syncType)
 	if err != nil {
 		return "", err
 	}
@@ -400,7 +352,7 @@ func (c *C1File) getCurrentSync(ctx context.Context) (*syncRun, error) {
 	defer span.End()
 
 	if c.currentSyncID == "" {
-		return nil, fmt.Errorf("c1file: sync must be running to checkpoint")
+		return nil, fmt.Errorf("c1file: sync must be running to get current sync")
 	}
 
 	return c.getSync(ctx, c.currentSyncID)
@@ -447,30 +399,82 @@ func (c *C1File) CheckpointSync(ctx context.Context, syncToken string) error {
 	return nil
 }
 
-// StartOrResumeSync checks if a sync is already running and resumes it if it is.
-// If no sync is running, it starts a new sync.
-// It returns the sync ID and a boolean indicating if a new sync was started.
-func (c *C1File) StartOrResumeSync(ctx context.Context, syncType connectorstore.SyncType) (string, bool, error) {
-	ctx, span := tracer.Start(ctx, "C1File.StartOrResumeSync")
+func (c *C1File) ResumeSync(ctx context.Context, syncType connectorstore.SyncType, syncID string) (string, error) {
+	ctx, span := tracer.Start(ctx, "C1File.ResumeSync")
 	defer span.End()
 
 	if c.currentSyncID != "" {
-		return c.currentSyncID, false, nil
+		if syncID == c.currentSyncID {
+			return c.currentSyncID, nil
+		}
+		if syncID != "" {
+			return "", status.Errorf(codes.FailedPrecondition, "current sync is %s, cannot resume %s", c.currentSyncID, syncID)
+		}
 	}
 
-	if syncType != connectorstore.SyncTypePartial {
-		// Find unfinished syncs of the same type and resume those if they exist.
-		syncs, err := c.getLatestUnfinishedSyncs(ctx, syncType)
+	if syncID != "" {
+		syncRun, err := c.getSync(ctx, syncID)
 		if err != nil {
+			return "", err
+		}
+		if syncRun.Type != syncType {
+			return "", status.Errorf(codes.FailedPrecondition, "cannot resume sync (%s) when a different sync type (%s) is running", syncRun.Type, syncType)
+		}
+		if syncRun.EndedAt != nil {
+			return "", status.Errorf(codes.FailedPrecondition, "cannot resume sync that has already ended")
+		}
+		c.currentSyncID = syncID
+		return c.currentSyncID, nil
+	}
+
+	if c.currentSyncID != "" {
+		syncRun, err := c.getSync(ctx, c.currentSyncID)
+		if err != nil {
+			return "", err
+		}
+		if syncType != connectorstore.SyncTypeAny && syncRun.Type != syncType {
+			return "", status.Errorf(codes.FailedPrecondition, "cannot resume sync. current sync %s is type %s, cannot resume as type %s", syncRun.ID, syncRun.Type, syncType)
+		}
+		if syncRun.EndedAt != nil {
+			return "", status.Errorf(codes.Internal, "current sync %s has already ended. this should never happen", syncRun.ID)
+		}
+
+		return c.currentSyncID, nil
+	}
+
+	syncRun, err := c.getLatestUnfinishedSync(ctx, syncType)
+	if err != nil {
+		return "", err
+	}
+	if syncRun == nil {
+		return "", status.Errorf(codes.NotFound, "no unfinished sync found for type %s", syncType)
+	}
+
+	c.currentSyncID = syncRun.ID
+	return c.currentSyncID, nil
+}
+
+// StartOrResumeSync checks if a sync is already running and resumes it if it is.
+// If no sync is running, it starts a new sync.
+// It returns the sync ID and a boolean indicating if a new sync was started.
+func (c *C1File) StartOrResumeSync(ctx context.Context, syncType connectorstore.SyncType, syncID string) (string, bool, error) {
+	ctx, span := tracer.Start(ctx, "C1File.StartOrResumeSync")
+	defer span.End()
+
+	resumedSyncID, err := c.ResumeSync(ctx, syncType, syncID)
+	if err != nil {
+		if status.Code(err) != codes.NotFound && !errors.Is(err, sql.ErrNoRows) {
 			return "", false, err
 		}
-		if len(syncs) > 0 && syncs[0].EndedAt == nil {
-			c.currentSyncID = syncs[0].ID
-			return c.currentSyncID, false, nil
-		}
+	} else {
+		return resumedSyncID, false, nil
 	}
 
-	syncID, err := c.startNewSyncInternal(ctx, syncType, "")
+	if syncID != "" {
+		return "", false, status.Errorf(codes.NotFound, "no sync with id %s found to resume", syncID)
+	}
+
+	syncID, err = c.StartNewSync(ctx, syncType, "")
 	if err != nil {
 		return "", false, err
 	}
@@ -480,21 +484,10 @@ func (c *C1File) StartOrResumeSync(ctx context.Context, syncType connectorstore.
 	return c.currentSyncID, true, nil
 }
 
-func (c *C1File) StartNewSync(ctx context.Context, syncType connectorstore.SyncType) (string, error) {
+func (c *C1File) StartNewSync(ctx context.Context, syncType connectorstore.SyncType, parentSyncID string) (string, error) {
 	ctx, span := tracer.Start(ctx, "C1File.StartNewSync")
 	defer span.End()
 
-	return c.startNewSyncInternal(ctx, syncType, "")
-}
-
-func (c *C1File) StartNewSyncV2(ctx context.Context, syncType connectorstore.SyncType, parentSyncID string) (string, error) {
-	ctx, span := tracer.Start(ctx, "C1File.StartNewSyncV2")
-	defer span.End()
-
-	return c.startNewSyncInternal(ctx, syncType, parentSyncID)
-}
-
-func (c *C1File) startNewSyncInternal(ctx context.Context, syncType connectorstore.SyncType, parentSyncID string) (string, error) {
 	if c.currentSyncID != "" {
 		cur, err := c.getSync(ctx, c.currentSyncID)
 		if err != nil {

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -285,7 +285,7 @@ func (s *syncer) startOrResumeSync(ctx context.Context) (string, bool, error) {
 	var newSync bool
 	var err error
 	if len(s.targetedSyncResourceIDs) == 0 {
-		syncID, newSync, err = s.store.StartOrResumeSync(ctx, s.syncType)
+		syncID, newSync, err = s.store.StartOrResumeSync(ctx, s.syncType, "")
 		if err != nil {
 			return "", false, err
 		}
@@ -304,7 +304,7 @@ func (s *syncer) startOrResumeSync(ctx context.Context) (string, bool, error) {
 	if latestFullSync != nil {
 		latestFullSyncId = latestFullSync.Id
 	}
-	syncID, err = s.store.StartNewSyncV2(ctx, connectorstore.SyncTypePartial, latestFullSyncId)
+	syncID, err = s.store.StartNewSync(ctx, connectorstore.SyncTypePartial, latestFullSyncId)
 	if err != nil {
 		return "", false, err
 	}
@@ -608,7 +608,7 @@ func (s *syncer) SkipSync(ctx context.Context) error {
 	}
 
 	// TODO: Create a new sync type for empty syncs.
-	_, err = s.store.StartNewSync(ctx, connectorstore.SyncTypeFull)
+	_, err = s.store.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
 	if err != nil {
 		return err
 	}

--- a/pkg/synccompactor/attached/attached.go
+++ b/pkg/synccompactor/attached/attached.go
@@ -25,7 +25,7 @@ func NewAttachedCompactor(base *dotc1z.C1File, applied *dotc1z.C1File, dest *dot
 }
 
 func (c *Compactor) CompactWithSyncID(ctx context.Context, destSyncID string) error {
-	baseSyncID, err := c.base.LatestFinishedSync(ctx, connectorstore.SyncTypeAny)
+	baseSyncID, err := c.base.LatestFinishedSyncID(ctx, connectorstore.SyncTypeAny)
 	if err != nil {
 		return fmt.Errorf("failed to get base sync ID: %w", err)
 	}
@@ -33,7 +33,7 @@ func (c *Compactor) CompactWithSyncID(ctx context.Context, destSyncID string) er
 		return fmt.Errorf("no finished sync found in base")
 	}
 
-	appliedSyncID, err := c.applied.LatestFinishedSync(ctx, connectorstore.SyncTypeAny)
+	appliedSyncID, err := c.applied.LatestFinishedSyncID(ctx, connectorstore.SyncTypeAny)
 	if err != nil {
 		return fmt.Errorf("failed to get applied sync ID: %w", err)
 	}

--- a/pkg/synccompactor/attached/attached.go
+++ b/pkg/synccompactor/attached/attached.go
@@ -25,7 +25,6 @@ func NewAttachedCompactor(base *dotc1z.C1File, applied *dotc1z.C1File, dest *dot
 }
 
 func (c *Compactor) CompactWithSyncID(ctx context.Context, destSyncID string) error {
-	// Get the latest finished full sync ID from base
 	baseSyncID, err := c.base.LatestFinishedSync(ctx, connectorstore.SyncTypeAny)
 	if err != nil {
 		return fmt.Errorf("failed to get base sync ID: %w", err)
@@ -34,7 +33,6 @@ func (c *Compactor) CompactWithSyncID(ctx context.Context, destSyncID string) er
 		return fmt.Errorf("no finished sync found in base")
 	}
 
-	// Get the latest finished sync ID from applied (any type)
 	appliedSyncID, err := c.applied.LatestFinishedSync(ctx, connectorstore.SyncTypeAny)
 	if err != nil {
 		return fmt.Errorf("failed to get applied sync ID: %w", err)

--- a/pkg/synccompactor/attached/attached_test.go
+++ b/pkg/synccompactor/attached/attached_test.go
@@ -30,7 +30,7 @@ func TestAttachedCompactor(t *testing.T) {
 	defer baseDB.Close()
 
 	// Start sync and add some base data
-	_, err = baseDB.StartNewSync(ctx, connectorstore.SyncTypeFull)
+	_, err = baseDB.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
 	require.NoError(t, err)
 
 	err = baseDB.EndSync(ctx)
@@ -42,7 +42,7 @@ func TestAttachedCompactor(t *testing.T) {
 	defer appliedDB.Close()
 
 	// Start sync and add some applied data
-	_, err = appliedDB.StartNewSync(ctx, connectorstore.SyncTypePartial)
+	_, err = appliedDB.StartNewSync(ctx, connectorstore.SyncTypePartial, "")
 	require.NoError(t, err)
 
 	err = appliedDB.EndSync(ctx)
@@ -54,7 +54,7 @@ func TestAttachedCompactor(t *testing.T) {
 	defer destDB.Close()
 
 	// Start a sync in destination and run compaction
-	destSyncID, err := destDB.StartNewSync(ctx, connectorstore.SyncTypeFull)
+	destSyncID, err := destDB.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
 	require.NoError(t, err)
 
 	compactor := NewAttachedCompactor(baseDB, appliedDB, destDB)
@@ -89,7 +89,7 @@ func TestAttachedCompactorMixedSyncTypes(t *testing.T) {
 	defer baseDB.Close()
 
 	// Start a full sync and add some base data
-	baseSyncID, err := baseDB.StartNewSyncV2(ctx, connectorstore.SyncTypeFull, "")
+	baseSyncID, err := baseDB.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
 	require.NoError(t, err)
 	require.NotEmpty(t, baseSyncID)
 
@@ -102,7 +102,7 @@ func TestAttachedCompactorMixedSyncTypes(t *testing.T) {
 	defer appliedDB.Close()
 
 	// Start an incremental sync and add some applied data
-	appliedSyncID, err := appliedDB.StartNewSyncV2(ctx, connectorstore.SyncTypePartial, baseSyncID)
+	appliedSyncID, err := appliedDB.StartNewSync(ctx, connectorstore.SyncTypePartial, baseSyncID)
 	require.NoError(t, err)
 	require.NotEmpty(t, appliedSyncID)
 
@@ -115,7 +115,7 @@ func TestAttachedCompactorMixedSyncTypes(t *testing.T) {
 	defer destDB.Close()
 
 	// Start a sync in destination and run compaction
-	destSyncID, err := destDB.StartNewSync(ctx, connectorstore.SyncTypeFull)
+	destSyncID, err := destDB.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
 	require.NoError(t, err)
 
 	compactor := NewAttachedCompactor(baseDB, appliedDB, destDB)
@@ -151,7 +151,7 @@ func TestAttachedCompactorUsesLatestAppliedSyncOfAnyType(t *testing.T) {
 	require.NoError(t, err)
 	defer baseDB.Close()
 
-	baseSyncID, err := baseDB.StartNewSyncV2(ctx, connectorstore.SyncTypeFull, "")
+	baseSyncID, err := baseDB.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
 	require.NoError(t, err)
 	require.NotEmpty(t, baseSyncID)
 
@@ -164,7 +164,7 @@ func TestAttachedCompactorUsesLatestAppliedSyncOfAnyType(t *testing.T) {
 	defer appliedDB.Close()
 
 	// First sync: full
-	firstAppliedSyncID, err := appliedDB.StartNewSyncV2(ctx, connectorstore.SyncTypeFull, "")
+	firstAppliedSyncID, err := appliedDB.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
 	require.NoError(t, err)
 	require.NotEmpty(t, firstAppliedSyncID)
 
@@ -172,7 +172,7 @@ func TestAttachedCompactorUsesLatestAppliedSyncOfAnyType(t *testing.T) {
 	require.NoError(t, err)
 
 	// Second sync: incremental (this should be the one selected)
-	secondAppliedSyncID, err := appliedDB.StartNewSyncV2(ctx, connectorstore.SyncTypePartial, firstAppliedSyncID)
+	secondAppliedSyncID, err := appliedDB.StartNewSync(ctx, connectorstore.SyncTypePartial, firstAppliedSyncID)
 	require.NoError(t, err)
 	require.NotEmpty(t, secondAppliedSyncID)
 
@@ -185,7 +185,7 @@ func TestAttachedCompactorUsesLatestAppliedSyncOfAnyType(t *testing.T) {
 	defer destDB.Close()
 
 	// Start a sync in destination and run compaction
-	destSyncID, err := destDB.StartNewSync(ctx, connectorstore.SyncTypeFull)
+	destSyncID, err := destDB.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
 	require.NoError(t, err)
 
 	compactor := NewAttachedCompactor(baseDB, appliedDB, destDB)

--- a/pkg/synccompactor/attached/comprehensive_test.go
+++ b/pkg/synccompactor/attached/comprehensive_test.go
@@ -39,7 +39,7 @@ func TestAttachedCompactorComprehensiveScenarios(t *testing.T) {
 	require.NoError(t, err)
 	defer baseDB.Close()
 
-	_, err = baseDB.StartNewSync(ctx, connectorstore.SyncTypeFull)
+	_, err = baseDB.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
 	require.NoError(t, err)
 
 	// Create resource types
@@ -127,7 +127,7 @@ func TestAttachedCompactorComprehensiveScenarios(t *testing.T) {
 	require.NoError(t, err)
 	defer appliedDB.Close()
 
-	_, err = appliedDB.StartNewSync(ctx, connectorstore.SyncTypePartial)
+	_, err = appliedDB.StartNewSync(ctx, connectorstore.SyncTypePartial, "")
 	require.NoError(t, err)
 
 	// Add same resource types to applied
@@ -211,7 +211,7 @@ func TestAttachedCompactorComprehensiveScenarios(t *testing.T) {
 	defer destDB.Close()
 
 	// Start a sync in destination and run compaction
-	destSyncID, err := destDB.StartNewSync(ctx, connectorstore.SyncTypeFull)
+	destSyncID, err := destDB.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
 	require.NoError(t, err)
 
 	compactor := NewAttachedCompactor(baseDB, appliedDB, destDB)

--- a/pkg/synccompactor/attached/timestamp_test.go
+++ b/pkg/synccompactor/attached/timestamp_test.go
@@ -35,7 +35,7 @@ func TestDiscoveredAtMergeLogic(t *testing.T) {
 		require.NoError(t, err)
 		defer baseDB.Close()
 
-		_, err = baseDB.StartNewSync(ctx, connectorstore.SyncTypeFull)
+		_, err = baseDB.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
 		require.NoError(t, err)
 
 		userRT := &v2.ResourceType{Id: "user", DisplayName: "User"}
@@ -64,7 +64,7 @@ func TestDiscoveredAtMergeLogic(t *testing.T) {
 		require.NoError(t, err)
 		defer appliedDB.Close()
 
-		_, err = appliedDB.StartNewSync(ctx, connectorstore.SyncTypeFull)
+		_, err = appliedDB.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
 		require.NoError(t, err)
 
 		err = appliedDB.PutResourceTypes(ctx, userRT)
@@ -89,7 +89,7 @@ func TestDiscoveredAtMergeLogic(t *testing.T) {
 		require.NoError(t, err)
 		defer destDB.Close()
 
-		destSyncID, err := destDB.StartNewSync(ctx, connectorstore.SyncTypeFull)
+		destSyncID, err := destDB.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
 		require.NoError(t, err)
 
 		compactor := NewAttachedCompactor(baseDB, appliedDB, destDB)
@@ -124,7 +124,7 @@ func TestDiscoveredAtMergeLogic(t *testing.T) {
 		require.NoError(t, err)
 		defer appliedDB.Close()
 
-		_, err = appliedDB.StartNewSync(ctx, connectorstore.SyncTypeFull)
+		_, err = appliedDB.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
 		require.NoError(t, err)
 
 		userRT := &v2.ResourceType{Id: "user", DisplayName: "User"}
@@ -153,7 +153,7 @@ func TestDiscoveredAtMergeLogic(t *testing.T) {
 		require.NoError(t, err)
 		defer baseDB.Close()
 
-		_, err = baseDB.StartNewSync(ctx, connectorstore.SyncTypeFull)
+		_, err = baseDB.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
 		require.NoError(t, err)
 
 		err = baseDB.PutResourceTypes(ctx, userRT)
@@ -178,7 +178,7 @@ func TestDiscoveredAtMergeLogic(t *testing.T) {
 		require.NoError(t, err)
 		defer destDB.Close()
 
-		destSyncID, err := destDB.StartNewSync(ctx, connectorstore.SyncTypeFull)
+		destSyncID, err := destDB.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
 		require.NoError(t, err)
 
 		compactor := NewAttachedCompactor(baseDB, appliedDB, destDB)

--- a/pkg/synccompactor/benchmark_test.go
+++ b/pkg/synccompactor/benchmark_test.go
@@ -79,7 +79,7 @@ func generateTestData(ctx context.Context, t *testing.B, tmpDir string, dataset 
 	// Generate resources for base sync (about 60% of total)
 	baseResourceCount := int(float64(dataset.Resources) * 0.6)
 	baseResources := make([]*v2.Resource, baseResourceCount)
-	for i := 0; i < baseResourceCount; i++ {
+	for i := range baseResourceCount {
 		resource := &v2.Resource{
 			Id: &v2.ResourceId{
 				ResourceType: resourceTypeIDs[i%len(resourceTypeIDs)],
@@ -95,7 +95,7 @@ func generateTestData(ctx context.Context, t *testing.B, tmpDir string, dataset 
 	// Generate entitlements for base sync
 	baseEntitlementCount := int(float64(dataset.Entitlements) * 0.6)
 	baseEntitlements := make([]*v2.Entitlement, baseEntitlementCount)
-	for i := 0; i < baseEntitlementCount; i++ {
+	for i := range baseEntitlementCount {
 		entitlement := &v2.Entitlement{
 			Id:          fmt.Sprintf("base-entitlement-%d", i),
 			DisplayName: fmt.Sprintf("Base Entitlement %d", i),
@@ -109,7 +109,7 @@ func generateTestData(ctx context.Context, t *testing.B, tmpDir string, dataset 
 
 	// Generate grants for base sync
 	baseGrantCount := int(float64(dataset.Grants) * 0.6)
-	for i := 0; i < baseGrantCount; i++ {
+	for i := range baseGrantCount {
 		grant := &v2.Grant{
 			Id:          fmt.Sprintf("base-grant-%d", i),
 			Principal:   baseResources[i%len(baseResources)],
@@ -146,7 +146,7 @@ func generateTestData(ctx context.Context, t *testing.B, tmpDir string, dataset 
 
 	// Add some overlapping resources from base
 	overlapCount := int(float64(baseResourceCount) * 0.2)
-	for i := 0; i < overlapCount; i++ {
+	for i := range overlapCount {
 		resource := &v2.Resource{
 			Id: &v2.ResourceId{
 				ResourceType: resourceTypeIDs[i%len(resourceTypeIDs)],
@@ -161,7 +161,7 @@ func generateTestData(ctx context.Context, t *testing.B, tmpDir string, dataset 
 
 	// Add new resources only in applied
 	newResourceCount := appliedResourceCount - overlapCount
-	for i := 0; i < newResourceCount; i++ {
+	for i := range newResourceCount {
 		resource := &v2.Resource{
 			Id: &v2.ResourceId{
 				ResourceType: resourceTypeIDs[i%len(resourceTypeIDs)],
@@ -177,7 +177,7 @@ func generateTestData(ctx context.Context, t *testing.B, tmpDir string, dataset 
 	// Generate entitlements for applied sync
 	appliedEntitlementCount := dataset.Entitlements - baseEntitlementCount
 	appliedEntitlements := make([]*v2.Entitlement, appliedEntitlementCount)
-	for i := 0; i < appliedEntitlementCount; i++ {
+	for i := range appliedEntitlementCount {
 		entitlement := &v2.Entitlement{
 			Id:          fmt.Sprintf("applied-entitlement-%d", i),
 			DisplayName: fmt.Sprintf("Applied Entitlement %d", i),
@@ -191,7 +191,7 @@ func generateTestData(ctx context.Context, t *testing.B, tmpDir string, dataset 
 
 	// Generate grants for applied sync
 	appliedGrantCount := dataset.Grants - baseGrantCount
-	for i := 0; i < appliedGrantCount; i++ {
+	for i := range appliedGrantCount {
 		grant := &v2.Grant{
 			Id:          fmt.Sprintf("applied-grant-%d", i),
 			Principal:   appliedResources[i%len(appliedResources)],
@@ -213,7 +213,7 @@ func generateTestData(ctx context.Context, t *testing.B, tmpDir string, dataset 
 func benchmarkNaiveCompactor(b *testing.B, dataset BenchmarkData) {
 	ctx := context.Background()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		b.StopTimer()
 
 		// Create temporary directories
@@ -277,7 +277,7 @@ func benchmarkAttachedCompactor(b *testing.B, dataset BenchmarkData) {
 		dotc1z.WithPragma("journal_mode", "WAL"),
 	}
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		b.StopTimer()
 
 		// Create temporary directories

--- a/pkg/synccompactor/benchmark_test.go
+++ b/pkg/synccompactor/benchmark_test.go
@@ -61,7 +61,7 @@ func generateTestData(ctx context.Context, t *testing.B, tmpDir string, dataset 
 	baseSync, err := dotc1z.NewC1ZFile(ctx, baseFile, opts...)
 	require.NoError(t, err)
 
-	baseSyncID, err := baseSync.StartNewSync(ctx, connectorstore.SyncTypeFull)
+	baseSyncID, err := baseSync.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
 	require.NoError(t, err)
 
 	// Generate resource types
@@ -128,7 +128,7 @@ func generateTestData(ctx context.Context, t *testing.B, tmpDir string, dataset 
 	appliedSync, err := dotc1z.NewC1ZFile(ctx, appliedFile, opts...)
 	require.NoError(t, err)
 
-	appliedSyncID, err := appliedSync.StartNewSync(ctx, connectorstore.SyncTypePartial)
+	appliedSyncID, err := appliedSync.StartNewSync(ctx, connectorstore.SyncTypePartial, "")
 	require.NoError(t, err)
 
 	// Reuse same resource types
@@ -251,7 +251,7 @@ func benchmarkNaiveCompactor(b *testing.B, dataset BenchmarkData) {
 		defer destC1Z.Close()
 
 		// Start a sync in the destination file
-		_, err = destC1Z.StartNewSync(ctx, connectorstore.SyncTypeFull)
+		_, err = destC1Z.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
 		require.NoError(b, err)
 
 		b.StartTimer()
@@ -313,7 +313,7 @@ func benchmarkAttachedCompactor(b *testing.B, dataset BenchmarkData) {
 		b.StartTimer()
 
 		// Start sync in destination
-		destSyncID, err := destC1Z.StartNewSync(ctx, connectorstore.SyncTypeFull)
+		destSyncID, err := destC1Z.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
 		require.NoError(b, err)
 
 		// Benchmark the attached compaction

--- a/pkg/synccompactor/compactor.go
+++ b/pkg/synccompactor/compactor.go
@@ -272,6 +272,7 @@ func (c *Compactor) doOneCompaction(ctx context.Context, base *CompactableSync, 
 
 	switch c.compactorType {
 	case CompactorTypeNaive:
+		// TODO: Add support for syncID or remove naive compactor.
 		runner := naive.NewNaiveCompactor(baseFile, appliedFile, newFile)
 		if err := runner.Compact(ctx); err != nil {
 			l.Error("error running compaction", zap.Error(err))

--- a/pkg/synccompactor/compactor.go
+++ b/pkg/synccompactor/compactor.go
@@ -283,7 +283,7 @@ func (c *Compactor) doOneCompaction(ctx context.Context, base *CompactableSync, 
 
 	combinedType := unionSyncTypes(baseType, appliedType)
 
-	newSyncId, err := newFile.StartNewSyncV2(ctx, combinedType, "")
+	newSyncId, err := newFile.StartNewSync(ctx, combinedType, "")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/synccompactor/compactor_test.go
+++ b/pkg/synccompactor/compactor_test.go
@@ -916,8 +916,8 @@ func runSyncTypeTest(
 	require.NoError(t, err)
 	defer compactedFile.Close()
 
-	// Verify the compacted file is the correct type.
-	compactedSyncType, err := compactedFile.LatestFinishedSyncType(ctx)
+	syncRuns, _, err := compactedFile.ListSyncRuns(ctx, "", 10)
 	require.NoError(t, err)
-	require.Equal(t, expectedSyncType, compactedSyncType)
+	require.Equal(t, 1, len(syncRuns))
+	require.Equal(t, expectedSyncType, syncRuns[0].Type)
 }

--- a/pkg/synccompactor/compactor_test.go
+++ b/pkg/synccompactor/compactor_test.go
@@ -69,7 +69,7 @@ func runCompactorTest(t *testing.T, ctx context.Context, inputSyncsDir string, c
 	require.NoError(t, err)
 
 	// Start a new sync
-	firstSyncID, isNewSync, err := firstSync.StartOrResumeSync(ctx, connectorstore.SyncTypeFull)
+	firstSyncID, isNewSync, err := firstSync.StartOrResumeSync(ctx, connectorstore.SyncTypeFull, "")
 	require.NoError(t, err)
 	require.NotEmpty(t, firstSyncID)
 	require.True(t, isNewSync)
@@ -201,7 +201,7 @@ func runCompactorTest(t *testing.T, ctx context.Context, inputSyncsDir string, c
 	require.NoError(t, err)
 
 	// Start a new sync
-	secondSyncID, isNewSync, err := secondSync.StartOrResumeSync(ctx, connectorstore.SyncTypePartial)
+	secondSyncID, isNewSync, err := secondSync.StartOrResumeSync(ctx, connectorstore.SyncTypePartial, "")
 	require.NoError(t, err)
 	require.NotEmpty(t, secondSyncID)
 	require.True(t, isNewSync)
@@ -331,7 +331,7 @@ func runCompactorTest(t *testing.T, ctx context.Context, inputSyncsDir string, c
 	require.NoError(t, err)
 
 	// Start a new sync
-	thirdSyncID, isNewSync, err := thirdSync.StartOrResumeSync(ctx, connectorstore.SyncTypePartial)
+	thirdSyncID, isNewSync, err := thirdSync.StartOrResumeSync(ctx, connectorstore.SyncTypePartial, "")
 	require.NoError(t, err)
 	require.NotEmpty(t, thirdSyncID)
 	require.True(t, isNewSync)
@@ -688,7 +688,7 @@ func makeEmptySync(t *testing.T, ctx context.Context, inputSyncsDir string, opts
 	require.NoError(t, err)
 
 	// Start a new sync
-	syncID, isNewSync, err := sync.StartOrResumeSync(ctx, syncType)
+	syncID, isNewSync, err := sync.StartOrResumeSync(ctx, syncType, "")
 	require.NoError(t, err)
 	require.NotEmpty(t, syncID)
 	require.True(t, isNewSync)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resume a specific sync by ID with single-resume semantics and stricter preconditions.
  * Per-sync statistics reporting counts by resource type for a resolved sync context.
  * Start new syncs can reference a parent/previous sync ID; new listing of sync runs for verification.

* **Refactor**
  * Sync APIs standardized: explicit sync type and optional sync ID/parent; resume/start flows consolidated and validations tightened; legacy variant removed.

* **Tests**
  * Test suites updated to exercise new signatures and stats/resume behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->