### PR TITLE
Classify transient network errors across lambda and uhttp

### DIFF
--- a/pkg/lambda/grpc/server.go
+++ b/pkg/lambda/grpc/server.go
@@ -254,9 +254,7 @@ func (s *Server) Handler(ctx context.Context, req *Request) (*Response, error) {
 		if ok {
 			err = appStatus.Err()
 		} else {
-			// Convert non-status application error to a status error with code
-			// Unknown, but handle context errors specifically.
-			appStatus = status.FromContextError(err)
+			appStatus = statusForApplicationError(err)
 			err = appStatus.Err()
 		}
 		return ErrorResponse(err), nil

--- a/pkg/lambda/grpc/util.go
+++ b/pkg/lambda/grpc/util.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"math"
+	"net/url"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"google.golang.org/grpc/codes"
@@ -147,19 +150,12 @@ func isTransientNetworkError(err error) bool {
 }
 
 // ErrorResponse converts a given error to a status.Status and returns a *pbtransport.Response.
-// status.FromError(err) must unwrap a status.Status for this to work - all other errors are converted
-// to grpc codes.Unknown errors.
+// status.FromError(err) must unwrap a status.Status for this to work. Non-status errors are mapped
+// through Baton lambda's application error classification before falling back to codes.Unknown.
 func ErrorResponse(err error) *Response {
 	st, ok := status.FromError(err)
 	if !ok {
-		switch {
-		case errors.Is(err, context.Canceled):
-			st = status.Newf(codes.Canceled, "canceled: %s", err)
-		case errors.Is(err, context.DeadlineExceeded):
-			st = status.Newf(codes.DeadlineExceeded, "deadline exceeded: %s", err)
-		default:
-			st = status.Newf(codes.Unknown, "unknown error: %s", err)
-		}
+		st = statusForApplicationError(err)
 	}
 	spb := st.Proto()
 	if spb == nil {
@@ -178,4 +174,35 @@ func ErrorResponse(err error) *Response {
 			Trailers: nil,
 		}.Build(),
 	}
+}
+
+// statusForApplicationError mirrors the transient network handling in uhttp for
+// connector SDK clients that bypass the Baton HTTP wrapper.
+func statusForApplicationError(err error) *status.Status {
+	switch {
+	case errors.Is(err, context.Canceled):
+		return status.Newf(codes.Canceled, "canceled: %s", err)
+	case errors.Is(err, context.DeadlineExceeded):
+		return status.Newf(codes.DeadlineExceeded, "deadline exceeded: %s", err)
+	case errors.Is(err, io.ErrUnexpectedEOF):
+		return status.Newf(codes.Unavailable, "unexpected EOF: %s", err)
+	case errors.Is(err, syscall.ECONNRESET):
+		return status.Newf(codes.Unavailable, "connection reset: %s", err)
+	}
+
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		if urlErr.Timeout() {
+			return status.Newf(codes.DeadlineExceeded, "request timeout: %s", err)
+		}
+		if urlErr.Temporary() {
+			return status.Newf(codes.Unavailable, "temporary error: %s", err)
+		}
+	}
+
+	if isTransientNetworkError(err) {
+		return status.Newf(codes.Unavailable, "transient network error: %s", err)
+	}
+
+	return status.Newf(codes.Unknown, "unknown error: %s", err)
 }

--- a/pkg/lambda/grpc/util_test.go
+++ b/pkg/lambda/grpc/util_test.go
@@ -3,6 +3,11 @@ package grpc
 import (
 	"context"
 	"fmt"
+	"io"
+	"net"
+	"net/url"
+	"os"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -39,11 +44,6 @@ func TestIsTransientNetworkError(t *testing.T) {
 	}
 }
 
-// TestErrorResponse_TransientNetworkError verifies that a plain transient
-// network error (not wrapped in a gRPC status) falls through to codes.Unknown
-// in ErrorResponse. The transient network classification is handled upstream:
-// connectors should use uhttp (which wraps ECONNRESET as Unavailable) or
-// classify errors in their own error handling before they reach ErrorResponse.
 func TestErrorResponse_TransientNetworkError(t *testing.T) {
 	err := fmt.Errorf("read tcp 169.254.100.6:53312->10.102.197.53:3128: read: connection reset by peer")
 	resp := ErrorResponse(err)
@@ -51,7 +51,44 @@ func TestErrorResponse_TransientNetworkError(t *testing.T) {
 
 	st, stErr := resp.Status()
 	require.NoError(t, stErr)
-	require.Equal(t, codes.Unknown, st.Code())
+	require.Equal(t, codes.Unavailable, st.Code())
+	require.Contains(t, st.Message(), "transient network error")
+	require.Contains(t, st.Message(), "connection reset by peer")
+}
+
+func TestStatusForApplicationError_ConnectionResetWrapped(t *testing.T) {
+	err := &url.Error{
+		Op:  "Get",
+		URL: "https://example.com",
+		Err: &net.OpError{
+			Op:  "read",
+			Net: "tcp",
+			Err: os.NewSyscallError("read", syscall.ECONNRESET),
+		},
+	}
+
+	st := statusForApplicationError(err)
+	require.Equal(t, codes.Unavailable, st.Code())
+	require.Contains(t, st.Message(), "connection reset")
+	require.Contains(t, st.Message(), "connection reset by peer")
+}
+
+func TestStatusForApplicationError_UnexpectedEOF(t *testing.T) {
+	st := statusForApplicationError(fmt.Errorf("wrapped: %w", io.ErrUnexpectedEOF))
+	require.Equal(t, codes.Unavailable, st.Code())
+	require.Contains(t, st.Message(), "unexpected EOF")
+}
+
+func TestStatusForApplicationError_URLTimeout(t *testing.T) {
+	err := &url.Error{
+		Op:  "Get",
+		URL: "https://example.com",
+		Err: timeoutError{err: fmt.Errorf("i/o timeout")},
+	}
+
+	st := statusForApplicationError(err)
+	require.Equal(t, codes.DeadlineExceeded, st.Code())
+	require.Contains(t, st.Message(), "request timeout")
 }
 
 func TestErrorResponse_UnknownError(t *testing.T) {
@@ -91,4 +128,20 @@ func TestErrorResponse_GRPCStatusPassthrough(t *testing.T) {
 	require.NoError(t, stErr)
 	require.Equal(t, codes.PermissionDenied, st.Code())
 	require.Contains(t, st.Message(), "access denied")
+}
+
+type timeoutError struct {
+	err error
+}
+
+func (e timeoutError) Error() string {
+	return e.err.Error()
+}
+
+func (timeoutError) Timeout() bool {
+	return true
+}
+
+func (timeoutError) Temporary() bool {
+	return false
 }

--- a/pkg/uhttp/errors.go
+++ b/pkg/uhttp/errors.go
@@ -39,5 +39,5 @@ func wrapTransientNetworkError(err error) error {
 		return status.Error(codes.DeadlineExceeded, "request timeout")
 	}
 
-	return nil
+	return err
 }

--- a/pkg/uhttp/errors.go
+++ b/pkg/uhttp/errors.go
@@ -1,0 +1,43 @@
+package uhttp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"syscall"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// wrapTransientNetworkError mirrors Baton HTTP retry classification for callers
+// that use the transport directly, such as oauth2-backed SDK clients.
+func wrapTransientNetworkError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, io.ErrUnexpectedEOF) {
+		return WrapErrors(codes.Unavailable, "unexpected EOF", err)
+	}
+	if errors.Is(err, syscall.ECONNRESET) {
+		return WrapErrors(codes.Unavailable, "connection reset", err)
+	}
+
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		if urlErr.Timeout() {
+			return WrapErrors(codes.DeadlineExceeded, fmt.Sprintf("request timeout: %v", urlErr.URL), urlErr)
+		}
+		if urlErr.Temporary() {
+			return WrapErrors(codes.Unavailable, fmt.Sprintf("temporary error: %v", urlErr.URL), urlErr)
+		}
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		return status.Error(codes.DeadlineExceeded, "request timeout")
+	}
+
+	return nil
+}

--- a/pkg/uhttp/transport.go
+++ b/pkg/uhttp/transport.go
@@ -163,6 +163,9 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		}
 	}()
 	resp, err := rt.RoundTrip(req)
+	if wrappedErr := wrapTransientNetworkError(err); wrappedErr != nil {
+		err = wrappedErr
+	}
 	if t.log {
 		duration := time.Since(start)
 		fields := []zap.Field{

--- a/pkg/uhttp/transport.go
+++ b/pkg/uhttp/transport.go
@@ -163,9 +163,7 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		}
 	}()
 	resp, err := rt.RoundTrip(req)
-	if wrappedErr := wrapTransientNetworkError(err); wrappedErr != nil {
-		err = wrappedErr
-	}
+	err = wrapTransientNetworkError(err)
 	if t.log {
 		duration := time.Since(start)
 		fields := []zap.Field{

--- a/pkg/uhttp/transport_test.go
+++ b/pkg/uhttp/transport_test.go
@@ -1,0 +1,95 @@
+package uhttp
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type errorRoundTripper struct {
+	err error
+}
+
+func (rt errorRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, rt.err
+}
+
+func TestTransportRoundTrip_ClassifiesConnectionReset(t *testing.T) {
+	tp := &Transport{
+		roundTripper: errorRoundTripper{
+			err: &url.Error{
+				Op:  "Get",
+				URL: "https://example.com",
+				Err: &net.OpError{
+					Op:  "read",
+					Net: "tcp",
+					Err: os.NewSyscallError("read", syscall.ECONNRESET),
+				},
+			},
+		},
+		nextCycle: time.Now().Add(time.Minute),
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.com", nil)
+	require.NoError(t, err)
+
+	resp, err := tp.RoundTrip(req)
+	require.Nil(t, resp)
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.Unavailable, st.Code())
+	require.Contains(t, st.Message(), "connection reset")
+}
+
+func TestTransportRoundTrip_ClassifiesTimeout(t *testing.T) {
+	tp := &Transport{
+		roundTripper: errorRoundTripper{
+			err: &url.Error{
+				Op:  "Get",
+				URL: "https://example.com",
+				Err: timeoutError{err: fmt.Errorf("i/o timeout")},
+			},
+		},
+		nextCycle: time.Now().Add(time.Minute),
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.com", nil)
+	require.NoError(t, err)
+
+	resp, err := tp.RoundTrip(req)
+	require.Nil(t, resp)
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.DeadlineExceeded, st.Code())
+	require.Contains(t, st.Message(), "request timeout")
+}
+
+type timeoutError struct {
+	err error
+}
+
+func (e timeoutError) Error() string {
+	return e.err.Error()
+}
+
+func (timeoutError) Timeout() bool {
+	return true
+}
+
+func (timeoutError) Temporary() bool {
+	return false
+}

--- a/pkg/uhttp/transport_test.go
+++ b/pkg/uhttp/transport_test.go
@@ -44,6 +44,9 @@ func TestTransportRoundTrip_ClassifiesConnectionReset(t *testing.T) {
 	require.NoError(t, err)
 
 	resp, err := tp.RoundTrip(req)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	require.Nil(t, resp)
 	require.Error(t, err)
 
@@ -69,6 +72,9 @@ func TestTransportRoundTrip_ClassifiesTimeout(t *testing.T) {
 	require.NoError(t, err)
 
 	resp, err := tp.RoundTrip(req)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	require.Nil(t, resp)
 	require.Error(t, err)
 

--- a/pkg/uhttp/wrapper.go
+++ b/pkg/uhttp/wrapper.go
@@ -464,11 +464,7 @@ func (c *BaseHttpClient) Do(req *http.Request, options ...DoOption) (*http.Respo
 		resp, err = c.HttpClient.Do(req)
 		if err != nil {
 			l.Error("base-http-client: HTTP error response", zap.Error(err))
-			// Turn certain network errors into grpc statuses so we retry.
-			if wrappedErr := wrapTransientNetworkError(err); wrappedErr != nil {
-				return resp, wrappedErr
-			}
-			return nil, err
+			return resp, wrapTransientNetworkError(err)
 		}
 	}
 
@@ -478,11 +474,7 @@ func (c *BaseHttpClient) Do(req *http.Request, options ...DoOption) (*http.Respo
 		if len(body) > 0 {
 			resp.Body = io.NopCloser(bytes.NewBuffer(body))
 		}
-		// Turn certain body read errors into grpc statuses so we retry
-		if wrappedErr := wrapTransientNetworkError(err); wrappedErr != nil {
-			return resp, wrappedErr
-		}
-		return resp, err
+		return resp, wrapTransientNetworkError(err)
 	}
 
 	// Replace resp.Body with a no-op closer so nobody has to worry about closing the reader.

--- a/pkg/uhttp/wrapper.go
+++ b/pkg/uhttp/wrapper.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
@@ -465,24 +464,9 @@ func (c *BaseHttpClient) Do(req *http.Request, options ...DoOption) (*http.Respo
 		resp, err = c.HttpClient.Do(req)
 		if err != nil {
 			l.Error("base-http-client: HTTP error response", zap.Error(err))
-			// Turn certain network errors into grpc statuses so we retry
-			if errors.Is(err, io.ErrUnexpectedEOF) {
-				return resp, WrapErrors(codes.Unavailable, "unexpected EOF", err)
-			}
-			if errors.Is(err, syscall.ECONNRESET) {
-				return nil, WrapErrors(codes.Unavailable, "connection reset", err)
-			}
-			var urlErr *url.Error
-			if errors.As(err, &urlErr) {
-				if urlErr.Timeout() {
-					return nil, WrapErrors(codes.DeadlineExceeded, fmt.Sprintf("request timeout: %v", urlErr.URL), urlErr)
-				}
-				if urlErr.Temporary() {
-					return nil, WrapErrors(codes.Unavailable, fmt.Sprintf("temporary error: %v", urlErr.URL), urlErr)
-				}
-			}
-			if errors.Is(err, context.DeadlineExceeded) {
-				return nil, status.Error(codes.DeadlineExceeded, "request timeout")
+			// Turn certain network errors into grpc statuses so we retry.
+			if wrappedErr := wrapTransientNetworkError(err); wrappedErr != nil {
+				return resp, wrappedErr
 			}
 			return nil, err
 		}
@@ -495,11 +479,8 @@ func (c *BaseHttpClient) Do(req *http.Request, options ...DoOption) (*http.Respo
 			resp.Body = io.NopCloser(bytes.NewBuffer(body))
 		}
 		// Turn certain body read errors into grpc statuses so we retry
-		if errors.Is(err, io.ErrUnexpectedEOF) {
-			return resp, WrapErrors(codes.Unavailable, "unexpected EOF", err)
-		}
-		if errors.Is(err, syscall.ECONNRESET) {
-			return resp, WrapErrors(codes.Unavailable, "connection reset", err)
+		if wrappedErr := wrapTransientNetworkError(err); wrappedErr != nil {
+			return resp, wrappedErr
 		}
 		return resp, err
 	}


### PR DESCRIPTION
## Why

Some connector SDK clients return raw Go network errors instead of gRPC status errors. Today those transient failures can fall through Baton SDK as `codes.Unknown` instead of a retryable status.

There are two places this shows up:

- the lambda gRPC server path, where non-status application errors can be converted to `Unknown`
- the `uhttp` transport path, where SDK clients that reuse the transport directly, such as through `oauth2`, can bypass the retryable wrapping that already exists in the higher-level HTTP client wrapper

That makes transient resets and timeouts look non-retryable to downstream sync handling, which can cause long-running syncs to drop current progress instead of resuming from the latest artifact state.

## What This Changes

- classify wrapped `ECONNRESET` and `unexpected EOF` as `codes.Unavailable` before non-status lambda errors fall through to `Unknown`
- classify URL timeouts as `codes.DeadlineExceeded`
- classify temporary URL errors as `codes.Unavailable`
- add shared transient network wrapping for the `uhttp` transport path so transport-based SDK clients get the same retryable behavior as callers that use the higher-level wrapper
- add focused tests for the lambda classifier and the `uhttp` transport path

This keeps transient network handling consistent across Baton SDK call paths instead of only the wrapper-based HTTP path.

## Validation

- `GOCACHE=/tmp/gocache GOLANGCI_LINT_CACHE=/tmp/golangci-lint-cache golangci-lint run ./pkg/uhttp ./pkg/lambda/grpc`
- `GOCACHE=/tmp/gocache go test -timeout 30s ./pkg/lambda/grpc ./pkg/uhttp`