### PR TITLE
Expose uhttp cache config

### DIFF
--- a/pkg/uhttp/wrapper.go
+++ b/pkg/uhttp/wrapper.go
@@ -110,9 +110,13 @@ func NewBaseHttpClient(httpClient *http.Client, opts ...WrapperOption) *BaseHttp
 }
 
 func NewBaseHttpClientWithContext(ctx context.Context, httpClient *http.Client, opts ...WrapperOption) (*BaseHttpClient, error) {
+	return NewBaseHttpClientWithContextCache(ctx, httpClient, nil, opts...)
+}
+
+func NewBaseHttpClientWithContextCache(ctx context.Context, httpClient *http.Client, cacheConfig *CacheConfig, opts ...WrapperOption) (*BaseHttpClient, error) {
 	l := ctxzap.Extract(ctx)
 
-	cache, err := NewHttpCache(ctx, nil)
+	cache, err := NewHttpCache(ctx, cacheConfig)
 	if err != nil {
 		l.Error("error creating http cache", zap.Error(err))
 		return nil, err


### PR DESCRIPTION
- Some scenarios we do not want cache, like pulling job status, but still want uhttp behaviour, like error handling and logs/debug

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable HTTP caching when creating HTTP clients. You can now provide a cache configuration to tailor cache behavior (e.g., size and policies) to your needs.
  * Backward compatible: existing client creation flows continue to work with default caching if no configuration is supplied.
  * Preserves existing error handling and behavior while enabling more flexible performance tuning through cache customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->