### PR TITLE
Derive compacted syncs "SyncType" from the sub syncs

### DIFF
--- a/pkg/dotc1z/sync_runs.go
+++ b/pkg/dotc1z/sync_runs.go
@@ -335,6 +335,22 @@ func (c *C1File) PreviousSyncID(ctx context.Context) (string, error) {
 	return s.ID, nil
 }
 
+func (c *C1File) LatestFinishedSyncType(ctx context.Context) (connectorstore.SyncType, error) {
+	ctx, span := tracer.Start(ctx, "C1File.LatestFinishedSyncType")
+	defer span.End()
+
+	s, err := c.getFinishedSync(ctx, 0, connectorstore.SyncTypeAny)
+	if err != nil {
+		return "", err
+	}
+
+	if s == nil {
+		return "", nil
+	}
+
+	return s.Type, nil
+}
+
 func (c *C1File) LatestFinishedSync(ctx context.Context, syncType connectorstore.SyncType) (string, error) {
 	ctx, span := tracer.Start(ctx, "C1File.LatestFinishedSync")
 	defer span.End()

--- a/pkg/synccompactor/attached/attached.go
+++ b/pkg/synccompactor/attached/attached.go
@@ -26,12 +26,12 @@ func NewAttachedCompactor(base *dotc1z.C1File, applied *dotc1z.C1File, dest *dot
 
 func (c *Compactor) CompactWithSyncID(ctx context.Context, destSyncID string) error {
 	// Get the latest finished full sync ID from base
-	baseSyncID, err := c.base.LatestFinishedSync(ctx, connectorstore.SyncTypeFull)
+	baseSyncID, err := c.base.LatestFinishedSync(ctx, connectorstore.SyncTypeAny)
 	if err != nil {
 		return fmt.Errorf("failed to get base sync ID: %w", err)
 	}
 	if baseSyncID == "" {
-		return fmt.Errorf("no finished full sync found in base")
+		return fmt.Errorf("no finished sync found in base")
 	}
 
 	// Get the latest finished sync ID from applied (any type)

--- a/pkg/synccompactor/attached/attached_test.go
+++ b/pkg/synccompactor/attached/attached_test.go
@@ -132,64 +132,6 @@ func TestAttachedCompactorMixedSyncTypes(t *testing.T) {
 	// - The compaction worked with mixed sync types
 }
 
-func TestAttachedCompactorFailsWithNoFullSyncInBase(t *testing.T) {
-	t.Skip("re-enable this if we fix this")
-	ctx := context.Background()
-
-	// Create temporary files for base, applied, and dest databases
-	tmpDir := t.TempDir()
-	baseFile := filepath.Join(tmpDir, "base.c1z")
-	appliedFile := filepath.Join(tmpDir, "applied.c1z")
-	destFile := filepath.Join(tmpDir, "dest.c1z")
-
-	opts := []dotc1z.C1ZOption{
-		dotc1z.WithPragma("journal_mode", "WAL"),
-		dotc1z.WithTmpDir(tmpDir),
-	}
-
-	// Create base database with only an incremental sync (no full sync)
-	baseDB, err := dotc1z.NewC1ZFile(ctx, baseFile, opts...)
-	require.NoError(t, err)
-	defer baseDB.Close()
-
-	// Start an incremental sync in base (should cause compaction to fail)
-	baseSyncID, err := baseDB.StartNewSyncV2(ctx, connectorstore.SyncTypePartial, "some-parent")
-	require.NoError(t, err)
-	require.NotEmpty(t, baseSyncID)
-
-	err = baseDB.EndSync(ctx)
-	require.NoError(t, err)
-
-	// Create applied database with any sync type
-	appliedDB, err := dotc1z.NewC1ZFile(ctx, appliedFile, opts...)
-	require.NoError(t, err)
-	defer appliedDB.Close()
-
-	appliedSyncID, err := appliedDB.StartNewSyncV2(ctx, connectorstore.SyncTypeFull, "")
-	require.NoError(t, err)
-	require.NotEmpty(t, appliedSyncID)
-
-	err = appliedDB.EndSync(ctx)
-	require.NoError(t, err)
-
-	// Create destination database
-	destDB, err := dotc1z.NewC1ZFile(ctx, destFile, opts...)
-	require.NoError(t, err)
-	defer destDB.Close()
-
-	// Start a sync in destination and attempt compaction - this should fail
-	destSyncID, err := destDB.StartNewSync(ctx, connectorstore.SyncTypeFull)
-	require.NoError(t, err)
-
-	compactor := NewAttachedCompactor(baseDB, appliedDB, destDB)
-	err = compactor.CompactWithSyncID(ctx, destSyncID)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "no finished full sync found in base")
-
-	// Clean up the started sync even though compaction failed
-	_ = destDB.EndSync(ctx)
-}
-
 func TestAttachedCompactorUsesLatestAppliedSyncOfAnyType(t *testing.T) {
 	ctx := context.Background()
 

--- a/pkg/synccompactor/attached/attached_test.go
+++ b/pkg/synccompactor/attached/attached_test.go
@@ -42,7 +42,7 @@ func TestAttachedCompactor(t *testing.T) {
 	defer appliedDB.Close()
 
 	// Start sync and add some applied data
-	_, err = appliedDB.StartNewSync(ctx, connectorstore.SyncTypeFull)
+	_, err = appliedDB.StartNewSync(ctx, connectorstore.SyncTypePartial)
 	require.NoError(t, err)
 
 	err = appliedDB.EndSync(ctx)
@@ -133,6 +133,7 @@ func TestAttachedCompactorMixedSyncTypes(t *testing.T) {
 }
 
 func TestAttachedCompactorFailsWithNoFullSyncInBase(t *testing.T) {
+	t.Skip("re-enable this if we fix this")
 	ctx := context.Background()
 
 	// Create temporary files for base, applied, and dest databases

--- a/pkg/synccompactor/attached/comprehensive_test.go
+++ b/pkg/synccompactor/attached/comprehensive_test.go
@@ -127,7 +127,7 @@ func TestAttachedCompactorComprehensiveScenarios(t *testing.T) {
 	require.NoError(t, err)
 	defer appliedDB.Close()
 
-	_, err = appliedDB.StartNewSync(ctx, connectorstore.SyncTypeFull)
+	_, err = appliedDB.StartNewSync(ctx, connectorstore.SyncTypePartial)
 	require.NoError(t, err)
 
 	// Add same resource types to applied

--- a/pkg/synccompactor/benchmark_test.go
+++ b/pkg/synccompactor/benchmark_test.go
@@ -128,7 +128,7 @@ func generateTestData(ctx context.Context, t *testing.B, tmpDir string, dataset 
 	appliedSync, err := dotc1z.NewC1ZFile(ctx, appliedFile, opts...)
 	require.NoError(t, err)
 
-	appliedSyncID, err := appliedSync.StartNewSync(ctx, connectorstore.SyncTypeFull)
+	appliedSyncID, err := appliedSync.StartNewSync(ctx, connectorstore.SyncTypePartial)
 	require.NoError(t, err)
 
 	// Reuse same resource types

--- a/pkg/synccompactor/compactor_test.go
+++ b/pkg/synccompactor/compactor_test.go
@@ -26,7 +26,7 @@ func TestAttachedCompactorWithTmpDir(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(outputDir)
 
-	// Create temporary directory for intermediate files
+	// Create temporary directory for intermediate files.
 	tmpDir, err := os.MkdirTemp("", "compactor-tmp")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
@@ -728,7 +728,7 @@ func makeEmptySync(t *testing.T, ctx context.Context, inputSyncsDir string, opts
 	}
 }
 
-// Test cases for sync type union logic
+// Test cases for sync type union logic.
 func TestSyncTypeUnion_AttachedCompactor(t *testing.T) {
 	runSyncTypeUnionTests(t, CompactorTypeAttached, getAllSyncTypeTestCases())
 }
@@ -737,7 +737,7 @@ func TestSyncTypeUnion_NaiveCompactor(t *testing.T) {
 	runSyncTypeUnionTests(t, CompactorTypeNaive, getBasicSyncTypeTestCases())
 }
 
-// getAllSyncTypeTestCases returns comprehensive test cases for sync type union logic
+// getAllSyncTypeTestCases returns comprehensive test cases for sync type union logic.
 func getAllSyncTypeTestCases() []syncTypeTestCase {
 	return []syncTypeTestCase{
 		// Two-sync combinations
@@ -762,7 +762,7 @@ func getAllSyncTypeTestCases() []syncTypeTestCase {
 	}
 }
 
-// getBasicSyncTypeTestCases returns a subset of test cases for basic validation
+// getBasicSyncTypeTestCases returns a subset of test cases for basic validation.
 func getBasicSyncTypeTestCases() []syncTypeTestCase {
 	return []syncTypeTestCase{
 		{name: "Full + Partial = Full", input: []connectorstore.SyncType{connectorstore.SyncTypeFull, connectorstore.SyncTypePartial}, expected: connectorstore.SyncTypeFull},
@@ -778,7 +778,7 @@ type syncTypeTestCase struct {
 	expected connectorstore.SyncType
 }
 
-// runSyncTypeUnionTests runs sync type union tests for a specific compactor type
+// runSyncTypeUnionTests runs sync type union tests for a specific compactor type.
 func runSyncTypeUnionTests(t *testing.T, compactorType CompactorType, testCases []syncTypeTestCase) {
 	ctx := context.Background()
 
@@ -790,7 +790,7 @@ func runSyncTypeUnionTests(t *testing.T, compactorType CompactorType, testCases 
 	require.NoError(t, err)
 	defer os.RemoveAll(outputDir)
 
-	// Create temporary directory for intermediate files
+	// Create temporary directory for intermediate files.
 	tmpDir, err := os.MkdirTemp("", "compactor-tmp")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
@@ -799,7 +799,7 @@ func runSyncTypeUnionTests(t *testing.T, compactorType CompactorType, testCases 
 		return NewCompactor(ctx, outputDir, compactableSyncs, WithTmpDir(tmpDir), WithCompactorType(compactorType))
 	}
 
-	// Run all test cases
+	// Run all test cases.
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			runSyncTypeTest(t, ctx, inputSyncsDir, createCompactor, tc.input, tc.expected)
@@ -813,14 +813,14 @@ func runSyncTypeTest(t *testing.T, ctx context.Context, inputSyncsDir string, cr
 		dotc1z.WithDecoderOptions(dotc1z.WithDecoderConcurrency(-1)),
 	}
 
-	// Create empty syncs for each sync type
+	// Create empty syncs for each sync type.
 	var compactableSyncs []*CompactableSync
 	for _, syncType := range types {
 		compactableSync := makeEmptySync(t, ctx, inputSyncsDir, opts, syncType)
 		compactableSyncs = append(compactableSyncs, compactableSync)
 	}
 
-	// Create compactor using the callback
+	// Create compactor using the callback.
 	compactor, cleanup, err := createCompactor(compactableSyncs)
 	require.NoError(t, err)
 	defer func() {
@@ -828,17 +828,17 @@ func runSyncTypeTest(t *testing.T, ctx context.Context, inputSyncsDir string, cr
 		require.NoError(t, err)
 	}()
 
-	// Run the compaction
+	// Run the compaction.
 	compactedSync, err := compactor.Compact(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, compactedSync)
 
-	// Open the compacted file
+	// Open the compacted file.
 	compactedFile, err := dotc1z.NewC1ZFile(ctx, compactedSync.FilePath, opts...)
 	require.NoError(t, err)
 	defer compactedFile.Close()
 
-	// Verify the compacted file is the correct type
+	// Verify the compacted file is the correct type.
 	compactedSyncType, err := compactedFile.LatestFinishedSyncType(ctx)
 	require.NoError(t, err)
 	require.Equal(t, expectedSyncType, compactedSyncType)

--- a/pkg/synccompactor/compactor_test.go
+++ b/pkg/synccompactor/compactor_test.go
@@ -199,7 +199,7 @@ func runCompactorTest(t *testing.T, ctx context.Context, inputSyncsDir string, c
 	require.NoError(t, err)
 
 	// Start a new sync
-	secondSyncID, isNewSync, err := secondSync.StartOrResumeSync(ctx, connectorstore.SyncTypeFull)
+	secondSyncID, isNewSync, err := secondSync.StartOrResumeSync(ctx, connectorstore.SyncTypePartial)
 	require.NoError(t, err)
 	require.NotEmpty(t, secondSyncID)
 	require.True(t, isNewSync)
@@ -329,7 +329,7 @@ func runCompactorTest(t *testing.T, ctx context.Context, inputSyncsDir string, c
 	require.NoError(t, err)
 
 	// Start a new sync
-	thirdSyncID, isNewSync, err := thirdSync.StartOrResumeSync(ctx, connectorstore.SyncTypeFull)
+	thirdSyncID, isNewSync, err := thirdSync.StartOrResumeSync(ctx, connectorstore.SyncTypePartial)
 	require.NoError(t, err)
 	require.NotEmpty(t, thirdSyncID)
 	require.True(t, isNewSync)
@@ -487,6 +487,11 @@ func runCompactorTest(t *testing.T, ctx context.Context, inputSyncsDir string, c
 	defer compactedFile.Close()
 
 	// Verify the compacted file contains the expected data
+
+	// sync type should be full
+	compactedSyncType, err := compactedFile.LatestFinishedSyncType(ctx)
+	require.NoError(t, err)
+	require.Equal(t, connectorstore.SyncTypeFull, compactedSyncType)
 
 	// ========= Resource Types Verification =========
 	// All resource types should be present

--- a/pkg/synccompactor/compactor_test.go
+++ b/pkg/synccompactor/compactor_test.go
@@ -879,7 +879,14 @@ func runSyncTypeUnionTests(t *testing.T, compactorType CompactorType, testCases 
 	}
 }
 
-func runSyncTypeTest(t *testing.T, ctx context.Context, inputSyncsDir string, createCompactor func([]*CompactableSync) (*Compactor, func() error, error), types []connectorstore.SyncType, expectedSyncType connectorstore.SyncType) {
+func runSyncTypeTest(
+	t *testing.T,
+	ctx context.Context,
+	inputSyncsDir string,
+	createCompactor func([]*CompactableSync) (*Compactor, func() error, error),
+	types []connectorstore.SyncType,
+	expectedSyncType connectorstore.SyncType,
+) {
 	opts := []dotc1z.C1ZOption{
 		dotc1z.WithPragma("journal_mode", "WAL"),
 		dotc1z.WithDecoderOptions(dotc1z.WithDecoderConcurrency(-1)),

--- a/pkg/synccompactor/compactor_test.go
+++ b/pkg/synccompactor/compactor_test.go
@@ -741,34 +741,106 @@ func TestSyncTypeUnion_NaiveCompactor(t *testing.T) {
 func getAllSyncTypeTestCases() []syncTypeTestCase {
 	return []syncTypeTestCase{
 		// Two-sync combinations
-		{name: "Full + Full = Full", input: []connectorstore.SyncType{connectorstore.SyncTypeFull, connectorstore.SyncTypeFull}, expected: connectorstore.SyncTypeFull},
-		{name: "Full + Partial = Full", input: []connectorstore.SyncType{connectorstore.SyncTypeFull, connectorstore.SyncTypePartial}, expected: connectorstore.SyncTypeFull},
-		{name: "Partial + Full = Full", input: []connectorstore.SyncType{connectorstore.SyncTypePartial, connectorstore.SyncTypeFull}, expected: connectorstore.SyncTypeFull},
-		{name: "Full + ResourcesOnly = Full", input: []connectorstore.SyncType{connectorstore.SyncTypeFull, connectorstore.SyncTypeResourcesOnly}, expected: connectorstore.SyncTypeFull},
-		{name: "ResourcesOnly + Full = Full", input: []connectorstore.SyncType{connectorstore.SyncTypeResourcesOnly, connectorstore.SyncTypeFull}, expected: connectorstore.SyncTypeFull},
-		{name: "ResourcesOnly + ResourcesOnly = ResourcesOnly", input: []connectorstore.SyncType{connectorstore.SyncTypeResourcesOnly, connectorstore.SyncTypeResourcesOnly}, expected: connectorstore.SyncTypeResourcesOnly},
-		{name: "ResourcesOnly + Partial = ResourcesOnly", input: []connectorstore.SyncType{connectorstore.SyncTypeResourcesOnly, connectorstore.SyncTypePartial}, expected: connectorstore.SyncTypeResourcesOnly},
-		{name: "Partial + ResourcesOnly = ResourcesOnly", input: []connectorstore.SyncType{connectorstore.SyncTypePartial, connectorstore.SyncTypeResourcesOnly}, expected: connectorstore.SyncTypeResourcesOnly},
-		{name: "Partial + Partial = Partial", input: []connectorstore.SyncType{connectorstore.SyncTypePartial, connectorstore.SyncTypePartial}, expected: connectorstore.SyncTypePartial},
+		{
+			name:     "Full + Full = Full",
+			input:    []connectorstore.SyncType{connectorstore.SyncTypeFull, connectorstore.SyncTypeFull},
+			expected: connectorstore.SyncTypeFull,
+		},
+		{
+			name:     "Full + Partial = Full",
+			input:    []connectorstore.SyncType{connectorstore.SyncTypeFull, connectorstore.SyncTypePartial},
+			expected: connectorstore.SyncTypeFull,
+		},
+		{
+			name:     "Partial + Full = Full",
+			input:    []connectorstore.SyncType{connectorstore.SyncTypePartial, connectorstore.SyncTypeFull},
+			expected: connectorstore.SyncTypeFull,
+		},
+		{
+			name:     "Full + ResourcesOnly = Full",
+			input:    []connectorstore.SyncType{connectorstore.SyncTypeFull, connectorstore.SyncTypeResourcesOnly},
+			expected: connectorstore.SyncTypeFull,
+		},
+		{
+			name:     "ResourcesOnly + Full = Full",
+			input:    []connectorstore.SyncType{connectorstore.SyncTypeResourcesOnly, connectorstore.SyncTypeFull},
+			expected: connectorstore.SyncTypeFull,
+		},
+		{
+			name:     "ResourcesOnly + ResourcesOnly = ResourcesOnly",
+			input:    []connectorstore.SyncType{connectorstore.SyncTypeResourcesOnly, connectorstore.SyncTypeResourcesOnly},
+			expected: connectorstore.SyncTypeResourcesOnly,
+		},
+		{
+			name:     "ResourcesOnly + Partial = ResourcesOnly",
+			input:    []connectorstore.SyncType{connectorstore.SyncTypeResourcesOnly, connectorstore.SyncTypePartial},
+			expected: connectorstore.SyncTypeResourcesOnly,
+		},
+		{
+			name:     "Partial + ResourcesOnly = ResourcesOnly",
+			input:    []connectorstore.SyncType{connectorstore.SyncTypePartial, connectorstore.SyncTypeResourcesOnly},
+			expected: connectorstore.SyncTypeResourcesOnly,
+		},
+		{
+			name:     "Partial + Partial = Partial",
+			input:    []connectorstore.SyncType{connectorstore.SyncTypePartial, connectorstore.SyncTypePartial},
+			expected: connectorstore.SyncTypePartial,
+		},
 
 		// Three-sync combinations
-		{name: "Full + Partial + ResourcesOnly = Full", input: []connectorstore.SyncType{connectorstore.SyncTypeFull, connectorstore.SyncTypePartial, connectorstore.SyncTypeResourcesOnly}, expected: connectorstore.SyncTypeFull},
-		{name: "Partial + ResourcesOnly + Partial = ResourcesOnly", input: []connectorstore.SyncType{connectorstore.SyncTypePartial, connectorstore.SyncTypeResourcesOnly, connectorstore.SyncTypePartial}, expected: connectorstore.SyncTypeResourcesOnly},
-		{name: "Partial + Partial + Partial = Partial", input: []connectorstore.SyncType{connectorstore.SyncTypePartial, connectorstore.SyncTypePartial, connectorstore.SyncTypePartial}, expected: connectorstore.SyncTypePartial},
+		{
+			name:     "Full + Partial + ResourcesOnly = Full",
+			input:    []connectorstore.SyncType{connectorstore.SyncTypeFull, connectorstore.SyncTypePartial, connectorstore.SyncTypeResourcesOnly},
+			expected: connectorstore.SyncTypeFull,
+		},
+		{
+			name:     "Partial + ResourcesOnly + Partial = ResourcesOnly",
+			input:    []connectorstore.SyncType{connectorstore.SyncTypePartial, connectorstore.SyncTypeResourcesOnly, connectorstore.SyncTypePartial},
+			expected: connectorstore.SyncTypeResourcesOnly,
+		},
+		{
+			name:     "Partial + Partial + Partial = Partial",
+			input:    []connectorstore.SyncType{connectorstore.SyncTypePartial, connectorstore.SyncTypePartial, connectorstore.SyncTypePartial},
+			expected: connectorstore.SyncTypePartial,
+		},
 
 		// Four-sync combinations
-		{name: "ResourcesOnly + Partial + Partial + Partial = ResourcesOnly", input: []connectorstore.SyncType{connectorstore.SyncTypeResourcesOnly, connectorstore.SyncTypePartial, connectorstore.SyncTypePartial, connectorstore.SyncTypePartial}, expected: connectorstore.SyncTypeResourcesOnly},
-		{name: "Partial + Full + ResourcesOnly + Partial = Full", input: []connectorstore.SyncType{connectorstore.SyncTypePartial, connectorstore.SyncTypeFull, connectorstore.SyncTypeResourcesOnly, connectorstore.SyncTypePartial}, expected: connectorstore.SyncTypeFull},
+		{
+			name:     "ResourcesOnly + Partial + Partial + Partial = ResourcesOnly",
+			input:    []connectorstore.SyncType{connectorstore.SyncTypeResourcesOnly, connectorstore.SyncTypePartial, connectorstore.SyncTypePartial, connectorstore.SyncTypePartial},
+			expected: connectorstore.SyncTypeResourcesOnly,
+		},
+		{
+			name:     "Partial + Full + ResourcesOnly + Partial = Full",
+			input:    []connectorstore.SyncType{connectorstore.SyncTypePartial, connectorstore.SyncTypeFull, connectorstore.SyncTypeResourcesOnly, connectorstore.SyncTypePartial},
+			expected: connectorstore.SyncTypeFull,
+		},
 	}
 }
 
 // getBasicSyncTypeTestCases returns a subset of test cases for basic validation.
 func getBasicSyncTypeTestCases() []syncTypeTestCase {
 	return []syncTypeTestCase{
-		{name: "Full + Partial = Full", input: []connectorstore.SyncType{connectorstore.SyncTypeFull, connectorstore.SyncTypePartial}, expected: connectorstore.SyncTypeFull},
-		{name: "ResourcesOnly + Partial = ResourcesOnly", input: []connectorstore.SyncType{connectorstore.SyncTypeResourcesOnly, connectorstore.SyncTypePartial}, expected: connectorstore.SyncTypeResourcesOnly},
-		{name: "Partial + Partial = Partial", input: []connectorstore.SyncType{connectorstore.SyncTypePartial, connectorstore.SyncTypePartial}, expected: connectorstore.SyncTypePartial},
-		{name: "Full + ResourcesOnly + Partial = Full", input: []connectorstore.SyncType{connectorstore.SyncTypeFull, connectorstore.SyncTypeResourcesOnly, connectorstore.SyncTypePartial}, expected: connectorstore.SyncTypeFull},
+		{
+			name:     "Full + Partial = Full",
+			input:    []connectorstore.SyncType{connectorstore.SyncTypeFull, connectorstore.SyncTypePartial},
+			expected: connectorstore.SyncTypeFull,
+		},
+		{
+			name:     "ResourcesOnly + Partial = ResourcesOnly",
+			input:    []connectorstore.SyncType{connectorstore.SyncTypeResourcesOnly, connectorstore.SyncTypePartial},
+			expected: connectorstore.SyncTypeResourcesOnly,
+		},
+		{
+			name:     "Partial + Partial = Partial",
+			input:    []connectorstore.SyncType{connectorstore.SyncTypePartial, connectorstore.SyncTypePartial},
+			expected: connectorstore.SyncTypePartial,
+		},
+		{
+			name:     "Full + ResourcesOnly + Partial = Full",
+			input:    []connectorstore.SyncType{connectorstore.SyncTypeFull, connectorstore.SyncTypeResourcesOnly, connectorstore.SyncTypePartial},
+			expected: connectorstore.SyncTypeFull,
+		},
 	}
 }
 


### PR DESCRIPTION
Instead of enforcing which syncs can compact, lets just make sure the compacted sync itself has a useful type by checking the types of its parts.

I though it made sense to have the type be the "widest" scoped sync of all it's parts. 

Includes a bunch of Cursor generated test cases. I don't know if they actually add value. I'll remove them or improve them at request. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Compaction now preserves and unifies sync types across inputs, producing an output sync type that reflects all inputs (Full, Partial, or Resources-only).
  - Supports compaction when the base has any finished sync, not just full syncs.

- Improvements
  - More accurate and validated detection of base and applied sync types; combined type is used for new compaction results.
  - Clearer error messages when required finished syncs are missing.

- Tests
  - Added comprehensive scenarios validating sync-type union for both compaction paths; adjusted tests to use partial syncs where applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->