### PR TITLE
fix: propagate trace context in action goroutines

### DIFF
--- a/pkg/actions/actions.go
+++ b/pkg/actions/actions.go
@@ -13,6 +13,7 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"github.com/segmentio/ksuid"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -444,7 +445,8 @@ func (a *ActionManager) invokeGlobalAction(ctx context.Context, name string, arg
 	go func() { //nolint:gosec // We want to run this in the background.
 		defer close(done)
 		oa.SetStatus(ctx, v2.BatonActionStatus_BATON_ACTION_STATUS_RUNNING)
-		handlerCtx, cancel := context.WithTimeoutCause(context.Background(), 1*time.Hour, errors.New("action handler timed out"))
+		bgCtx := trace.ContextWithSpanContext(context.Background(), trace.SpanContextFromContext(ctx))
+		handlerCtx, cancel := context.WithTimeoutCause(bgCtx, 1*time.Hour, errors.New("action handler timed out"))
 		defer cancel()
 		var oaErr error
 		oa.Rv, oa.Annos, oaErr = handler(handlerCtx, args)
@@ -522,7 +524,9 @@ func (a *ActionManager) invokeResourceAction(
 	go func() { //nolint:gosec // We want to run this in the background.
 		defer close(done)
 		oa.SetStatus(ctx, v2.BatonActionStatus_BATON_ACTION_STATUS_RUNNING)
-		handlerCtx, cancel := context.WithTimeoutCause(ctxzap.ToContext(context.Background(), ctxzap.Extract(ctx)), 1*time.Hour, errors.New("action handler timed out"))
+		bgCtx := trace.ContextWithSpanContext(context.Background(), trace.SpanContextFromContext(ctx))
+		bgCtx = ctxzap.ToContext(bgCtx, ctxzap.Extract(ctx))
+		handlerCtx, cancel := context.WithTimeoutCause(bgCtx, 1*time.Hour, errors.New("action handler timed out"))
 		defer cancel()
 		var oaErr error
 		oa.Rv, oa.Annos, oaErr = handler(handlerCtx, args)

--- a/pkg/connectorbuilder/assets.go
+++ b/pkg/connectorbuilder/assets.go
@@ -46,8 +46,5 @@ import v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 // GetAsset streams the asset to the client.
 // FIXME(jirwin): Asset streaming is disabled.
 func (b *builder) GetAsset(request *v2.AssetServiceGetAssetRequest, server v2.AssetService_GetAssetServer) error {
-	_, span := tracer.Start(server.Context(), "builderImpl.GetAsset")
-	defer span.End()
-
 	return nil
 }


### PR DESCRIPTION
## Summary
- Propagate OpenTelemetry span context into action handler goroutines that were using `context.Background()`, which lost the parent trace — making them invisible in Datadog
- Remove trivial no-op span in `GetAsset` (asset streaming is disabled, function just returns nil)

## Details
Both `invokeGlobalAction` and `invokeResourceAction` spawn goroutines with `context.Background()` to avoid inheriting the parent's cancellation. This is intentional for the timeout behavior, but it also drops the trace context. Fix: use `trace.ContextWithSpanContext()` to carry the span context forward while keeping the fresh cancellation scope.

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [ ] Deploy to dev and verify action handler spans appear as children of the invoking trace in Datadog

🤖 Generated with [Claude Code](https://claude.com/claude-code)