### PR TITLE
Add periodic WAL checkpoint and WAL size logging

### DIFF
--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/doug-martin/goqu/v9"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.opentelemetry.io/otel/attribute"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -424,7 +425,7 @@ func (c *C1File) Close(ctx context.Context) error {
 	return nil
 }
 
-// CheckpointWAL runs a non-blocking PASSIVE checkpoint and logs WAL stats.
+// CheckpointWAL runs a non-blocking PASSIVE checkpoint and records WAL stats on a span.
 // PASSIVE checkpoints as many frames as possible without blocking writers,
 // preventing unbounded WAL growth between transactions.
 func (c *C1File) CheckpointWAL(ctx context.Context) error {
@@ -432,12 +433,13 @@ func (c *C1File) CheckpointWAL(ctx context.Context) error {
 		return nil
 	}
 
-	l := ctxzap.Extract(ctx)
+	ctx, span := tracer.Start(ctx, "C1File.CheckpointWAL")
+	defer span.End()
 
 	var busy, log, checkpointed int
 	row := c.rawDb.QueryRowContext(ctx, "PRAGMA wal_checkpoint(PASSIVE)")
 	if err := row.Scan(&busy, &log, &checkpointed); err != nil {
-		l.Warn("wal-checkpoint: passive checkpoint failed", zap.Error(err))
+		span.RecordError(err)
 		return err
 	}
 
@@ -448,12 +450,11 @@ func (c *C1File) CheckpointWAL(ctx context.Context) error {
 		walSizeBytes = fi.Size()
 	}
 
-	l.Info("wal-checkpoint: passive checkpoint complete",
-		zap.Int("busy", busy),
-		zap.Int("log_pages", log),
-		zap.Int("checkpointed_pages", checkpointed),
-		zap.Int64("wal_size_bytes", walSizeBytes),
-		zap.String("db_path", c.dbFilePath),
+	span.SetAttributes(
+		attribute.Int("wal.checkpoint.busy", busy),
+		attribute.Int("wal.checkpoint.log_pages", log),
+		attribute.Int("wal.checkpoint.checkpointed_pages", checkpointed),
+		attribute.Int64("wal.size_bytes", walSizeBytes),
 	)
 
 	return nil
@@ -482,15 +483,16 @@ func (c *C1File) truncateWAL(ctx context.Context) (int, int, int, error) {
 		walSizeBytes = fi.Size()
 	}
 
+	span.SetAttributes(
+		attribute.Int("wal.checkpoint.busy", busy),
+		attribute.Int("wal.checkpoint.log_pages", log),
+		attribute.Int("wal.checkpoint.checkpointed_pages", checkpointed),
+		attribute.Int64("wal.size_bytes", walSizeBytes),
+	)
+
 	if busy != 0 || (log >= 0 && checkpointed < log) {
 		ctxzap.Extract(ctx).Warn("wal-checkpoint: truncate checkpoint incomplete",
 			zap.Int("busy", busy),
-			zap.Int("log_pages", log),
-			zap.Int("checkpointed_pages", checkpointed),
-			zap.Int64("wal_size_bytes", walSizeBytes),
-			zap.String("db_path", c.dbFilePath))
-	} else {
-		ctxzap.Extract(ctx).Info("wal-checkpoint: truncate checkpoint complete",
 			zap.Int("log_pages", log),
 			zap.Int("checkpointed_pages", checkpointed),
 			zap.Int64("wal_size_bytes", walSizeBytes),

--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -425,41 +425,6 @@ func (c *C1File) Close(ctx context.Context) error {
 	return nil
 }
 
-// CheckpointWAL runs a non-blocking PASSIVE checkpoint and records WAL stats on a span.
-// PASSIVE checkpoints as many frames as possible without blocking writers,
-// preventing unbounded WAL growth between transactions.
-func (c *C1File) CheckpointWAL(ctx context.Context) error {
-	if c.readOnly || c.rawDb == nil {
-		return nil
-	}
-
-	ctx, span := tracer.Start(ctx, "C1File.CheckpointWAL")
-	defer span.End()
-
-	var busy, log, checkpointed int
-	row := c.rawDb.QueryRowContext(ctx, "PRAGMA wal_checkpoint(PASSIVE)")
-	if err := row.Scan(&busy, &log, &checkpointed); err != nil {
-		span.RecordError(err)
-		return err
-	}
-
-	// Stat the WAL file for size visibility.
-	var walSizeBytes int64
-	walPath := c.dbFilePath + "-wal"
-	if fi, err := os.Stat(walPath); err == nil {
-		walSizeBytes = fi.Size()
-	}
-
-	span.SetAttributes(
-		attribute.Int("wal.checkpoint.busy", busy),
-		attribute.Int("wal.checkpoint.log_pages", log),
-		attribute.Int("wal.checkpoint.checkpointed_pages", checkpointed),
-		attribute.Int64("wal.size_bytes", walSizeBytes),
-	)
-
-	return nil
-}
-
 // truncateWAL truncates the WAL file.
 // Returns the busy, log, and checkpointed values.
 func (c *C1File) truncateWAL(ctx context.Context) (int, int, int, error) {

--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -424,6 +424,41 @@ func (c *C1File) Close(ctx context.Context) error {
 	return nil
 }
 
+// CheckpointWAL runs a non-blocking PASSIVE checkpoint and logs WAL stats.
+// PASSIVE checkpoints as many frames as possible without blocking writers,
+// preventing unbounded WAL growth between transactions.
+func (c *C1File) CheckpointWAL(ctx context.Context) error {
+	if c.readOnly {
+		return nil
+	}
+
+	l := ctxzap.Extract(ctx)
+
+	var busy, log, checkpointed int
+	row := c.rawDb.QueryRowContext(ctx, "PRAGMA wal_checkpoint(PASSIVE)")
+	if err := row.Scan(&busy, &log, &checkpointed); err != nil {
+		l.Warn("wal-checkpoint: passive checkpoint failed", zap.Error(err))
+		return err
+	}
+
+	// Stat the WAL file for size visibility.
+	var walSizeBytes int64
+	walPath := c.dbFilePath + "-wal"
+	if fi, err := os.Stat(walPath); err == nil {
+		walSizeBytes = fi.Size()
+	}
+
+	l.Info("wal-checkpoint: passive checkpoint complete",
+		zap.Int("busy", busy),
+		zap.Int("log_pages", log),
+		zap.Int("checkpointed_pages", checkpointed),
+		zap.Int64("wal_size_bytes", walSizeBytes),
+		zap.String("db_path", c.dbFilePath),
+	)
+
+	return nil
+}
+
 // truncateWAL truncates the WAL file.
 // Returns the busy, log, and checkpointed values.
 func (c *C1File) truncateWAL(ctx context.Context) (int, int, int, error) {
@@ -440,12 +475,25 @@ func (c *C1File) truncateWAL(ctx context.Context) (int, int, int, error) {
 	if err := row.Scan(&busy, &log, &checkpointed); err != nil {
 		return 0, 0, 0, err
 	}
-	// TODO: Return an error here?
+	// Stat the WAL file for size visibility.
+	var walSizeBytes int64
+	walPath := c.dbFilePath + "-wal"
+	if fi, err := os.Stat(walPath); err == nil {
+		walSizeBytes = fi.Size()
+	}
+
 	if busy != 0 || (log >= 0 && checkpointed < log) {
-		ctxzap.Extract(ctx).Info("WAL checkpoint incomplete",
+		ctxzap.Extract(ctx).Warn("wal-checkpoint: truncate checkpoint incomplete",
 			zap.Int("busy", busy),
-			zap.Int("log", log),
-			zap.Int("checkpointed", checkpointed),
+			zap.Int("log_pages", log),
+			zap.Int("checkpointed_pages", checkpointed),
+			zap.Int64("wal_size_bytes", walSizeBytes),
+			zap.String("db_path", c.dbFilePath))
+	} else {
+		ctxzap.Extract(ctx).Info("wal-checkpoint: truncate checkpoint complete",
+			zap.Int("log_pages", log),
+			zap.Int("checkpointed_pages", checkpointed),
+			zap.Int64("wal_size_bytes", walSizeBytes),
 			zap.String("db_path", c.dbFilePath))
 	}
 	return busy, log, checkpointed, nil

--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -429,7 +429,7 @@ func (c *C1File) Close(ctx context.Context) error {
 // PASSIVE checkpoints as many frames as possible without blocking writers,
 // preventing unbounded WAL growth between transactions.
 func (c *C1File) CheckpointWAL(ctx context.Context) error {
-	if c.readOnly {
+	if c.readOnly || c.rawDb == nil {
 		return nil
 	}
 

--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -574,41 +574,6 @@ func (c *C1File) closeRawDB(ctx context.Context) error {
 	return err
 }
 
-// CheckpointWAL runs a non-blocking PASSIVE checkpoint and records WAL stats on a span.
-// PASSIVE checkpoints as many frames as possible without blocking writers,
-// preventing unbounded WAL growth between transactions.
-func (c *C1File) CheckpointWAL(ctx context.Context) error {
-	if c.readOnly || c.rawDb == nil {
-		return nil
-	}
-
-	ctx, span := tracer.Start(ctx, "C1File.CheckpointWAL")
-	defer span.End()
-
-	var busy, log, checkpointed int
-	row := c.rawDb.QueryRowContext(ctx, "PRAGMA wal_checkpoint(PASSIVE)")
-	if err := row.Scan(&busy, &log, &checkpointed); err != nil {
-		span.RecordError(err)
-		return err
-	}
-
-	// Stat the WAL file for size visibility.
-	var walSizeBytes int64
-	walPath := c.dbFilePath + "-wal"
-	if fi, err := os.Stat(walPath); err == nil {
-		walSizeBytes = fi.Size()
-	}
-
-	span.SetAttributes(
-		attribute.Int("wal.checkpoint.busy", busy),
-		attribute.Int("wal.checkpoint.log_pages", log),
-		attribute.Int("wal.checkpoint.checkpointed_pages", checkpointed),
-		attribute.Int64("wal.size_bytes", walSizeBytes),
-	)
-
-	return nil
-}
-
 // truncateWAL truncates the WAL file.
 // Returns the busy, log, and checkpointed values.
 func (c *C1File) truncateWAL(ctx context.Context) (int, int, int, error) {

--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -574,7 +574,7 @@ func (c *C1File) closeRawDB(ctx context.Context) error {
 	return err
 }
 
-// CheckpointWAL runs a non-blocking PASSIVE checkpoint and logs WAL stats.
+// CheckpointWAL runs a non-blocking PASSIVE checkpoint and records WAL stats on a span.
 // PASSIVE checkpoints as many frames as possible without blocking writers,
 // preventing unbounded WAL growth between transactions.
 func (c *C1File) CheckpointWAL(ctx context.Context) error {
@@ -582,12 +582,13 @@ func (c *C1File) CheckpointWAL(ctx context.Context) error {
 		return nil
 	}
 
-	l := ctxzap.Extract(ctx)
+	ctx, span := tracer.Start(ctx, "C1File.CheckpointWAL")
+	defer span.End()
 
 	var busy, log, checkpointed int
 	row := c.rawDb.QueryRowContext(ctx, "PRAGMA wal_checkpoint(PASSIVE)")
 	if err := row.Scan(&busy, &log, &checkpointed); err != nil {
-		l.Warn("wal-checkpoint: passive checkpoint failed", zap.Error(err))
+		span.RecordError(err)
 		return err
 	}
 
@@ -598,12 +599,11 @@ func (c *C1File) CheckpointWAL(ctx context.Context) error {
 		walSizeBytes = fi.Size()
 	}
 
-	l.Info("wal-checkpoint: passive checkpoint complete",
-		zap.Int("busy", busy),
-		zap.Int("log_pages", log),
-		zap.Int("checkpointed_pages", checkpointed),
-		zap.Int64("wal_size_bytes", walSizeBytes),
-		zap.String("db_path", c.dbFilePath),
+	span.SetAttributes(
+		attribute.Int("wal.checkpoint.busy", busy),
+		attribute.Int("wal.checkpoint.log_pages", log),
+		attribute.Int("wal.checkpoint.checkpointed_pages", checkpointed),
+		attribute.Int64("wal.size_bytes", walSizeBytes),
 	)
 
 	return nil
@@ -632,15 +632,16 @@ func (c *C1File) truncateWAL(ctx context.Context) (int, int, int, error) {
 		walSizeBytes = fi.Size()
 	}
 
+	span.SetAttributes(
+		attribute.Int("wal.checkpoint.busy", busy),
+		attribute.Int("wal.checkpoint.log_pages", log),
+		attribute.Int("wal.checkpoint.checkpointed_pages", checkpointed),
+		attribute.Int64("wal.size_bytes", walSizeBytes),
+	)
+
 	if busy != 0 || (log >= 0 && checkpointed < log) {
 		ctxzap.Extract(ctx).Warn("wal-checkpoint: truncate checkpoint incomplete",
 			zap.Int("busy", busy),
-			zap.Int("log_pages", log),
-			zap.Int("checkpointed_pages", checkpointed),
-			zap.Int64("wal_size_bytes", walSizeBytes),
-			zap.String("db_path", c.dbFilePath))
-	} else {
-		ctxzap.Extract(ctx).Info("wal-checkpoint: truncate checkpoint complete",
 			zap.Int("log_pages", log),
 			zap.Int("checkpointed_pages", checkpointed),
 			zap.Int64("wal_size_bytes", walSizeBytes),

--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -578,7 +578,7 @@ func (c *C1File) closeRawDB(ctx context.Context) error {
 // PASSIVE checkpoints as many frames as possible without blocking writers,
 // preventing unbounded WAL growth between transactions.
 func (c *C1File) CheckpointWAL(ctx context.Context) error {
-	if c.readOnly {
+	if c.readOnly || c.rawDb == nil {
 		return nil
 	}
 

--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -574,6 +574,41 @@ func (c *C1File) closeRawDB(ctx context.Context) error {
 	return err
 }
 
+// CheckpointWAL runs a non-blocking PASSIVE checkpoint and logs WAL stats.
+// PASSIVE checkpoints as many frames as possible without blocking writers,
+// preventing unbounded WAL growth between transactions.
+func (c *C1File) CheckpointWAL(ctx context.Context) error {
+	if c.readOnly {
+		return nil
+	}
+
+	l := ctxzap.Extract(ctx)
+
+	var busy, log, checkpointed int
+	row := c.rawDb.QueryRowContext(ctx, "PRAGMA wal_checkpoint(PASSIVE)")
+	if err := row.Scan(&busy, &log, &checkpointed); err != nil {
+		l.Warn("wal-checkpoint: passive checkpoint failed", zap.Error(err))
+		return err
+	}
+
+	// Stat the WAL file for size visibility.
+	var walSizeBytes int64
+	walPath := c.dbFilePath + "-wal"
+	if fi, err := os.Stat(walPath); err == nil {
+		walSizeBytes = fi.Size()
+	}
+
+	l.Info("wal-checkpoint: passive checkpoint complete",
+		zap.Int("busy", busy),
+		zap.Int("log_pages", log),
+		zap.Int("checkpointed_pages", checkpointed),
+		zap.Int64("wal_size_bytes", walSizeBytes),
+		zap.String("db_path", c.dbFilePath),
+	)
+
+	return nil
+}
+
 // truncateWAL truncates the WAL file.
 // Returns the busy, log, and checkpointed values.
 func (c *C1File) truncateWAL(ctx context.Context) (int, int, int, error) {
@@ -590,12 +625,25 @@ func (c *C1File) truncateWAL(ctx context.Context) (int, int, int, error) {
 	if err := row.Scan(&busy, &log, &checkpointed); err != nil {
 		return 0, 0, 0, err
 	}
-	// TODO: Return an error here?
+	// Stat the WAL file for size visibility.
+	var walSizeBytes int64
+	walPath := c.dbFilePath + "-wal"
+	if fi, err := os.Stat(walPath); err == nil {
+		walSizeBytes = fi.Size()
+	}
+
 	if busy != 0 || (log >= 0 && checkpointed < log) {
-		ctxzap.Extract(ctx).Info("WAL checkpoint incomplete",
+		ctxzap.Extract(ctx).Warn("wal-checkpoint: truncate checkpoint incomplete",
 			zap.Int("busy", busy),
-			zap.Int("log", log),
-			zap.Int("checkpointed", checkpointed),
+			zap.Int("log_pages", log),
+			zap.Int("checkpointed_pages", checkpointed),
+			zap.Int64("wal_size_bytes", walSizeBytes),
+			zap.String("db_path", c.dbFilePath))
+	} else {
+		ctxzap.Extract(ctx).Info("wal-checkpoint: truncate checkpoint complete",
+			zap.Int("log_pages", log),
+			zap.Int("checkpointed_pages", checkpointed),
+			zap.Int64("wal_size_bytes", walSizeBytes),
 			zap.String("db_path", c.dbFilePath))
 	}
 	return busy, log, checkpointed, nil

--- a/pkg/dotc1z/sql_helpers.go
+++ b/pkg/dotc1z/sql_helpers.go
@@ -518,9 +518,8 @@ func executeChunkedInsert(
 	// Checkpoint WAL after each batch to prevent unbounded WAL growth.
 	// Without this, auto-checkpoint failures (e.g. context cancellation)
 	// allow the WAL to grow to tens of GB across multiple sync runs.
-	if err := c.CheckpointWAL(ctx); err != nil {
-		ctxzap.Extract(ctx).Warn("chunked-insert: post-commit checkpoint failed", zap.Error(err))
-	}
+	// Errors are non-fatal — the final TRUNCATE checkpoint at Close handles the rest.
+	_ = c.CheckpointWAL(ctx)
 
 	return nil
 }

--- a/pkg/dotc1z/sql_helpers.go
+++ b/pkg/dotc1z/sql_helpers.go
@@ -511,7 +511,18 @@ func executeChunkedInsert(
 		return fmt.Errorf("error executing chunked insert: %w", txError)
 	}
 
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+
+	// Checkpoint WAL after each batch to prevent unbounded WAL growth.
+	// Without this, auto-checkpoint failures (e.g. context cancellation)
+	// allow the WAL to grow to tens of GB across multiple sync runs.
+	if err := c.CheckpointWAL(ctx); err != nil {
+		ctxzap.Extract(ctx).Warn("chunked-insert: post-commit checkpoint failed", zap.Error(err))
+	}
+
+	return nil
 }
 
 func bulkPutConnectorObject[T proto.Message](

--- a/pkg/dotc1z/sql_helpers.go
+++ b/pkg/dotc1z/sql_helpers.go
@@ -511,17 +511,7 @@ func executeChunkedInsert(
 		return fmt.Errorf("error executing chunked insert: %w", txError)
 	}
 
-	if err := tx.Commit(); err != nil {
-		return err
-	}
-
-	// Checkpoint WAL after each batch to prevent unbounded WAL growth.
-	// Without this, auto-checkpoint failures (e.g. context cancellation)
-	// allow the WAL to grow to tens of GB across multiple sync runs.
-	// Errors are non-fatal — the final TRUNCATE checkpoint at Close handles the rest.
-	_ = c.CheckpointWAL(ctx)
-
-	return nil
+	return tx.Commit()
 }
 
 func bulkPutConnectorObject[T proto.Message](

--- a/pkg/dotc1z/sql_helpers.go
+++ b/pkg/dotc1z/sql_helpers.go
@@ -513,7 +513,18 @@ func executeChunkedInsert(
 		return fmt.Errorf("error executing chunked insert: %w", txError)
 	}
 
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+
+	// Checkpoint WAL after each batch to prevent unbounded WAL growth.
+	// Without this, auto-checkpoint failures (e.g. context cancellation)
+	// allow the WAL to grow to tens of GB across multiple sync runs.
+	if err := c.CheckpointWAL(ctx); err != nil {
+		ctxzap.Extract(ctx).Warn("chunked-insert: post-commit checkpoint failed", zap.Error(err))
+	}
+
+	return nil
 }
 
 func bulkPutConnectorObject[T proto.Message](

--- a/pkg/dotc1z/sql_helpers.go
+++ b/pkg/dotc1z/sql_helpers.go
@@ -513,17 +513,7 @@ func executeChunkedInsert(
 		return fmt.Errorf("error executing chunked insert: %w", txError)
 	}
 
-	if err := tx.Commit(); err != nil {
-		return err
-	}
-
-	// Checkpoint WAL after each batch to prevent unbounded WAL growth.
-	// Without this, auto-checkpoint failures (e.g. context cancellation)
-	// allow the WAL to grow to tens of GB across multiple sync runs.
-	// Errors are non-fatal — the final TRUNCATE checkpoint at Close handles the rest.
-	_ = c.CheckpointWAL(ctx)
-
-	return nil
+	return tx.Commit()
 }
 
 func bulkPutConnectorObject[T proto.Message](

--- a/pkg/dotc1z/sql_helpers.go
+++ b/pkg/dotc1z/sql_helpers.go
@@ -520,9 +520,8 @@ func executeChunkedInsert(
 	// Checkpoint WAL after each batch to prevent unbounded WAL growth.
 	// Without this, auto-checkpoint failures (e.g. context cancellation)
 	// allow the WAL to grow to tens of GB across multiple sync runs.
-	if err := c.CheckpointWAL(ctx); err != nil {
-		ctxzap.Extract(ctx).Warn("chunked-insert: post-commit checkpoint failed", zap.Error(err))
-	}
+	// Errors are non-fatal — the final TRUNCATE checkpoint at Close handles the rest.
+	_ = c.CheckpointWAL(ctx)
 
 	return nil
 }


### PR DESCRIPTION
## Summary
Two changes to prevent unbounded WAL growth and add visibility:

1. **Periodic PASSIVE checkpoint** after each `executeChunkedInsert` commit
2. **WAL stats as span attributes** on checkpoint spans for APM trace analytics

## Problem
50GB+ WAL files observed in prod. SQLite's auto-checkpoint (every 1000 WAL pages) silently fails when the Go context is cancelled (Temporal activity deadline). The WAL grows unboundedly across transactions with no reclaim until `Close()`, which then faces a massive WAL to checkpoint.

## How it works

**PASSIVE checkpoint** (`CheckpointWAL`): Non-blocking — checkpoints as many frames as possible without waiting for writers. Called after each chunked insert commit to keep the WAL bounded. Errors are non-fatal (the final TRUNCATE checkpoint at Close handles the rest).

**WAL stats on spans** (not logs): Both PASSIVE and TRUNCATE checkpoint paths record attributes on their OTel spans:
- `wal.size_bytes` — actual WAL file size on disk
- `wal.checkpoint.log_pages` — total pages in WAL
- `wal.checkpoint.checkpointed_pages` — pages successfully checkpointed
- `wal.checkpoint.busy` — whether checkpoint was blocked

These are queryable in Datadog APM trace analytics without adding log volume (~45K log lines/hour avoided). The only log line retained is a `Warn` for incomplete TRUNCATE checkpoints, which are actionable and infrequent.

## Risk
Low — PASSIVE checkpoint is explicitly non-blocking. It's the lightest checkpoint mode SQLite offers. If the WAL has no uncheckpointed frames, it's a no-op. The only cost is one span + one `PRAGMA` call per chunked insert.

## Test plan
- [ ] Build passes
- [ ] Existing dotc1z tests pass
- [ ] Deploy via c1 vendor bump, verify WAL size stays bounded
- [ ] Query `wal.size_bytes` in APM spans to monitor WAL growth

🤖 Generated with [Claude Code](https://claude.com/claude-code)