### PR TITLE
Partial Uplift: Incremental Grant Expansion for Invalidated Subgraph

### DIFF
--- a/pkg/connectorstore/connectorstore.go
+++ b/pkg/connectorstore/connectorstore.go
@@ -62,6 +62,9 @@ type InternalWriter interface {
 	ListGrantsInternal(ctx context.Context, opts GrantListOptions) (*InternalGrantListResponse, error)
 	// SetSupportsDiff marks the sync as supporting diff operations.
 	SetSupportsDiff(ctx context.Context, syncID string) error
+	SetNeedsExpansionForGrants(ctx context.Context, syncID string, grantExternalIDs []string, needsExpansion bool) error
+	// DeleteGrantInternal deletes a grant using optional explicit sync targeting.
+	DeleteGrantInternal(ctx context.Context, opts GrantDeleteOptions, grantID string) error
 }
 
 // GrantUpsertMode controls how grant conflicts are resolved during upsert.
@@ -79,7 +82,13 @@ const (
 
 // GrantUpsertOptions configures internal grant upsert behavior.
 type GrantUpsertOptions struct {
-	Mode GrantUpsertMode
+	Mode   GrantUpsertMode
+	SyncID string
+}
+
+// GrantDeleteOptions configures internal grant delete behavior.
+type GrantDeleteOptions struct {
+	SyncID string
 }
 
 // ConnectorStoreWriter defines an implementation for a connector v2 datasource writer. This is used to store sync data from an upstream provider.
@@ -132,7 +141,7 @@ type GrantListOptions struct {
 	NeedsExpansionOnly bool
 
 	// PageToken and PageSize are used for pagination in all modes.
-	// SyncID is used for expansion-only modes.
+	// SyncID scopes the query to a specific sync in all modes.
 	SyncID    string
 	PageToken string
 	PageSize  uint32

--- a/pkg/dotc1z/c1file_attached.go
+++ b/pkg/dotc1z/c1file_attached.go
@@ -189,6 +189,7 @@ func (c *C1FileAttached) UpdateSync(ctx context.Context, baseSync *reader_v2.Syn
 // marker set. This indicates the sync was expanded with older code that dropped grant annotations,
 // making it unsuitable for diff-based incremental expansion.
 var ErrOldSyncMissingExpansionMarker = errors.New("old sync is missing expansion marker; cannot generate diff from sync expanded with older code that dropped annotations")
+var ErrSyncMissingSourcesReadyMarker = errors.New("sync is not sources-ready for diff; cannot generate diff from sync that may still embed sources in grant data")
 
 // GenerateSyncDiffFromFile compares the old sync (in attached) with the new sync (in main)
 // and generates two new syncs in the main database.
@@ -210,14 +211,12 @@ func (c *C1FileAttached) GenerateSyncDiffFromFile(ctx context.Context, oldSyncID
 	ctx, span := tracer.Start(ctx, "C1FileAttached.GenerateSyncDiffFromFile")
 	defer span.End()
 
-	// Verify both source syncs have been backfilled and support diff before
-	// generating derived syncs. If they haven't, the expansion columns in
-	// copied grants may be incomplete.
-	var oldBackfilled, oldDiff int
+	// Verify both source syncs are diff-ready before generating derived syncs.
+	var oldBackfilled, oldDiff, oldSourcesReady int
 	err := c.file.rawDb.QueryRowContext(ctx,
-		fmt.Sprintf("SELECT grants_backfilled, supports_diff FROM attached.%s WHERE sync_id = ?", syncRuns.Name()),
+		fmt.Sprintf("SELECT grants_backfilled, supports_diff, sources_ready FROM attached.%s WHERE sync_id = ?", syncRuns.Name()),
 		oldSyncID,
-	).Scan(&oldBackfilled, &oldDiff)
+	).Scan(&oldBackfilled, &oldDiff, &oldSourcesReady)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to check old sync %s readiness: %w", oldSyncID, err)
 	}
@@ -227,17 +226,23 @@ func (c *C1FileAttached) GenerateSyncDiffFromFile(ctx context.Context, oldSyncID
 	if oldDiff != 1 {
 		return "", "", ErrOldSyncMissingExpansionMarker
 	}
+	if oldSourcesReady != 1 {
+		return "", "", fmt.Errorf("old sync %s is not sources-ready for diff (sources_ready=%d): %w", oldSyncID, oldSourcesReady, ErrSyncMissingSourcesReadyMarker)
+	}
 
-	var newBackfilled int
+	var newBackfilled, newSourcesReady int
 	err = c.file.rawDb.QueryRowContext(ctx,
-		fmt.Sprintf("SELECT grants_backfilled FROM main.%s WHERE sync_id = ?", syncRuns.Name()),
+		fmt.Sprintf("SELECT grants_backfilled, sources_ready FROM main.%s WHERE sync_id = ?", syncRuns.Name()),
 		newSyncID,
-	).Scan(&newBackfilled)
+	).Scan(&newBackfilled, &newSourcesReady)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to check new sync %s readiness: %w", newSyncID, err)
 	}
 	if newBackfilled != 1 {
 		return "", "", fmt.Errorf("new sync %s has not been backfilled (grants_backfilled=%d)", newSyncID, newBackfilled)
+	}
+	if newSourcesReady != 1 {
+		return "", "", fmt.Errorf("new sync %s is not sources-ready for diff (sources_ready=%d): %w", newSyncID, newSourcesReady, ErrSyncMissingSourcesReadyMarker)
 	}
 
 	// Generate unique IDs for the diff syncs
@@ -271,6 +276,7 @@ func (c *C1FileAttached) GenerateSyncDiffFromFile(ctx context.Context, oldSyncID
 		"linked_sync_id":    upsertsSyncID,
 		"supports_diff":     1,
 		"grants_backfilled": 1,
+		"sources_ready":     1,
 	})
 	query, args, err := deletionsInsert.ToSQL()
 	if err != nil {
@@ -290,6 +296,7 @@ func (c *C1FileAttached) GenerateSyncDiffFromFile(ctx context.Context, oldSyncID
 		"linked_sync_id":    deletionsSyncID,
 		"supports_diff":     1,
 		"grants_backfilled": 1,
+		"sources_ready":     1,
 	})
 	query, args, err = upsertsInsert.ToSQL()
 	if err != nil {
@@ -354,6 +361,152 @@ func (c *C1FileAttached) GenerateSyncDiffFromFile(ctx context.Context, oldSyncID
 	c.file.dbUpdated = true
 
 	return upsertsSyncID, deletionsSyncID, nil
+}
+
+// AppendPostExpansionGrantSourcesUpserts appends grant rows to an existing upserts sync
+// when the grant sources payload changed between OLD and NEW.  Grant sources are calculated by expansion, which is
+// the output of incremental expansion (ie, the dirty subgraph generated from the initial diff)
+//
+// This is intended for a second pass after incremental expansion has run on NEW.
+// It only appends to upserts (no deletions), and uses INSERT OR IGNORE so rows that
+// are already present in upserts due to connector-truth changes are left untouched.
+func (c *C1FileAttached) AppendPostExpansionGrantSourcesUpserts(ctx context.Context, oldSyncID, newSyncID, upsertsSyncID string) error {
+	if !c.safe {
+		return errors.New("database has been detached")
+	}
+
+	tx, err := c.file.rawDb.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	columns, err := c.getTableColumns(ctx, tx, grants.Name())
+	if err != nil {
+		return err
+	}
+
+	columnList := ""
+	selectList := ""
+	for i, col := range columns {
+		if i > 0 {
+			columnList += ", "
+			selectList += ", "
+		}
+		columnList += col
+		if col == "sync_id" {
+			selectList += "? as sync_id"
+		} else {
+			selectList += col
+		}
+	}
+
+	// Append source-only changes:
+	// - grant exists in both OLD and NEW by external_id
+	// - connector-truth payload is unchanged (data + expansion)
+	// - sources differs
+	// - insert NEW row into existing upserts sync
+	query := fmt.Sprintf(`
+		INSERT OR IGNORE INTO main.%s (%s)
+		SELECT %s
+		FROM main.%s AS m
+		WHERE m.sync_id = ?
+		  AND EXISTS (
+		    SELECT 1
+		    FROM attached.%s AS a
+		    WHERE a.external_id = m.external_id
+		      AND a.sync_id = ?
+		      AND a.data = m.data
+		      AND IFNULL(a.expansion, X'') = IFNULL(m.expansion, X'')
+		      AND IFNULL(a.sources, X'') != IFNULL(m.sources, X'')
+		  )
+	`, grants.Name(), columnList, selectList, grants.Name(), grants.Name())
+	if _, err = tx.ExecContext(ctx, query, upsertsSyncID, newSyncID, oldSyncID); err != nil {
+		return err
+	}
+
+	if err = tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+	committed = true
+	c.file.dbUpdated = true
+	return nil
+}
+
+// AppendPostExpansionGrantDeletions appends grant rows to an existing deletions sync
+// for grants that existed in both OLD and NEW before expansion but were deleted from
+// NEW during expansion (e.g. immutable grants that became sourceless).
+//
+// The pre-expansion deletions diff only catches grants missing from NEW entirely.
+// Grants carried forward from OLD into NEW that are later removed by expansion
+// would otherwise be invisible to downstream consumers.
+func (c *C1FileAttached) AppendPostExpansionGrantDeletions(ctx context.Context, oldSyncID, newSyncID, deletionsSyncID string) error {
+	if !c.safe {
+		return errors.New("database has been detached")
+	}
+
+	tx, err := c.file.rawDb.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	columns, err := c.getTableColumns(ctx, tx, grants.Name())
+	if err != nil {
+		return err
+	}
+
+	columnList := ""
+	selectList := ""
+	for i, col := range columns {
+		if i > 0 {
+			columnList += ", "
+			selectList += ", "
+		}
+		columnList += col
+		if col == "sync_id" {
+			selectList += "? as sync_id"
+		} else {
+			selectList += col
+		}
+	}
+
+	// Find grants in OLD that no longer exist in NEW (deleted during expansion)
+	// and are not already in the deletions sync (captured by pre-expansion diff).
+	query := fmt.Sprintf(`
+		INSERT OR IGNORE INTO main.%s (%s)
+		SELECT %s
+		FROM attached.%s AS a
+		WHERE a.sync_id = ?
+		  AND NOT EXISTS (
+		    SELECT 1 FROM main.%s AS m
+		    WHERE m.external_id = a.external_id AND m.sync_id = ?
+		  )
+		  AND NOT EXISTS (
+		    SELECT 1 FROM main.%s AS d
+		    WHERE d.external_id = a.external_id AND d.sync_id = ?
+		  )
+	`, grants.Name(), columnList, selectList, grants.Name(), grants.Name(), grants.Name())
+	if _, err = tx.ExecContext(ctx, query, deletionsSyncID, oldSyncID, newSyncID, deletionsSyncID); err != nil {
+		return err
+	}
+
+	if err = tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+	committed = true
+	c.file.dbUpdated = true
+	return nil
 }
 
 // diffTableFromAttachedTx finds items in attached (OLD) that don't exist in main (NEW).
@@ -429,12 +582,14 @@ func (c *C1FileAttached) diffTableFromMainTx(ctx context.Context, tx *sql.Tx, ta
 	// 2. In attached but with different data - modifications
 	// newSyncID is in main, oldSyncID is in attached
 	//
-	// For grants, we also compare the expansion column since GrantExpandable
-	// annotation is stored separately from data.
+	// For grants, compare connector-truth fields only:
+	// - data (connector payload)
+	// - expansion (GrantExpandable annotation stored separately)
+	//
+	// Sources are compared in a second pass after expansion settles.
 	var dataCompare string
 	if tableName == grants.Name() {
-		// For grants: compare both data AND expansion columns.
-		// Use IFNULL to handle NULL expansion values.
+		// Use IFNULL to handle NULL values.
 		dataCompare = "(a.data != m.data OR IFNULL(a.expansion, X'') != IFNULL(m.expansion, X''))"
 	} else {
 		dataCompare = "a.data != m.data"

--- a/pkg/dotc1z/clone_sync_test.go
+++ b/pkg/dotc1z/clone_sync_test.go
@@ -68,11 +68,15 @@ func TestCloneSyncMigratedColumnOrder(t *testing.T) {
 	require.NoError(t, err)
 
 	// Add migration columns — ALTER TABLE appends them to the END in SQLite.
+	// Include sources to mirror current grant schema migrations.
 	_, err = srcFile.db.ExecContext(ctx,
 		fmt.Sprintf("ALTER TABLE %s ADD COLUMN expansion blob", grants.Name()))
 	require.NoError(t, err)
 	_, err = srcFile.db.ExecContext(ctx,
 		fmt.Sprintf("ALTER TABLE %s ADD COLUMN needs_expansion integer not null default 0", grants.Name()))
+	require.NoError(t, err)
+	_, err = srcFile.db.ExecContext(ctx,
+		fmt.Sprintf("ALTER TABLE %s ADD COLUMN sources blob", grants.Name()))
 	require.NoError(t, err)
 
 	// Create partial indexes that the migration would add.

--- a/pkg/dotc1z/diff_bench_test.go
+++ b/pkg/dotc1z/diff_bench_test.go
@@ -1,0 +1,380 @@
+package dotc1z
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/stretchr/testify/require"
+)
+
+type diffBenchConfig struct {
+	totalGrants int
+	addedPct    int // % of grants that are new in the applied sync
+	removedPct  int // % of grants that were removed from the applied sync
+	modifiedPct int // % of grants that were modified in the applied sync
+	expandable  bool
+}
+
+func (c diffBenchConfig) name() string {
+	tag := ""
+	if c.expandable {
+		tag = "/expandable"
+	}
+	return fmt.Sprintf("grants=%d/add=%d%%/del=%d%%/mod=%d%%%s",
+		c.totalGrants, c.addedPct, c.removedPct, c.modifiedPct, tag)
+}
+
+// buildDiffFixture creates two c1z files (old and new) that share a baseline of grants with the
+// specified add/remove/modify ratios. It returns both files, the old sync ID, the new sync ID, and
+// a cleanup function. The old file is opened with normal locking so it can be attached.
+func buildDiffFixture(b *testing.B, cfg diffBenchConfig) (*C1File, *C1File, string, string, func()) {
+	b.Helper()
+	ctx := b.Context()
+
+	tempDir, err := os.MkdirTemp("", "diff-bench-*")
+	require.NoError(b, err)
+
+	opts := []C1ZOption{
+		WithTmpDir(tempDir),
+		WithPragma("journal_mode", "WAL"),
+		WithEncoderConcurrency(0),
+		WithDecoderOptions(WithDecoderConcurrency(0)),
+	}
+	oldOpts := append(slices.Clone(opts), WithPragma("locking_mode", "normal"))
+
+	oldPath := filepath.Join(tempDir, "old.c1z")
+	newPath := filepath.Join(tempDir, "new.c1z")
+
+	oldFile, err := NewC1ZFile(ctx, oldPath, oldOpts...)
+	require.NoError(b, err)
+
+	newFile, err := NewC1ZFile(ctx, newPath, opts...)
+	require.NoError(b, err)
+
+	rt := &v2.ResourceType{Id: "user", DisplayName: "User"}
+	ent := &v2.Entitlement{
+		Id: "group:g1:member",
+		Resource: &v2.Resource{
+			Id: &v2.ResourceId{ResourceType: "group", Resource: "g1"},
+		},
+	}
+	ent2 := &v2.Entitlement{
+		Id: "group:g2:member",
+		Resource: &v2.Resource{
+			Id: &v2.ResourceId{ResourceType: "group", Resource: "g2"},
+		},
+	}
+
+	total := cfg.totalGrants
+	nAdded := total * cfg.addedPct / 100
+	nRemoved := total * cfg.removedPct / 100
+	nModified := total * cfg.modifiedPct / 100
+	nUnchanged := total - nAdded - nRemoved - nModified
+
+	// OLD sync
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(b, err)
+	require.NoError(b, oldFile.PutResourceTypes(ctx, rt))
+	require.NoError(b, oldFile.PutEntitlements(ctx, ent, ent2))
+
+	batchSize := 1000
+	batch := make([]*v2.Grant, 0, batchSize)
+	flush := func(f *C1File) {
+		if len(batch) > 0 {
+			require.NoError(b, f.PutGrants(ctx, batch...))
+			batch = batch[:0]
+		}
+	}
+
+	makeGrant := func(idx int, entitlement *v2.Entitlement, exp bool) *v2.Grant {
+		g := v2.Grant_builder{
+			Id:          fmt.Sprintf("grant-%d", idx),
+			Entitlement: entitlement,
+			Principal: &v2.Resource{
+				Id: &v2.ResourceId{ResourceType: "user", Resource: fmt.Sprintf("u%d", idx)},
+			},
+		}
+		if exp {
+			g.Annotations = annotations.New(v2.GrantExpandable_builder{
+				EntitlementIds:  []string{ent2.GetId()},
+				Shallow:         false,
+				ResourceTypeIds: []string{"user"},
+			}.Build())
+		}
+		return g.Build()
+	}
+
+	id := 0
+
+	// Grants that exist in both syncs unchanged
+	for range nUnchanged {
+		batch = append(batch, makeGrant(id, ent, cfg.expandable))
+		id++
+		if len(batch) >= batchSize {
+			flush(oldFile)
+		}
+	}
+	unchangedEnd := id
+
+	// Grants that exist in old but are removed from new
+	for range nRemoved {
+		batch = append(batch, makeGrant(id, ent, cfg.expandable))
+		id++
+		if len(batch) >= batchSize {
+			flush(oldFile)
+		}
+	}
+	removedEnd := id
+
+	// Grants that will be modified: old version uses ent, new version uses ent2
+	for range nModified {
+		batch = append(batch, makeGrant(id, ent, cfg.expandable))
+		id++
+		if len(batch) >= batchSize {
+			flush(oldFile)
+		}
+	}
+	modifiedEnd := id
+
+	flush(oldFile)
+	require.NoError(b, oldFile.SetSupportsDiff(ctx, oldSyncID))
+	require.NoError(b, oldFile.EndSync(ctx))
+
+	// NEW sync
+	newSyncID, err := newFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(b, err)
+	require.NoError(b, newFile.PutResourceTypes(ctx, rt))
+	require.NoError(b, newFile.PutEntitlements(ctx, ent, ent2))
+
+	// Unchanged grants (same as old)
+	for i := range unchangedEnd {
+		batch = append(batch, makeGrant(i, ent, cfg.expandable))
+		if len(batch) >= batchSize {
+			flush(newFile)
+		}
+	}
+
+	// Skip removed grants (removedEnd - unchangedEnd grants absent)
+
+	// Modified grants — change entitlement to ent2
+	for i := removedEnd; i < modifiedEnd; i++ {
+		batch = append(batch, makeGrant(i, ent2, cfg.expandable))
+		if len(batch) >= batchSize {
+			flush(newFile)
+		}
+	}
+
+	// Added grants
+	for range nAdded {
+		batch = append(batch, makeGrant(id, ent, cfg.expandable))
+		id++
+		if len(batch) >= batchSize {
+			flush(newFile)
+		}
+	}
+	flush(newFile)
+
+	require.NoError(b, newFile.EndSync(ctx))
+
+	cleanup := func() {
+		_ = oldFile.Close(ctx)
+		_ = newFile.Close(ctx)
+		_ = os.RemoveAll(tempDir)
+	}
+
+	return oldFile, newFile, oldSyncID, newSyncID, cleanup
+}
+
+func BenchmarkGenerateSyncDiffFromFile(b *testing.B) {
+	configs := []diffBenchConfig{
+		// Steady state: mostly unchanged
+		{totalGrants: 1_000, addedPct: 1, removedPct: 1, modifiedPct: 1},
+		{totalGrants: 10_000, addedPct: 1, removedPct: 1, modifiedPct: 1},
+		{totalGrants: 100_000, addedPct: 1, removedPct: 1, modifiedPct: 1},
+		{totalGrants: 1_000_000, addedPct: 1, removedPct: 1, modifiedPct: 1},
+
+		// High churn
+		{totalGrants: 10_000, addedPct: 20, removedPct: 20, modifiedPct: 10},
+		{totalGrants: 100_000, addedPct: 20, removedPct: 20, modifiedPct: 10},
+
+		// With expandable grants (expansion column comparison)
+		{totalGrants: 10_000, addedPct: 1, removedPct: 1, modifiedPct: 1, expandable: true},
+		{totalGrants: 100_000, addedPct: 1, removedPct: 1, modifiedPct: 1, expandable: true},
+	}
+
+	for _, cfg := range configs {
+		b.Run(cfg.name(), func(b *testing.B) {
+			oldFile, newFile, oldSyncID, newSyncID, cleanup := buildDiffFixture(b, cfg)
+			defer cleanup()
+
+			ctx := b.Context()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+
+				attached, err := newFile.AttachFile(oldFile, "attached")
+				require.NoError(b, err)
+
+				b.StartTimer()
+
+				upsertsSyncID, deletionsSyncID, err := attached.GenerateSyncDiffFromFile(ctx, oldSyncID, newSyncID)
+				require.NoError(b, err)
+				require.NotEmpty(b, upsertsSyncID)
+				require.NotEmpty(b, deletionsSyncID)
+
+				b.StopTimer()
+
+				for _, table := range []string{
+					resourceTypes.Name(), resources.Name(), entitlements.Name(), grants.Name(), syncRuns.Name(),
+				} {
+					_, err := newFile.db.ExecContext(ctx,
+						fmt.Sprintf("DELETE FROM %s WHERE sync_id IN (?, ?)", table),
+						upsertsSyncID, deletionsSyncID,
+					)
+					require.NoError(b, err)
+				}
+
+				_, err = attached.DetachFile("attached")
+				require.NoError(b, err)
+			}
+		})
+	}
+}
+
+func BenchmarkGenerateSyncDiff(b *testing.B) {
+	configs := []diffBenchConfig{
+		{totalGrants: 1_000, addedPct: 1, removedPct: 1, modifiedPct: 0},
+		{totalGrants: 10_000, addedPct: 1, removedPct: 1, modifiedPct: 0},
+		{totalGrants: 100_000, addedPct: 1, removedPct: 1, modifiedPct: 0},
+		{totalGrants: 10_000, addedPct: 20, removedPct: 20, modifiedPct: 0},
+	}
+
+	for _, cfg := range configs {
+		b.Run(cfg.name(), func(b *testing.B) {
+			ctx := b.Context()
+
+			tempDir, err := os.MkdirTemp("", "diff-bench-same-*")
+			require.NoError(b, err)
+			defer os.RemoveAll(tempDir)
+
+			fPath := filepath.Join(tempDir, "diff.c1z")
+			opts := []C1ZOption{
+				WithTmpDir(tempDir),
+				WithPragma("journal_mode", "WAL"),
+				WithEncoderConcurrency(0),
+				WithDecoderOptions(WithDecoderConcurrency(0)),
+			}
+
+			f, err := NewC1ZFile(ctx, fPath, opts...)
+			require.NoError(b, err)
+			defer f.Close(ctx)
+
+			total := cfg.totalGrants
+			nAdded := total * cfg.addedPct / 100
+			nRemoved := total * cfg.removedPct / 100
+			nUnchanged := total - nAdded - nRemoved
+
+			rt := &v2.ResourceType{Id: "user", DisplayName: "User"}
+			ent := &v2.Entitlement{
+				Id: "group:g1:member",
+				Resource: &v2.Resource{
+					Id: &v2.ResourceId{ResourceType: "group", Resource: "g1"},
+				},
+			}
+
+			makeGrant := func(idx int) *v2.Grant {
+				return v2.Grant_builder{
+					Id:          fmt.Sprintf("grant-%d", idx),
+					Entitlement: ent,
+					Principal: &v2.Resource{
+						Id: &v2.ResourceId{ResourceType: "user", Resource: fmt.Sprintf("u%d", idx)},
+					},
+				}.Build()
+			}
+
+			batchSize := 1000
+			batch := make([]*v2.Grant, 0, batchSize)
+			flush := func() {
+				if len(batch) > 0 {
+					require.NoError(b, f.PutGrants(ctx, batch...))
+					batch = batch[:0]
+				}
+			}
+
+			// Base sync
+			baseSyncID, err := f.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+			require.NoError(b, err)
+			require.NoError(b, f.PutResourceTypes(ctx, rt))
+			require.NoError(b, f.PutEntitlements(ctx, ent))
+
+			id := 0
+			for range nUnchanged {
+				batch = append(batch, makeGrant(id))
+				id++
+				if len(batch) >= batchSize {
+					flush()
+				}
+			}
+			for range nRemoved {
+				batch = append(batch, makeGrant(id))
+				id++
+				if len(batch) >= batchSize {
+					flush()
+				}
+			}
+			flush()
+			require.NoError(b, f.EndSync(ctx))
+
+			// Applied sync
+			appliedSyncID, err := f.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+			require.NoError(b, err)
+			require.NoError(b, f.PutResourceTypes(ctx, rt))
+			require.NoError(b, f.PutEntitlements(ctx, ent))
+
+			for i := range nUnchanged {
+				batch = append(batch, makeGrant(i))
+				if len(batch) >= batchSize {
+					flush()
+				}
+			}
+			for range nAdded {
+				batch = append(batch, makeGrant(id))
+				id++
+				if len(batch) >= batchSize {
+					flush()
+				}
+			}
+			flush()
+			require.NoError(b, f.EndSync(ctx))
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				diffSyncID, err := f.GenerateSyncDiff(ctx, baseSyncID, appliedSyncID)
+				require.NoError(b, err)
+				require.NotEmpty(b, diffSyncID)
+
+				b.StopTimer()
+				for _, table := range []string{
+					resourceTypes.Name(), resources.Name(), entitlements.Name(), grants.Name(), syncRuns.Name(),
+				} {
+					_, err := f.db.ExecContext(ctx,
+						fmt.Sprintf("DELETE FROM %s WHERE sync_id = ?", table), diffSyncID,
+					)
+					require.NoError(b, err)
+				}
+				b.StartTimer()
+			}
+		})
+	}
+}

--- a/pkg/dotc1z/diff_test.go
+++ b/pkg/dotc1z/diff_test.go
@@ -2,6 +2,7 @@ package dotc1z
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"slices"
@@ -10,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
 )
 
@@ -134,6 +136,9 @@ func TestGenerateSyncDiffFromFile_Additions(t *testing.T) {
 		}.Build(),
 		DisplayName: "Resource A",
 	}.Build())
+	require.NoError(t, err)
+
+	err = oldFile.SetSupportsDiff(ctx, oldSyncID)
 	require.NoError(t, err)
 
 	err = oldFile.EndSync(ctx)
@@ -273,6 +278,9 @@ func TestGenerateSyncDiffFromFile_Deletions(t *testing.T) {
 	}.Build())
 	require.NoError(t, err)
 
+	err = oldFile.SetSupportsDiff(ctx, oldSyncID)
+	require.NoError(t, err)
+
 	err = oldFile.EndSync(ctx)
 	require.NoError(t, err)
 	err = oldFile.SetSupportsDiff(ctx, oldSyncID)
@@ -366,6 +374,9 @@ func TestGenerateSyncDiffFromFile_Modifications(t *testing.T) {
 		}.Build(),
 		DisplayName: "Original Name",
 	}.Build())
+	require.NoError(t, err)
+
+	err = oldFile.SetSupportsDiff(ctx, oldSyncID)
 	require.NoError(t, err)
 
 	err = oldFile.EndSync(ctx)
@@ -465,6 +476,9 @@ func TestGenerateSyncDiffFromFile_MixedChanges(t *testing.T) {
 		}.Build())
 		require.NoError(t, err)
 	}
+
+	err = oldFile.SetSupportsDiff(ctx, oldSyncID)
+	require.NoError(t, err)
 
 	err = oldFile.EndSync(ctx)
 	require.NoError(t, err)
@@ -597,6 +611,9 @@ func TestGenerateSyncDiffFromFile_NoChanges(t *testing.T) {
 	}.Build())
 	require.NoError(t, err)
 
+	err = oldFile.SetSupportsDiff(ctx, oldSyncID)
+	require.NoError(t, err)
+
 	err = oldFile.EndSync(ctx)
 	require.NoError(t, err)
 	err = oldFile.SetSupportsDiff(ctx, oldSyncID)
@@ -644,7 +661,12 @@ func TestGenerateSyncDiffFromFile_NoChanges(t *testing.T) {
 		ResourceTypeId: resourceTypeID,
 	}.Build())
 	require.NoError(t, err)
-	require.Len(t, resourcesResp.GetList(), 0, "upserts should be empty when no changes")
+	require.Len(t, resourcesResp.GetList(), 0, "upserts should not include resources when no changes")
+
+	// Resource types are always included in upserts.
+	rtResp, err := newFile.ListResourceTypes(ctx, v2.ResourceTypesServiceListResourceTypesRequest_builder{}.Build())
+	require.NoError(t, err)
+	require.Len(t, rtResp.GetList(), 1, "upserts should include resource types")
 
 	// Verify deletions is empty
 	err = newFile.ViewSync(ctx, deletionsSyncID)
@@ -655,6 +677,10 @@ func TestGenerateSyncDiffFromFile_NoChanges(t *testing.T) {
 	}.Build())
 	require.NoError(t, err)
 	require.Len(t, resourcesResp.GetList(), 0, "deletions should be empty when no changes")
+
+	rtResp, err = newFile.ListResourceTypes(ctx, v2.ResourceTypesServiceListResourceTypesRequest_builder{}.Build())
+	require.NoError(t, err)
+	require.Len(t, rtResp.GetList(), 0, "deletions should not include resource types when no changes")
 
 	_ = oldFile.Close(ctx)
 	_ = newFile.Close(ctx)
@@ -692,6 +718,9 @@ func TestGenerateSyncDiffFromFile_EntitlementsOnly(t *testing.T) {
 		}.Build(),
 		DisplayName: "Entitlement A",
 	}.Build())
+	require.NoError(t, err)
+
+	err = oldFile.SetSupportsDiff(ctx, oldSyncID)
 	require.NoError(t, err)
 
 	err = oldFile.EndSync(ctx)
@@ -811,6 +840,9 @@ func TestGenerateSyncDiffFromFile_GrantsOnly(t *testing.T) {
 	}.Build())
 	require.NoError(t, err)
 
+	err = oldFile.SetSupportsDiff(ctx, oldSyncID)
+	require.NoError(t, err)
+
 	err = oldFile.EndSync(ctx)
 	require.NoError(t, err)
 	err = oldFile.SetSupportsDiff(ctx, oldSyncID)
@@ -925,6 +957,9 @@ func TestGenerateSyncDiffFromFile_EmptyBase(t *testing.T) {
 	require.NoError(t, err)
 
 	// No resources added - empty sync
+
+	err = oldFile.SetSupportsDiff(ctx, oldSyncID)
+	require.NoError(t, err)
 
 	err = oldFile.EndSync(ctx)
 	require.NoError(t, err)
@@ -1046,6 +1081,9 @@ func TestGenerateSyncDiffFromFile_EmptyNew(t *testing.T) {
 	}.Build())
 	require.NoError(t, err)
 
+	err = oldFile.SetSupportsDiff(ctx, oldSyncID)
+	require.NoError(t, err)
+
 	err = oldFile.EndSync(ctx)
 	require.NoError(t, err)
 	err = oldFile.SetSupportsDiff(ctx, oldSyncID)
@@ -1156,6 +1194,9 @@ func TestGenerateSyncDiffFromFile_EntitlementsDeletions(t *testing.T) {
 	}.Build())
 	require.NoError(t, err)
 
+	err = oldFile.SetSupportsDiff(ctx, oldSyncID)
+	require.NoError(t, err)
+
 	err = oldFile.EndSync(ctx)
 	require.NoError(t, err)
 	err = oldFile.SetSupportsDiff(ctx, oldSyncID)
@@ -1251,6 +1292,9 @@ func TestGenerateSyncDiffFromFile_EntitlementsModifications(t *testing.T) {
 		}.Build(),
 		DisplayName: "Original Entitlement A",
 	}.Build())
+	require.NoError(t, err)
+
+	err = oldFile.SetSupportsDiff(ctx, oldSyncID)
 	require.NoError(t, err)
 
 	err = oldFile.EndSync(ctx)
@@ -1379,6 +1423,9 @@ func TestGenerateSyncDiffFromFile_GrantsDeletions(t *testing.T) {
 	}.Build())
 	require.NoError(t, err)
 
+	err = oldFile.SetSupportsDiff(ctx, oldSyncID)
+	require.NoError(t, err)
+
 	err = oldFile.EndSync(ctx)
 	require.NoError(t, err)
 	err = oldFile.SetSupportsDiff(ctx, oldSyncID)
@@ -1445,6 +1492,884 @@ func TestGenerateSyncDiffFromFile_GrantsDeletions(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, grantsResp.GetList(), 1)
 	require.Equal(t, "grant-B", grantsResp.GetList()[0].GetId())
+
+	_ = oldFile.Close(ctx)
+	_ = newFile.Close(ctx)
+}
+
+func TestGenerateSyncDiffFromFile_MissingExpansionMarker(t *testing.T) {
+	ctx := context.Background()
+
+	oldPath := filepath.Join(c1zTests.workingDir, "diff_missing_marker_old.c1z")
+	newPath := filepath.Join(c1zTests.workingDir, "diff_missing_marker_new.c1z")
+	defer os.Remove(oldPath)
+	defer os.Remove(newPath)
+
+	opts := []C1ZOption{WithPragma("journal_mode", "WAL")}
+	oldOpts := append(slices.Clone(opts), WithPragma("locking_mode", "normal"))
+
+	// Create the OLD file with an expandable grant (but WITHOUT setting expansion marker)
+	oldFile, err := NewC1ZFile(ctx, oldPath, oldOpts...)
+	require.NoError(t, err)
+
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+	err = oldFile.PutResourceTypes(ctx, groupRT, userRT)
+	require.NoError(t, err)
+
+	g1 := v2.Resource_builder{
+		Id:          v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(),
+		DisplayName: "G1",
+	}.Build()
+	g2 := v2.Resource_builder{
+		Id:          v2.ResourceId_builder{ResourceType: "group", Resource: "g2"}.Build(),
+		DisplayName: "G2",
+	}.Build()
+	err = oldFile.PutResources(ctx, g1, g2)
+	require.NoError(t, err)
+
+	e1 := v2.Entitlement_builder{
+		Id:          "group:g1:member",
+		Resource:    g1,
+		Slug:        "member",
+		DisplayName: "member",
+	}.Build()
+	e2 := v2.Entitlement_builder{
+		Id:          "group:g2:member",
+		Resource:    g2,
+		Slug:        "member",
+		DisplayName: "member",
+	}.Build()
+	err = oldFile.PutEntitlements(ctx, e1, e2)
+	require.NoError(t, err)
+
+	// Create an expandable grant (g1 -> e2 with expansion annotation)
+	expandableGrant := v2.Grant_builder{
+		Id:          "grant:g1:e2",
+		Entitlement: e2,
+		Principal:   g1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{e1.GetId()},
+			Shallow:         false,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+	err = oldFile.PutGrants(ctx, expandableGrant)
+	require.NoError(t, err)
+
+	// Simulate an old sync that predates supports_diff by explicitly clearing it.
+	// (New code defaults supports_diff=1 for newly created syncs.)
+	_, err = oldFile.db.ExecContext(ctx, "UPDATE "+syncRuns.Name()+" SET supports_diff=0 WHERE sync_id = ?", oldSyncID)
+	require.NoError(t, err)
+
+	err = oldFile.EndSync(ctx)
+	require.NoError(t, err)
+
+	// Create the NEW file (minimal, just needs to exist)
+	newFile, err := NewC1ZFile(ctx, newPath, opts...)
+	require.NoError(t, err)
+
+	newSyncID, err := newFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	err = newFile.PutResourceTypes(ctx, groupRT, userRT)
+	require.NoError(t, err)
+	err = newFile.PutResources(ctx, g1, g2)
+	require.NoError(t, err)
+	err = newFile.PutEntitlements(ctx, e1, e2)
+	require.NoError(t, err)
+	err = newFile.EndSync(ctx)
+	require.NoError(t, err)
+
+	// Attach and try to generate diff - should fail
+	attached, err := newFile.AttachFile(oldFile, "attached")
+	require.NoError(t, err)
+
+	_, _, err = attached.GenerateSyncDiffFromFile(ctx, oldSyncID, newSyncID)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrOldSyncMissingExpansionMarker), "expected ErrOldSyncMissingExpansionMarker, got: %v", err)
+
+	_, err = attached.DetachFile("attached")
+	require.NoError(t, err)
+
+	_ = oldFile.Close(ctx)
+	_ = newFile.Close(ctx)
+}
+
+func TestGenerateSyncDiffFromFile_WithExpansionMarker(t *testing.T) {
+	ctx := context.Background()
+
+	oldPath := filepath.Join(c1zTests.workingDir, "diff_with_marker_old.c1z")
+	newPath := filepath.Join(c1zTests.workingDir, "diff_with_marker_new.c1z")
+	defer os.Remove(oldPath)
+	defer os.Remove(newPath)
+
+	opts := []C1ZOption{WithPragma("journal_mode", "WAL")}
+	oldOpts := append(slices.Clone(opts), WithPragma("locking_mode", "normal"))
+
+	// Create the OLD file with an expandable grant AND set expansion marker
+	oldFile, err := NewC1ZFile(ctx, oldPath, oldOpts...)
+	require.NoError(t, err)
+
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+	err = oldFile.PutResourceTypes(ctx, groupRT, userRT)
+	require.NoError(t, err)
+
+	g1 := v2.Resource_builder{
+		Id:          v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(),
+		DisplayName: "G1",
+	}.Build()
+	g2 := v2.Resource_builder{
+		Id:          v2.ResourceId_builder{ResourceType: "group", Resource: "g2"}.Build(),
+		DisplayName: "G2",
+	}.Build()
+	err = oldFile.PutResources(ctx, g1, g2)
+	require.NoError(t, err)
+
+	e1 := v2.Entitlement_builder{
+		Id:          "group:g1:member",
+		Resource:    g1,
+		Slug:        "member",
+		DisplayName: "member",
+	}.Build()
+	e2 := v2.Entitlement_builder{
+		Id:          "group:g2:member",
+		Resource:    g2,
+		Slug:        "member",
+		DisplayName: "member",
+	}.Build()
+	err = oldFile.PutEntitlements(ctx, e1, e2)
+	require.NoError(t, err)
+
+	// Create an expandable grant (g1 -> e2 with expansion annotation)
+	expandableGrant := v2.Grant_builder{
+		Id:          "grant:g1:e2",
+		Entitlement: e2,
+		Principal:   g1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{e1.GetId()},
+			Shallow:         false,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+	err = oldFile.PutGrants(ctx, expandableGrant)
+	require.NoError(t, err)
+
+	// Set the expansion marker - simulates sync expanded with new code
+	err = oldFile.SetSupportsDiff(ctx, oldSyncID)
+	require.NoError(t, err)
+
+	err = oldFile.EndSync(ctx)
+	require.NoError(t, err)
+
+	// Create the NEW file (minimal, just needs to exist)
+	newFile, err := NewC1ZFile(ctx, newPath, opts...)
+	require.NoError(t, err)
+
+	newSyncID, err := newFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	err = newFile.PutResourceTypes(ctx, groupRT, userRT)
+	require.NoError(t, err)
+	err = newFile.PutResources(ctx, g1, g2)
+	require.NoError(t, err)
+	err = newFile.PutEntitlements(ctx, e1, e2)
+	require.NoError(t, err)
+	err = newFile.EndSync(ctx)
+	require.NoError(t, err)
+
+	// Attach and generate diff - should succeed
+	attached, err := newFile.AttachFile(oldFile, "attached")
+	require.NoError(t, err)
+
+	upsertsSyncID, deletionsSyncID, err := attached.GenerateSyncDiffFromFile(ctx, oldSyncID, newSyncID)
+	require.NoError(t, err)
+	require.NotEmpty(t, upsertsSyncID)
+	require.NotEmpty(t, deletionsSyncID)
+
+	_, err = attached.DetachFile("attached")
+	require.NoError(t, err)
+
+	_ = oldFile.Close(ctx)
+	_ = newFile.Close(ctx)
+}
+
+// TestGenerateSyncDiffFromFile_ExpansionOnlyChange verifies that a grant whose
+// data blob is identical but whose expansion column changed is detected as a
+// modification in the cross-file diff.
+func TestGenerateSyncDiffFromFile_ExpansionOnlyChange(t *testing.T) {
+	ctx := context.Background()
+
+	oldPath := filepath.Join(c1zTests.workingDir, "diff_expansion_only_old.c1z")
+	newPath := filepath.Join(c1zTests.workingDir, "diff_expansion_only_new.c1z")
+	defer os.Remove(oldPath)
+	defer os.Remove(newPath)
+
+	opts := []C1ZOption{WithPragma("journal_mode", "WAL")}
+	oldOpts := append(slices.Clone(opts), WithPragma("locking_mode", "normal"))
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "G1"}.Build()
+	g2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g2"}.Build(), DisplayName: "G2"}.Build()
+
+	e1 := v2.Entitlement_builder{Id: "group:g1:member", Resource: g1, Slug: "member", DisplayName: "member"}.Build()
+	e2 := v2.Entitlement_builder{Id: "group:g2:member", Resource: g2, Slug: "member", DisplayName: "member"}.Build()
+
+	grantID := "grant:g1:e2"
+
+	// OLD: grant with expansion shallow=false
+	grantOld := v2.Grant_builder{
+		Id:          grantID,
+		Entitlement: e2,
+		Principal:   g1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{e1.GetId()},
+			Shallow:         false,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	// NEW: same grant but expansion shallow=true (expansion column differs)
+	grantNew := v2.Grant_builder{
+		Id:          grantID,
+		Entitlement: e2,
+		Principal:   g1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{e1.GetId()},
+			Shallow:         true,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	// Create OLD file
+	oldFile, err := NewC1ZFile(ctx, oldPath, oldOpts...)
+	require.NoError(t, err)
+
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, oldFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, oldFile.PutResources(ctx, g1, g2))
+	require.NoError(t, oldFile.PutEntitlements(ctx, e1, e2))
+	require.NoError(t, oldFile.PutGrants(ctx, grantOld))
+	require.NoError(t, oldFile.SetSupportsDiff(ctx, oldSyncID))
+	require.NoError(t, oldFile.EndSync(ctx))
+
+	// Create NEW file
+	newFile, err := NewC1ZFile(ctx, newPath, opts...)
+	require.NoError(t, err)
+
+	newSyncID, err := newFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, newFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, newFile.PutResources(ctx, g1, g2))
+	require.NoError(t, newFile.PutEntitlements(ctx, e1, e2))
+	require.NoError(t, newFile.PutGrants(ctx, grantNew))
+	require.NoError(t, newFile.EndSync(ctx))
+
+	// Generate diff
+	attached, err := newFile.AttachFile(oldFile, "attached")
+	require.NoError(t, err)
+
+	upsertsSyncID, _, err := attached.GenerateSyncDiffFromFile(ctx, oldSyncID, newSyncID)
+	require.NoError(t, err)
+
+	// Verify added edges via cross-DB query (NEW version: shallow=true).
+	addedDefs, err := attached.ComputeAddedExpandableGrants(ctx, oldSyncID, newSyncID)
+	require.NoError(t, err)
+	require.Len(t, addedDefs, 1, "should have one added expandable grant")
+	require.True(t, addedDefs[0].Shallow, "added grant should have NEW expansion (shallow=true)")
+
+	// Verify removed edges via cross-DB query (OLD version: shallow=false).
+	removedDefs, err := attached.ComputeRemovedExpandableGrants(ctx, oldSyncID, newSyncID)
+	require.NoError(t, err)
+	require.Len(t, removedDefs, 1, "should have one removed expandable grant")
+	require.False(t, removedDefs[0].Shallow, "removed grant should have OLD expansion (shallow=false)")
+
+	_, err = attached.DetachFile("attached")
+	require.NoError(t, err)
+
+	// Also verify the upserts sync in main has the NEW version.
+	upsertsRows, err := newFile.ListGrantsInternal(ctx, connectorstore.GrantListOptions{
+		Mode:   connectorstore.GrantListModeExpansion,
+		SyncID: upsertsSyncID,
+	})
+	require.NoError(t, err)
+	require.Len(t, upsertsRows.Rows, 1, "upserts should contain the modified grant")
+	require.Equal(t, grantID, upsertsRows.Rows[0].Expansion.GrantExternalID)
+	require.True(t, upsertsRows.Rows[0].Expansion.Shallow, "upserts should contain NEW expansion version (shallow=true)")
+
+	_ = oldFile.Close(ctx)
+	_ = newFile.Close(ctx)
+}
+
+// TestComputeExpandableGrants_StableExternalIDRetarget verifies that moving an expandable grant
+// to a different entitlement with the same external_id is surfaced as remove+add edge delta.
+func TestComputeExpandableGrants_StableExternalIDRetarget(t *testing.T) {
+	ctx := context.Background()
+
+	oldPath := filepath.Join(c1zTests.workingDir, "diff_expandable_retarget_old.c1z")
+	newPath := filepath.Join(c1zTests.workingDir, "diff_expandable_retarget_new.c1z")
+	defer os.Remove(oldPath)
+	defer os.Remove(newPath)
+
+	opts := []C1ZOption{WithPragma("journal_mode", "WAL")}
+	oldOpts := append(slices.Clone(opts), WithPragma("locking_mode", "normal"))
+
+	groupRT := v2.ResourceType_builder{Id: "group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user"}.Build()
+
+	g1 := v2.Resource_builder{
+		Id:          v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(),
+		DisplayName: "G1",
+	}.Build()
+	g2 := v2.Resource_builder{
+		Id:          v2.ResourceId_builder{ResourceType: "group", Resource: "g2"}.Build(),
+		DisplayName: "G2",
+	}.Build()
+	g3 := v2.Resource_builder{
+		Id:          v2.ResourceId_builder{ResourceType: "group", Resource: "g3"}.Build(),
+		DisplayName: "G3",
+	}.Build()
+
+	eSrc := v2.Entitlement_builder{Id: "group:g1:member", Resource: g1, Slug: "member", DisplayName: "member"}.Build()
+	eOld := v2.Entitlement_builder{Id: "group:g2:member", Resource: g2, Slug: "member", DisplayName: "member"}.Build()
+	eNew := v2.Entitlement_builder{Id: "group:g3:member", Resource: g3, Slug: "member", DisplayName: "member"}.Build()
+
+	grantID := "grant:stable-retarget"
+	expandable := annotations.New(v2.GrantExpandable_builder{
+		EntitlementIds:  []string{eSrc.GetId()},
+		Shallow:         false,
+		ResourceTypeIds: []string{"user"},
+	}.Build())
+
+	grantOld := v2.Grant_builder{
+		Id:          grantID,
+		Entitlement: eOld,
+		Principal:   g1,
+		Annotations: expandable,
+	}.Build()
+	grantNew := v2.Grant_builder{
+		Id:          grantID,
+		Entitlement: eNew,
+		Principal:   g1,
+		Annotations: expandable,
+	}.Build()
+
+	oldFile, err := NewC1ZFile(ctx, oldPath, oldOpts...)
+	require.NoError(t, err)
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, oldFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, oldFile.PutResources(ctx, g1, g2, g3))
+	require.NoError(t, oldFile.PutEntitlements(ctx, eSrc, eOld, eNew))
+	require.NoError(t, oldFile.PutGrants(ctx, grantOld))
+	require.NoError(t, oldFile.SetSupportsDiff(ctx, oldSyncID))
+	require.NoError(t, oldFile.EndSync(ctx))
+
+	newFile, err := NewC1ZFile(ctx, newPath, opts...)
+	require.NoError(t, err)
+	newSyncID, err := newFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, newFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, newFile.PutResources(ctx, g1, g2, g3))
+	require.NoError(t, newFile.PutEntitlements(ctx, eSrc, eOld, eNew))
+	require.NoError(t, newFile.PutGrants(ctx, grantNew))
+	require.NoError(t, newFile.EndSync(ctx))
+
+	attached, err := newFile.AttachFile(oldFile, "attached")
+	require.NoError(t, err)
+
+	addedDefs, err := attached.ComputeAddedExpandableGrants(ctx, oldSyncID, newSyncID)
+	require.NoError(t, err)
+	removedDefs, err := attached.ComputeRemovedExpandableGrants(ctx, oldSyncID, newSyncID)
+	require.NoError(t, err)
+
+	_, err = attached.DetachFile("attached")
+	require.NoError(t, err)
+
+	require.Len(t, addedDefs, 1, "retarget should add one edge definition for the NEW destination")
+	require.Equal(t, grantID, addedDefs[0].GrantExternalID)
+	require.Equal(t, eNew.GetId(), addedDefs[0].TargetEntitlementID)
+
+	require.Len(t, removedDefs, 1, "retarget should remove one edge definition for the OLD destination")
+	require.Equal(t, grantID, removedDefs[0].GrantExternalID)
+	require.Equal(t, eOld.GetId(), removedDefs[0].TargetEntitlementID)
+
+	_ = oldFile.Close(ctx)
+	_ = newFile.Close(ctx)
+}
+
+// TestGenerateSyncDiffFromFile_GrantDataModification verifies that modifying a grant's
+// data blob (not expansion) emits the NEW version in upserts and the OLD version in deletions.
+func TestGenerateSyncDiffFromFile_GrantDataModification(t *testing.T) {
+	ctx := context.Background()
+
+	oldPath := filepath.Join(c1zTests.workingDir, "diff_grant_data_mod_old.c1z")
+	newPath := filepath.Join(c1zTests.workingDir, "diff_grant_data_mod_new.c1z")
+	defer os.Remove(oldPath)
+	defer os.Remove(newPath)
+
+	opts := []C1ZOption{WithPragma("journal_mode", "WAL")}
+	oldOpts := append(slices.Clone(opts), WithPragma("locking_mode", "normal"))
+
+	rt := v2.ResourceType_builder{Id: "group"}.Build()
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build()}.Build()
+	ent := v2.Entitlement_builder{Id: "ent1", Resource: g1}.Build()
+
+	grantOld := v2.Grant_builder{
+		Id: "grant-mod", Entitlement: ent, Principal: u1,
+	}.Build()
+	grantNew := v2.Grant_builder{
+		Id: "grant-mod", Entitlement: ent, Principal: u1,
+		Annotations: annotations.New(&v2.GrantImmutable{}),
+	}.Build()
+
+	oldFile, err := NewC1ZFile(ctx, oldPath, oldOpts...)
+	require.NoError(t, err)
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, oldFile.PutResourceTypes(ctx, rt))
+	require.NoError(t, oldFile.PutResources(ctx, g1, u1))
+	require.NoError(t, oldFile.PutEntitlements(ctx, ent))
+	require.NoError(t, oldFile.PutGrants(ctx, grantOld))
+	require.NoError(t, oldFile.SetSupportsDiff(ctx, oldSyncID))
+	require.NoError(t, oldFile.EndSync(ctx))
+
+	newFile, err := NewC1ZFile(ctx, newPath, opts...)
+	require.NoError(t, err)
+	newSyncID, err := newFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, newFile.PutResourceTypes(ctx, rt))
+	require.NoError(t, newFile.PutResources(ctx, g1, u1))
+	require.NoError(t, newFile.PutEntitlements(ctx, ent))
+	require.NoError(t, newFile.PutGrants(ctx, grantNew))
+	require.NoError(t, newFile.EndSync(ctx))
+
+	attached, err := newFile.AttachFile(oldFile, "attached")
+	require.NoError(t, err)
+	upsertsSyncID, _, err := attached.GenerateSyncDiffFromFile(ctx, oldSyncID, newSyncID)
+	require.NoError(t, err)
+
+	// Verify changed grant entitlement IDs via cross-DB query.
+	changedIDs, err := attached.ComputeChangedGrantEntitlementIDs(ctx, oldSyncID, newSyncID)
+	require.NoError(t, err)
+	require.Contains(t, changedIDs, "ent1", "modified grant's entitlement should appear in changed IDs")
+
+	_, err = attached.DetachFile("attached")
+	require.NoError(t, err)
+
+	upserts, err := newFile.ListGrantsInternal(ctx, connectorstore.GrantListOptions{
+		Mode: connectorstore.GrantListModePayload, SyncID: upsertsSyncID,
+	})
+	require.NoError(t, err)
+	require.Len(t, upserts.Rows, 1, "upserts should contain the modified grant")
+	require.Equal(t, "grant-mod", upserts.Rows[0].Grant.GetId())
+
+	_ = oldFile.Close(ctx)
+	_ = newFile.Close(ctx)
+}
+
+// TestGenerateSyncDiffFromFile_GrantMixedChanges tests add + modify + delete + unchanged grants in one diff.
+func TestGenerateSyncDiffFromFile_GrantMixedChanges(t *testing.T) {
+	ctx := context.Background()
+
+	oldPath := filepath.Join(c1zTests.workingDir, "diff_grant_mixed_old.c1z")
+	newPath := filepath.Join(c1zTests.workingDir, "diff_grant_mixed_new.c1z")
+	defer os.Remove(oldPath)
+	defer os.Remove(newPath)
+
+	opts := []C1ZOption{WithPragma("journal_mode", "WAL")}
+	oldOpts := append(slices.Clone(opts), WithPragma("locking_mode", "normal"))
+
+	rt := v2.ResourceType_builder{Id: "group"}.Build()
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build()}.Build()
+	u2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u2"}.Build()}.Build()
+	u3 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u3"}.Build()}.Build()
+	u4 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u4"}.Build()}.Build()
+	ent := v2.Entitlement_builder{Id: "ent1", Resource: g1}.Build()
+
+	grantA := v2.Grant_builder{Id: "grant-A", Entitlement: ent, Principal: u1}.Build()
+	grantBOld := v2.Grant_builder{Id: "grant-B", Entitlement: ent, Principal: u2}.Build()
+	grantBNew := v2.Grant_builder{
+		Id: "grant-B", Entitlement: ent, Principal: u2,
+		Annotations: annotations.New(&v2.GrantImmutable{}),
+	}.Build()
+	grantC := v2.Grant_builder{Id: "grant-C", Entitlement: ent, Principal: u3}.Build()
+	grantD := v2.Grant_builder{Id: "grant-D", Entitlement: ent, Principal: u4}.Build()
+
+	oldFile, err := NewC1ZFile(ctx, oldPath, oldOpts...)
+	require.NoError(t, err)
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, oldFile.PutResourceTypes(ctx, rt))
+	require.NoError(t, oldFile.PutResources(ctx, g1, u1, u2, u3, u4))
+	require.NoError(t, oldFile.PutEntitlements(ctx, ent))
+	require.NoError(t, oldFile.PutGrants(ctx, grantA, grantBOld, grantC))
+	require.NoError(t, oldFile.SetSupportsDiff(ctx, oldSyncID))
+	require.NoError(t, oldFile.EndSync(ctx))
+
+	newFile, err := NewC1ZFile(ctx, newPath, opts...)
+	require.NoError(t, err)
+	newSyncID, err := newFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, newFile.PutResourceTypes(ctx, rt))
+	require.NoError(t, newFile.PutResources(ctx, g1, u1, u2, u3, u4))
+	require.NoError(t, newFile.PutEntitlements(ctx, ent))
+	require.NoError(t, newFile.PutGrants(ctx, grantA, grantBNew, grantD))
+	require.NoError(t, newFile.EndSync(ctx))
+
+	attached, err := newFile.AttachFile(oldFile, "attached")
+	require.NoError(t, err)
+	upsertsSyncID, deletionsSyncID, err := attached.GenerateSyncDiffFromFile(ctx, oldSyncID, newSyncID)
+	require.NoError(t, err)
+
+	// Verify changed grants via cross-DB query (should include B's entitlement and C's entitlement).
+	changedIDs, err := attached.ComputeChangedGrantEntitlementIDs(ctx, oldSyncID, newSyncID)
+	require.NoError(t, err)
+	require.Contains(t, changedIDs, "ent1")
+
+	_, err = attached.DetachFile("attached")
+	require.NoError(t, err)
+
+	// Upserts: grant-B (modified NEW) and grant-D (added). NOT grant-A (unchanged).
+	upserts, err := newFile.ListGrantsInternal(ctx, connectorstore.GrantListOptions{
+		Mode: connectorstore.GrantListModePayload, SyncID: upsertsSyncID,
+	})
+	require.NoError(t, err)
+	upsertIDs := map[string]bool{}
+	for _, r := range upserts.Rows {
+		upsertIDs[r.Grant.GetId()] = true
+	}
+	require.Len(t, upsertIDs, 2)
+	require.True(t, upsertIDs["grant-B"], "modified grant should be in upserts")
+	require.True(t, upsertIDs["grant-D"], "added grant should be in upserts")
+	require.False(t, upsertIDs["grant-A"], "unchanged grant should NOT be in upserts")
+
+	// Deletions: only grant-C (purely deleted). Modified grants' OLD rows are no longer copied here.
+	deletions, err := newFile.ListGrantsInternal(ctx, connectorstore.GrantListOptions{
+		Mode: connectorstore.GrantListModePayload, SyncID: deletionsSyncID,
+	})
+	require.NoError(t, err)
+	deletionIDs := map[string]bool{}
+	for _, r := range deletions.Rows {
+		deletionIDs[r.Grant.GetId()] = true
+	}
+	require.Len(t, deletionIDs, 1)
+	require.True(t, deletionIDs["grant-C"], "deleted grant should be in deletions")
+
+	_ = oldFile.Close(ctx)
+	_ = newFile.Close(ctx)
+}
+
+// TestGenerateSyncDiffFromFile_NeedsExpansionPreserved verifies that the needs_expansion
+// column value is preserved in diff output rows.
+func TestGenerateSyncDiffFromFile_NeedsExpansionPreserved(t *testing.T) {
+	ctx := context.Background()
+
+	oldPath := filepath.Join(c1zTests.workingDir, "diff_needs_exp_old.c1z")
+	newPath := filepath.Join(c1zTests.workingDir, "diff_needs_exp_new.c1z")
+	defer os.Remove(oldPath)
+	defer os.Remove(newPath)
+
+	opts := []C1ZOption{WithPragma("journal_mode", "WAL")}
+	oldOpts := append(slices.Clone(opts), WithPragma("locking_mode", "normal"))
+
+	rt := v2.ResourceType_builder{Id: "group"}.Build()
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	g2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g2"}.Build()}.Build()
+	ent1 := v2.Entitlement_builder{Id: "group:g1:member", Resource: g1}.Build()
+	ent2 := v2.Entitlement_builder{Id: "group:g2:member", Resource: g2}.Build()
+
+	expandableGrant := v2.Grant_builder{
+		Id: "grant-expandable", Entitlement: ent2, Principal: g1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds: []string{ent1.GetId()}, Shallow: false, ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	oldFile, err := NewC1ZFile(ctx, oldPath, oldOpts...)
+	require.NoError(t, err)
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, oldFile.PutResourceTypes(ctx, rt))
+	require.NoError(t, oldFile.SetSupportsDiff(ctx, oldSyncID))
+	require.NoError(t, oldFile.EndSync(ctx))
+
+	newFile, err := NewC1ZFile(ctx, newPath, opts...)
+	require.NoError(t, err)
+	newSyncID, err := newFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, newFile.PutResourceTypes(ctx, rt))
+	require.NoError(t, newFile.PutResources(ctx, g1, g2))
+	require.NoError(t, newFile.PutEntitlements(ctx, ent1, ent2))
+	require.NoError(t, newFile.PutGrants(ctx, expandableGrant))
+	require.NoError(t, newFile.EndSync(ctx))
+
+	attached, err := newFile.AttachFile(oldFile, "attached")
+	require.NoError(t, err)
+	upsertsSyncID, _, err := attached.GenerateSyncDiffFromFile(ctx, oldSyncID, newSyncID)
+	require.NoError(t, err)
+	_, err = attached.DetachFile("attached")
+	require.NoError(t, err)
+
+	upserts, err := newFile.ListGrantsInternal(ctx, connectorstore.GrantListOptions{
+		Mode:   connectorstore.GrantListModeExpansion,
+		SyncID: upsertsSyncID,
+	})
+	require.NoError(t, err)
+	require.Len(t, upserts.Rows, 1)
+	require.True(t, upserts.Rows[0].Expansion.NeedsExpansion, "needs_expansion should be preserved as true in upserts")
+
+	_ = oldFile.Close(ctx)
+	_ = newFile.Close(ctx)
+}
+
+// TestGenerateSyncDiffFromFile_ModifiedResourceNoOldRowInDeletions verifies that
+// diffModifiedFromAttachedTx only runs for grants. Modified resources and entitlements
+// should appear in upserts but their OLD versions should NOT appear in deletions.
+func TestGenerateSyncDiffFromFile_ModifiedResourceNoOldRowInDeletions(t *testing.T) {
+	ctx := context.Background()
+
+	oldPath := filepath.Join(c1zTests.workingDir, "diff_mod_res_no_old_old.c1z")
+	newPath := filepath.Join(c1zTests.workingDir, "diff_mod_res_no_old_new.c1z")
+	defer os.Remove(oldPath)
+	defer os.Remove(newPath)
+
+	opts := []C1ZOption{WithPragma("journal_mode", "WAL")}
+	oldOpts := append(slices.Clone(opts), WithPragma("locking_mode", "normal"))
+	rt := v2.ResourceType_builder{Id: "group"}.Build()
+
+	oldFile, err := NewC1ZFile(ctx, oldPath, oldOpts...)
+	require.NoError(t, err)
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, oldFile.PutResourceTypes(ctx, rt))
+	require.NoError(t, oldFile.PutResources(ctx, v2.Resource_builder{
+		Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "Old Name",
+	}.Build()))
+	require.NoError(t, oldFile.PutEntitlements(ctx, v2.Entitlement_builder{
+		Id: "ent-old", Resource: v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build(),
+		DisplayName: "Old Ent",
+	}.Build()))
+	require.NoError(t, oldFile.SetSupportsDiff(ctx, oldSyncID))
+	require.NoError(t, oldFile.EndSync(ctx))
+
+	newFile, err := NewC1ZFile(ctx, newPath, opts...)
+	require.NoError(t, err)
+	newSyncID, err := newFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, newFile.PutResourceTypes(ctx, rt))
+	require.NoError(t, newFile.PutResources(ctx, v2.Resource_builder{
+		Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "New Name",
+	}.Build()))
+	require.NoError(t, newFile.PutEntitlements(ctx, v2.Entitlement_builder{
+		Id: "ent-old", Resource: v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build(),
+		DisplayName: "New Ent",
+	}.Build()))
+	require.NoError(t, newFile.EndSync(ctx))
+
+	attached, err := newFile.AttachFile(oldFile, "attached")
+	require.NoError(t, err)
+	upsertsSyncID, deletionsSyncID, err := attached.GenerateSyncDiffFromFile(ctx, oldSyncID, newSyncID)
+	require.NoError(t, err)
+	_, err = attached.DetachFile("attached")
+	require.NoError(t, err)
+
+	require.NoError(t, newFile.ViewSync(ctx, upsertsSyncID))
+	resources, err := newFile.ListResources(ctx, v2.ResourcesServiceListResourcesRequest_builder{ResourceTypeId: "group"}.Build())
+	require.NoError(t, err)
+	require.Len(t, resources.GetList(), 1)
+	require.Equal(t, "New Name", resources.GetList()[0].GetDisplayName())
+
+	ents, err := newFile.ListEntitlements(ctx, v2.EntitlementsServiceListEntitlementsRequest_builder{}.Build())
+	require.NoError(t, err)
+	require.Len(t, ents.GetList(), 1)
+	require.Equal(t, "New Ent", ents.GetList()[0].GetDisplayName())
+
+	require.NoError(t, newFile.ViewSync(ctx, deletionsSyncID))
+	delResources, err := newFile.ListResources(ctx, v2.ResourcesServiceListResourcesRequest_builder{ResourceTypeId: "group"}.Build())
+	require.NoError(t, err)
+	require.Len(t, delResources.GetList(), 0, "modified resources should NOT have OLD rows in deletions")
+
+	delEnts, err := newFile.ListEntitlements(ctx, v2.EntitlementsServiceListEntitlementsRequest_builder{}.Build())
+	require.NoError(t, err)
+	require.Len(t, delEnts.GetList(), 0, "modified entitlements should NOT have OLD rows in deletions")
+
+	_ = oldFile.Close(ctx)
+	_ = newFile.Close(ctx)
+}
+
+// TestGenerateSyncDiffFromFile_ResourceTypesAlwaysCopied verifies that resource types
+// are always fully copied into the upserts sync even when unchanged, and never appear in deletions.
+func TestGenerateSyncDiffFromFile_ResourceTypesAlwaysCopied(t *testing.T) {
+	ctx := context.Background()
+
+	oldPath := filepath.Join(c1zTests.workingDir, "diff_rt_copy_old.c1z")
+	newPath := filepath.Join(c1zTests.workingDir, "diff_rt_copy_new.c1z")
+	defer os.Remove(oldPath)
+	defer os.Remove(newPath)
+
+	opts := []C1ZOption{WithPragma("journal_mode", "WAL")}
+	oldOpts := append(slices.Clone(opts), WithPragma("locking_mode", "normal"))
+
+	rtA := v2.ResourceType_builder{Id: "typeA", DisplayName: "Type A"}.Build()
+	rtB := v2.ResourceType_builder{Id: "typeB", DisplayName: "Type B"}.Build()
+
+	oldFile, err := NewC1ZFile(ctx, oldPath, oldOpts...)
+	require.NoError(t, err)
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, oldFile.PutResourceTypes(ctx, rtA, rtB))
+	require.NoError(t, oldFile.SetSupportsDiff(ctx, oldSyncID))
+	require.NoError(t, oldFile.EndSync(ctx))
+
+	newFile, err := NewC1ZFile(ctx, newPath, opts...)
+	require.NoError(t, err)
+	newSyncID, err := newFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, newFile.PutResourceTypes(ctx, rtA))
+	require.NoError(t, newFile.EndSync(ctx))
+
+	attached, err := newFile.AttachFile(oldFile, "attached")
+	require.NoError(t, err)
+	upsertsSyncID, deletionsSyncID, err := attached.GenerateSyncDiffFromFile(ctx, oldSyncID, newSyncID)
+	require.NoError(t, err)
+	_, err = attached.DetachFile("attached")
+	require.NoError(t, err)
+
+	require.NoError(t, newFile.ViewSync(ctx, upsertsSyncID))
+	rts, err := newFile.ListResourceTypes(ctx, v2.ResourceTypesServiceListResourceTypesRequest_builder{}.Build())
+	require.NoError(t, err)
+	rtIDs := map[string]bool{}
+	for _, r := range rts.GetList() {
+		rtIDs[r.GetId()] = true
+	}
+	require.True(t, rtIDs["typeA"], "unchanged resource type should still be in upserts (full copy)")
+
+	require.NoError(t, newFile.ViewSync(ctx, deletionsSyncID))
+	delRts, err := newFile.ListResourceTypes(ctx, v2.ResourceTypesServiceListResourceTypesRequest_builder{}.Build())
+	require.NoError(t, err)
+	require.Len(t, delRts.GetList(), 0, "resource types should never appear in deletions")
+
+	_ = oldFile.Close(ctx)
+	_ = newFile.Close(ctx)
+}
+
+// TestGenerateSyncDiffFromFile_ExpansionNullEdgeCases tests NULL expansion transitions:
+// NULL->non-NULL (grant becomes expandable), non-NULL->NULL (stops being expandable),
+// and NULL->NULL (should NOT be detected as a modification).
+func TestGenerateSyncDiffFromFile_ExpansionNullEdgeCases(t *testing.T) {
+	ctx := context.Background()
+
+	oldPath := filepath.Join(c1zTests.workingDir, "diff_exp_null_old.c1z")
+	newPath := filepath.Join(c1zTests.workingDir, "diff_exp_null_new.c1z")
+	defer os.Remove(oldPath)
+	defer os.Remove(newPath)
+
+	opts := []C1ZOption{WithPragma("journal_mode", "WAL")}
+	oldOpts := append(slices.Clone(opts), WithPragma("locking_mode", "normal"))
+
+	rt := v2.ResourceType_builder{Id: "group"}.Build()
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	g2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g2"}.Build()}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build()}.Build()
+	ent1 := v2.Entitlement_builder{Id: "group:g1:member", Resource: g1}.Build()
+	ent2 := v2.Entitlement_builder{Id: "group:g2:member", Resource: g2}.Build()
+
+	expandAnno := annotations.New(v2.GrantExpandable_builder{
+		EntitlementIds: []string{ent1.GetId()}, Shallow: false, ResourceTypeIds: []string{"user"},
+	}.Build())
+
+	grantBecomeExpandableOld := v2.Grant_builder{Id: "grant-becomes-expandable", Entitlement: ent2, Principal: g1}.Build()
+	grantBecomeExpandableNew := v2.Grant_builder{Id: "grant-becomes-expandable", Entitlement: ent2, Principal: g1, Annotations: expandAnno}.Build()
+
+	grantStopsExpandableOld := v2.Grant_builder{Id: "grant-stops-expandable", Entitlement: ent2, Principal: g1, Annotations: expandAnno}.Build()
+	grantStopsExpandableNew := v2.Grant_builder{Id: "grant-stops-expandable", Entitlement: ent2, Principal: g1}.Build()
+
+	grantAlwaysPlain := v2.Grant_builder{Id: "grant-always-plain", Entitlement: ent2, Principal: u1}.Build()
+
+	oldFile, err := NewC1ZFile(ctx, oldPath, oldOpts...)
+	require.NoError(t, err)
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, oldFile.PutResourceTypes(ctx, rt))
+	require.NoError(t, oldFile.PutResources(ctx, g1, g2, u1))
+	require.NoError(t, oldFile.PutEntitlements(ctx, ent1, ent2))
+	require.NoError(t, oldFile.PutGrants(ctx, grantBecomeExpandableOld, grantStopsExpandableOld, grantAlwaysPlain))
+	require.NoError(t, oldFile.SetSupportsDiff(ctx, oldSyncID))
+	require.NoError(t, oldFile.EndSync(ctx))
+
+	newFile, err := NewC1ZFile(ctx, newPath, opts...)
+	require.NoError(t, err)
+	newSyncID, err := newFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, newFile.PutResourceTypes(ctx, rt))
+	require.NoError(t, newFile.PutResources(ctx, g1, g2, u1))
+	require.NoError(t, newFile.PutEntitlements(ctx, ent1, ent2))
+	require.NoError(t, newFile.PutGrants(ctx, grantBecomeExpandableNew, grantStopsExpandableNew, grantAlwaysPlain))
+	require.NoError(t, newFile.EndSync(ctx))
+
+	attached, err := newFile.AttachFile(oldFile, "attached")
+	require.NoError(t, err)
+	upsertsSyncID, _, err := attached.GenerateSyncDiffFromFile(ctx, oldSyncID, newSyncID)
+	require.NoError(t, err)
+
+	// Verify via cross-DB queries: added and removed expandable grants.
+	addedDefs, err := attached.ComputeAddedExpandableGrants(ctx, oldSyncID, newSyncID)
+	require.NoError(t, err)
+	addedByID := map[string]bool{}
+	for _, d := range addedDefs {
+		addedByID[d.GrantExternalID] = true
+	}
+	require.True(t, addedByID["grant-becomes-expandable"], "NULL->non-NULL should appear in added expandable grants")
+	require.False(t, addedByID["grant-stops-expandable"], "non-NULL->NULL should NOT appear in added expandable grants")
+	require.False(t, addedByID["grant-always-plain"], "NULL->NULL should NOT appear in added expandable grants")
+
+	removedDefs, err := attached.ComputeRemovedExpandableGrants(ctx, oldSyncID, newSyncID)
+	require.NoError(t, err)
+	removedByID := map[string]bool{}
+	for _, d := range removedDefs {
+		removedByID[d.GrantExternalID] = true
+	}
+	require.False(t, removedByID["grant-becomes-expandable"], "NULL->non-NULL should NOT appear in removed expandable grants")
+	require.True(t, removedByID["grant-stops-expandable"], "non-NULL->NULL should appear in removed expandable grants")
+	require.False(t, removedByID["grant-always-plain"], "NULL->NULL should NOT appear in removed expandable grants")
+
+	// Verify changed grant entitlement IDs includes both modified grants.
+	changedIDs, err := attached.ComputeChangedGrantEntitlementIDs(ctx, oldSyncID, newSyncID)
+	require.NoError(t, err)
+	require.Contains(t, changedIDs, ent2.GetId(), "changed IDs should include entitlement of modified grants")
+
+	_, err = attached.DetachFile("attached")
+	require.NoError(t, err)
+
+	// Verify upserts in main still have both modified grants with correct expansion state.
+	upserts, err := newFile.ListGrantsInternal(ctx, connectorstore.GrantListOptions{
+		Mode: connectorstore.GrantListModePayloadWithExpansion, SyncID: upsertsSyncID,
+	})
+	require.NoError(t, err)
+	upsertIDs := map[string]bool{}
+	for _, r := range upserts.Rows {
+		upsertIDs[r.Grant.GetId()] = true
+		if r.Grant.GetId() == "grant-becomes-expandable" {
+			require.NotNil(t, r.Expansion, "NULL->non-NULL: upserts should have expansion metadata")
+		}
+		if r.Grant.GetId() == "grant-stops-expandable" {
+			require.Nil(t, r.Expansion, "non-NULL->NULL: upserts should have no expansion metadata")
+		}
+	}
+	require.True(t, upsertIDs["grant-becomes-expandable"], "NULL->non-NULL grant should be in upserts")
+	require.True(t, upsertIDs["grant-stops-expandable"], "non-NULL->NULL grant should be in upserts")
+	require.False(t, upsertIDs["grant-always-plain"], "NULL->NULL unchanged grant should NOT be in upserts")
 
 	_ = oldFile.Close(ctx)
 	_ = newFile.Close(ctx)

--- a/pkg/dotc1z/diff_test.go
+++ b/pkg/dotc1z/diff_test.go
@@ -1699,6 +1699,94 @@ func TestGenerateSyncDiffFromFile_WithExpansionMarker(t *testing.T) {
 	_ = newFile.Close(ctx)
 }
 
+func TestGenerateSyncDiffFromFile_MissingSourcesReadyMarkerOldSync(t *testing.T) {
+	ctx := context.Background()
+
+	oldPath := filepath.Join(c1zTests.workingDir, "diff_missing_sources_marker_old.c1z")
+	newPath := filepath.Join(c1zTests.workingDir, "diff_missing_sources_marker_new.c1z")
+	defer os.Remove(oldPath)
+	defer os.Remove(newPath)
+
+	opts := []C1ZOption{WithPragma("journal_mode", "WAL")}
+	oldOpts := append(slices.Clone(opts), WithPragma("locking_mode", "normal"))
+
+	oldFile, err := NewC1ZFile(ctx, oldPath, oldOpts...)
+	require.NoError(t, err)
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, oldFile.PutResourceTypes(ctx, v2.ResourceType_builder{Id: "group"}.Build()))
+	require.NoError(t, oldFile.SetSupportsDiff(ctx, oldSyncID))
+	require.NoError(t, oldFile.EndSync(ctx))
+
+	// Simulate legacy sync format where sources may still be embedded in grant data.
+	_, err = oldFile.db.ExecContext(ctx, "UPDATE "+syncRuns.Name()+" SET sources_ready=0 WHERE sync_id = ?", oldSyncID)
+	require.NoError(t, err)
+
+	newFile, err := NewC1ZFile(ctx, newPath, opts...)
+	require.NoError(t, err)
+	newSyncID, err := newFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, newFile.PutResourceTypes(ctx, v2.ResourceType_builder{Id: "group"}.Build()))
+	require.NoError(t, newFile.SetSupportsDiff(ctx, newSyncID))
+	require.NoError(t, newFile.EndSync(ctx))
+
+	attached, err := newFile.AttachFile(oldFile, "attached")
+	require.NoError(t, err)
+
+	_, _, err = attached.GenerateSyncDiffFromFile(ctx, oldSyncID, newSyncID)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrSyncMissingSourcesReadyMarker), "expected ErrSyncMissingSourcesReadyMarker, got: %v", err)
+
+	_, err = attached.DetachFile("attached")
+	require.NoError(t, err)
+	_ = oldFile.Close(ctx)
+	_ = newFile.Close(ctx)
+}
+
+func TestGenerateSyncDiffFromFile_MissingSourcesReadyMarkerNewSync(t *testing.T) {
+	ctx := context.Background()
+
+	oldPath := filepath.Join(c1zTests.workingDir, "diff_missing_sources_marker_old2.c1z")
+	newPath := filepath.Join(c1zTests.workingDir, "diff_missing_sources_marker_new2.c1z")
+	defer os.Remove(oldPath)
+	defer os.Remove(newPath)
+
+	opts := []C1ZOption{WithPragma("journal_mode", "WAL")}
+	oldOpts := append(slices.Clone(opts), WithPragma("locking_mode", "normal"))
+
+	oldFile, err := NewC1ZFile(ctx, oldPath, oldOpts...)
+	require.NoError(t, err)
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, oldFile.PutResourceTypes(ctx, v2.ResourceType_builder{Id: "group"}.Build()))
+	require.NoError(t, oldFile.SetSupportsDiff(ctx, oldSyncID))
+	require.NoError(t, oldFile.EndSync(ctx))
+
+	newFile, err := NewC1ZFile(ctx, newPath, opts...)
+	require.NoError(t, err)
+	newSyncID, err := newFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, newFile.PutResourceTypes(ctx, v2.ResourceType_builder{Id: "group"}.Build()))
+	require.NoError(t, newFile.SetSupportsDiff(ctx, newSyncID))
+	require.NoError(t, newFile.EndSync(ctx))
+
+	// Simulate legacy new sync format where sources may still be embedded in grant data.
+	_, err = newFile.db.ExecContext(ctx, "UPDATE "+syncRuns.Name()+" SET sources_ready=0 WHERE sync_id = ?", newSyncID)
+	require.NoError(t, err)
+
+	attached, err := newFile.AttachFile(oldFile, "attached")
+	require.NoError(t, err)
+
+	_, _, err = attached.GenerateSyncDiffFromFile(ctx, oldSyncID, newSyncID)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrSyncMissingSourcesReadyMarker), "expected ErrSyncMissingSourcesReadyMarker, got: %v", err)
+
+	_, err = attached.DetachFile("attached")
+	require.NoError(t, err)
+	_ = oldFile.Close(ctx)
+	_ = newFile.Close(ctx)
+}
+
 // TestGenerateSyncDiffFromFile_ExpansionOnlyChange verifies that a grant whose
 // data blob is identical but whose expansion column changed is detected as a
 // modification in the cross-file diff.
@@ -1973,6 +2061,322 @@ func TestGenerateSyncDiffFromFile_GrantDataModification(t *testing.T) {
 	require.Len(t, upserts.Rows, 1, "upserts should contain the modified grant")
 	require.Equal(t, "grant-mod", upserts.Rows[0].Grant.GetId())
 
+	_ = oldFile.Close(ctx)
+	_ = newFile.Close(ctx)
+}
+
+// TestGenerateSyncDiffFromFile_GrantSourcesOnlyModification verifies that a grant with unchanged
+// payload/expansion but changed sources is NOT included in pre-expansion upserts output.
+func TestGenerateSyncDiffFromFile_GrantSourcesOnlyModification(t *testing.T) {
+	ctx := context.Background()
+
+	oldPath := filepath.Join(c1zTests.workingDir, "diff_grant_sources_only_old.c1z")
+	newPath := filepath.Join(c1zTests.workingDir, "diff_grant_sources_only_new.c1z")
+	defer os.Remove(oldPath)
+	defer os.Remove(newPath)
+
+	opts := []C1ZOption{WithPragma("journal_mode", "WAL")}
+	oldOpts := append(slices.Clone(opts), WithPragma("locking_mode", "normal"))
+
+	rt := v2.ResourceType_builder{Id: "group"}.Build()
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build()}.Build()
+	ent := v2.Entitlement_builder{Id: "ent1", Resource: g1}.Build()
+
+	grantOld := v2.Grant_builder{
+		Id: "grant-sources-mod", Entitlement: ent, Principal: u1,
+		Sources: v2.GrantSources_builder{
+			Sources: map[string]*v2.GrantSources_GrantSource{
+				"ent1": {IsDirect: true},
+			},
+		}.Build(),
+	}.Build()
+	grantNew := v2.Grant_builder{
+		Id: "grant-sources-mod", Entitlement: ent, Principal: u1,
+		Sources: v2.GrantSources_builder{
+			Sources: map[string]*v2.GrantSources_GrantSource{
+				"ent1": {IsDirect: false},
+			},
+		}.Build(),
+	}.Build()
+
+	oldFile, err := NewC1ZFile(ctx, oldPath, oldOpts...)
+	require.NoError(t, err)
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, oldFile.PutResourceTypes(ctx, rt))
+	require.NoError(t, oldFile.PutResources(ctx, g1, u1))
+	require.NoError(t, oldFile.PutEntitlements(ctx, ent))
+	require.NoError(t, oldFile.PutGrants(ctx, grantOld))
+	require.NoError(t, oldFile.SetSupportsDiff(ctx, oldSyncID))
+	require.NoError(t, oldFile.EndSync(ctx))
+
+	newFile, err := NewC1ZFile(ctx, newPath, opts...)
+	require.NoError(t, err)
+	newSyncID, err := newFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, newFile.PutResourceTypes(ctx, rt))
+	require.NoError(t, newFile.PutResources(ctx, g1, u1))
+	require.NoError(t, newFile.PutEntitlements(ctx, ent))
+	require.NoError(t, newFile.PutGrants(ctx, grantNew))
+	require.NoError(t, newFile.EndSync(ctx))
+
+	attached, err := newFile.AttachFile(oldFile, "attached")
+	require.NoError(t, err)
+	upsertsSyncID, deletionsSyncID, err := attached.GenerateSyncDiffFromFile(ctx, oldSyncID, newSyncID)
+	require.NoError(t, err)
+
+	// Sources-only changes should not be treated as connector truth changes.
+	changedIDs, err := attached.ComputeChangedGrantEntitlementIDs(ctx, oldSyncID, newSyncID)
+	require.NoError(t, err)
+	require.NotContains(t, changedIDs, "ent1")
+
+	_, err = attached.DetachFile("attached")
+	require.NoError(t, err)
+
+	upserts, err := newFile.ListGrantsInternal(ctx, connectorstore.GrantListOptions{
+		Mode: connectorstore.GrantListModePayload, SyncID: upsertsSyncID,
+	})
+	require.NoError(t, err)
+	require.Len(t, upserts.Rows, 0, "pre-expansion upserts should not contain source-only modified grant")
+
+	deletions, err := newFile.ListGrantsInternal(ctx, connectorstore.GrantListOptions{
+		Mode: connectorstore.GrantListModePayload, SyncID: deletionsSyncID,
+	})
+	require.NoError(t, err)
+	require.Len(t, deletions.Rows, 0)
+
+	_ = oldFile.Close(ctx)
+	_ = newFile.Close(ctx)
+}
+
+// TestAppendPostExpansionSourcesUpserts_DedupsWithFirstPass verifies that when a grant
+// appears in both the first-pass upserts (data change) and qualifies for the second-pass
+// sources upsert, the INSERT OR IGNORE does not duplicate the row.
+func TestAppendPostExpansionSourcesUpserts_DedupsWithFirstPass(t *testing.T) {
+	ctx := context.Background()
+
+	oldPath := filepath.Join(c1zTests.workingDir, "diff_dedup_old.c1z")
+	newPath := filepath.Join(c1zTests.workingDir, "diff_dedup_new.c1z")
+	defer os.Remove(oldPath)
+	defer os.Remove(newPath)
+
+	opts := []C1ZOption{WithPragma("journal_mode", "WAL")}
+	oldOpts := append(slices.Clone(opts), WithPragma("locking_mode", "normal"))
+
+	rt := v2.ResourceType_builder{Id: "group"}.Build()
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build()}.Build()
+	ent := v2.Entitlement_builder{Id: "ent1", Resource: g1}.Build()
+
+	grantOld := v2.Grant_builder{
+		Id: "grant-dedup", Entitlement: ent, Principal: u1,
+		Sources: v2.GrantSources_builder{
+			Sources: map[string]*v2.GrantSources_GrantSource{"ent1": {IsDirect: true}},
+		}.Build(),
+	}.Build()
+	grantNew := v2.Grant_builder{
+		Id: "grant-dedup", Entitlement: ent, Principal: u1,
+		Annotations: annotations.New(&v2.GrantImmutable{}),
+		Sources: v2.GrantSources_builder{
+			Sources: map[string]*v2.GrantSources_GrantSource{"ent1": {IsDirect: false}},
+		}.Build(),
+	}.Build()
+
+	oldFile, err := NewC1ZFile(ctx, oldPath, oldOpts...)
+	require.NoError(t, err)
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, oldFile.PutResourceTypes(ctx, rt))
+	require.NoError(t, oldFile.PutResources(ctx, g1, u1))
+	require.NoError(t, oldFile.PutEntitlements(ctx, ent))
+	require.NoError(t, oldFile.PutGrants(ctx, grantOld))
+	require.NoError(t, oldFile.SetSupportsDiff(ctx, oldSyncID))
+	require.NoError(t, oldFile.EndSync(ctx))
+
+	newFile, err := NewC1ZFile(ctx, newPath, opts...)
+	require.NoError(t, err)
+	newSyncID, err := newFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, newFile.PutResourceTypes(ctx, rt))
+	require.NoError(t, newFile.PutResources(ctx, g1, u1))
+	require.NoError(t, newFile.PutEntitlements(ctx, ent))
+	require.NoError(t, newFile.PutGrants(ctx, grantNew))
+	require.NoError(t, newFile.EndSync(ctx))
+
+	attached, err := newFile.AttachFile(oldFile, "attached")
+	require.NoError(t, err)
+	upsertsSyncID, _, err := attached.GenerateSyncDiffFromFile(ctx, oldSyncID, newSyncID)
+	require.NoError(t, err)
+
+	// First pass should include the grant (data changed due to annotation).
+	upsertsBefore, err := newFile.ListGrantsInternal(ctx, connectorstore.GrantListOptions{
+		Mode: connectorstore.GrantListModePayload, SyncID: upsertsSyncID,
+	})
+	require.NoError(t, err)
+	require.Len(t, upsertsBefore.Rows, 1, "first pass should include data-changed grant")
+
+	// Second pass: also qualifies for sources change. Should not duplicate.
+	require.NoError(t, attached.AppendPostExpansionGrantSourcesUpserts(ctx, oldSyncID, newSyncID, upsertsSyncID))
+
+	upsertsAfter, err := newFile.ListGrantsInternal(ctx, connectorstore.GrantListOptions{
+		Mode: connectorstore.GrantListModePayload, SyncID: upsertsSyncID,
+	})
+	require.NoError(t, err)
+	require.Len(t, upsertsAfter.Rows, 1, "second pass INSERT OR IGNORE must not duplicate the row")
+
+	_, err = attached.DetachFile("attached")
+	require.NoError(t, err)
+	_ = oldFile.Close(ctx)
+	_ = newFile.Close(ctx)
+}
+
+// TestAppendPostExpansionSourcesUpserts_NullToNonNullSources verifies that a grant
+// transitioning from NULL sources to non-NULL sources is detected by the second pass.
+func TestAppendPostExpansionSourcesUpserts_NullToNonNullSources(t *testing.T) {
+	ctx := context.Background()
+
+	oldPath := filepath.Join(c1zTests.workingDir, "diff_null_sources_old.c1z")
+	newPath := filepath.Join(c1zTests.workingDir, "diff_null_sources_new.c1z")
+	defer os.Remove(oldPath)
+	defer os.Remove(newPath)
+
+	opts := []C1ZOption{WithPragma("journal_mode", "WAL")}
+	oldOpts := append(slices.Clone(opts), WithPragma("locking_mode", "normal"))
+
+	rt := v2.ResourceType_builder{Id: "group"}.Build()
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build()}.Build()
+	ent := v2.Entitlement_builder{Id: "ent1", Resource: g1}.Build()
+
+	grantNoSources := v2.Grant_builder{
+		Id: "grant-null-sources", Entitlement: ent, Principal: u1,
+	}.Build()
+	grantWithSources := v2.Grant_builder{
+		Id: "grant-null-sources", Entitlement: ent, Principal: u1,
+		Sources: v2.GrantSources_builder{
+			Sources: map[string]*v2.GrantSources_GrantSource{"ent1": {IsDirect: true}},
+		}.Build(),
+	}.Build()
+
+	oldFile, err := NewC1ZFile(ctx, oldPath, oldOpts...)
+	require.NoError(t, err)
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, oldFile.PutResourceTypes(ctx, rt))
+	require.NoError(t, oldFile.PutResources(ctx, g1, u1))
+	require.NoError(t, oldFile.PutEntitlements(ctx, ent))
+	require.NoError(t, oldFile.PutGrants(ctx, grantNoSources))
+	require.NoError(t, oldFile.SetSupportsDiff(ctx, oldSyncID))
+	require.NoError(t, oldFile.EndSync(ctx))
+
+	newFile, err := NewC1ZFile(ctx, newPath, opts...)
+	require.NoError(t, err)
+	newSyncID, err := newFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, newFile.PutResourceTypes(ctx, rt))
+	require.NoError(t, newFile.PutResources(ctx, g1, u1))
+	require.NoError(t, newFile.PutEntitlements(ctx, ent))
+	require.NoError(t, newFile.PutGrants(ctx, grantWithSources))
+	require.NoError(t, newFile.EndSync(ctx))
+
+	attached, err := newFile.AttachFile(oldFile, "attached")
+	require.NoError(t, err)
+	upsertsSyncID, _, err := attached.GenerateSyncDiffFromFile(ctx, oldSyncID, newSyncID)
+	require.NoError(t, err)
+
+	// First pass: data + expansion unchanged, so no upserts.
+	upsertsBefore, err := newFile.ListGrantsInternal(ctx, connectorstore.GrantListOptions{
+		Mode: connectorstore.GrantListModePayload, SyncID: upsertsSyncID,
+	})
+	require.NoError(t, err)
+	require.Empty(t, upsertsBefore.Rows, "pre-expansion upserts should be empty for sources-only change")
+
+	// Second pass detects NULL→non-NULL sources transition.
+	require.NoError(t, attached.AppendPostExpansionGrantSourcesUpserts(ctx, oldSyncID, newSyncID, upsertsSyncID))
+
+	upsertsAfter, err := newFile.ListGrantsInternal(ctx, connectorstore.GrantListOptions{
+		Mode: connectorstore.GrantListModePayload, SyncID: upsertsSyncID,
+	})
+	require.NoError(t, err)
+	require.Len(t, upsertsAfter.Rows, 1, "second pass should detect NULL→non-NULL sources transition")
+	require.Equal(t, "grant-null-sources", upsertsAfter.Rows[0].Grant.GetId())
+
+	_, err = attached.DetachFile("attached")
+	require.NoError(t, err)
+	_ = oldFile.Close(ctx)
+	_ = newFile.Close(ctx)
+}
+
+// TestAppendPostExpansionSourcesUpserts_SkipsNewOnlyGrants verifies that grants that
+// only exist in NEW (additions) are not picked up by the second-pass sources upsert.
+func TestAppendPostExpansionSourcesUpserts_SkipsNewOnlyGrants(t *testing.T) {
+	ctx := context.Background()
+
+	oldPath := filepath.Join(c1zTests.workingDir, "diff_newonly_old.c1z")
+	newPath := filepath.Join(c1zTests.workingDir, "diff_newonly_new.c1z")
+	defer os.Remove(oldPath)
+	defer os.Remove(newPath)
+
+	opts := []C1ZOption{WithPragma("journal_mode", "WAL")}
+	oldOpts := append(slices.Clone(opts), WithPragma("locking_mode", "normal"))
+
+	rt := v2.ResourceType_builder{Id: "group"}.Build()
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build()}.Build()
+	ent := v2.Entitlement_builder{Id: "ent1", Resource: g1}.Build()
+
+	// OLD: empty (no grants).
+	oldFile, err := NewC1ZFile(ctx, oldPath, oldOpts...)
+	require.NoError(t, err)
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, oldFile.PutResourceTypes(ctx, rt))
+	require.NoError(t, oldFile.PutResources(ctx, g1, u1))
+	require.NoError(t, oldFile.PutEntitlements(ctx, ent))
+	require.NoError(t, oldFile.SetSupportsDiff(ctx, oldSyncID))
+	require.NoError(t, oldFile.EndSync(ctx))
+
+	// NEW: one grant with sources (addition).
+	newFile, err := NewC1ZFile(ctx, newPath, opts...)
+	require.NoError(t, err)
+	newSyncID, err := newFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, newFile.PutResourceTypes(ctx, rt))
+	require.NoError(t, newFile.PutResources(ctx, g1, u1))
+	require.NoError(t, newFile.PutEntitlements(ctx, ent))
+	grantNew := v2.Grant_builder{
+		Id: "grant-new-only", Entitlement: ent, Principal: u1,
+		Sources: v2.GrantSources_builder{
+			Sources: map[string]*v2.GrantSources_GrantSource{"ent1": {IsDirect: true}},
+		}.Build(),
+	}.Build()
+	require.NoError(t, newFile.PutGrants(ctx, grantNew))
+	require.NoError(t, newFile.EndSync(ctx))
+
+	attached, err := newFile.AttachFile(oldFile, "attached")
+	require.NoError(t, err)
+	upsertsSyncID, _, err := attached.GenerateSyncDiffFromFile(ctx, oldSyncID, newSyncID)
+	require.NoError(t, err)
+
+	// First pass catches it as an addition.
+	upsertsBefore, err := newFile.ListGrantsInternal(ctx, connectorstore.GrantListOptions{
+		Mode: connectorstore.GrantListModePayload, SyncID: upsertsSyncID,
+	})
+	require.NoError(t, err)
+	require.Len(t, upsertsBefore.Rows, 1, "first pass should include the new grant as an addition")
+
+	// Second pass should not touch it (no OLD row to compare sources with).
+	require.NoError(t, attached.AppendPostExpansionGrantSourcesUpserts(ctx, oldSyncID, newSyncID, upsertsSyncID))
+
+	upsertsAfter, err := newFile.ListGrantsInternal(ctx, connectorstore.GrantListOptions{
+		Mode: connectorstore.GrantListModePayload, SyncID: upsertsSyncID,
+	})
+	require.NoError(t, err)
+	require.Len(t, upsertsAfter.Rows, 1, "second pass should not duplicate new-only grants")
+
+	_, err = attached.DetachFile("attached")
+	require.NoError(t, err)
 	_ = oldFile.Close(ctx)
 	_ = newFile.Close(ctx)
 }

--- a/pkg/dotc1z/entitlements.go
+++ b/pkg/dotc1z/entitlements.go
@@ -48,7 +48,7 @@ func (r *entitlementsTable) Schema() (string, []interface{}) {
 	}
 }
 
-func (r *entitlementsTable) Migrations(ctx context.Context, db *goqu.Database) error {
+func (r *entitlementsTable) Migrations(_ context.Context, _ *goqu.Database) error {
 	return nil
 }
 

--- a/pkg/dotc1z/grants.go
+++ b/pkg/dotc1z/grants.go
@@ -420,7 +420,7 @@ func extractAndStripExpansion(grant *v2.Grant) ([]byte, bool) {
 	if !hasValid {
 		return nil, false
 	}
-	// Note:modify by reference, nil is OK.
+	slices.Sort(expandable.GetEntitlementIds())
 	slices.Sort(expandable.GetResourceTypeIds())
 
 	data, err := proto.Marshal(expandable)
@@ -685,7 +685,7 @@ func backfillGrantSourcesColumn(ctx context.Context, db *goqu.Database, tableNam
 
 			sourcesBytes := extractAndClearSources(g)
 
-			newData, err := proto.Marshal(g)
+			newData, err := protoMarshaler.Marshal(g)
 			if err != nil {
 				_ = stmt.Close()
 				_ = tx.Rollback()
@@ -812,5 +812,6 @@ func (c *C1File) deleteGrantInternal(ctx context.Context, opts connectorstore.Gr
 		return err
 	}
 
+	c.dbUpdated = true
 	return nil
 }

--- a/pkg/dotc1z/grants.go
+++ b/pkg/dotc1z/grants.go
@@ -119,8 +119,7 @@ func (r *grantsTable) Migrations(ctx context.Context, db *goqu.Database) error {
 		return err
 	}
 
-	// Backfill sources column: strip Sources from data blobs and store them in the sources column.
-	return backfillGrantSourcesColumn(ctx, db, r.Name())
+	return nil
 }
 
 func (c *C1File) ListGrants(ctx context.Context, request *v2.GrantsServiceListGrantsRequest) (*v2.GrantsServiceListGrantsResponse, error) {
@@ -280,7 +279,7 @@ func extractAndClearSources(grant *v2.Grant) []byte {
 		grant.SetSources(nil)
 		return nil
 	}
-	b, err := proto.Marshal(srcs)
+	b, err := protoMarshaler.Marshal(srcs)
 	if err != nil {
 		grant.SetSources(nil)
 		return nil
@@ -620,109 +619,6 @@ func backfillGrantExpansionColumn(ctx context.Context, db *goqu.Database, tableN
 	return nil
 }
 
-// backfillGrantSourcesColumn strips Sources from data blobs that still contain them
-// and stores them in the separate sources column. Only processes grants from syncs
-// that support diff (supports_diff=1) because those are the ones that had expansion
-// run with code that wrote Sources into the data blob.
-func backfillGrantSourcesColumn(ctx context.Context, db *goqu.Database, tableName string) error {
-	for {
-		rows, err := db.QueryContext(ctx, fmt.Sprintf(
-			`SELECT g.id, g.data FROM %s g
-			 JOIN %s sr ON g.sync_id = sr.sync_id
-			 WHERE g.sources IS NULL
-			   AND sr.supports_diff = 1
-			 LIMIT 1000`,
-			tableName, syncRuns.Name(),
-		))
-		if err != nil {
-			return err
-		}
-
-		type row struct {
-			id   int64
-			data []byte
-		}
-		batch := make([]row, 0, 1000)
-		for rows.Next() {
-			var r row
-			if err := rows.Scan(&r.id, &r.data); err != nil {
-				_ = rows.Close()
-				return err
-			}
-			batch = append(batch, r)
-		}
-		if err := rows.Err(); err != nil {
-			_ = rows.Close()
-			return err
-		}
-		_ = rows.Close()
-
-		if len(batch) == 0 {
-			break
-		}
-
-		tx, err := db.BeginTx(ctx, nil)
-		if err != nil {
-			return err
-		}
-
-		stmt, err := tx.PrepareContext(ctx, fmt.Sprintf(
-			`UPDATE %s SET sources=?, data=? WHERE id=?`,
-			tableName,
-		))
-		if err != nil {
-			_ = tx.Rollback()
-			return err
-		}
-
-		for _, r := range batch {
-			g := &v2.Grant{}
-			if err := proto.Unmarshal(r.data, g); err != nil {
-				_ = stmt.Close()
-				_ = tx.Rollback()
-				return err
-			}
-
-			sourcesBytes := extractAndClearSources(g)
-
-			newData, err := protoMarshaler.Marshal(g)
-			if err != nil {
-				_ = stmt.Close()
-				_ = tx.Rollback()
-				return err
-			}
-
-			// Use empty blob as sentinel for grants without sources so
-			// they won't match "sources IS NULL" on the next iteration.
-			var sourcesVal any
-			if sourcesBytes != nil {
-				sourcesVal = sourcesBytes
-			} else {
-				sourcesVal = []byte{}
-			}
-
-			if _, err := stmt.ExecContext(ctx, sourcesVal, newData, r.id); err != nil {
-				_ = stmt.Close()
-				_ = tx.Rollback()
-				return err
-			}
-		}
-
-		_ = stmt.Close()
-		if err := tx.Commit(); err != nil {
-			return err
-		}
-	}
-
-	// Convert empty-blob sentinels back to NULL.
-	if _, err := db.ExecContext(ctx, fmt.Sprintf(
-		`UPDATE %s SET sources = NULL WHERE sources = X''`, tableName,
-	)); err != nil {
-		return err
-	}
-
-	return nil
-}
 
 func executeGrantChunkedUpsert(
 	ctx context.Context, c *C1File,

--- a/pkg/dotc1z/grants_diff_helpers.go
+++ b/pkg/dotc1z/grants_diff_helpers.go
@@ -1,0 +1,47 @@
+package dotc1z
+
+import (
+	"context"
+
+	"github.com/doug-martin/goqu/v9"
+)
+
+// ListDistinctEntitlementIDsForSync returns the set of entitlement IDs that appear in v1_entitlements for the given sync.
+func (c *C1File) ListDistinctEntitlementIDsForSync(ctx context.Context, syncID string) ([]string, error) {
+	ctx, span := tracer.Start(ctx, "C1File.ListDistinctEntitlementIDsForSync")
+	defer span.End()
+
+	if err := c.validateDb(ctx); err != nil {
+		return nil, err
+	}
+
+	q := c.db.From(entitlements.Name()).Prepared(true)
+	q = q.Select("external_id").Distinct()
+	q = q.Where(goqu.C("sync_id").Eq(syncID))
+
+	query, args, err := q.ToSQL()
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := c.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := make([]string, 0)
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		if id != "" {
+			out = append(out, id)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/pkg/dotc1z/grants_needs_expansion.go
+++ b/pkg/dotc1z/grants_needs_expansion.go
@@ -1,0 +1,67 @@
+package dotc1z
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/doug-martin/goqu/v9"
+)
+
+// SetNeedsExpansionForGrants sets needs_expansion for the provided grant external IDs in the given sync.
+func (c *C1File) SetNeedsExpansionForGrants(ctx context.Context, syncID string, grantExternalIDs []string, needsExpansion bool) error {
+	ctx, span := tracer.Start(ctx, "C1File.SetNeedsExpansionForGrants")
+	defer span.End()
+
+	if c.readOnly {
+		return ErrReadOnly
+	}
+	if err := c.validateDb(ctx); err != nil {
+		return err
+	}
+	if len(grantExternalIDs) == 0 {
+		return nil
+	}
+
+	q := c.db.Update(grants.Name()).Prepared(true)
+	q = q.Set(goqu.Record{"needs_expansion": needsExpansion})
+	q = q.Where(goqu.C("sync_id").Eq(syncID))
+	q = q.Where(goqu.C("external_id").In(grantExternalIDs))
+
+	query, args, err := q.ToSQL()
+	if err != nil {
+		return err
+	}
+	if _, err := c.db.ExecContext(ctx, query, args...); err != nil {
+		return fmt.Errorf("set needs_expansion: %w", err)
+	}
+	c.dbUpdated = true
+	return nil
+}
+
+// ClearNeedsExpansionForSync clears needs_expansion for all grants in the given sync.
+func (c *C1File) ClearNeedsExpansionForSync(ctx context.Context, syncID string) error {
+	ctx, span := tracer.Start(ctx, "C1File.ClearNeedsExpansionForSync")
+	defer span.End()
+
+	if c.readOnly {
+		return ErrReadOnly
+	}
+	if err := c.validateDb(ctx); err != nil {
+		return err
+	}
+
+	q := c.db.Update(grants.Name()).Prepared(true)
+	q = q.Set(goqu.Record{"needs_expansion": 0})
+	q = q.Where(goqu.C("sync_id").Eq(syncID))
+	q = q.Where(goqu.C("needs_expansion").Eq(1))
+
+	query, args, err := q.ToSQL()
+	if err != nil {
+		return err
+	}
+	if _, err := c.db.ExecContext(ctx, query, args...); err != nil {
+		return fmt.Errorf("clear needs_expansion: %w", err)
+	}
+	c.dbUpdated = true
+	return nil
+}

--- a/pkg/dotc1z/grants_test.go
+++ b/pkg/dotc1z/grants_test.go
@@ -640,115 +640,6 @@ func TestBackfillMigration_OldSyncGetsExpansionColumn(t *testing.T) {
 	require.Equal(t, 1, grantsBackfilled, "backfill should mark the sync as grants_backfilled=1")
 }
 
-// TestBackfillMigration_OldSyncGetsSourcesColumn verifies that opening a c1z file
-// where grants still have Sources embedded in the data blob (old format) correctly
-// backfills the dedicated sources column and strips sources from data.
-func TestBackfillMigration_OldSyncGetsSourcesColumn(t *testing.T) {
-	ctx := context.Background()
-
-	tmpFile, err := os.CreateTemp("", "test-backfill-sources-*.c1z")
-	require.NoError(t, err)
-	defer os.Remove(tmpFile.Name())
-	tmpFile.Close()
-
-	c1f, err := NewC1ZFile(ctx, tmpFile.Name())
-	require.NoError(t, err)
-	defer c1f.Close(ctx)
-
-	syncID, err := c1f.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
-	require.NoError(t, err)
-
-	groupRT := v2.ResourceType_builder{Id: "group"}.Build()
-	userRT := v2.ResourceType_builder{Id: "user"}.Build()
-	require.NoError(t, c1f.PutResourceTypes(ctx, groupRT, userRT))
-
-	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
-	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build()}.Build()
-	require.NoError(t, c1f.PutResources(ctx, g1, u1))
-
-	ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1}.Build()
-	require.NoError(t, c1f.PutEntitlements(ctx, ent1))
-
-	grantWithSources := v2.Grant_builder{
-		Id:          "grant-sources-backfill",
-		Entitlement: ent1,
-		Principal:   u1,
-		Sources: v2.GrantSources_builder{
-			Sources: map[string]*v2.GrantSources_GrantSource{
-				"ent1": {IsDirect: true},
-			},
-		}.Build(),
-	}.Build()
-	grantNoSources := v2.Grant_builder{
-		Id:          "grant-no-sources-backfill",
-		Entitlement: ent1,
-		Principal:   g1,
-	}.Build()
-	require.NoError(t, c1f.PutGrants(ctx, grantWithSources, grantNoSources))
-
-	// Mark this sync as supports_diff=1 to match the migration's filter.
-	require.NoError(t, c1f.SetSupportsDiff(ctx, syncID))
-	require.NoError(t, c1f.EndSync(ctx))
-
-	// Simulate old format: sources embedded in data blob, sources column NULL.
-	oldFormatGrant := v2.Grant_builder{
-		Id:          "grant-sources-backfill",
-		Entitlement: ent1,
-		Principal:   u1,
-		Sources: v2.GrantSources_builder{
-			Sources: map[string]*v2.GrantSources_GrantSource{
-				"ent1": {IsDirect: true},
-			},
-		}.Build(),
-	}.Build()
-	oldFormatData, err := proto.MarshalOptions{Deterministic: true}.Marshal(oldFormatGrant)
-	require.NoError(t, err)
-
-	_, err = c1f.db.ExecContext(ctx,
-		"UPDATE "+grants.Name()+" SET data=?, sources=NULL WHERE external_id='grant-sources-backfill' AND sync_id=?",
-		oldFormatData, syncID,
-	)
-	require.NoError(t, err)
-
-	_, err = c1f.db.ExecContext(ctx,
-		"UPDATE "+grants.Name()+" SET sources=NULL WHERE external_id='grant-no-sources-backfill' AND sync_id=?",
-		syncID,
-	)
-	require.NoError(t, err)
-
-	// Run the backfill explicitly.
-	require.NoError(t, backfillGrantSourcesColumn(ctx, c1f.db, grants.Name()))
-
-	// Verify migrated row: sources moved to column and stripped from data.
-	withSources := getRawGrantRowWithDataAndSourcesForSync(ctx, t, c1f, "grant-sources-backfill", syncID)
-	require.NotNil(t, withSources.sources, "sources column should be populated after backfill")
-	migratedSources := &v2.GrantSources{}
-	require.NoError(t, proto.Unmarshal(withSources.sources, migratedSources))
-	require.True(t, migratedSources.GetSources()["ent1"].GetIsDirect())
-
-	migratedDataGrant := &v2.Grant{}
-	require.NoError(t, proto.Unmarshal(withSources.data, migratedDataGrant))
-	require.Nil(t, migratedDataGrant.GetSources(), "data blob should have sources stripped after backfill")
-
-	// Verify row with no sources remains SQL NULL in sources column.
-	requireSourcesSQLNullForSync(ctx, t, c1f, "grant-no-sources-backfill", syncID)
-
-	// Verify API rehydration still returns the expected sources.
-	c1f.currentSyncID = ""
-	require.NoError(t, c1f.ViewSync(ctx, syncID))
-	listResp, err := c1f.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{}.Build())
-	require.NoError(t, err)
-	require.Len(t, listResp.GetList(), 2)
-
-	byID := map[string]*v2.Grant{}
-	for _, g := range listResp.GetList() {
-		byID[g.GetId()] = g
-	}
-	require.Len(t, byID["grant-sources-backfill"].GetSources().GetSources(), 1)
-	require.True(t, byID["grant-sources-backfill"].GetSources().GetSources()["ent1"].GetIsDirect())
-	require.Nil(t, byID["grant-no-sources-backfill"].GetSources())
-}
-
 // grantRawRow holds the raw SQL column values for a grant row.
 type grantRawRow struct {
 	data           []byte
@@ -757,7 +648,7 @@ type grantRawRow struct {
 	needsExpansion int
 }
 
-// getRawGrantRowWithDataAndSources reads raw data + sources columns for a grant row.
+// getRawGrantRow reads the raw expansion and needs_expansion columns for a grant by external_id.
 func getRawGrantRowWithDataAndSources(ctx context.Context, t *testing.T, c1f *C1File, externalID string) grantRawRow {
 	t.Helper()
 	var r grantRawRow
@@ -774,25 +665,6 @@ func getRawGrantRowWithDataAndSources(ctx context.Context, t *testing.T, c1f *C1
 	return r
 }
 
-func getRawGrantRowWithDataAndSourcesForSync(ctx context.Context, t *testing.T, c1f *C1File, externalID string, syncID string) grantRawRow {
-	t.Helper()
-	var r grantRawRow
-	err := c1f.db.QueryRowContext(ctx,
-		"SELECT data, sources, expansion, needs_expansion FROM "+grants.Name()+" WHERE external_id=? AND sync_id=?",
-		externalID,
-		syncID,
-	).Scan(&r.data, &r.sources, &r.expansion, &r.needsExpansion)
-	require.NoError(t, err)
-	if len(r.expansion) == 0 {
-		r.expansion = nil
-	}
-	if len(r.sources) == 0 {
-		r.sources = nil
-	}
-	return r
-}
-
-// getRawGrantRow reads the raw expansion and needs_expansion columns for a grant by external_id.
 func getRawGrantRow(ctx context.Context, t *testing.T, c1f *C1File, externalID string) grantRawRow {
 	t.Helper()
 	var r grantRawRow
@@ -873,18 +745,6 @@ func requireExpansionSQLNull(ctx context.Context, t *testing.T, c1f *C1File, ext
 	require.Equal(t, 1, isNull, "expansion must be SQL NULL, not empty blob")
 }
 
-func requireSourcesSQLNullForSync(ctx context.Context, t *testing.T, c1f *C1File, externalID string, syncID string) {
-	t.Helper()
-	var isNull int
-	err := c1f.db.QueryRowContext(
-		ctx,
-		"SELECT sources IS NULL FROM "+grants.Name()+" WHERE external_id=? AND sync_id=?",
-		externalID,
-		syncID,
-	).Scan(&isNull)
-	require.NoError(t, err)
-	require.Equal(t, 1, isNull, "sources must be SQL NULL, not empty blob")
-}
 
 // setupTestC1Z creates a fresh c1z with a started full sync and common resource types,
 // resources, and entitlements. Returns the c1z, sync ID, and a cleanup function.
@@ -1898,4 +1758,123 @@ func TestPutGrants_ReplaceOverwritesExpansion(t *testing.T) {
 	requireExpansionSQLNullForSync(ctx, t, c1f, "grant-replace", syncID)
 	rawCleared := getRawGrantRowForSync(ctx, t, c1f, "grant-replace", syncID)
 	require.Equal(t, 0, rawCleared.needsExpansion, "needs_expansion should be 0 after clearing expansion via Replace")
+}
+
+// TestGrantSourcesMarshalingDeterministic verifies that writing the same grant with
+// multiple map keys in Sources produces identical bytes every time, protecting against
+// non-deterministic proto.Marshal on map-containing messages.
+func TestGrantSourcesMarshalingDeterministic(t *testing.T) {
+	ctx := context.Background()
+	c1f, _, cleanup := setupTestC1Z(ctx, t)
+	defer cleanup()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build()}.Build()
+	ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1}.Build()
+
+	makeSources := func() *v2.GrantSources {
+		return v2.GrantSources_builder{
+			Sources: map[string]*v2.GrantSources_GrantSource{
+				"ent-alpha": {IsDirect: true},
+				"ent-beta":  {IsDirect: false},
+				"ent-gamma": {IsDirect: true},
+				"ent-delta": {IsDirect: false},
+			},
+		}.Build()
+	}
+
+	grant1 := v2.Grant_builder{
+		Id: "grant-deterministic", Entitlement: ent1, Principal: u1,
+		Sources: makeSources(),
+	}.Build()
+	require.NoError(t, c1f.PutGrants(ctx, grant1))
+	raw1 := getRawGrantRowWithDataAndSources(ctx, t, c1f, "grant-deterministic")
+	require.NotNil(t, raw1.sources)
+
+	grant2 := v2.Grant_builder{
+		Id: "grant-deterministic", Entitlement: ent1, Principal: u1,
+		Sources: makeSources(),
+	}.Build()
+	require.NoError(t, c1f.PutGrants(ctx, grant2))
+	raw2 := getRawGrantRowWithDataAndSources(ctx, t, c1f, "grant-deterministic")
+	require.NotNil(t, raw2.sources)
+
+	require.Equal(t, raw1.sources, raw2.sources, "sources bytes must be identical across writes")
+	require.Equal(t, raw1.data, raw2.data, "data bytes must be identical across writes")
+}
+
+// TestExtractAndStripExpansion_EntitlementIdsSorted verifies that expansion bytes are
+// identical regardless of the input order of EntitlementIds.
+func TestExtractAndStripExpansion_EntitlementIdsSorted(t *testing.T) {
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build()}.Build()
+	ent := v2.Entitlement_builder{Id: "ent1", Resource: g1}.Build()
+
+	grantA := v2.Grant_builder{
+		Id: "grant-sort", Entitlement: ent, Principal: u1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{"zzz", "aaa", "mmm"},
+			ResourceTypeIds: []string{"user", "group"},
+		}.Build()),
+	}.Build()
+
+	grantB := v2.Grant_builder{
+		Id: "grant-sort", Entitlement: ent, Principal: u1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{"mmm", "zzz", "aaa"},
+			ResourceTypeIds: []string{"group", "user"},
+		}.Build()),
+	}.Build()
+
+	bytesA, okA := extractAndStripExpansion(grantA)
+	bytesB, okB := extractAndStripExpansion(grantB)
+	require.True(t, okA)
+	require.True(t, okB)
+	require.Equal(t, bytesA, bytesB, "expansion bytes must be identical regardless of input order")
+}
+
+// TestDeleteGrantInternal_PersistsAfterCloseReopen verifies that the dbUpdated flag is set
+// so the delete survives a close/reopen cycle.
+func TestDeleteGrantInternal_PersistsAfterCloseReopen(t *testing.T) {
+	ctx := context.Background()
+
+	tmpFile, err := os.CreateTemp("", "test-delete-persist-*.c1z")
+	require.NoError(t, err)
+	path := tmpFile.Name()
+	defer os.Remove(path)
+	tmpFile.Close()
+
+	c1f, err := NewC1ZFile(ctx, path)
+	require.NoError(t, err)
+
+	syncID, err := c1f.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, c1f.PutResourceTypes(ctx, v2.ResourceType_builder{Id: "group"}.Build(), v2.ResourceType_builder{Id: "user"}.Build()))
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build()}.Build()
+	require.NoError(t, c1f.PutResources(ctx, g1, u1))
+
+	ent := v2.Entitlement_builder{Id: "ent1", Resource: g1}.Build()
+	require.NoError(t, c1f.PutEntitlements(ctx, ent))
+
+	grant := v2.Grant_builder{Id: "grant-persist-delete", Entitlement: ent, Principal: u1}.Build()
+	require.NoError(t, c1f.PutGrants(ctx, grant))
+	require.NoError(t, c1f.EndSync(ctx))
+
+	require.NoError(t, c1f.DeleteGrantInternal(ctx, connectorstore.GrantDeleteOptions{
+		SyncID: syncID,
+	}, grant.GetId()))
+	require.NoError(t, c1f.Close(ctx))
+
+	c1f2, err := NewC1ZFile(ctx, path)
+	require.NoError(t, err)
+	defer c1f2.Close(ctx)
+
+	require.NoError(t, c1f2.ViewSync(ctx, syncID))
+	resp, err := c1f2.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{}.Build())
+	require.NoError(t, err)
+	for _, g := range resp.GetList() {
+		require.NotEqual(t, "grant-persist-delete", g.GetId(), "deleted grant should not reappear after close/reopen")
+	}
 }

--- a/pkg/dotc1z/resouce_types.go
+++ b/pkg/dotc1z/resouce_types.go
@@ -43,7 +43,7 @@ func (r *resourceTypesTable) Schema() (string, []interface{}) {
 	}
 }
 
-func (r *resourceTypesTable) Migrations(ctx context.Context, db *goqu.Database) error {
+func (r *resourceTypesTable) Migrations(_ context.Context, _ *goqu.Database) error {
 	return nil
 }
 

--- a/pkg/dotc1z/resources.go
+++ b/pkg/dotc1z/resources.go
@@ -53,7 +53,7 @@ func (r *resourcesTable) Schema() (string, []interface{}) {
 	}
 }
 
-func (r *resourcesTable) Migrations(ctx context.Context, db *goqu.Database) error {
+func (r *resourcesTable) Migrations(_ context.Context, _ *goqu.Database) error {
 	return nil
 }
 

--- a/pkg/dotc1z/sync_runs.go
+++ b/pkg/dotc1z/sync_runs.go
@@ -35,7 +35,8 @@ create table if not exists %s (
     parent_sync_id text not null default '',
     linked_sync_id text not null default '',
     supports_diff integer not null default 0,
-    grants_backfilled integer not null default 0
+    grants_backfilled integer not null default 0,
+    sources_ready integer not null default 0
 );
 create unique index if not exists %s on %s (sync_id);`
 
@@ -106,6 +107,21 @@ func (r *syncRunsTable) Migrations(ctx context.Context, db *goqu.Database) error
 	// Track whether grant expansion backfill has completed for this sync.
 	if _, err = db.ExecContext(ctx, fmt.Sprintf("alter table %s add column grants_backfilled integer not null default 0", r.Name())); err != nil && !isAlreadyExistsError(err) {
 		return err
+	}
+	// Track whether this sync is sources-ready for diff generation.
+	if _, err = db.ExecContext(ctx, fmt.Sprintf("alter table %s add column sources_ready integer not null default 0", r.Name())); err != nil && !isAlreadyExistsError(err) {
+		return err
+	}
+	// Branch-local compatibility: if an older branch build created sources_backfilled,
+	// copy it into the renamed sources_ready column.
+	var sourcesBackfilledExists int
+	if err = db.QueryRowContext(ctx, fmt.Sprintf("select count(*) from pragma_table_info('%s') where name='sources_backfilled'", r.Name())).Scan(&sourcesBackfilledExists); err != nil {
+		return err
+	}
+	if sourcesBackfilledExists == 1 {
+		if _, err = db.ExecContext(ctx, fmt.Sprintf("update %s set sources_ready = sources_backfilled where sources_backfilled = 1", r.Name())); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -607,6 +623,7 @@ func (c *C1File) insertSyncRunWithLink(ctx context.Context, syncID string, syncT
 		"parent_sync_id":    parentSyncID,
 		"linked_sync_id":    linkedSyncID,
 		"grants_backfilled": 1, // New syncs do not require grants backfill.
+		"sources_ready":     1, // New syncs already write sources to dedicated column.
 	})
 
 	query, args, err := q.ToSQL()

--- a/pkg/sync/expand/expand_benchmark_test.go
+++ b/pkg/sync/expand/expand_benchmark_test.go
@@ -117,7 +117,11 @@ func loadEntitlementGraphFromC1Z(ctx context.Context, c1f *dotc1z.C1File, syncID
 					EntitlementId: srcEntitlementID,
 				}.Build())
 				if err != nil {
-					continue // Skip if source entitlement not found
+					// Only skip not-found entitlements; propagate other errors.
+					if errors.Is(err, sql.ErrNoRows) {
+						continue
+					}
+					return nil, fmt.Errorf("error fetching source entitlement %q: %w", srcEntitlementID, err)
 				}
 
 				graph.AddEntitlementID(def.TargetEntitlementID)

--- a/pkg/sync/incrementalexpansion/apply.go
+++ b/pkg/sync/incrementalexpansion/apply.go
@@ -1,0 +1,156 @@
+package incrementalexpansion
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
+)
+
+// RunParams configures an incremental expansion run between old and new sync states.
+type RunParams struct {
+	OldFile   *dotc1z.C1File
+	OldSyncID string
+	NewSyncID string
+}
+
+// RunResult contains IDs for the generated grant diff syncs.
+type RunResult struct {
+	UpsertsSyncID   string
+	DeletionsSyncID string
+}
+
+// Run computes grant/edge diffs from old->new and applies incremental expansion for NewSyncID.
+// TODO(kans): pagination, checkpointing, resumability.
+// TODO(kans): investigate if past some threshold, a full expansion pass is faster than an incremental one.
+func Run(
+	ctx context.Context,
+	newFile *dotc1z.C1File,
+	params RunParams,
+) (_ *RunResult, err error) {
+	if newFile == nil {
+		return nil, errors.New("new file was nil")
+	}
+	if params.OldFile == nil {
+		return nil, errors.New("old file was nil")
+	}
+	if params.OldSyncID == "" {
+		return nil, errors.New("old sync id was empty")
+	}
+	if params.NewSyncID == "" {
+		return nil, errors.New("new sync id was empty")
+	}
+
+	const attachedName = "attached"
+	attached, err := newFile.AttachFile(params.OldFile, attachedName)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_, detachErr := attached.DetachFile(attachedName)
+		if detachErr != nil {
+			err = errors.Join(err, fmt.Errorf("detach old file: %w", detachErr))
+		}
+	}()
+
+	upsertsSyncID, deletionsSyncID, err := attached.GenerateSyncDiffFromFile(ctx, params.OldSyncID, params.NewSyncID)
+	if err != nil {
+		return nil, err
+	}
+
+	addedDefs, err := attached.ComputeAddedExpandableGrants(ctx, params.OldSyncID, params.NewSyncID)
+	if err != nil {
+		return nil, err
+	}
+	removedDefs, err := attached.ComputeRemovedExpandableGrants(ctx, params.OldSyncID, params.NewSyncID)
+	if err != nil {
+		return nil, err
+	}
+	changedEntitlementIDs, err := attached.ComputeChangedGrantEntitlementIDs(ctx, params.OldSyncID, params.NewSyncID)
+	if err != nil {
+		return nil, err
+	}
+
+	delta := edgeDeltaFromExpandableGrants(addedDefs, removedDefs)
+
+	l := ctxzap.Extract(ctx)
+	l.Debug("incremental expansion: computed diff",
+		zap.Int("edges_added", len(delta.added)),
+		zap.Int("edges_removed", len(delta.removed)),
+		zap.Int("changed_entitlements", len(changedEntitlementIDs)),
+	)
+
+	// Seed the set of "changed sources" from grant-level diffs. These are source
+	// entitlements whose grants changed and therefore may need propagation updates.
+	changedSources := make(map[string]struct{}, len(changedEntitlementIDs))
+	for _, id := range changedEntitlementIDs {
+		if id != "" {
+			changedSources[id] = struct{}{}
+		}
+	}
+
+	addSeeds := func(ids []string) {
+		for _, id := range ids {
+			if id != "" {
+				changedSources[id] = struct{}{}
+			}
+		}
+	}
+
+	// Entitlement-level seeding still uses the diff syncs in the main file,
+	// since entitlement rows are still diffed into upserts/deletions syncs.
+	ids, err := newFile.ListDistinctEntitlementIDsForSync(ctx, upsertsSyncID)
+	if err != nil {
+		return nil, err
+	}
+	addSeeds(ids)
+	ids, err = newFile.ListDistinctEntitlementIDsForSync(ctx, deletionsSyncID)
+	if err != nil {
+		return nil, err
+	}
+	addSeeds(ids)
+
+	// Compute the transitive entitlement closure impacted by edge-definition changes
+	// (added/removed expandable edges). This closure is used for dirty marking.
+	affected, err := affectedEntitlements(ctx, newFile, params.NewSyncID, delta)
+	if err != nil {
+		return nil, err
+	}
+
+	// Stage 1: remove stale propagated sources implied by removed edges.
+	// This may delete derived immutable grants that became sourceless.
+	if err := invalidateRemovedEdges(ctx, newFile, params.NewSyncID, delta); err != nil {
+		return nil, err
+	}
+
+	// Stage 2: invalidate grants for source entitlements whose grants changed
+	// (add/remove/modify), even if edge definitions themselves did not change.
+	if err := invalidateChangedSourceEntitlements(ctx, newFile, params.NewSyncID, changedSources); err != nil {
+		return nil, err
+	}
+
+	// Changed sources themselves must be marked affected so outgoing propagation
+	// is recomputed from these nodes during dirty expansion.
+	for id := range changedSources {
+		affected[id] = struct{}{}
+	}
+
+	// Mark only grants on affected nodes as needing expansion. This bounds the
+	// subsequent expansion pass to the dirty subgraph instead of full recompute.
+	if err := markNeedsExpansionForAffectedEdges(ctx, newFile, params.NewSyncID, affected); err != nil {
+		return nil, err
+	}
+
+	// Re-expand just the dirty subgraph and clear needs_expansion flags when done.
+	if err := expandDirtySubgraph(ctx, newFile, params.NewSyncID); err != nil {
+		return nil, fmt.Errorf("expand dirty subgraph: %w", err)
+	}
+
+	return &RunResult{
+		UpsertsSyncID:   upsertsSyncID,
+		DeletionsSyncID: deletionsSyncID,
+	}, nil
+}

--- a/pkg/sync/incrementalexpansion/apply.go
+++ b/pkg/sync/incrementalexpansion/apply.go
@@ -149,6 +149,19 @@ func Run(
 		return nil, fmt.Errorf("expand dirty subgraph: %w", err)
 	}
 
+	// Second pass: append grant rows whose connector-truth payload is unchanged but
+	// sources changed after expansion (output-only delta).
+	if err := attached.AppendPostExpansionGrantSourcesUpserts(ctx, params.OldSyncID, params.NewSyncID, upsertsSyncID); err != nil {
+		return nil, fmt.Errorf("append post-expansion sources upserts: %w", err)
+	}
+
+	// Second pass (deletions): grants that existed in both OLD and NEW before
+	// expansion but were deleted during expansion (e.g. immutable grants that
+	// became sourceless) need to appear in the deletions sync.
+	if err := attached.AppendPostExpansionGrantDeletions(ctx, params.OldSyncID, params.NewSyncID, deletionsSyncID); err != nil {
+		return nil, fmt.Errorf("append post-expansion grant deletions: %w", err)
+	}
+
 	return &RunResult{
 		UpsertsSyncID:   upsertsSyncID,
 		DeletionsSyncID: deletionsSyncID,

--- a/pkg/sync/incrementalexpansion/edge_delta.go
+++ b/pkg/sync/incrementalexpansion/edge_delta.go
@@ -1,0 +1,62 @@
+package incrementalexpansion
+
+import (
+	"strings"
+
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+)
+
+type edge struct {
+	srcEntitlementID string
+	dstEntitlementID string
+	shallow          bool
+	// principalResourceTypeIDs is the filter applied when listing source grants to propagate.
+	principalResourceTypeIDs []string
+}
+
+func (e edge) key() string {
+	sep := "\x1f"
+	shallow := "0"
+	if e.shallow {
+		shallow = "1"
+	}
+	return strings.Join([]string{
+		e.srcEntitlementID,
+		e.dstEntitlementID,
+		shallow,
+		strings.Join(e.principalResourceTypeIDs, sep),
+	}, sep)
+}
+
+type edgeDelta struct {
+	added   map[string]edge
+	removed map[string]edge
+}
+
+// edgeDeltaFromExpandableGrants builds an edgeDelta from added/removed expandable grant definitions.
+// The returned delta always has non-nil maps.
+func edgeDeltaFromExpandableGrants(added, removed []*connectorstore.ExpandableGrantDef) *edgeDelta {
+	return &edgeDelta{
+		added:   edgeSetFromDefs(added),
+		removed: edgeSetFromDefs(removed),
+	}
+}
+
+func edgeSetFromDefs(defs []*connectorstore.ExpandableGrantDef) map[string]edge {
+	out := make(map[string]edge, len(defs))
+	for _, def := range defs {
+		if def == nil {
+			continue
+		}
+		for _, src := range def.SourceEntitlementIDs {
+			e := edge{
+				srcEntitlementID:         src,
+				dstEntitlementID:         def.TargetEntitlementID,
+				shallow:                  def.Shallow,
+				principalResourceTypeIDs: def.ResourceTypeIDs,
+			}
+			out[e.key()] = e
+		}
+	}
+	return out
+}

--- a/pkg/sync/incrementalexpansion/helpers_test.go
+++ b/pkg/sync/incrementalexpansion/helpers_test.go
@@ -1,0 +1,130 @@
+package incrementalexpansion
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	"github.com/conductorone/baton-sdk/pkg/sync/expand"
+	"github.com/stretchr/testify/require"
+)
+
+func setupExpandableSync(
+	ctx context.Context,
+	t *testing.T,
+	tmpDir, name string,
+	resourceTypes []*v2.ResourceType,
+	resources []*v2.Resource,
+	entitlements []*v2.Entitlement,
+	grants []*v2.Grant,
+	opts ...dotc1z.C1ZOption,
+) (*dotc1z.C1File, string) {
+	t.Helper()
+	dbPath := filepath.Join(tmpDir, name+".c1z")
+	c1f, err := dotc1z.NewC1ZFile(ctx, dbPath, opts...)
+	require.NoError(t, err)
+
+	syncID, err := c1f.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	if len(resourceTypes) > 0 {
+		require.NoError(t, c1f.PutResourceTypes(ctx, resourceTypes...))
+	}
+	if len(resources) > 0 {
+		require.NoError(t, c1f.PutResources(ctx, resources...))
+	}
+	if len(entitlements) > 0 {
+		require.NoError(t, c1f.PutEntitlements(ctx, entitlements...))
+	}
+	if len(grants) > 0 {
+		require.NoError(t, c1f.PutGrants(ctx, grants...))
+	}
+	require.NoError(t, c1f.EndSync(ctx))
+	require.NoError(t, c1f.SetSupportsDiff(ctx, syncID))
+
+	return c1f, syncID
+}
+
+func runFullExpansion(ctx context.Context, c1f *dotc1z.C1File, syncID string) error {
+	if err := c1f.SetSupportsDiff(ctx, syncID); err != nil {
+		return err
+	}
+
+	graph := expand.NewEntitlementGraph(ctx)
+
+	pageToken := ""
+	for {
+		resp, err := c1f.ListGrantsInternal(ctx, connectorstore.GrantListOptions{
+			Mode:           connectorstore.GrantListModeExpansion,
+			SyncID:         syncID,
+			PageToken:      pageToken,
+			ExpandableOnly: true,
+		})
+		if err != nil {
+			return err
+		}
+		for _, row := range resp.Rows {
+			def := row.Expansion
+			if def == nil {
+				continue
+			}
+
+			for _, src := range def.SourceEntitlementIDs {
+				graph.AddEntitlementID(def.TargetEntitlementID)
+				graph.AddEntitlementID(src)
+				if err := graph.AddEdge(ctx, src, def.TargetEntitlementID, def.Shallow, def.ResourceTypeIDs); err != nil {
+					return err
+				}
+			}
+		}
+		if resp.NextPageToken == "" {
+			break
+		}
+		pageToken = resp.NextPageToken
+	}
+
+	graph.Loaded = true
+	if err := graph.FixCycles(ctx); err != nil {
+		return err
+	}
+
+	expander := expand.NewExpander(c1f, graph).WithSyncID(syncID)
+	if err := expander.Run(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func loadGrantSourcesByKey(ctx context.Context, c1f *dotc1z.C1File, syncID string) (map[string]map[string]bool, error) {
+	err := c1f.SetSyncID(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+	if err := c1f.ViewSync(ctx, syncID); err != nil {
+		return nil, err
+	}
+
+	out := make(map[string]map[string]bool)
+	pageToken := ""
+	for {
+		resp, err := c1f.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{PageToken: pageToken}.Build())
+		if err != nil {
+			return nil, err
+		}
+		for _, g := range resp.GetList() {
+			key := g.GetEntitlement().GetId() + "|" + g.GetPrincipal().GetId().GetResourceType() + "|" + g.GetPrincipal().GetId().GetResource()
+			srcs := make(map[string]bool)
+			for s, src := range g.GetSources().GetSources() {
+				srcs[s] = src.GetIsDirect()
+			}
+			out[key] = srcs
+		}
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			break
+		}
+	}
+	return out, nil
+}

--- a/pkg/sync/incrementalexpansion/incremental_correctness_test.go
+++ b/pkg/sync/incrementalexpansion/incremental_correctness_test.go
@@ -1,0 +1,2883 @@
+package incrementalexpansion_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	"github.com/conductorone/baton-sdk/pkg/sync/expand"
+	"github.com/conductorone/baton-sdk/pkg/sync/incrementalexpansion"
+	batonEntitlement "github.com/conductorone/baton-sdk/pkg/types/entitlement"
+	batonGrant "github.com/conductorone/baton-sdk/pkg/types/grant"
+	"github.com/stretchr/testify/require"
+)
+
+// diffAndApplyIncremental is a test helper that runs the full incremental expansion pipeline.
+func diffAndApplyIncremental(t *testing.T, ctx context.Context, newFile *dotc1z.C1File, oldFile *dotc1z.C1File, oldSyncID, newSyncID string) {
+	t.Helper()
+	_, err := incrementalexpansion.Run(ctx, newFile, incrementalexpansion.RunParams{
+		OldFile:   oldFile,
+		OldSyncID: oldSyncID,
+		NewSyncID: newSyncID,
+	})
+	require.NoError(t, err)
+}
+
+func runFullExpansion(ctx context.Context, c1f *dotc1z.C1File, syncID string) error {
+	// Mark the sync as supporting diff operations (SQL-layer data is ready).
+	if err := c1f.SetSupportsDiff(ctx, syncID); err != nil {
+		return err
+	}
+
+	graph := expand.NewEntitlementGraph(ctx)
+
+	pageToken := ""
+	for {
+		resp, err := c1f.ListGrantsInternal(ctx, connectorstore.GrantListOptions{
+			Mode:           connectorstore.GrantListModeExpansion,
+			SyncID:         syncID,
+			PageToken:      pageToken,
+			ExpandableOnly: true,
+		})
+		if err != nil {
+			return err
+		}
+		for _, row := range resp.Rows {
+			def := row.Expansion
+			if def == nil {
+				continue
+			}
+
+			// defs, next, err := c1f.ListExpandableGrants(
+			// 	ctx,
+			// 	dotc1z.WithExpandableGrantsSyncID(syncID),
+			// 	dotc1z.WithExpandableGrantsPageToken(pageToken),
+			// 	dotc1z.WithExpandableGrantsNeedsExpansionOnly(false),
+			// )
+
+			for _, src := range def.SourceEntitlementIDs {
+				graph.AddEntitlementID(def.TargetEntitlementID)
+				graph.AddEntitlementID(src)
+				if err := graph.AddEdge(ctx, src, def.TargetEntitlementID, def.Shallow, def.ResourceTypeIDs); err != nil {
+					return err
+				}
+			}
+		}
+		if resp.NextPageToken == "" {
+			break
+		}
+		pageToken = resp.NextPageToken
+	}
+
+	graph.Loaded = true
+	if err := graph.FixCycles(ctx); err != nil {
+		return err
+	}
+
+	return expand.NewExpander(c1f, graph).WithSyncID(syncID).Run(ctx)
+}
+
+func loadGrantSourcesByKey(ctx context.Context, c1f *dotc1z.C1File, syncID string) (map[string]map[string]bool, error) {
+	// Ensure we're not in a "current sync" context (ViewSync rejects that).
+	err := c1f.SetSyncID(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+	if err := c1f.ViewSync(ctx, syncID); err != nil {
+		return nil, err
+	}
+
+	out := make(map[string]map[string]bool)
+	pageToken := ""
+	for {
+		resp, err := c1f.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{PageToken: pageToken}.Build())
+		if err != nil {
+			return nil, err
+		}
+		for _, g := range resp.GetList() {
+			key := g.GetEntitlement().GetId() + "|" + g.GetPrincipal().GetId().GetResourceType() + "|" + g.GetPrincipal().GetId().GetResource()
+			srcs := make(map[string]bool)
+			for s, src := range g.GetSources().GetSources() {
+				srcs[s] = src.GetIsDirect()
+			}
+			out[key] = srcs
+		}
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			break
+		}
+	}
+	return out, nil
+}
+
+// listGrantsWithStoredExpansion returns grants from the currently selected/viewed sync
+// and rehydrates GrantExpandable from internal expansion columns for test copy flows.
+func listGrantsWithStoredExpansion(ctx context.Context, c1f *dotc1z.C1File) ([]*v2.Grant, error) {
+	out := make([]*v2.Grant, 0, 1024)
+	pageToken := ""
+	for {
+		resp, err := c1f.ListGrantsInternal(ctx, connectorstore.GrantListOptions{
+			Mode:      connectorstore.GrantListModePayloadWithExpansion,
+			PageToken: pageToken,
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, row := range resp.Rows {
+			g := row.Grant
+			if g == nil {
+				continue
+			}
+			if def := row.Expansion; def != nil {
+				annos := annotations.Annotations(g.GetAnnotations())
+				annos.Append(v2.GrantExpandable_builder{
+					EntitlementIds:  append([]string(nil), def.SourceEntitlementIDs...),
+					Shallow:         def.Shallow,
+					ResourceTypeIds: append([]string(nil), def.ResourceTypeIDs...),
+				}.Build())
+				g.SetAnnotations(annos)
+			}
+			out = append(out, g)
+		}
+		if resp.NextPageToken == "" {
+			break
+		}
+		pageToken = resp.NextPageToken
+	}
+	return out, nil
+}
+
+func TestIncrementalExpansion_RemovedEdgeDeletesDerivedGrant(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	oldPath := filepath.Join(tmpDir, "old.c1z")
+	newPath := filepath.Join(tmpDir, "new.c1z")
+	expectedPath := filepath.Join(tmpDir, "expected.c1z")
+
+	// Common objects
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "G1"}.Build()
+	g2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g2"}.Build(), DisplayName: "G2"}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "U1"}.Build()
+
+	e1 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g1, "member"), Resource: g1, Slug: "member", DisplayName: "member"}.Build()
+	e2 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g2, "member"), Resource: g2, Slug: "member", DisplayName: "member"}.Build()
+
+	// Direct grant U1 -> E1
+	grantU1E1 := v2.Grant_builder{
+		Id:          batonGrant.NewGrantID(u1, e1),
+		Entitlement: e1,
+		Principal:   u1,
+	}.Build()
+
+	// Nesting grant G1 -> E2 defining edge E1 -> E2
+	nestingGrantID := batonGrant.NewGrantID(g1, e2)
+	grantG1E2 := v2.Grant_builder{
+		Id:          nestingGrantID,
+		Entitlement: e2,
+		Principal:   g1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{e1.GetId()},
+			Shallow:         false,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	// OLD (expanded)
+	oldFile, err := dotc1z.NewC1ZFile(ctx, oldPath, dotc1z.WithPragma("journal_mode", "WAL"), dotc1z.WithPragma("locking_mode", "normal"))
+	require.NoError(t, err)
+	defer oldFile.Close(ctx)
+
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, oldFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, oldFile.PutResources(ctx, g1, g2, u1))
+	require.NoError(t, oldFile.PutEntitlements(ctx, e1, e2))
+	require.NoError(t, oldFile.PutGrants(ctx, grantU1E1, grantG1E2))
+	require.NoError(t, oldFile.EndSync(ctx))
+
+	// Expand old sync in place
+	require.NoError(t, runFullExpansion(ctx, oldFile, oldSyncID))
+
+	// NEW starts as a copy of OLD expanded data, but without the nesting grant row.
+	newFile, err := dotc1z.NewC1ZFile(ctx, newPath)
+	require.NoError(t, err)
+	defer newFile.Close(ctx)
+
+	newSyncID, err := newFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, newFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, newFile.PutResources(ctx, g1, g2, u1))
+	require.NoError(t, newFile.PutEntitlements(ctx, e1, e2))
+
+	// Copy all grants from old expanded sync -> new sync, skipping nesting grant (edge removal).
+	require.NoError(t, oldFile.SetSyncID(ctx, ""))
+	require.NoError(t, oldFile.ViewSync(ctx, oldSyncID))
+	pageToken := ""
+	for {
+		resp, err := oldFile.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{PageToken: pageToken}.Build())
+		require.NoError(t, err)
+		for _, g := range resp.GetList() {
+			if g.GetId() == nestingGrantID {
+				continue
+			}
+			require.NoError(t, newFile.PutGrants(ctx, g))
+		}
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			break
+		}
+	}
+	require.NoError(t, newFile.EndSync(ctx))
+
+	// Generate diff syncs: main=NEW, attached=OLD
+	diffAndApplyIncremental(t, ctx, newFile, oldFile, oldSyncID, newSyncID)
+
+	// EXPECTED: start from connector truth after removal (no nesting grant), then expand fully.
+	expectedFile, err := dotc1z.NewC1ZFile(ctx, expectedPath)
+	require.NoError(t, err)
+	defer expectedFile.Close(ctx)
+
+	expectedSyncID, err := expectedFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, expectedFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, expectedFile.PutResources(ctx, g1, g2, u1))
+	require.NoError(t, expectedFile.PutEntitlements(ctx, e1, e2))
+	require.NoError(t, expectedFile.PutGrants(ctx, grantU1E1 /* no nesting */))
+	require.NoError(t, expectedFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, expectedFile, expectedSyncID))
+
+	got, err := loadGrantSourcesByKey(ctx, newFile, newSyncID)
+	require.NoError(t, err)
+	want, err := loadGrantSourcesByKey(ctx, expectedFile, expectedSyncID)
+	require.NoError(t, err)
+
+	require.Equal(t, want, got)
+}
+
+func TestIncrementalExpansion_RemovedEdgeRemovesOnlyOneSource(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	oldPath := filepath.Join(tmpDir, "old2.c1z")
+	newPath := filepath.Join(tmpDir, "new2.c1z")
+	expectedPath := filepath.Join(tmpDir, "expected2.c1z")
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "G1"}.Build()
+	g2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g2"}.Build(), DisplayName: "G2"}.Build()
+	g3 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g3"}.Build(), DisplayName: "G3"}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "U1"}.Build()
+
+	e1 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g1, "member"), Resource: g1, Slug: "member", DisplayName: "member"}.Build()
+	e2 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g2, "member"), Resource: g2, Slug: "member", DisplayName: "member"}.Build()
+	e3 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g3, "member"), Resource: g3, Slug: "member", DisplayName: "member"}.Build()
+
+	grantU1E1 := v2.Grant_builder{Id: batonGrant.NewGrantID(u1, e1), Entitlement: e1, Principal: u1}.Build()
+	grantU1E3 := v2.Grant_builder{Id: batonGrant.NewGrantID(u1, e3), Entitlement: e3, Principal: u1}.Build()
+
+	nestingGrantID1 := batonGrant.NewGrantID(g1, e2)
+	grantG1E2 := v2.Grant_builder{
+		Id:          nestingGrantID1,
+		Entitlement: e2,
+		Principal:   g1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{e1.GetId()},
+			Shallow:         false,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	nestingGrantID3 := batonGrant.NewGrantID(g3, e2)
+	grantG3E2 := v2.Grant_builder{
+		Id:          nestingGrantID3,
+		Entitlement: e2,
+		Principal:   g3,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{e3.GetId()},
+			Shallow:         false,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	oldFile, err := dotc1z.NewC1ZFile(ctx, oldPath, dotc1z.WithPragma("journal_mode", "WAL"), dotc1z.WithPragma("locking_mode", "normal"))
+	require.NoError(t, err)
+	defer oldFile.Close(ctx)
+
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, oldFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, oldFile.PutResources(ctx, g1, g2, g3, u1))
+	require.NoError(t, oldFile.PutEntitlements(ctx, e1, e2, e3))
+	require.NoError(t, oldFile.PutGrants(ctx, grantU1E1, grantU1E3, grantG1E2, grantG3E2))
+	require.NoError(t, oldFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, oldFile, oldSyncID))
+
+	newFile, err := dotc1z.NewC1ZFile(ctx, newPath)
+	require.NoError(t, err)
+	defer newFile.Close(ctx)
+
+	newSyncID, err := newFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, newFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, newFile.PutResources(ctx, g1, g2, g3, u1))
+	require.NoError(t, newFile.PutEntitlements(ctx, e1, e2, e3))
+
+	require.NoError(t, oldFile.SetSyncID(ctx, ""))
+	require.NoError(t, oldFile.ViewSync(ctx, oldSyncID))
+	grantsToCopy, err := listGrantsWithStoredExpansion(ctx, oldFile)
+	require.NoError(t, err)
+	for _, g := range grantsToCopy {
+		if g.GetId() == nestingGrantID1 {
+			continue
+		}
+		require.NoError(t, newFile.PutGrants(ctx, g))
+	}
+	require.NoError(t, newFile.EndSync(ctx))
+
+	diffAndApplyIncremental(t, ctx, newFile, oldFile, oldSyncID, newSyncID)
+
+	expectedFile, err := dotc1z.NewC1ZFile(ctx, expectedPath)
+	require.NoError(t, err)
+	defer expectedFile.Close(ctx)
+
+	expectedSyncID, err := expectedFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, expectedFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, expectedFile.PutResources(ctx, g1, g2, g3, u1))
+	require.NoError(t, expectedFile.PutEntitlements(ctx, e1, e2, e3))
+	require.NoError(t, expectedFile.PutGrants(ctx, grantU1E1, grantU1E3 /* no G1->E2 */, grantG3E2))
+	require.NoError(t, expectedFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, expectedFile, expectedSyncID))
+
+	got, err := loadGrantSourcesByKey(ctx, newFile, newSyncID)
+	require.NoError(t, err)
+	want, err := loadGrantSourcesByKey(ctx, expectedFile, expectedSyncID)
+	require.NoError(t, err)
+
+	require.Equal(t, want, got)
+}
+
+func TestIncrementalExpansion_NoChangesIsNoop(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	oldPath := filepath.Join(tmpDir, "old_noop.c1z")
+	newPath := filepath.Join(tmpDir, "new_noop.c1z")
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "G1"}.Build()
+	g2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g2"}.Build(), DisplayName: "G2"}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "U1"}.Build()
+
+	e1 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g1, "member"), Resource: g1, Slug: "member", DisplayName: "member"}.Build()
+	e2 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g2, "member"), Resource: g2, Slug: "member", DisplayName: "member"}.Build()
+
+	grantU1E1 := v2.Grant_builder{Id: batonGrant.NewGrantID(u1, e1), Entitlement: e1, Principal: u1}.Build()
+	grantG1E2 := v2.Grant_builder{
+		Id:          batonGrant.NewGrantID(g1, e2),
+		Entitlement: e2,
+		Principal:   g1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{e1.GetId()},
+			Shallow:         false,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	// OLD (expanded)
+	oldFile, err := dotc1z.NewC1ZFile(ctx, oldPath, dotc1z.WithPragma("journal_mode", "WAL"), dotc1z.WithPragma("locking_mode", "normal"))
+	require.NoError(t, err)
+	defer oldFile.Close(ctx)
+
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, oldFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, oldFile.PutResources(ctx, g1, g2, u1))
+	require.NoError(t, oldFile.PutEntitlements(ctx, e1, e2))
+	require.NoError(t, oldFile.PutGrants(ctx, grantU1E1, grantG1E2))
+	require.NoError(t, oldFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, oldFile, oldSyncID))
+
+	// NEW is identical to OLD expanded state.
+	newFile, err := dotc1z.NewC1ZFile(ctx, newPath)
+	require.NoError(t, err)
+	defer newFile.Close(ctx)
+
+	newSyncID, err := newFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, newFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, newFile.PutResources(ctx, g1, g2, u1))
+	require.NoError(t, newFile.PutEntitlements(ctx, e1, e2))
+
+	require.NoError(t, oldFile.SetSyncID(ctx, ""))
+	require.NoError(t, oldFile.ViewSync(ctx, oldSyncID))
+	grantsToCopy, err := listGrantsWithStoredExpansion(ctx, oldFile)
+	require.NoError(t, err)
+	for _, g := range grantsToCopy {
+		require.NoError(t, newFile.PutGrants(ctx, g))
+	}
+	require.NoError(t, newFile.EndSync(ctx))
+
+	// Should be a no-op.
+	diffAndApplyIncremental(t, ctx, newFile, oldFile, oldSyncID, newSyncID)
+
+	got, err := loadGrantSourcesByKey(ctx, newFile, newSyncID)
+	require.NoError(t, err)
+	want, err := loadGrantSourcesByKey(ctx, oldFile, oldSyncID)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func TestIncrementalExpansion_MultipleDisjointSubgraphs(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	oldPath := filepath.Join(tmpDir, "old_multi.c1z")
+	newPath := filepath.Join(tmpDir, "new_multi.c1z")
+	expectedPath := filepath.Join(tmpDir, "expected_multi.c1z")
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+
+	// Subgraph A
+	ga1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "ga1"}.Build(), DisplayName: "GA1"}.Build()
+	ga2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "ga2"}.Build(), DisplayName: "GA2"}.Build()
+	ua := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "ua"}.Build(), DisplayName: "UA"}.Build()
+
+	ea1 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(ga1, "member"), Resource: ga1, Slug: "member", DisplayName: "member"}.Build()
+	ea2 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(ga2, "member"), Resource: ga2, Slug: "member", DisplayName: "member"}.Build()
+
+	grantUAEA1 := v2.Grant_builder{Id: batonGrant.NewGrantID(ua, ea1), Entitlement: ea1, Principal: ua}.Build()
+	nestingAID := batonGrant.NewGrantID(ga1, ea2)
+	grantGA1EA2 := v2.Grant_builder{
+		Id:          nestingAID,
+		Entitlement: ea2,
+		Principal:   ga1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{ea1.GetId()},
+			Shallow:         false,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	// Subgraph B
+	gb1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "gb1"}.Build(), DisplayName: "GB1"}.Build()
+	gb2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "gb2"}.Build(), DisplayName: "GB2"}.Build()
+	ub := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "ub"}.Build(), DisplayName: "UB"}.Build()
+
+	eb1 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(gb1, "member"), Resource: gb1, Slug: "member", DisplayName: "member"}.Build()
+	eb2 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(gb2, "member"), Resource: gb2, Slug: "member", DisplayName: "member"}.Build()
+
+	grantUBEB1 := v2.Grant_builder{Id: batonGrant.NewGrantID(ub, eb1), Entitlement: eb1, Principal: ub}.Build()
+	nestingBID := batonGrant.NewGrantID(gb1, eb2)
+	grantGB1EB2 := v2.Grant_builder{
+		Id:          nestingBID,
+		Entitlement: eb2,
+		Principal:   gb1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{eb1.GetId()},
+			Shallow:         false,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	// OLD (expanded)
+	oldFile, err := dotc1z.NewC1ZFile(ctx, oldPath, dotc1z.WithPragma("journal_mode", "WAL"), dotc1z.WithPragma("locking_mode", "normal"))
+	require.NoError(t, err)
+	defer oldFile.Close(ctx)
+
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, oldFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, oldFile.PutResources(ctx, ga1, ga2, ua, gb1, gb2, ub))
+	require.NoError(t, oldFile.PutEntitlements(ctx, ea1, ea2, eb1, eb2))
+	require.NoError(t, oldFile.PutGrants(ctx, grantUAEA1, grantGA1EA2, grantUBEB1, grantGB1EB2))
+	require.NoError(t, oldFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, oldFile, oldSyncID))
+
+	// NEW is old expanded minus both nesting grants.
+	newFile, err := dotc1z.NewC1ZFile(ctx, newPath)
+	require.NoError(t, err)
+	defer newFile.Close(ctx)
+
+	newSyncID, err := newFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, newFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, newFile.PutResources(ctx, ga1, ga2, ua, gb1, gb2, ub))
+	require.NoError(t, newFile.PutEntitlements(ctx, ea1, ea2, eb1, eb2))
+
+	require.NoError(t, oldFile.SetSyncID(ctx, ""))
+	require.NoError(t, oldFile.ViewSync(ctx, oldSyncID))
+	pageToken := ""
+	for {
+		resp, err := oldFile.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{PageToken: pageToken}.Build())
+		require.NoError(t, err)
+		for _, g := range resp.GetList() {
+			if g.GetId() == nestingAID || g.GetId() == nestingBID {
+				continue
+			}
+			require.NoError(t, newFile.PutGrants(ctx, g))
+		}
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			break
+		}
+	}
+	require.NoError(t, newFile.EndSync(ctx))
+
+	diffAndApplyIncremental(t, ctx, newFile, oldFile, oldSyncID, newSyncID)
+
+	// EXPECTED: connector truth after removal (no nesting grants), fully expanded.
+	expectedFile, err := dotc1z.NewC1ZFile(ctx, expectedPath)
+	require.NoError(t, err)
+	defer expectedFile.Close(ctx)
+	expectedSyncID, err := expectedFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, expectedFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, expectedFile.PutResources(ctx, ga1, ga2, ua, gb1, gb2, ub))
+	require.NoError(t, expectedFile.PutEntitlements(ctx, ea1, ea2, eb1, eb2))
+	require.NoError(t, expectedFile.PutGrants(ctx, grantUAEA1, grantUBEB1 /* no nesting */))
+	require.NoError(t, expectedFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, expectedFile, expectedSyncID))
+
+	got, err := loadGrantSourcesByKey(ctx, newFile, newSyncID)
+	require.NoError(t, err)
+	want, err := loadGrantSourcesByKey(ctx, expectedFile, expectedSyncID)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func TestIncrementalExpansion_EntitlementDeleted(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	oldPath := filepath.Join(tmpDir, "old_ent_deleted.c1z")
+	newPath := filepath.Join(tmpDir, "new_ent_deleted.c1z")
+	expectedPath := filepath.Join(tmpDir, "expected_ent_deleted.c1z")
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+
+	// Chain: e1 -> e2 -> e3. Deleting e2 should remove propagated membership on e3.
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "G1"}.Build()
+	g2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g2"}.Build(), DisplayName: "G2"}.Build()
+	g3 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g3"}.Build(), DisplayName: "G3"}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "U1"}.Build()
+
+	e1 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g1, "member"), Resource: g1, Slug: "member", DisplayName: "member"}.Build()
+	e2 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g2, "member"), Resource: g2, Slug: "member", DisplayName: "member"}.Build()
+	e3 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g3, "member"), Resource: g3, Slug: "member", DisplayName: "member"}.Build()
+
+	grantU1E1 := v2.Grant_builder{Id: batonGrant.NewGrantID(u1, e1), Entitlement: e1, Principal: u1}.Build()
+
+	grantG1E2 := v2.Grant_builder{
+		Id:          batonGrant.NewGrantID(g1, e2),
+		Entitlement: e2,
+		Principal:   g1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{e1.GetId()},
+			Shallow:         false,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	grantG2E3 := v2.Grant_builder{
+		Id:          batonGrant.NewGrantID(g2, e3),
+		Entitlement: e3,
+		Principal:   g2,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{e2.GetId()},
+			Shallow:         false,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	// OLD (expanded)
+	oldFile, err := dotc1z.NewC1ZFile(ctx, oldPath, dotc1z.WithPragma("journal_mode", "WAL"), dotc1z.WithPragma("locking_mode", "normal"))
+	require.NoError(t, err)
+	defer oldFile.Close(ctx)
+
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, oldFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, oldFile.PutResources(ctx, g1, g2, g3, u1))
+	require.NoError(t, oldFile.PutEntitlements(ctx, e1, e2, e3))
+	require.NoError(t, oldFile.PutGrants(ctx, grantU1E1, grantG1E2, grantG2E3))
+	require.NoError(t, oldFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, oldFile, oldSyncID))
+
+	// NEW is OLD expanded minus the e2 entitlement and any grants on e2.
+	newFile, err := dotc1z.NewC1ZFile(ctx, newPath)
+	require.NoError(t, err)
+	defer newFile.Close(ctx)
+
+	newSyncID, err := newFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, newFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, newFile.PutResources(ctx, g1, g2, g3, u1))
+	require.NoError(t, newFile.PutEntitlements(ctx, e1 /* e2 deleted */, e3))
+
+	require.NoError(t, oldFile.SetSyncID(ctx, ""))
+	require.NoError(t, oldFile.ViewSync(ctx, oldSyncID))
+	pageToken := ""
+	for {
+		resp, err := oldFile.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{PageToken: pageToken}.Build())
+		require.NoError(t, err)
+		for _, g := range resp.GetList() {
+			if g.GetEntitlement().GetId() == e2.GetId() {
+				continue
+			}
+			require.NoError(t, newFile.PutGrants(ctx, g))
+		}
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			break
+		}
+	}
+	require.NoError(t, newFile.EndSync(ctx))
+
+	diffAndApplyIncremental(t, ctx, newFile, oldFile, oldSyncID, newSyncID)
+
+	// EXPECTED: connector truth with e2 removed (no grants on e2), expanded fully.
+	expectedFile, err := dotc1z.NewC1ZFile(ctx, expectedPath)
+	require.NoError(t, err)
+	defer expectedFile.Close(ctx)
+	expectedSyncID, err := expectedFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, expectedFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, expectedFile.PutResources(ctx, g1, g2, g3, u1))
+	require.NoError(t, expectedFile.PutEntitlements(ctx, e1 /* e2 deleted */, e3))
+	require.NoError(t, expectedFile.PutGrants(ctx, grantU1E1 /* no g1->e2 */, grantG2E3))
+	require.NoError(t, expectedFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, expectedFile, expectedSyncID))
+
+	got, err := loadGrantSourcesByKey(ctx, newFile, newSyncID)
+	require.NoError(t, err)
+	want, err := loadGrantSourcesByKey(ctx, expectedFile, expectedSyncID)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func TestIncrementalExpansion_GrantNoLongerExpandable(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	oldPath := filepath.Join(tmpDir, "old_noexpand.c1z")
+	newPath := filepath.Join(tmpDir, "new_noexpand.c1z")
+	expectedPath := filepath.Join(tmpDir, "expected_noexpand.c1z")
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "G1"}.Build()
+	g2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g2"}.Build(), DisplayName: "G2"}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "U1"}.Build()
+
+	e1 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g1, "member"), Resource: g1, Slug: "member", DisplayName: "member"}.Build()
+	e2 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g2, "member"), Resource: g2, Slug: "member", DisplayName: "member"}.Build()
+
+	grantU1E1 := v2.Grant_builder{Id: batonGrant.NewGrantID(u1, e1), Entitlement: e1, Principal: u1}.Build()
+	nestingID := batonGrant.NewGrantID(g1, e2)
+	grantExpandable := v2.Grant_builder{
+		Id:          nestingID,
+		Entitlement: e2,
+		Principal:   g1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{e1.GetId()},
+			Shallow:         false,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+	grantNotExpandable := v2.Grant_builder{
+		Id:          nestingID,
+		Entitlement: e2,
+		Principal:   g1,
+		Annotations: nil, // removed GrantExpandable
+	}.Build()
+
+	// OLD (expanded)
+	oldFile, err := dotc1z.NewC1ZFile(ctx, oldPath, dotc1z.WithPragma("journal_mode", "WAL"), dotc1z.WithPragma("locking_mode", "normal"))
+	require.NoError(t, err)
+	defer oldFile.Close(ctx)
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, oldFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, oldFile.PutResources(ctx, g1, g2, u1))
+	require.NoError(t, oldFile.PutEntitlements(ctx, e1, e2))
+	require.NoError(t, oldFile.PutGrants(ctx, grantU1E1, grantExpandable))
+	require.NoError(t, oldFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, oldFile, oldSyncID))
+
+	// NEW is OLD expanded, but the nesting grant is still present and is no longer expandable.
+	newFile, err := dotc1z.NewC1ZFile(ctx, newPath)
+	require.NoError(t, err)
+	defer newFile.Close(ctx)
+	newSyncID, err := newFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, newFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, newFile.PutResources(ctx, g1, g2, u1))
+	require.NoError(t, newFile.PutEntitlements(ctx, e1, e2))
+
+	require.NoError(t, oldFile.SetSyncID(ctx, ""))
+	require.NoError(t, oldFile.ViewSync(ctx, oldSyncID))
+	pageToken := ""
+	for {
+		resp, err := oldFile.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{PageToken: pageToken}.Build())
+		require.NoError(t, err)
+		for _, g := range resp.GetList() {
+			// Replace the edge-defining grant with the non-expandable version.
+			if g.GetId() == nestingID {
+				require.NoError(t, newFile.PutGrants(ctx, grantNotExpandable))
+				continue
+			}
+			require.NoError(t, newFile.PutGrants(ctx, g))
+		}
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			break
+		}
+	}
+	require.NoError(t, newFile.EndSync(ctx))
+
+	diffAndApplyIncremental(t, ctx, newFile, oldFile, oldSyncID, newSyncID)
+
+	// EXPECTED: connector truth with nesting grant non-expandable, expanded fully.
+	expectedFile, err := dotc1z.NewC1ZFile(ctx, expectedPath)
+	require.NoError(t, err)
+	defer expectedFile.Close(ctx)
+	expectedSyncID, err := expectedFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, expectedFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, expectedFile.PutResources(ctx, g1, g2, u1))
+	require.NoError(t, expectedFile.PutEntitlements(ctx, e1, e2))
+	require.NoError(t, expectedFile.PutGrants(ctx, grantU1E1, grantNotExpandable))
+	require.NoError(t, expectedFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, expectedFile, expectedSyncID))
+
+	got, err := loadGrantSourcesByKey(ctx, newFile, newSyncID)
+	require.NoError(t, err)
+	want, err := loadGrantSourcesByKey(ctx, expectedFile, expectedSyncID)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func TestIncrementalExpansion_ResourceDeleted(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	oldPath := filepath.Join(tmpDir, "old_res_deleted.c1z")
+	newPath := filepath.Join(tmpDir, "new_res_deleted.c1z")
+	expectedPath := filepath.Join(tmpDir, "expected_res_deleted.c1z")
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+
+	// Chain: e1 -> e2 -> e3. Deleting resource g2 (and therefore entitlement e2) should remove propagated membership on e3.
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "G1"}.Build()
+	g2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g2"}.Build(), DisplayName: "G2"}.Build()
+	g3 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g3"}.Build(), DisplayName: "G3"}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "U1"}.Build()
+
+	e1 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g1, "member"), Resource: g1, Slug: "member", DisplayName: "member"}.Build()
+	e2 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g2, "member"), Resource: g2, Slug: "member", DisplayName: "member"}.Build()
+	e3 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g3, "member"), Resource: g3, Slug: "member", DisplayName: "member"}.Build()
+
+	grantU1E1 := v2.Grant_builder{Id: batonGrant.NewGrantID(u1, e1), Entitlement: e1, Principal: u1}.Build()
+
+	grantG1E2 := v2.Grant_builder{
+		Id:          batonGrant.NewGrantID(g1, e2),
+		Entitlement: e2,
+		Principal:   g1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{e1.GetId()},
+			Shallow:         false,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	grantG2E3 := v2.Grant_builder{
+		Id:          batonGrant.NewGrantID(g2, e3),
+		Entitlement: e3,
+		Principal:   g2,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{e2.GetId()},
+			Shallow:         false,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	// OLD (expanded)
+	oldFile, err := dotc1z.NewC1ZFile(ctx, oldPath, dotc1z.WithPragma("journal_mode", "WAL"), dotc1z.WithPragma("locking_mode", "normal"))
+	require.NoError(t, err)
+	defer oldFile.Close(ctx)
+
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, oldFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, oldFile.PutResources(ctx, g1, g2, g3, u1))
+	require.NoError(t, oldFile.PutEntitlements(ctx, e1, e2, e3))
+	require.NoError(t, oldFile.PutGrants(ctx, grantU1E1, grantG1E2, grantG2E3))
+	require.NoError(t, oldFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, oldFile, oldSyncID))
+
+	// NEW is OLD expanded minus resource g2, entitlement e2, and any grants on e2.
+	newFile, err := dotc1z.NewC1ZFile(ctx, newPath)
+	require.NoError(t, err)
+	defer newFile.Close(ctx)
+
+	newSyncID, err := newFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, newFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, newFile.PutResources(ctx, g1 /* g2 deleted */, g3, u1))
+	require.NoError(t, newFile.PutEntitlements(ctx, e1 /* e2 deleted */, e3))
+
+	require.NoError(t, oldFile.SetSyncID(ctx, ""))
+	require.NoError(t, oldFile.ViewSync(ctx, oldSyncID))
+	pageToken := ""
+	for {
+		resp, err := oldFile.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{PageToken: pageToken}.Build())
+		require.NoError(t, err)
+		for _, g := range resp.GetList() {
+			if g.GetEntitlement().GetId() == e2.GetId() {
+				continue
+			}
+			require.NoError(t, newFile.PutGrants(ctx, g))
+		}
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			break
+		}
+	}
+	require.NoError(t, newFile.EndSync(ctx))
+
+	diffAndApplyIncremental(t, ctx, newFile, oldFile, oldSyncID, newSyncID)
+
+	// EXPECTED: connector truth with g2/e2 removed (no grants on e2), expanded fully.
+	expectedFile, err := dotc1z.NewC1ZFile(ctx, expectedPath)
+	require.NoError(t, err)
+	defer expectedFile.Close(ctx)
+	expectedSyncID, err := expectedFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, expectedFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, expectedFile.PutResources(ctx, g1 /* g2 deleted */, g3, u1))
+	require.NoError(t, expectedFile.PutEntitlements(ctx, e1 /* e2 deleted */, e3))
+	require.NoError(t, expectedFile.PutGrants(ctx, grantU1E1 /* no g1->e2 */, grantG2E3))
+	require.NoError(t, expectedFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, expectedFile, expectedSyncID))
+
+	got, err := loadGrantSourcesByKey(ctx, newFile, newSyncID)
+	require.NoError(t, err)
+	want, err := loadGrantSourcesByKey(ctx, expectedFile, expectedSyncID)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func TestIncrementalExpansion_AddedEdgeCreatesNewDerivedGrant(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	oldPath := filepath.Join(tmpDir, "old_add_edge.c1z")
+	newPath := filepath.Join(tmpDir, "new_add_edge.c1z")
+	expectedPath := filepath.Join(tmpDir, "expected_add_edge.c1z")
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "G1"}.Build()
+	g2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g2"}.Build(), DisplayName: "G2"}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "U1"}.Build()
+
+	e1 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g1, "member"), Resource: g1, Slug: "member", DisplayName: "member"}.Build()
+	e2 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g2, "member"), Resource: g2, Slug: "member", DisplayName: "member"}.Build()
+
+	grantU1E1 := v2.Grant_builder{Id: batonGrant.NewGrantID(u1, e1), Entitlement: e1, Principal: u1}.Build()
+
+	// Edge-defining grant to be added in NEW
+	grantG1E2 := v2.Grant_builder{
+		Id:          batonGrant.NewGrantID(g1, e2),
+		Entitlement: e2,
+		Principal:   g1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{e1.GetId()},
+			Shallow:         false,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	// OLD: just the direct grant, no edges, expanded (nothing to expand)
+	oldFile, err := dotc1z.NewC1ZFile(ctx, oldPath, dotc1z.WithPragma("journal_mode", "WAL"), dotc1z.WithPragma("locking_mode", "normal"))
+	require.NoError(t, err)
+	defer oldFile.Close(ctx)
+
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, oldFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, oldFile.PutResources(ctx, g1, g2, u1))
+	require.NoError(t, oldFile.PutEntitlements(ctx, e1, e2))
+	require.NoError(t, oldFile.PutGrants(ctx, grantU1E1))
+	require.NoError(t, oldFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, oldFile, oldSyncID))
+
+	// NEW: same as OLD but with the new edge-defining grant added
+	newFile, err := dotc1z.NewC1ZFile(ctx, newPath)
+	require.NoError(t, err)
+	defer newFile.Close(ctx)
+
+	newSyncID, err := newFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, newFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, newFile.PutResources(ctx, g1, g2, u1))
+	require.NoError(t, newFile.PutEntitlements(ctx, e1, e2))
+
+	// Copy grants from OLD expanded state
+	require.NoError(t, oldFile.SetSyncID(ctx, ""))
+	require.NoError(t, oldFile.ViewSync(ctx, oldSyncID))
+	pageToken := ""
+	for {
+		resp, err := oldFile.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{PageToken: pageToken}.Build())
+		require.NoError(t, err)
+		for _, g := range resp.GetList() {
+			require.NoError(t, newFile.PutGrants(ctx, g))
+		}
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			break
+		}
+	}
+	// Add the new edge-defining grant
+	require.NoError(t, newFile.PutGrants(ctx, grantG1E2))
+	require.NoError(t, newFile.EndSync(ctx))
+
+	diffAndApplyIncremental(t, ctx, newFile, oldFile, oldSyncID, newSyncID)
+
+	// EXPECTED: connector truth with new edge, fully expanded
+	expectedFile, err := dotc1z.NewC1ZFile(ctx, expectedPath)
+	require.NoError(t, err)
+	defer expectedFile.Close(ctx)
+	expectedSyncID, err := expectedFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, expectedFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, expectedFile.PutResources(ctx, g1, g2, u1))
+	require.NoError(t, expectedFile.PutEntitlements(ctx, e1, e2))
+	require.NoError(t, expectedFile.PutGrants(ctx, grantU1E1, grantG1E2))
+	require.NoError(t, expectedFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, expectedFile, expectedSyncID))
+
+	got, err := loadGrantSourcesByKey(ctx, newFile, newSyncID)
+	require.NoError(t, err)
+	want, err := loadGrantSourcesByKey(ctx, expectedFile, expectedSyncID)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func TestIncrementalExpansion_AddedDirectGrantPropagates(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	oldPath := filepath.Join(tmpDir, "old_add_direct.c1z")
+	newPath := filepath.Join(tmpDir, "new_add_direct.c1z")
+	expectedPath := filepath.Join(tmpDir, "expected_add_direct.c1z")
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "G1"}.Build()
+	g2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g2"}.Build(), DisplayName: "G2"}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "U1"}.Build()
+	u2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u2"}.Build(), DisplayName: "U2"}.Build()
+
+	e1 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g1, "member"), Resource: g1, Slug: "member", DisplayName: "member"}.Build()
+	e2 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g2, "member"), Resource: g2, Slug: "member", DisplayName: "member"}.Build()
+
+	grantU1E1 := v2.Grant_builder{Id: batonGrant.NewGrantID(u1, e1), Entitlement: e1, Principal: u1}.Build()
+	grantU2E1 := v2.Grant_builder{Id: batonGrant.NewGrantID(u2, e1), Entitlement: e1, Principal: u2}.Build()
+
+	grantG1E2 := v2.Grant_builder{
+		Id:          batonGrant.NewGrantID(g1, e2),
+		Entitlement: e2,
+		Principal:   g1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{e1.GetId()},
+			Shallow:         false,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	// OLD: U1 → E1, edge E1 → E2, expanded (U1 → E2 derived)
+	oldFile, err := dotc1z.NewC1ZFile(ctx, oldPath, dotc1z.WithPragma("journal_mode", "WAL"), dotc1z.WithPragma("locking_mode", "normal"))
+	require.NoError(t, err)
+	defer oldFile.Close(ctx)
+
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, oldFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, oldFile.PutResources(ctx, g1, g2, u1, u2))
+	require.NoError(t, oldFile.PutEntitlements(ctx, e1, e2))
+	require.NoError(t, oldFile.PutGrants(ctx, grantU1E1, grantG1E2))
+	require.NoError(t, oldFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, oldFile, oldSyncID))
+
+	// NEW: same as OLD expanded, plus new direct grant U2 → E1
+	newFile, err := dotc1z.NewC1ZFile(ctx, newPath)
+	require.NoError(t, err)
+	defer newFile.Close(ctx)
+
+	newSyncID, err := newFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, newFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, newFile.PutResources(ctx, g1, g2, u1, u2))
+	require.NoError(t, newFile.PutEntitlements(ctx, e1, e2))
+
+	require.NoError(t, oldFile.SetSyncID(ctx, ""))
+	require.NoError(t, oldFile.ViewSync(ctx, oldSyncID))
+	grantsToCopy, err := listGrantsWithStoredExpansion(ctx, oldFile)
+	require.NoError(t, err)
+	for _, g := range grantsToCopy {
+		require.NoError(t, newFile.PutGrants(ctx, g))
+	}
+	// Add the new direct grant
+	require.NoError(t, newFile.PutGrants(ctx, grantU2E1))
+	require.NoError(t, newFile.EndSync(ctx))
+
+	diffAndApplyIncremental(t, ctx, newFile, oldFile, oldSyncID, newSyncID)
+
+	// EXPECTED: connector truth with both direct grants, fully expanded (U2 → E2 derived)
+	expectedFile, err := dotc1z.NewC1ZFile(ctx, expectedPath)
+	require.NoError(t, err)
+	defer expectedFile.Close(ctx)
+	expectedSyncID, err := expectedFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, expectedFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, expectedFile.PutResources(ctx, g1, g2, u1, u2))
+	require.NoError(t, expectedFile.PutEntitlements(ctx, e1, e2))
+	require.NoError(t, expectedFile.PutGrants(ctx, grantU1E1, grantU2E1, grantG1E2))
+	require.NoError(t, expectedFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, expectedFile, expectedSyncID))
+
+	got, err := loadGrantSourcesByKey(ctx, newFile, newSyncID)
+	require.NoError(t, err)
+	want, err := loadGrantSourcesByKey(ctx, expectedFile, expectedSyncID)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func TestIncrementalExpansion_ShallowEdgeRemoval(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	oldPath := filepath.Join(tmpDir, "old_shallow.c1z")
+	newPath := filepath.Join(tmpDir, "new_shallow.c1z")
+	expectedPath := filepath.Join(tmpDir, "expected_shallow.c1z")
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "G1"}.Build()
+	g2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g2"}.Build(), DisplayName: "G2"}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "U1"}.Build()
+
+	e1 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g1, "member"), Resource: g1, Slug: "member", DisplayName: "member"}.Build()
+	e2 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g2, "member"), Resource: g2, Slug: "member", DisplayName: "member"}.Build()
+
+	grantU1E1 := v2.Grant_builder{Id: batonGrant.NewGrantID(u1, e1), Entitlement: e1, Principal: u1}.Build()
+
+	// Shallow edge E1 -> E2 (only direct grants on E1 propagate)
+	nestingID := batonGrant.NewGrantID(g1, e2)
+	grantG1E2Shallow := v2.Grant_builder{
+		Id:          nestingID,
+		Entitlement: e2,
+		Principal:   g1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{e1.GetId()},
+			Shallow:         true, // shallow!
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	// OLD: U1 → E1, shallow edge E1 → E2, expanded (U1 → E2 derived)
+	oldFile, err := dotc1z.NewC1ZFile(ctx, oldPath, dotc1z.WithPragma("journal_mode", "WAL"), dotc1z.WithPragma("locking_mode", "normal"))
+	require.NoError(t, err)
+	defer oldFile.Close(ctx)
+
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, oldFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, oldFile.PutResources(ctx, g1, g2, u1))
+	require.NoError(t, oldFile.PutEntitlements(ctx, e1, e2))
+	require.NoError(t, oldFile.PutGrants(ctx, grantU1E1, grantG1E2Shallow))
+	require.NoError(t, oldFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, oldFile, oldSyncID))
+
+	// NEW: same as OLD expanded, but remove the shallow edge
+	newFile, err := dotc1z.NewC1ZFile(ctx, newPath)
+	require.NoError(t, err)
+	defer newFile.Close(ctx)
+
+	newSyncID, err := newFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, newFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, newFile.PutResources(ctx, g1, g2, u1))
+	require.NoError(t, newFile.PutEntitlements(ctx, e1, e2))
+
+	require.NoError(t, oldFile.SetSyncID(ctx, ""))
+	require.NoError(t, oldFile.ViewSync(ctx, oldSyncID))
+	pageToken := ""
+	for {
+		resp, err := oldFile.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{PageToken: pageToken}.Build())
+		require.NoError(t, err)
+		for _, g := range resp.GetList() {
+			if g.GetId() == nestingID {
+				continue // skip the shallow edge-defining grant
+			}
+			require.NoError(t, newFile.PutGrants(ctx, g))
+		}
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			break
+		}
+	}
+	require.NoError(t, newFile.EndSync(ctx))
+
+	diffAndApplyIncremental(t, ctx, newFile, oldFile, oldSyncID, newSyncID)
+
+	// EXPECTED: connector truth without edge, fully expanded (no derived grants)
+	expectedFile, err := dotc1z.NewC1ZFile(ctx, expectedPath)
+	require.NoError(t, err)
+	defer expectedFile.Close(ctx)
+	expectedSyncID, err := expectedFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, expectedFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, expectedFile.PutResources(ctx, g1, g2, u1))
+	require.NoError(t, expectedFile.PutEntitlements(ctx, e1, e2))
+	require.NoError(t, expectedFile.PutGrants(ctx, grantU1E1 /* no edge */))
+	require.NoError(t, expectedFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, expectedFile, expectedSyncID))
+
+	got, err := loadGrantSourcesByKey(ctx, newFile, newSyncID)
+	require.NoError(t, err)
+	want, err := loadGrantSourcesByKey(ctx, expectedFile, expectedSyncID)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func TestIncrementalExpansion_DirectGrantRemovedFromSource(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	oldPath := filepath.Join(tmpDir, "old_remove_direct.c1z")
+	newPath := filepath.Join(tmpDir, "new_remove_direct.c1z")
+	expectedPath := filepath.Join(tmpDir, "expected_remove_direct.c1z")
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "G1"}.Build()
+	g2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g2"}.Build(), DisplayName: "G2"}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "U1"}.Build()
+
+	e1 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g1, "member"), Resource: g1, Slug: "member", DisplayName: "member"}.Build()
+	e2 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g2, "member"), Resource: g2, Slug: "member", DisplayName: "member"}.Build()
+
+	directGrantID := batonGrant.NewGrantID(u1, e1)
+	grantU1E1 := v2.Grant_builder{Id: directGrantID, Entitlement: e1, Principal: u1}.Build()
+
+	grantG1E2 := v2.Grant_builder{
+		Id:          batonGrant.NewGrantID(g1, e2),
+		Entitlement: e2,
+		Principal:   g1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{e1.GetId()},
+			Shallow:         false,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	// OLD: U1 → E1, edge E1 → E2, expanded (U1 → E2 derived)
+	oldFile, err := dotc1z.NewC1ZFile(ctx, oldPath, dotc1z.WithPragma("journal_mode", "WAL"), dotc1z.WithPragma("locking_mode", "normal"))
+	require.NoError(t, err)
+	defer oldFile.Close(ctx)
+
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, oldFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, oldFile.PutResources(ctx, g1, g2, u1))
+	require.NoError(t, oldFile.PutEntitlements(ctx, e1, e2))
+	require.NoError(t, oldFile.PutGrants(ctx, grantU1E1, grantG1E2))
+	require.NoError(t, oldFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, oldFile, oldSyncID))
+
+	// NEW: same as OLD expanded, but remove the direct grant U1 → E1
+	newFile, err := dotc1z.NewC1ZFile(ctx, newPath)
+	require.NoError(t, err)
+	defer newFile.Close(ctx)
+
+	newSyncID, err := newFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, newFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, newFile.PutResources(ctx, g1, g2, u1))
+	require.NoError(t, newFile.PutEntitlements(ctx, e1, e2))
+
+	require.NoError(t, oldFile.SetSyncID(ctx, ""))
+	require.NoError(t, oldFile.ViewSync(ctx, oldSyncID))
+	pageToken := ""
+	for {
+		resp, err := oldFile.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{PageToken: pageToken}.Build())
+		require.NoError(t, err)
+		for _, g := range resp.GetList() {
+			if g.GetId() == directGrantID {
+				continue // skip the direct grant we're removing
+			}
+			require.NoError(t, newFile.PutGrants(ctx, g))
+		}
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			break
+		}
+	}
+	require.NoError(t, newFile.EndSync(ctx))
+
+	diffAndApplyIncremental(t, ctx, newFile, oldFile, oldSyncID, newSyncID)
+
+	// EXPECTED: connector truth without the direct grant, fully expanded (U1 → E2 should be gone)
+	expectedFile, err := dotc1z.NewC1ZFile(ctx, expectedPath)
+	require.NoError(t, err)
+	defer expectedFile.Close(ctx)
+	expectedSyncID, err := expectedFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, expectedFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, expectedFile.PutResources(ctx, g1, g2, u1))
+	require.NoError(t, expectedFile.PutEntitlements(ctx, e1, e2))
+	require.NoError(t, expectedFile.PutGrants(ctx, grantG1E2 /* no U1 → E1 */))
+	require.NoError(t, expectedFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, expectedFile, expectedSyncID))
+
+	got, err := loadGrantSourcesByKey(ctx, newFile, newSyncID)
+	require.NoError(t, err)
+	want, err := loadGrantSourcesByKey(ctx, expectedFile, expectedSyncID)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func TestIncrementalExpansion_DirectGrantBecomesSourceless(t *testing.T) {
+	// When a direct grant (no GrantImmutable) loses all expansion sources,
+	// the grant should persist with sources=nil, matching a fresh full expansion.
+	//
+	// The expander adds a "self-source" during expansion to mark direct grants,
+	// but when all expansion sources are removed, we also remove the self-source
+	// to ensure incremental expansion produces the same result as full expansion.
+
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	oldPath := filepath.Join(tmpDir, "old_sourceless.c1z")
+	newPath := filepath.Join(tmpDir, "new_sourceless.c1z")
+	expectedPath := filepath.Join(tmpDir, "expected_sourceless.c1z")
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "G1"}.Build()
+	g2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g2"}.Build(), DisplayName: "G2"}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "U1"}.Build()
+
+	e1 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g1, "member"), Resource: g1, Slug: "member", DisplayName: "member"}.Build()
+	e2 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g2, "member"), Resource: g2, Slug: "member", DisplayName: "member"}.Build()
+
+	// U1 is directly a member of both E1 and E2
+	grantU1E1 := v2.Grant_builder{Id: batonGrant.NewGrantID(u1, e1), Entitlement: e1, Principal: u1}.Build()
+	grantU1E2 := v2.Grant_builder{Id: batonGrant.NewGrantID(u1, e2), Entitlement: e2, Principal: u1}.Build()
+
+	// Edge E1 → E2 via nesting grant
+	nestingID := batonGrant.NewGrantID(g1, e2)
+	grantG1E2 := v2.Grant_builder{
+		Id:          nestingID,
+		Entitlement: e2,
+		Principal:   g1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{e1.GetId()},
+			Shallow:         false,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	// OLD: U1 → E1 (direct), U1 → E2 (direct), edge E1 → E2
+	// After expansion: U1 → E2 acquires sources={E1}
+	oldFile, err := dotc1z.NewC1ZFile(ctx, oldPath, dotc1z.WithPragma("journal_mode", "WAL"), dotc1z.WithPragma("locking_mode", "normal"))
+	require.NoError(t, err)
+	defer oldFile.Close(ctx)
+
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, oldFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, oldFile.PutResources(ctx, g1, g2, u1))
+	require.NoError(t, oldFile.PutEntitlements(ctx, e1, e2))
+	require.NoError(t, oldFile.PutGrants(ctx, grantU1E1, grantU1E2, grantG1E2))
+	require.NoError(t, oldFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, oldFile, oldSyncID))
+
+	// NEW: same as OLD expanded, but remove the edge (nesting grant)
+	// U1 → E2 should lose sources but remain as a direct grant
+	newFile, err := dotc1z.NewC1ZFile(ctx, newPath)
+	require.NoError(t, err)
+	defer newFile.Close(ctx)
+
+	newSyncID, err := newFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, newFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, newFile.PutResources(ctx, g1, g2, u1))
+	require.NoError(t, newFile.PutEntitlements(ctx, e1, e2))
+
+	require.NoError(t, oldFile.SetSyncID(ctx, ""))
+	require.NoError(t, oldFile.ViewSync(ctx, oldSyncID))
+	pageToken := ""
+	for {
+		resp, err := oldFile.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{PageToken: pageToken}.Build())
+		require.NoError(t, err)
+		for _, g := range resp.GetList() {
+			if g.GetId() == nestingID {
+				continue // remove the edge
+			}
+			require.NoError(t, newFile.PutGrants(ctx, g))
+		}
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			break
+		}
+	}
+	require.NoError(t, newFile.EndSync(ctx))
+
+	diffAndApplyIncremental(t, ctx, newFile, oldFile, oldSyncID, newSyncID)
+
+	// EXPECTED: U1 → E2 still exists (it's a direct grant), but with no sources
+	expectedFile, err := dotc1z.NewC1ZFile(ctx, expectedPath)
+	require.NoError(t, err)
+	defer expectedFile.Close(ctx)
+	expectedSyncID, err := expectedFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, expectedFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, expectedFile.PutResources(ctx, g1, g2, u1))
+	require.NoError(t, expectedFile.PutEntitlements(ctx, e1, e2))
+	require.NoError(t, expectedFile.PutGrants(ctx, grantU1E1, grantU1E2 /* no edge, U1→E2 persists without sources */))
+	require.NoError(t, expectedFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, expectedFile, expectedSyncID))
+
+	got, err := loadGrantSourcesByKey(ctx, newFile, newSyncID)
+	require.NoError(t, err)
+	want, err := loadGrantSourcesByKey(ctx, expectedFile, expectedSyncID)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func TestIncrementalExpansion_CycleEdgeRemoval(t *testing.T) {
+	// Test removing an edge in a cycle: E1 → E2 → E1 (bidirectional cycle)
+	// When one edge is removed, the cycle is broken.
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	oldPath := filepath.Join(tmpDir, "old_cycle.c1z")
+	newPath := filepath.Join(tmpDir, "new_cycle.c1z")
+	expectedPath := filepath.Join(tmpDir, "expected_cycle.c1z")
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "G1"}.Build()
+	g2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g2"}.Build(), DisplayName: "G2"}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "U1"}.Build()
+
+	e1 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g1, "member"), Resource: g1, Slug: "member", DisplayName: "member"}.Build()
+	e2 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g2, "member"), Resource: g2, Slug: "member", DisplayName: "member"}.Build()
+
+	grantU1E1 := v2.Grant_builder{Id: batonGrant.NewGrantID(u1, e1), Entitlement: e1, Principal: u1}.Build()
+
+	// Edge E1 → E2
+	grantG1E2ID := batonGrant.NewGrantID(g1, e2)
+	grantG1E2 := v2.Grant_builder{
+		Id:          grantG1E2ID,
+		Entitlement: e2,
+		Principal:   g1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{e1.GetId()},
+			Shallow:         false,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	// Edge E2 → E1 (creates a cycle)
+	grantG2E1ID := batonGrant.NewGrantID(g2, e1)
+	grantG2E1 := v2.Grant_builder{
+		Id:          grantG2E1ID,
+		Entitlement: e1,
+		Principal:   g2,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{e2.GetId()},
+			Shallow:         false,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	// OLD: U1 → E1, edges E1 → E2 and E2 → E1 (cycle)
+	oldFile, err := dotc1z.NewC1ZFile(ctx, oldPath, dotc1z.WithPragma("journal_mode", "WAL"), dotc1z.WithPragma("locking_mode", "normal"))
+	require.NoError(t, err)
+	defer oldFile.Close(ctx)
+
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, oldFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, oldFile.PutResources(ctx, g1, g2, u1))
+	require.NoError(t, oldFile.PutEntitlements(ctx, e1, e2))
+	require.NoError(t, oldFile.PutGrants(ctx, grantU1E1, grantG1E2, grantG2E1))
+	require.NoError(t, oldFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, oldFile, oldSyncID))
+
+	// NEW: same as OLD expanded, but remove one edge (E2 → E1) to break the cycle
+	newFile, err := dotc1z.NewC1ZFile(ctx, newPath)
+	require.NoError(t, err)
+	defer newFile.Close(ctx)
+
+	newSyncID, err := newFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, newFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, newFile.PutResources(ctx, g1, g2, u1))
+	require.NoError(t, newFile.PutEntitlements(ctx, e1, e2))
+
+	require.NoError(t, oldFile.SetSyncID(ctx, ""))
+	require.NoError(t, oldFile.ViewSync(ctx, oldSyncID))
+	grantsToCopy, err := listGrantsWithStoredExpansion(ctx, oldFile)
+	require.NoError(t, err)
+	for _, g := range grantsToCopy {
+		if g.GetId() == grantG2E1ID {
+			continue // remove E2 → E1 edge
+		}
+		require.NoError(t, newFile.PutGrants(ctx, g))
+	}
+	require.NoError(t, newFile.EndSync(ctx))
+
+	diffAndApplyIncremental(t, ctx, newFile, oldFile, oldSyncID, newSyncID)
+
+	// EXPECTED: connector truth with only E1 → E2 edge (no cycle), fully expanded
+	expectedFile, err := dotc1z.NewC1ZFile(ctx, expectedPath)
+	require.NoError(t, err)
+	defer expectedFile.Close(ctx)
+	expectedSyncID, err := expectedFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, expectedFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, expectedFile.PutResources(ctx, g1, g2, u1))
+	require.NoError(t, expectedFile.PutEntitlements(ctx, e1, e2))
+	require.NoError(t, expectedFile.PutGrants(ctx, grantU1E1, grantG1E2 /* no E2→E1 */))
+	require.NoError(t, expectedFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, expectedFile, expectedSyncID))
+
+	got, err := loadGrantSourcesByKey(ctx, newFile, newSyncID)
+	require.NoError(t, err)
+	want, err := loadGrantSourcesByKey(ctx, expectedFile, expectedSyncID)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func TestIncrementalExpansion_PrincipalTypeFilterMismatch(t *testing.T) {
+	// Test that PrincipalResourceTypeIDs filter excludes non-matching principals.
+	// Edge E1 → E2 with filter ["user"] should only propagate user grants, not group grants.
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	oldPath := filepath.Join(tmpDir, "old_filter.c1z")
+	newPath := filepath.Join(tmpDir, "new_filter.c1z")
+	expectedPath := filepath.Join(tmpDir, "expected_filter.c1z")
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "G1"}.Build()
+	g2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g2"}.Build(), DisplayName: "G2"}.Build()
+	g3 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g3"}.Build(), DisplayName: "G3"}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "U1"}.Build()
+
+	e1 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g1, "member"), Resource: g1, Slug: "member", DisplayName: "member"}.Build()
+	e2 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g2, "member"), Resource: g2, Slug: "member", DisplayName: "member"}.Build()
+
+	// U1 (user) → E1 - should propagate
+	grantU1E1 := v2.Grant_builder{Id: batonGrant.NewGrantID(u1, e1), Entitlement: e1, Principal: u1}.Build()
+	// G3 (group) → E1 - should NOT propagate (filter is ["user"])
+	grantG3E1 := v2.Grant_builder{Id: batonGrant.NewGrantID(g3, e1), Entitlement: e1, Principal: g3}.Build()
+
+	// Edge E1 → E2 with filter ["user"]
+	nestingID := batonGrant.NewGrantID(g1, e2)
+	grantG1E2 := v2.Grant_builder{
+		Id:          nestingID,
+		Entitlement: e2,
+		Principal:   g1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{e1.GetId()},
+			Shallow:         false,
+			ResourceTypeIds: []string{"user"}, // only users propagate
+		}.Build()),
+	}.Build()
+
+	// OLD: U1 → E1, G3 → E1, edge E1 → E2 (filter=user)
+	// After expansion: only U1 → E2 (G3 is excluded by filter)
+	oldFile, err := dotc1z.NewC1ZFile(ctx, oldPath, dotc1z.WithPragma("journal_mode", "WAL"), dotc1z.WithPragma("locking_mode", "normal"))
+	require.NoError(t, err)
+	defer oldFile.Close(ctx)
+
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, oldFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, oldFile.PutResources(ctx, g1, g2, g3, u1))
+	require.NoError(t, oldFile.PutEntitlements(ctx, e1, e2))
+	require.NoError(t, oldFile.PutGrants(ctx, grantU1E1, grantG3E1, grantG1E2))
+	require.NoError(t, oldFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, oldFile, oldSyncID))
+
+	// NEW: same as OLD expanded, but remove the edge
+	// The derived grant U1 → E2 should be deleted, but G3 → E1 should remain unchanged
+	newFile, err := dotc1z.NewC1ZFile(ctx, newPath)
+	require.NoError(t, err)
+	defer newFile.Close(ctx)
+
+	newSyncID, err := newFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, newFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, newFile.PutResources(ctx, g1, g2, g3, u1))
+	require.NoError(t, newFile.PutEntitlements(ctx, e1, e2))
+
+	require.NoError(t, oldFile.SetSyncID(ctx, ""))
+	require.NoError(t, oldFile.ViewSync(ctx, oldSyncID))
+	pageToken := ""
+	for {
+		resp, err := oldFile.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{PageToken: pageToken}.Build())
+		require.NoError(t, err)
+		for _, g := range resp.GetList() {
+			if g.GetId() == nestingID {
+				continue // remove the edge
+			}
+			require.NoError(t, newFile.PutGrants(ctx, g))
+		}
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			break
+		}
+	}
+	require.NoError(t, newFile.EndSync(ctx))
+
+	diffAndApplyIncremental(t, ctx, newFile, oldFile, oldSyncID, newSyncID)
+
+	// EXPECTED: connector truth without edge, fully expanded
+	// U1 → E1 remains, G3 → E1 remains, no derived grants
+	expectedFile, err := dotc1z.NewC1ZFile(ctx, expectedPath)
+	require.NoError(t, err)
+	defer expectedFile.Close(ctx)
+	expectedSyncID, err := expectedFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, expectedFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, expectedFile.PutResources(ctx, g1, g2, g3, u1))
+	require.NoError(t, expectedFile.PutEntitlements(ctx, e1, e2))
+	require.NoError(t, expectedFile.PutGrants(ctx, grantU1E1, grantG3E1 /* no edge */))
+	require.NoError(t, expectedFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, expectedFile, expectedSyncID))
+
+	got, err := loadGrantSourcesByKey(ctx, newFile, newSyncID)
+	require.NoError(t, err)
+	want, err := loadGrantSourcesByKey(ctx, expectedFile, expectedSyncID)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+// TestIncrementalExpansion_FullPartialCompactDiff tests the realistic workflow:
+// 1. Full sync with full expansion
+// 2. First partial sync (new data, no expansion)
+// 3. Compaction (merge partial into full)
+// 4. Second partial sync (more new data, no expansion)
+// 5. Compaction (merge second partial into full)
+// 6. Generate diff between old full and compacted
+// 7. Apply incremental expansion using the diff
+// 8. Compare against fresh full expansion of the compacted state.
+func TestIncrementalExpansion_FullPartialCompactDiff(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	basePath := filepath.Join(tmpDir, "base.c1z")
+	partial1Path := filepath.Join(tmpDir, "partial1.c1z")
+	partial2Path := filepath.Join(tmpDir, "partial2.c1z")
+	expectedPath := filepath.Join(tmpDir, "expected.c1z")
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+
+	// Resources
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "G1"}.Build()
+	g2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g2"}.Build(), DisplayName: "G2"}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "U1"}.Build()
+	u2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u2"}.Build(), DisplayName: "U2"}.Build()
+	u3 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u3"}.Build(), DisplayName: "U3"}.Build()
+
+	// Entitlements
+	e1 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g1, "member"), Resource: g1, Slug: "member", DisplayName: "member"}.Build()
+	e2 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g2, "member"), Resource: g2, Slug: "member", DisplayName: "member"}.Build()
+
+	// Grants
+	// U1 is a direct member of G1
+	grantU1E1 := v2.Grant_builder{Id: batonGrant.NewGrantID(u1, e1), Entitlement: e1, Principal: u1}.Build()
+	// G1 is a member of G2 with expansion (G1 members propagate to G2)
+	grantG1E2 := v2.Grant_builder{
+		Id:          batonGrant.NewGrantID(g1, e2),
+		Entitlement: e2,
+		Principal:   g1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{e1.GetId()},
+			Shallow:         false,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+	// U2 is a direct member of G1 (added in first partial sync)
+	grantU2E1 := v2.Grant_builder{Id: batonGrant.NewGrantID(u2, e1), Entitlement: e1, Principal: u2}.Build()
+	// U3 is a direct member of G1 (added in second partial sync)
+	grantU3E1 := v2.Grant_builder{Id: batonGrant.NewGrantID(u3, e1), Entitlement: e1, Principal: u3}.Build()
+
+	// ==========================================================================
+	// STEP 1: Create BASE with full sync + full expansion
+	// Initial state: U1 → E1, G1 → E2 (expandable). After expansion: U1 → E2 (derived).
+	// ==========================================================================
+	baseFile, err := dotc1z.NewC1ZFile(ctx, basePath)
+	require.NoError(t, err)
+	defer baseFile.Close(ctx)
+
+	baseSyncID, err := baseFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, baseFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, baseFile.PutResources(ctx, g1, g2, u1))
+	require.NoError(t, baseFile.PutEntitlements(ctx, e1, e2))
+	require.NoError(t, baseFile.PutGrants(ctx, grantU1E1, grantG1E2))
+	require.NoError(t, baseFile.EndSync(ctx))
+
+	// Run full expansion on base
+	require.NoError(t, runFullExpansion(ctx, baseFile, baseSyncID))
+
+	// Verify base expansion worked: U1 should have derived membership in E2
+	baseGrants, err := loadGrantSourcesByKey(ctx, baseFile, baseSyncID)
+	require.NoError(t, err)
+	require.Contains(t, baseGrants, "group:g2:member|user|u1", "U1 should have derived membership in G2 after base expansion")
+
+	// ==========================================================================
+	// STEP 2: Create FIRST PARTIAL sync with new user U2 as member of G1
+	// Partial syncs don't run expansion.
+	// ==========================================================================
+	partial1File, err := dotc1z.NewC1ZFile(ctx, partial1Path, dotc1z.WithPragma("journal_mode", "WAL"), dotc1z.WithPragma("locking_mode", "normal"))
+	require.NoError(t, err)
+	defer partial1File.Close(ctx)
+
+	partial1SyncID, err := partial1File.StartNewSync(ctx, connectorstore.SyncTypePartial, "")
+	require.NoError(t, err)
+	// Partial sync: just the new user and their grant
+	require.NoError(t, partial1File.PutResourceTypes(ctx, userRT))
+	require.NoError(t, partial1File.PutResources(ctx, u2))
+	require.NoError(t, partial1File.PutGrants(ctx, grantU2E1))
+	require.NoError(t, partial1File.EndSync(ctx))
+
+	// ==========================================================================
+	// STEP 3: Compact first partial into base
+	// After compaction, base has the new user U2 and grant U2→E1.
+	// Note: CompactTable uses hardcoded "attached" as the database alias.
+	// ==========================================================================
+	compact1Attached, err := baseFile.AttachFile(partial1File, "attached")
+	require.NoError(t, err)
+	require.NoError(t, compact1Attached.CompactResourceTypes(ctx, baseSyncID, partial1SyncID))
+	require.NoError(t, compact1Attached.CompactResources(ctx, baseSyncID, partial1SyncID))
+	require.NoError(t, compact1Attached.CompactEntitlements(ctx, baseSyncID, partial1SyncID))
+	require.NoError(t, compact1Attached.CompactGrants(ctx, baseSyncID, partial1SyncID))
+	_, err = compact1Attached.DetachFile("attached")
+	require.NoError(t, err)
+
+	// ==========================================================================
+	// STEP 4: Create SECOND PARTIAL sync with new user U3 as member of G1
+	// ==========================================================================
+	partial2File, err := dotc1z.NewC1ZFile(ctx, partial2Path, dotc1z.WithPragma("journal_mode", "WAL"), dotc1z.WithPragma("locking_mode", "normal"))
+	require.NoError(t, err)
+	defer partial2File.Close(ctx)
+
+	partial2SyncID, err := partial2File.StartNewSync(ctx, connectorstore.SyncTypePartial, "")
+	require.NoError(t, err)
+	// Partial sync: just the new user and their grant
+	require.NoError(t, partial2File.PutResourceTypes(ctx, userRT))
+	require.NoError(t, partial2File.PutResources(ctx, u3))
+	require.NoError(t, partial2File.PutGrants(ctx, grantU3E1))
+	require.NoError(t, partial2File.EndSync(ctx))
+
+	// ==========================================================================
+	// STEP 5: Compact second partial into base
+	// After compaction, base has both U2 and U3 as G1 members.
+	// ==========================================================================
+	compact2Attached, err := baseFile.AttachFile(partial2File, "attached")
+	require.NoError(t, err)
+	require.NoError(t, compact2Attached.CompactResourceTypes(ctx, baseSyncID, partial2SyncID))
+	require.NoError(t, compact2Attached.CompactResources(ctx, baseSyncID, partial2SyncID))
+	require.NoError(t, compact2Attached.CompactEntitlements(ctx, baseSyncID, partial2SyncID))
+	require.NoError(t, compact2Attached.CompactGrants(ctx, baseSyncID, partial2SyncID))
+	_, err = compact2Attached.DetachFile("attached")
+	require.NoError(t, err)
+
+	// Sanity-check the compacted state before incremental expansion:
+	// - U2/U3 direct memberships in G1 should exist (from partial syncs + compaction).
+	// - U2/U3 derived memberships in G2 should NOT exist yet (because we haven't re-expanded).
+	compactedBefore, err := loadGrantSourcesByKey(ctx, baseFile, baseSyncID)
+	require.NoError(t, err)
+	require.Contains(t, compactedBefore, "group:g1:member|user|u2")
+	require.Contains(t, compactedBefore, "group:g1:member|user|u3")
+	require.NotContains(t, compactedBefore, "group:g2:member|user|u2")
+	require.NotContains(t, compactedBefore, "group:g2:member|user|u3")
+
+	// ==========================================================================
+	// STEP 6: Generate diff between pre-compaction and post-compaction states
+	// We need a "snapshot" of the old state to diff against. In practice, this would
+	// be the previous sync. Here we simulate by creating a copy of the old state.
+	// ==========================================================================
+	// For this test, we'll create a separate "old" file representing pre-compaction state
+	oldPath := filepath.Join(tmpDir, "old_snapshot.c1z")
+	oldFile, err := dotc1z.NewC1ZFile(ctx, oldPath, dotc1z.WithPragma("journal_mode", "WAL"), dotc1z.WithPragma("locking_mode", "normal"))
+	require.NoError(t, err)
+	defer oldFile.Close(ctx)
+
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, oldFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, oldFile.PutResources(ctx, g1, g2, u1))
+	require.NoError(t, oldFile.PutEntitlements(ctx, e1, e2))
+	require.NoError(t, oldFile.PutGrants(ctx, grantU1E1, grantG1E2))
+	require.NoError(t, oldFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, oldFile, oldSyncID))
+
+	// Now generate diff: base (compacted) is NEW, oldFile is OLD
+	result, err := incrementalexpansion.Run(ctx, baseFile, incrementalexpansion.RunParams{
+		OldFile:   oldFile,
+		OldSyncID: oldSyncID,
+		NewSyncID: baseSyncID,
+	})
+	require.NoError(t, err)
+	upsertsSyncID := result.UpsertsSyncID
+
+	// Sanity-check the upserts diff: it should include the NEW direct grants (U2/U3→E1),
+	// but it should not already contain the derived grants (U2/U3→E2).
+	upserts, err := loadGrantSourcesByKey(ctx, baseFile, upsertsSyncID)
+	require.NoError(t, err)
+	require.Contains(t, upserts, "group:g1:member|user|u2")
+	require.Contains(t, upserts, "group:g1:member|user|u3")
+	require.NotContains(t, upserts, "group:g2:member|user|u2")
+	require.NotContains(t, upserts, "group:g2:member|user|u3")
+
+	// ==========================================================================
+	// STEP 8: Create EXPECTED file with fresh full expansion of the compacted state
+	// ==========================================================================
+	expectedFile, err := dotc1z.NewC1ZFile(ctx, expectedPath)
+	require.NoError(t, err)
+	defer expectedFile.Close(ctx)
+
+	expectedSyncID, err := expectedFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, expectedFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, expectedFile.PutResources(ctx, g1, g2, u1, u2, u3))
+	require.NoError(t, expectedFile.PutEntitlements(ctx, e1, e2))
+	require.NoError(t, expectedFile.PutGrants(ctx, grantU1E1, grantG1E2, grantU2E1, grantU3E1))
+	require.NoError(t, expectedFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, expectedFile, expectedSyncID))
+
+	// ==========================================================================
+	// STEP 9: Compare incremental result against expected
+	// ==========================================================================
+	got, err := loadGrantSourcesByKey(ctx, baseFile, baseSyncID)
+	require.NoError(t, err)
+	want, err := loadGrantSourcesByKey(ctx, expectedFile, expectedSyncID)
+	require.NoError(t, err)
+
+	// U1, U2, and U3 should all have derived membership in G2
+	require.Contains(t, want, "group:g2:member|user|u1", "Expected: U1 should have derived membership in G2")
+	require.Contains(t, want, "group:g2:member|user|u2", "Expected: U2 should have derived membership in G2")
+	require.Contains(t, want, "group:g2:member|user|u3", "Expected: U3 should have derived membership in G2")
+
+	require.Equal(t, want, got, "Incremental expansion should match fresh full expansion")
+}
+
+// TestIncrementalExpansion_DiamondGraph tests a diamond-shaped graph where two
+// independent paths converge on the same entitlement. Removing one path should
+// retain the derived grant via the other path (with correct sources).
+//
+//	E1 → E3
+//	E2 → E3
+//	U1 → E1, U1 → E2
+//
+// After expansion: U1 → E3 with sources {E1, E2, E3(self)}.
+// Remove edge E1→E3 → U1 → E3 should remain with source {E2, E3(self)}.
+func TestIncrementalExpansion_DiamondGraph(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	oldPath := filepath.Join(tmpDir, "old_diamond.c1z")
+	newPath := filepath.Join(tmpDir, "new_diamond.c1z")
+	expectedPath := filepath.Join(tmpDir, "expected_diamond.c1z")
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "G1"}.Build()
+	g2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g2"}.Build(), DisplayName: "G2"}.Build()
+	g3 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g3"}.Build(), DisplayName: "G3"}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "U1"}.Build()
+
+	e1 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g1, "member"), Resource: g1, Slug: "member", DisplayName: "member"}.Build()
+	e2 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g2, "member"), Resource: g2, Slug: "member", DisplayName: "member"}.Build()
+	e3 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g3, "member"), Resource: g3, Slug: "member", DisplayName: "member"}.Build()
+
+	grantU1E1 := v2.Grant_builder{Id: batonGrant.NewGrantID(u1, e1), Entitlement: e1, Principal: u1}.Build()
+	grantU1E2 := v2.Grant_builder{Id: batonGrant.NewGrantID(u1, e2), Entitlement: e2, Principal: u1}.Build()
+
+	// Edge E1 → E3
+	nestingE1E3ID := batonGrant.NewGrantID(g1, e3)
+	grantG1E3 := v2.Grant_builder{
+		Id:          nestingE1E3ID,
+		Entitlement: e3,
+		Principal:   g1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{e1.GetId()},
+			Shallow:         false,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	// Edge E2 → E3
+	grantG2E3 := v2.Grant_builder{
+		Id:          batonGrant.NewGrantID(g2, e3),
+		Entitlement: e3,
+		Principal:   g2,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{e2.GetId()},
+			Shallow:         false,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	// OLD (expanded): both diamond paths active
+	oldFile, err := dotc1z.NewC1ZFile(ctx, oldPath, dotc1z.WithPragma("journal_mode", "WAL"), dotc1z.WithPragma("locking_mode", "normal"))
+	require.NoError(t, err)
+	defer oldFile.Close(ctx)
+
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, oldFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, oldFile.PutResources(ctx, g1, g2, g3, u1))
+	require.NoError(t, oldFile.PutEntitlements(ctx, e1, e2, e3))
+	require.NoError(t, oldFile.PutGrants(ctx, grantU1E1, grantU1E2, grantG1E3, grantG2E3))
+	require.NoError(t, oldFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, oldFile, oldSyncID))
+
+	// NEW: remove edge E1→E3, keep edge E2→E3
+	newFile, err := dotc1z.NewC1ZFile(ctx, newPath)
+	require.NoError(t, err)
+	defer newFile.Close(ctx)
+
+	newSyncID, err := newFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, newFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, newFile.PutResources(ctx, g1, g2, g3, u1))
+	require.NoError(t, newFile.PutEntitlements(ctx, e1, e2, e3))
+
+	require.NoError(t, oldFile.SetSyncID(ctx, ""))
+	require.NoError(t, oldFile.ViewSync(ctx, oldSyncID))
+	grantsToCopy, err := listGrantsWithStoredExpansion(ctx, oldFile)
+	require.NoError(t, err)
+	for _, g := range grantsToCopy {
+		if g.GetId() == nestingE1E3ID {
+			continue
+		}
+		require.NoError(t, newFile.PutGrants(ctx, g))
+	}
+	require.NoError(t, newFile.EndSync(ctx))
+
+	diffAndApplyIncremental(t, ctx, newFile, oldFile, oldSyncID, newSyncID)
+
+	// EXPECTED: U1→E3 still exists (via E2→E3 path), with correct sources
+	expectedFile, err := dotc1z.NewC1ZFile(ctx, expectedPath)
+	require.NoError(t, err)
+	defer expectedFile.Close(ctx)
+	expectedSyncID, err := expectedFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, expectedFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, expectedFile.PutResources(ctx, g1, g2, g3, u1))
+	require.NoError(t, expectedFile.PutEntitlements(ctx, e1, e2, e3))
+	require.NoError(t, expectedFile.PutGrants(ctx, grantU1E1, grantU1E2, grantG2E3))
+	require.NoError(t, expectedFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, expectedFile, expectedSyncID))
+
+	got, err := loadGrantSourcesByKey(ctx, newFile, newSyncID)
+	require.NoError(t, err)
+	want, err := loadGrantSourcesByKey(ctx, expectedFile, expectedSyncID)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+// TestIncrementalExpansion_ShallowToDeepToggle tests that changing an edge's shallow flag
+// from true to false (making it deep) is correctly handled as a remove+add in the delta.
+func TestIncrementalExpansion_ShallowToDeepToggle(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	oldPath := filepath.Join(tmpDir, "old_shallow_toggle.c1z")
+	newPath := filepath.Join(tmpDir, "new_shallow_toggle.c1z")
+	expectedPath := filepath.Join(tmpDir, "expected_shallow_toggle.c1z")
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "G1"}.Build()
+	g2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g2"}.Build(), DisplayName: "G2"}.Build()
+	g3 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g3"}.Build(), DisplayName: "G3"}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "U1"}.Build()
+
+	e1 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g1, "member"), Resource: g1, Slug: "member", DisplayName: "member"}.Build()
+	e2 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g2, "member"), Resource: g2, Slug: "member", DisplayName: "member"}.Build()
+	e3 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g3, "member"), Resource: g3, Slug: "member", DisplayName: "member"}.Build()
+
+	grantU1E1 := v2.Grant_builder{Id: batonGrant.NewGrantID(u1, e1), Entitlement: e1, Principal: u1}.Build()
+
+	// Edge E1→E2 (deep)
+	grantG1E2 := v2.Grant_builder{
+		Id:          batonGrant.NewGrantID(g1, e2),
+		Entitlement: e2,
+		Principal:   g1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{e1.GetId()},
+			Shallow:         false,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	// Edge E2→E3 was SHALLOW, becomes DEEP
+	nestingE2E3ID := batonGrant.NewGrantID(g2, e3)
+	grantG2E3Shallow := v2.Grant_builder{
+		Id:          nestingE2E3ID,
+		Entitlement: e3,
+		Principal:   g2,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{e2.GetId()},
+			Shallow:         true,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+	grantG2E3Deep := v2.Grant_builder{
+		Id:          nestingE2E3ID,
+		Entitlement: e3,
+		Principal:   g2,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{e2.GetId()},
+			Shallow:         false,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	// OLD: U1→E1, E1→E2 (deep), E2→E3 (shallow)
+	// With shallow: U1 propagates to E2 (via deep E1→E2), but NOT to E3 (shallow blocks it)
+	oldFile, err := dotc1z.NewC1ZFile(ctx, oldPath, dotc1z.WithPragma("journal_mode", "WAL"), dotc1z.WithPragma("locking_mode", "normal"))
+	require.NoError(t, err)
+	defer oldFile.Close(ctx)
+
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, oldFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, oldFile.PutResources(ctx, g1, g2, g3, u1))
+	require.NoError(t, oldFile.PutEntitlements(ctx, e1, e2, e3))
+	require.NoError(t, oldFile.PutGrants(ctx, grantU1E1, grantG1E2, grantG2E3Shallow))
+	require.NoError(t, oldFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, oldFile, oldSyncID))
+
+	// NEW: same but E2→E3 is now DEEP
+	newFile, err := dotc1z.NewC1ZFile(ctx, newPath)
+	require.NoError(t, err)
+	defer newFile.Close(ctx)
+
+	newSyncID, err := newFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, newFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, newFile.PutResources(ctx, g1, g2, g3, u1))
+	require.NoError(t, newFile.PutEntitlements(ctx, e1, e2, e3))
+
+	require.NoError(t, oldFile.SetSyncID(ctx, ""))
+	require.NoError(t, oldFile.ViewSync(ctx, oldSyncID))
+	grantsToCopy, err := listGrantsWithStoredExpansion(ctx, oldFile)
+	require.NoError(t, err)
+	for _, g := range grantsToCopy {
+		if g.GetId() == nestingE2E3ID {
+			require.NoError(t, newFile.PutGrants(ctx, grantG2E3Deep))
+			continue
+		}
+		require.NoError(t, newFile.PutGrants(ctx, g))
+	}
+	require.NoError(t, newFile.EndSync(ctx))
+
+	diffAndApplyIncremental(t, ctx, newFile, oldFile, oldSyncID, newSyncID)
+
+	// EXPECTED: E2→E3 is now deep, so U1 should propagate through to E3
+	expectedFile, err := dotc1z.NewC1ZFile(ctx, expectedPath)
+	require.NoError(t, err)
+	defer expectedFile.Close(ctx)
+	expectedSyncID, err := expectedFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, expectedFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, expectedFile.PutResources(ctx, g1, g2, g3, u1))
+	require.NoError(t, expectedFile.PutEntitlements(ctx, e1, e2, e3))
+	require.NoError(t, expectedFile.PutGrants(ctx, grantU1E1, grantG1E2, grantG2E3Deep))
+	require.NoError(t, expectedFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, expectedFile, expectedSyncID))
+
+	got, err := loadGrantSourcesByKey(ctx, newFile, newSyncID)
+	require.NoError(t, err)
+	want, err := loadGrantSourcesByKey(ctx, expectedFile, expectedSyncID)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+// TestIncrementalExpansion_ResourceTypeFilterChange tests that changing the
+// PrincipalResourceTypeIDs filter on an edge is handled correctly.
+func TestIncrementalExpansion_ResourceTypeFilterChange(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	oldPath := filepath.Join(tmpDir, "old_filter_change.c1z")
+	newPath := filepath.Join(tmpDir, "new_filter_change.c1z")
+	expectedPath := filepath.Join(tmpDir, "expected_filter_change.c1z")
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+	saRT := v2.ResourceType_builder{Id: "serviceaccount", DisplayName: "ServiceAccount"}.Build()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "G1"}.Build()
+	g2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g2"}.Build(), DisplayName: "G2"}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "U1"}.Build()
+	sa1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "serviceaccount", Resource: "sa1"}.Build(), DisplayName: "SA1"}.Build()
+
+	e1 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g1, "member"), Resource: g1, Slug: "member", DisplayName: "member"}.Build()
+	e2 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g2, "member"), Resource: g2, Slug: "member", DisplayName: "member"}.Build()
+
+	grantU1E1 := v2.Grant_builder{Id: batonGrant.NewGrantID(u1, e1), Entitlement: e1, Principal: u1}.Build()
+	grantSA1E1 := v2.Grant_builder{Id: batonGrant.NewGrantID(sa1, e1), Entitlement: e1, Principal: sa1}.Build()
+
+	// Edge E1→E2 with filter ["user"] (only propagates users)
+	nestingID := batonGrant.NewGrantID(g1, e2)
+	grantG1E2UserOnly := v2.Grant_builder{
+		Id:          nestingID,
+		Entitlement: e2,
+		Principal:   g1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{e1.GetId()},
+			Shallow:         false,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	// Same edge but with filter ["user", "serviceaccount"] (now also propagates SAs)
+	grantG1E2UserAndSA := v2.Grant_builder{
+		Id:          nestingID,
+		Entitlement: e2,
+		Principal:   g1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{e1.GetId()},
+			Shallow:         false,
+			ResourceTypeIds: []string{"user", "serviceaccount"},
+		}.Build()),
+	}.Build()
+
+	// OLD: filter=["user"], so only U1 propagates
+	oldFile, err := dotc1z.NewC1ZFile(ctx, oldPath, dotc1z.WithPragma("journal_mode", "WAL"), dotc1z.WithPragma("locking_mode", "normal"))
+	require.NoError(t, err)
+	defer oldFile.Close(ctx)
+
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, oldFile.PutResourceTypes(ctx, groupRT, userRT, saRT))
+	require.NoError(t, oldFile.PutResources(ctx, g1, g2, u1, sa1))
+	require.NoError(t, oldFile.PutEntitlements(ctx, e1, e2))
+	require.NoError(t, oldFile.PutGrants(ctx, grantU1E1, grantSA1E1, grantG1E2UserOnly))
+	require.NoError(t, oldFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, oldFile, oldSyncID))
+
+	// NEW: filter=["user","serviceaccount"], so both propagate
+	newFile, err := dotc1z.NewC1ZFile(ctx, newPath)
+	require.NoError(t, err)
+	defer newFile.Close(ctx)
+
+	newSyncID, err := newFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, newFile.PutResourceTypes(ctx, groupRT, userRT, saRT))
+	require.NoError(t, newFile.PutResources(ctx, g1, g2, u1, sa1))
+	require.NoError(t, newFile.PutEntitlements(ctx, e1, e2))
+
+	require.NoError(t, oldFile.SetSyncID(ctx, ""))
+	require.NoError(t, oldFile.ViewSync(ctx, oldSyncID))
+	grantsToCopy, err := listGrantsWithStoredExpansion(ctx, oldFile)
+	require.NoError(t, err)
+	for _, g := range grantsToCopy {
+		if g.GetId() == nestingID {
+			require.NoError(t, newFile.PutGrants(ctx, grantG1E2UserAndSA))
+			continue
+		}
+		require.NoError(t, newFile.PutGrants(ctx, g))
+	}
+	require.NoError(t, newFile.EndSync(ctx))
+
+	diffAndApplyIncremental(t, ctx, newFile, oldFile, oldSyncID, newSyncID)
+
+	// EXPECTED: both U1 and SA1 should now have derived membership in E2
+	expectedFile, err := dotc1z.NewC1ZFile(ctx, expectedPath)
+	require.NoError(t, err)
+	defer expectedFile.Close(ctx)
+	expectedSyncID, err := expectedFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, expectedFile.PutResourceTypes(ctx, groupRT, userRT, saRT))
+	require.NoError(t, expectedFile.PutResources(ctx, g1, g2, u1, sa1))
+	require.NoError(t, expectedFile.PutEntitlements(ctx, e1, e2))
+	require.NoError(t, expectedFile.PutGrants(ctx, grantU1E1, grantSA1E1, grantG1E2UserAndSA))
+	require.NoError(t, expectedFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, expectedFile, expectedSyncID))
+
+	got, err := loadGrantSourcesByKey(ctx, newFile, newSyncID)
+	require.NoError(t, err)
+	want, err := loadGrantSourcesByKey(ctx, expectedFile, expectedSyncID)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+// TestIncrementalExpansion_ConvergingEdgesRemoval tests two independent edges
+// converging on the same destination entitlement. Removing one edge should keep
+// derived grants from the surviving path and remove only those from the removed path.
+func TestIncrementalExpansion_ConvergingEdgesRemoval(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	oldPath := filepath.Join(tmpDir, "old_multisrc.c1z")
+	newPath := filepath.Join(tmpDir, "new_multisrc.c1z")
+	expectedPath := filepath.Join(tmpDir, "expected_multisrc.c1z")
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "G1"}.Build()
+	g2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g2"}.Build(), DisplayName: "G2"}.Build()
+	g3 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g3"}.Build(), DisplayName: "G3"}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "U1"}.Build()
+	u2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u2"}.Build(), DisplayName: "U2"}.Build()
+
+	e1 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g1, "member"), Resource: g1, Slug: "member", DisplayName: "member"}.Build()
+	e2 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g2, "member"), Resource: g2, Slug: "member", DisplayName: "member"}.Build()
+	e3 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g3, "member"), Resource: g3, Slug: "member", DisplayName: "member"}.Build()
+
+	grantU1E1 := v2.Grant_builder{Id: batonGrant.NewGrantID(u1, e1), Entitlement: e1, Principal: u1}.Build()
+	grantU2E2 := v2.Grant_builder{Id: batonGrant.NewGrantID(u2, e2), Entitlement: e2, Principal: u2}.Build()
+
+	// Note: this is a converging-edges scenario (two separate edge-defining grants),
+	// not a single grant with multiple source entitlement IDs.
+
+	// Edge E1→E3 via g1 nesting
+	nestingG1E3ID := batonGrant.NewGrantID(g1, e3)
+	grantG1E3 := v2.Grant_builder{
+		Id:          nestingG1E3ID,
+		Entitlement: e3,
+		Principal:   g1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{e1.GetId()},
+			Shallow:         false,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	// Edge E2→E3 via g2 nesting
+	nestingG2E3ID := batonGrant.NewGrantID(g2, e3)
+	grantG2E3 := v2.Grant_builder{
+		Id:          nestingG2E3ID,
+		Entitlement: e3,
+		Principal:   g2,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{e2.GetId()},
+			Shallow:         false,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	// OLD: U1→E1, U2→E2, edges E1→E3 and E2→E3.
+	// After expansion: U1→E3 (via E1), U2→E3 (via E2)
+	oldFile, err := dotc1z.NewC1ZFile(ctx, oldPath, dotc1z.WithPragma("journal_mode", "WAL"), dotc1z.WithPragma("locking_mode", "normal"))
+	require.NoError(t, err)
+	defer oldFile.Close(ctx)
+
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, oldFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, oldFile.PutResources(ctx, g1, g2, g3, u1, u2))
+	require.NoError(t, oldFile.PutEntitlements(ctx, e1, e2, e3))
+	require.NoError(t, oldFile.PutGrants(ctx, grantU1E1, grantU2E2, grantG1E3, grantG2E3))
+	require.NoError(t, oldFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, oldFile, oldSyncID))
+
+	// NEW: remove edge E2→E3, keep E1→E3
+	newFile, err := dotc1z.NewC1ZFile(ctx, newPath)
+	require.NoError(t, err)
+	defer newFile.Close(ctx)
+
+	newSyncID, err := newFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, newFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, newFile.PutResources(ctx, g1, g2, g3, u1, u2))
+	require.NoError(t, newFile.PutEntitlements(ctx, e1, e2, e3))
+
+	require.NoError(t, oldFile.SetSyncID(ctx, ""))
+	require.NoError(t, oldFile.ViewSync(ctx, oldSyncID))
+	grantsToCopy, err := listGrantsWithStoredExpansion(ctx, oldFile)
+	require.NoError(t, err)
+	for _, g := range grantsToCopy {
+		if g.GetId() == nestingG2E3ID {
+			continue
+		}
+		require.NoError(t, newFile.PutGrants(ctx, g))
+	}
+	require.NoError(t, newFile.EndSync(ctx))
+
+	diffAndApplyIncremental(t, ctx, newFile, oldFile, oldSyncID, newSyncID)
+
+	// EXPECTED: U1→E3 remains (via E1), U2→E3 removed
+	expectedFile, err := dotc1z.NewC1ZFile(ctx, expectedPath)
+	require.NoError(t, err)
+	defer expectedFile.Close(ctx)
+	expectedSyncID, err := expectedFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, expectedFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, expectedFile.PutResources(ctx, g1, g2, g3, u1, u2))
+	require.NoError(t, expectedFile.PutEntitlements(ctx, e1, e2, e3))
+	require.NoError(t, expectedFile.PutGrants(ctx, grantU1E1, grantU2E2, grantG1E3))
+	require.NoError(t, expectedFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, expectedFile, expectedSyncID))
+
+	got, err := loadGrantSourcesByKey(ctx, newFile, newSyncID)
+	require.NoError(t, err)
+	want, err := loadGrantSourcesByKey(ctx, expectedFile, expectedSyncID)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+// TestIncrementalExpansion_GrantReplacementAtSource tests that when a direct grant
+// at a source entitlement is replaced (U1→E1 removed, U2→E1 added), the incremental
+// pipeline correctly removes the old derived grant and creates the new one.
+func TestIncrementalExpansion_GrantReplacementAtSource(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	oldPath := filepath.Join(tmpDir, "old_replace.c1z")
+	newPath := filepath.Join(tmpDir, "new_replace.c1z")
+	expectedPath := filepath.Join(tmpDir, "expected_replace.c1z")
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "G1"}.Build()
+	g2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g2"}.Build(), DisplayName: "G2"}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "U1"}.Build()
+	u2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u2"}.Build(), DisplayName: "U2"}.Build()
+
+	e1 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g1, "member"), Resource: g1, Slug: "member", DisplayName: "member"}.Build()
+	e2 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g2, "member"), Resource: g2, Slug: "member", DisplayName: "member"}.Build()
+
+	grantU1E1 := v2.Grant_builder{Id: batonGrant.NewGrantID(u1, e1), Entitlement: e1, Principal: u1}.Build()
+	grantU2E1 := v2.Grant_builder{Id: batonGrant.NewGrantID(u2, e1), Entitlement: e1, Principal: u2}.Build()
+
+	grantG1E2 := v2.Grant_builder{
+		Id:          batonGrant.NewGrantID(g1, e2),
+		Entitlement: e2,
+		Principal:   g1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{e1.GetId()},
+			Shallow:         false,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	// OLD: U1→E1, edge E1→E2, expanded (U1→E2 derived)
+	oldFile, err := dotc1z.NewC1ZFile(ctx, oldPath, dotc1z.WithPragma("journal_mode", "WAL"), dotc1z.WithPragma("locking_mode", "normal"))
+	require.NoError(t, err)
+	defer oldFile.Close(ctx)
+
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, oldFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, oldFile.PutResources(ctx, g1, g2, u1, u2))
+	require.NoError(t, oldFile.PutEntitlements(ctx, e1, e2))
+	require.NoError(t, oldFile.PutGrants(ctx, grantU1E1, grantG1E2))
+	require.NoError(t, oldFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, oldFile, oldSyncID))
+
+	// NEW: U1→E1 removed, U2→E1 added, edge still present
+	// U1→E2 (derived) should be removed, U2→E2 (derived) should be created
+	newFile, err := dotc1z.NewC1ZFile(ctx, newPath)
+	require.NoError(t, err)
+	defer newFile.Close(ctx)
+
+	newSyncID, err := newFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, newFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, newFile.PutResources(ctx, g1, g2, u1, u2))
+	require.NoError(t, newFile.PutEntitlements(ctx, e1, e2))
+
+	require.NoError(t, oldFile.SetSyncID(ctx, ""))
+	require.NoError(t, oldFile.ViewSync(ctx, oldSyncID))
+	grantsToCopy, err := listGrantsWithStoredExpansion(ctx, oldFile)
+	require.NoError(t, err)
+	for _, g := range grantsToCopy {
+		if g.GetId() == grantU1E1.GetId() {
+			continue // remove U1→E1
+		}
+		require.NoError(t, newFile.PutGrants(ctx, g))
+	}
+	require.NoError(t, newFile.PutGrants(ctx, grantU2E1)) // add U2→E1
+	require.NoError(t, newFile.EndSync(ctx))
+
+	diffAndApplyIncremental(t, ctx, newFile, oldFile, oldSyncID, newSyncID)
+
+	// EXPECTED: U2→E1, edge E1→E2, expanded (U2→E2 derived, no U1→E2)
+	expectedFile, err := dotc1z.NewC1ZFile(ctx, expectedPath)
+	require.NoError(t, err)
+	defer expectedFile.Close(ctx)
+	expectedSyncID, err := expectedFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, expectedFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, expectedFile.PutResources(ctx, g1, g2, u1, u2))
+	require.NoError(t, expectedFile.PutEntitlements(ctx, e1, e2))
+	require.NoError(t, expectedFile.PutGrants(ctx, grantU2E1, grantG1E2))
+	require.NoError(t, expectedFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, expectedFile, expectedSyncID))
+
+	got, err := loadGrantSourcesByKey(ctx, newFile, newSyncID)
+	require.NoError(t, err)
+	want, err := loadGrantSourcesByKey(ctx, expectedFile, expectedSyncID)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+// TestIncrementalExpansion_AddNewEdgeAtEndOfChain tests adding a new edge
+// at the end of an existing chain (E1→E2 exists, E2→E3 added).
+func TestIncrementalExpansion_AddNewEdgeAtEndOfChain(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	oldPath := filepath.Join(tmpDir, "old_chain_extend.c1z")
+	newPath := filepath.Join(tmpDir, "new_chain_extend.c1z")
+	expectedPath := filepath.Join(tmpDir, "expected_chain_extend.c1z")
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "G1"}.Build()
+	g2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g2"}.Build(), DisplayName: "G2"}.Build()
+	g3 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g3"}.Build(), DisplayName: "G3"}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "U1"}.Build()
+
+	e1 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g1, "member"), Resource: g1, Slug: "member", DisplayName: "member"}.Build()
+	e2 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g2, "member"), Resource: g2, Slug: "member", DisplayName: "member"}.Build()
+	e3 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g3, "member"), Resource: g3, Slug: "member", DisplayName: "member"}.Build()
+
+	grantU1E1 := v2.Grant_builder{Id: batonGrant.NewGrantID(u1, e1), Entitlement: e1, Principal: u1}.Build()
+
+	// Existing edge E1→E2
+	grantG1E2 := v2.Grant_builder{
+		Id:          batonGrant.NewGrantID(g1, e2),
+		Entitlement: e2,
+		Principal:   g1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{e1.GetId()},
+			Shallow:         false,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	// New edge E2→E3 (added in NEW)
+	grantG2E3 := v2.Grant_builder{
+		Id:          batonGrant.NewGrantID(g2, e3),
+		Entitlement: e3,
+		Principal:   g2,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{e2.GetId()},
+			Shallow:         false,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	// OLD: U1→E1, E1→E2, expanded (U1→E2 derived)
+	oldFile, err := dotc1z.NewC1ZFile(ctx, oldPath, dotc1z.WithPragma("journal_mode", "WAL"), dotc1z.WithPragma("locking_mode", "normal"))
+	require.NoError(t, err)
+	defer oldFile.Close(ctx)
+
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, oldFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, oldFile.PutResources(ctx, g1, g2, g3, u1))
+	require.NoError(t, oldFile.PutEntitlements(ctx, e1, e2, e3))
+	require.NoError(t, oldFile.PutGrants(ctx, grantU1E1, grantG1E2))
+	require.NoError(t, oldFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, oldFile, oldSyncID))
+
+	// NEW: same as OLD expanded + E2→E3 edge added
+	newFile, err := dotc1z.NewC1ZFile(ctx, newPath)
+	require.NoError(t, err)
+	defer newFile.Close(ctx)
+
+	newSyncID, err := newFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, newFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, newFile.PutResources(ctx, g1, g2, g3, u1))
+	require.NoError(t, newFile.PutEntitlements(ctx, e1, e2, e3))
+
+	require.NoError(t, oldFile.SetSyncID(ctx, ""))
+	require.NoError(t, oldFile.ViewSync(ctx, oldSyncID))
+	grantsToCopy, err := listGrantsWithStoredExpansion(ctx, oldFile)
+	require.NoError(t, err)
+	for _, g := range grantsToCopy {
+		require.NoError(t, newFile.PutGrants(ctx, g))
+	}
+	require.NoError(t, newFile.PutGrants(ctx, grantG2E3))
+	require.NoError(t, newFile.EndSync(ctx))
+
+	diffAndApplyIncremental(t, ctx, newFile, oldFile, oldSyncID, newSyncID)
+
+	// EXPECTED: U1→E1, E1→E2, E2→E3, expanded (U1→E2, U1→E3 both derived)
+	expectedFile, err := dotc1z.NewC1ZFile(ctx, expectedPath)
+	require.NoError(t, err)
+	defer expectedFile.Close(ctx)
+	expectedSyncID, err := expectedFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, expectedFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, expectedFile.PutResources(ctx, g1, g2, g3, u1))
+	require.NoError(t, expectedFile.PutEntitlements(ctx, e1, e2, e3))
+	require.NoError(t, expectedFile.PutGrants(ctx, grantU1E1, grantG1E2, grantG2E3))
+	require.NoError(t, expectedFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, expectedFile, expectedSyncID))
+
+	got, err := loadGrantSourcesByKey(ctx, newFile, newSyncID)
+	require.NoError(t, err)
+	want, err := loadGrantSourcesByKey(ctx, expectedFile, expectedSyncID)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+// TestIncrementalExpansion_SourceListChange tests changing the source entitlement
+// list on an edge-defining grant. G1 has two entitlements (member, admin). The nesting
+// grant starts with source [e1_member] and changes to [e1_member, e1_admin].
+// Since both source entitlements are on the same resource (G1 = the nesting grant's
+// principal), this is a valid multi-source configuration.
+func TestIncrementalExpansion_SourceListChange(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	oldPath := filepath.Join(tmpDir, "old_srclist.c1z")
+	newPath := filepath.Join(tmpDir, "new_srclist.c1z")
+	expectedPath := filepath.Join(tmpDir, "expected_srclist.c1z")
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "G1"}.Build()
+	g2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g2"}.Build(), DisplayName: "G2"}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "U1"}.Build()
+	u2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u2"}.Build(), DisplayName: "U2"}.Build()
+
+	// G1 has two entitlements: member and admin
+	e1Member := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g1, "member"), Resource: g1, Slug: "member", DisplayName: "member"}.Build()
+	e1Admin := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g1, "admin"), Resource: g1, Slug: "admin", DisplayName: "admin"}.Build()
+	e2 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g2, "member"), Resource: g2, Slug: "member", DisplayName: "member"}.Build()
+
+	// U1 is a member of G1, U2 is an admin of G1
+	grantU1E1Member := v2.Grant_builder{Id: batonGrant.NewGrantID(u1, e1Member), Entitlement: e1Member, Principal: u1}.Build()
+	grantU2E1Admin := v2.Grant_builder{Id: batonGrant.NewGrantID(u2, e1Admin), Entitlement: e1Admin, Principal: u2}.Build()
+
+	// OLD: nesting grant with source [e1_member] only
+	nestingID := batonGrant.NewGrantID(g1, e2)
+	grantG1E2OneSrc := v2.Grant_builder{
+		Id:          nestingID,
+		Entitlement: e2,
+		Principal:   g1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{e1Member.GetId()},
+			Shallow:         false,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	// NEW: nesting grant with sources [e1_member, e1_admin]
+	grantG1E2TwoSrc := v2.Grant_builder{
+		Id:          nestingID,
+		Entitlement: e2,
+		Principal:   g1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{e1Member.GetId(), e1Admin.GetId()},
+			Shallow:         false,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	// OLD: U1→e1_member, U2→e1_admin, edge [e1_member]→E2
+	// After expansion: U1→E2 (via e1_member)
+	oldFile, err := dotc1z.NewC1ZFile(ctx, oldPath, dotc1z.WithPragma("journal_mode", "WAL"), dotc1z.WithPragma("locking_mode", "normal"))
+	require.NoError(t, err)
+	defer oldFile.Close(ctx)
+
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, oldFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, oldFile.PutResources(ctx, g1, g2, u1, u2))
+	require.NoError(t, oldFile.PutEntitlements(ctx, e1Member, e1Admin, e2))
+	require.NoError(t, oldFile.PutGrants(ctx, grantU1E1Member, grantU2E1Admin, grantG1E2OneSrc))
+	require.NoError(t, oldFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, oldFile, oldSyncID))
+
+	// NEW: edge now has two sources [e1_member, e1_admin]
+	newFile, err := dotc1z.NewC1ZFile(ctx, newPath)
+	require.NoError(t, err)
+	defer newFile.Close(ctx)
+
+	newSyncID, err := newFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, newFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, newFile.PutResources(ctx, g1, g2, u1, u2))
+	require.NoError(t, newFile.PutEntitlements(ctx, e1Member, e1Admin, e2))
+
+	require.NoError(t, oldFile.SetSyncID(ctx, ""))
+	require.NoError(t, oldFile.ViewSync(ctx, oldSyncID))
+	grantsToCopy, err := listGrantsWithStoredExpansion(ctx, oldFile)
+	require.NoError(t, err)
+	for _, g := range grantsToCopy {
+		if g.GetId() == nestingID {
+			require.NoError(t, newFile.PutGrants(ctx, grantG1E2TwoSrc))
+			continue
+		}
+		require.NoError(t, newFile.PutGrants(ctx, g))
+	}
+	require.NoError(t, newFile.EndSync(ctx))
+
+	diffAndApplyIncremental(t, ctx, newFile, oldFile, oldSyncID, newSyncID)
+
+	// EXPECTED: U1→E2 (via e1_member) AND U2→E2 (via e1_admin) should be derived
+	expectedFile, err := dotc1z.NewC1ZFile(ctx, expectedPath)
+	require.NoError(t, err)
+	defer expectedFile.Close(ctx)
+	expectedSyncID, err := expectedFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, expectedFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, expectedFile.PutResources(ctx, g1, g2, u1, u2))
+	require.NoError(t, expectedFile.PutEntitlements(ctx, e1Member, e1Admin, e2))
+	require.NoError(t, expectedFile.PutGrants(ctx, grantU1E1Member, grantU2E1Admin, grantG1E2TwoSrc))
+	require.NoError(t, expectedFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, expectedFile, expectedSyncID))
+
+	got, err := loadGrantSourcesByKey(ctx, newFile, newSyncID)
+	require.NoError(t, err)
+	want, err := loadGrantSourcesByKey(ctx, expectedFile, expectedSyncID)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+// TestIncrementalExpansion_SourcesInDataBlobNoop verifies that when a connector produces
+// identical grants across two syncs (a true no-op), the diff does not report false-positive
+// changed grant entitlements caused by expansion having written Sources into the data blob.
+//
+// Scenario:
+//   - U1 has a direct grant on both E1 and E2 (destination of edge E1→E2).
+//   - After full expansion of the old sync, U1→E2 acquires Sources={E2, E1} in its data blob.
+//   - The new sync has the same connector-provided grants (no Sources, since the connector
+//     never sets them).
+//   - The diff should detect zero changed grant entitlements because nothing changed from the
+//     connector's perspective.
+//
+// Regression target: when Sources leaked into grant data blobs, this scenario falsely reported
+// E2 as changed even though connector-provided grants were identical.
+func TestIncrementalExpansion_SourcesInDataBlobNoop(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	oldPath := filepath.Join(tmpDir, "old_sources_noop.c1z")
+	newPath := filepath.Join(tmpDir, "new_sources_noop.c1z")
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "G1"}.Build()
+	g2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g2"}.Build(), DisplayName: "G2"}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "U1"}.Build()
+
+	e1 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g1, "member"), Resource: g1, Slug: "member", DisplayName: "member"}.Build()
+	e2 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g2, "member"), Resource: g2, Slug: "member", DisplayName: "member"}.Build()
+
+	grantU1E1 := v2.Grant_builder{Id: batonGrant.NewGrantID(u1, e1), Entitlement: e1, Principal: u1}.Build()
+	grantU1E2 := v2.Grant_builder{Id: batonGrant.NewGrantID(u1, e2), Entitlement: e2, Principal: u1}.Build()
+	grantG1E2 := v2.Grant_builder{
+		Id:          batonGrant.NewGrantID(g1, e2),
+		Entitlement: e2,
+		Principal:   g1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{e1.GetId()},
+			Shallow:         false,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	// OLD: connector grants + full expansion.
+	// After expansion U1→E2 acquires Sources={E2: IsDirect=true, E1: IsDirect=true}
+	// baked into its data blob.
+	oldFile, err := dotc1z.NewC1ZFile(ctx, oldPath, dotc1z.WithPragma("journal_mode", "WAL"), dotc1z.WithPragma("locking_mode", "normal"))
+	require.NoError(t, err)
+	defer oldFile.Close(ctx)
+
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, oldFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, oldFile.PutResources(ctx, g1, g2, u1))
+	require.NoError(t, oldFile.PutEntitlements(ctx, e1, e2))
+	require.NoError(t, oldFile.PutGrants(ctx, grantU1E1, grantU1E2, grantG1E2))
+	require.NoError(t, oldFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, oldFile, oldSyncID))
+
+	// NEW: exact same connector grants, fresh (no Sources).
+	newFile, err := dotc1z.NewC1ZFile(ctx, newPath)
+	require.NoError(t, err)
+	defer newFile.Close(ctx)
+
+	newSyncID, err := newFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, newFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, newFile.PutResources(ctx, g1, g2, u1))
+	require.NoError(t, newFile.PutEntitlements(ctx, e1, e2))
+	require.NoError(t, newFile.PutGrants(ctx, grantU1E1, grantU1E2, grantG1E2))
+	require.NoError(t, newFile.EndSync(ctx))
+
+	attached, err := newFile.AttachFile(oldFile, "attached")
+	require.NoError(t, err)
+
+	upsertsSyncID, deletionsSyncID, err := attached.GenerateSyncDiffFromFile(ctx, oldSyncID, newSyncID)
+	require.NoError(t, err)
+
+	changedEntIDs, err := attached.ComputeChangedGrantEntitlementIDs(ctx, oldSyncID, newSyncID)
+	require.NoError(t, err)
+
+	// The connector produced identical grants, so the diff should report no changed entitlements.
+	require.Empty(t, changedEntIDs, "diff should report no changed grant entitlements for a connector-level no-op")
+
+	// Grant-level diffs should also be empty (no false-positive upserts/deletions).
+	upserts, err := newFile.ListGrantsInternal(ctx, connectorstore.GrantListOptions{
+		Mode:   connectorstore.GrantListModePayload,
+		SyncID: upsertsSyncID,
+	})
+	require.NoError(t, err)
+	require.Empty(t, upserts.Rows, "grant upserts should be empty for connector-level no-op")
+
+	deletions, err := newFile.ListGrantsInternal(ctx, connectorstore.GrantListOptions{
+		Mode:   connectorstore.GrantListModePayload,
+		SyncID: deletionsSyncID,
+	})
+	require.NoError(t, err)
+	require.Empty(t, deletions.Rows, "grant deletions should be empty for connector-level no-op")
+
+	_, err = attached.DetachFile("attached")
+	require.NoError(t, err)
+}
+
+// -----------------------------------------------------------------------
+// GrantImmutable vs non-immutable sourceless behavior
+// -----------------------------------------------------------------------
+
+func TestIncrementalExpansion_ImmutableSourcelessGrantDeleted(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	oldPath := filepath.Join(tmpDir, "old_immutable.c1z")
+	newPath := filepath.Join(tmpDir, "new_immutable.c1z")
+	expectedPath := filepath.Join(tmpDir, "expected_immutable.c1z")
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "G1"}.Build()
+	g2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g2"}.Build(), DisplayName: "G2"}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "U1"}.Build()
+
+	e1 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g1, "member"), Resource: g1, Slug: "member", DisplayName: "member"}.Build()
+	e2 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g2, "member"), Resource: g2, Slug: "member", DisplayName: "member"}.Build()
+
+	grantU1E1 := v2.Grant_builder{Id: batonGrant.NewGrantID(u1, e1), Entitlement: e1, Principal: u1}.Build()
+
+	nestingID := batonGrant.NewGrantID(g1, e2)
+	grantG1E2 := v2.Grant_builder{
+		Id:          nestingID,
+		Entitlement: e2,
+		Principal:   g1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{e1.GetId()},
+			Shallow:         false,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	oldFile, err := dotc1z.NewC1ZFile(ctx, oldPath, dotc1z.WithPragma("journal_mode", "WAL"), dotc1z.WithPragma("locking_mode", "normal"))
+	require.NoError(t, err)
+	defer oldFile.Close(ctx)
+
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, oldFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, oldFile.PutResources(ctx, g1, g2, u1))
+	require.NoError(t, oldFile.PutEntitlements(ctx, e1, e2))
+	require.NoError(t, oldFile.PutGrants(ctx, grantU1E1, grantG1E2))
+	require.NoError(t, oldFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, oldFile, oldSyncID))
+
+	oldGrants, err := loadGrantSourcesByKey(ctx, oldFile, oldSyncID)
+	require.NoError(t, err)
+	require.Contains(t, oldGrants, "group:g2:member|user|u1", "derived grant U1→E2 should exist after expansion")
+
+	newFile, err := dotc1z.NewC1ZFile(ctx, newPath)
+	require.NoError(t, err)
+	defer newFile.Close(ctx)
+
+	newSyncID, err := newFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, newFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, newFile.PutResources(ctx, g1, g2, u1))
+	require.NoError(t, newFile.PutEntitlements(ctx, e1, e2))
+
+	require.NoError(t, oldFile.SetSyncID(ctx, ""))
+	require.NoError(t, oldFile.ViewSync(ctx, oldSyncID))
+	grantsToCopy, err := listGrantsWithStoredExpansion(ctx, oldFile)
+	require.NoError(t, err)
+	for _, g := range grantsToCopy {
+		if g.GetId() == nestingID {
+			continue
+		}
+		require.NoError(t, newFile.PutGrants(ctx, g))
+	}
+	require.NoError(t, newFile.EndSync(ctx))
+
+	diffAndApplyIncremental(t, ctx, newFile, oldFile, oldSyncID, newSyncID)
+
+	expectedFile, err := dotc1z.NewC1ZFile(ctx, expectedPath)
+	require.NoError(t, err)
+	defer expectedFile.Close(ctx)
+	expectedSyncID, err := expectedFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, expectedFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, expectedFile.PutResources(ctx, g1, g2, u1))
+	require.NoError(t, expectedFile.PutEntitlements(ctx, e1, e2))
+	require.NoError(t, expectedFile.PutGrants(ctx, grantU1E1))
+	require.NoError(t, expectedFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, expectedFile, expectedSyncID))
+
+	got, err := loadGrantSourcesByKey(ctx, newFile, newSyncID)
+	require.NoError(t, err)
+	want, err := loadGrantSourcesByKey(ctx, expectedFile, expectedSyncID)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+
+	require.NotContains(t, got, "group:g2:member|user|u1", "immutable derived grant should be deleted when sourceless")
+}
+
+func TestIncrementalExpansion_NonImmutableSourcelessGrantKept(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	oldPath := filepath.Join(tmpDir, "old_nonimmutable.c1z")
+	newPath := filepath.Join(tmpDir, "new_nonimmutable.c1z")
+	expectedPath := filepath.Join(tmpDir, "expected_nonimmutable.c1z")
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "G1"}.Build()
+	g2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g2"}.Build(), DisplayName: "G2"}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "U1"}.Build()
+
+	e1 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g1, "member"), Resource: g1, Slug: "member", DisplayName: "member"}.Build()
+	e2 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g2, "member"), Resource: g2, Slug: "member", DisplayName: "member"}.Build()
+
+	grantU1E1 := v2.Grant_builder{Id: batonGrant.NewGrantID(u1, e1), Entitlement: e1, Principal: u1}.Build()
+	grantU1E2 := v2.Grant_builder{Id: batonGrant.NewGrantID(u1, e2), Entitlement: e2, Principal: u1}.Build()
+
+	nestingID := batonGrant.NewGrantID(g1, e2)
+	grantG1E2 := v2.Grant_builder{
+		Id:          nestingID,
+		Entitlement: e2,
+		Principal:   g1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{e1.GetId()},
+			Shallow:         false,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	oldFile, err := dotc1z.NewC1ZFile(ctx, oldPath, dotc1z.WithPragma("journal_mode", "WAL"), dotc1z.WithPragma("locking_mode", "normal"))
+	require.NoError(t, err)
+	defer oldFile.Close(ctx)
+
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, oldFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, oldFile.PutResources(ctx, g1, g2, u1))
+	require.NoError(t, oldFile.PutEntitlements(ctx, e1, e2))
+	require.NoError(t, oldFile.PutGrants(ctx, grantU1E1, grantU1E2, grantG1E2))
+	require.NoError(t, oldFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, oldFile, oldSyncID))
+
+	newFile, err := dotc1z.NewC1ZFile(ctx, newPath)
+	require.NoError(t, err)
+	defer newFile.Close(ctx)
+
+	newSyncID, err := newFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, newFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, newFile.PutResources(ctx, g1, g2, u1))
+	require.NoError(t, newFile.PutEntitlements(ctx, e1, e2))
+
+	require.NoError(t, oldFile.SetSyncID(ctx, ""))
+	require.NoError(t, oldFile.ViewSync(ctx, oldSyncID))
+	grantsToCopy, err := listGrantsWithStoredExpansion(ctx, oldFile)
+	require.NoError(t, err)
+	for _, g := range grantsToCopy {
+		if g.GetId() == nestingID {
+			continue
+		}
+		require.NoError(t, newFile.PutGrants(ctx, g))
+	}
+	require.NoError(t, newFile.EndSync(ctx))
+
+	diffAndApplyIncremental(t, ctx, newFile, oldFile, oldSyncID, newSyncID)
+
+	expectedFile, err := dotc1z.NewC1ZFile(ctx, expectedPath)
+	require.NoError(t, err)
+	defer expectedFile.Close(ctx)
+	expectedSyncID, err := expectedFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, expectedFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, expectedFile.PutResources(ctx, g1, g2, u1))
+	require.NoError(t, expectedFile.PutEntitlements(ctx, e1, e2))
+	require.NoError(t, expectedFile.PutGrants(ctx, grantU1E1, grantU1E2))
+	require.NoError(t, expectedFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, expectedFile, expectedSyncID))
+
+	got, err := loadGrantSourcesByKey(ctx, newFile, newSyncID)
+	require.NoError(t, err)
+	want, err := loadGrantSourcesByKey(ctx, expectedFile, expectedSyncID)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+
+	require.Contains(t, got, "group:g2:member|user|u1", "non-immutable direct grant should persist when sourceless")
+}

--- a/pkg/sync/incrementalexpansion/incremental_correctness_test.go
+++ b/pkg/sync/incrementalexpansion/incremental_correctness_test.go
@@ -2590,8 +2590,8 @@ func TestIncrementalExpansion_SourceListChange(t *testing.T) {
 }
 
 // TestIncrementalExpansion_SourcesInDataBlobNoop verifies that when a connector produces
-// identical grants across two syncs (a true no-op), the diff does not report false-positive
-// changed grant entitlements caused by expansion having written Sources into the data blob.
+// identical grants across two syncs (a true no-op), pre-expansion grant diffing does not
+// report false-positive changed entitlements.
 //
 // Scenario:
 //   - U1 has a direct grant on both E1 and E2 (destination of edge E1→E2).
@@ -2674,13 +2674,13 @@ func TestIncrementalExpansion_SourcesInDataBlobNoop(t *testing.T) {
 	// The connector produced identical grants, so the diff should report no changed entitlements.
 	require.Empty(t, changedEntIDs, "diff should report no changed grant entitlements for a connector-level no-op")
 
-	// Grant-level diffs should also be empty (no false-positive upserts/deletions).
+	// Pre-expansion grant upserts should not include source-only changes.
 	upserts, err := newFile.ListGrantsInternal(ctx, connectorstore.GrantListOptions{
 		Mode:   connectorstore.GrantListModePayload,
 		SyncID: upsertsSyncID,
 	})
 	require.NoError(t, err)
-	require.Empty(t, upserts.Rows, "grant upserts should be empty for connector-level no-op")
+	require.Empty(t, upserts.Rows, "pre-expansion grant upserts should be empty for source-only changes")
 
 	deletions, err := newFile.ListGrantsInternal(ctx, connectorstore.GrantListOptions{
 		Mode:   connectorstore.GrantListModePayload,
@@ -2691,6 +2691,223 @@ func TestIncrementalExpansion_SourcesInDataBlobNoop(t *testing.T) {
 
 	_, err = attached.DetachFile("attached")
 	require.NoError(t, err)
+
+	// Full incremental run should remain a no-op for output grant diffs.
+	result, err := incrementalexpansion.Run(ctx, newFile, incrementalexpansion.RunParams{
+		OldFile:   oldFile,
+		OldSyncID: oldSyncID,
+		NewSyncID: newSyncID,
+	})
+	require.NoError(t, err)
+
+	finalUpserts, err := newFile.ListGrantsInternal(ctx, connectorstore.GrantListOptions{
+		Mode:   connectorstore.GrantListModePayload,
+		SyncID: result.UpsertsSyncID,
+	})
+	require.NoError(t, err)
+	require.Empty(t, finalUpserts.Rows, "post-expansion upserts should remain empty for connector-level no-op")
+}
+
+func TestIncrementalExpansion_PostExpansionSourcesOnlyDeltaIncludedInUpserts(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	oldPath := filepath.Join(tmpDir, "old_sources_delta.c1z")
+	newPath := filepath.Join(tmpDir, "new_sources_delta.c1z")
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "G1"}.Build()
+	g2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g2"}.Build(), DisplayName: "G2"}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "U1"}.Build()
+
+	e1 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g1, "member"), Resource: g1, Slug: "member", DisplayName: "member"}.Build()
+	e2 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g2, "member"), Resource: g2, Slug: "member", DisplayName: "member"}.Build()
+
+	grantU1E1 := v2.Grant_builder{Id: batonGrant.NewGrantID(u1, e1), Entitlement: e1, Principal: u1}.Build()
+	grantU1E2 := v2.Grant_builder{Id: batonGrant.NewGrantID(u1, e2), Entitlement: e2, Principal: u1}.Build()
+	grantG1E2 := v2.Grant_builder{
+		Id:          batonGrant.NewGrantID(g1, e2),
+		Entitlement: e2,
+		Principal:   g1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{e1.GetId()},
+			Shallow:         false,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	// OLD: direct grants + edge grant, then expanded.
+	oldFile, err := dotc1z.NewC1ZFile(ctx, oldPath, dotc1z.WithPragma("journal_mode", "WAL"), dotc1z.WithPragma("locking_mode", "normal"))
+	require.NoError(t, err)
+	defer oldFile.Close(ctx)
+
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, oldFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, oldFile.PutResources(ctx, g1, g2, u1))
+	require.NoError(t, oldFile.PutEntitlements(ctx, e1, e2))
+	require.NoError(t, oldFile.PutGrants(ctx, grantU1E1, grantU1E2, grantG1E2))
+	require.NoError(t, oldFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, oldFile, oldSyncID))
+
+	// NEW: same direct grants, edge removed.
+	newFile, err := dotc1z.NewC1ZFile(ctx, newPath)
+	require.NoError(t, err)
+	defer newFile.Close(ctx)
+
+	newSyncID, err := newFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, newFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, newFile.PutResources(ctx, g1, g2, u1))
+	require.NoError(t, newFile.PutEntitlements(ctx, e1, e2))
+	require.NoError(t, newFile.PutGrants(ctx, grantU1E1, grantU1E2))
+	require.NoError(t, newFile.EndSync(ctx))
+
+	result, err := incrementalexpansion.Run(ctx, newFile, incrementalexpansion.RunParams{
+		OldFile:   oldFile,
+		OldSyncID: oldSyncID,
+		NewSyncID: newSyncID,
+	})
+	require.NoError(t, err)
+
+	upserts, err := newFile.ListGrantsInternal(ctx, connectorstore.GrantListOptions{
+		Mode:   connectorstore.GrantListModePayload,
+		SyncID: result.UpsertsSyncID,
+	})
+	require.NoError(t, err)
+
+	// U1->E2 should be emitted as an output-only source delta after edge removal.
+	found := false
+	for _, r := range upserts.Rows {
+		if r.Grant.GetId() == grantU1E2.GetId() {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "post-expansion upserts should include grant with sources-only change")
+}
+
+// TestIncrementalExpansion_ExpansionDeletedGrantMissingFromDeletionsSync verifies that
+// an immutable derived grant that exists in both OLD and NEW (carried forward from OLD
+// expanded state), and is then deleted during incremental expansion because it becomes
+// sourceless, appears in the deletions sync so downstream consumers know it was removed.
+//
+// The key difference from TestIncrementalExpansion_ImmutableSourcelessGrantDeleted is
+// that the derived grant is present in the NEW pre-expansion state (carried forward),
+// so the pre-expansion deletions diff does NOT catch it. Only the expansion pass deletes it.
+//
+// Scenario:
+//   - OLD: U1→E1 (direct), G1→E2 (expandable edge E1→E2).
+//     After expansion: derived immutable U1→E2.
+//   - NEW: same direct U1→E1, edge removed. But derived U1→E2 is carried forward
+//     from OLD expanded state into NEW (simulating compaction carry-forward).
+//   - After incremental expansion: U1→E2 deleted (immutable + sourceless).
+//   - The derived U1→E2 should appear in the deletions sync.
+func TestIncrementalExpansion_ExpansionDeletedGrantMissingFromDeletionsSync(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	oldPath := filepath.Join(tmpDir, "old_del_derived.c1z")
+	newPath := filepath.Join(tmpDir, "new_del_derived.c1z")
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "G1"}.Build()
+	g2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g2"}.Build(), DisplayName: "G2"}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "U1"}.Build()
+
+	e1 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g1, "member"), Resource: g1, Slug: "member", DisplayName: "member"}.Build()
+	e2 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g2, "member"), Resource: g2, Slug: "member", DisplayName: "member"}.Build()
+
+	grantU1E1 := v2.Grant_builder{Id: batonGrant.NewGrantID(u1, e1), Entitlement: e1, Principal: u1}.Build()
+	nestingID := batonGrant.NewGrantID(g1, e2)
+	grantG1E2 := v2.Grant_builder{
+		Id:          nestingID,
+		Entitlement: e2,
+		Principal:   g1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{e1.GetId()},
+			Shallow:         false,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	// OLD: direct grant + edge, expanded → derived immutable U1→E2.
+	oldFile, err := dotc1z.NewC1ZFile(ctx, oldPath, dotc1z.WithPragma("journal_mode", "WAL"), dotc1z.WithPragma("locking_mode", "normal"))
+	require.NoError(t, err)
+	defer oldFile.Close(ctx)
+
+	oldSyncID, err := oldFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, oldFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, oldFile.PutResources(ctx, g1, g2, u1))
+	require.NoError(t, oldFile.PutEntitlements(ctx, e1, e2))
+	require.NoError(t, oldFile.PutGrants(ctx, grantU1E1, grantG1E2))
+	require.NoError(t, oldFile.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, oldFile, oldSyncID))
+
+	derivedKey := "group:g2:member|user|u1"
+	oldGrants, err := loadGrantSourcesByKey(ctx, oldFile, oldSyncID)
+	require.NoError(t, err)
+	require.Contains(t, oldGrants, derivedKey, "derived grant U1→E2 should exist after expansion")
+
+	// NEW: direct grant U1→E1 (no edge), but carry forward ALL grants from OLD
+	// expanded state (including the derived U1→E2) except the edge grant.
+	newFile, err := dotc1z.NewC1ZFile(ctx, newPath)
+	require.NoError(t, err)
+	defer newFile.Close(ctx)
+
+	newSyncID, err := newFile.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, newFile.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, newFile.PutResources(ctx, g1, g2, u1))
+	require.NoError(t, newFile.PutEntitlements(ctx, e1, e2))
+
+	require.NoError(t, oldFile.SetSyncID(ctx, ""))
+	require.NoError(t, oldFile.ViewSync(ctx, oldSyncID))
+	grantsToCopy, err := listGrantsWithStoredExpansion(ctx, oldFile)
+	require.NoError(t, err)
+	for _, g := range grantsToCopy {
+		if g.GetId() == nestingID {
+			continue
+		}
+		require.NoError(t, newFile.PutGrants(ctx, g))
+	}
+	require.NoError(t, newFile.EndSync(ctx))
+
+	result, err := incrementalexpansion.Run(ctx, newFile, incrementalexpansion.RunParams{
+		OldFile:   oldFile,
+		OldSyncID: oldSyncID,
+		NewSyncID: newSyncID,
+	})
+	require.NoError(t, err)
+
+	// Verify the derived grant was actually deleted from newSyncID.
+	newGrants, err := loadGrantSourcesByKey(ctx, newFile, newSyncID)
+	require.NoError(t, err)
+	require.NotContains(t, newGrants, derivedKey, "derived grant should be deleted after incremental expansion")
+
+	// The derived immutable U1→E2 existed in both OLD and NEW before expansion,
+	// so the pre-expansion deletions diff did NOT catch it. The expansion pass
+	// deleted it. It should still appear in the deletions sync.
+	deletions, err := newFile.ListGrantsInternal(ctx, connectorstore.GrantListOptions{
+		Mode:   connectorstore.GrantListModePayload,
+		SyncID: result.DeletionsSyncID,
+	})
+	require.NoError(t, err)
+
+	derivedGrantID := batonGrant.NewGrantID(u1, e2)
+	found := false
+	for _, r := range deletions.Rows {
+		if r.Grant.GetId() == derivedGrantID {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "derived immutable grant deleted during expansion should appear in deletions sync (bug: currently missing)")
 }
 
 // -----------------------------------------------------------------------

--- a/pkg/sync/incrementalexpansion/stages.go
+++ b/pkg/sync/incrementalexpansion/stages.go
@@ -1,0 +1,429 @@
+package incrementalexpansion
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	c1zpb "github.com/conductorone/baton-sdk/pb/c1/c1z/v1"
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	reader_v2 "github.com/conductorone/baton-sdk/pb/c1/reader/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	"github.com/conductorone/baton-sdk/pkg/sync/expand"
+)
+
+// affectedEntitlements computes the forward-closure of entitlements potentially impacted by an edge delta.
+// Seeds include all src/dst entitlements that appear in added/removed edge sets.
+//
+// The closure is computed over the current edge set for targetSyncID (read from expandable-grant columns),
+// following src -> dst direction.
+func affectedEntitlements(ctx context.Context, store connectorstore.InternalWriter, targetSyncID string, delta *edgeDelta) (map[string]struct{}, error) {
+	if delta == nil {
+		return map[string]struct{}{}, nil
+	}
+
+	adj, err := buildAdjacency(ctx, store, targetSyncID)
+	if err != nil {
+		return nil, err
+	}
+
+	affected := make(map[string]struct{}, 256)
+	queue := make([]string, 0, 256)
+
+	seed := func(entID string) {
+		if entID == "" {
+			return
+		}
+		if _, ok := affected[entID]; ok {
+			return
+		}
+		affected[entID] = struct{}{}
+		queue = append(queue, entID)
+	}
+
+	for _, e := range delta.added {
+		seed(e.srcEntitlementID)
+		seed(e.dstEntitlementID)
+	}
+	for _, e := range delta.removed {
+		seed(e.srcEntitlementID)
+		seed(e.dstEntitlementID)
+	}
+
+	for len(queue) > 0 {
+		u := queue[0]
+		queue = queue[1:]
+		for _, v := range adj[u] {
+			if _, ok := affected[v]; ok {
+				continue
+			}
+			affected[v] = struct{}{}
+			queue = append(queue, v)
+		}
+	}
+
+	return affected, nil
+}
+
+func buildAdjacency(ctx context.Context, store connectorstore.InternalWriter, syncID string) (map[string][]string, error) {
+	adj := make(map[string][]string, 1024)
+	pageToken := ""
+	for {
+		resp, err := store.ListGrantsInternal(ctx, connectorstore.GrantListOptions{
+			Mode:           connectorstore.GrantListModeExpansion,
+			SyncID:         syncID,
+			PageToken:      pageToken,
+			ExpandableOnly: true,
+		})
+
+		if err != nil {
+			return nil, fmt.Errorf("build adjacency: %w", err)
+		}
+
+		for _, row := range resp.Rows {
+			def := row.Expansion
+			if def == nil {
+				continue
+			}
+			dst := def.TargetEntitlementID
+			for _, src := range def.SourceEntitlementIDs {
+				if src == "" || dst == "" {
+					continue
+				}
+				adj[src] = append(adj[src], dst)
+			}
+		}
+
+		if resp.NextPageToken == "" {
+			break
+		}
+		pageToken = resp.NextPageToken
+	}
+	return adj, nil
+}
+
+// invalidateChangedSourceEntitlements invalidates propagated sources for any entitlement whose grant-set changed.
+// It removes only the specific source key (the entitlement ID) from downstream grants along outgoing edges.
+func invalidateChangedSourceEntitlements(ctx context.Context, store connectorstore.InternalWriter, targetSyncID string, changedSources map[string]struct{}) error {
+	if len(changedSources) == 0 {
+		return nil
+	}
+
+	outgoing := make(map[string]edge)
+	pageToken := ""
+	for {
+		resp, err := store.ListGrantsInternal(ctx, connectorstore.GrantListOptions{
+			Mode:           connectorstore.GrantListModeExpansion,
+			SyncID:         targetSyncID,
+			PageToken:      pageToken,
+			ExpandableOnly: true,
+		})
+		if err != nil {
+			return err
+		}
+		for _, row := range resp.Rows {
+			def := row.Expansion
+			if def == nil {
+				continue
+			}
+			for _, src := range def.SourceEntitlementIDs {
+				if _, ok := changedSources[src]; !ok {
+					continue
+				}
+				e := edge{
+					srcEntitlementID:         src,
+					dstEntitlementID:         def.TargetEntitlementID,
+					shallow:                  def.Shallow,
+					principalResourceTypeIDs: def.ResourceTypeIDs,
+				}
+				outgoing[e.key()] = e
+			}
+		}
+		if resp.NextPageToken == "" {
+			break
+		}
+		pageToken = resp.NextPageToken
+	}
+
+	if len(outgoing) == 0 {
+		return nil
+	}
+
+	return invalidateRemovedEdges(ctx, store, targetSyncID, &edgeDelta{removed: outgoing})
+}
+
+// invalidateRemovedEdges removes only the specific source keys implied by removed edges.
+//
+// For each removed edge srcE->dstE (source entitlement to destination entitlement):
+// - list grants G for entitlement dstE (filtered by edge principal resource types)
+// - remove sources[srcE] from those grants
+// - if a grant G becomes sourceless and is GrantImmutable, delete it
+// - otherwise, persist the updated sources map.
+func invalidateRemovedEdges(ctx context.Context, store connectorstore.InternalWriter, targetSyncID string, delta *edgeDelta) error {
+	if delta == nil || len(delta.removed) == 0 {
+		return nil
+	}
+
+	type groupKey struct {
+		dstEntitlementID string
+		principalTypes   string
+	}
+
+	removedByGroup := make(map[groupKey]map[string]struct{}, len(delta.removed))
+	for _, e := range delta.removed {
+		k := groupKey{
+			dstEntitlementID: e.dstEntitlementID,
+			principalTypes:   strings.Join(e.principalResourceTypeIDs, "\x1f"),
+		}
+		m := removedByGroup[k]
+		if m == nil {
+			m = make(map[string]struct{}, 4)
+			removedByGroup[k] = m
+		}
+		m[e.srcEntitlementID] = struct{}{}
+	}
+
+	const chunkSize = 10000
+	updates := make([]*v2.Grant, 0, chunkSize)
+
+	flush := func() error {
+		if len(updates) == 0 {
+			return nil
+		}
+		if err := store.UpsertGrants(ctx, connectorstore.GrantUpsertOptions{
+			Mode:   connectorstore.GrantUpsertModeReplace,
+			SyncID: targetSyncID,
+		}, updates...); err != nil {
+			return err
+		}
+		updates = updates[:0]
+		return nil
+	}
+
+	for k, srcIDs := range removedByGroup {
+		ent := v2.Entitlement_builder{Id: k.dstEntitlementID}.Build()
+		reqAnnos := annotations.New(c1zpb.SyncDetails_builder{Id: targetSyncID}.Build())
+		var principalTypes []string
+		if k.principalTypes != "" {
+			principalTypes = strings.Split(k.principalTypes, "\x1f")
+		}
+		pageToken := ""
+		for {
+			resp, err := store.ListGrantsForEntitlement(ctx, reader_v2.GrantsReaderServiceListGrantsForEntitlementRequest_builder{
+				Entitlement:              ent,
+				PageToken:                pageToken,
+				PrincipalResourceTypeIds: principalTypes,
+				Annotations:              reqAnnos,
+			}.Build())
+			if err != nil {
+				return err
+			}
+
+			for _, g := range resp.GetList() {
+				srcs := g.GetSources().GetSources()
+				if len(srcs) == 0 {
+					continue
+				}
+				removedAny := false
+				for srcID := range srcIDs {
+					if _, ok := srcs[srcID]; !ok {
+						continue
+					}
+					delete(srcs, srcID)
+					removedAny = true
+				}
+				if !removedAny {
+					continue
+				}
+
+				// The expander adds a "self-source" (destination entitlement ID) to mark
+				// that a grant was originally direct. When all expansion sources are removed,
+				// we should also remove the self-source so the grant matches a fresh full
+				// expansion (which would have no sources for a direct grant).
+				selfSourceID := g.GetEntitlement().GetId()
+				if len(srcs) == 1 {
+					delete(srcs, selfSourceID)
+				}
+
+				if len(srcs) == 0 {
+					annos := annotations.Annotations(g.GetAnnotations())
+					if annos.Contains(&v2.GrantImmutable{}) {
+						if err := store.DeleteGrantInternal(ctx, connectorstore.GrantDeleteOptions{
+							SyncID: targetSyncID,
+						}, g.GetId()); err != nil {
+							return err
+						}
+						continue
+					}
+					g.SetSources(nil)
+				} else {
+					g.SetSources(v2.GrantSources_builder{Sources: srcs}.Build())
+				}
+
+				updates = append(updates, g)
+				if len(updates) >= chunkSize {
+					if err := flush(); err != nil {
+						return err
+					}
+				}
+			}
+
+			pageToken = resp.GetNextPageToken()
+			if pageToken == "" {
+				break
+			}
+		}
+	}
+
+	if err := flush(); err != nil {
+		return fmt.Errorf("invalidate removed edges: %w", err)
+	}
+	return nil
+}
+
+// markNeedsExpansionForAffectedEdges sets needs_expansion=1 for expandable grants whose edges are
+// in/leading into the affected subgraph.
+//
+// With grant-column storage, we conservatively mark an expandable grant dirty if:
+// - its destination entitlement is affected, OR
+// - any of its source entitlement IDs is affected.
+func markNeedsExpansionForAffectedEdges(ctx context.Context, store connectorstore.InternalWriter, targetSyncID string, affected map[string]struct{}) error {
+	if len(affected) == 0 {
+		return nil
+	}
+
+	pageToken := ""
+	toMark := make([]string, 0, 1024)
+
+	for {
+		resp, err := store.ListGrantsInternal(ctx, connectorstore.GrantListOptions{
+			Mode:           connectorstore.GrantListModeExpansion,
+			SyncID:         targetSyncID,
+			PageToken:      pageToken,
+			ExpandableOnly: true,
+		})
+		if err != nil {
+			return err
+		}
+
+		for _, def := range resp.Rows {
+			_, dstAffected := affected[def.Expansion.TargetEntitlementID]
+			srcAffected := false
+			if !dstAffected {
+				for _, src := range def.Expansion.SourceEntitlementIDs {
+					if _, ok := affected[src]; ok {
+						srcAffected = true
+						break
+					}
+				}
+			}
+			if dstAffected || srcAffected {
+				toMark = append(toMark, def.Expansion.GrantExternalID)
+			}
+		}
+
+		if resp.NextPageToken == "" {
+			break
+		}
+		pageToken = resp.NextPageToken
+	}
+
+	const chunk = 5000
+	for i := 0; i < len(toMark); i += chunk {
+		j := i + chunk
+		if j > len(toMark) {
+			j = len(toMark)
+		}
+		if err := store.SetNeedsExpansionForGrants(ctx, targetSyncID, toMark[i:j], true); err != nil {
+			return fmt.Errorf("mark needs_expansion: %w", err)
+		}
+	}
+	return nil
+}
+
+// expandDirtySubgraph loads only expandable edges marked needs_expansion=1 for syncID,
+// runs the standard expander, then clears needs_expansion.
+//
+// NOTE: This expands only edges present in the loaded subgraph. The caller is responsible for
+// marking the correct edge-defining grants as needs_expansion based on the affected subgraph.
+func expandDirtySubgraph(ctx context.Context, c1f *dotc1z.C1File, syncID string) error {
+	if err := c1f.SetSupportsDiff(ctx, syncID); err != nil {
+		return err
+	}
+
+	graph := expand.NewEntitlementGraph(ctx)
+	reqAnnos := annotations.New(c1zpb.SyncDetails_builder{Id: syncID}.Build())
+
+	pageToken := ""
+	for {
+		resp, err := c1f.ListGrantsInternal(ctx, connectorstore.GrantListOptions{
+			Mode:               connectorstore.GrantListModeExpansionNeedsOnly,
+			SyncID:             syncID,
+			PageToken:          pageToken,
+			NeedsExpansionOnly: true,
+		})
+		if err != nil {
+			return err
+		}
+
+		for _, row := range resp.Rows {
+			def := row.Expansion
+			if def == nil {
+				continue
+			}
+			principalID := v2.ResourceId_builder{
+				ResourceType: def.PrincipalResourceTypeID,
+				Resource:     def.PrincipalResourceID,
+			}.Build()
+
+			for _, srcEntitlementID := range def.SourceEntitlementIDs {
+				srcEntitlement, err := c1f.GetEntitlement(ctx, reader_v2.EntitlementsReaderServiceGetEntitlementRequest_builder{
+					EntitlementId: srcEntitlementID,
+					Annotations:   reqAnnos,
+				}.Build())
+				if err != nil {
+					if errors.Is(err, sql.ErrNoRows) {
+						continue
+					}
+					return fmt.Errorf("error fetching source entitlement %q: %w", srcEntitlementID, err)
+				}
+
+				sourceEntitlementResourceID := srcEntitlement.GetEntitlement().GetResource().GetId()
+				if sourceEntitlementResourceID == nil {
+					return fmt.Errorf("source entitlement resource id was nil")
+				}
+				if principalID.GetResourceType() != sourceEntitlementResourceID.GetResourceType() ||
+					principalID.GetResource() != sourceEntitlementResourceID.GetResource() {
+					return fmt.Errorf("source entitlement resource id did not match grant principal id")
+				}
+
+				graph.AddEntitlementID(def.TargetEntitlementID)
+				graph.AddEntitlementID(srcEntitlementID)
+				if err := graph.AddEdge(ctx, srcEntitlementID, def.TargetEntitlementID, def.Shallow, def.ResourceTypeIDs); err != nil {
+					return fmt.Errorf("error adding edge to graph: %w", err)
+				}
+			}
+		}
+
+		if resp.NextPageToken == "" {
+			break
+		}
+		pageToken = resp.NextPageToken
+	}
+	graph.Loaded = true
+
+	if err := graph.FixCycles(ctx); err != nil {
+		return err
+	}
+
+	expander := expand.NewExpander(c1f, graph).WithSyncID(syncID)
+	if err := expander.Run(ctx); err != nil {
+		return err
+	}
+
+	return c1f.ClearNeedsExpansionForSync(ctx, syncID)
+}

--- a/pkg/sync/incrementalexpansion/stages.go
+++ b/pkg/sync/incrementalexpansion/stages.go
@@ -195,7 +195,7 @@ func invalidateRemovedEdges(ctx context.Context, store connectorstore.InternalWr
 			return nil
 		}
 		if err := store.UpsertGrants(ctx, connectorstore.GrantUpsertOptions{
-			Mode:   connectorstore.GrantUpsertModeReplace,
+			Mode:   connectorstore.GrantUpsertModePreserveExpansion,
 			SyncID: targetSyncID,
 		}, updates...); err != nil {
 			return err

--- a/pkg/sync/incrementalexpansion/stages_test.go
+++ b/pkg/sync/incrementalexpansion/stages_test.go
@@ -1,0 +1,924 @@
+package incrementalexpansion
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	batonEntitlement "github.com/conductorone/baton-sdk/pkg/types/entitlement"
+	batonGrant "github.com/conductorone/baton-sdk/pkg/types/grant"
+	"github.com/stretchr/testify/require"
+)
+
+// -----------------------------------------------------------------------
+// EdgeDelta unit tests (cross-DB attached queries)
+// -----------------------------------------------------------------------
+
+func TestEdgeDelta_EmptySyncs(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+
+	walNormal := []dotc1z.C1ZOption{dotc1z.WithPragma("journal_mode", "WAL"), dotc1z.WithPragma("locking_mode", "normal")}
+	walOpts := []dotc1z.C1ZOption{dotc1z.WithPragma("journal_mode", "WAL")}
+
+	oldFile, oldSyncID := setupExpandableSync(ctx, t, tmpDir, "old_empty",
+		[]*v2.ResourceType{groupRT, userRT}, nil, nil, nil, walNormal...)
+	defer oldFile.Close(ctx)
+
+	newFile, newSyncID := setupExpandableSync(ctx, t, tmpDir, "new_empty",
+		[]*v2.ResourceType{groupRT, userRT}, nil, nil, nil, walOpts...)
+	defer newFile.Close(ctx)
+
+	attached, err := newFile.AttachFile(oldFile, "attached")
+	require.NoError(t, err)
+	addedDefs, err := attached.ComputeAddedExpandableGrants(ctx, oldSyncID, newSyncID)
+	require.NoError(t, err)
+	removedDefs, err := attached.ComputeRemovedExpandableGrants(ctx, oldSyncID, newSyncID)
+	require.NoError(t, err)
+	_, err = attached.DetachFile("attached")
+	require.NoError(t, err)
+
+	delta := edgeDeltaFromExpandableGrants(addedDefs, removedDefs)
+	require.Empty(t, delta.added)
+	require.Empty(t, delta.removed)
+}
+
+func TestEdgeDelta_AddsAndRemoves(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+
+	walNormal := []dotc1z.C1ZOption{dotc1z.WithPragma("journal_mode", "WAL"), dotc1z.WithPragma("locking_mode", "normal")}
+	walOpts := []dotc1z.C1ZOption{dotc1z.WithPragma("journal_mode", "WAL")}
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "G1"}.Build()
+	g2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g2"}.Build(), DisplayName: "G2"}.Build()
+	g3 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g3"}.Build(), DisplayName: "G3"}.Build()
+
+	e1 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g1, "member"), Resource: g1, Slug: "member", DisplayName: "member"}.Build()
+	e2 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g2, "member"), Resource: g2, Slug: "member", DisplayName: "member"}.Build()
+	e3 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g3, "member"), Resource: g3, Slug: "member", DisplayName: "member"}.Build()
+
+	grantE1E2 := v2.Grant_builder{
+		Id: batonGrant.NewGrantID(g1, e2), Entitlement: e2, Principal: g1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds: []string{e1.GetId()}, ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	oldFile, oldSyncID := setupExpandableSync(ctx, t, tmpDir, "old_delta",
+		[]*v2.ResourceType{groupRT, userRT},
+		[]*v2.Resource{g1, g2, g3},
+		[]*v2.Entitlement{e1, e2, e3},
+		[]*v2.Grant{grantE1E2},
+		walNormal...)
+	defer oldFile.Close(ctx)
+
+	grantE2E3 := v2.Grant_builder{
+		Id: batonGrant.NewGrantID(g2, e3), Entitlement: e3, Principal: g2,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds: []string{e2.GetId()}, ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	newFile, newSyncID := setupExpandableSync(ctx, t, tmpDir, "new_delta",
+		[]*v2.ResourceType{groupRT, userRT},
+		[]*v2.Resource{g1, g2, g3},
+		[]*v2.Entitlement{e1, e2, e3},
+		[]*v2.Grant{grantE2E3},
+		walOpts...)
+	defer newFile.Close(ctx)
+
+	attached, err := newFile.AttachFile(oldFile, "attached")
+	require.NoError(t, err)
+	addedDefs, err := attached.ComputeAddedExpandableGrants(ctx, oldSyncID, newSyncID)
+	require.NoError(t, err)
+	removedDefs, err := attached.ComputeRemovedExpandableGrants(ctx, oldSyncID, newSyncID)
+	require.NoError(t, err)
+	_, err = attached.DetachFile("attached")
+	require.NoError(t, err)
+
+	delta := edgeDeltaFromExpandableGrants(addedDefs, removedDefs)
+
+	require.Len(t, delta.added, 1, "should have one added edge (E2→E3)")
+	require.Len(t, delta.removed, 1, "should have one removed edge (E1→E2)")
+
+	for _, e := range delta.added {
+		require.Equal(t, e2.GetId(), e.srcEntitlementID)
+		require.Equal(t, e3.GetId(), e.dstEntitlementID)
+	}
+	for _, e := range delta.removed {
+		require.Equal(t, e1.GetId(), e.srcEntitlementID)
+		require.Equal(t, e2.GetId(), e.dstEntitlementID)
+	}
+}
+
+func TestEdgeDelta_ShallowFlagCreatesDistinctKeys(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+
+	walNormal := []dotc1z.C1ZOption{dotc1z.WithPragma("journal_mode", "WAL"), dotc1z.WithPragma("locking_mode", "normal")}
+	walOpts := []dotc1z.C1ZOption{dotc1z.WithPragma("journal_mode", "WAL")}
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "G1"}.Build()
+	g2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g2"}.Build(), DisplayName: "G2"}.Build()
+
+	e1 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g1, "member"), Resource: g1, Slug: "member", DisplayName: "member"}.Build()
+	e2 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g2, "member"), Resource: g2, Slug: "member", DisplayName: "member"}.Build()
+
+	nestingID := batonGrant.NewGrantID(g1, e2)
+	grantShallow := v2.Grant_builder{
+		Id: nestingID, Entitlement: e2, Principal: g1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds: []string{e1.GetId()}, Shallow: true, ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	oldFile, oldSyncID := setupExpandableSync(ctx, t, tmpDir, "old_shallow_key",
+		[]*v2.ResourceType{groupRT, userRT},
+		[]*v2.Resource{g1, g2},
+		[]*v2.Entitlement{e1, e2},
+		[]*v2.Grant{grantShallow},
+		walNormal...)
+	defer oldFile.Close(ctx)
+
+	grantDeep := v2.Grant_builder{
+		Id: nestingID, Entitlement: e2, Principal: g1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds: []string{e1.GetId()}, Shallow: false, ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	newFile, newSyncID := setupExpandableSync(ctx, t, tmpDir, "new_shallow_key",
+		[]*v2.ResourceType{groupRT, userRT},
+		[]*v2.Resource{g1, g2},
+		[]*v2.Entitlement{e1, e2},
+		[]*v2.Grant{grantDeep},
+		walOpts...)
+	defer newFile.Close(ctx)
+
+	attached, err := newFile.AttachFile(oldFile, "attached")
+	require.NoError(t, err)
+	addedDefs, err := attached.ComputeAddedExpandableGrants(ctx, oldSyncID, newSyncID)
+	require.NoError(t, err)
+	removedDefs, err := attached.ComputeRemovedExpandableGrants(ctx, oldSyncID, newSyncID)
+	require.NoError(t, err)
+	_, err = attached.DetachFile("attached")
+	require.NoError(t, err)
+
+	delta := edgeDeltaFromExpandableGrants(addedDefs, removedDefs)
+
+	require.Len(t, delta.added, 1, "new deep edge should be in added")
+	require.Len(t, delta.removed, 1, "old shallow edge should be in removed")
+
+	for _, e := range delta.added {
+		require.False(t, e.shallow)
+	}
+	for _, e := range delta.removed {
+		require.True(t, e.shallow)
+	}
+}
+
+// -----------------------------------------------------------------------
+// affectedEntitlements unit tests
+// -----------------------------------------------------------------------
+
+func TestAffectedEntitlements_NilDelta(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	c1f, syncID := setupExpandableSync(ctx, t, tmpDir, "nil_delta",
+		[]*v2.ResourceType{groupRT}, nil, nil, nil)
+	defer c1f.Close(ctx)
+
+	affected, err := affectedEntitlements(ctx, c1f, syncID, nil)
+	require.NoError(t, err)
+	require.Empty(t, affected)
+}
+
+func TestAffectedEntitlements_EmptyDelta(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	c1f, syncID := setupExpandableSync(ctx, t, tmpDir, "empty_delta",
+		[]*v2.ResourceType{groupRT}, nil, nil, nil)
+	defer c1f.Close(ctx)
+
+	delta := &edgeDelta{
+		added:   map[string]edge{},
+		removed: map[string]edge{},
+	}
+
+	affected, err := affectedEntitlements(ctx, c1f, syncID, delta)
+	require.NoError(t, err)
+	require.Empty(t, affected)
+}
+
+func TestAffectedEntitlements_ForwardClosure(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "G1"}.Build()
+	g2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g2"}.Build(), DisplayName: "G2"}.Build()
+	g3 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g3"}.Build(), DisplayName: "G3"}.Build()
+	g4 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g4"}.Build(), DisplayName: "G4"}.Build()
+
+	e1 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g1, "member"), Resource: g1, Slug: "member", DisplayName: "member"}.Build()
+	e2 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g2, "member"), Resource: g2, Slug: "member", DisplayName: "member"}.Build()
+	e3 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g3, "member"), Resource: g3, Slug: "member", DisplayName: "member"}.Build()
+	e4 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g4, "member"), Resource: g4, Slug: "member", DisplayName: "member"}.Build()
+
+	mkEdge := func(src *v2.Entitlement, dst *v2.Entitlement, principal *v2.Resource) *v2.Grant {
+		return v2.Grant_builder{
+			Id: batonGrant.NewGrantID(principal, dst), Entitlement: dst, Principal: principal,
+			Annotations: annotations.New(v2.GrantExpandable_builder{
+				EntitlementIds: []string{src.GetId()}, ResourceTypeIds: []string{"user"},
+			}.Build()),
+		}.Build()
+	}
+
+	c1f, syncID := setupExpandableSync(ctx, t, tmpDir, "chain",
+		[]*v2.ResourceType{groupRT, userRT},
+		[]*v2.Resource{g1, g2, g3, g4},
+		[]*v2.Entitlement{e1, e2, e3, e4},
+		[]*v2.Grant{mkEdge(e1, e2, g1), mkEdge(e2, e3, g2), mkEdge(e3, e4, g3)})
+	defer c1f.Close(ctx)
+
+	e := edge{srcEntitlementID: e1.GetId(), dstEntitlementID: e2.GetId()}
+	delta := &edgeDelta{
+		added: map[string]edge{e.key(): e},
+	}
+
+	affected, err := affectedEntitlements(ctx, c1f, syncID, delta)
+	require.NoError(t, err)
+
+	for _, eid := range []string{e1.GetId(), e2.GetId(), e3.GetId(), e4.GetId()} {
+		_, ok := affected[eid]
+		require.True(t, ok, "entitlement %s should be in affected set", eid)
+	}
+}
+
+// -----------------------------------------------------------------------
+// markNeedsExpansionForAffectedEdges unit tests
+// -----------------------------------------------------------------------
+
+func TestMarkNeedsExpansion_EmptyAffected(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	c1f, syncID := setupExpandableSync(ctx, t, tmpDir, "empty_affected",
+		[]*v2.ResourceType{groupRT}, nil, nil, nil)
+	defer c1f.Close(ctx)
+
+	err := markNeedsExpansionForAffectedEdges(ctx, c1f, syncID, map[string]struct{}{})
+	require.NoError(t, err)
+}
+
+func TestMarkNeedsExpansion_MarksCorrectGrants(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "G1"}.Build()
+	g2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g2"}.Build(), DisplayName: "G2"}.Build()
+	g3 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g3"}.Build(), DisplayName: "G3"}.Build()
+
+	e1 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g1, "member"), Resource: g1, Slug: "member", DisplayName: "member"}.Build()
+	e2 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g2, "member"), Resource: g2, Slug: "member", DisplayName: "member"}.Build()
+	e3 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g3, "member"), Resource: g3, Slug: "member", DisplayName: "member"}.Build()
+
+	grantE1E2 := v2.Grant_builder{
+		Id: batonGrant.NewGrantID(g1, e2), Entitlement: e2, Principal: g1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds: []string{e1.GetId()}, ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	grantE2E3 := v2.Grant_builder{
+		Id: batonGrant.NewGrantID(g2, e3), Entitlement: e3, Principal: g2,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds: []string{e2.GetId()}, ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	c1f, syncID := setupExpandableSync(ctx, t, tmpDir, "mark_grants",
+		[]*v2.ResourceType{groupRT, userRT},
+		[]*v2.Resource{g1, g2, g3},
+		[]*v2.Entitlement{e1, e2, e3},
+		[]*v2.Grant{grantE1E2, grantE2E3})
+	defer c1f.Close(ctx)
+
+	require.NoError(t, c1f.ClearNeedsExpansionForSync(ctx, syncID))
+
+	affected := map[string]struct{}{e1.GetId(): {}}
+	err := markNeedsExpansionForAffectedEdges(ctx, c1f, syncID, affected)
+	require.NoError(t, err)
+
+	resp, err := c1f.ListGrantsInternal(ctx, connectorstore.GrantListOptions{
+		Mode:               connectorstore.GrantListModeExpansionNeedsOnly,
+		SyncID:             syncID,
+		NeedsExpansionOnly: true,
+	})
+	require.NoError(t, err)
+
+	markedIDs := make(map[string]bool)
+	for _, row := range resp.Rows {
+		markedIDs[row.Expansion.GrantExternalID] = true
+	}
+
+	require.True(t, markedIDs[grantE1E2.GetId()], "E1→E2 should be marked (source E1 is affected)")
+	require.False(t, markedIDs[grantE2E3.GetId()], "E2→E3 should NOT be marked (neither E2 nor E3 is in affected set)")
+}
+
+// Regression coverage for "expand too much" bugs:
+// - verifies mixed edge delta shapes (add/remove/source-list/shallow/filter changes),
+// - verifies the exact affected entitlement closure,
+// - verifies exact dirty expandable grants (no extras) are marked for re-expansion.
+func TestMarkNeedsExpansion_WhitelistExpectedDirtySubgraph(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+
+	walNormal := []dotc1z.C1ZOption{dotc1z.WithPragma("journal_mode", "WAL"), dotc1z.WithPragma("locking_mode", "normal")}
+	walOpts := []dotc1z.C1ZOption{dotc1z.WithPragma("journal_mode", "WAL")}
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "G1"}.Build()
+	g2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g2"}.Build(), DisplayName: "G2"}.Build()
+	g3 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g3"}.Build(), DisplayName: "G3"}.Build()
+	g4 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g4"}.Build(), DisplayName: "G4"}.Build()
+	g5 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g5"}.Build(), DisplayName: "G5"}.Build()
+	g6 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g6"}.Build(), DisplayName: "G6"}.Build()
+	g7 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g7"}.Build(), DisplayName: "G7"}.Build()
+	g8 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g8"}.Build(), DisplayName: "G8"}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "U1"}.Build()
+	u2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u2"}.Build(), DisplayName: "U2"}.Build()
+
+	e1 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g1, "member"), Resource: g1, Slug: "member", DisplayName: "member"}.Build()
+	e2m := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g2, "member"), Resource: g2, Slug: "member", DisplayName: "member"}.Build()
+	e2a := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g2, "admin"), Resource: g2, Slug: "admin", DisplayName: "admin"}.Build()
+	e3 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g3, "member"), Resource: g3, Slug: "member", DisplayName: "member"}.Build()
+	e4 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g4, "member"), Resource: g4, Slug: "member", DisplayName: "member"}.Build()
+	e5 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g5, "member"), Resource: g5, Slug: "member", DisplayName: "member"}.Build()
+	e6 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g6, "member"), Resource: g6, Slug: "member", DisplayName: "member"}.Build()
+	e7 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g7, "member"), Resource: g7, Slug: "member", DisplayName: "member"}.Build()
+	e8 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g8, "member"), Resource: g8, Slug: "member", DisplayName: "member"}.Build()
+
+	// Old graph edges:
+	// e1->e2m, e2m->e3(deep), e3->e4(filter=user), e2m->e5, e5->e6, e7->e8(unaffected branch)
+	oldEdge12 := v2.Grant_builder{
+		Id: batonGrant.NewGrantID(g1, e2m), Entitlement: e2m, Principal: g1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds: []string{e1.GetId()}, ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+	oldEdge23 := v2.Grant_builder{
+		Id: batonGrant.NewGrantID(g2, e3), Entitlement: e3, Principal: g2,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds: []string{e2m.GetId()}, Shallow: false, ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+	oldEdge34 := v2.Grant_builder{
+		Id: batonGrant.NewGrantID(g3, e4), Entitlement: e4, Principal: g3,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds: []string{e3.GetId()}, ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+	oldEdge25 := v2.Grant_builder{
+		Id: batonGrant.NewGrantID(g2, e5), Entitlement: e5, Principal: g2,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds: []string{e2m.GetId()}, ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+	oldEdge56 := v2.Grant_builder{
+		Id: batonGrant.NewGrantID(g5, e6), Entitlement: e6, Principal: g5,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds: []string{e5.GetId()}, ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+	oldEdge78 := v2.Grant_builder{
+		Id: batonGrant.NewGrantID(g7, e8), Entitlement: e8, Principal: g7,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds: []string{e7.GetId()}, ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+	oldDirectU1E1 := v2.Grant_builder{Id: batonGrant.NewGrantID(u1, e1), Entitlement: e1, Principal: u1}.Build()
+
+	oldFile, oldSyncID := setupExpandableSync(ctx, t, tmpDir, "old_whitelist",
+		[]*v2.ResourceType{groupRT, userRT},
+		[]*v2.Resource{g1, g2, g3, g4, g5, g6, g7, g8, u1, u2},
+		[]*v2.Entitlement{e1, e2m, e2a, e3, e4, e5, e6, e7, e8},
+		[]*v2.Grant{oldDirectU1E1, oldEdge12, oldEdge23, oldEdge34, oldEdge25, oldEdge56, oldEdge78},
+		walNormal...)
+	defer oldFile.Close(ctx)
+
+	// New graph edges:
+	// - keep e1->e2m
+	// - toggle e2m->e3 to shallow=true
+	// - change e3->e4 filter to user+group
+	// - source-list replacement e2m->e5 -> e2a->e5
+	// - remove e5->e6
+	// - add e4->e6
+	// - keep unaffected e7->e8
+	newEdge12 := oldEdge12
+	newEdge23 := v2.Grant_builder{
+		Id: oldEdge23.GetId(), Entitlement: e3, Principal: g2,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds: []string{e2m.GetId()}, Shallow: true, ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+	newEdge34 := v2.Grant_builder{
+		Id: oldEdge34.GetId(), Entitlement: e4, Principal: g3,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds: []string{e3.GetId()}, ResourceTypeIds: []string{"user", "group"},
+		}.Build()),
+	}.Build()
+	newEdge25 := v2.Grant_builder{
+		Id: oldEdge25.GetId(), Entitlement: e5, Principal: g2,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds: []string{e2a.GetId()}, ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+	newEdge46 := v2.Grant_builder{
+		Id: batonGrant.NewGrantID(g4, e6), Entitlement: e6, Principal: g4,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds: []string{e4.GetId()}, ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+	newEdge78 := oldEdge78
+	// Source-grant change independent of edge-definition changes: add direct grant on e1.
+	newDirectU2E1 := v2.Grant_builder{Id: batonGrant.NewGrantID(u2, e1), Entitlement: e1, Principal: u2}.Build()
+
+	newFile, newSyncID := setupExpandableSync(ctx, t, tmpDir, "new_whitelist",
+		[]*v2.ResourceType{groupRT, userRT},
+		[]*v2.Resource{g1, g2, g3, g4, g5, g6, g7, g8, u1, u2},
+		[]*v2.Entitlement{e1, e2m, e2a, e3, e4, e5, e6, e7, e8},
+		[]*v2.Grant{oldDirectU1E1, newDirectU2E1, newEdge12, newEdge23, newEdge34, newEdge25, newEdge46, newEdge78},
+		walOpts...)
+	defer newFile.Close(ctx)
+
+	attached, err := newFile.AttachFile(oldFile, "attached")
+	require.NoError(t, err)
+	addedDefs, err := attached.ComputeAddedExpandableGrants(ctx, oldSyncID, newSyncID)
+	require.NoError(t, err)
+	removedDefs, err := attached.ComputeRemovedExpandableGrants(ctx, oldSyncID, newSyncID)
+	require.NoError(t, err)
+	_, err = attached.DetachFile("attached")
+	require.NoError(t, err)
+
+	delta := edgeDeltaFromExpandableGrants(addedDefs, removedDefs)
+	require.Len(t, delta.added, 4, "expected added edges: e2a->e5, e2m->e3(shallow), e3->e4(filter), e4->e6")
+	require.Len(t, delta.removed, 4, "expected removed edges: e2m->e5, e2m->e3(old shallow), e3->e4(old filter), e5->e6")
+
+	affected, err := affectedEntitlements(ctx, newFile, newSyncID, delta)
+	require.NoError(t, err)
+
+	wantAffected := map[string]struct{}{
+		e2a.GetId(): {},
+		e5.GetId():  {},
+		e4.GetId():  {},
+		e6.GetId():  {},
+		e2m.GetId(): {},
+		e3.GetId():  {},
+	}
+	require.Equal(t, wantAffected, affected, "affected entitlement closure should match exact whitelist")
+
+	// Add a changed source seed (grant-set change on e1) as Apply/Run do.
+	affected[e1.GetId()] = struct{}{}
+
+	require.NoError(t, newFile.ClearNeedsExpansionForSync(ctx, newSyncID))
+	require.NoError(t, markNeedsExpansionForAffectedEdges(ctx, newFile, newSyncID, affected))
+
+	resp, err := newFile.ListGrantsInternal(ctx, connectorstore.GrantListOptions{
+		Mode:               connectorstore.GrantListModeExpansionNeedsOnly,
+		SyncID:             newSyncID,
+		NeedsExpansionOnly: true,
+	})
+	require.NoError(t, err)
+
+	gotMarked := make(map[string]struct{}, len(resp.Rows))
+	for _, row := range resp.Rows {
+		gotMarked[row.Expansion.GrantExternalID] = struct{}{}
+	}
+	wantMarked := map[string]struct{}{
+		newEdge12.GetId(): {},
+		newEdge23.GetId(): {},
+		newEdge34.GetId(): {},
+		newEdge25.GetId(): {},
+		newEdge46.GetId(): {},
+	}
+	require.Equal(t, wantMarked, gotMarked, "dirty expandable grants should match exact whitelist (no over-marking)")
+}
+
+// -----------------------------------------------------------------------
+// invalidateRemovedEdges unit tests
+// -----------------------------------------------------------------------
+
+func TestInvalidateRemovedEdges_NilDelta(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	c1f, syncID := setupExpandableSync(ctx, t, tmpDir, "nil_delta_inv",
+		[]*v2.ResourceType{groupRT}, nil, nil, nil)
+	defer c1f.Close(ctx)
+
+	err := invalidateRemovedEdges(ctx, c1f, syncID, nil)
+	require.NoError(t, err)
+}
+
+func TestInvalidateRemovedEdges_EmptyRemoved(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	c1f, syncID := setupExpandableSync(ctx, t, tmpDir, "empty_removed",
+		[]*v2.ResourceType{groupRT}, nil, nil, nil)
+	defer c1f.Close(ctx)
+
+	delta := &edgeDelta{removed: map[string]edge{}}
+	err := invalidateRemovedEdges(ctx, c1f, syncID, delta)
+	require.NoError(t, err)
+}
+
+// -----------------------------------------------------------------------
+// invalidateChangedSourceEntitlements unit tests
+// -----------------------------------------------------------------------
+
+func TestInvalidateChangedSources_EmptySet(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	c1f, syncID := setupExpandableSync(ctx, t, tmpDir, "empty_changed",
+		[]*v2.ResourceType{groupRT}, nil, nil, nil)
+	defer c1f.Close(ctx)
+
+	err := invalidateChangedSourceEntitlements(ctx, c1f, syncID, map[string]struct{}{})
+	require.NoError(t, err)
+}
+
+func TestInvalidateChangedSources_NonEmptyRemovesDownstreamDerived(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	dbPath := filepath.Join(tmpDir, "changed_sources_nonempty.c1z")
+	c1f, err := dotc1z.NewC1ZFile(ctx, dbPath)
+	require.NoError(t, err)
+	defer c1f.Close(ctx)
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "G1"}.Build()
+	g2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g2"}.Build(), DisplayName: "G2"}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "U1"}.Build()
+
+	e1 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g1, "member"), Resource: g1, Slug: "member", DisplayName: "member"}.Build()
+	e2 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g2, "member"), Resource: g2, Slug: "member", DisplayName: "member"}.Build()
+
+	grantU1E1 := v2.Grant_builder{Id: batonGrant.NewGrantID(u1, e1), Entitlement: e1, Principal: u1}.Build()
+	grantG1E2 := v2.Grant_builder{
+		Id:          batonGrant.NewGrantID(g1, e2),
+		Entitlement: e2,
+		Principal:   g1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{e1.GetId()},
+			Shallow:         false,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	syncID, err := c1f.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, c1f.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, c1f.PutResources(ctx, g1, g2, u1))
+	require.NoError(t, c1f.PutEntitlements(ctx, e1, e2))
+	require.NoError(t, c1f.PutGrants(ctx, grantU1E1, grantG1E2))
+	require.NoError(t, c1f.EndSync(ctx))
+	require.NoError(t, runFullExpansion(ctx, c1f, syncID))
+
+	before, err := loadGrantSourcesByKey(ctx, c1f, syncID)
+	require.NoError(t, err)
+	require.Contains(t, before, "group:g2:member|user|u1", "derived grant should exist pre-invalidation")
+
+	err = invalidateChangedSourceEntitlements(ctx, c1f, syncID, map[string]struct{}{e1.GetId(): {}})
+	require.NoError(t, err)
+
+	after, err := loadGrantSourcesByKey(ctx, c1f, syncID)
+	require.NoError(t, err)
+	require.NotContains(t, after, "group:g2:member|user|u1", "changed source invalidation should remove downstream derived grant")
+}
+
+// -----------------------------------------------------------------------
+// markNeedsExpansionForAffectedEdges chunk boundary
+// -----------------------------------------------------------------------
+
+func TestMarkNeedsExpansion_ChunkBoundary5001(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+
+	srcResource := v2.Resource_builder{
+		Id:          v2.ResourceId_builder{ResourceType: "group", Resource: "g-src"}.Build(),
+		DisplayName: "G-Src",
+	}.Build()
+	srcEnt := v2.Entitlement_builder{
+		Id:          batonEntitlement.NewEntitlementID(srcResource, "member"),
+		Resource:    srcResource,
+		Slug:        "member",
+		DisplayName: "member",
+	}.Build()
+
+	resources := []*v2.Resource{srcResource}
+	entitlements := []*v2.Entitlement{srcEnt}
+	grants := make([]*v2.Grant, 0, 5001)
+
+	for i := 0; i < 5001; i++ {
+		dstResource := v2.Resource_builder{
+			Id:          v2.ResourceId_builder{ResourceType: "group", Resource: fmt.Sprintf("g-dst-%d", i)}.Build(),
+			DisplayName: fmt.Sprintf("G-Dst-%d", i),
+		}.Build()
+		dstEnt := v2.Entitlement_builder{
+			Id:          batonEntitlement.NewEntitlementID(dstResource, "member"),
+			Resource:    dstResource,
+			Slug:        "member",
+			DisplayName: "member",
+		}.Build()
+
+		resources = append(resources, dstResource)
+		entitlements = append(entitlements, dstEnt)
+		grants = append(grants, v2.Grant_builder{
+			Id:          batonGrant.NewGrantID(srcResource, dstEnt),
+			Entitlement: dstEnt,
+			Principal:   srcResource,
+			Annotations: annotations.New(v2.GrantExpandable_builder{
+				EntitlementIds:  []string{srcEnt.GetId()},
+				Shallow:         false,
+				ResourceTypeIds: []string{"user"},
+			}.Build()),
+		}.Build())
+	}
+
+	c1f, syncID := setupExpandableSync(ctx, t, tmpDir, "chunk_5001",
+		[]*v2.ResourceType{groupRT, userRT},
+		resources,
+		entitlements,
+		grants,
+	)
+	defer c1f.Close(ctx)
+
+	require.NoError(t, c1f.ClearNeedsExpansionForSync(ctx, syncID))
+
+	err := markNeedsExpansionForAffectedEdges(ctx, c1f, syncID, map[string]struct{}{srcEnt.GetId(): {}})
+	require.NoError(t, err)
+
+	pageToken := ""
+	count := 0
+	for {
+		resp, err := c1f.ListGrantsInternal(ctx, connectorstore.GrantListOptions{
+			Mode:               connectorstore.GrantListModeExpansionNeedsOnly,
+			SyncID:             syncID,
+			PageToken:          pageToken,
+			NeedsExpansionOnly: true,
+		})
+		require.NoError(t, err)
+		count += len(resp.Rows)
+		if resp.NextPageToken == "" {
+			break
+		}
+		pageToken = resp.NextPageToken
+	}
+	require.Equal(t, 5001, count, "all expandable grants should be marked across chunk boundary")
+}
+
+// -----------------------------------------------------------------------
+// EdgeDelta pagination
+// -----------------------------------------------------------------------
+
+func TestEdgeDelta_PaginationOver10000Rows(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+
+	walNormal := []dotc1z.C1ZOption{dotc1z.WithPragma("journal_mode", "WAL"), dotc1z.WithPragma("locking_mode", "normal")}
+	walOpts := []dotc1z.C1ZOption{dotc1z.WithPragma("journal_mode", "WAL")}
+	oldFile, oldSyncID := setupExpandableSync(ctx, t, tmpDir, "old_paged_delta",
+		[]*v2.ResourceType{groupRT, userRT}, nil, nil, nil, walNormal...)
+	defer oldFile.Close(ctx)
+
+	srcResource := v2.Resource_builder{
+		Id:          v2.ResourceId_builder{ResourceType: "group", Resource: "g-src"}.Build(),
+		DisplayName: "G-Src",
+	}.Build()
+	srcEnt := v2.Entitlement_builder{
+		Id:          batonEntitlement.NewEntitlementID(srcResource, "member"),
+		Resource:    srcResource,
+		Slug:        "member",
+		DisplayName: "member",
+	}.Build()
+
+	resources := []*v2.Resource{srcResource}
+	entitlements := []*v2.Entitlement{srcEnt}
+	grants := make([]*v2.Grant, 0, 10001)
+	for i := 0; i < 10001; i++ {
+		dstResource := v2.Resource_builder{
+			Id:          v2.ResourceId_builder{ResourceType: "group", Resource: fmt.Sprintf("g-delta-%d", i)}.Build(),
+			DisplayName: fmt.Sprintf("G-Delta-%d", i),
+		}.Build()
+		dstEnt := v2.Entitlement_builder{
+			Id:          batonEntitlement.NewEntitlementID(dstResource, "member"),
+			Resource:    dstResource,
+			Slug:        "member",
+			DisplayName: "member",
+		}.Build()
+
+		resources = append(resources, dstResource)
+		entitlements = append(entitlements, dstEnt)
+		grants = append(grants, v2.Grant_builder{
+			Id:          batonGrant.NewGrantID(srcResource, dstEnt),
+			Entitlement: dstEnt,
+			Principal:   srcResource,
+			Annotations: annotations.New(v2.GrantExpandable_builder{
+				EntitlementIds:  []string{srcEnt.GetId()},
+				Shallow:         false,
+				ResourceTypeIds: []string{"user"},
+			}.Build()),
+		}.Build())
+	}
+
+	newFile, newSyncID := setupExpandableSync(ctx, t, tmpDir, "new_paged_delta",
+		[]*v2.ResourceType{groupRT, userRT},
+		resources,
+		entitlements,
+		grants,
+		walOpts...)
+	defer newFile.Close(ctx)
+
+	attached, err := newFile.AttachFile(oldFile, "attached")
+	require.NoError(t, err)
+	addedDefs, err := attached.ComputeAddedExpandableGrants(ctx, oldSyncID, newSyncID)
+	require.NoError(t, err)
+	removedDefs, err := attached.ComputeRemovedExpandableGrants(ctx, oldSyncID, newSyncID)
+	require.NoError(t, err)
+	_, err = attached.DetachFile("attached")
+	require.NoError(t, err)
+
+	delta := edgeDeltaFromExpandableGrants(addedDefs, removedDefs)
+	require.Len(t, delta.added, 10001, "all edges should be read across page boundaries")
+	require.Len(t, delta.removed, 0)
+}
+
+// -----------------------------------------------------------------------
+// expandDirtySubgraph unit tests
+// -----------------------------------------------------------------------
+
+func TestExpandDirtySubgraph_MissingSourceEntitlementSkipped(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.c1z")
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "G1"}.Build()
+	g2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g2"}.Build(), DisplayName: "G2"}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "U1"}.Build()
+
+	e2 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g2, "member"), Resource: g2, Slug: "member", DisplayName: "member"}.Build()
+
+	grantU1E2 := v2.Grant_builder{
+		Id: batonGrant.NewGrantID(u1, e2), Entitlement: e2, Principal: u1,
+	}.Build()
+
+	nonExistentEntitlementID := batonEntitlement.NewEntitlementID(g1, "member")
+	grantG1E2 := v2.Grant_builder{
+		Id: batonGrant.NewGrantID(g1, e2), Entitlement: e2, Principal: g1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{nonExistentEntitlementID},
+			Shallow:         false,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	c1f, err := dotc1z.NewC1ZFile(ctx, dbPath)
+	require.NoError(t, err)
+	defer c1f.Close(ctx)
+
+	syncID, err := c1f.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, c1f.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, c1f.PutResources(ctx, g1, g2, u1))
+	require.NoError(t, c1f.PutEntitlements(ctx, e2))
+	require.NoError(t, c1f.PutGrants(ctx, grantU1E2, grantG1E2))
+	require.NoError(t, c1f.EndSync(ctx))
+
+	require.NoError(t, c1f.SetNeedsExpansionForGrants(ctx, syncID, []string{grantG1E2.GetId()}, true))
+
+	err = expandDirtySubgraph(ctx, c1f, syncID)
+	require.NoError(t, err, "expandDirtySubgraph should skip missing source entitlements gracefully")
+
+	require.NoError(t, c1f.SetSyncID(ctx, ""))
+	require.NoError(t, c1f.ViewSync(ctx, syncID))
+
+	grantCount := 0
+	pageToken := ""
+	for {
+		resp, err := c1f.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{PageToken: pageToken}.Build())
+		require.NoError(t, err)
+		grantCount += len(resp.GetList())
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			break
+		}
+	}
+	require.Equal(t, 2, grantCount, "should have exactly 2 grants (no derived grants from missing source)")
+}
+
+func TestExpandDirtySubgraph_ValidSourceEntitlementWorks(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.c1z")
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "G1"}.Build()
+	g2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g2"}.Build(), DisplayName: "G2"}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "U1"}.Build()
+
+	e1 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g1, "member"), Resource: g1, Slug: "member", DisplayName: "member"}.Build()
+	e2 := v2.Entitlement_builder{Id: batonEntitlement.NewEntitlementID(g2, "member"), Resource: g2, Slug: "member", DisplayName: "member"}.Build()
+
+	grantU1E1 := v2.Grant_builder{
+		Id: batonGrant.NewGrantID(u1, e1), Entitlement: e1, Principal: u1,
+	}.Build()
+
+	grantG1E2 := v2.Grant_builder{
+		Id: batonGrant.NewGrantID(g1, e2), Entitlement: e2, Principal: g1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{e1.GetId()},
+			Shallow:         false,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	c1f, err := dotc1z.NewC1ZFile(ctx, dbPath)
+	require.NoError(t, err)
+	defer c1f.Close(ctx)
+
+	syncID, err := c1f.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, c1f.PutResourceTypes(ctx, groupRT, userRT))
+	require.NoError(t, c1f.PutResources(ctx, g1, g2, u1))
+	require.NoError(t, c1f.PutEntitlements(ctx, e1, e2))
+	require.NoError(t, c1f.PutGrants(ctx, grantU1E1, grantG1E2))
+	require.NoError(t, c1f.EndSync(ctx))
+
+	require.NoError(t, c1f.SetNeedsExpansionForGrants(ctx, syncID, []string{grantG1E2.GetId()}, true))
+
+	err = expandDirtySubgraph(ctx, c1f, syncID)
+	require.NoError(t, err)
+
+	require.NoError(t, c1f.SetSyncID(ctx, ""))
+	require.NoError(t, c1f.ViewSync(ctx, syncID))
+
+	grantCount := 0
+	pageToken := ""
+	for {
+		resp, err := c1f.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{PageToken: pageToken}.Build())
+		require.NoError(t, err)
+		grantCount += len(resp.GetList())
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			break
+		}
+	}
+	require.Equal(t, 3, grantCount, "should have 3 grants (2 original + 1 derived)")
+}

--- a/pkg/synccompactor/attached/attached_test.go
+++ b/pkg/synccompactor/attached/attached_test.go
@@ -262,6 +262,7 @@ func TestAttachedCompactorDoesNotOperateOnDiffSyncTypes(t *testing.T) {
 
 	oldSyncID, err := oldDB.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
 	require.NoError(t, err)
+	require.NoError(t, oldDB.SetSupportsDiff(ctx, oldSyncID))
 	require.NoError(t, oldDB.EndSync(ctx))
 	require.NoError(t, oldDB.SetSupportsDiff(ctx, oldSyncID))
 


### PR DESCRIPTION
## Goals:
   * Bound incremental work for grant expansion to only affected subgraphs.
   * Prevent broad re-expansion from metadata artifacts.
   * Thorough correctness coverage with targeted performance-regression coverage.

## Summary
1. Implement SQL-driven incremental expansion over old/new sync diffs (attached DB), including:
   * edge delta computation (added/removed expandable edges),
   * changed grant entitlement detection,
   *  staged invalidation + targeted re-expansion.
2. Move expansion/source metadata into SQL columns (expansion, needs_expansion, sources) and make grant diffing compare stable payload fields (data + expansion) to avoid false-positive churn.
3. Fix two major over-expansion regressions:
   * direct-grant source tracking causing broad false diffs,
   * stale needs_expansion flags after full expansion causing later partial runs to re-expand too much.
4. Add chunked dirty marking + pagination-safe processing for large grant sets.
6. Expand coverage substantially:
   * end-to-end incremental correctness matrix,
   * dirty-subgraph and needs-expansion stage tests,
   * migration/backfill tests for grant metadata columns,
   * perf/regression-focused tests and diff/expand benchmarks.
