### PR TITLE
Add more test cases for stats.

### DIFF
--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -240,18 +240,19 @@ func (c *C1File) Stats(ctx context.Context, syncType connectorstore.SyncType, sy
 		if err != nil {
 			return nil, err
 		}
-	} else {
-		sync, err := c.GetSync(ctx, &reader_v2.SyncsReaderServiceGetSyncRequest{SyncId: syncId})
-		if err != nil {
-			return nil, err
-		}
-		if sync == nil {
-			return nil, status.Errorf(codes.NotFound, "sync '%s' not found", syncId)
-		}
-		if syncType != connectorstore.SyncTypeAny && syncType != connectorstore.SyncType(sync.Sync.SyncType) {
-			return nil, status.Errorf(codes.InvalidArgument, "sync '%s' is not of type '%s'", syncId, syncType)
-		}
 	}
+	resp, err := c.GetSync(ctx, &reader_v2.SyncsReaderServiceGetSyncRequest{SyncId: syncId})
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil || resp.Sync == nil {
+		return nil, status.Errorf(codes.NotFound, "sync '%s' not found", syncId)
+	}
+	sync := resp.Sync
+	if syncType != connectorstore.SyncTypeAny && syncType != connectorstore.SyncType(sync.SyncType) {
+		return nil, status.Errorf(codes.InvalidArgument, "sync '%s' is not of type '%s'", syncId, syncType)
+	}
+	syncType = connectorstore.SyncType(sync.SyncType)
 
 	counts["resource_types"] = 0
 


### PR DESCRIPTION
Fix bug where grants/entitlements were reported for resource only sync if stats was called with SyncTypeAny.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Always retrieve and use the actual sync type, consolidating logic to ensure stats reflect the true sync and returning clear errors when types mismatch.

* **Tests**
  * Added coverage for Resources-only sync scenarios.
  * Simplified and strengthened stats assertions with a symmetric equality helper for precise comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->