### PR TITLE
Add lambda runtime state and bundle fetch to SDK

### DIFF
--- a/pb/c1/connectorapi/baton/v1/config.pb.go
+++ b/pb/c1/connectorapi/baton/v1/config.pb.go
@@ -513,6 +513,7 @@ func (b0 GetConnectorRuntimeBundleRequest_builder) Build() *GetConnectorRuntimeB
 type GetConnectorRuntimeBundleResponse struct {
 	state         protoimpl.MessageState `protogen:"hybrid.v1"`
 	Bundle        []byte                 `protobuf:"bytes,1,opt,name=bundle,proto3" json:"bundle,omitempty"`
+	RuntimeSchema []byte                 `protobuf:"bytes,2,opt,name=runtime_schema,json=runtimeSchema,proto3" json:"runtime_schema,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -549,6 +550,13 @@ func (x *GetConnectorRuntimeBundleResponse) GetBundle() []byte {
 	return nil
 }
 
+func (x *GetConnectorRuntimeBundleResponse) GetRuntimeSchema() []byte {
+	if x != nil {
+		return x.RuntimeSchema
+	}
+	return nil
+}
+
 func (x *GetConnectorRuntimeBundleResponse) SetBundle(v []byte) {
 	if v == nil {
 		v = []byte{}
@@ -556,10 +564,18 @@ func (x *GetConnectorRuntimeBundleResponse) SetBundle(v []byte) {
 	x.Bundle = v
 }
 
+func (x *GetConnectorRuntimeBundleResponse) SetRuntimeSchema(v []byte) {
+	if v == nil {
+		v = []byte{}
+	}
+	x.RuntimeSchema = v
+}
+
 type GetConnectorRuntimeBundleResponse_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	Bundle []byte
+	Bundle        []byte
+	RuntimeSchema []byte
 }
 
 func (b0 GetConnectorRuntimeBundleResponse_builder) Build() *GetConnectorRuntimeBundleResponse {
@@ -567,6 +583,7 @@ func (b0 GetConnectorRuntimeBundleResponse_builder) Build() *GetConnectorRuntime
 	b, x := &b0, m0
 	_, _ = b, x
 	x.Bundle = b.Bundle
+	x.RuntimeSchema = b.RuntimeSchema
 	return m0
 }
 
@@ -869,9 +886,10 @@ const file_c1_connectorapi_baton_v1_config_proto_rawDesc = "" +
 	" GetConnectorRuntimeStateResponse\x12=\n" +
 	"\flast_updated\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\vlastUpdated\x12K\n" +
 	"\rruntime_state\x18\x02 \x01(\v2&.c1.connectorapi.baton.v1.RuntimeStateR\fruntimeState\"\"\n" +
-	" GetConnectorRuntimeBundleRequest\";\n" +
+	" GetConnectorRuntimeBundleRequest\"b\n" +
 	"!GetConnectorRuntimeBundleResponse\x12\x16\n" +
-	"\x06bundle\x18\x01 \x01(\fR\x06bundle\"6\n" +
+	"\x06bundle\x18\x01 \x01(\fR\x06bundle\x12%\n" +
+	"\x0eruntime_schema\x18\x02 \x01(\fR\rruntimeSchema\"6\n" +
 	"\fSignedHeader\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x03(\tR\x05value\"\xb2\x01\n" +

--- a/pb/c1/connectorapi/baton/v1/config.pb.go
+++ b/pb/c1/connectorapi/baton/v1/config.pb.go
@@ -66,17 +66,159 @@ func (b0 GetConnectorConfigRequest_builder) Build() *GetConnectorConfigRequest {
 	return m0
 }
 
+type RuntimeState struct {
+	state                       protoimpl.MessageState `protogen:"hybrid.v1"`
+	RuntimeRevisionId           string                 `protobuf:"bytes,1,opt,name=runtime_revision_id,json=runtimeRevisionId,proto3" json:"runtime_revision_id,omitempty"`
+	RuntimeGeneration           int64                  `protobuf:"varint,2,opt,name=runtime_generation,json=runtimeGeneration,proto3" json:"runtime_generation,omitempty"`
+	ReleaseRevisionId           string                 `protobuf:"bytes,3,opt,name=release_revision_id,json=releaseRevisionId,proto3" json:"release_revision_id,omitempty"`
+	EffectiveBundleDigest       string                 `protobuf:"bytes,4,opt,name=effective_bundle_digest,json=effectiveBundleDigest,proto3" json:"effective_bundle_digest,omitempty"`
+	InstanceConfigRevisionId    string                 `protobuf:"bytes,5,opt,name=instance_config_revision_id,json=instanceConfigRevisionId,proto3" json:"instance_config_revision_id,omitempty"`
+	InstanceConfigDigest        string                 `protobuf:"bytes,6,opt,name=instance_config_digest,json=instanceConfigDigest,proto3" json:"instance_config_digest,omitempty"`
+	RuntimeConfigContractDigest string                 `protobuf:"bytes,7,opt,name=runtime_config_contract_digest,json=runtimeConfigContractDigest,proto3" json:"runtime_config_contract_digest,omitempty"`
+	unknownFields               protoimpl.UnknownFields
+	sizeCache                   protoimpl.SizeCache
+}
+
+func (x *RuntimeState) Reset() {
+	*x = RuntimeState{}
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RuntimeState) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RuntimeState) ProtoMessage() {}
+
+func (x *RuntimeState) ProtoReflect() protoreflect.Message {
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *RuntimeState) GetRuntimeRevisionId() string {
+	if x != nil {
+		return x.RuntimeRevisionId
+	}
+	return ""
+}
+
+func (x *RuntimeState) GetRuntimeGeneration() int64 {
+	if x != nil {
+		return x.RuntimeGeneration
+	}
+	return 0
+}
+
+func (x *RuntimeState) GetReleaseRevisionId() string {
+	if x != nil {
+		return x.ReleaseRevisionId
+	}
+	return ""
+}
+
+func (x *RuntimeState) GetEffectiveBundleDigest() string {
+	if x != nil {
+		return x.EffectiveBundleDigest
+	}
+	return ""
+}
+
+func (x *RuntimeState) GetInstanceConfigRevisionId() string {
+	if x != nil {
+		return x.InstanceConfigRevisionId
+	}
+	return ""
+}
+
+func (x *RuntimeState) GetInstanceConfigDigest() string {
+	if x != nil {
+		return x.InstanceConfigDigest
+	}
+	return ""
+}
+
+func (x *RuntimeState) GetRuntimeConfigContractDigest() string {
+	if x != nil {
+		return x.RuntimeConfigContractDigest
+	}
+	return ""
+}
+
+func (x *RuntimeState) SetRuntimeRevisionId(v string) {
+	x.RuntimeRevisionId = v
+}
+
+func (x *RuntimeState) SetRuntimeGeneration(v int64) {
+	x.RuntimeGeneration = v
+}
+
+func (x *RuntimeState) SetReleaseRevisionId(v string) {
+	x.ReleaseRevisionId = v
+}
+
+func (x *RuntimeState) SetEffectiveBundleDigest(v string) {
+	x.EffectiveBundleDigest = v
+}
+
+func (x *RuntimeState) SetInstanceConfigRevisionId(v string) {
+	x.InstanceConfigRevisionId = v
+}
+
+func (x *RuntimeState) SetInstanceConfigDigest(v string) {
+	x.InstanceConfigDigest = v
+}
+
+func (x *RuntimeState) SetRuntimeConfigContractDigest(v string) {
+	x.RuntimeConfigContractDigest = v
+}
+
+type RuntimeState_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	RuntimeRevisionId           string
+	RuntimeGeneration           int64
+	ReleaseRevisionId           string
+	EffectiveBundleDigest       string
+	InstanceConfigRevisionId    string
+	InstanceConfigDigest        string
+	RuntimeConfigContractDigest string
+}
+
+func (b0 RuntimeState_builder) Build() *RuntimeState {
+	m0 := &RuntimeState{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.RuntimeRevisionId = b.RuntimeRevisionId
+	x.RuntimeGeneration = b.RuntimeGeneration
+	x.ReleaseRevisionId = b.ReleaseRevisionId
+	x.EffectiveBundleDigest = b.EffectiveBundleDigest
+	x.InstanceConfigRevisionId = b.InstanceConfigRevisionId
+	x.InstanceConfigDigest = b.InstanceConfigDigest
+	x.RuntimeConfigContractDigest = b.RuntimeConfigContractDigest
+	return m0
+}
+
 type GetConnectorConfigResponse struct {
 	state         protoimpl.MessageState `protogen:"hybrid.v1"`
 	Config        []byte                 `protobuf:"bytes,1,opt,name=config,proto3" json:"config,omitempty"`
 	LastUpdated   *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=last_updated,json=lastUpdated,proto3" json:"last_updated,omitempty"`
+	RuntimeState  *RuntimeState          `protobuf:"bytes,3,opt,name=runtime_state,json=runtimeState,proto3" json:"runtime_state,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *GetConnectorConfigResponse) Reset() {
 	*x = GetConnectorConfigResponse{}
-	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[1]
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -88,7 +230,7 @@ func (x *GetConnectorConfigResponse) String() string {
 func (*GetConnectorConfigResponse) ProtoMessage() {}
 
 func (x *GetConnectorConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[1]
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -113,6 +255,13 @@ func (x *GetConnectorConfigResponse) GetLastUpdated() *timestamppb.Timestamp {
 	return nil
 }
 
+func (x *GetConnectorConfigResponse) GetRuntimeState() *RuntimeState {
+	if x != nil {
+		return x.RuntimeState
+	}
+	return nil
+}
+
 func (x *GetConnectorConfigResponse) SetConfig(v []byte) {
 	if v == nil {
 		v = []byte{}
@@ -124,6 +273,10 @@ func (x *GetConnectorConfigResponse) SetLastUpdated(v *timestamppb.Timestamp) {
 	x.LastUpdated = v
 }
 
+func (x *GetConnectorConfigResponse) SetRuntimeState(v *RuntimeState) {
+	x.RuntimeState = v
+}
+
 func (x *GetConnectorConfigResponse) HasLastUpdated() bool {
 	if x == nil {
 		return false
@@ -131,15 +284,27 @@ func (x *GetConnectorConfigResponse) HasLastUpdated() bool {
 	return x.LastUpdated != nil
 }
 
+func (x *GetConnectorConfigResponse) HasRuntimeState() bool {
+	if x == nil {
+		return false
+	}
+	return x.RuntimeState != nil
+}
+
 func (x *GetConnectorConfigResponse) ClearLastUpdated() {
 	x.LastUpdated = nil
+}
+
+func (x *GetConnectorConfigResponse) ClearRuntimeState() {
+	x.RuntimeState = nil
 }
 
 type GetConnectorConfigResponse_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	Config      []byte
-	LastUpdated *timestamppb.Timestamp
+	Config       []byte
+	LastUpdated  *timestamppb.Timestamp
+	RuntimeState *RuntimeState
 }
 
 func (b0 GetConnectorConfigResponse_builder) Build() *GetConnectorConfigResponse {
@@ -148,6 +313,246 @@ func (b0 GetConnectorConfigResponse_builder) Build() *GetConnectorConfigResponse
 	_, _ = b, x
 	x.Config = b.Config
 	x.LastUpdated = b.LastUpdated
+	x.RuntimeState = b.RuntimeState
+	return m0
+}
+
+type GetConnectorRuntimeStateRequest struct {
+	state         protoimpl.MessageState `protogen:"hybrid.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetConnectorRuntimeStateRequest) Reset() {
+	*x = GetConnectorRuntimeStateRequest{}
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetConnectorRuntimeStateRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetConnectorRuntimeStateRequest) ProtoMessage() {}
+
+func (x *GetConnectorRuntimeStateRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+type GetConnectorRuntimeStateRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+}
+
+func (b0 GetConnectorRuntimeStateRequest_builder) Build() *GetConnectorRuntimeStateRequest {
+	m0 := &GetConnectorRuntimeStateRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	return m0
+}
+
+type GetConnectorRuntimeStateResponse struct {
+	state         protoimpl.MessageState `protogen:"hybrid.v1"`
+	LastUpdated   *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=last_updated,json=lastUpdated,proto3" json:"last_updated,omitempty"`
+	RuntimeState  *RuntimeState          `protobuf:"bytes,2,opt,name=runtime_state,json=runtimeState,proto3" json:"runtime_state,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetConnectorRuntimeStateResponse) Reset() {
+	*x = GetConnectorRuntimeStateResponse{}
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetConnectorRuntimeStateResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetConnectorRuntimeStateResponse) ProtoMessage() {}
+
+func (x *GetConnectorRuntimeStateResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *GetConnectorRuntimeStateResponse) GetLastUpdated() *timestamppb.Timestamp {
+	if x != nil {
+		return x.LastUpdated
+	}
+	return nil
+}
+
+func (x *GetConnectorRuntimeStateResponse) GetRuntimeState() *RuntimeState {
+	if x != nil {
+		return x.RuntimeState
+	}
+	return nil
+}
+
+func (x *GetConnectorRuntimeStateResponse) SetLastUpdated(v *timestamppb.Timestamp) {
+	x.LastUpdated = v
+}
+
+func (x *GetConnectorRuntimeStateResponse) SetRuntimeState(v *RuntimeState) {
+	x.RuntimeState = v
+}
+
+func (x *GetConnectorRuntimeStateResponse) HasLastUpdated() bool {
+	if x == nil {
+		return false
+	}
+	return x.LastUpdated != nil
+}
+
+func (x *GetConnectorRuntimeStateResponse) HasRuntimeState() bool {
+	if x == nil {
+		return false
+	}
+	return x.RuntimeState != nil
+}
+
+func (x *GetConnectorRuntimeStateResponse) ClearLastUpdated() {
+	x.LastUpdated = nil
+}
+
+func (x *GetConnectorRuntimeStateResponse) ClearRuntimeState() {
+	x.RuntimeState = nil
+}
+
+type GetConnectorRuntimeStateResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	LastUpdated  *timestamppb.Timestamp
+	RuntimeState *RuntimeState
+}
+
+func (b0 GetConnectorRuntimeStateResponse_builder) Build() *GetConnectorRuntimeStateResponse {
+	m0 := &GetConnectorRuntimeStateResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.LastUpdated = b.LastUpdated
+	x.RuntimeState = b.RuntimeState
+	return m0
+}
+
+type GetConnectorRuntimeBundleRequest struct {
+	state         protoimpl.MessageState `protogen:"hybrid.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetConnectorRuntimeBundleRequest) Reset() {
+	*x = GetConnectorRuntimeBundleRequest{}
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetConnectorRuntimeBundleRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetConnectorRuntimeBundleRequest) ProtoMessage() {}
+
+func (x *GetConnectorRuntimeBundleRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+type GetConnectorRuntimeBundleRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+}
+
+func (b0 GetConnectorRuntimeBundleRequest_builder) Build() *GetConnectorRuntimeBundleRequest {
+	m0 := &GetConnectorRuntimeBundleRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	return m0
+}
+
+type GetConnectorRuntimeBundleResponse struct {
+	state         protoimpl.MessageState `protogen:"hybrid.v1"`
+	Bundle        []byte                 `protobuf:"bytes,1,opt,name=bundle,proto3" json:"bundle,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetConnectorRuntimeBundleResponse) Reset() {
+	*x = GetConnectorRuntimeBundleResponse{}
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetConnectorRuntimeBundleResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetConnectorRuntimeBundleResponse) ProtoMessage() {}
+
+func (x *GetConnectorRuntimeBundleResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *GetConnectorRuntimeBundleResponse) GetBundle() []byte {
+	if x != nil {
+		return x.Bundle
+	}
+	return nil
+}
+
+func (x *GetConnectorRuntimeBundleResponse) SetBundle(v []byte) {
+	if v == nil {
+		v = []byte{}
+	}
+	x.Bundle = v
+}
+
+type GetConnectorRuntimeBundleResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	Bundle []byte
+}
+
+func (b0 GetConnectorRuntimeBundleResponse_builder) Build() *GetConnectorRuntimeBundleResponse {
+	m0 := &GetConnectorRuntimeBundleResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Bundle = b.Bundle
 	return m0
 }
 
@@ -161,7 +566,7 @@ type SignedHeader struct {
 
 func (x *SignedHeader) Reset() {
 	*x = SignedHeader{}
-	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[2]
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -173,7 +578,7 @@ func (x *SignedHeader) String() string {
 func (*SignedHeader) ProtoMessage() {}
 
 func (x *SignedHeader) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[2]
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -234,7 +639,7 @@ type Sigv4SignedRequestSTSGetCallerIdentity struct {
 
 func (x *Sigv4SignedRequestSTSGetCallerIdentity) Reset() {
 	*x = Sigv4SignedRequestSTSGetCallerIdentity{}
-	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[3]
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -246,7 +651,7 @@ func (x *Sigv4SignedRequestSTSGetCallerIdentity) String() string {
 func (*Sigv4SignedRequestSTSGetCallerIdentity) ProtoMessage() {}
 
 func (x *Sigv4SignedRequestSTSGetCallerIdentity) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[3]
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -332,7 +737,7 @@ type GetConnectorOauthTokenRequest struct {
 
 func (x *GetConnectorOauthTokenRequest) Reset() {
 	*x = GetConnectorOauthTokenRequest{}
-	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[4]
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -344,7 +749,7 @@ func (x *GetConnectorOauthTokenRequest) String() string {
 func (*GetConnectorOauthTokenRequest) ProtoMessage() {}
 
 func (x *GetConnectorOauthTokenRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[4]
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -376,7 +781,7 @@ type GetConnectorOauthTokenResponse struct {
 
 func (x *GetConnectorOauthTokenResponse) Reset() {
 	*x = GetConnectorOauthTokenResponse{}
-	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[5]
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -388,7 +793,7 @@ func (x *GetConnectorOauthTokenResponse) String() string {
 func (*GetConnectorOauthTokenResponse) ProtoMessage() {}
 
 func (x *GetConnectorOauthTokenResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[5]
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -432,10 +837,26 @@ var File_c1_connectorapi_baton_v1_config_proto protoreflect.FileDescriptor
 const file_c1_connectorapi_baton_v1_config_proto_rawDesc = "" +
 	"\n" +
 	"%c1/connectorapi/baton/v1/config.proto\x12\x18c1.connectorapi.baton.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\x1b\n" +
-	"\x19GetConnectorConfigRequest\"s\n" +
+	"\x19GetConnectorConfigRequest\"\x8f\x03\n" +
+	"\fRuntimeState\x12.\n" +
+	"\x13runtime_revision_id\x18\x01 \x01(\tR\x11runtimeRevisionId\x12-\n" +
+	"\x12runtime_generation\x18\x02 \x01(\x03R\x11runtimeGeneration\x12.\n" +
+	"\x13release_revision_id\x18\x03 \x01(\tR\x11releaseRevisionId\x126\n" +
+	"\x17effective_bundle_digest\x18\x04 \x01(\tR\x15effectiveBundleDigest\x12=\n" +
+	"\x1binstance_config_revision_id\x18\x05 \x01(\tR\x18instanceConfigRevisionId\x124\n" +
+	"\x16instance_config_digest\x18\x06 \x01(\tR\x14instanceConfigDigest\x12C\n" +
+	"\x1eruntime_config_contract_digest\x18\a \x01(\tR\x1bruntimeConfigContractDigest\"\xc0\x01\n" +
 	"\x1aGetConnectorConfigResponse\x12\x16\n" +
 	"\x06config\x18\x01 \x01(\fR\x06config\x12=\n" +
-	"\flast_updated\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\vlastUpdated\"6\n" +
+	"\flast_updated\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\vlastUpdated\x12K\n" +
+	"\rruntime_state\x18\x03 \x01(\v2&.c1.connectorapi.baton.v1.RuntimeStateR\fruntimeState\"!\n" +
+	"\x1fGetConnectorRuntimeStateRequest\"\xae\x01\n" +
+	" GetConnectorRuntimeStateResponse\x12=\n" +
+	"\flast_updated\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\vlastUpdated\x12K\n" +
+	"\rruntime_state\x18\x02 \x01(\v2&.c1.connectorapi.baton.v1.RuntimeStateR\fruntimeState\"\"\n" +
+	" GetConnectorRuntimeBundleRequest\";\n" +
+	"!GetConnectorRuntimeBundleResponse\x12\x16\n" +
+	"\x06bundle\x18\x01 \x01(\fR\x06bundle\"6\n" +
 	"\fSignedHeader\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x03(\tR\x05value\"\xb2\x01\n" +
@@ -446,33 +867,47 @@ const file_c1_connectorapi_baton_v1_config_proto_rawDesc = "" +
 	"\x04body\x18\x04 \x01(\fR\x04body\"\x1f\n" +
 	"\x1dGetConnectorOauthTokenRequest\"6\n" +
 	"\x1eGetConnectorOauthTokenResponse\x12\x14\n" +
-	"\x05token\x18\x01 \x01(\fR\x05token2\xa7\x02\n" +
+	"\x05token\x18\x01 \x01(\fR\x05token2\xd2\x04\n" +
 	"\x16ConnectorConfigService\x12\x7f\n" +
-	"\x12GetConnectorConfig\x123.c1.connectorapi.baton.v1.GetConnectorConfigRequest\x1a4.c1.connectorapi.baton.v1.GetConnectorConfigResponse\x12\x8b\x01\n" +
+	"\x12GetConnectorConfig\x123.c1.connectorapi.baton.v1.GetConnectorConfigRequest\x1a4.c1.connectorapi.baton.v1.GetConnectorConfigResponse\x12\x91\x01\n" +
+	"\x18GetConnectorRuntimeState\x129.c1.connectorapi.baton.v1.GetConnectorRuntimeStateRequest\x1a:.c1.connectorapi.baton.v1.GetConnectorRuntimeStateResponse\x12\x94\x01\n" +
+	"\x19GetConnectorRuntimeBundle\x12:.c1.connectorapi.baton.v1.GetConnectorRuntimeBundleRequest\x1a;.c1.connectorapi.baton.v1.GetConnectorRuntimeBundleResponse\x12\x8b\x01\n" +
 	"\x16GetConnectorOauthToken\x127.c1.connectorapi.baton.v1.GetConnectorOauthTokenRequest\x1a8.c1.connectorapi.baton.v1.GetConnectorOauthTokenResponseB7Z5gitlab.com/ductone/c1/pkg/pb/c1/connectorapi/baton/v1b\x06proto3"
 
-var file_c1_connectorapi_baton_v1_config_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
+var file_c1_connectorapi_baton_v1_config_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
 var file_c1_connectorapi_baton_v1_config_proto_goTypes = []any{
 	(*GetConnectorConfigRequest)(nil),              // 0: c1.connectorapi.baton.v1.GetConnectorConfigRequest
-	(*GetConnectorConfigResponse)(nil),             // 1: c1.connectorapi.baton.v1.GetConnectorConfigResponse
-	(*SignedHeader)(nil),                           // 2: c1.connectorapi.baton.v1.SignedHeader
-	(*Sigv4SignedRequestSTSGetCallerIdentity)(nil), // 3: c1.connectorapi.baton.v1.Sigv4SignedRequestSTSGetCallerIdentity
-	(*GetConnectorOauthTokenRequest)(nil),          // 4: c1.connectorapi.baton.v1.GetConnectorOauthTokenRequest
-	(*GetConnectorOauthTokenResponse)(nil),         // 5: c1.connectorapi.baton.v1.GetConnectorOauthTokenResponse
-	(*timestamppb.Timestamp)(nil),                  // 6: google.protobuf.Timestamp
+	(*RuntimeState)(nil),                           // 1: c1.connectorapi.baton.v1.RuntimeState
+	(*GetConnectorConfigResponse)(nil),             // 2: c1.connectorapi.baton.v1.GetConnectorConfigResponse
+	(*GetConnectorRuntimeStateRequest)(nil),        // 3: c1.connectorapi.baton.v1.GetConnectorRuntimeStateRequest
+	(*GetConnectorRuntimeStateResponse)(nil),       // 4: c1.connectorapi.baton.v1.GetConnectorRuntimeStateResponse
+	(*GetConnectorRuntimeBundleRequest)(nil),       // 5: c1.connectorapi.baton.v1.GetConnectorRuntimeBundleRequest
+	(*GetConnectorRuntimeBundleResponse)(nil),      // 6: c1.connectorapi.baton.v1.GetConnectorRuntimeBundleResponse
+	(*SignedHeader)(nil),                           // 7: c1.connectorapi.baton.v1.SignedHeader
+	(*Sigv4SignedRequestSTSGetCallerIdentity)(nil), // 8: c1.connectorapi.baton.v1.Sigv4SignedRequestSTSGetCallerIdentity
+	(*GetConnectorOauthTokenRequest)(nil),          // 9: c1.connectorapi.baton.v1.GetConnectorOauthTokenRequest
+	(*GetConnectorOauthTokenResponse)(nil),         // 10: c1.connectorapi.baton.v1.GetConnectorOauthTokenResponse
+	(*timestamppb.Timestamp)(nil),                  // 11: google.protobuf.Timestamp
 }
 var file_c1_connectorapi_baton_v1_config_proto_depIdxs = []int32{
-	6, // 0: c1.connectorapi.baton.v1.GetConnectorConfigResponse.last_updated:type_name -> google.protobuf.Timestamp
-	2, // 1: c1.connectorapi.baton.v1.Sigv4SignedRequestSTSGetCallerIdentity.headers:type_name -> c1.connectorapi.baton.v1.SignedHeader
-	0, // 2: c1.connectorapi.baton.v1.ConnectorConfigService.GetConnectorConfig:input_type -> c1.connectorapi.baton.v1.GetConnectorConfigRequest
-	4, // 3: c1.connectorapi.baton.v1.ConnectorConfigService.GetConnectorOauthToken:input_type -> c1.connectorapi.baton.v1.GetConnectorOauthTokenRequest
-	1, // 4: c1.connectorapi.baton.v1.ConnectorConfigService.GetConnectorConfig:output_type -> c1.connectorapi.baton.v1.GetConnectorConfigResponse
-	5, // 5: c1.connectorapi.baton.v1.ConnectorConfigService.GetConnectorOauthToken:output_type -> c1.connectorapi.baton.v1.GetConnectorOauthTokenResponse
-	4, // [4:6] is the sub-list for method output_type
-	2, // [2:4] is the sub-list for method input_type
-	2, // [2:2] is the sub-list for extension type_name
-	2, // [2:2] is the sub-list for extension extendee
-	0, // [0:2] is the sub-list for field type_name
+	11, // 0: c1.connectorapi.baton.v1.GetConnectorConfigResponse.last_updated:type_name -> google.protobuf.Timestamp
+	1,  // 1: c1.connectorapi.baton.v1.GetConnectorConfigResponse.runtime_state:type_name -> c1.connectorapi.baton.v1.RuntimeState
+	11, // 2: c1.connectorapi.baton.v1.GetConnectorRuntimeStateResponse.last_updated:type_name -> google.protobuf.Timestamp
+	1,  // 3: c1.connectorapi.baton.v1.GetConnectorRuntimeStateResponse.runtime_state:type_name -> c1.connectorapi.baton.v1.RuntimeState
+	7,  // 4: c1.connectorapi.baton.v1.Sigv4SignedRequestSTSGetCallerIdentity.headers:type_name -> c1.connectorapi.baton.v1.SignedHeader
+	0,  // 5: c1.connectorapi.baton.v1.ConnectorConfigService.GetConnectorConfig:input_type -> c1.connectorapi.baton.v1.GetConnectorConfigRequest
+	3,  // 6: c1.connectorapi.baton.v1.ConnectorConfigService.GetConnectorRuntimeState:input_type -> c1.connectorapi.baton.v1.GetConnectorRuntimeStateRequest
+	5,  // 7: c1.connectorapi.baton.v1.ConnectorConfigService.GetConnectorRuntimeBundle:input_type -> c1.connectorapi.baton.v1.GetConnectorRuntimeBundleRequest
+	9,  // 8: c1.connectorapi.baton.v1.ConnectorConfigService.GetConnectorOauthToken:input_type -> c1.connectorapi.baton.v1.GetConnectorOauthTokenRequest
+	2,  // 9: c1.connectorapi.baton.v1.ConnectorConfigService.GetConnectorConfig:output_type -> c1.connectorapi.baton.v1.GetConnectorConfigResponse
+	4,  // 10: c1.connectorapi.baton.v1.ConnectorConfigService.GetConnectorRuntimeState:output_type -> c1.connectorapi.baton.v1.GetConnectorRuntimeStateResponse
+	6,  // 11: c1.connectorapi.baton.v1.ConnectorConfigService.GetConnectorRuntimeBundle:output_type -> c1.connectorapi.baton.v1.GetConnectorRuntimeBundleResponse
+	10, // 12: c1.connectorapi.baton.v1.ConnectorConfigService.GetConnectorOauthToken:output_type -> c1.connectorapi.baton.v1.GetConnectorOauthTokenResponse
+	9,  // [9:13] is the sub-list for method output_type
+	5,  // [5:9] is the sub-list for method input_type
+	5,  // [5:5] is the sub-list for extension type_name
+	5,  // [5:5] is the sub-list for extension extendee
+	0,  // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_c1_connectorapi_baton_v1_config_proto_init() }
@@ -486,7 +921,7 @@ func file_c1_connectorapi_baton_v1_config_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_c1_connectorapi_baton_v1_config_proto_rawDesc), len(file_c1_connectorapi_baton_v1_config_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   6,
+			NumMessages:   11,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pb/c1/connectorapi/baton/v1/config.pb.go
+++ b/pb/c1/connectorapi/baton/v1/config.pb.go
@@ -67,16 +67,17 @@ func (b0 GetConnectorConfigRequest_builder) Build() *GetConnectorConfigRequest {
 }
 
 type RuntimeState struct {
-	state                       protoimpl.MessageState `protogen:"hybrid.v1"`
-	RuntimeRevisionId           string                 `protobuf:"bytes,1,opt,name=runtime_revision_id,json=runtimeRevisionId,proto3" json:"runtime_revision_id,omitempty"`
-	RuntimeGeneration           int64                  `protobuf:"varint,2,opt,name=runtime_generation,json=runtimeGeneration,proto3" json:"runtime_generation,omitempty"`
-	ReleaseRevisionId           string                 `protobuf:"bytes,3,opt,name=release_revision_id,json=releaseRevisionId,proto3" json:"release_revision_id,omitempty"`
-	EffectiveBundleDigest       string                 `protobuf:"bytes,4,opt,name=effective_bundle_digest,json=effectiveBundleDigest,proto3" json:"effective_bundle_digest,omitempty"`
-	InstanceConfigRevisionId    string                 `protobuf:"bytes,5,opt,name=instance_config_revision_id,json=instanceConfigRevisionId,proto3" json:"instance_config_revision_id,omitempty"`
-	InstanceConfigDigest        string                 `protobuf:"bytes,6,opt,name=instance_config_digest,json=instanceConfigDigest,proto3" json:"instance_config_digest,omitempty"`
-	RuntimeConfigContractDigest string                 `protobuf:"bytes,7,opt,name=runtime_config_contract_digest,json=runtimeConfigContractDigest,proto3" json:"runtime_config_contract_digest,omitempty"`
-	unknownFields               protoimpl.UnknownFields
-	sizeCache                   protoimpl.SizeCache
+	state                        protoimpl.MessageState `protogen:"hybrid.v1"`
+	RuntimeRevisionId            string                 `protobuf:"bytes,1,opt,name=runtime_revision_id,json=runtimeRevisionId,proto3" json:"runtime_revision_id,omitempty"`
+	RuntimeGeneration            int64                  `protobuf:"varint,2,opt,name=runtime_generation,json=runtimeGeneration,proto3" json:"runtime_generation,omitempty"`
+	ReleaseRevisionId            string                 `protobuf:"bytes,3,opt,name=release_revision_id,json=releaseRevisionId,proto3" json:"release_revision_id,omitempty"`
+	EffectiveBundleDigest        string                 `protobuf:"bytes,4,opt,name=effective_bundle_digest,json=effectiveBundleDigest,proto3" json:"effective_bundle_digest,omitempty"`
+	InstanceConfigRevisionId     string                 `protobuf:"bytes,5,opt,name=instance_config_revision_id,json=instanceConfigRevisionId,proto3" json:"instance_config_revision_id,omitempty"`
+	InstanceConfigDigest         string                 `protobuf:"bytes,6,opt,name=instance_config_digest,json=instanceConfigDigest,proto3" json:"instance_config_digest,omitempty"`
+	RuntimeConfigContractDigest  string                 `protobuf:"bytes,7,opt,name=runtime_config_contract_digest,json=runtimeConfigContractDigest,proto3" json:"runtime_config_contract_digest,omitempty"`
+	EffectiveRuntimePolicyDigest string                 `protobuf:"bytes,8,opt,name=effective_runtime_policy_digest,json=effectiveRuntimePolicyDigest,proto3" json:"effective_runtime_policy_digest,omitempty"`
+	unknownFields                protoimpl.UnknownFields
+	sizeCache                    protoimpl.SizeCache
 }
 
 func (x *RuntimeState) Reset() {
@@ -153,6 +154,13 @@ func (x *RuntimeState) GetRuntimeConfigContractDigest() string {
 	return ""
 }
 
+func (x *RuntimeState) GetEffectiveRuntimePolicyDigest() string {
+	if x != nil {
+		return x.EffectiveRuntimePolicyDigest
+	}
+	return ""
+}
+
 func (x *RuntimeState) SetRuntimeRevisionId(v string) {
 	x.RuntimeRevisionId = v
 }
@@ -181,16 +189,21 @@ func (x *RuntimeState) SetRuntimeConfigContractDigest(v string) {
 	x.RuntimeConfigContractDigest = v
 }
 
+func (x *RuntimeState) SetEffectiveRuntimePolicyDigest(v string) {
+	x.EffectiveRuntimePolicyDigest = v
+}
+
 type RuntimeState_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	RuntimeRevisionId           string
-	RuntimeGeneration           int64
-	ReleaseRevisionId           string
-	EffectiveBundleDigest       string
-	InstanceConfigRevisionId    string
-	InstanceConfigDigest        string
-	RuntimeConfigContractDigest string
+	RuntimeRevisionId            string
+	RuntimeGeneration            int64
+	ReleaseRevisionId            string
+	EffectiveBundleDigest        string
+	InstanceConfigRevisionId     string
+	InstanceConfigDigest         string
+	RuntimeConfigContractDigest  string
+	EffectiveRuntimePolicyDigest string
 }
 
 func (b0 RuntimeState_builder) Build() *RuntimeState {
@@ -204,6 +217,7 @@ func (b0 RuntimeState_builder) Build() *RuntimeState {
 	x.InstanceConfigRevisionId = b.InstanceConfigRevisionId
 	x.InstanceConfigDigest = b.InstanceConfigDigest
 	x.RuntimeConfigContractDigest = b.RuntimeConfigContractDigest
+	x.EffectiveRuntimePolicyDigest = b.EffectiveRuntimePolicyDigest
 	return m0
 }
 
@@ -837,7 +851,7 @@ var File_c1_connectorapi_baton_v1_config_proto protoreflect.FileDescriptor
 const file_c1_connectorapi_baton_v1_config_proto_rawDesc = "" +
 	"\n" +
 	"%c1/connectorapi/baton/v1/config.proto\x12\x18c1.connectorapi.baton.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\x1b\n" +
-	"\x19GetConnectorConfigRequest\"\x8f\x03\n" +
+	"\x19GetConnectorConfigRequest\"\xd6\x03\n" +
 	"\fRuntimeState\x12.\n" +
 	"\x13runtime_revision_id\x18\x01 \x01(\tR\x11runtimeRevisionId\x12-\n" +
 	"\x12runtime_generation\x18\x02 \x01(\x03R\x11runtimeGeneration\x12.\n" +
@@ -845,7 +859,8 @@ const file_c1_connectorapi_baton_v1_config_proto_rawDesc = "" +
 	"\x17effective_bundle_digest\x18\x04 \x01(\tR\x15effectiveBundleDigest\x12=\n" +
 	"\x1binstance_config_revision_id\x18\x05 \x01(\tR\x18instanceConfigRevisionId\x124\n" +
 	"\x16instance_config_digest\x18\x06 \x01(\tR\x14instanceConfigDigest\x12C\n" +
-	"\x1eruntime_config_contract_digest\x18\a \x01(\tR\x1bruntimeConfigContractDigest\"\xc0\x01\n" +
+	"\x1eruntime_config_contract_digest\x18\a \x01(\tR\x1bruntimeConfigContractDigest\x12E\n" +
+	"\x1feffective_runtime_policy_digest\x18\b \x01(\tR\x1ceffectiveRuntimePolicyDigest\"\xc0\x01\n" +
 	"\x1aGetConnectorConfigResponse\x12\x16\n" +
 	"\x06config\x18\x01 \x01(\fR\x06config\x12=\n" +
 	"\flast_updated\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\vlastUpdated\x12K\n" +

--- a/pb/c1/connectorapi/baton/v1/config.pb.validate.go
+++ b/pb/c1/connectorapi/baton/v1/config.pb.validate.go
@@ -137,6 +137,119 @@ var _ interface {
 	ErrorName() string
 } = GetConnectorConfigRequestValidationError{}
 
+// Validate checks the field values on RuntimeState with the rules defined in
+// the proto definition for this message. If any rules are violated, the first
+// error encountered is returned, or nil if there are no violations.
+func (m *RuntimeState) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on RuntimeState with the rules defined
+// in the proto definition for this message. If any rules are violated, the
+// result is a list of violation errors wrapped in RuntimeStateMultiError, or
+// nil if none found.
+func (m *RuntimeState) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *RuntimeState) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	// no validation rules for RuntimeRevisionId
+
+	// no validation rules for RuntimeGeneration
+
+	// no validation rules for ReleaseRevisionId
+
+	// no validation rules for EffectiveBundleDigest
+
+	// no validation rules for InstanceConfigRevisionId
+
+	// no validation rules for InstanceConfigDigest
+
+	// no validation rules for RuntimeConfigContractDigest
+
+	if len(errors) > 0 {
+		return RuntimeStateMultiError(errors)
+	}
+
+	return nil
+}
+
+// RuntimeStateMultiError is an error wrapping multiple validation errors
+// returned by RuntimeState.ValidateAll() if the designated constraints aren't met.
+type RuntimeStateMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m RuntimeStateMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m RuntimeStateMultiError) AllErrors() []error { return m }
+
+// RuntimeStateValidationError is the validation error returned by
+// RuntimeState.Validate if the designated constraints aren't met.
+type RuntimeStateValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e RuntimeStateValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e RuntimeStateValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e RuntimeStateValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e RuntimeStateValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e RuntimeStateValidationError) ErrorName() string { return "RuntimeStateValidationError" }
+
+// Error satisfies the builtin error interface
+func (e RuntimeStateValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sRuntimeState.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = RuntimeStateValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = RuntimeStateValidationError{}
+
 // Validate checks the field values on GetConnectorConfigResponse with the
 // rules defined in the proto definition for this message. If any rules are
 // violated, the first error encountered is returned, or nil if there are no violations.
@@ -184,6 +297,35 @@ func (m *GetConnectorConfigResponse) validate(all bool) error {
 		if err := v.Validate(); err != nil {
 			return GetConnectorConfigResponseValidationError{
 				field:  "LastUpdated",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetRuntimeState()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, GetConnectorConfigResponseValidationError{
+					field:  "RuntimeState",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, GetConnectorConfigResponseValidationError{
+					field:  "RuntimeState",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetRuntimeState()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return GetConnectorConfigResponseValidationError{
+				field:  "RuntimeState",
 				reason: "embedded message failed validation",
 				cause:  err,
 			}
@@ -269,6 +411,484 @@ var _ interface {
 	Cause() error
 	ErrorName() string
 } = GetConnectorConfigResponseValidationError{}
+
+// Validate checks the field values on GetConnectorRuntimeStateRequest with the
+// rules defined in the proto definition for this message. If any rules are
+// violated, the first error encountered is returned, or nil if there are no violations.
+func (m *GetConnectorRuntimeStateRequest) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on GetConnectorRuntimeStateRequest with
+// the rules defined in the proto definition for this message. If any rules
+// are violated, the result is a list of violation errors wrapped in
+// GetConnectorRuntimeStateRequestMultiError, or nil if none found.
+func (m *GetConnectorRuntimeStateRequest) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *GetConnectorRuntimeStateRequest) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	if len(errors) > 0 {
+		return GetConnectorRuntimeStateRequestMultiError(errors)
+	}
+
+	return nil
+}
+
+// GetConnectorRuntimeStateRequestMultiError is an error wrapping multiple
+// validation errors returned by GetConnectorRuntimeStateRequest.ValidateAll()
+// if the designated constraints aren't met.
+type GetConnectorRuntimeStateRequestMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m GetConnectorRuntimeStateRequestMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m GetConnectorRuntimeStateRequestMultiError) AllErrors() []error { return m }
+
+// GetConnectorRuntimeStateRequestValidationError is the validation error
+// returned by GetConnectorRuntimeStateRequest.Validate if the designated
+// constraints aren't met.
+type GetConnectorRuntimeStateRequestValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e GetConnectorRuntimeStateRequestValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e GetConnectorRuntimeStateRequestValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e GetConnectorRuntimeStateRequestValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e GetConnectorRuntimeStateRequestValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e GetConnectorRuntimeStateRequestValidationError) ErrorName() string {
+	return "GetConnectorRuntimeStateRequestValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e GetConnectorRuntimeStateRequestValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sGetConnectorRuntimeStateRequest.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = GetConnectorRuntimeStateRequestValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = GetConnectorRuntimeStateRequestValidationError{}
+
+// Validate checks the field values on GetConnectorRuntimeStateResponse with
+// the rules defined in the proto definition for this message. If any rules
+// are violated, the first error encountered is returned, or nil if there are
+// no violations.
+func (m *GetConnectorRuntimeStateResponse) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on GetConnectorRuntimeStateResponse with
+// the rules defined in the proto definition for this message. If any rules
+// are violated, the result is a list of violation errors wrapped in
+// GetConnectorRuntimeStateResponseMultiError, or nil if none found.
+func (m *GetConnectorRuntimeStateResponse) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *GetConnectorRuntimeStateResponse) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	if all {
+		switch v := interface{}(m.GetLastUpdated()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, GetConnectorRuntimeStateResponseValidationError{
+					field:  "LastUpdated",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, GetConnectorRuntimeStateResponseValidationError{
+					field:  "LastUpdated",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetLastUpdated()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return GetConnectorRuntimeStateResponseValidationError{
+				field:  "LastUpdated",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetRuntimeState()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, GetConnectorRuntimeStateResponseValidationError{
+					field:  "RuntimeState",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, GetConnectorRuntimeStateResponseValidationError{
+					field:  "RuntimeState",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetRuntimeState()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return GetConnectorRuntimeStateResponseValidationError{
+				field:  "RuntimeState",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
+	if len(errors) > 0 {
+		return GetConnectorRuntimeStateResponseMultiError(errors)
+	}
+
+	return nil
+}
+
+// GetConnectorRuntimeStateResponseMultiError is an error wrapping multiple
+// validation errors returned by
+// GetConnectorRuntimeStateResponse.ValidateAll() if the designated
+// constraints aren't met.
+type GetConnectorRuntimeStateResponseMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m GetConnectorRuntimeStateResponseMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m GetConnectorRuntimeStateResponseMultiError) AllErrors() []error { return m }
+
+// GetConnectorRuntimeStateResponseValidationError is the validation error
+// returned by GetConnectorRuntimeStateResponse.Validate if the designated
+// constraints aren't met.
+type GetConnectorRuntimeStateResponseValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e GetConnectorRuntimeStateResponseValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e GetConnectorRuntimeStateResponseValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e GetConnectorRuntimeStateResponseValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e GetConnectorRuntimeStateResponseValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e GetConnectorRuntimeStateResponseValidationError) ErrorName() string {
+	return "GetConnectorRuntimeStateResponseValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e GetConnectorRuntimeStateResponseValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sGetConnectorRuntimeStateResponse.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = GetConnectorRuntimeStateResponseValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = GetConnectorRuntimeStateResponseValidationError{}
+
+// Validate checks the field values on GetConnectorRuntimeBundleRequest with
+// the rules defined in the proto definition for this message. If any rules
+// are violated, the first error encountered is returned, or nil if there are
+// no violations.
+func (m *GetConnectorRuntimeBundleRequest) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on GetConnectorRuntimeBundleRequest with
+// the rules defined in the proto definition for this message. If any rules
+// are violated, the result is a list of violation errors wrapped in
+// GetConnectorRuntimeBundleRequestMultiError, or nil if none found.
+func (m *GetConnectorRuntimeBundleRequest) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *GetConnectorRuntimeBundleRequest) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	if len(errors) > 0 {
+		return GetConnectorRuntimeBundleRequestMultiError(errors)
+	}
+
+	return nil
+}
+
+// GetConnectorRuntimeBundleRequestMultiError is an error wrapping multiple
+// validation errors returned by
+// GetConnectorRuntimeBundleRequest.ValidateAll() if the designated
+// constraints aren't met.
+type GetConnectorRuntimeBundleRequestMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m GetConnectorRuntimeBundleRequestMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m GetConnectorRuntimeBundleRequestMultiError) AllErrors() []error { return m }
+
+// GetConnectorRuntimeBundleRequestValidationError is the validation error
+// returned by GetConnectorRuntimeBundleRequest.Validate if the designated
+// constraints aren't met.
+type GetConnectorRuntimeBundleRequestValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e GetConnectorRuntimeBundleRequestValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e GetConnectorRuntimeBundleRequestValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e GetConnectorRuntimeBundleRequestValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e GetConnectorRuntimeBundleRequestValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e GetConnectorRuntimeBundleRequestValidationError) ErrorName() string {
+	return "GetConnectorRuntimeBundleRequestValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e GetConnectorRuntimeBundleRequestValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sGetConnectorRuntimeBundleRequest.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = GetConnectorRuntimeBundleRequestValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = GetConnectorRuntimeBundleRequestValidationError{}
+
+// Validate checks the field values on GetConnectorRuntimeBundleResponse with
+// the rules defined in the proto definition for this message. If any rules
+// are violated, the first error encountered is returned, or nil if there are
+// no violations.
+func (m *GetConnectorRuntimeBundleResponse) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on GetConnectorRuntimeBundleResponse
+// with the rules defined in the proto definition for this message. If any
+// rules are violated, the result is a list of violation errors wrapped in
+// GetConnectorRuntimeBundleResponseMultiError, or nil if none found.
+func (m *GetConnectorRuntimeBundleResponse) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *GetConnectorRuntimeBundleResponse) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	// no validation rules for Bundle
+
+	if len(errors) > 0 {
+		return GetConnectorRuntimeBundleResponseMultiError(errors)
+	}
+
+	return nil
+}
+
+// GetConnectorRuntimeBundleResponseMultiError is an error wrapping multiple
+// validation errors returned by
+// GetConnectorRuntimeBundleResponse.ValidateAll() if the designated
+// constraints aren't met.
+type GetConnectorRuntimeBundleResponseMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m GetConnectorRuntimeBundleResponseMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m GetConnectorRuntimeBundleResponseMultiError) AllErrors() []error { return m }
+
+// GetConnectorRuntimeBundleResponseValidationError is the validation error
+// returned by GetConnectorRuntimeBundleResponse.Validate if the designated
+// constraints aren't met.
+type GetConnectorRuntimeBundleResponseValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e GetConnectorRuntimeBundleResponseValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e GetConnectorRuntimeBundleResponseValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e GetConnectorRuntimeBundleResponseValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e GetConnectorRuntimeBundleResponseValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e GetConnectorRuntimeBundleResponseValidationError) ErrorName() string {
+	return "GetConnectorRuntimeBundleResponseValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e GetConnectorRuntimeBundleResponseValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sGetConnectorRuntimeBundleResponse.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = GetConnectorRuntimeBundleResponseValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = GetConnectorRuntimeBundleResponseValidationError{}
 
 // Validate checks the field values on SignedHeader with the rules defined in
 // the proto definition for this message. If any rules are violated, the first

--- a/pb/c1/connectorapi/baton/v1/config.pb.validate.go
+++ b/pb/c1/connectorapi/baton/v1/config.pb.validate.go
@@ -173,6 +173,8 @@ func (m *RuntimeState) validate(all bool) error {
 
 	// no validation rules for RuntimeConfigContractDigest
 
+	// no validation rules for EffectiveRuntimePolicyDigest
+
 	if len(errors) > 0 {
 		return RuntimeStateMultiError(errors)
 	}

--- a/pb/c1/connectorapi/baton/v1/config.pb.validate.go
+++ b/pb/c1/connectorapi/baton/v1/config.pb.validate.go
@@ -810,6 +810,8 @@ func (m *GetConnectorRuntimeBundleResponse) validate(all bool) error {
 
 	// no validation rules for Bundle
 
+	// no validation rules for RuntimeSchema
+
 	if len(errors) > 0 {
 		return GetConnectorRuntimeBundleResponseMultiError(errors)
 	}

--- a/pb/c1/connectorapi/baton/v1/config_grpc.pb.go
+++ b/pb/c1/connectorapi/baton/v1/config_grpc.pb.go
@@ -19,8 +19,10 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	ConnectorConfigService_GetConnectorConfig_FullMethodName     = "/c1.connectorapi.baton.v1.ConnectorConfigService/GetConnectorConfig"
-	ConnectorConfigService_GetConnectorOauthToken_FullMethodName = "/c1.connectorapi.baton.v1.ConnectorConfigService/GetConnectorOauthToken"
+	ConnectorConfigService_GetConnectorConfig_FullMethodName        = "/c1.connectorapi.baton.v1.ConnectorConfigService/GetConnectorConfig"
+	ConnectorConfigService_GetConnectorRuntimeState_FullMethodName  = "/c1.connectorapi.baton.v1.ConnectorConfigService/GetConnectorRuntimeState"
+	ConnectorConfigService_GetConnectorRuntimeBundle_FullMethodName = "/c1.connectorapi.baton.v1.ConnectorConfigService/GetConnectorRuntimeBundle"
+	ConnectorConfigService_GetConnectorOauthToken_FullMethodName    = "/c1.connectorapi.baton.v1.ConnectorConfigService/GetConnectorOauthToken"
 )
 
 // ConnectorConfigServiceClient is the client API for ConnectorConfigService service.
@@ -28,6 +30,8 @@ const (
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type ConnectorConfigServiceClient interface {
 	GetConnectorConfig(ctx context.Context, in *GetConnectorConfigRequest, opts ...grpc.CallOption) (*GetConnectorConfigResponse, error)
+	GetConnectorRuntimeState(ctx context.Context, in *GetConnectorRuntimeStateRequest, opts ...grpc.CallOption) (*GetConnectorRuntimeStateResponse, error)
+	GetConnectorRuntimeBundle(ctx context.Context, in *GetConnectorRuntimeBundleRequest, opts ...grpc.CallOption) (*GetConnectorRuntimeBundleResponse, error)
 	GetConnectorOauthToken(ctx context.Context, in *GetConnectorOauthTokenRequest, opts ...grpc.CallOption) (*GetConnectorOauthTokenResponse, error)
 }
 
@@ -49,6 +53,26 @@ func (c *connectorConfigServiceClient) GetConnectorConfig(ctx context.Context, i
 	return out, nil
 }
 
+func (c *connectorConfigServiceClient) GetConnectorRuntimeState(ctx context.Context, in *GetConnectorRuntimeStateRequest, opts ...grpc.CallOption) (*GetConnectorRuntimeStateResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetConnectorRuntimeStateResponse)
+	err := c.cc.Invoke(ctx, ConnectorConfigService_GetConnectorRuntimeState_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *connectorConfigServiceClient) GetConnectorRuntimeBundle(ctx context.Context, in *GetConnectorRuntimeBundleRequest, opts ...grpc.CallOption) (*GetConnectorRuntimeBundleResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetConnectorRuntimeBundleResponse)
+	err := c.cc.Invoke(ctx, ConnectorConfigService_GetConnectorRuntimeBundle_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *connectorConfigServiceClient) GetConnectorOauthToken(ctx context.Context, in *GetConnectorOauthTokenRequest, opts ...grpc.CallOption) (*GetConnectorOauthTokenResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(GetConnectorOauthTokenResponse)
@@ -64,6 +88,8 @@ func (c *connectorConfigServiceClient) GetConnectorOauthToken(ctx context.Contex
 // for forward compatibility.
 type ConnectorConfigServiceServer interface {
 	GetConnectorConfig(context.Context, *GetConnectorConfigRequest) (*GetConnectorConfigResponse, error)
+	GetConnectorRuntimeState(context.Context, *GetConnectorRuntimeStateRequest) (*GetConnectorRuntimeStateResponse, error)
+	GetConnectorRuntimeBundle(context.Context, *GetConnectorRuntimeBundleRequest) (*GetConnectorRuntimeBundleResponse, error)
 	GetConnectorOauthToken(context.Context, *GetConnectorOauthTokenRequest) (*GetConnectorOauthTokenResponse, error)
 }
 
@@ -76,6 +102,12 @@ type UnimplementedConnectorConfigServiceServer struct{}
 
 func (UnimplementedConnectorConfigServiceServer) GetConnectorConfig(context.Context, *GetConnectorConfigRequest) (*GetConnectorConfigResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetConnectorConfig not implemented")
+}
+func (UnimplementedConnectorConfigServiceServer) GetConnectorRuntimeState(context.Context, *GetConnectorRuntimeStateRequest) (*GetConnectorRuntimeStateResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetConnectorRuntimeState not implemented")
+}
+func (UnimplementedConnectorConfigServiceServer) GetConnectorRuntimeBundle(context.Context, *GetConnectorRuntimeBundleRequest) (*GetConnectorRuntimeBundleResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetConnectorRuntimeBundle not implemented")
 }
 func (UnimplementedConnectorConfigServiceServer) GetConnectorOauthToken(context.Context, *GetConnectorOauthTokenRequest) (*GetConnectorOauthTokenResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetConnectorOauthToken not implemented")
@@ -118,6 +150,42 @@ func _ConnectorConfigService_GetConnectorConfig_Handler(srv interface{}, ctx con
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ConnectorConfigService_GetConnectorRuntimeState_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetConnectorRuntimeStateRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ConnectorConfigServiceServer).GetConnectorRuntimeState(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ConnectorConfigService_GetConnectorRuntimeState_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ConnectorConfigServiceServer).GetConnectorRuntimeState(ctx, req.(*GetConnectorRuntimeStateRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ConnectorConfigService_GetConnectorRuntimeBundle_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetConnectorRuntimeBundleRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ConnectorConfigServiceServer).GetConnectorRuntimeBundle(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ConnectorConfigService_GetConnectorRuntimeBundle_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ConnectorConfigServiceServer).GetConnectorRuntimeBundle(ctx, req.(*GetConnectorRuntimeBundleRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _ConnectorConfigService_GetConnectorOauthToken_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(GetConnectorOauthTokenRequest)
 	if err := dec(in); err != nil {
@@ -146,6 +214,14 @@ var ConnectorConfigService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetConnectorConfig",
 			Handler:    _ConnectorConfigService_GetConnectorConfig_Handler,
+		},
+		{
+			MethodName: "GetConnectorRuntimeState",
+			Handler:    _ConnectorConfigService_GetConnectorRuntimeState_Handler,
+		},
+		{
+			MethodName: "GetConnectorRuntimeBundle",
+			Handler:    _ConnectorConfigService_GetConnectorRuntimeBundle_Handler,
 		},
 		{
 			MethodName: "GetConnectorOauthToken",

--- a/pb/c1/connectorapi/baton/v1/config_protoopaque.pb.go
+++ b/pb/c1/connectorapi/baton/v1/config_protoopaque.pb.go
@@ -67,16 +67,17 @@ func (b0 GetConnectorConfigRequest_builder) Build() *GetConnectorConfigRequest {
 }
 
 type RuntimeState struct {
-	state                                  protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_RuntimeRevisionId           string                 `protobuf:"bytes,1,opt,name=runtime_revision_id,json=runtimeRevisionId,proto3"`
-	xxx_hidden_RuntimeGeneration           int64                  `protobuf:"varint,2,opt,name=runtime_generation,json=runtimeGeneration,proto3"`
-	xxx_hidden_ReleaseRevisionId           string                 `protobuf:"bytes,3,opt,name=release_revision_id,json=releaseRevisionId,proto3"`
-	xxx_hidden_EffectiveBundleDigest       string                 `protobuf:"bytes,4,opt,name=effective_bundle_digest,json=effectiveBundleDigest,proto3"`
-	xxx_hidden_InstanceConfigRevisionId    string                 `protobuf:"bytes,5,opt,name=instance_config_revision_id,json=instanceConfigRevisionId,proto3"`
-	xxx_hidden_InstanceConfigDigest        string                 `protobuf:"bytes,6,opt,name=instance_config_digest,json=instanceConfigDigest,proto3"`
-	xxx_hidden_RuntimeConfigContractDigest string                 `protobuf:"bytes,7,opt,name=runtime_config_contract_digest,json=runtimeConfigContractDigest,proto3"`
-	unknownFields                          protoimpl.UnknownFields
-	sizeCache                              protoimpl.SizeCache
+	state                                   protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_RuntimeRevisionId            string                 `protobuf:"bytes,1,opt,name=runtime_revision_id,json=runtimeRevisionId,proto3"`
+	xxx_hidden_RuntimeGeneration            int64                  `protobuf:"varint,2,opt,name=runtime_generation,json=runtimeGeneration,proto3"`
+	xxx_hidden_ReleaseRevisionId            string                 `protobuf:"bytes,3,opt,name=release_revision_id,json=releaseRevisionId,proto3"`
+	xxx_hidden_EffectiveBundleDigest        string                 `protobuf:"bytes,4,opt,name=effective_bundle_digest,json=effectiveBundleDigest,proto3"`
+	xxx_hidden_InstanceConfigRevisionId     string                 `protobuf:"bytes,5,opt,name=instance_config_revision_id,json=instanceConfigRevisionId,proto3"`
+	xxx_hidden_InstanceConfigDigest         string                 `protobuf:"bytes,6,opt,name=instance_config_digest,json=instanceConfigDigest,proto3"`
+	xxx_hidden_RuntimeConfigContractDigest  string                 `protobuf:"bytes,7,opt,name=runtime_config_contract_digest,json=runtimeConfigContractDigest,proto3"`
+	xxx_hidden_EffectiveRuntimePolicyDigest string                 `protobuf:"bytes,8,opt,name=effective_runtime_policy_digest,json=effectiveRuntimePolicyDigest,proto3"`
+	unknownFields                           protoimpl.UnknownFields
+	sizeCache                               protoimpl.SizeCache
 }
 
 func (x *RuntimeState) Reset() {
@@ -153,6 +154,13 @@ func (x *RuntimeState) GetRuntimeConfigContractDigest() string {
 	return ""
 }
 
+func (x *RuntimeState) GetEffectiveRuntimePolicyDigest() string {
+	if x != nil {
+		return x.xxx_hidden_EffectiveRuntimePolicyDigest
+	}
+	return ""
+}
+
 func (x *RuntimeState) SetRuntimeRevisionId(v string) {
 	x.xxx_hidden_RuntimeRevisionId = v
 }
@@ -181,16 +189,21 @@ func (x *RuntimeState) SetRuntimeConfigContractDigest(v string) {
 	x.xxx_hidden_RuntimeConfigContractDigest = v
 }
 
+func (x *RuntimeState) SetEffectiveRuntimePolicyDigest(v string) {
+	x.xxx_hidden_EffectiveRuntimePolicyDigest = v
+}
+
 type RuntimeState_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	RuntimeRevisionId           string
-	RuntimeGeneration           int64
-	ReleaseRevisionId           string
-	EffectiveBundleDigest       string
-	InstanceConfigRevisionId    string
-	InstanceConfigDigest        string
-	RuntimeConfigContractDigest string
+	RuntimeRevisionId            string
+	RuntimeGeneration            int64
+	ReleaseRevisionId            string
+	EffectiveBundleDigest        string
+	InstanceConfigRevisionId     string
+	InstanceConfigDigest         string
+	RuntimeConfigContractDigest  string
+	EffectiveRuntimePolicyDigest string
 }
 
 func (b0 RuntimeState_builder) Build() *RuntimeState {
@@ -204,6 +217,7 @@ func (b0 RuntimeState_builder) Build() *RuntimeState {
 	x.xxx_hidden_InstanceConfigRevisionId = b.InstanceConfigRevisionId
 	x.xxx_hidden_InstanceConfigDigest = b.InstanceConfigDigest
 	x.xxx_hidden_RuntimeConfigContractDigest = b.RuntimeConfigContractDigest
+	x.xxx_hidden_EffectiveRuntimePolicyDigest = b.EffectiveRuntimePolicyDigest
 	return m0
 }
 
@@ -839,7 +853,7 @@ var File_c1_connectorapi_baton_v1_config_proto protoreflect.FileDescriptor
 const file_c1_connectorapi_baton_v1_config_proto_rawDesc = "" +
 	"\n" +
 	"%c1/connectorapi/baton/v1/config.proto\x12\x18c1.connectorapi.baton.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\x1b\n" +
-	"\x19GetConnectorConfigRequest\"\x8f\x03\n" +
+	"\x19GetConnectorConfigRequest\"\xd6\x03\n" +
 	"\fRuntimeState\x12.\n" +
 	"\x13runtime_revision_id\x18\x01 \x01(\tR\x11runtimeRevisionId\x12-\n" +
 	"\x12runtime_generation\x18\x02 \x01(\x03R\x11runtimeGeneration\x12.\n" +
@@ -847,7 +861,8 @@ const file_c1_connectorapi_baton_v1_config_proto_rawDesc = "" +
 	"\x17effective_bundle_digest\x18\x04 \x01(\tR\x15effectiveBundleDigest\x12=\n" +
 	"\x1binstance_config_revision_id\x18\x05 \x01(\tR\x18instanceConfigRevisionId\x124\n" +
 	"\x16instance_config_digest\x18\x06 \x01(\tR\x14instanceConfigDigest\x12C\n" +
-	"\x1eruntime_config_contract_digest\x18\a \x01(\tR\x1bruntimeConfigContractDigest\"\xc0\x01\n" +
+	"\x1eruntime_config_contract_digest\x18\a \x01(\tR\x1bruntimeConfigContractDigest\x12E\n" +
+	"\x1feffective_runtime_policy_digest\x18\b \x01(\tR\x1ceffectiveRuntimePolicyDigest\"\xc0\x01\n" +
 	"\x1aGetConnectorConfigResponse\x12\x16\n" +
 	"\x06config\x18\x01 \x01(\fR\x06config\x12=\n" +
 	"\flast_updated\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\vlastUpdated\x12K\n" +

--- a/pb/c1/connectorapi/baton/v1/config_protoopaque.pb.go
+++ b/pb/c1/connectorapi/baton/v1/config_protoopaque.pb.go
@@ -511,10 +511,11 @@ func (b0 GetConnectorRuntimeBundleRequest_builder) Build() *GetConnectorRuntimeB
 }
 
 type GetConnectorRuntimeBundleResponse struct {
-	state             protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_Bundle []byte                 `protobuf:"bytes,1,opt,name=bundle,proto3"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	state                    protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Bundle        []byte                 `protobuf:"bytes,1,opt,name=bundle,proto3"`
+	xxx_hidden_RuntimeSchema []byte                 `protobuf:"bytes,2,opt,name=runtime_schema,json=runtimeSchema,proto3"`
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
 }
 
 func (x *GetConnectorRuntimeBundleResponse) Reset() {
@@ -549,6 +550,13 @@ func (x *GetConnectorRuntimeBundleResponse) GetBundle() []byte {
 	return nil
 }
 
+func (x *GetConnectorRuntimeBundleResponse) GetRuntimeSchema() []byte {
+	if x != nil {
+		return x.xxx_hidden_RuntimeSchema
+	}
+	return nil
+}
+
 func (x *GetConnectorRuntimeBundleResponse) SetBundle(v []byte) {
 	if v == nil {
 		v = []byte{}
@@ -556,10 +564,18 @@ func (x *GetConnectorRuntimeBundleResponse) SetBundle(v []byte) {
 	x.xxx_hidden_Bundle = v
 }
 
+func (x *GetConnectorRuntimeBundleResponse) SetRuntimeSchema(v []byte) {
+	if v == nil {
+		v = []byte{}
+	}
+	x.xxx_hidden_RuntimeSchema = v
+}
+
 type GetConnectorRuntimeBundleResponse_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	Bundle []byte
+	Bundle        []byte
+	RuntimeSchema []byte
 }
 
 func (b0 GetConnectorRuntimeBundleResponse_builder) Build() *GetConnectorRuntimeBundleResponse {
@@ -567,6 +583,7 @@ func (b0 GetConnectorRuntimeBundleResponse_builder) Build() *GetConnectorRuntime
 	b, x := &b0, m0
 	_, _ = b, x
 	x.xxx_hidden_Bundle = b.Bundle
+	x.xxx_hidden_RuntimeSchema = b.RuntimeSchema
 	return m0
 }
 
@@ -871,9 +888,10 @@ const file_c1_connectorapi_baton_v1_config_proto_rawDesc = "" +
 	" GetConnectorRuntimeStateResponse\x12=\n" +
 	"\flast_updated\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\vlastUpdated\x12K\n" +
 	"\rruntime_state\x18\x02 \x01(\v2&.c1.connectorapi.baton.v1.RuntimeStateR\fruntimeState\"\"\n" +
-	" GetConnectorRuntimeBundleRequest\";\n" +
+	" GetConnectorRuntimeBundleRequest\"b\n" +
 	"!GetConnectorRuntimeBundleResponse\x12\x16\n" +
-	"\x06bundle\x18\x01 \x01(\fR\x06bundle\"6\n" +
+	"\x06bundle\x18\x01 \x01(\fR\x06bundle\x12%\n" +
+	"\x0eruntime_schema\x18\x02 \x01(\fR\rruntimeSchema\"6\n" +
 	"\fSignedHeader\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x03(\tR\x05value\"\xb2\x01\n" +

--- a/pb/c1/connectorapi/baton/v1/config_protoopaque.pb.go
+++ b/pb/c1/connectorapi/baton/v1/config_protoopaque.pb.go
@@ -66,17 +66,159 @@ func (b0 GetConnectorConfigRequest_builder) Build() *GetConnectorConfigRequest {
 	return m0
 }
 
+type RuntimeState struct {
+	state                                  protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_RuntimeRevisionId           string                 `protobuf:"bytes,1,opt,name=runtime_revision_id,json=runtimeRevisionId,proto3"`
+	xxx_hidden_RuntimeGeneration           int64                  `protobuf:"varint,2,opt,name=runtime_generation,json=runtimeGeneration,proto3"`
+	xxx_hidden_ReleaseRevisionId           string                 `protobuf:"bytes,3,opt,name=release_revision_id,json=releaseRevisionId,proto3"`
+	xxx_hidden_EffectiveBundleDigest       string                 `protobuf:"bytes,4,opt,name=effective_bundle_digest,json=effectiveBundleDigest,proto3"`
+	xxx_hidden_InstanceConfigRevisionId    string                 `protobuf:"bytes,5,opt,name=instance_config_revision_id,json=instanceConfigRevisionId,proto3"`
+	xxx_hidden_InstanceConfigDigest        string                 `protobuf:"bytes,6,opt,name=instance_config_digest,json=instanceConfigDigest,proto3"`
+	xxx_hidden_RuntimeConfigContractDigest string                 `protobuf:"bytes,7,opt,name=runtime_config_contract_digest,json=runtimeConfigContractDigest,proto3"`
+	unknownFields                          protoimpl.UnknownFields
+	sizeCache                              protoimpl.SizeCache
+}
+
+func (x *RuntimeState) Reset() {
+	*x = RuntimeState{}
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RuntimeState) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RuntimeState) ProtoMessage() {}
+
+func (x *RuntimeState) ProtoReflect() protoreflect.Message {
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *RuntimeState) GetRuntimeRevisionId() string {
+	if x != nil {
+		return x.xxx_hidden_RuntimeRevisionId
+	}
+	return ""
+}
+
+func (x *RuntimeState) GetRuntimeGeneration() int64 {
+	if x != nil {
+		return x.xxx_hidden_RuntimeGeneration
+	}
+	return 0
+}
+
+func (x *RuntimeState) GetReleaseRevisionId() string {
+	if x != nil {
+		return x.xxx_hidden_ReleaseRevisionId
+	}
+	return ""
+}
+
+func (x *RuntimeState) GetEffectiveBundleDigest() string {
+	if x != nil {
+		return x.xxx_hidden_EffectiveBundleDigest
+	}
+	return ""
+}
+
+func (x *RuntimeState) GetInstanceConfigRevisionId() string {
+	if x != nil {
+		return x.xxx_hidden_InstanceConfigRevisionId
+	}
+	return ""
+}
+
+func (x *RuntimeState) GetInstanceConfigDigest() string {
+	if x != nil {
+		return x.xxx_hidden_InstanceConfigDigest
+	}
+	return ""
+}
+
+func (x *RuntimeState) GetRuntimeConfigContractDigest() string {
+	if x != nil {
+		return x.xxx_hidden_RuntimeConfigContractDigest
+	}
+	return ""
+}
+
+func (x *RuntimeState) SetRuntimeRevisionId(v string) {
+	x.xxx_hidden_RuntimeRevisionId = v
+}
+
+func (x *RuntimeState) SetRuntimeGeneration(v int64) {
+	x.xxx_hidden_RuntimeGeneration = v
+}
+
+func (x *RuntimeState) SetReleaseRevisionId(v string) {
+	x.xxx_hidden_ReleaseRevisionId = v
+}
+
+func (x *RuntimeState) SetEffectiveBundleDigest(v string) {
+	x.xxx_hidden_EffectiveBundleDigest = v
+}
+
+func (x *RuntimeState) SetInstanceConfigRevisionId(v string) {
+	x.xxx_hidden_InstanceConfigRevisionId = v
+}
+
+func (x *RuntimeState) SetInstanceConfigDigest(v string) {
+	x.xxx_hidden_InstanceConfigDigest = v
+}
+
+func (x *RuntimeState) SetRuntimeConfigContractDigest(v string) {
+	x.xxx_hidden_RuntimeConfigContractDigest = v
+}
+
+type RuntimeState_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	RuntimeRevisionId           string
+	RuntimeGeneration           int64
+	ReleaseRevisionId           string
+	EffectiveBundleDigest       string
+	InstanceConfigRevisionId    string
+	InstanceConfigDigest        string
+	RuntimeConfigContractDigest string
+}
+
+func (b0 RuntimeState_builder) Build() *RuntimeState {
+	m0 := &RuntimeState{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_RuntimeRevisionId = b.RuntimeRevisionId
+	x.xxx_hidden_RuntimeGeneration = b.RuntimeGeneration
+	x.xxx_hidden_ReleaseRevisionId = b.ReleaseRevisionId
+	x.xxx_hidden_EffectiveBundleDigest = b.EffectiveBundleDigest
+	x.xxx_hidden_InstanceConfigRevisionId = b.InstanceConfigRevisionId
+	x.xxx_hidden_InstanceConfigDigest = b.InstanceConfigDigest
+	x.xxx_hidden_RuntimeConfigContractDigest = b.RuntimeConfigContractDigest
+	return m0
+}
+
 type GetConnectorConfigResponse struct {
-	state                  protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_Config      []byte                 `protobuf:"bytes,1,opt,name=config,proto3"`
-	xxx_hidden_LastUpdated *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=last_updated,json=lastUpdated,proto3"`
-	unknownFields          protoimpl.UnknownFields
-	sizeCache              protoimpl.SizeCache
+	state                   protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Config       []byte                 `protobuf:"bytes,1,opt,name=config,proto3"`
+	xxx_hidden_LastUpdated  *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=last_updated,json=lastUpdated,proto3"`
+	xxx_hidden_RuntimeState *RuntimeState          `protobuf:"bytes,3,opt,name=runtime_state,json=runtimeState,proto3"`
+	unknownFields           protoimpl.UnknownFields
+	sizeCache               protoimpl.SizeCache
 }
 
 func (x *GetConnectorConfigResponse) Reset() {
 	*x = GetConnectorConfigResponse{}
-	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[1]
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -88,7 +230,7 @@ func (x *GetConnectorConfigResponse) String() string {
 func (*GetConnectorConfigResponse) ProtoMessage() {}
 
 func (x *GetConnectorConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[1]
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -113,6 +255,13 @@ func (x *GetConnectorConfigResponse) GetLastUpdated() *timestamppb.Timestamp {
 	return nil
 }
 
+func (x *GetConnectorConfigResponse) GetRuntimeState() *RuntimeState {
+	if x != nil {
+		return x.xxx_hidden_RuntimeState
+	}
+	return nil
+}
+
 func (x *GetConnectorConfigResponse) SetConfig(v []byte) {
 	if v == nil {
 		v = []byte{}
@@ -124,6 +273,10 @@ func (x *GetConnectorConfigResponse) SetLastUpdated(v *timestamppb.Timestamp) {
 	x.xxx_hidden_LastUpdated = v
 }
 
+func (x *GetConnectorConfigResponse) SetRuntimeState(v *RuntimeState) {
+	x.xxx_hidden_RuntimeState = v
+}
+
 func (x *GetConnectorConfigResponse) HasLastUpdated() bool {
 	if x == nil {
 		return false
@@ -131,15 +284,27 @@ func (x *GetConnectorConfigResponse) HasLastUpdated() bool {
 	return x.xxx_hidden_LastUpdated != nil
 }
 
+func (x *GetConnectorConfigResponse) HasRuntimeState() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_RuntimeState != nil
+}
+
 func (x *GetConnectorConfigResponse) ClearLastUpdated() {
 	x.xxx_hidden_LastUpdated = nil
+}
+
+func (x *GetConnectorConfigResponse) ClearRuntimeState() {
+	x.xxx_hidden_RuntimeState = nil
 }
 
 type GetConnectorConfigResponse_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	Config      []byte
-	LastUpdated *timestamppb.Timestamp
+	Config       []byte
+	LastUpdated  *timestamppb.Timestamp
+	RuntimeState *RuntimeState
 }
 
 func (b0 GetConnectorConfigResponse_builder) Build() *GetConnectorConfigResponse {
@@ -148,6 +313,246 @@ func (b0 GetConnectorConfigResponse_builder) Build() *GetConnectorConfigResponse
 	_, _ = b, x
 	x.xxx_hidden_Config = b.Config
 	x.xxx_hidden_LastUpdated = b.LastUpdated
+	x.xxx_hidden_RuntimeState = b.RuntimeState
+	return m0
+}
+
+type GetConnectorRuntimeStateRequest struct {
+	state         protoimpl.MessageState `protogen:"opaque.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetConnectorRuntimeStateRequest) Reset() {
+	*x = GetConnectorRuntimeStateRequest{}
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetConnectorRuntimeStateRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetConnectorRuntimeStateRequest) ProtoMessage() {}
+
+func (x *GetConnectorRuntimeStateRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+type GetConnectorRuntimeStateRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+}
+
+func (b0 GetConnectorRuntimeStateRequest_builder) Build() *GetConnectorRuntimeStateRequest {
+	m0 := &GetConnectorRuntimeStateRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	return m0
+}
+
+type GetConnectorRuntimeStateResponse struct {
+	state                   protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_LastUpdated  *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=last_updated,json=lastUpdated,proto3"`
+	xxx_hidden_RuntimeState *RuntimeState          `protobuf:"bytes,2,opt,name=runtime_state,json=runtimeState,proto3"`
+	unknownFields           protoimpl.UnknownFields
+	sizeCache               protoimpl.SizeCache
+}
+
+func (x *GetConnectorRuntimeStateResponse) Reset() {
+	*x = GetConnectorRuntimeStateResponse{}
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetConnectorRuntimeStateResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetConnectorRuntimeStateResponse) ProtoMessage() {}
+
+func (x *GetConnectorRuntimeStateResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *GetConnectorRuntimeStateResponse) GetLastUpdated() *timestamppb.Timestamp {
+	if x != nil {
+		return x.xxx_hidden_LastUpdated
+	}
+	return nil
+}
+
+func (x *GetConnectorRuntimeStateResponse) GetRuntimeState() *RuntimeState {
+	if x != nil {
+		return x.xxx_hidden_RuntimeState
+	}
+	return nil
+}
+
+func (x *GetConnectorRuntimeStateResponse) SetLastUpdated(v *timestamppb.Timestamp) {
+	x.xxx_hidden_LastUpdated = v
+}
+
+func (x *GetConnectorRuntimeStateResponse) SetRuntimeState(v *RuntimeState) {
+	x.xxx_hidden_RuntimeState = v
+}
+
+func (x *GetConnectorRuntimeStateResponse) HasLastUpdated() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_LastUpdated != nil
+}
+
+func (x *GetConnectorRuntimeStateResponse) HasRuntimeState() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_RuntimeState != nil
+}
+
+func (x *GetConnectorRuntimeStateResponse) ClearLastUpdated() {
+	x.xxx_hidden_LastUpdated = nil
+}
+
+func (x *GetConnectorRuntimeStateResponse) ClearRuntimeState() {
+	x.xxx_hidden_RuntimeState = nil
+}
+
+type GetConnectorRuntimeStateResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	LastUpdated  *timestamppb.Timestamp
+	RuntimeState *RuntimeState
+}
+
+func (b0 GetConnectorRuntimeStateResponse_builder) Build() *GetConnectorRuntimeStateResponse {
+	m0 := &GetConnectorRuntimeStateResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_LastUpdated = b.LastUpdated
+	x.xxx_hidden_RuntimeState = b.RuntimeState
+	return m0
+}
+
+type GetConnectorRuntimeBundleRequest struct {
+	state         protoimpl.MessageState `protogen:"opaque.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetConnectorRuntimeBundleRequest) Reset() {
+	*x = GetConnectorRuntimeBundleRequest{}
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetConnectorRuntimeBundleRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetConnectorRuntimeBundleRequest) ProtoMessage() {}
+
+func (x *GetConnectorRuntimeBundleRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+type GetConnectorRuntimeBundleRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+}
+
+func (b0 GetConnectorRuntimeBundleRequest_builder) Build() *GetConnectorRuntimeBundleRequest {
+	m0 := &GetConnectorRuntimeBundleRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	return m0
+}
+
+type GetConnectorRuntimeBundleResponse struct {
+	state             protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Bundle []byte                 `protobuf:"bytes,1,opt,name=bundle,proto3"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *GetConnectorRuntimeBundleResponse) Reset() {
+	*x = GetConnectorRuntimeBundleResponse{}
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetConnectorRuntimeBundleResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetConnectorRuntimeBundleResponse) ProtoMessage() {}
+
+func (x *GetConnectorRuntimeBundleResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *GetConnectorRuntimeBundleResponse) GetBundle() []byte {
+	if x != nil {
+		return x.xxx_hidden_Bundle
+	}
+	return nil
+}
+
+func (x *GetConnectorRuntimeBundleResponse) SetBundle(v []byte) {
+	if v == nil {
+		v = []byte{}
+	}
+	x.xxx_hidden_Bundle = v
+}
+
+type GetConnectorRuntimeBundleResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	Bundle []byte
+}
+
+func (b0 GetConnectorRuntimeBundleResponse_builder) Build() *GetConnectorRuntimeBundleResponse {
+	m0 := &GetConnectorRuntimeBundleResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Bundle = b.Bundle
 	return m0
 }
 
@@ -161,7 +566,7 @@ type SignedHeader struct {
 
 func (x *SignedHeader) Reset() {
 	*x = SignedHeader{}
-	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[2]
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -173,7 +578,7 @@ func (x *SignedHeader) String() string {
 func (*SignedHeader) ProtoMessage() {}
 
 func (x *SignedHeader) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[2]
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -234,7 +639,7 @@ type Sigv4SignedRequestSTSGetCallerIdentity struct {
 
 func (x *Sigv4SignedRequestSTSGetCallerIdentity) Reset() {
 	*x = Sigv4SignedRequestSTSGetCallerIdentity{}
-	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[3]
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -246,7 +651,7 @@ func (x *Sigv4SignedRequestSTSGetCallerIdentity) String() string {
 func (*Sigv4SignedRequestSTSGetCallerIdentity) ProtoMessage() {}
 
 func (x *Sigv4SignedRequestSTSGetCallerIdentity) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[3]
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -334,7 +739,7 @@ type GetConnectorOauthTokenRequest struct {
 
 func (x *GetConnectorOauthTokenRequest) Reset() {
 	*x = GetConnectorOauthTokenRequest{}
-	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[4]
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -346,7 +751,7 @@ func (x *GetConnectorOauthTokenRequest) String() string {
 func (*GetConnectorOauthTokenRequest) ProtoMessage() {}
 
 func (x *GetConnectorOauthTokenRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[4]
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -378,7 +783,7 @@ type GetConnectorOauthTokenResponse struct {
 
 func (x *GetConnectorOauthTokenResponse) Reset() {
 	*x = GetConnectorOauthTokenResponse{}
-	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[5]
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -390,7 +795,7 @@ func (x *GetConnectorOauthTokenResponse) String() string {
 func (*GetConnectorOauthTokenResponse) ProtoMessage() {}
 
 func (x *GetConnectorOauthTokenResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[5]
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -434,10 +839,26 @@ var File_c1_connectorapi_baton_v1_config_proto protoreflect.FileDescriptor
 const file_c1_connectorapi_baton_v1_config_proto_rawDesc = "" +
 	"\n" +
 	"%c1/connectorapi/baton/v1/config.proto\x12\x18c1.connectorapi.baton.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\x1b\n" +
-	"\x19GetConnectorConfigRequest\"s\n" +
+	"\x19GetConnectorConfigRequest\"\x8f\x03\n" +
+	"\fRuntimeState\x12.\n" +
+	"\x13runtime_revision_id\x18\x01 \x01(\tR\x11runtimeRevisionId\x12-\n" +
+	"\x12runtime_generation\x18\x02 \x01(\x03R\x11runtimeGeneration\x12.\n" +
+	"\x13release_revision_id\x18\x03 \x01(\tR\x11releaseRevisionId\x126\n" +
+	"\x17effective_bundle_digest\x18\x04 \x01(\tR\x15effectiveBundleDigest\x12=\n" +
+	"\x1binstance_config_revision_id\x18\x05 \x01(\tR\x18instanceConfigRevisionId\x124\n" +
+	"\x16instance_config_digest\x18\x06 \x01(\tR\x14instanceConfigDigest\x12C\n" +
+	"\x1eruntime_config_contract_digest\x18\a \x01(\tR\x1bruntimeConfigContractDigest\"\xc0\x01\n" +
 	"\x1aGetConnectorConfigResponse\x12\x16\n" +
 	"\x06config\x18\x01 \x01(\fR\x06config\x12=\n" +
-	"\flast_updated\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\vlastUpdated\"6\n" +
+	"\flast_updated\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\vlastUpdated\x12K\n" +
+	"\rruntime_state\x18\x03 \x01(\v2&.c1.connectorapi.baton.v1.RuntimeStateR\fruntimeState\"!\n" +
+	"\x1fGetConnectorRuntimeStateRequest\"\xae\x01\n" +
+	" GetConnectorRuntimeStateResponse\x12=\n" +
+	"\flast_updated\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\vlastUpdated\x12K\n" +
+	"\rruntime_state\x18\x02 \x01(\v2&.c1.connectorapi.baton.v1.RuntimeStateR\fruntimeState\"\"\n" +
+	" GetConnectorRuntimeBundleRequest\";\n" +
+	"!GetConnectorRuntimeBundleResponse\x12\x16\n" +
+	"\x06bundle\x18\x01 \x01(\fR\x06bundle\"6\n" +
 	"\fSignedHeader\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x03(\tR\x05value\"\xb2\x01\n" +
@@ -448,33 +869,47 @@ const file_c1_connectorapi_baton_v1_config_proto_rawDesc = "" +
 	"\x04body\x18\x04 \x01(\fR\x04body\"\x1f\n" +
 	"\x1dGetConnectorOauthTokenRequest\"6\n" +
 	"\x1eGetConnectorOauthTokenResponse\x12\x14\n" +
-	"\x05token\x18\x01 \x01(\fR\x05token2\xa7\x02\n" +
+	"\x05token\x18\x01 \x01(\fR\x05token2\xd2\x04\n" +
 	"\x16ConnectorConfigService\x12\x7f\n" +
-	"\x12GetConnectorConfig\x123.c1.connectorapi.baton.v1.GetConnectorConfigRequest\x1a4.c1.connectorapi.baton.v1.GetConnectorConfigResponse\x12\x8b\x01\n" +
+	"\x12GetConnectorConfig\x123.c1.connectorapi.baton.v1.GetConnectorConfigRequest\x1a4.c1.connectorapi.baton.v1.GetConnectorConfigResponse\x12\x91\x01\n" +
+	"\x18GetConnectorRuntimeState\x129.c1.connectorapi.baton.v1.GetConnectorRuntimeStateRequest\x1a:.c1.connectorapi.baton.v1.GetConnectorRuntimeStateResponse\x12\x94\x01\n" +
+	"\x19GetConnectorRuntimeBundle\x12:.c1.connectorapi.baton.v1.GetConnectorRuntimeBundleRequest\x1a;.c1.connectorapi.baton.v1.GetConnectorRuntimeBundleResponse\x12\x8b\x01\n" +
 	"\x16GetConnectorOauthToken\x127.c1.connectorapi.baton.v1.GetConnectorOauthTokenRequest\x1a8.c1.connectorapi.baton.v1.GetConnectorOauthTokenResponseB7Z5gitlab.com/ductone/c1/pkg/pb/c1/connectorapi/baton/v1b\x06proto3"
 
-var file_c1_connectorapi_baton_v1_config_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
+var file_c1_connectorapi_baton_v1_config_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
 var file_c1_connectorapi_baton_v1_config_proto_goTypes = []any{
 	(*GetConnectorConfigRequest)(nil),              // 0: c1.connectorapi.baton.v1.GetConnectorConfigRequest
-	(*GetConnectorConfigResponse)(nil),             // 1: c1.connectorapi.baton.v1.GetConnectorConfigResponse
-	(*SignedHeader)(nil),                           // 2: c1.connectorapi.baton.v1.SignedHeader
-	(*Sigv4SignedRequestSTSGetCallerIdentity)(nil), // 3: c1.connectorapi.baton.v1.Sigv4SignedRequestSTSGetCallerIdentity
-	(*GetConnectorOauthTokenRequest)(nil),          // 4: c1.connectorapi.baton.v1.GetConnectorOauthTokenRequest
-	(*GetConnectorOauthTokenResponse)(nil),         // 5: c1.connectorapi.baton.v1.GetConnectorOauthTokenResponse
-	(*timestamppb.Timestamp)(nil),                  // 6: google.protobuf.Timestamp
+	(*RuntimeState)(nil),                           // 1: c1.connectorapi.baton.v1.RuntimeState
+	(*GetConnectorConfigResponse)(nil),             // 2: c1.connectorapi.baton.v1.GetConnectorConfigResponse
+	(*GetConnectorRuntimeStateRequest)(nil),        // 3: c1.connectorapi.baton.v1.GetConnectorRuntimeStateRequest
+	(*GetConnectorRuntimeStateResponse)(nil),       // 4: c1.connectorapi.baton.v1.GetConnectorRuntimeStateResponse
+	(*GetConnectorRuntimeBundleRequest)(nil),       // 5: c1.connectorapi.baton.v1.GetConnectorRuntimeBundleRequest
+	(*GetConnectorRuntimeBundleResponse)(nil),      // 6: c1.connectorapi.baton.v1.GetConnectorRuntimeBundleResponse
+	(*SignedHeader)(nil),                           // 7: c1.connectorapi.baton.v1.SignedHeader
+	(*Sigv4SignedRequestSTSGetCallerIdentity)(nil), // 8: c1.connectorapi.baton.v1.Sigv4SignedRequestSTSGetCallerIdentity
+	(*GetConnectorOauthTokenRequest)(nil),          // 9: c1.connectorapi.baton.v1.GetConnectorOauthTokenRequest
+	(*GetConnectorOauthTokenResponse)(nil),         // 10: c1.connectorapi.baton.v1.GetConnectorOauthTokenResponse
+	(*timestamppb.Timestamp)(nil),                  // 11: google.protobuf.Timestamp
 }
 var file_c1_connectorapi_baton_v1_config_proto_depIdxs = []int32{
-	6, // 0: c1.connectorapi.baton.v1.GetConnectorConfigResponse.last_updated:type_name -> google.protobuf.Timestamp
-	2, // 1: c1.connectorapi.baton.v1.Sigv4SignedRequestSTSGetCallerIdentity.headers:type_name -> c1.connectorapi.baton.v1.SignedHeader
-	0, // 2: c1.connectorapi.baton.v1.ConnectorConfigService.GetConnectorConfig:input_type -> c1.connectorapi.baton.v1.GetConnectorConfigRequest
-	4, // 3: c1.connectorapi.baton.v1.ConnectorConfigService.GetConnectorOauthToken:input_type -> c1.connectorapi.baton.v1.GetConnectorOauthTokenRequest
-	1, // 4: c1.connectorapi.baton.v1.ConnectorConfigService.GetConnectorConfig:output_type -> c1.connectorapi.baton.v1.GetConnectorConfigResponse
-	5, // 5: c1.connectorapi.baton.v1.ConnectorConfigService.GetConnectorOauthToken:output_type -> c1.connectorapi.baton.v1.GetConnectorOauthTokenResponse
-	4, // [4:6] is the sub-list for method output_type
-	2, // [2:4] is the sub-list for method input_type
-	2, // [2:2] is the sub-list for extension type_name
-	2, // [2:2] is the sub-list for extension extendee
-	0, // [0:2] is the sub-list for field type_name
+	11, // 0: c1.connectorapi.baton.v1.GetConnectorConfigResponse.last_updated:type_name -> google.protobuf.Timestamp
+	1,  // 1: c1.connectorapi.baton.v1.GetConnectorConfigResponse.runtime_state:type_name -> c1.connectorapi.baton.v1.RuntimeState
+	11, // 2: c1.connectorapi.baton.v1.GetConnectorRuntimeStateResponse.last_updated:type_name -> google.protobuf.Timestamp
+	1,  // 3: c1.connectorapi.baton.v1.GetConnectorRuntimeStateResponse.runtime_state:type_name -> c1.connectorapi.baton.v1.RuntimeState
+	7,  // 4: c1.connectorapi.baton.v1.Sigv4SignedRequestSTSGetCallerIdentity.headers:type_name -> c1.connectorapi.baton.v1.SignedHeader
+	0,  // 5: c1.connectorapi.baton.v1.ConnectorConfigService.GetConnectorConfig:input_type -> c1.connectorapi.baton.v1.GetConnectorConfigRequest
+	3,  // 6: c1.connectorapi.baton.v1.ConnectorConfigService.GetConnectorRuntimeState:input_type -> c1.connectorapi.baton.v1.GetConnectorRuntimeStateRequest
+	5,  // 7: c1.connectorapi.baton.v1.ConnectorConfigService.GetConnectorRuntimeBundle:input_type -> c1.connectorapi.baton.v1.GetConnectorRuntimeBundleRequest
+	9,  // 8: c1.connectorapi.baton.v1.ConnectorConfigService.GetConnectorOauthToken:input_type -> c1.connectorapi.baton.v1.GetConnectorOauthTokenRequest
+	2,  // 9: c1.connectorapi.baton.v1.ConnectorConfigService.GetConnectorConfig:output_type -> c1.connectorapi.baton.v1.GetConnectorConfigResponse
+	4,  // 10: c1.connectorapi.baton.v1.ConnectorConfigService.GetConnectorRuntimeState:output_type -> c1.connectorapi.baton.v1.GetConnectorRuntimeStateResponse
+	6,  // 11: c1.connectorapi.baton.v1.ConnectorConfigService.GetConnectorRuntimeBundle:output_type -> c1.connectorapi.baton.v1.GetConnectorRuntimeBundleResponse
+	10, // 12: c1.connectorapi.baton.v1.ConnectorConfigService.GetConnectorOauthToken:output_type -> c1.connectorapi.baton.v1.GetConnectorOauthTokenResponse
+	9,  // [9:13] is the sub-list for method output_type
+	5,  // [5:9] is the sub-list for method input_type
+	5,  // [5:5] is the sub-list for extension type_name
+	5,  // [5:5] is the sub-list for extension extendee
+	0,  // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_c1_connectorapi_baton_v1_config_proto_init() }
@@ -488,7 +923,7 @@ func file_c1_connectorapi_baton_v1_config_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_c1_connectorapi_baton_v1_config_proto_rawDesc), len(file_c1_connectorapi_baton_v1_config_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   6,
+			NumMessages:   11,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"strings"
 
+	v1 "github.com/conductorone/baton-sdk/pb/c1/connectorapi/baton/v1"
 	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
 	"github.com/conductorone/baton-sdk/pkg/field"
 	"github.com/conductorone/baton-sdk/pkg/types"
@@ -16,13 +17,82 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"golang.org/x/oauth2"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
+type ConnectorConfigSnapshot struct {
+	Config        *structpb.Struct
+	RuntimeState  *v1.RuntimeState
+	RuntimeBundle []byte
+}
+
 type RunTimeOpts struct {
-	SessionStore        sessions.SessionStore
-	TokenSource         oauth2.TokenSource
-	SelectedAuthMethod  string
-	SyncResourceTypeIDs []string
+	SessionStore          sessions.SessionStore
+	TokenSource           oauth2.TokenSource
+	SelectedAuthMethod    string
+	SyncResourceTypeIDs   []string
+	RuntimeState          *v1.RuntimeState
+	RuntimeBundle         []byte
+	BootstrapConfig       map[string]any
+	ConnectorConfigClient v1.ConnectorConfigServiceClient
+	ReloadConnectorConfig func(context.Context) (*ConnectorConfigSnapshot, error)
+}
+
+func CloneConfigSettings(v *viper.Viper) map[string]any {
+	if v == nil {
+		return map[string]any{}
+	}
+	return cloneSettingsMap(v.AllSettings())
+}
+
+func HydrateConnectorConfig(base map[string]any, snapshot *ConnectorConfigSnapshot) *viper.Viper {
+	cfg := viper.New()
+	for key, value := range cloneSettingsMap(base) {
+		cfg.Set(key, value)
+	}
+	if snapshot == nil || snapshot.Config == nil {
+		return cfg
+	}
+	for key, value := range snapshot.Config.AsMap() {
+		cfg.Set(key, value)
+	}
+	return cfg
+}
+
+func cloneSettingsMap(in map[string]any) map[string]any {
+	if len(in) == 0 {
+		return map[string]any{}
+	}
+	out := make(map[string]any, len(in))
+	for key, value := range in {
+		out[key] = cloneSettingsValue(value)
+	}
+	return out
+}
+
+func cloneSettingsValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		return cloneSettingsMap(typed)
+	case map[any]any:
+		out := make(map[string]any, len(typed))
+		for key, nested := range typed {
+			out[fmt.Sprint(key)] = cloneSettingsValue(nested)
+		}
+		return out
+	case []any:
+		out := make([]any, len(typed))
+		for i, nested := range typed {
+			out[i] = cloneSettingsValue(nested)
+		}
+		return out
+	case []string:
+		out := make([]string, len(typed))
+		copy(out, typed)
+		return out
+	default:
+		return typed
+	}
 }
 
 // GetConnectorFunc is a function type that creates a connector instance.

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -20,22 +20,37 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
+// ConnectorConfigSnapshot is the authoritative config snapshot returned by C1
+// for a managed connector generation. It carries the encrypted connector config
+// payload plus the resolved runtime assets the framework needs to rebuild the
+// connector in place.
 type ConnectorConfigSnapshot struct {
 	Config        *structpb.Struct
 	RuntimeState  *v1.RuntimeState
+	RuntimeSchema []byte
 	RuntimeBundle []byte
+	RuntimePolicy []byte
 }
 
-type RunTimeOpts struct {
-	SessionStore          sessions.SessionStore
-	TokenSource           oauth2.TokenSource
-	SelectedAuthMethod    string
-	SyncResourceTypeIDs   []string
-	RuntimeState          *v1.RuntimeState
-	RuntimeBundle         []byte
+// ManagedRuntimeOpts groups the framework-owned snapshot and refresh plumbing
+// used by managed runtimes. Native connectors can ignore this block entirely.
+type ManagedRuntimeOpts struct {
+	Snapshot              *ConnectorConfigSnapshot
 	BootstrapConfig       map[string]any
 	ConnectorConfigClient v1.ConnectorConfigServiceClient
 	ReloadConnectorConfig func(context.Context) (*ConnectorConfigSnapshot, error)
+}
+
+// RunTimeOpts carries framework-owned runtime state and assets into a connector
+// factory invocation. Native connectors typically use only the auth/session
+// pieces. Managed runtimes opt into the additional snapshot/reload plumbing by
+// populating ManagedRuntime.
+type RunTimeOpts struct {
+	SessionStore        sessions.SessionStore
+	TokenSource         oauth2.TokenSource
+	SelectedAuthMethod  string
+	SyncResourceTypeIDs []string
+	ManagedRuntime      *ManagedRuntimeOpts
 }
 
 func CloneConfigSettings(v *viper.Viper) map[string]any {

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"encoding/base64"
 	"os"
 	"path/filepath"
 	"sort"
@@ -11,7 +12,47 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
 )
+
+type testLambdaConfig struct {
+	ConfigPath string   `mapstructure:"config-path"`
+	Name       string   `mapstructure:"name"`
+	Tags       []string `mapstructure:"tags"`
+	Payload    []byte   `mapstructure:"payload"`
+}
+
+func (c *testLambdaConfig) GetString(key string) string {
+	switch key {
+	case "config-path":
+		return c.ConfigPath
+	case "name":
+		return c.Name
+	default:
+		return ""
+	}
+}
+
+func (c *testLambdaConfig) GetBool(key string) bool {
+	return false
+}
+
+func (c *testLambdaConfig) GetInt(key string) int {
+	return 0
+}
+
+func (c *testLambdaConfig) GetStringSlice(key string) []string {
+	switch key {
+	case "tags":
+		return append([]string(nil), c.Tags...)
+	default:
+		return nil
+	}
+}
+
+func (c *testLambdaConfig) GetStringMap(key string) map[string]any {
+	return nil
+}
 
 // setupCommand creates a cobra command with registered flags from the given schema,
 // then calls VisitFlags to transfer viper values into pflag.
@@ -167,6 +208,59 @@ func TestVisitFlags_StringToString_YAMLMap(t *testing.T) {
 	got, err := cmd.Flags().GetStringToString("labels")
 	require.NoError(t, err)
 	require.Equal(t, map[string]string{"env": "prod", "team": "platform"}, got)
+}
+
+func TestHydrateConnectorConfig_ViperConfigPreservesBootstrapFields(t *testing.T) {
+	base := viper.New()
+	base.Set("config-path", "/tmp/runtime/config.yaml")
+	base.Set("bootstrap-js-path", "/tmp/runtime/bootstrap.js")
+	base.Set("connector-js-path", "/tmp/runtime/connector.js")
+	base.Set("jira-url", "https://old.example.com")
+
+	snapshotConfig, err := structpb.NewStruct(map[string]any{
+		"jira-url":       "https://new.example.com",
+		"jira-api-token": "secret",
+	})
+	require.NoError(t, err)
+
+	effective := HydrateConnectorConfig(CloneConfigSettings(base), &ConnectorConfigSnapshot{
+		Config: snapshotConfig,
+	})
+
+	require.Equal(t, "/tmp/runtime/config.yaml", effective.GetString("config-path"))
+	require.Equal(t, "/tmp/runtime/bootstrap.js", effective.GetString("bootstrap-js-path"))
+	require.Equal(t, "/tmp/runtime/connector.js", effective.GetString("connector-js-path"))
+	require.Equal(t, "https://new.example.com", effective.GetString("jira-url"))
+	require.Equal(t, "secret", effective.GetString("jira-api-token"))
+}
+
+func TestHydrateConnectorConfig_TypedConfigRetainsBootstrapAndDecodeHooks(t *testing.T) {
+	base := viper.New()
+	base.Set("config-path", "/tmp/runtime/config.yaml")
+	base.Set("name", "bootstrap-name")
+
+	payload := []byte(`{"hello":"world"}`)
+	snapshotConfig, err := structpb.NewStruct(map[string]any{
+		"name":    "c1-name",
+		"tags":    "alpha,beta",
+		"payload": base64.StdEncoding.EncodeToString(payload),
+	})
+	require.NoError(t, err)
+
+	effective := HydrateConnectorConfig(CloneConfigSettings(base), &ConnectorConfigSnapshot{
+		Config: snapshotConfig,
+	})
+
+	cfg, err := MakeGenericConfiguration[*testLambdaConfig](
+		effective,
+		field.WithAdditionalDecodeHooks(field.FileUploadDecodeHook(false)),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	require.Equal(t, "/tmp/runtime/config.yaml", cfg.ConfigPath)
+	require.Equal(t, "c1-name", cfg.Name)
+	require.Equal(t, []string{"alpha", "beta"}, cfg.Tags)
+	require.Equal(t, payload, cfg.Payload)
 }
 
 func TestVisitFlags_StringToString_SingleEntry(t *testing.T) {

--- a/pkg/cli/lambda_server__added.go
+++ b/pkg/cli/lambda_server__added.go
@@ -58,7 +58,9 @@ func fetchConnectorConfigSnapshot(
 	return &ConnectorConfigSnapshot{
 		Config:        configStruct,
 		RuntimeState:  config.GetRuntimeState(),
+		RuntimeSchema: nil,
 		RuntimeBundle: runtimeBundle,
+		RuntimePolicy: nil,
 	}, nil
 }
 
@@ -249,14 +251,15 @@ func OptionallyAddLambdaCommand[T field.Configurable](
 					otterOptions.MaximumWeight = uint64(sessionStoreMaximumSize)
 				}
 			}),
-			SelectedAuthMethod:    authMethodStr,
-			SyncResourceTypeIDs:   v.GetStringSlice("sync-resource-types"),
-			RuntimeState:          configSnapshot.RuntimeState,
-			RuntimeBundle:         configSnapshot.RuntimeBundle,
-			BootstrapConfig:       bootstrapConfig,
-			ConnectorConfigClient: configClient,
-			ReloadConnectorConfig: func(ctx context.Context) (*ConnectorConfigSnapshot, error) {
-				return fetchConnectorConfigSnapshot(ctx, configClient, ed25519PrivateKey)
+			SelectedAuthMethod:  authMethodStr,
+			SyncResourceTypeIDs: v.GetStringSlice("sync-resource-types"),
+			ManagedRuntime: &ManagedRuntimeOpts{
+				Snapshot:              configSnapshot,
+				BootstrapConfig:       bootstrapConfig,
+				ConnectorConfigClient: configClient,
+				ReloadConnectorConfig: func(ctx context.Context) (*ConnectorConfigSnapshot, error) {
+					return fetchConnectorConfigSnapshot(ctx, configClient, ed25519PrivateKey)
+				},
 			},
 		}
 

--- a/pkg/cli/lambda_server__added.go
+++ b/pkg/cli/lambda_server__added.go
@@ -45,7 +45,7 @@ func fetchConnectorConfigSnapshot(
 		return nil, fmt.Errorf("lambda-run: failed to get connector config: %w", err)
 	}
 
-	runtimeBundle, err := fetchConnectorRuntimeBundle(ctx, configClient, config.GetRuntimeState())
+	runtimeAssets, err := fetchConnectorRuntimeAssets(ctx, configClient, config.GetRuntimeState())
 	if err != nil {
 		return nil, err
 	}
@@ -58,26 +58,37 @@ func fetchConnectorConfigSnapshot(
 	return &ConnectorConfigSnapshot{
 		Config:        configStruct,
 		RuntimeState:  config.GetRuntimeState(),
-		RuntimeSchema: nil,
-		RuntimeBundle: runtimeBundle,
+		RuntimeSchema: runtimeAssets.RuntimeSchema,
+		RuntimeBundle: runtimeAssets.RuntimeBundle,
 		RuntimePolicy: nil,
 	}, nil
 }
 
-func fetchConnectorRuntimeBundle(
+type connectorRuntimeAssets struct {
+	RuntimeSchema []byte
+	RuntimeBundle []byte
+}
+
+func fetchConnectorRuntimeAssets(
 	ctx context.Context,
 	configClient v1.ConnectorConfigServiceClient,
 	runtimeState *v1.RuntimeState,
-) ([]byte, error) {
-	if runtimeState == nil || runtimeState.GetEffectiveBundleDigest() == "" {
-		return nil, nil
+) (*connectorRuntimeAssets, error) {
+	if runtimeState == nil {
+		return &connectorRuntimeAssets{}, nil
+	}
+	if runtimeState.GetEffectiveBundleDigest() == "" && runtimeState.GetRuntimeConfigContractDigest() == "" {
+		return &connectorRuntimeAssets{}, nil
 	}
 
 	resp, err := configClient.GetConnectorRuntimeBundle(ctx, &v1.GetConnectorRuntimeBundleRequest{})
 	if err != nil {
-		return nil, fmt.Errorf("lambda-run: failed to get connector runtime bundle: %w", err)
+		return nil, fmt.Errorf("lambda-run: failed to get connector runtime assets: %w", err)
 	}
-	return resp.GetBundle(), nil
+	return &connectorRuntimeAssets{
+		RuntimeSchema: resp.GetRuntimeSchema(),
+		RuntimeBundle: resp.GetBundle(),
+	}, nil
 }
 
 func decryptConnectorConfig(privateKey ed25519.PrivateKey, encrypted []byte) (*structpb.Struct, error) {

--- a/pkg/cli/lambda_server__added.go
+++ b/pkg/cli/lambda_server__added.go
@@ -18,7 +18,6 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/ugrpc"
 	"github.com/go-jose/go-jose/v4"
 	"github.com/maypok86/otter/v2"
-	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
@@ -35,6 +34,62 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/types/sessions"
 	"google.golang.org/grpc"
 )
+
+func fetchConnectorConfigSnapshot(
+	ctx context.Context,
+	configClient v1.ConnectorConfigServiceClient,
+	privateKey ed25519.PrivateKey,
+) (*ConnectorConfigSnapshot, error) {
+	config, err := configClient.GetConnectorConfig(ctx, &v1.GetConnectorConfigRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("lambda-run: failed to get connector config: %w", err)
+	}
+
+	runtimeBundle, err := fetchConnectorRuntimeBundle(ctx, configClient, config.GetRuntimeState())
+	if err != nil {
+		return nil, err
+	}
+
+	configStruct, err := decryptConnectorConfig(privateKey, config.GetConfig())
+	if err != nil {
+		return nil, err
+	}
+
+	return &ConnectorConfigSnapshot{
+		Config:        configStruct,
+		RuntimeState:  config.GetRuntimeState(),
+		RuntimeBundle: runtimeBundle,
+	}, nil
+}
+
+func fetchConnectorRuntimeBundle(
+	ctx context.Context,
+	configClient v1.ConnectorConfigServiceClient,
+	runtimeState *v1.RuntimeState,
+) ([]byte, error) {
+	if runtimeState == nil || runtimeState.GetEffectiveBundleDigest() == "" {
+		return nil, nil
+	}
+
+	resp, err := configClient.GetConnectorRuntimeBundle(ctx, &v1.GetConnectorRuntimeBundleRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("lambda-run: failed to get connector runtime bundle: %w", err)
+	}
+	return resp.GetBundle(), nil
+}
+
+func decryptConnectorConfig(privateKey ed25519.PrivateKey, encrypted []byte) (*structpb.Struct, error) {
+	decrypted, err := jwk.DecryptED25519(privateKey, encrypted)
+	if err != nil {
+		return nil, fmt.Errorf("lambda-run: failed to decrypt config: %w", err)
+	}
+
+	configStruct := &structpb.Struct{}
+	if err := json.Unmarshal(decrypted, configStruct); err != nil {
+		return nil, fmt.Errorf("lambda-run: failed to unmarshal decrypted config: %w", err)
+	}
+	return configStruct, nil
+}
 
 func OptionallyAddLambdaCommand[T field.Configurable](
 	ctx context.Context,
@@ -109,12 +164,10 @@ func OptionallyAddLambdaCommand[T field.Configurable](
 				zap.L().Error("error shutting down otel", zap.Error(err))
 			}
 		}()
-
 		if err := field.Validate(lambdaSchema, v); err != nil {
 			return err
 		}
 
-		// Create DPoP client with authentication
 		grpcClient, webKey, _, err := c1_lambda_config.NewDPoPClient(
 			runCtx,
 			v.GetString(field.LambdaServerClientIDField.GetName()),
@@ -124,59 +177,29 @@ func OptionallyAddLambdaCommand[T field.Configurable](
 			return fmt.Errorf("lambda-run: failed to create DPoP client: %w", err)
 		}
 
-		// Create connector config service client using the DPoP client
 		configClient := v1.NewConnectorConfigServiceClient(grpcClient)
-
-		// Get configuration, convert it to viper flag values, then proceed.
-		config, err := configClient.GetConnectorConfig(runCtx, &v1.GetConnectorConfigRequest{})
-		if err != nil {
-			return fmt.Errorf("lambda-run: failed to get connector config: %w", err)
-		}
 
 		ed25519PrivateKey, ok := webKey.Key.(ed25519.PrivateKey)
 		if !ok {
 			return fmt.Errorf("lambda-run: failed to cast webkey to ed25519.PrivateKey")
 		}
 
-		decrypted, err := jwk.DecryptED25519(ed25519PrivateKey, config.Config)
+		configSnapshot, err := fetchConnectorConfigSnapshot(runCtx, configClient, ed25519PrivateKey)
 		if err != nil {
-			return fmt.Errorf("lambda-run: failed to decrypt config: %w", err)
+			return err
 		}
-
-		configStruct := structpb.Struct{}
-		err = json.Unmarshal(decrypted, &configStruct)
-		if err != nil {
-			return fmt.Errorf("lambda-run: failed to unmarshal decrypted config: %w", err)
-		}
+		bootstrapConfig := CloneConfigSettings(v)
+		effectiveConnectorConfig := HydrateConnectorConfig(bootstrapConfig, configSnapshot)
 
 		// parse content directly for lambdas, don't read from file
 		readFromPath := false
 		decodeOpts := field.WithAdditionalDecodeHooks(field.FileUploadDecodeHook(readFromPath))
-		t, err := MakeGenericConfiguration[T](v, decodeOpts)
+		t, err := MakeGenericConfiguration[T](effectiveConnectorConfig, decodeOpts)
 		if err != nil {
 			return fmt.Errorf("lambda-run: failed to make generic configuration: %w", err)
 		}
-		switch cfg := any(t).(type) {
-		case *viper.Viper:
-			for k, v := range configStruct.AsMap() {
-				cfg.Set(k, v)
-			}
-		default:
-			// Use mapstructure with decode hook for file upload fields
-			decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
-				DecodeHook: field.ComposeDecodeHookFunc(decodeOpts),
-				Result:     cfg,
-			})
-			if err != nil {
-				return fmt.Errorf("lambda-run: failed to create decoder: %w", err)
-			}
-			err = decoder.Decode(configStruct.AsMap())
-			if err != nil {
-				return fmt.Errorf("lambda-run: failed to decode config: %w", err)
-			}
-		}
 
-		configStructMap := configStruct.AsMap()
+		configStructMap := effectiveConnectorConfig.AllSettings()
 
 		var (
 			fieldOptions  []field.Option
@@ -226,8 +249,15 @@ func OptionallyAddLambdaCommand[T field.Configurable](
 					otterOptions.MaximumWeight = uint64(sessionStoreMaximumSize)
 				}
 			}),
-			SelectedAuthMethod:  authMethodStr,
-			SyncResourceTypeIDs: v.GetStringSlice("sync-resource-types"),
+			SelectedAuthMethod:    authMethodStr,
+			SyncResourceTypeIDs:   v.GetStringSlice("sync-resource-types"),
+			RuntimeState:          configSnapshot.RuntimeState,
+			RuntimeBundle:         configSnapshot.RuntimeBundle,
+			BootstrapConfig:       bootstrapConfig,
+			ConnectorConfigClient: configClient,
+			ReloadConnectorConfig: func(ctx context.Context) (*ConnectorConfigSnapshot, error) {
+				return fetchConnectorConfigSnapshot(ctx, configClient, ed25519PrivateKey)
+			},
 		}
 
 		if hasOauthField(schemaFields) {

--- a/pkg/cli/lambda_server__added_test.go
+++ b/pkg/cli/lambda_server__added_test.go
@@ -1,0 +1,97 @@
+//go:build baton_lambda_support
+
+package cli
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"testing"
+
+	v1 "github.com/conductorone/baton-sdk/pb/c1/connectorapi/baton/v1"
+	"github.com/conductorone/baton-sdk/pkg/crypto/providers/jwk"
+	"golang.org/x/oauth2"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+type stubConnectorConfigClient struct {
+	configResp        *v1.GetConnectorConfigResponse
+	runtimeBundleResp *v1.GetConnectorRuntimeBundleResponse
+}
+
+func (s *stubConnectorConfigClient) GetConnectorConfig(context.Context, *v1.GetConnectorConfigRequest, ...grpc.CallOption) (*v1.GetConnectorConfigResponse, error) {
+	return s.configResp, nil
+}
+
+func (s *stubConnectorConfigClient) GetConnectorRuntimeState(context.Context, *v1.GetConnectorRuntimeStateRequest, ...grpc.CallOption) (*v1.GetConnectorRuntimeStateResponse, error) {
+	return &v1.GetConnectorRuntimeStateResponse{}, nil
+}
+
+func (s *stubConnectorConfigClient) GetConnectorRuntimeBundle(context.Context, *v1.GetConnectorRuntimeBundleRequest, ...grpc.CallOption) (*v1.GetConnectorRuntimeBundleResponse, error) {
+	return s.runtimeBundleResp, nil
+}
+
+func (s *stubConnectorConfigClient) GetConnectorOauthToken(context.Context, *v1.GetConnectorOauthTokenRequest, ...grpc.CallOption) (*v1.GetConnectorOauthTokenResponse, error) {
+	return &v1.GetConnectorOauthTokenResponse{Token: []byte("token")}, nil
+}
+
+func TestFetchConnectorConfigSnapshotIncludesRuntimeSchema(t *testing.T) {
+	t.Parallel()
+
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+
+	configStruct, err := structpb.NewStruct(map[string]any{
+		"runtime-schema": "/runtime/runtime-schema.yaml",
+		"jira-url":       "https://example.atlassian.net",
+	})
+	if err != nil {
+		t.Fatalf("NewStruct() error = %v", err)
+	}
+
+	configJSON, err := json.Marshal(configStruct)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+
+	encryptedConfig, err := jwk.EncryptED25519(pub, configJSON)
+	if err != nil {
+		t.Fatalf("EncryptED25519() error = %v", err)
+	}
+
+	client := &stubConnectorConfigClient{
+		configResp: &v1.GetConnectorConfigResponse{
+			Config: encryptedConfig,
+			RuntimeState: &v1.RuntimeState{
+				EffectiveBundleDigest:       "sha256:bundle",
+				RuntimeConfigContractDigest: "sha256:schema",
+			},
+		},
+		runtimeBundleResp: &v1.GetConnectorRuntimeBundleResponse{
+			Bundle:        []byte("bundle-bytes"),
+			RuntimeSchema: []byte("meta:\n  version: \"1\"\n"),
+		},
+	}
+
+	snapshot, err := fetchConnectorConfigSnapshot(context.Background(), client, priv)
+	if err != nil {
+		t.Fatalf("fetchConnectorConfigSnapshot() error = %v", err)
+	}
+
+	if got := string(snapshot.RuntimeBundle); got != "bundle-bytes" {
+		t.Fatalf("RuntimeBundle = %q, want %q", got, "bundle-bytes")
+	}
+	if got := string(snapshot.RuntimeSchema); got != "meta:\n  version: \"1\"\n" {
+		t.Fatalf("RuntimeSchema = %q, want runtime schema bytes", got)
+	}
+	if got := snapshot.Config.AsMap()["jira-url"]; got != "https://example.atlassian.net" {
+		t.Fatalf("Config[jira-url] = %v, want https://example.atlassian.net", got)
+	}
+}
+
+var _ v1.ConnectorConfigServiceClient = (*stubConnectorConfigClient)(nil)
+var _ oauth2.TokenSource = (*lambdaTokenSource)(nil)

--- a/proto/c1/connectorapi/baton/v1/config.proto
+++ b/proto/c1/connectorapi/baton/v1/config.proto
@@ -43,6 +43,7 @@ message GetConnectorRuntimeBundleRequest {}
 
 message GetConnectorRuntimeBundleResponse {
   bytes bundle = 1;
+  bytes runtime_schema = 2;
 }
 
 message SignedHeader {

--- a/proto/c1/connectorapi/baton/v1/config.proto
+++ b/proto/c1/connectorapi/baton/v1/config.proto
@@ -23,6 +23,7 @@ message RuntimeState {
   string instance_config_revision_id = 5;
   string instance_config_digest = 6;
   string runtime_config_contract_digest = 7;
+  string effective_runtime_policy_digest = 8;
 }
 
 message GetConnectorConfigResponse {

--- a/proto/c1/connectorapi/baton/v1/config.proto
+++ b/proto/c1/connectorapi/baton/v1/config.proto
@@ -8,14 +8,40 @@ option go_package = "gitlab.com/ductone/c1/pkg/pb/c1/connectorapi/baton/v1";
 
 service ConnectorConfigService {
   rpc GetConnectorConfig(GetConnectorConfigRequest) returns (GetConnectorConfigResponse);
+  rpc GetConnectorRuntimeState(GetConnectorRuntimeStateRequest) returns (GetConnectorRuntimeStateResponse);
+  rpc GetConnectorRuntimeBundle(GetConnectorRuntimeBundleRequest) returns (GetConnectorRuntimeBundleResponse);
   rpc GetConnectorOauthToken(GetConnectorOauthTokenRequest) returns (GetConnectorOauthTokenResponse);
 }
 
 message GetConnectorConfigRequest {}
 
+message RuntimeState {
+  string runtime_revision_id = 1;
+  int64 runtime_generation = 2;
+  string release_revision_id = 3;
+  string effective_bundle_digest = 4;
+  string instance_config_revision_id = 5;
+  string instance_config_digest = 6;
+  string runtime_config_contract_digest = 7;
+}
+
 message GetConnectorConfigResponse {
   bytes config = 1;
   google.protobuf.Timestamp last_updated = 2;
+  RuntimeState runtime_state = 3;
+}
+
+message GetConnectorRuntimeStateRequest {}
+
+message GetConnectorRuntimeStateResponse {
+  google.protobuf.Timestamp last_updated = 1;
+  RuntimeState runtime_state = 2;
+}
+
+message GetConnectorRuntimeBundleRequest {}
+
+message GetConnectorRuntimeBundleResponse {
+  bytes bundle = 1;
 }
 
 message SignedHeader {


### PR DESCRIPTION
## Why
Lambda-managed connectors need to refresh runtime state, config, and runtime bundle bytes without waiting for a full redeploy. The SDK is the natural seam for that because it already owns the config client, the lambda startup path, and the warm refresh callback.

## What this changes
- adds runtime-state RPC support to the SDK config client
- carries runtime bundle bytes through the lambda config snapshot
- fetches runtime bundles during both cold start and warm refresh
- preserves bootstrap config across reload so the rebuilt connector uses the same host settings
- adds focused tests around lambda config hydration and startup behavior

## Validation
This branch is part of the D2 hotload test stack. With the matching runtime-framework branch and the Jira test connector branch, we proved:
- warm refresh from a fetched runtime bundle archive
- cold start from a fetched runtime bundle archive
- fail-closed behavior when the runtime bundle is missing or invalid

## Notes
This PR is intended to land with the matching runtime-framework work. The D2 bundle insertion helper lives on the C1 side of the stack and is part of the recorded test path.