### PR TITLE
InvokeAction: Use context.Background() when running actions.

### DIFF
--- a/pkg/actions/actions.go
+++ b/pkg/actions/actions.go
@@ -233,7 +233,7 @@ func (a *ActionManager) InvokeAction(ctx context.Context, name string, args *str
 	// If handler takes longer than an hour, return status failed.
 	go func() {
 		oa.SetStatus(ctx, v2.BatonActionStatus_BATON_ACTION_STATUS_RUNNING)
-		handlerCtx, cancel := context.WithTimeoutCause(ctx, 1*time.Hour, errors.New("action handler timed out"))
+		handlerCtx, cancel := context.WithTimeoutCause(context.Background(), 1*time.Hour, errors.New("action handler timed out"))
 		defer cancel()
 		var oaErr error
 		oa.Rv, oa.Annos, oaErr = handler(handlerCtx, args)


### PR DESCRIPTION
Without this, invoking an action can error when the parent context is cancelled. This happens immediately after InvokeAction if running in oneshot mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of action execution by isolating its timeout from the outer request lifecycle, preventing unexpected cancellations due to parent request timeouts or cancellations.
  * Maintains the same 1-hour timeout and clear error reporting for long-running actions, ensuring predictable behavior.
  * Reduces flaky terminations in chained or high-load scenarios, enhancing overall stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->