### PR TITLE
Don't report grants/entitlements in stats for resource only syncs.

### DIFF
--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -283,22 +283,23 @@ func (c *C1File) Stats(ctx context.Context, syncType connectorstore.SyncType, sy
 		counts[rt.Id] = resourceCount
 	}
 
-	entitlementsCount, err := c.db.From(entitlements.Name()).
-		Where(goqu.C("sync_id").Eq(syncId)).
-		CountContext(ctx)
-	if err != nil {
-		return nil, err
-	}
-	counts["entitlements"] = entitlementsCount
+	if syncType != connectorstore.SyncTypeResourcesOnly {
+		entitlementsCount, err := c.db.From(entitlements.Name()).
+			Where(goqu.C("sync_id").Eq(syncId)).
+			CountContext(ctx)
+		if err != nil {
+			return nil, err
+		}
+		counts["entitlements"] = entitlementsCount
 
-	grantsCount, err := c.db.From(grants.Name()).
-		Where(goqu.C("sync_id").Eq(syncId)).
-		CountContext(ctx)
-	if err != nil {
-		return nil, err
+		grantsCount, err := c.db.From(grants.Name()).
+			Where(goqu.C("sync_id").Eq(syncId)).
+			CountContext(ctx)
+		if err != nil {
+			return nil, err
+		}
+		counts["grants"] = grantsCount
 	}
-
-	counts["grants"] = grantsCount
 
 	return counts, nil
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * In ResourcesOnly sync mode, stats no longer include entitlements and grants, preventing misleading results.

* **Performance**
  * Skips entitlements and grants computations in ResourcesOnly mode to reduce unnecessary queries and improve efficiency.

* **API/Behavior**
  * Stats response in ResourcesOnly mode now omits entitlements and grants keys; resource_types and per-resource_type counts are unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->