### PR TITLE
feat: add skip cleanup option to local c1z manager

### DIFF
--- a/pkg/dotc1z/manager/local/local.go
+++ b/pkg/dotc1z/manager/local/local.go
@@ -21,6 +21,7 @@ type localManager struct {
 	tmpPath        string
 	tmpDir         string
 	decoderOptions []dotc1z.DecoderOption
+	skipCleanup    bool
 }
 
 type Option func(*localManager)
@@ -34,6 +35,12 @@ func WithTmpDir(tmpDir string) Option {
 func WithDecoderOptions(opts ...dotc1z.DecoderOption) Option {
 	return func(o *localManager) {
 		o.decoderOptions = opts
+	}
+}
+
+func WithSkipCleanup(skip bool) Option {
+	return func(o *localManager) {
+		o.skipCleanup = skip
 	}
 }
 
@@ -118,6 +125,9 @@ func (l *localManager) LoadC1Z(ctx context.Context) (*dotc1z.C1File, error) {
 	}
 	if len(l.decoderOptions) > 0 {
 		opts = append(opts, dotc1z.WithDecoderOptions(l.decoderOptions...))
+	}
+	if l.skipCleanup {
+		opts = append(opts, dotc1z.WithSkipCleanup(true))
 	}
 	return dotc1z.NewC1ZFile(ctx, l.tmpPath, opts...)
 }


### PR DESCRIPTION
## Summary
- Adds `local.WithSkipCleanup(bool)` option that forwards to `dotc1z.WithSkipCleanup(true)` in `LoadC1Z`
- Follows up on #768 which added the underlying `WithSkipCleanup` option to the dotc1z package

## Test plan
- [x] All existing tests pass
- [x] Lint passes (pre-existing issue only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)