### PR TITLE
Remove initial graph log, output is excessive and not useful

### DIFF
--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -1417,7 +1417,7 @@ func (s *syncer) SyncGrantExpansion(ctx context.Context) error {
 				zap.Any("cycle", comps[0]),
 				zap.Any("scc_metrics", sccMetrics),
 			)
-			l.Debug("initial graph", zap.Any("initial graph", entitlementGraph))
+			//l.Debug("initial graph", zap.Any("initial graph", entitlementGraph))
 			if dontFixCycles {
 				return fmt.Errorf("cycles detected in entitlement graph")
 			}

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -1417,7 +1417,13 @@ func (s *syncer) SyncGrantExpansion(ctx context.Context) error {
 				zap.Any("cycle", comps[0]),
 				zap.Any("scc_metrics", sccMetrics),
 			)
-			//l.Debug("initial graph", zap.Any("initial graph", entitlementGraph))
+			l.Debug("initial graph stats",
+				zap.Int("edges", len(entitlementGraph.Edges)),
+				zap.Int("nodes", len(entitlementGraph.Nodes)),
+				zap.Int("actions", len(entitlementGraph.Actions)),
+				zap.Int("depth", entitlementGraph.Depth),
+				zap.Bool("has_no_cycles", entitlementGraph.HasNoCycles),
+			)
 			if dontFixCycles {
 				return fmt.Errorf("cycles detected in entitlement graph")
 			}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replace verbose entitlement graph debug log with concise stats (edges, nodes, actions, depth, has_no_cycles) during cycle detection.
> 
> - **Logging**:
>   - In `pkg/sync/syncer.go` (`SyncGrantExpansion`), replace full `entitlementGraph` debug dump with concise metrics: `edges`, `nodes`, `actions`, `depth`, and `has_no_cycles`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4bab008d902e6f0ce1915b709a620c31664db8e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Reduced internal debug log verbosity during entitlement cycle detection to produce cleaner logs and improve signal-to-noise for monitoring. Detection, remediation, and error-handling behavior remain unchanged; no user-facing functionality, performance, stability, or configuration changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->