### PR TITLE
feat: add span error recording helpers

### DIFF
--- a/pkg/uotel/span_helpers.go
+++ b/pkg/uotel/span_helpers.go
@@ -23,6 +23,7 @@ func IsExpectedError(err error) bool {
 		switch s.Code() {
 		case grpccodes.Canceled, grpccodes.DeadlineExceeded:
 			return true
+		default:
 		}
 	}
 	return false

--- a/pkg/uotel/span_helpers.go
+++ b/pkg/uotel/span_helpers.go
@@ -1,0 +1,44 @@
+package uotel
+
+import (
+	"context"
+	"errors"
+
+	otelcodes "go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+	grpccodes "google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// IsExpectedError returns true for errors that are expected during normal
+// operation and should not be recorded as span errors.
+func IsExpectedError(err error) bool {
+	if err == nil {
+		return true
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	if s, ok := status.FromError(err); ok {
+		switch s.Code() {
+		case grpccodes.Canceled, grpccodes.DeadlineExceeded:
+			return true
+		}
+	}
+	return false
+}
+
+// EndSpanWithError ends a span and records the error if it is non-nil and not
+// an expected error. Expected errors (context cancellation, deadline exceeded)
+// are recorded with an Unset status to avoid polluting error dashboards.
+func EndSpanWithError(span trace.Span, err error) {
+	if err != nil {
+		if IsExpectedError(err) {
+			span.SetStatus(otelcodes.Unset, err.Error())
+		} else {
+			span.RecordError(err)
+			span.SetStatus(otelcodes.Error, err.Error())
+		}
+	}
+	span.End()
+}

--- a/pkg/uotel/span_helpers_test.go
+++ b/pkg/uotel/span_helpers_test.go
@@ -1,0 +1,38 @@
+package uotel
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestIsExpectedError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{"nil error", nil, true},
+		{"context canceled", context.Canceled, true},
+		{"context deadline exceeded", context.DeadlineExceeded, true},
+		{"wrapped context canceled", fmt.Errorf("wrapped: %w", context.Canceled), true},
+		{"grpc canceled", status.Error(codes.Canceled, "canceled"), true},
+		{"grpc deadline exceeded", status.Error(codes.DeadlineExceeded, "deadline"), true},
+		{"generic error", errors.New("something broke"), false},
+		{"grpc not found", status.Error(codes.NotFound, "not found"), false},
+		{"grpc internal", status.Error(codes.Internal, "internal"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsExpectedError(tt.err)
+			if got != tt.expected {
+				t.Errorf("IsExpectedError(%v) = %v, want %v", tt.err, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add `EndSpanWithError(span, err)` helper that records errors on spans and sets appropriate OTel status codes
- Add `IsExpectedError(err)` to distinguish real errors from expected ones (context cancellation, deadline exceeded, gRPC Canceled/DeadlineExceeded)
- Expected errors get `Unset` status; real errors get `Error` status with `RecordError` — prevents noise in Datadog error dashboards

## Context
The baton-sdk has 186 spans across 10 packages, with **zero** calls to `span.RecordError()` or `span.SetStatus()`. All spans use bare `defer span.End()`, making it impossible to filter failed spans in Datadog. This PR adds the foundation helpers; follow-up PRs will adopt them across the codebase.

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./pkg/uotel/...` — 9 test cases covering nil, context cancellation, deadline exceeded, wrapped errors, gRPC status codes, and generic errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)