### PR TITLE
feat: expose sync-resource-types in ConnectorOpts

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -19,9 +19,10 @@ import (
 )
 
 type RunTimeOpts struct {
-	SessionStore       sessions.SessionStore
-	TokenSource        oauth2.TokenSource
-	SelectedAuthMethod string
+	SessionStore        sessions.SessionStore
+	TokenSource         oauth2.TokenSource
+	SelectedAuthMethod  string
+	SyncResourceTypeIDs []string
 }
 
 // GetConnectorFunc is a function type that creates a connector instance.
@@ -39,8 +40,9 @@ func WithSessionCache(ctx context.Context, constructor sessions.SessionStoreCons
 }
 
 type ConnectorOpts struct {
-	TokenSource        oauth2.TokenSource
-	SelectedAuthMethod string
+	TokenSource         oauth2.TokenSource
+	SelectedAuthMethod  string
+	SyncResourceTypeIDs []string
 }
 type NewConnector[T field.Configurable] func(ctx context.Context, cfg T, opts *ConnectorOpts) (connectorbuilder.ConnectorBuilderV2, []connectorbuilder.Opt, error)
 

--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -406,7 +406,10 @@ func MakeMainCommand[T field.Configurable](
 		runCtx = context.WithValue(runCtx, uhttp.ContextHTTPTimeoutKey, time.Duration(httpTimeout)*time.Second)
 
 		// Save the selected authentication method and get the connector.
-		c, err := getconnector(runCtx, t, RunTimeOpts{SelectedAuthMethod: v.GetString("auth-method")})
+		c, err := getconnector(runCtx, t, RunTimeOpts{
+			SelectedAuthMethod:  v.GetString("auth-method"),
+			SyncResourceTypeIDs: v.GetStringSlice("sync-resource-types"),
+		})
 		if err != nil {
 			return err
 		}
@@ -585,7 +588,8 @@ func MakeGRPCServerCommand[T field.Configurable](
 					otterOptions.MaximumWeight = uint64(sessionStoreMaximumSize)
 				}
 			}),
-			SelectedAuthMethod: v.GetString("auth-method"),
+			SelectedAuthMethod:  v.GetString("auth-method"),
+			SyncResourceTypeIDs: v.GetStringSlice("sync-resource-types"),
 		})
 		if err != nil {
 			return err
@@ -693,7 +697,10 @@ func MakeCapabilitiesCommand[T field.Configurable](
 				return err
 			}
 
-			c, err = getconnector(runCtx, t, RunTimeOpts{SelectedAuthMethod: authMethod})
+			c, err = getconnector(runCtx, t, RunTimeOpts{
+				SelectedAuthMethod:  authMethod,
+				SyncResourceTypeIDs: v.GetStringSlice("sync-resource-types"),
+			})
 			if err != nil {
 				return err
 			}

--- a/pkg/cli/lambda_server__added.go
+++ b/pkg/cli/lambda_server__added.go
@@ -226,7 +226,8 @@ func OptionallyAddLambdaCommand[T field.Configurable](
 					otterOptions.MaximumWeight = uint64(sessionStoreMaximumSize)
 				}
 			}),
-			SelectedAuthMethod: authMethodStr,
+			SelectedAuthMethod:  authMethodStr,
+			SyncResourceTypeIDs: v.GetStringSlice("sync-resource-types"),
 		}
 
 		if hasOauthField(schemaFields) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,8 +30,11 @@ func RunConnector[T field.Configurable](
 ) {
 	f := func(ctx context.Context, cfg T, runTimeOpts cli.RunTimeOpts) (types.ConnectorServer, error) {
 		l := ctxzap.Extract(ctx)
-		connector, builderOpts, err := cf(ctx, cfg, &cli.ConnectorOpts{TokenSource: runTimeOpts.TokenSource,
-			SelectedAuthMethod: runTimeOpts.SelectedAuthMethod})
+		connector, builderOpts, err := cf(ctx, cfg, &cli.ConnectorOpts{
+			TokenSource:         runTimeOpts.TokenSource,
+			SelectedAuthMethod:  runTimeOpts.SelectedAuthMethod,
+			SyncResourceTypeIDs: runTimeOpts.SyncResourceTypeIDs,
+		})
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary

- Added `SyncResourceTypeIDs []string` to `RunTimeOpts` and `ConnectorOpts`
- Populated the field from the `--sync-resource-types` CLI flag at all `RunTimeOpts` construction sites (`commands.go`, `lambda_server__added.go`)
- Passed it through to `ConnectorOpts` in `pkg/config/config.go`

Connector builder functions can now read `opts.SyncResourceTypeIDs` to know which resource types are being synced.

## Test plan

- [ ] Verify a connector receiving `opts.SyncResourceTypeIDs` gets the correct values when `--sync-resource-types` is passed
- [ ] Verify existing behavior is unchanged when the flag is not set (empty slice)

🤖 Generated with [Claude Code](https://claude.com/claude-code)