### PR TITLE
OPS-458: Remove redundant size verification from c1z managers

### DIFF
--- a/pkg/dotc1z/manager/local/local.go
+++ b/pkg/dotc1z/manager/local/local.go
@@ -59,35 +59,13 @@ func (l *localManager) copyFileToTmp(ctx context.Context) error {
 		}
 		defer f.Close()
 
-		// Get source file size for verification
-		sourceStat, err := f.Stat()
-		if err != nil {
-			return fmt.Errorf("failed to stat source file: %w", err)
-		}
-		expectedSize := sourceStat.Size()
-
-		written, err := io.Copy(tmp, f)
+		_, err = io.Copy(tmp, f)
 		if err != nil {
 			return err
 		}
 
-		// CRITICAL: Sync to ensure all data is written before file is used.
-		// This is especially important on ZFS ARC where writes may be cached
-		// and reads can happen before buffers are flushed to disk.
 		if err := tmp.Sync(); err != nil {
 			return fmt.Errorf("failed to sync temp file: %w", err)
-		}
-
-		// Verify file size matches what we wrote (defensive check)
-		stat, err := tmp.Stat()
-		if err != nil {
-			return fmt.Errorf("failed to stat temp file: %w", err)
-		}
-		if stat.Size() != written {
-			return fmt.Errorf("file size mismatch: wrote %d bytes but file is %d bytes", written, stat.Size())
-		}
-		if written != expectedSize {
-			return fmt.Errorf("copy size mismatch: expected %d bytes from source but copied %d bytes", expectedSize, written)
 		}
 	}
 

--- a/pkg/dotc1z/manager/s3/s3.go
+++ b/pkg/dotc1z/manager/s3/s3.go
@@ -53,29 +53,15 @@ func (s *s3Manager) copyToTempFile(ctx context.Context, r io.Reader) error {
 	s.tmpFile = f.Name()
 
 	if r != nil {
-		written, err := io.Copy(f, r)
+		_, err = io.Copy(f, r)
 		if err != nil {
 			_ = f.Close()
 			return err
 		}
 
-		// CRITICAL: Sync to ensure all data is written before file is used.
-		// This is especially important on ZFS ARC where writes may be cached
-		// and reads can happen before buffers are flushed to disk.
 		if err := f.Sync(); err != nil {
 			_ = f.Close()
 			return fmt.Errorf("failed to sync temp file: %w", err)
-		}
-
-		// Verify file size matches what we wrote (defensive check)
-		stat, err := f.Stat()
-		if err != nil {
-			_ = f.Close()
-			return fmt.Errorf("failed to stat temp file: %w", err)
-		}
-		if stat.Size() != written {
-			_ = f.Close()
-			return fmt.Errorf("file size mismatch: wrote %d bytes but file is %d bytes", written, stat.Size())
 		}
 	}
 


### PR DESCRIPTION
## Summary

Removes redundant post-fsync file size verification from the local and S3 c1z managers. Keeps the `Sync()` calls.

## What's removed and why

Both `local.go` and `s3.go` had this pattern after `io.Copy` + `Sync()`:

```go
stat, err := tmp.Stat()
if stat.Size() != written {
    return fmt.Errorf("file size mismatch: ...")
}
```

**Why it's redundant:** After `fsync()` completes successfully, `Stat().Size()` is guaranteed to match the bytes written. The only scenario where they'd differ is a hardware-level storage failure — but such a failure would also corrupt the data content, which a size-only check wouldn't catch. The c1z zstd stream validation on the upload path in c1 is a strictly better integrity check.

The `local.go` source-size pre-check (`sourceStat.Size() != written`) is also removed — if the source file is being concurrently modified, this check is racy anyway, and if it's not being modified, `io.Copy` will copy the exact contents.

## What's preserved

- `tmp.Sync()` / `f.Sync()` — ensures data is flushed to disk before SQLite opens the file
- All other fsync calls in `file.go` (decompression sync, save sync)

## Context

These checks were added during c1z corruption investigation. The actual root causes have since been identified and fixed:
- platform-repo PR (fd leak fix) — fd leak fix
- platform-repo PR (fd leak follow-up) — fd leak follow-up
- [C1Z Defensive Fsync Audit](https://www.notion.so/3244694ad8468167a139d641909ce342) — full analysis
- Linear: OPS-458

## Test plan

- [x] Package compiles cleanly
- [x] goimports passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
