### PR TITLE
CXH-1277: handle weighted rate limit header format

### DIFF
--- a/pkg/ratelimit/http.go
+++ b/pkg/ratelimit/http.go
@@ -3,6 +3,7 @@ package ratelimit
 import (
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
@@ -63,6 +64,19 @@ func parseTime(timeStr string) (time.Time, error) {
 	return t, nil
 }
 
+// normalizeRateLimitValue extracts the primary integer value from a rate limit
+// header that may use the weighted format from the RateLimit header RFC draft
+// (e.g. "500, 500;w=1, 20000;w=60" → "500", "100;w=60" → "100").
+func normalizeRateLimitValue(s string) string {
+	if i := strings.IndexByte(s, ','); i >= 0 {
+		s = strings.TrimSpace(s[:i])
+	}
+	if i := strings.IndexByte(s, ';'); i >= 0 {
+		s = s[:i]
+	}
+	return s
+}
+
 func ExtractRateLimitData(statusCode int, header *http.Header) (*v2.RateLimitDescription, error) {
 	if header == nil {
 		return nil, nil
@@ -75,7 +89,7 @@ func ExtractRateLimitData(statusCode int, header *http.Header) (*v2.RateLimitDes
 	for _, limitHeader := range limitHeaders {
 		limitStr := header.Get(limitHeader)
 		if limitStr != "" {
-			limit, err = strconv.ParseInt(limitStr, 10, 64)
+			limit, err = strconv.ParseInt(normalizeRateLimitValue(limitStr), 10, 64)
 			if err != nil {
 				return nil, err
 			}
@@ -87,7 +101,7 @@ func ExtractRateLimitData(statusCode int, header *http.Header) (*v2.RateLimitDes
 	for _, remainingHeader := range remainingHeaders {
 		remainingStr := header.Get(remainingHeader)
 		if remainingStr != "" {
-			remaining, err = strconv.ParseInt(remainingStr, 10, 64)
+			remaining, err = strconv.ParseInt(normalizeRateLimitValue(remainingStr), 10, 64)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/ratelimit/http.go
+++ b/pkg/ratelimit/http.go
@@ -64,15 +64,15 @@ func parseTime(timeStr string) (time.Time, error) {
 	return t, nil
 }
 
-// normalizeRateLimitValue extracts the primary integer value from a rate limit
-// header that may use the weighted format from the RateLimit header RFC draft
+// normalizeRateLimitValue extracts the leading integer from a rate limit header
+// that may use the weighted format from the RateLimit header RFC draft
 // (e.g. "500, 500;w=1, 20000;w=60" → "500", "100;w=60" → "100").
 func normalizeRateLimitValue(s string) string {
-	if i := strings.IndexByte(s, ','); i >= 0 {
-		s = strings.TrimSpace(s[:i])
-	}
-	if i := strings.IndexByte(s, ';'); i >= 0 {
-		s = s[:i]
+	s = strings.TrimSpace(s)
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return s[:i]
+		}
 	}
 	return s
 }

--- a/pkg/ratelimit/http.go
+++ b/pkg/ratelimit/http.go
@@ -67,6 +67,7 @@ func parseTime(timeStr string) (time.Time, error) {
 // normalizeRateLimitValue extracts the leading integer from a rate limit header
 // that may use the weighted format from the RateLimit header RFC draft
 // (e.g. "500, 500;w=1, 20000;w=60" → "500", "100;w=60" → "100").
+// docs: https://www.ietf.org/archive/id/draft-polli-ratelimit-headers-02.html#name-ratelimit-limit
 func normalizeRateLimitValue(s string) string {
 	s = strings.TrimSpace(s)
 	for i := 0; i < len(s); i++ {

--- a/pkg/ratelimit/http_test.go
+++ b/pkg/ratelimit/http_test.go
@@ -8,6 +8,39 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestExtractRateLimitData_WeightedHeaders(t *testing.T) {
+	n := time.Now()
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header: map[string][]string{
+			"X-Ratelimit-Limit":     {"500, 500;w=1, 20000;w=60"},
+			"X-Ratelimit-Remaining": {"499, 499;w=1, 19999;w=60"},
+			"X-Ratelimit-Reset":     {"30"},
+		},
+	}
+
+	rl, err := ExtractRateLimitData(resp.StatusCode, &resp.Header)
+	require.NoError(t, err)
+	require.Equal(t, int64(500), rl.GetLimit())
+	require.Equal(t, int64(499), rl.GetRemaining())
+	require.Equal(t, n.Add(time.Second*30).Unix(), rl.GetResetAt().AsTime().Unix())
+
+	resp = &http.Response{
+		StatusCode: http.StatusOK,
+		Header: map[string][]string{
+			"X-Ratelimit-Limit":     {"100;w=60"},
+			"X-Ratelimit-Remaining": {"42;w=60"},
+			"X-Ratelimit-Reset":     {"30"},
+		},
+	}
+
+	rl, err = ExtractRateLimitData(resp.StatusCode, &resp.Header)
+	require.NoError(t, err)
+	require.Equal(t, int64(100), rl.GetLimit())
+	require.Equal(t, int64(42), rl.GetRemaining())
+}
+
 func TestHelpers_ExtractRateLimitData(t *testing.T) {
 	n := time.Now()
 

--- a/pkg/ratelimit/http_test.go
+++ b/pkg/ratelimit/http_test.go
@@ -39,6 +39,20 @@ func TestExtractRateLimitData_WeightedHeaders(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(100), rl.GetLimit())
 	require.Equal(t, int64(42), rl.GetRemaining())
+
+	resp = &http.Response{
+		StatusCode: http.StatusOK,
+		Header: map[string][]string{
+			"X-Ratelimit-Limit":     {" 200"},
+			"X-Ratelimit-Remaining": {" 99"},
+			"X-Ratelimit-Reset":     {"30"},
+		},
+	}
+
+	rl, err = ExtractRateLimitData(resp.StatusCode, &resp.Header)
+	require.NoError(t, err)
+	require.Equal(t, int64(200), rl.GetLimit())
+	require.Equal(t, int64(99), rl.GetRemaining())
 }
 
 func TestHelpers_ExtractRateLimitData(t *testing.T) {


### PR DESCRIPTION
RFC format: https://www.ietf.org/archive/id/draft-polli-ratelimit-headers-02.html#name-ratelimit-limit
Zscaler returns rate limit headers in the weighted format from the RateLimit header RFC draft (e.g. `500, 500;w=1, 20000;w=60`), which caused `strconv.ParseInt` to fail and propagate an error that masked the real 500 response.

- Add `normalizeRateLimitValue` to extract the leading integer from weighted header values
- Apply normalization in `ExtractRateLimitData` for both limit and remaining headers