### PR TITLE
Improve column name handling in C1Z operations

### DIFF
--- a/pkg/dotc1z/c1file_attached.go
+++ b/pkg/dotc1z/c1file_attached.go
@@ -39,11 +39,12 @@ func (c *C1FileAttached) CompactTable(ctx context.Context, baseSyncID string, ap
 			columnList += ", "
 			selectList += ", "
 		}
-		columnList += col
+		qcol := quoteIdentifier(col)
+		columnList += qcol
 		if col == "sync_id" { //nolint:goconst,nolintlint // ...
-			selectList += "? as sync_id" //nolint:goconst,nolintlint // ...
+			selectList += "? as " + qcol //nolint:goconst,nolintlint // ...
 		} else {
-			selectList += col
+			selectList += qcol
 		}
 	}
 
@@ -102,6 +103,9 @@ func (c *C1FileAttached) getTableColumns(ctx context.Context, q sqlQuerier, tabl
 
 		// Skip the 'id' column as it's auto-increment
 		if name != "id" {
+			if err := validateColumnName(name); err != nil {
+				return nil, err
+			}
 			columns = append(columns, name)
 		}
 	}
@@ -361,17 +365,18 @@ func (c *C1FileAttached) diffTableFromAttachedTx(ctx context.Context, tx *sql.Tx
 			columnList += ", "
 			selectList += ", "
 		}
-		columnList += col
+		qcol := quoteIdentifier(col)
+		columnList += qcol
 		if col == "sync_id" {
-			selectList += "? as sync_id"
+			selectList += "? as " + qcol
 		} else {
-			selectList += col
+			selectList += qcol
 		}
 	}
 
 	// Insert items from attached (OLD) that don't exist in main (NEW)
 	// oldSyncID is in attached, newSyncID is in main
-	//nolint:gosec // table names are from hardcoded list, not user input
+	//nolint:gosec // table names are from hardcoded list; column names are validated
 	query := fmt.Sprintf(`
 		INSERT INTO main.%s (%s)
 		SELECT %s
@@ -404,11 +409,12 @@ func (c *C1FileAttached) diffTableFromMainTx(ctx context.Context, tx *sql.Tx, ta
 			columnList += ", "
 			selectList += ", "
 		}
-		columnList += col
+		qcol := quoteIdentifier(col)
+		columnList += qcol
 		if col == "sync_id" {
-			selectList += "? as sync_id"
+			selectList += "? as " + qcol
 		} else {
-			selectList += col
+			selectList += qcol
 		}
 	}
 
@@ -428,7 +434,7 @@ func (c *C1FileAttached) diffTableFromMainTx(ctx context.Context, tx *sql.Tx, ta
 		dataCompare = "a.data != m.data"
 	}
 
-	//nolint:gosec // table names are from hardcoded list, not user input
+	//nolint:gosec // table names are from hardcoded list; column names are validated
 	query := fmt.Sprintf(`
 		INSERT INTO main.%s (%s)
 		SELECT %s

--- a/pkg/dotc1z/clone_sync.go
+++ b/pkg/dotc1z/clone_sync.go
@@ -8,12 +8,31 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
 )
+
+var validColumnNameRe = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+
+// validateColumnName rejects column names that contain anything other than
+// ASCII letters, digits, and underscores.  This prevents SQL injection via
+// malicious column names embedded in a crafted .c1z database.
+func validateColumnName(name string) error {
+	if !validColumnNameRe.MatchString(name) {
+		return fmt.Errorf("invalid column name: %q", name)
+	}
+	return nil
+}
+
+// quoteIdentifier wraps a SQLite identifier in double-quotes, escaping any
+// embedded double-quote characters by doubling them per the SQL standard.
+func quoteIdentifier(name string) string {
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+}
 
 // cloneTableColumns returns the non-autoincrement column names for tableName
 // by querying PRAGMA table_info on the given connection. The column names are
@@ -37,6 +56,9 @@ func cloneTableColumns(ctx context.Context, conn *sql.Conn, tableName string) ([
 			return nil, err
 		}
 		if name != "id" {
+			if err := validateColumnName(name); err != nil {
+				return nil, err
+			}
 			columns = append(columns, name)
 		}
 	}
@@ -47,7 +69,11 @@ func cloneTableColumns(ctx context.Context, conn *sql.Conn, tableName string) ([
 // column name rather than relying on SELECT *, which is sensitive to the
 // physical column order of the source vs destination tables.
 func cloneTableQuery(tableName string, columns []string) string {
-	colList := strings.Join(columns, ", ")
+	quoted := make([]string, len(columns))
+	for i, c := range columns {
+		quoted[i] = quoteIdentifier(c)
+	}
+	colList := strings.Join(quoted, ", ")
 	return fmt.Sprintf(
 		"INSERT INTO clone.%s (%s) SELECT %s FROM %s WHERE sync_id=?",
 		tableName, colList, colList, tableName,

--- a/pkg/dotc1z/column_validation_test.go
+++ b/pkg/dotc1z/column_validation_test.go
@@ -1,0 +1,105 @@
+package dotc1z
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/glebarez/go-sqlite"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateColumnName(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		// Valid: normal schema column names that must always be accepted.
+		{name: "lowercase", input: "sync_id", wantErr: false},
+		{name: "leading underscore", input: "_private", wantErr: false},
+		{name: "mixed case", input: "resourceTypeId", wantErr: false},
+
+		// Invalid: injection payloads and structural characters that would
+		// alter SQL semantics if interpolated into a query unquoted.
+		{name: "semicolon injection", input: "evil); DROP TABLE t; --", wantErr: true},
+		{name: "double quote", input: `col"name`, wantErr: true},
+		{name: "space", input: "col name", wantErr: true},
+		{name: "parenthesis", input: "col(1)", wantErr: true},
+		{name: "empty string", input: "", wantErr: true},
+		{name: "starts with digit", input: "1col", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateColumnName(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// openTestDB creates a throwaway SQLite database with a single table whose
+// schema includes one extra column with the given name.  The table otherwise
+// matches the structure of v1_grants so the column-reading functions treat it
+// as a realistic schema.
+func openTestDB(t *testing.T, extraColumnName string) *sql.DB {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+
+	// Create a table with normal columns plus one attacker-controlled column.
+	// The malicious name must be double-quoted in the DDL so SQLite accepts it
+	// as an identifier — this is exactly what an attacker would do when
+	// crafting a .c1z file.
+	ddl := fmt.Sprintf(`CREATE TABLE v1_grants (
+		id INTEGER PRIMARY KEY,
+		external_id TEXT NOT NULL,
+		data BLOB NOT NULL,
+		sync_id TEXT NOT NULL,
+		discovered_at DATETIME NOT NULL,
+		%s TEXT
+	)`, quoteIdentifier(extraColumnName))
+
+	_, err = db.ExecContext(context.Background(), ddl)
+	require.NoError(t, err)
+	return db
+}
+
+// TestCloneTableColumnsRejectsMaliciousName verifies that cloneTableColumns
+// (used by CloneSync) refuses to return column names that contain SQL
+// metacharacters.  Without validation, such names would be interpolated
+// directly into INSERT…SELECT queries, enabling SQL injection via crafted
+// .c1z files.
+func TestCloneTableColumnsRejectsMaliciousName(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t, "evil); DROP TABLE v1_grants; --")
+
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	_, err = cloneTableColumns(ctx, conn, "v1_grants")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid column name")
+}
+
+// TestGetTableColumnsRejectsMaliciousName verifies the same invariant for
+// getTableColumns (used by CompactTable and the diff functions).  This is a
+// separate code path from cloneTableColumns and could regress independently.
+func TestGetTableColumnsRejectsMaliciousName(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t, "x' OR '1'='1")
+
+	attached := &C1FileAttached{safe: true, file: &C1File{rawDb: db}}
+	_, err := attached.getTableColumns(ctx, db, "v1_grants")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid column name")
+}


### PR DESCRIPTION
## Summary
This PR adds improved handling of column names in database operations by implementing column name validation and proper identifier quoting. Column names from untrusted sources (e.g., crafted .c1z database files) are now validated against an allowlist pattern and properly quoted in SQL queries.

## Key Changes
- **Column name validation**: Added `validateColumnName()` function that rejects column names containing anything other than ASCII letters, digits, and underscores
- **Identifier quoting**: Added `quoteIdentifier()` function that wraps SQLite identifiers in double-quotes with proper escaping per SQL standard
- **Applied validation and quoting** in three locations:
  - `CompactTable()` method in c1file_attached.go
  - `diffTableFromAttachedTx()` method in c1file_attached.go
  - `diffTableFromMainTx()` method in c1file_attached.go
  - `getTableColumns()` method in c1file_attached.go
  - `cloneTableColumns()` function in clone_sync.go
  - `cloneTableQuery()` function in clone_sync.go
- **Updated security comments**: Modified gosec linter comments to reflect that column names are now validated in addition to table names being from hardcoded lists

## Implementation Details
- Column name validation uses a regex pattern: `^[a-zA-Z_][a-zA-Z0-9_]*$`
- Identifier quoting escapes embedded double-quotes by doubling them per SQL standard
- Validation is performed when reading column metadata from the database schema
- All dynamically constructed SQL queries now use quoted identifiers for column names
