### PR TITLE
Set SQLite temp_store_directory to database parent directory

### DIFF
--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -440,6 +440,19 @@ func (c *C1File) init(ctx context.Context) error {
 		return err
 	}
 
+	// Direct SQLite temp files into the same directory as the database file.
+	// Without this, SQLite writes temp files (sort spill, temp tables, temp
+	// indexes) to the OS temp directory (/tmp), outside the managed c1z
+	// directory tree. Those files are only cleaned up on db.Close(); if the
+	// process is killed they leak. By pointing temp_store_directory at the
+	// db's parent directory, cleanupDbDir's RemoveAll catches them.
+	dbDir := filepath.Dir(c.dbFilePath)
+	//nolint:gosec // dbDir is derived from our own dbFilePath, not user input.
+	_, err = c.db.ExecContext(ctx, fmt.Sprintf("PRAGMA temp_store_directory = '%s'", dbDir))
+	if err != nil {
+		return fmt.Errorf("c1file-init: error setting temp_store_directory: %w", err)
+	}
+
 	err = c.InitTables(ctx)
 	if err != nil {
 		l.Error("c1file-init: error initializing tables", zap.Error(err))

--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -447,7 +447,6 @@ func (c *C1File) init(ctx context.Context) error {
 	// process is killed they leak. By pointing temp_store_directory at the
 	// db's parent directory, cleanupDbDir's RemoveAll catches them.
 	dbDir := filepath.Dir(c.dbFilePath)
-	//nolint:gosec // dbDir is derived from our own dbFilePath, not user input.
 	_, err = c.db.ExecContext(ctx, fmt.Sprintf("PRAGMA temp_store_directory = '%s'", dbDir))
 	if err != nil {
 		return fmt.Errorf("c1file-init: error setting temp_store_directory: %w", err)

--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -664,6 +664,19 @@ func (c *C1File) init(ctx context.Context) error {
 		return err
 	}
 
+	// Direct SQLite temp files into the same directory as the database file.
+	// Without this, SQLite writes temp files (sort spill, temp tables, temp
+	// indexes) to the OS temp directory (/tmp), outside the managed c1z
+	// directory tree. Those files are only cleaned up on db.Close(); if the
+	// process is killed they leak. By pointing temp_store_directory at the
+	// db's parent directory, cleanupDbDir's RemoveAll catches them.
+	dbDir := filepath.Dir(c.dbFilePath)
+	//nolint:gosec // dbDir is derived from our own dbFilePath, not user input.
+	_, err = c.db.ExecContext(ctx, fmt.Sprintf("PRAGMA temp_store_directory = '%s'", dbDir))
+	if err != nil {
+		return fmt.Errorf("c1file-init: error setting temp_store_directory: %w", err)
+	}
+
 	shouldOptimize, err := c.InitTables(ctx)
 	if err != nil {
 		l.Error("c1file-init: error initializing tables", zap.Error(err))

--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -671,7 +671,6 @@ func (c *C1File) init(ctx context.Context) error {
 	// process is killed they leak. By pointing temp_store_directory at the
 	// db's parent directory, cleanupDbDir's RemoveAll catches them.
 	dbDir := filepath.Dir(c.dbFilePath)
-	//nolint:gosec // dbDir is derived from our own dbFilePath, not user input.
 	_, err = c.db.ExecContext(ctx, fmt.Sprintf("PRAGMA temp_store_directory = '%s'", dbDir))
 	if err != nil {
 		return fmt.Errorf("c1file-init: error setting temp_store_directory: %w", err)


### PR DESCRIPTION
SQLite writes temp files (sort spill, temp tables, temp indexes) to the OS temp directory by default. After the removal of temp_store=MEMORY, these files land in /tmp outside the managed c1z directory tree. If the process is killed before db.Close(), they leak.

By setting temp_store_directory to the database file's parent directory, cleanupDbDir's os.RemoveAll catches any leftover SQLite temp files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized database temporary file storage location for enhanced performance and system resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->