### PR TITLE
fix: normalize protojson whitespace in capabilities output

### DIFF
--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -752,7 +753,15 @@ func MakeCapabilitiesCommand[T field.Configurable](
 			return err
 		}
 
-		_, err = fmt.Fprint(os.Stdout, string(outBytes))
+		// Re-indent to normalize protojson's non-deterministic whitespace.
+		// protojson uses detrand.Bool() to randomly insert extra spaces after colons;
+		// json.Indent rewrites all whitespace from the token stream, preserving key order.
+		var normalized bytes.Buffer
+		if err := json.Indent(&normalized, outBytes, "", "  "); err != nil {
+			return err
+		}
+
+		_, err = fmt.Fprint(os.Stdout, normalized.String())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary
- `protojson` intentionally injects non-deterministic whitespace via `detrand.Bool()`, causing the `capabilities` command to produce cosmetically different JSON across runs (single vs double space after colons)
- This creates noise commits in CI workflows that capture `baton_capabilities.json`
- Fix: round-trip through `json.Indent` to normalize all whitespace from the token stream, preserving protojson's key order while producing byte-identical output every time
- This is the [approach recommended by the protobuf maintainers](https://github.com/golang/protobuf/issues/1121)

## Test plan
- [ ] Run `capabilities` command multiple times and verify output is byte-identical: `for i in $(seq 20); do ./connector capabilities 2>/dev/null | md5sum; done`
- [ ] Verify JSON output is valid and parses correctly
- [ ] Verify no semantic changes vs current output (only whitespace normalization)