### PR TITLE
perf: add streaming iterator API for memory-efficient result processing

### DIFF
--- a/pkg/dotc1z/sql_helpers.go
+++ b/pkg/dotc1z/sql_helpers.go
@@ -27,6 +27,101 @@ const bulkPutParallelThreshold = 100
 const insertChunkSize = 1000
 const maxPageSize = 10000
 
+// rowIterator provides streaming access to query results without materializing the entire result slice.
+// Use this for memory-efficient processing of large result sets.
+type rowIterator[T proto.Message] struct {
+	rows          *sql.Rows
+	factory       func() T
+	unmarshalOpts proto.UnmarshalOptions
+	err           error
+	current       T
+	count         uint32
+	pageSize      uint32
+	lastRow       int
+	nextPageToken string
+	done          bool
+}
+
+// Next advances the iterator to the next row.
+// Returns true if a row is available, false when iteration is complete or an error occurred.
+func (it *rowIterator[T]) Next() bool {
+	if it.done || it.err != nil {
+		return false
+	}
+
+	if !it.rows.Next() {
+		it.done = true
+		it.err = it.rows.Err()
+		return false
+	}
+
+	it.count++
+	if it.count > it.pageSize {
+		// We've hit the extra row that indicates more pages exist
+		it.nextPageToken = strconv.Itoa(it.lastRow + 1)
+		it.done = true
+		return false
+	}
+
+	var data sql.RawBytes
+	if err := it.rows.Scan(&it.lastRow, &data); err != nil {
+		it.err = err
+		it.done = true
+		return false
+	}
+
+	it.current = it.factory()
+	if err := it.unmarshalOpts.Unmarshal(data, it.current); err != nil {
+		it.err = err
+		it.done = true
+		return false
+	}
+
+	return true
+}
+
+// Value returns the current row. Only valid after a successful Next() call.
+func (it *rowIterator[T]) Value() T {
+	return it.current
+}
+
+// Err returns any error encountered during iteration.
+func (it *rowIterator[T]) Err() error {
+	return it.err
+}
+
+// NextPageToken returns the pagination token for the next page, if any.
+// Only valid after iteration completes (Next returns false).
+func (it *rowIterator[T]) NextPageToken() string {
+	return it.nextPageToken
+}
+
+// Close releases database resources. Must be called when done with iteration.
+func (it *rowIterator[T]) Close() error {
+	return it.rows.Close()
+}
+
+// Collect materializes all remaining rows into a slice.
+// Useful when you want to use streaming for some operations but need a slice for others.
+func (it *rowIterator[T]) Collect() ([]T, error) {
+	// Pre-allocate with remaining capacity estimate
+	remaining := int(it.pageSize) - int(it.count)
+	if remaining < 0 {
+		remaining = 0
+	}
+	result := make([]T, 0, remaining)
+
+	for it.Next() {
+		result = append(result, it.Value())
+	}
+
+	if err := it.Err(); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
 // Use worker pool to limit goroutines.
 var numWorkers = min(max(runtime.GOMAXPROCS(0), 1), 4)
 
@@ -140,21 +235,22 @@ func resolveSyncID(ctx context.Context, c *C1File, req listRequest) (string, err
 	return "", nil
 }
 
-// listConnectorObjects uses a connector list request to fetch the corresponding data from the local db.
-// It returns a slice of typed proto messages constructed via the provided factory function.
-func listConnectorObjects[T proto.Message](ctx context.Context, c *C1File, tableName string, req listRequest, factory func() T) ([]T, string, error) {
-	ctx, span := tracer.Start(ctx, "C1File.listConnectorObjects")
+// streamConnectorObjects returns an iterator for memory-efficient streaming of query results.
+// The caller MUST call Close() on the iterator when done.
+// Use this instead of listConnectorObjects when processing large result sets or when early termination is needed.
+func streamConnectorObjects[T proto.Message](ctx context.Context, c *C1File, tableName string, req listRequest, factory func() T) (*rowIterator[T], error) {
+	ctx, span := tracer.Start(ctx, "C1File.streamConnectorObjects")
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
 	err = c.validateDb(ctx)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 
 	reqSyncID, err := resolveSyncID(ctx, c, req)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 
 	q := c.db.From(tableName).Prepared(true)
@@ -237,7 +333,7 @@ func listConnectorObjects[T proto.Message](ctx context.Context, c *C1File, table
 
 	query, args, err := q.ToSQL()
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 
 	// Start timing the query execution
@@ -246,51 +342,41 @@ func listConnectorObjects[T proto.Message](ctx context.Context, c *C1File, table
 	// Execute the query
 	rows, err := c.db.QueryContext(ctx, query, args...)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
-	defer rows.Close()
 
-	// Calculate the query duration
+	// Calculate the query duration and log slow queries
 	queryDuration := time.Since(queryStartTime)
-
-	// If the query took longer than the threshold, log a warning (rate-limited)
 	if queryDuration > c.slowQueryThreshold {
 		c.throttledWarnSlowQuery(ctx, query, queryDuration)
 	}
 
-	var unmarshalerOptions = proto.UnmarshalOptions{
-		Merge:          true,
-		DiscardUnknown: true,
+	return &rowIterator[T]{
+		rows:    rows,
+		factory: factory,
+		unmarshalOpts: proto.UnmarshalOptions{
+			Merge:          true,
+			DiscardUnknown: true,
+		},
+		pageSize: pageSize,
+	}, nil
+}
+
+// listConnectorObjects uses a connector list request to fetch the corresponding data from the local db.
+// It returns a slice of typed proto messages constructed via the provided factory function.
+func listConnectorObjects[T proto.Message](ctx context.Context, c *C1File, tableName string, req listRequest, factory func() T) ([]T, string, error) {
+	iter, err := streamConnectorObjects(ctx, c, tableName, req, factory)
+	if err != nil {
+		return nil, "", err
 	}
-	var count uint32 = 0
-	lastRow := 0
-	var data sql.RawBytes
-	var ret []T
-	for rows.Next() {
-		count++
-		if count > pageSize {
-			break
-		}
-		err := rows.Scan(&lastRow, &data)
-		if err != nil {
-			return nil, "", err
-		}
-		t := factory()
-		err = unmarshalerOptions.Unmarshal(data, t)
-		if err != nil {
-			return nil, "", err
-		}
-		ret = append(ret, t)
-	}
-	if rows.Err() != nil {
-		return nil, "", rows.Err()
+	defer iter.Close()
+
+	ret, err := iter.Collect()
+	if err != nil {
+		return nil, "", err
 	}
 
-	nextPageToken := ""
-	if count > pageSize {
-		nextPageToken = strconv.Itoa(lastRow + 1)
-	}
-	return ret, nextPageToken, nil
+	return ret, iter.NextPageToken(), nil
 }
 
 // This is required for sync diffs to work.  Its not much slower.

--- a/pkg/dotc1z/sql_helpers.go
+++ b/pkg/dotc1z/sql_helpers.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/doug-martin/goqu/v9"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -31,6 +32,7 @@ const maxPageSize = 10000
 // Use this for memory-efficient processing of large result sets.
 type rowIterator[T proto.Message] struct {
 	rows          *sql.Rows
+	span          trace.Span
 	factory       func() T
 	unmarshalOpts proto.UnmarshalOptions
 	err           error
@@ -40,6 +42,7 @@ type rowIterator[T proto.Message] struct {
 	lastRow       int
 	nextPageToken string
 	done          bool
+	closed        bool
 }
 
 // Next advances the iterator to the next row.
@@ -96,9 +99,21 @@ func (it *rowIterator[T]) NextPageToken() string {
 	return it.nextPageToken
 }
 
-// Close releases database resources. Must be called when done with iteration.
+// Close releases database resources and ends the tracing span. Safe to call multiple times.
+// Must be called when done with iteration.
 func (it *rowIterator[T]) Close() error {
-	return it.rows.Close()
+	if it.closed {
+		return nil
+	}
+	it.closed = true
+	closeErr := it.rows.Close()
+	// Prefer the iteration error for span recording; fall back to close error.
+	spanErr := it.err
+	if spanErr == nil {
+		spanErr = closeErr
+	}
+	uotel.EndSpanWithError(it.span, spanErr)
+	return closeErr
 }
 
 // Collect materializes all remaining rows into a slice.
@@ -236,12 +251,20 @@ func resolveSyncID(ctx context.Context, c *C1File, req listRequest) (string, err
 }
 
 // streamConnectorObjects returns an iterator for memory-efficient streaming of query results.
-// The caller MUST call Close() on the iterator when done.
-// Use this instead of listConnectorObjects when processing large result sets or when early termination is needed.
-func streamConnectorObjects[T proto.Message](ctx context.Context, c *C1File, tableName string, req listRequest, factory func() T) (*rowIterator[T], error) {
+// The caller MUST call Close() on the iterator when done; Close finalizes the tracing span.
+//
+// IMPORTANT: the underlying sqlite *sql.DB has MaxOpenConns=1 (see c1file.go). A live
+// iterator pins that sole connection, so any other DB call issued before Close() will
+// block until iteration finishes. Do not interleave iteration with other store operations.
+// See TestStreamIteratorHoldsSingleConnection for enforcement.
+func streamConnectorObjects[T proto.Message](ctx context.Context, c *C1File, tableName string, req listRequest, factory func() T) (_ *rowIterator[T], err error) {
 	ctx, span := tracer.Start(ctx, "C1File.streamConnectorObjects")
-	var err error
-	defer func() { uotel.EndSpanWithError(span, err) }()
+	// Span ownership transfers to the iterator on success; end it here only on early error.
+	defer func() {
+		if err != nil {
+			uotel.EndSpanWithError(span, err)
+		}
+	}()
 
 	err = c.validateDb(ctx)
 	if err != nil {
@@ -353,6 +376,7 @@ func streamConnectorObjects[T proto.Message](ctx context.Context, c *C1File, tab
 
 	return &rowIterator[T]{
 		rows:    rows,
+		span:    span,
 		factory: factory,
 		unmarshalOpts: proto.UnmarshalOptions{
 			Merge:          true,

--- a/pkg/dotc1z/stream_deadlock_test.go
+++ b/pkg/dotc1z/stream_deadlock_test.go
@@ -1,0 +1,67 @@
+package dotc1z
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+)
+
+// TestStreamIteratorHoldsSingleConnection verifies the hard constraint that a live
+// rowIterator pins the sole sqlite connection (MaxOpenConns=1). Any additional DB
+// call issued before Close() blocks until the iterator is drained/closed, so callers
+// must never interleave iteration with other store operations.
+func TestStreamIteratorHoldsSingleConnection(t *testing.T) {
+	ctx := t.Context()
+
+	tempDir := filepath.Join(t.TempDir(), "test.c1z")
+	c1zFile, err := NewC1ZFile(ctx, tempDir, WithPragma("journal_mode", "WAL"))
+	require.NoError(t, err)
+	defer func() { _ = c1zFile.Close(ctx) }()
+
+	_, err = c1zFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+
+	rt := v2.ResourceType_builder{Id: "rt1", DisplayName: "rt1"}.Build()
+	require.NoError(t, c1zFile.PutResourceTypes(ctx, rt))
+	require.NoError(t, c1zFile.PutResources(ctx, generateResources(50, rt)...))
+	require.NoError(t, c1zFile.EndSync(ctx))
+
+	req := v2.ResourcesServiceListResourcesRequest_builder{
+		ResourceTypeId: "rt1",
+	}.Build()
+
+	iter, err := streamConnectorObjects(ctx, c1zFile, resources.Name(), req, func() *v2.Resource { return &v2.Resource{} })
+	require.NoError(t, err)
+	require.True(t, iter.Next(), "expected at least one row")
+
+	// Concurrent DB call should block until iterator is closed.
+	done := make(chan error, 1)
+	ctxShort, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer cancel()
+	go func() {
+		_, err := c1zFile.ListResources(ctxShort, v2.ResourcesServiceListResourcesRequest_builder{ResourceTypeId: "rt1"}.Build())
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		t.Fatalf("concurrent DB call returned while iterator was open (err=%v); expected block until Close()", err)
+	case <-time.After(300 * time.Millisecond):
+		// Still blocked — confirms single-connection deadlock risk for streaming iterators.
+	}
+
+	// Close iter so the concurrent call can unblock (it will still get its own ctx deadline).
+	require.NoError(t, iter.Close())
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("concurrent call never unblocked after iter.Close()")
+	}
+}

--- a/pkg/dotc1z/sync_runs.go
+++ b/pkg/dotc1z/sync_runs.go
@@ -275,7 +275,7 @@ func (c *C1File) ListSyncRuns(ctx context.Context, pageToken string, pageSize ui
 	q = q.Order(goqu.C("id").Asc())
 	q = q.Limit(uint(pageSize + 1))
 
-	var ret []*syncRun
+	ret := make([]*syncRun, 0, pageSize)
 
 	query, args, err := q.ToSQL()
 	if err != nil {


### PR DESCRIPTION
## Summary

- Add `rowIterator[T]` type for streaming access to query results without materializing the entire result slice
- Add `streamConnectorObjects()` function that returns the iterator
- Refactor `listConnectorObjects()` to use the streaming API internally, reducing code duplication
- Pre-allocate result slices in `ListSyncRuns()` based on pageSize

The iterator provides:
- `Next()/Value()/Err()` for standard iteration pattern
- `Collect()` to materialize remaining results when a slice is needed
- `Close()` to release database resources
- `NextPageToken()` for pagination

This is useful for:
- Memory-efficient processing of large result sets
- Early termination when a specific item is found
- Chained processing pipelines

## Context

Profile analysis of `temporal_sync` showed `go-sqlite.(*conn).columnText` allocating ~914 MB/sec. While the root cause is in the driver, application-level optimizations provide defense in depth and reduce peak memory usage.

## Test plan

- [x] Existing tests pass
- [x] Verified `listConnectorObjects` behavior unchanged (uses iterator internally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized query result streaming with enhanced memory management to support efficient handling of large result sets.
  * Refined internal memory allocation strategy for improved performance in result collection operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->