### PR TITLE
add dummy info to buildInfo if not present

### DIFF
--- a/pkg/tasks/c1api/hello.go
+++ b/pkg/tasks/c1api/hello.go
@@ -52,18 +52,31 @@ func (c *helloTaskHandler) osInfo(ctx context.Context) (*v1.BatonServiceHelloReq
 
 func (c *helloTaskHandler) buildInfo(ctx context.Context) *v1.BatonServiceHelloRequest_BuildInfo {
 	l := ctxzap.Extract(ctx)
+	buildInfo := &v1.BatonServiceHelloRequest_BuildInfo{
+		LangVersion:    "0.0.0",
+		Package:        "/dummy/path",
+		PackageVersion: "0.0.0",
+	}
 
 	bi, ok := debug.ReadBuildInfo()
 	if !ok {
 		l.Error("failed to get build info")
-		return &v1.BatonServiceHelloRequest_BuildInfo{}
+		return buildInfo
 	}
 
-	return &v1.BatonServiceHelloRequest_BuildInfo{
-		LangVersion:    bi.GoVersion,
-		Package:        bi.Main.Path,
-		PackageVersion: bi.Main.Version,
+	if bi.Main.Path != "" {
+		buildInfo.Package = bi.Main.Path
 	}
+
+	if bi.Main.Version != "" {
+		buildInfo.PackageVersion = bi.Main.Version
+	}
+
+	if bi.GoVersion != "" {
+		buildInfo.LangVersion = bi.GoVersion
+	}
+
+	return buildInfo
 }
 
 func (c *helloTaskHandler) HandleTask(ctx context.Context) error {

--- a/pkg/tasks/c1api/hello.go
+++ b/pkg/tasks/c1api/hello.go
@@ -65,14 +65,17 @@ func (c *helloTaskHandler) buildInfo(ctx context.Context) *v1.BatonServiceHelloR
 	}
 
 	if bi.Main.Path != "" {
+		l.Warn("missing build info Main.path")
 		buildInfo.Package = bi.Main.Path
 	}
 
 	if bi.Main.Version != "" {
+		l.Warn("missing build info Main.version")
 		buildInfo.PackageVersion = bi.Main.Version
 	}
 
 	if bi.GoVersion != "" {
+		l.Warn("missing build info GoVersion")
 		buildInfo.LangVersion = bi.GoVersion
 	}
 

--- a/pkg/tasks/c1api/hello.go
+++ b/pkg/tasks/c1api/hello.go
@@ -64,18 +64,21 @@ func (c *helloTaskHandler) buildInfo(ctx context.Context) *v1.BatonServiceHelloR
 		return buildInfo
 	}
 
-	if bi.Main.Path != "" {
+	if bi.Main.Path == "" {
 		l.Warn("missing build info Main.path")
+	} else {
 		buildInfo.Package = bi.Main.Path
 	}
 
-	if bi.Main.Version != "" {
+	if bi.Main.Version == "" {
 		l.Warn("missing build info Main.version")
+	} else {
 		buildInfo.PackageVersion = bi.Main.Version
 	}
 
-	if bi.GoVersion != "" {
+	if bi.GoVersion == "" {
 		l.Warn("missing build info GoVersion")
+	} else {
 		buildInfo.LangVersion = bi.GoVersion
 	}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Provide default build metadata and warn on missing fields in hello task buildInfo.
> 
> - **Build info handling (`buildInfo`)** in `pkg/tasks/c1api/hello.go`:
>   - Initialize `BatonServiceHelloRequest_BuildInfo` with default values and return defaults when `debug.ReadBuildInfo` fails.
>   - Set `Package`, `PackageVersion`, and `LangVersion` only if present; emit warnings when any field is missing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 889107f14e97f7d44f21fe39d902d25236da68e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of build and version info displayed in the app.
  - Preserves package name, application version, and runtime/Go version when available.
  - Prevents existing values from being overwritten by incomplete or empty build metadata.
  - Reduces inconsistencies and missing fields when build information is partial.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->