### PR TITLE
Remove sync type restrictions in compaction

### DIFF
--- a/pkg/synccompactor/attached/attached.go
+++ b/pkg/synccompactor/attached/attached.go
@@ -26,12 +26,12 @@ func NewAttachedCompactor(base *dotc1z.C1File, applied *dotc1z.C1File, dest *dot
 
 func (c *Compactor) CompactWithSyncID(ctx context.Context, destSyncID string) error {
 	// Get the latest finished full sync ID from base
-	baseSyncID, err := c.base.LatestFinishedSync(ctx, connectorstore.SyncTypeFull)
+	baseSyncID, err := c.base.LatestFinishedSync(ctx, connectorstore.SyncTypeAny)
 	if err != nil {
 		return fmt.Errorf("failed to get base sync ID: %w", err)
 	}
 	if baseSyncID == "" {
-		return fmt.Errorf("no finished full sync found in base")
+		return fmt.Errorf("no finished sync found in base")
 	}
 
 	// Get the latest finished sync ID from applied (any type)

--- a/pkg/synccompactor/attached/attached_test.go
+++ b/pkg/synccompactor/attached/attached_test.go
@@ -42,7 +42,7 @@ func TestAttachedCompactor(t *testing.T) {
 	defer appliedDB.Close()
 
 	// Start sync and add some applied data
-	_, err = appliedDB.StartNewSync(ctx, connectorstore.SyncTypeFull)
+	_, err = appliedDB.StartNewSync(ctx, connectorstore.SyncTypePartial)
 	require.NoError(t, err)
 
 	err = appliedDB.EndSync(ctx)
@@ -133,6 +133,7 @@ func TestAttachedCompactorMixedSyncTypes(t *testing.T) {
 }
 
 func TestAttachedCompactorFailsWithNoFullSyncInBase(t *testing.T) {
+	t.Skip("re-enable this if we fix this")
 	ctx := context.Background()
 
 	// Create temporary files for base, applied, and dest databases


### PR DESCRIPTION
The current sync type restrictions (in do compaction) will always fail for compaction of more that 2 (because we process them in reverse order).

This PR trivially removes them, but I'll work on another to try and do a smart thing here