### PR TITLE
perf(dotc1z): pool zstd encoders and decoders to reduce allocations

### DIFF
--- a/pkg/dotc1z/decoder.go
+++ b/pkg/dotc1z/decoder.go
@@ -120,8 +120,8 @@ type decoder struct {
 	f  io.Reader
 	zd *zstd.Decoder
 
-	decodedBytes uint64
-	fromPool     bool // true if zd came from the pool
+	decodedBytes   uint64
+	poolCompatible bool // true if zd has pool-compatible settings and should be returned to pool
 
 	initOnce       sync.Once
 	headerCheckErr error
@@ -149,14 +149,14 @@ func (d *decoder) Read(p []byte) (int, error) {
 		// Pool decoders use: concurrency=1, lowmem=true, maxMemory=defaultDecoderMaxMemory.
 		usePool := d.o.decoderConcurrency == 1 && d.getMaxMemSize() == defaultDecoderMaxMemory
 		if usePool {
-			zd, ok := getDecoder()
+			zd, _ := getDecoder()
 			if zd != nil {
 				if err := zd.Reset(d.f); err != nil {
 					// Reset failed, return decoder to pool and fall through to create new one.
 					putDecoder(zd)
 				} else {
 					d.zd = zd
-					d.fromPool = ok
+					d.poolCompatible = true // Mark for return to pool on Close()
 					return
 				}
 			}
@@ -180,6 +180,8 @@ func (d *decoder) Read(p []byte) (int, error) {
 			return
 		}
 		d.zd = zd
+		// If settings are pool-compatible, mark for return to pool on Close()
+		d.poolCompatible = usePool
 	})
 
 	// Check header
@@ -222,8 +224,8 @@ func (d *decoder) Read(p []byte) (int, error) {
 
 func (d *decoder) Close() error {
 	if d.zd != nil {
-		if d.fromPool {
-			// Return pooled decoder for reuse.
+		if d.poolCompatible {
+			// Return decoder to pool for reuse.
 			putDecoder(d.zd)
 		} else {
 			d.zd.Close()

--- a/pkg/dotc1z/decoder.go
+++ b/pkg/dotc1z/decoder.go
@@ -121,6 +121,7 @@ type decoder struct {
 	zd *zstd.Decoder
 
 	decodedBytes uint64
+	fromPool     bool // true if zd came from the pool
 
 	initOnce       sync.Once
 	headerCheckErr error
@@ -144,6 +145,24 @@ func (d *decoder) Read(p []byte) (int, error) {
 			return
 		}
 
+		// Try to use a pooled decoder if options match the pool's defaults.
+		// Pool decoders use: concurrency=1, lowmem=true, maxMemory=defaultDecoderMaxMemory.
+		usePool := d.o.decoderConcurrency == 1 && d.getMaxMemSize() == defaultDecoderMaxMemory
+		if usePool {
+			zd, ok := getDecoder()
+			if zd != nil {
+				if err := zd.Reset(d.f); err != nil {
+					// Reset failed, return decoder to pool and fall through to create new one.
+					putDecoder(zd)
+				} else {
+					d.zd = zd
+					d.fromPool = ok
+					return
+				}
+			}
+		}
+
+		// Non-default options or pool unavailable: create new decoder.
 		zstdOpts := []zstd.DOption{
 			zstd.WithDecoderLowmem(true),                 // uses lower memory, trading potentially more allocations
 			zstd.WithDecoderMaxMemory(d.getMaxMemSize()), // sets limit on maximum memory used when decoding stream
@@ -203,7 +222,13 @@ func (d *decoder) Read(p []byte) (int, error) {
 
 func (d *decoder) Close() error {
 	if d.zd != nil {
-		d.zd.Close()
+		if d.fromPool {
+			// Return pooled decoder for reuse.
+			putDecoder(d.zd)
+		} else {
+			d.zd.Close()
+		}
+		d.zd = nil
 	}
 	return nil
 }

--- a/pkg/dotc1z/file.go
+++ b/pkg/dotc1z/file.go
@@ -151,25 +151,48 @@ func saveC1z(dbFilePath string, outputFilePath string, encoderConcurrency int) e
 	if encoderConcurrency == 0 {
 		encoderConcurrency = runtime.GOMAXPROCS(0)
 	}
-	c1z, err := zstd.NewWriter(outFile,
-		zstd.WithEncoderConcurrency(encoderConcurrency),
-	)
-	if err != nil {
-		return err
+
+	// Try to use a pooled encoder if concurrency matches the pool's default.
+	// This reduces allocation overhead for the common case.
+	var c1z *zstd.Encoder
+	var fromPool bool
+	if encoderConcurrency == pooledEncoderConcurrency {
+		c1z, fromPool = getEncoder()
+	}
+	if c1z != nil {
+		c1z.Reset(outFile)
+	} else {
+		// Non-default concurrency or pool returned nil: create new encoder.
+		var err error
+		c1z, err = zstd.NewWriter(outFile,
+			zstd.WithEncoderConcurrency(encoderConcurrency),
+		)
+		if err != nil {
+			return err
+		}
 	}
 
 	_, err = io.Copy(c1z, dbFile)
 	if err != nil {
+		// Always close encoder to release resources. Don't return to pool - may be in bad state.
+		_ = c1z.Close()
 		return err
 	}
 
 	err = c1z.Flush()
 	if err != nil {
+		_ = c1z.Close()
 		return fmt.Errorf("failed to flush c1z: %w", err)
 	}
 	err = c1z.Close()
 	if err != nil {
+		// Close failed, don't return to pool.
 		return fmt.Errorf("failed to close c1z: %w", err)
+	}
+
+	// Successfully finished - return encoder to pool if it came from there.
+	if fromPool {
+		putEncoder(c1z)
 	}
 
 	err = outFile.Sync()

--- a/pkg/dotc1z/file.go
+++ b/pkg/dotc1z/file.go
@@ -155,9 +155,8 @@ func saveC1z(dbFilePath string, outputFilePath string, encoderConcurrency int) e
 	// Try to use a pooled encoder if concurrency matches the pool's default.
 	// This reduces allocation overhead for the common case.
 	var c1z *zstd.Encoder
-	var fromPool bool
 	if encoderConcurrency == pooledEncoderConcurrency {
-		c1z, fromPool = getEncoder()
+		c1z, _ = getEncoder()
 	}
 	if c1z != nil {
 		c1z.Reset(outFile)
@@ -190,8 +189,9 @@ func saveC1z(dbFilePath string, outputFilePath string, encoderConcurrency int) e
 		return fmt.Errorf("failed to close c1z: %w", err)
 	}
 
-	// Successfully finished - return encoder to pool if it came from there.
-	if fromPool {
+	// Successfully finished - return encoder to pool if it has pool-compatible settings.
+	// This ensures the pool grows even when initially empty.
+	if encoderConcurrency == pooledEncoderConcurrency {
 		putEncoder(c1z)
 	}
 

--- a/pkg/dotc1z/pool.go
+++ b/pkg/dotc1z/pool.go
@@ -1,0 +1,88 @@
+package dotc1z
+
+import (
+	"runtime"
+	"sync"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+// encoderPool manages reusable zstd.Encoder instances to reduce allocation overhead.
+// All pooled encoders are configured with GOMAXPROCS concurrency.
+var encoderPool sync.Pool
+
+// pooledEncoderConcurrency is the concurrency level used for pooled encoders.
+// Set at package init to GOMAXPROCS to match the default behavior.
+var pooledEncoderConcurrency = runtime.GOMAXPROCS(0)
+
+// getEncoder retrieves a zstd encoder from the pool or creates a new one.
+// The returned encoder is NOT bound to any writer - call Reset(w) before use.
+// Returns the encoder and a boolean indicating if it came from the pool.
+func getEncoder() (*zstd.Encoder, bool) {
+	if enc, ok := encoderPool.Get().(*zstd.Encoder); ok && enc != nil {
+		return enc, true
+	}
+
+	// Create new encoder with default concurrency.
+	// This should not fail with valid options, but handle it gracefully.
+	enc, err := zstd.NewWriter(nil,
+		zstd.WithEncoderConcurrency(pooledEncoderConcurrency),
+	)
+	if err != nil {
+		// Fallback: return nil and let caller create encoder with their options
+		return nil, false
+	}
+	return enc, false
+}
+
+// putEncoder returns a zstd encoder to the pool for reuse.
+// The encoder is reset to release any reference to the previous writer.
+// Encoders should be in a clean state (Close() called) before returning.
+func putEncoder(enc *zstd.Encoder) {
+	if enc == nil {
+		return
+	}
+	// Reset to nil writer to release reference to previous output.
+	// This is safe even if the encoder was already closed.
+	enc.Reset(nil)
+	encoderPool.Put(enc)
+}
+
+// decoderPool manages reusable zstd.Decoder instances to reduce allocation overhead.
+// All pooled decoders are configured with concurrency=1 (single-threaded) and low memory mode.
+var decoderPool sync.Pool
+
+// getDecoder retrieves a zstd decoder from the pool or creates a new one.
+// The returned decoder is NOT bound to any reader - call Reset(r) before use.
+// Returns the decoder and a boolean indicating if it came from the pool.
+func getDecoder() (*zstd.Decoder, bool) {
+	if dec, ok := decoderPool.Get().(*zstd.Decoder); ok && dec != nil {
+		return dec, true
+	}
+
+	// Create new decoder with default options matching decoder.go defaults.
+	dec, err := zstd.NewReader(nil,
+		zstd.WithDecoderConcurrency(1),
+		zstd.WithDecoderLowmem(true),
+		zstd.WithDecoderMaxMemory(defaultDecoderMaxMemory),
+	)
+	if err != nil {
+		// Fallback: return nil and let caller create decoder with their options
+		return nil, false
+	}
+	return dec, false
+}
+
+// putDecoder returns a zstd decoder to the pool for reuse.
+// The decoder is reset to release any reference to the previous reader.
+func putDecoder(dec *zstd.Decoder) {
+	if dec == nil {
+		return
+	}
+	// Reset to nil reader to release reference to previous input.
+	// If Reset fails (bad state), don't return to pool.
+	if err := dec.Reset(nil); err != nil {
+		return
+	}
+	decoderPool.Put(dec)
+}

--- a/pkg/dotc1z/pool.go
+++ b/pkg/dotc1z/pool.go
@@ -15,7 +15,8 @@ var encoderPool = &sync.Pool{}
 
 // pooledEncoderConcurrency is the concurrency level used for pooled encoders.
 // Must match the c1zOptions / C1File default (1) so the pool actually engages
-// on the sync hot path.
+// on the sync hot path. Note: pkg/synccompactor/compactor.go passes
+// WithEncoderConcurrency(0) (GOMAXPROCS) and intentionally bypasses the pool.
 const pooledEncoderConcurrency = 1
 
 // getEncoder retrieves a zstd encoder from the pool or creates a new one.

--- a/pkg/dotc1z/pool.go
+++ b/pkg/dotc1z/pool.go
@@ -1,10 +1,18 @@
 package dotc1z
 
 import (
+	"os"
 	"sync"
 
 	"github.com/klauspost/compress/zstd"
 )
+
+// poolDisabled is an operational kill-switch. Set BATON_ZSTD_POOL_DISABLE=1
+// in the environment to bypass the encoder and decoder pools entirely and
+// let callers fall back to fresh encoder/decoder creation. Zero behavior
+// change when unset. Useful for rolling back pool behavior without a
+// revert + re-release cycle if a latent Reset or Close bug surfaces in prod.
+var poolDisabled = os.Getenv("BATON_ZSTD_POOL_DISABLE") == "1"
 
 // encoderPool manages reusable zstd.Encoder instances to reduce allocation overhead.
 // Pooled encoders are single-threaded (concurrency=1) to match the production
@@ -23,6 +31,9 @@ const pooledEncoderConcurrency = 1
 // The returned encoder is NOT bound to any writer - call Reset(w) before use.
 // Returns the encoder and a boolean indicating if it came from the pool.
 func getEncoder() (*zstd.Encoder, bool) {
+	if poolDisabled {
+		return nil, false
+	}
 	if enc, ok := encoderPool.Get().(*zstd.Encoder); ok && enc != nil {
 		return enc, true
 	}
@@ -46,6 +57,9 @@ func putEncoder(enc *zstd.Encoder) {
 	if enc == nil {
 		return
 	}
+	if poolDisabled {
+		return
+	}
 	// Reset to nil writer to release reference to previous output.
 	// This is safe even if the encoder was already closed.
 	enc.Reset(nil)
@@ -60,6 +74,9 @@ var decoderPool = &sync.Pool{}
 // The returned decoder is NOT bound to any reader - call Reset(r) before use.
 // Returns the decoder and a boolean indicating if it came from the pool.
 func getDecoder() (*zstd.Decoder, bool) {
+	if poolDisabled {
+		return nil, false
+	}
 	if dec, ok := decoderPool.Get().(*zstd.Decoder); ok && dec != nil {
 		return dec, true
 	}
@@ -81,6 +98,9 @@ func getDecoder() (*zstd.Decoder, bool) {
 // The decoder is reset to release any reference to the previous reader.
 func putDecoder(dec *zstd.Decoder) {
 	if dec == nil {
+		return
+	}
+	if poolDisabled {
 		return
 	}
 	// Reset to nil reader to release reference to previous input.

--- a/pkg/dotc1z/pool.go
+++ b/pkg/dotc1z/pool.go
@@ -1,19 +1,22 @@
 package dotc1z
 
 import (
-	"runtime"
 	"sync"
 
 	"github.com/klauspost/compress/zstd"
 )
 
 // encoderPool manages reusable zstd.Encoder instances to reduce allocation overhead.
-// All pooled encoders are configured with GOMAXPROCS concurrency.
-var encoderPool sync.Pool
+// Pooled encoders are single-threaded (concurrency=1) to match the production
+// default set in c1file.go. A concurrent encoder path (GOMAXPROCS) is intentionally
+// avoided here because klauspost/compress's multi-threaded encoder has theoretical
+// race concerns in its goroutine synchronization.
+var encoderPool = &sync.Pool{}
 
 // pooledEncoderConcurrency is the concurrency level used for pooled encoders.
-// Set at package init to GOMAXPROCS to match the default behavior.
-var pooledEncoderConcurrency = runtime.GOMAXPROCS(0)
+// Must match the c1zOptions / C1File default (1) so the pool actually engages
+// on the sync hot path.
+const pooledEncoderConcurrency = 1
 
 // getEncoder retrieves a zstd encoder from the pool or creates a new one.
 // The returned encoder is NOT bound to any writer - call Reset(w) before use.
@@ -50,7 +53,7 @@ func putEncoder(enc *zstd.Encoder) {
 
 // decoderPool manages reusable zstd.Decoder instances to reduce allocation overhead.
 // All pooled decoders are configured with concurrency=1 (single-threaded) and low memory mode.
-var decoderPool sync.Pool
+var decoderPool = &sync.Pool{}
 
 // getDecoder retrieves a zstd decoder from the pool or creates a new one.
 // The returned decoder is NOT bound to any reader - call Reset(r) before use.

--- a/pkg/dotc1z/pool_test.go
+++ b/pkg/dotc1z/pool_test.go
@@ -207,7 +207,7 @@ func TestPoolGrowsFromDecoder(t *testing.T) {
 	for {
 		dec, fromPool := getDecoder()
 		if !fromPool {
-			dec.Close()
+			dec.Close() // zstd.Decoder.Close() returns nothing
 			break
 		}
 		dec.Close() // Don't return to pool
@@ -244,8 +244,10 @@ func TestPoolGrowsFromDecoder(t *testing.T) {
 	_, err = io.ReadAll(decoder)
 	require.NoError(t, err)
 
-	decoder.Close()
-	f.Close()
+	err = decoder.Close()
+	require.NoError(t, err)
+	err = f.Close()
+	require.NoError(t, err)
 
 	// Now the decoder pool should have a decoder
 	dec2, fromPool2 := getDecoder()
@@ -306,8 +308,8 @@ func TestPooledRoundTrip(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, testData, decoded)
 
-			decoder.Close()
-			f.Close()
+			_ = decoder.Close()
+			_ = f.Close()
 		}
 	})
 }
@@ -410,8 +412,8 @@ func BenchmarkDecoderPoolAllocs(b *testing.B) {
 			f, _ := os.Open(c1zFile)
 			dec, _ := NewDecoder(f)
 			_, _ = io.ReadAll(dec)
-			dec.Close()
-			f.Close()
+			_ = dec.Close()
+			_ = f.Close()
 		}
 	})
 
@@ -432,7 +434,7 @@ func BenchmarkDecoderPoolAllocs(b *testing.B) {
 			)
 			_, _ = io.ReadAll(dec)
 			dec.Close()
-			f.Close()
+			_ = f.Close()
 		}
 	})
 }

--- a/pkg/dotc1z/pool_test.go
+++ b/pkg/dotc1z/pool_test.go
@@ -308,8 +308,10 @@ func TestPooledRoundTrip(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, testData, decoded)
 
-			_ = decoder.Close()
-			_ = f.Close()
+			err = decoder.Close()
+			require.NoError(t, err)
+			err = f.Close()
+			require.NoError(t, err)
 		}
 	})
 }

--- a/pkg/dotc1z/pool_test.go
+++ b/pkg/dotc1z/pool_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -69,15 +70,21 @@ func TestEncoderPool(t *testing.T) {
 				defer wg.Done()
 				for j := 0; j < iterations; j++ {
 					enc, _ := getEncoder()
-					require.NotNil(t, enc)
+					if !assert.NotNil(t, enc) {
+						return
+					}
 
 					var buf bytes.Buffer
 					enc.Reset(&buf)
 
 					data := []byte("concurrent test data")
 					_, err := enc.Write(data)
-					require.NoError(t, err)
-					require.NoError(t, enc.Close())
+					if !assert.NoError(t, err) {
+						return
+					}
+					if !assert.NoError(t, enc.Close()) {
+						return
+					}
 
 					putEncoder(enc)
 				}
@@ -155,14 +162,22 @@ func TestDecoderPool(t *testing.T) {
 				defer wg.Done()
 				for j := 0; j < iterations; j++ {
 					dec, _ := getDecoder()
-					require.NotNil(t, dec)
+					if !assert.NotNil(t, dec) {
+						return
+					}
 
 					err := dec.Reset(bytes.NewReader(compressed))
-					require.NoError(t, err)
+					if !assert.NoError(t, err) {
+						return
+					}
 
 					decoded, err := io.ReadAll(dec)
-					require.NoError(t, err)
-					require.Equal(t, testData, decoded)
+					if !assert.NoError(t, err) {
+						return
+					}
+					if !assert.Equal(t, testData, decoded) {
+						return
+					}
 
 					putDecoder(dec)
 				}

--- a/pkg/dotc1z/pool_test.go
+++ b/pkg/dotc1z/pool_test.go
@@ -1,0 +1,346 @@
+package dotc1z
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncoderPool(t *testing.T) {
+	t.Run("get returns valid encoder", func(t *testing.T) {
+		enc, fromPool := getEncoder()
+		require.NotNil(t, enc)
+		// First call won't be from pool (pool is empty)
+		require.False(t, fromPool)
+
+		// Return to pool and get again
+		putEncoder(enc)
+
+		enc2, fromPool2 := getEncoder()
+		require.NotNil(t, enc2)
+		require.True(t, fromPool2)
+		putEncoder(enc2)
+	})
+
+	t.Run("pooled encoder produces correct output", func(t *testing.T) {
+		testData := []byte("test data for compression with pooled encoder")
+
+		// Get encoder from pool
+		enc, _ := getEncoder()
+		require.NotNil(t, enc)
+
+		var buf bytes.Buffer
+		enc.Reset(&buf)
+
+		_, err := enc.Write(testData)
+		require.NoError(t, err)
+
+		err = enc.Close()
+		require.NoError(t, err)
+
+		putEncoder(enc)
+
+		// Verify we can decompress
+		dec, err := zstd.NewReader(bytes.NewReader(buf.Bytes()))
+		require.NoError(t, err)
+		defer dec.Close()
+
+		decoded, err := io.ReadAll(dec)
+		require.NoError(t, err)
+		require.Equal(t, testData, decoded)
+	})
+
+	t.Run("concurrent pool access", func(t *testing.T) {
+		const numGoroutines = 10
+		const iterations = 100
+
+		var wg sync.WaitGroup
+		wg.Add(numGoroutines)
+
+		for i := 0; i < numGoroutines; i++ {
+			go func(id int) {
+				defer wg.Done()
+				for j := 0; j < iterations; j++ {
+					enc, _ := getEncoder()
+					require.NotNil(t, enc)
+
+					var buf bytes.Buffer
+					enc.Reset(&buf)
+
+					data := []byte("concurrent test data")
+					_, err := enc.Write(data)
+					require.NoError(t, err)
+					require.NoError(t, enc.Close())
+
+					putEncoder(enc)
+				}
+			}(i)
+		}
+
+		wg.Wait()
+	})
+}
+
+func TestDecoderPool(t *testing.T) {
+	// Create some test compressed data
+	createCompressedData := func(data []byte) []byte {
+		var buf bytes.Buffer
+		enc, _ := zstd.NewWriter(&buf)
+		_, _ = enc.Write(data)
+		_ = enc.Close()
+		return buf.Bytes()
+	}
+
+	t.Run("get returns valid decoder", func(t *testing.T) {
+		dec, fromPool := getDecoder()
+		require.NotNil(t, dec)
+		require.False(t, fromPool) // First call, pool is empty
+
+		putDecoder(dec)
+
+		dec2, fromPool2 := getDecoder()
+		require.NotNil(t, dec2)
+		require.True(t, fromPool2)
+		putDecoder(dec2)
+	})
+
+	t.Run("pooled decoder produces correct output", func(t *testing.T) {
+		testData := []byte("test data for decompression with pooled decoder")
+		compressed := createCompressedData(testData)
+
+		dec, _ := getDecoder()
+		require.NotNil(t, dec)
+
+		err := dec.Reset(bytes.NewReader(compressed))
+		require.NoError(t, err)
+
+		decoded, err := io.ReadAll(dec)
+		require.NoError(t, err)
+		require.Equal(t, testData, decoded)
+
+		putDecoder(dec)
+	})
+
+	t.Run("concurrent decoder pool access", func(t *testing.T) {
+		testData := []byte("concurrent decoder test data")
+		compressed := createCompressedData(testData)
+
+		const numGoroutines = 10
+		const iterations = 100
+
+		var wg sync.WaitGroup
+		wg.Add(numGoroutines)
+
+		for i := 0; i < numGoroutines; i++ {
+			go func() {
+				defer wg.Done()
+				for j := 0; j < iterations; j++ {
+					dec, _ := getDecoder()
+					require.NotNil(t, dec)
+
+					err := dec.Reset(bytes.NewReader(compressed))
+					require.NoError(t, err)
+
+					decoded, err := io.ReadAll(dec)
+					require.NoError(t, err)
+					require.Equal(t, testData, decoded)
+
+					putDecoder(dec)
+				}
+			}()
+		}
+
+		wg.Wait()
+	})
+}
+
+func TestPooledRoundTrip(t *testing.T) {
+	t.Run("encode decode round trip with pooled codecs", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		testData := bytes.Repeat([]byte("test data for round trip "), 1000)
+
+		// Write test db file
+		dbFile := filepath.Join(tmpDir, "test.db")
+		err := os.WriteFile(dbFile, testData, 0600)
+		require.NoError(t, err)
+
+		// Save using pooled encoder
+		c1zFile := filepath.Join(tmpDir, "test.c1z")
+		err = saveC1z(dbFile, c1zFile, 0)
+		require.NoError(t, err)
+
+		// Load using pooled decoder
+		f, err := os.Open(c1zFile)
+		require.NoError(t, err)
+		defer f.Close()
+
+		decoder, err := NewDecoder(f)
+		require.NoError(t, err)
+		defer decoder.Close()
+
+		decoded, err := io.ReadAll(decoder)
+		require.NoError(t, err)
+		require.Equal(t, testData, decoded)
+	})
+
+	t.Run("multiple round trips reuse pool", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		for i := 0; i < 10; i++ {
+			testData := bytes.Repeat([]byte("iteration data "), 100*(i+1))
+
+			dbFile := filepath.Join(tmpDir, "test.db")
+			err := os.WriteFile(dbFile, testData, 0600)
+			require.NoError(t, err)
+
+			c1zFile := filepath.Join(tmpDir, "test.c1z")
+			err = saveC1z(dbFile, c1zFile, 0)
+			require.NoError(t, err)
+
+			f, err := os.Open(c1zFile)
+			require.NoError(t, err)
+
+			decoder, err := NewDecoder(f)
+			require.NoError(t, err)
+
+			decoded, err := io.ReadAll(decoder)
+			require.NoError(t, err)
+			require.Equal(t, testData, decoded)
+
+			decoder.Close()
+			f.Close()
+		}
+	})
+}
+
+// BenchmarkEncoderPoolAllocs measures allocations with and without pooling.
+// Run with: go test -bench=BenchmarkEncoderPoolAllocs -benchmem
+func BenchmarkEncoderPoolAllocs(b *testing.B) {
+	testData := bytes.Repeat([]byte("benchmark data "), 1000)
+	tmpDir := b.TempDir()
+
+	dbFile := filepath.Join(tmpDir, "bench.db")
+	err := os.WriteFile(dbFile, testData, 0600)
+	require.NoError(b, err)
+
+	b.Run("pooled_encoder", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			c1zFile := filepath.Join(tmpDir, "bench.c1z")
+			err := saveC1z(dbFile, c1zFile, 0)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("new_encoder_each_time", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			c1zFile := filepath.Join(tmpDir, "bench2.c1z")
+
+			dbF, _ := os.Open(dbFile)
+			outF, _ := os.Create(c1zFile)
+
+			_, _ = outF.Write(C1ZFileHeader)
+
+			// Create new encoder each time (simulates old behavior)
+			enc, _ := zstd.NewWriter(outF, zstd.WithEncoderConcurrency(runtime.GOMAXPROCS(0)))
+			_, _ = io.Copy(enc, dbF)
+			_ = enc.Flush()
+			_ = enc.Close()
+
+			_ = outF.Sync()
+			_ = outF.Close()
+			_ = dbF.Close()
+		}
+	})
+}
+
+// BenchmarkEncoderAllocationOnly isolates encoder allocation overhead.
+// This shows the direct benefit of pooling without file I/O noise.
+func BenchmarkEncoderAllocationOnly(b *testing.B) {
+	testData := []byte("small test data for encoder benchmark")
+
+	b.Run("pooled", func(b *testing.B) {
+		// Warm up the pool
+		enc, _ := getEncoder()
+		putEncoder(enc)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			enc, _ := getEncoder()
+			var buf bytes.Buffer
+			enc.Reset(&buf)
+			_, _ = enc.Write(testData)
+			_ = enc.Close()
+			putEncoder(enc)
+		}
+	})
+
+	b.Run("new_each_time", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			var buf bytes.Buffer
+			enc, _ := zstd.NewWriter(&buf, zstd.WithEncoderConcurrency(runtime.GOMAXPROCS(0)))
+			_, _ = enc.Write(testData)
+			_ = enc.Close()
+		}
+	})
+}
+
+// BenchmarkDecoderPoolAllocs measures decoder allocations.
+func BenchmarkDecoderPoolAllocs(b *testing.B) {
+	// Create test c1z file
+	tmpDir := b.TempDir()
+	testData := bytes.Repeat([]byte("benchmark data "), 1000)
+
+	dbFile := filepath.Join(tmpDir, "bench.db")
+	err := os.WriteFile(dbFile, testData, 0600)
+	require.NoError(b, err)
+
+	c1zFile := filepath.Join(tmpDir, "bench.c1z")
+	err = saveC1z(dbFile, c1zFile, 0)
+	require.NoError(b, err)
+
+	b.Run("pooled_decoder", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			f, _ := os.Open(c1zFile)
+			dec, _ := NewDecoder(f)
+			_, _ = io.ReadAll(dec)
+			dec.Close()
+			f.Close()
+		}
+	})
+
+	b.Run("new_decoder_each_time", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			f, _ := os.Open(c1zFile)
+
+			// Skip header manually
+			headerBuf := make([]byte, len(C1ZFileHeader))
+			_, _ = f.Read(headerBuf)
+
+			// Create new decoder each time (simulates old behavior)
+			dec, _ := zstd.NewReader(f,
+				zstd.WithDecoderConcurrency(1),
+				zstd.WithDecoderLowmem(true),
+				zstd.WithDecoderMaxMemory(defaultDecoderMaxMemory),
+			)
+			_, _ = io.ReadAll(dec)
+			dec.Close()
+			f.Close()
+		}
+	})
+}

--- a/pkg/dotc1z/pool_test.go
+++ b/pkg/dotc1z/pool_test.go
@@ -221,7 +221,7 @@ func TestPooledRoundTrip(t *testing.T) {
 }
 
 // BenchmarkEncoderPoolAllocs measures allocations with and without pooling.
-// Run with: go test -bench=BenchmarkEncoderPoolAllocs -benchmem
+// Run with: go test -bench=BenchmarkEncoderPoolAllocs -benchmem.
 func BenchmarkEncoderPoolAllocs(b *testing.B) {
 	testData := bytes.Repeat([]byte("benchmark data "), 1000)
 	tmpDir := b.TempDir()

--- a/pkg/dotc1z/pool_test.go
+++ b/pkg/dotc1z/pool_test.go
@@ -353,6 +353,7 @@ func BenchmarkEncoderPoolAllocs(b *testing.B) {
 
 	b.Run("pooled_encoder", func(b *testing.B) {
 		b.ReportAllocs()
+		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			c1zFile := filepath.Join(tmpDir, "bench.c1z")
 			err := saveC1z(dbFile, c1zFile, pooledEncoderConcurrency)
@@ -364,6 +365,7 @@ func BenchmarkEncoderPoolAllocs(b *testing.B) {
 
 	b.Run("new_encoder_each_time", func(b *testing.B) {
 		b.ReportAllocs()
+		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			c1zFile := filepath.Join(tmpDir, "bench2.c1z")
 
@@ -480,6 +482,7 @@ func BenchmarkDecoderPoolAllocs(b *testing.B) {
 
 	b.Run("pooled_decoder", func(b *testing.B) {
 		b.ReportAllocs()
+		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			f, err := os.Open(c1zFile)
 			if err != nil {
@@ -507,6 +510,7 @@ func BenchmarkDecoderPoolAllocs(b *testing.B) {
 
 	b.Run("new_decoder_each_time", func(b *testing.B) {
 		b.ReportAllocs()
+		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			f, err := os.Open(c1zFile)
 			if err != nil {

--- a/pkg/dotc1z/pool_test.go
+++ b/pkg/dotc1z/pool_test.go
@@ -205,6 +205,50 @@ func withIsolatedPools(t *testing.T) {
 	})
 }
 
+// TestPoolDisabled verifies the BATON_ZSTD_POOL_DISABLE kill-switch:
+// getEncoder and getDecoder return (nil, false) so callers fall through to
+// fresh creation, and putEncoder/putDecoder do not populate the pool.
+func TestPoolDisabled(t *testing.T) {
+	withIsolatedPools(t)
+
+	orig := poolDisabled
+	poolDisabled = true
+	t.Cleanup(func() { poolDisabled = orig })
+
+	enc, fromPool := getEncoder()
+	require.Nil(t, enc, "getEncoder should return nil when pool is disabled")
+	require.False(t, fromPool)
+
+	// Create an encoder the caller's way and verify putEncoder doesn't pool it.
+	freshEnc, err := zstd.NewWriter(nil, zstd.WithEncoderConcurrency(pooledEncoderConcurrency))
+	require.NoError(t, err)
+	require.NoError(t, freshEnc.Close())
+	putEncoder(freshEnc) // should be a no-op when disabled
+
+	// Decoder: same shape.
+	dec, fromPool := getDecoder()
+	require.Nil(t, dec, "getDecoder should return nil when pool is disabled")
+	require.False(t, fromPool)
+
+	freshDec, err := zstd.NewReader(nil)
+	require.NoError(t, err)
+	putDecoder(freshDec) // should be a no-op when disabled
+	freshDec.Close()
+
+	// Now flip the switch back and confirm the pools are still empty —
+	// putEncoder/putDecoder must not have added anything while disabled.
+	poolDisabled = false
+	enc2, fromPool2 := getEncoder()
+	require.NotNil(t, enc2)
+	require.False(t, fromPool2, "pool should be empty: put* were no-ops while disabled")
+	_ = enc2.Close()
+
+	dec2, fromPool2 := getDecoder()
+	require.NotNil(t, dec2)
+	require.False(t, fromPool2, "pool should be empty: put* were no-ops while disabled")
+	dec2.Close()
+}
+
 // TestPoolGrowsFromSaveC1z verifies that saveC1z populates the encoder pool
 // even when starting with an empty pool. This was a bug where only encoders
 // that came FROM the pool were returned TO the pool.

--- a/pkg/dotc1z/pool_test.go
+++ b/pkg/dotc1z/pool_test.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sync"
 	"testing"
 
@@ -15,6 +14,7 @@ import (
 )
 
 func TestEncoderPool(t *testing.T) {
+	withIsolatedPools(t)
 	t.Run("get returns valid encoder", func(t *testing.T) {
 		enc, fromPool := getEncoder()
 		require.NotNil(t, enc)
@@ -96,6 +96,7 @@ func TestEncoderPool(t *testing.T) {
 }
 
 func TestDecoderPool(t *testing.T) {
+	withIsolatedPools(t)
 	// Create some test compressed data
 	createCompressedData := func(t *testing.T, data []byte) []byte {
 		t.Helper()
@@ -188,28 +189,34 @@ func TestDecoderPool(t *testing.T) {
 	})
 }
 
+// withIsolatedPools swaps the package-global encoder/decoder pools with fresh
+// sync.Pool values for the duration of the test. Needed because sync.Pool can
+// evict entries via GC between Gets, and because concurrent tests in the same
+// package could otherwise race with exact-membership assertions.
+func withIsolatedPools(t *testing.T) {
+	t.Helper()
+	origEnc := encoderPool
+	origDec := decoderPool
+	encoderPool = &sync.Pool{}
+	decoderPool = &sync.Pool{}
+	t.Cleanup(func() {
+		encoderPool = origEnc
+		decoderPool = origDec
+	})
+}
+
 // TestPoolGrowsFromSaveC1z verifies that saveC1z populates the encoder pool
 // even when starting with an empty pool. This was a bug where only encoders
 // that came FROM the pool were returned TO the pool.
 func TestPoolGrowsFromSaveC1z(t *testing.T) {
-	// Clear any existing pool state by getting and not returning
-	for {
-		enc, fromPool := getEncoder()
-		if !fromPool {
-			// This was a fresh encoder, pool is now empty
-			// Don't return it - let it be GC'd
-			_ = enc.Close()
-			break
-		}
-		_ = enc.Close() // Don't return to pool
-	}
+	withIsolatedPools(t)
 
-	// Verify pool is empty
+	// Pool is freshly empty (see withIsolatedPools).
 	enc, fromPool := getEncoder()
-	require.False(t, fromPool, "pool should be empty after draining")
-	_ = enc.Close() // Don't return
+	require.False(t, fromPool, "isolated pool should be empty")
+	_ = enc.Close() // Drop it; don't return to pool.
 
-	// Now use saveC1z which should populate the pool
+	// Now use saveC1z which should populate the pool.
 	tmpDir := t.TempDir()
 	testData := bytes.Repeat([]byte("test data "), 100)
 
@@ -218,10 +225,10 @@ func TestPoolGrowsFromSaveC1z(t *testing.T) {
 	require.NoError(t, err)
 
 	c1zFile := filepath.Join(tmpDir, "test.c1z")
-	err = saveC1z(dbFile, c1zFile, 0)
+	err = saveC1z(dbFile, c1zFile, pooledEncoderConcurrency)
 	require.NoError(t, err)
 
-	// Now the pool should have an encoder
+	// Now the pool should have an encoder.
 	enc2, fromPool2 := getEncoder()
 	require.True(t, fromPool2, "saveC1z should have returned encoder to pool")
 	putEncoder(enc2)
@@ -230,22 +237,13 @@ func TestPoolGrowsFromSaveC1z(t *testing.T) {
 // TestPoolGrowsFromDecoder verifies that NewDecoder populates the decoder pool
 // even when starting with an empty pool.
 func TestPoolGrowsFromDecoder(t *testing.T) {
-	// Clear any existing pool state
-	for {
-		dec, fromPool := getDecoder()
-		if !fromPool {
-			dec.Close() // zstd.Decoder.Close() returns nothing
-			break
-		}
-		dec.Close() // Don't return to pool
-	}
+	withIsolatedPools(t)
 
-	// Verify pool is empty
 	dec, fromPool := getDecoder()
-	require.False(t, fromPool, "pool should be empty after draining")
+	require.False(t, fromPool, "isolated pool should be empty")
 	dec.Close()
 
-	// Create a c1z file to decode
+	// Create a c1z file to decode.
 	tmpDir := t.TempDir()
 	testData := bytes.Repeat([]byte("test data "), 100)
 
@@ -254,14 +252,14 @@ func TestPoolGrowsFromDecoder(t *testing.T) {
 	require.NoError(t, err)
 
 	c1zFile := filepath.Join(tmpDir, "test.c1z")
-	err = saveC1z(dbFile, c1zFile, 0)
+	err = saveC1z(dbFile, c1zFile, pooledEncoderConcurrency)
 	require.NoError(t, err)
 
-	// Drain encoder pool (saveC1z added one)
+	// Drain encoder pool (saveC1z added one) so we're only asserting on the decoder pool below.
 	enc, _ := getEncoder()
 	_ = enc.Close()
 
-	// Now use NewDecoder which should populate the decoder pool
+	// Now use NewDecoder which should populate the decoder pool.
 	f, err := os.Open(c1zFile)
 	require.NoError(t, err)
 
@@ -276,7 +274,7 @@ func TestPoolGrowsFromDecoder(t *testing.T) {
 	err = f.Close()
 	require.NoError(t, err)
 
-	// Now the decoder pool should have a decoder
+	// Now the decoder pool should have a decoder.
 	dec2, fromPool2 := getDecoder()
 	require.True(t, fromPool2, "NewDecoder.Close should have returned decoder to pool")
 	putDecoder(dec2)
@@ -292,9 +290,9 @@ func TestPooledRoundTrip(t *testing.T) {
 		err := os.WriteFile(dbFile, testData, 0600)
 		require.NoError(t, err)
 
-		// Save using pooled encoder
+		// Save using pooled encoder.
 		c1zFile := filepath.Join(tmpDir, "test.c1z")
-		err = saveC1z(dbFile, c1zFile, 0)
+		err = saveC1z(dbFile, c1zFile, pooledEncoderConcurrency)
 		require.NoError(t, err)
 
 		// Load using pooled decoder
@@ -322,7 +320,7 @@ func TestPooledRoundTrip(t *testing.T) {
 			require.NoError(t, err)
 
 			c1zFile := filepath.Join(tmpDir, "test.c1z")
-			err = saveC1z(dbFile, c1zFile, 0)
+			err = saveC1z(dbFile, c1zFile, pooledEncoderConcurrency)
 			require.NoError(t, err)
 
 			f, err := os.Open(c1zFile)
@@ -357,7 +355,7 @@ func BenchmarkEncoderPoolAllocs(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
 			c1zFile := filepath.Join(tmpDir, "bench.c1z")
-			err := saveC1z(dbFile, c1zFile, 0)
+			err := saveC1z(dbFile, c1zFile, pooledEncoderConcurrency)
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -385,8 +383,8 @@ func BenchmarkEncoderPoolAllocs(b *testing.B) {
 				b.Fatal(err)
 			}
 
-			// Create new encoder each time (simulates old behavior)
-			enc, err := zstd.NewWriter(outF, zstd.WithEncoderConcurrency(runtime.GOMAXPROCS(0)))
+			// Apples-to-apples with pooled_encoder above (concurrency=1).
+			enc, err := zstd.NewWriter(outF, zstd.WithEncoderConcurrency(pooledEncoderConcurrency))
 			if err != nil {
 				outF.Close()
 				dbF.Close()
@@ -454,7 +452,7 @@ func BenchmarkEncoderAllocationOnly(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			var buf bytes.Buffer
-			enc, err := zstd.NewWriter(&buf, zstd.WithEncoderConcurrency(runtime.GOMAXPROCS(0)))
+			enc, err := zstd.NewWriter(&buf, zstd.WithEncoderConcurrency(pooledEncoderConcurrency))
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -477,7 +475,7 @@ func BenchmarkDecoderPoolAllocs(b *testing.B) {
 	require.NoError(b, err)
 
 	c1zFile := filepath.Join(tmpDir, "bench.c1z")
-	err = saveC1z(dbFile, c1zFile, 0)
+	err = saveC1z(dbFile, c1zFile, pooledEncoderConcurrency)
 	require.NoError(b, err)
 
 	b.Run("pooled_decoder", func(b *testing.B) {


### PR DESCRIPTION
Reviving #622 (closed, not merged). This re-opens the same branch with btipling's two non-blocking follow-ups from the prior review folded in.

## Summary

- Add `sync.Pool` for `zstd.Encoder` and `zstd.Decoder` to eliminate per-call allocation overhead on the dotc1z hot path.
- Profiling showed `zstd.ensureHist` allocating **~215 MB/min** in `temporal_sync` from encoder churn, and the decoder side allocating **~3.2 GB/min** in `temporal_worker`.
- Pool only engages when options match pool defaults; callers with custom concurrency/memory settings fall back to fresh instances.

## Changes

| File | Change |
|---|---|
| `pkg/dotc1z/pool.go` | NEW — encoder/decoder pool with `get*`/`put*` helpers |
| `pkg/dotc1z/pool_test.go` | NEW — unit tests, concurrent stress, round-trip, benchmarks |
| `pkg/dotc1z/file.go` | `saveC1z` uses pooled encoder when concurrency matches |
| `pkg/dotc1z/decoder.go` | decoder uses pooled decoder when options match |

## Follow-ups from prior review (new in this revival)

1. **Pool now engages at the production default.** In the prior PR, `pooledEncoderConcurrency = GOMAXPROCS` but the callers default to `encoderConcurrency = 1`, so the gate at `file.go:158` was always false and the pool carried zero traffic in prod. Pinning `pooledEncoderConcurrency = 1` makes the pool match the actual sync-path default. The alternative — flipping callers to `0` (→GOMAXPROCS) — was deliberately avoided because klauspost/compress's multi-threaded encoder has theoretical race concerns.

2. **Pool-growth tests are now hermetic.** `TestPoolGrowsFromSaveC1z`, `TestPoolGrowsFromDecoder`, `TestEncoderPool`, and `TestDecoderPool` now swap the package-global `sync.Pool` via `t.Cleanup`, so GC eviction and cross-test ordering can't flake the exact-membership assertions. The package globals became pointer-valued to allow the swap.

## Safety Measures

- Pool only used when options match pool defaults (concurrency, maxMemory).
- Encoders always closed on error paths (not returned to pool in bad state).
- `Reset(nil)` called before returning to pool to release writer/reader references.
- Decoder `Reset()` errors handled gracefully (don't return bad decoders to pool).

## Benchmark (apples-to-apples at concurrency=1)

```
BenchmarkEncoderAllocationOnly/pooled-16          1,202,396     1000 ns/op     116 B/op     2 allocs/op
BenchmarkEncoderAllocationOnly/new_each_time-16       4,809   338275 ns/op 1758312 B/op    19 allocs/op
```

~15,000x reduction in bytes allocated per encode.

## Production Profile Context

- `temporal_sync` (60s profile): `zstd.(*fastBase).ensureHist` ≈ 384 MB, total zstd allocs ≈ 665 MB (12.4% of total).
- `temporal_worker` (62s profile): decoder-side allocs ≈ 3.26 GB (17.9% of total) via `protozstd.Unmarshal` → `decompressValue`.

## Test plan

- [x] All existing `dotc1z` tests pass
- [x] Pool unit tests (concurrent access, round-trip correctness)
- [x] Regression tests verify pool grows from empty state
- [x] Isolated-pool tests are no longer sensitive to cross-test ordering
- [x] Benchmark demonstrates allocation reduction at production concurrency
- [ ] Deploy to staging and profile to verify improvement

Prior approval: @btipling on #622.

🤖 Generated with [Claude Code](https://claude.com/claude-code)