### PR TITLE
Log Errors from Targeted Sync, but don't stop the whole sync

### DIFF
--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -493,7 +493,10 @@ func (s *syncer) Sync(ctx context.Context) error {
 				continue
 			}
 			if !retryer.ShouldWaitAndRetry(ctx, err) {
-				return err
+				l.Error("max attempts reached for sync targeted resource action", zap.Any("stateAction", stateAction), zap.Error(err))
+				// We want to continue here to make sure we finish other syncs
+				// we need a better solution for this.
+				continue
 			}
 			continue
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sync resilience: when a targeted resource is missing during a partial sync, the system logs a warning, skips that resource, and continues processing remaining actions—reducing aborted syncs and improving overall reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->