### PR TITLE
upgrade go to 1.25.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.25.x
+          go-version: 1.25.2
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Run linters
@@ -18,7 +18,7 @@ jobs:
   go-test:
     strategy:
       matrix:
-        go-version: [1.25.x]
+        go-version: [1.25.2]
         platform: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.25.x
+          go-version: 1.25.2
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Run linters
@@ -37,7 +37,7 @@ jobs:
   go-test:
     strategy:
       matrix:
-        go-version: [ 1.25.x ]
+        go-version: [ 1.25.2 ]
         platform: [ ubuntu-latest, windows-latest ]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/conductorone/baton-sdk
 
-go 1.25
+go 1.25.2
 
 require (
 	filippo.io/age v1.2.1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Upgraded the Go toolchain to 1.25.2 and pinned CI to use 1.25.2 instead of a wildcard patch version.
  - No changes to features, behavior, or public APIs.
  - No dependency updates; builds and runtime behavior remain consistent.
  - CI/test matrix now targets the specific Go release.
  - No user action required; no user-facing changes expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->