### PR TITLE
GetLatestFinishedSync: default to sync type any rather than sync type full.

### DIFF
--- a/pkg/dotc1z/sync_runs.go
+++ b/pkg/dotc1z/sync_runs.go
@@ -795,12 +795,7 @@ func (c *C1File) GetLatestFinishedSync(ctx context.Context, request *reader_v2.S
 	ctx, span := tracer.Start(ctx, "C1File.GetLatestFinishedSync")
 	defer span.End()
 
-	syncType := request.SyncType
-	if syncType == "" {
-		syncType = string(connectorstore.SyncTypeFull)
-	}
-
-	sync, err := c.getFinishedSync(ctx, 0, connectorstore.SyncType(syncType))
+	sync, err := c.getFinishedSync(ctx, 0, connectorstore.SyncType(request.SyncType))
 	if err != nil {
 		return nil, fmt.Errorf("error fetching latest finished sync: %w", err)
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved validation for sync runs: an empty sync type is no longer defaulted to a full sync. Requests without a specified sync type now return a clear invalid-argument error instead of proceeding. This change makes outcomes predictable and avoids unexpected full syncs. Please ensure clients explicitly provide a sync type when initiating a sync.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->