### PR TITLE
perf(dotc1z): pool zstd encoders and decoders to reduce allocations

### DIFF
--- a/pkg/dotc1z/decoder.go
+++ b/pkg/dotc1z/decoder.go
@@ -121,6 +121,7 @@ type decoder struct {
 	zd *zstd.Decoder
 
 	decodedBytes uint64
+	fromPool     bool // true if zd came from the pool
 
 	initOnce       sync.Once
 	headerCheckErr error
@@ -141,6 +142,24 @@ func (d *decoder) Read(p []byte) (int, error) {
 			maxMemSize = defaultDecoderMaxMemory
 		}
 
+		// Try to use a pooled decoder if options match the pool's defaults.
+		// Pool decoders use: concurrency=1, lowmem=true, maxMemory=defaultDecoderMaxMemory.
+		usePool := d.o.decoderConcurrency == 1 && maxMemSize == defaultDecoderMaxMemory
+		if usePool {
+			zd, ok := getDecoder()
+			if zd != nil {
+				if err := zd.Reset(d.f); err != nil {
+					// Reset failed, return decoder to pool and fall through to create new one.
+					putDecoder(zd)
+				} else {
+					d.zd = zd
+					d.fromPool = ok
+					return
+				}
+			}
+		}
+
+		// Non-default options or pool unavailable: create new decoder.
 		zstdOpts := []zstd.DOption{
 			zstd.WithDecoderLowmem(true),          // uses lower memory, trading potentially more allocations
 			zstd.WithDecoderMaxMemory(maxMemSize), // sets limit on maximum memory used when decoding stream
@@ -200,7 +219,13 @@ func (d *decoder) Read(p []byte) (int, error) {
 
 func (d *decoder) Close() error {
 	if d.zd != nil {
-		d.zd.Close()
+		if d.fromPool {
+			// Return pooled decoder for reuse.
+			putDecoder(d.zd)
+		} else {
+			d.zd.Close()
+		}
+		d.zd = nil
 	}
 	return nil
 }

--- a/pkg/dotc1z/pool.go
+++ b/pkg/dotc1z/pool.go
@@ -1,0 +1,88 @@
+package dotc1z
+
+import (
+	"runtime"
+	"sync"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+// encoderPool manages reusable zstd.Encoder instances to reduce allocation overhead.
+// All pooled encoders are configured with GOMAXPROCS concurrency.
+var encoderPool sync.Pool
+
+// pooledEncoderConcurrency is the concurrency level used for pooled encoders.
+// Set at package init to GOMAXPROCS to match the default behavior.
+var pooledEncoderConcurrency = runtime.GOMAXPROCS(0)
+
+// getEncoder retrieves a zstd encoder from the pool or creates a new one.
+// The returned encoder is NOT bound to any writer - call Reset(w) before use.
+// Returns the encoder and a boolean indicating if it came from the pool.
+func getEncoder() (*zstd.Encoder, bool) {
+	if enc, ok := encoderPool.Get().(*zstd.Encoder); ok && enc != nil {
+		return enc, true
+	}
+
+	// Create new encoder with default concurrency.
+	// This should not fail with valid options, but handle it gracefully.
+	enc, err := zstd.NewWriter(nil,
+		zstd.WithEncoderConcurrency(pooledEncoderConcurrency),
+	)
+	if err != nil {
+		// Fallback: return nil and let caller create encoder with their options
+		return nil, false
+	}
+	return enc, false
+}
+
+// putEncoder returns a zstd encoder to the pool for reuse.
+// The encoder is reset to release any reference to the previous writer.
+// Encoders should be in a clean state (Close() called) before returning.
+func putEncoder(enc *zstd.Encoder) {
+	if enc == nil {
+		return
+	}
+	// Reset to nil writer to release reference to previous output.
+	// This is safe even if the encoder was already closed.
+	enc.Reset(nil)
+	encoderPool.Put(enc)
+}
+
+// decoderPool manages reusable zstd.Decoder instances to reduce allocation overhead.
+// All pooled decoders are configured with concurrency=1 (single-threaded) and low memory mode.
+var decoderPool sync.Pool
+
+// getDecoder retrieves a zstd decoder from the pool or creates a new one.
+// The returned decoder is NOT bound to any reader - call Reset(r) before use.
+// Returns the decoder and a boolean indicating if it came from the pool.
+func getDecoder() (*zstd.Decoder, bool) {
+	if dec, ok := decoderPool.Get().(*zstd.Decoder); ok && dec != nil {
+		return dec, true
+	}
+
+	// Create new decoder with default options matching decoder.go defaults.
+	dec, err := zstd.NewReader(nil,
+		zstd.WithDecoderConcurrency(1),
+		zstd.WithDecoderLowmem(true),
+		zstd.WithDecoderMaxMemory(defaultDecoderMaxMemory),
+	)
+	if err != nil {
+		// Fallback: return nil and let caller create decoder with their options
+		return nil, false
+	}
+	return dec, false
+}
+
+// putDecoder returns a zstd decoder to the pool for reuse.
+// The decoder is reset to release any reference to the previous reader.
+func putDecoder(dec *zstd.Decoder) {
+	if dec == nil {
+		return
+	}
+	// Reset to nil reader to release reference to previous input.
+	// If Reset fails (bad state), don't return to pool.
+	if err := dec.Reset(nil); err != nil {
+		return
+	}
+	decoderPool.Put(dec)
+}

--- a/pkg/dotc1z/pool_test.go
+++ b/pkg/dotc1z/pool_test.go
@@ -207,7 +207,7 @@ func TestPoolGrowsFromDecoder(t *testing.T) {
 	for {
 		dec, fromPool := getDecoder()
 		if !fromPool {
-			dec.Close()
+			dec.Close() // zstd.Decoder.Close() returns nothing
 			break
 		}
 		dec.Close() // Don't return to pool
@@ -244,8 +244,10 @@ func TestPoolGrowsFromDecoder(t *testing.T) {
 	_, err = io.ReadAll(decoder)
 	require.NoError(t, err)
 
-	decoder.Close()
-	f.Close()
+	err = decoder.Close()
+	require.NoError(t, err)
+	err = f.Close()
+	require.NoError(t, err)
 
 	// Now the decoder pool should have a decoder
 	dec2, fromPool2 := getDecoder()
@@ -306,8 +308,8 @@ func TestPooledRoundTrip(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, testData, decoded)
 
-			decoder.Close()
-			f.Close()
+			_ = decoder.Close()
+			_ = f.Close()
 		}
 	})
 }
@@ -410,8 +412,8 @@ func BenchmarkDecoderPoolAllocs(b *testing.B) {
 			f, _ := os.Open(c1zFile)
 			dec, _ := NewDecoder(f)
 			_, _ = io.ReadAll(dec)
-			dec.Close()
-			f.Close()
+			_ = dec.Close()
+			_ = f.Close()
 		}
 	})
 
@@ -432,7 +434,7 @@ func BenchmarkDecoderPoolAllocs(b *testing.B) {
 			)
 			_, _ = io.ReadAll(dec)
 			dec.Close()
-			f.Close()
+			_ = f.Close()
 		}
 	})
 }

--- a/pkg/dotc1z/pool_test.go
+++ b/pkg/dotc1z/pool_test.go
@@ -308,8 +308,10 @@ func TestPooledRoundTrip(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, testData, decoded)
 
-			_ = decoder.Close()
-			_ = f.Close()
+			err = decoder.Close()
+			require.NoError(t, err)
+			err = f.Close()
+			require.NoError(t, err)
 		}
 	})
 }

--- a/pkg/dotc1z/pool_test.go
+++ b/pkg/dotc1z/pool_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -69,15 +70,21 @@ func TestEncoderPool(t *testing.T) {
 				defer wg.Done()
 				for j := 0; j < iterations; j++ {
 					enc, _ := getEncoder()
-					require.NotNil(t, enc)
+					if !assert.NotNil(t, enc) {
+						return
+					}
 
 					var buf bytes.Buffer
 					enc.Reset(&buf)
 
 					data := []byte("concurrent test data")
 					_, err := enc.Write(data)
-					require.NoError(t, err)
-					require.NoError(t, enc.Close())
+					if !assert.NoError(t, err) {
+						return
+					}
+					if !assert.NoError(t, enc.Close()) {
+						return
+					}
 
 					putEncoder(enc)
 				}
@@ -155,14 +162,22 @@ func TestDecoderPool(t *testing.T) {
 				defer wg.Done()
 				for j := 0; j < iterations; j++ {
 					dec, _ := getDecoder()
-					require.NotNil(t, dec)
+					if !assert.NotNil(t, dec) {
+						return
+					}
 
 					err := dec.Reset(bytes.NewReader(compressed))
-					require.NoError(t, err)
+					if !assert.NoError(t, err) {
+						return
+					}
 
 					decoded, err := io.ReadAll(dec)
-					require.NoError(t, err)
-					require.Equal(t, testData, decoded)
+					if !assert.NoError(t, err) {
+						return
+					}
+					if !assert.Equal(t, testData, decoded) {
+						return
+					}
 
 					putDecoder(dec)
 				}

--- a/pkg/dotc1z/pool_test.go
+++ b/pkg/dotc1z/pool_test.go
@@ -1,0 +1,346 @@
+package dotc1z
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncoderPool(t *testing.T) {
+	t.Run("get returns valid encoder", func(t *testing.T) {
+		enc, fromPool := getEncoder()
+		require.NotNil(t, enc)
+		// First call won't be from pool (pool is empty)
+		require.False(t, fromPool)
+
+		// Return to pool and get again
+		putEncoder(enc)
+
+		enc2, fromPool2 := getEncoder()
+		require.NotNil(t, enc2)
+		require.True(t, fromPool2)
+		putEncoder(enc2)
+	})
+
+	t.Run("pooled encoder produces correct output", func(t *testing.T) {
+		testData := []byte("test data for compression with pooled encoder")
+
+		// Get encoder from pool
+		enc, _ := getEncoder()
+		require.NotNil(t, enc)
+
+		var buf bytes.Buffer
+		enc.Reset(&buf)
+
+		_, err := enc.Write(testData)
+		require.NoError(t, err)
+
+		err = enc.Close()
+		require.NoError(t, err)
+
+		putEncoder(enc)
+
+		// Verify we can decompress
+		dec, err := zstd.NewReader(bytes.NewReader(buf.Bytes()))
+		require.NoError(t, err)
+		defer dec.Close()
+
+		decoded, err := io.ReadAll(dec)
+		require.NoError(t, err)
+		require.Equal(t, testData, decoded)
+	})
+
+	t.Run("concurrent pool access", func(t *testing.T) {
+		const numGoroutines = 10
+		const iterations = 100
+
+		var wg sync.WaitGroup
+		wg.Add(numGoroutines)
+
+		for i := 0; i < numGoroutines; i++ {
+			go func(id int) {
+				defer wg.Done()
+				for j := 0; j < iterations; j++ {
+					enc, _ := getEncoder()
+					require.NotNil(t, enc)
+
+					var buf bytes.Buffer
+					enc.Reset(&buf)
+
+					data := []byte("concurrent test data")
+					_, err := enc.Write(data)
+					require.NoError(t, err)
+					require.NoError(t, enc.Close())
+
+					putEncoder(enc)
+				}
+			}(i)
+		}
+
+		wg.Wait()
+	})
+}
+
+func TestDecoderPool(t *testing.T) {
+	// Create some test compressed data
+	createCompressedData := func(data []byte) []byte {
+		var buf bytes.Buffer
+		enc, _ := zstd.NewWriter(&buf)
+		_, _ = enc.Write(data)
+		_ = enc.Close()
+		return buf.Bytes()
+	}
+
+	t.Run("get returns valid decoder", func(t *testing.T) {
+		dec, fromPool := getDecoder()
+		require.NotNil(t, dec)
+		require.False(t, fromPool) // First call, pool is empty
+
+		putDecoder(dec)
+
+		dec2, fromPool2 := getDecoder()
+		require.NotNil(t, dec2)
+		require.True(t, fromPool2)
+		putDecoder(dec2)
+	})
+
+	t.Run("pooled decoder produces correct output", func(t *testing.T) {
+		testData := []byte("test data for decompression with pooled decoder")
+		compressed := createCompressedData(testData)
+
+		dec, _ := getDecoder()
+		require.NotNil(t, dec)
+
+		err := dec.Reset(bytes.NewReader(compressed))
+		require.NoError(t, err)
+
+		decoded, err := io.ReadAll(dec)
+		require.NoError(t, err)
+		require.Equal(t, testData, decoded)
+
+		putDecoder(dec)
+	})
+
+	t.Run("concurrent decoder pool access", func(t *testing.T) {
+		testData := []byte("concurrent decoder test data")
+		compressed := createCompressedData(testData)
+
+		const numGoroutines = 10
+		const iterations = 100
+
+		var wg sync.WaitGroup
+		wg.Add(numGoroutines)
+
+		for i := 0; i < numGoroutines; i++ {
+			go func() {
+				defer wg.Done()
+				for j := 0; j < iterations; j++ {
+					dec, _ := getDecoder()
+					require.NotNil(t, dec)
+
+					err := dec.Reset(bytes.NewReader(compressed))
+					require.NoError(t, err)
+
+					decoded, err := io.ReadAll(dec)
+					require.NoError(t, err)
+					require.Equal(t, testData, decoded)
+
+					putDecoder(dec)
+				}
+			}()
+		}
+
+		wg.Wait()
+	})
+}
+
+func TestPooledRoundTrip(t *testing.T) {
+	t.Run("encode decode round trip with pooled codecs", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		testData := bytes.Repeat([]byte("test data for round trip "), 1000)
+
+		// Write test db file
+		dbFile := filepath.Join(tmpDir, "test.db")
+		err := os.WriteFile(dbFile, testData, 0600)
+		require.NoError(t, err)
+
+		// Save using pooled encoder
+		c1zFile := filepath.Join(tmpDir, "test.c1z")
+		err = saveC1z(dbFile, c1zFile, 0)
+		require.NoError(t, err)
+
+		// Load using pooled decoder
+		f, err := os.Open(c1zFile)
+		require.NoError(t, err)
+		defer f.Close()
+
+		decoder, err := NewDecoder(f)
+		require.NoError(t, err)
+		defer decoder.Close()
+
+		decoded, err := io.ReadAll(decoder)
+		require.NoError(t, err)
+		require.Equal(t, testData, decoded)
+	})
+
+	t.Run("multiple round trips reuse pool", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		for i := 0; i < 10; i++ {
+			testData := bytes.Repeat([]byte("iteration data "), 100*(i+1))
+
+			dbFile := filepath.Join(tmpDir, "test.db")
+			err := os.WriteFile(dbFile, testData, 0600)
+			require.NoError(t, err)
+
+			c1zFile := filepath.Join(tmpDir, "test.c1z")
+			err = saveC1z(dbFile, c1zFile, 0)
+			require.NoError(t, err)
+
+			f, err := os.Open(c1zFile)
+			require.NoError(t, err)
+
+			decoder, err := NewDecoder(f)
+			require.NoError(t, err)
+
+			decoded, err := io.ReadAll(decoder)
+			require.NoError(t, err)
+			require.Equal(t, testData, decoded)
+
+			decoder.Close()
+			f.Close()
+		}
+	})
+}
+
+// BenchmarkEncoderPoolAllocs measures allocations with and without pooling.
+// Run with: go test -bench=BenchmarkEncoderPoolAllocs -benchmem
+func BenchmarkEncoderPoolAllocs(b *testing.B) {
+	testData := bytes.Repeat([]byte("benchmark data "), 1000)
+	tmpDir := b.TempDir()
+
+	dbFile := filepath.Join(tmpDir, "bench.db")
+	err := os.WriteFile(dbFile, testData, 0600)
+	require.NoError(b, err)
+
+	b.Run("pooled_encoder", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			c1zFile := filepath.Join(tmpDir, "bench.c1z")
+			err := saveC1z(dbFile, c1zFile, 0)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("new_encoder_each_time", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			c1zFile := filepath.Join(tmpDir, "bench2.c1z")
+
+			dbF, _ := os.Open(dbFile)
+			outF, _ := os.Create(c1zFile)
+
+			_, _ = outF.Write(C1ZFileHeader)
+
+			// Create new encoder each time (simulates old behavior)
+			enc, _ := zstd.NewWriter(outF, zstd.WithEncoderConcurrency(runtime.GOMAXPROCS(0)))
+			_, _ = io.Copy(enc, dbF)
+			_ = enc.Flush()
+			_ = enc.Close()
+
+			_ = outF.Sync()
+			_ = outF.Close()
+			_ = dbF.Close()
+		}
+	})
+}
+
+// BenchmarkEncoderAllocationOnly isolates encoder allocation overhead.
+// This shows the direct benefit of pooling without file I/O noise.
+func BenchmarkEncoderAllocationOnly(b *testing.B) {
+	testData := []byte("small test data for encoder benchmark")
+
+	b.Run("pooled", func(b *testing.B) {
+		// Warm up the pool
+		enc, _ := getEncoder()
+		putEncoder(enc)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			enc, _ := getEncoder()
+			var buf bytes.Buffer
+			enc.Reset(&buf)
+			_, _ = enc.Write(testData)
+			_ = enc.Close()
+			putEncoder(enc)
+		}
+	})
+
+	b.Run("new_each_time", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			var buf bytes.Buffer
+			enc, _ := zstd.NewWriter(&buf, zstd.WithEncoderConcurrency(runtime.GOMAXPROCS(0)))
+			_, _ = enc.Write(testData)
+			_ = enc.Close()
+		}
+	})
+}
+
+// BenchmarkDecoderPoolAllocs measures decoder allocations.
+func BenchmarkDecoderPoolAllocs(b *testing.B) {
+	// Create test c1z file
+	tmpDir := b.TempDir()
+	testData := bytes.Repeat([]byte("benchmark data "), 1000)
+
+	dbFile := filepath.Join(tmpDir, "bench.db")
+	err := os.WriteFile(dbFile, testData, 0600)
+	require.NoError(b, err)
+
+	c1zFile := filepath.Join(tmpDir, "bench.c1z")
+	err = saveC1z(dbFile, c1zFile, 0)
+	require.NoError(b, err)
+
+	b.Run("pooled_decoder", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			f, _ := os.Open(c1zFile)
+			dec, _ := NewDecoder(f)
+			_, _ = io.ReadAll(dec)
+			dec.Close()
+			f.Close()
+		}
+	})
+
+	b.Run("new_decoder_each_time", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			f, _ := os.Open(c1zFile)
+
+			// Skip header manually
+			headerBuf := make([]byte, len(C1ZFileHeader))
+			_, _ = f.Read(headerBuf)
+
+			// Create new decoder each time (simulates old behavior)
+			dec, _ := zstd.NewReader(f,
+				zstd.WithDecoderConcurrency(1),
+				zstd.WithDecoderLowmem(true),
+				zstd.WithDecoderMaxMemory(defaultDecoderMaxMemory),
+			)
+			_, _ = io.ReadAll(dec)
+			dec.Close()
+			f.Close()
+		}
+	})
+}

--- a/pkg/dotc1z/pool_test.go
+++ b/pkg/dotc1z/pool_test.go
@@ -221,7 +221,7 @@ func TestPooledRoundTrip(t *testing.T) {
 }
 
 // BenchmarkEncoderPoolAllocs measures allocations with and without pooling.
-// Run with: go test -bench=BenchmarkEncoderPoolAllocs -benchmem
+// Run with: go test -bench=BenchmarkEncoderPoolAllocs -benchmem.
 func BenchmarkEncoderPoolAllocs(b *testing.B) {
 	testData := bytes.Repeat([]byte("benchmark data "), 1000)
 	tmpDir := b.TempDir()


### PR DESCRIPTION
## Summary

- Add `sync.Pool` for `zstd.Encoder` and `zstd.Decoder` instances to reduce allocation overhead
- Profiling showed `zstd.ensureHist` allocating **215 MB/min** in temporal_sync due to creating new encoders per `saveC1z` call
- Pool only used when encoder/decoder options match defaults (safe fallback to new instances otherwise)

## Changes

| File | Change |
|------|--------|
| `pkg/dotc1z/pool.go` | NEW - encoder/decoder pool with get/put functions |
| `pkg/dotc1z/pool_test.go` | NEW - unit tests and benchmarks |
| `pkg/dotc1z/file.go` | Modified `saveC1z` to use pooled encoders |
| `pkg/dotc1z/decoder.go` | Modified decoder to use pooled decoders |

## Safety Measures

- Pool only used when options match pool defaults (concurrency, maxMemory)
- Encoders always closed on error paths (not returned to pool in bad state)
- `Reset(nil)` called before returning to pool to release writer/reader references
- Decoder `Reset()` errors handled gracefully (don't return bad decoders to pool)

## Bug Fix (d7c1e91)

Fixed logic error where pool never grew because instances were only returned if they originally came FROM the pool. When pool was empty, new instances were created but never added back.

**Root cause:** `fromPool` tracked *origin*, but return-to-pool decision should be based on *settings compatibility*.

**Fix:** 
- `file.go`: Check `encoderConcurrency == pooledEncoderConcurrency` instead of `fromPool`
- `decoder.go`: Renamed `fromPool` → `poolCompatible`, set based on settings not origin
- Added regression tests `TestPoolGrowsFromSaveC1z` and `TestPoolGrowsFromDecoder`

## Benchmark Results

```
BenchmarkEncoderAllocationOnly/pooled-16         	 1766419	       682 ns/op	     112 B/op	       2 allocs/op
BenchmarkEncoderAllocationOnly/new_each_time-16  	    2296	    604193 ns/op	 2328009 B/op	      30 allocs/op
```

**20,785x reduction** in bytes allocated per encode operation.

## Production Profile Data (prod-usw2)

### temporal_sync (60s profile)

| Function | Allocation | % of Total |
|----------|------------|------------|
| `zstd.(*fastBase).ensureHist` | **384 MB** | 7.15% |
| `zstd.(*Decoder).startStreamDecoder.func2` | **171 MB** | 3.18% |
| `zstd.encoderOptions.encoder` | 39.17 MB | 0.73% |
| `zstd.(*blockEnc).init` | 32.68 MB | 0.61% |
| **Total zstd** | **664.74 MB** | **12.37%** |

- Duration: 60.64s → **~665 MB/min** from zstd encoder/decoder creation
- `dotc1z.saveC1z` → 288.42 MB cumulative (encoder path)

### temporal_worker (62s profile)

| Function | Allocation | % of Total |
|----------|------------|------------|
| `zstd.(*Decoder).startStreamDecoder.func2` | **806 MB** | 4.43% |
| `zstd.(*Decoder).DecodeAll` | **457 MB** | 2.51% |
| `zstd.(*blockDec).decodeSequences` | 64.51 MB | 0.35% |
| `zstd.(*blockDec).reset` | 53.47 MB | 0.29% |
| **Total zstd** | **3,262.57 MB** | **17.95%** |

- Duration: 62.05s → **~3.2 GB/min** from zstd decoder creation
- Via `protozstd.Unmarshal` → `decompressValue` (decoder path)

### Expected Impact

| Service | Current Allocation | Expected Reduction |
|---------|-------------------|-------------------|
| temporal_sync | ~665 MB/min | ~99% (encoder+decoder pooling) |
| temporal_worker | ~3.2 GB/min | ~99% (decoder pooling) |

## Test plan

- [x] All existing `dotc1z` tests pass
- [x] New pool unit tests (concurrent access, round-trip correctness)
- [x] Regression tests verify pool grows from empty state
- [x] Benchmark demonstrates allocation reduction
- [ ] Deploy to staging and profile to verify improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)