### PR TITLE
fix(sync): repair silently-broken latestSyncFetcher type assertion

### DIFF
--- a/pkg/connectorstore/connectorstore.go
+++ b/pkg/connectorstore/connectorstore.go
@@ -64,6 +64,19 @@ type InternalWriter interface {
 	SetSupportsDiff(ctx context.Context, syncID string) error
 }
 
+// LatestFinishedSyncIDFetcher returns the most-recently-finished sync ID of the
+// given type, or empty string if no such sync exists. This is a small optional
+// capability separate from Reader/Writer because not every store implementation
+// can answer it (e.g. gRPC-backed readers have a different flavor via
+// SyncsReaderServiceGetLatestFinishedSync).
+//
+// This interface lives in connectorstore so that producers (e.g. *dotc1z.C1File)
+// and consumers (e.g. pkg/sync) reference a single authoritative declaration,
+// preventing the name/signature drift that occurred between PR #473 and this fix.
+type LatestFinishedSyncIDFetcher interface {
+	LatestFinishedSyncID(ctx context.Context, syncType SyncType) (string, error)
+}
+
 // GrantUpsertMode controls how grant conflicts are resolved during upsert.
 type GrantUpsertMode int
 

--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -71,7 +71,10 @@ type C1File struct {
 	skipCleanup bool
 }
 
-var _ connectorstore.InternalWriter = (*C1File)(nil)
+var (
+	_ connectorstore.InternalWriter              = (*C1File)(nil)
+	_ connectorstore.LatestFinishedSyncIDFetcher = (*C1File)(nil)
+)
 
 type C1FOption func(*C1File)
 

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -182,14 +182,14 @@ func (s *syncer) getPreviousFullSyncID(ctx context.Context) (string, error) {
 		return *ptr, nil
 	}
 
-	psf, ok := s.store.(latestSyncFetcher)
+	psf, ok := s.store.(connectorstore.LatestFinishedSyncIDFetcher)
 	if !ok {
 		empty := ""
 		s.previousSyncIDPtr.Store(&empty)
 		return "", nil
 	}
 
-	previousSyncID, err := psf.LatestFinishedSync(ctx, connectorstore.SyncTypeFull)
+	previousSyncID, err := psf.LatestFinishedSyncID(ctx, connectorstore.SyncTypeFull)
 	if err == nil {
 		s.previousSyncIDPtr.Store(&previousSyncID)
 	}
@@ -1542,10 +1542,6 @@ func (s *syncer) SyncGrants(ctx context.Context, action *Action) error {
 	}
 
 	return nil
-}
-
-type latestSyncFetcher interface {
-	LatestFinishedSync(ctx context.Context, syncType connectorstore.SyncType) (string, error)
 }
 
 func (s *syncer) fetchResourceForPreviousSync(ctx context.Context, resourceID *v2.ResourceId) (string, *v2.ETag, error) {

--- a/pkg/sync/syncer_test.go
+++ b/pkg/sync/syncer_test.go
@@ -1883,6 +1883,23 @@ type etagMockConnector struct {
 	secondPageGrants []*v2.Grant
 	nextPageToken    string
 	forceMatch       bool
+	// skipEtag, when true, causes ListGrants responses to omit the ETag annotation
+	// entirely. Used to simulate connectors that don't return etags, so the syncer
+	// genuinely has no previous etag to compare against on subsequent syncs.
+	skipEtag bool
+}
+
+// etagAnnotations returns a fresh annotations slice containing this mock's ETag,
+// or nil if skipEtag is set. Using nil here means no ETag annotation is attached
+// to the response, so the syncer does not persist one on the resource.
+func (mc *etagMockConnector) etagAnnotations() annotations.Annotations {
+	if mc.skipEtag {
+		return nil
+	}
+	return annotations.New(&v2.ETag{
+		Value:         mc.etagValue,
+		EntitlementId: mc.entitlementID,
+	})
 }
 
 func newEtagMockConnector(etagValue string) *etagMockConnector {
@@ -1945,18 +1962,12 @@ func (mc *etagMockConnector) ListGrants(ctx context.Context, in *v2.GrantsServic
 			return v2.GrantsServiceListGrantsResponse_builder{
 				List:          mc.firstPageGrants,
 				NextPageToken: mc.nextPageToken,
-				Annotations: annotations.New(&v2.ETag{
-					Value:         mc.etagValue,
-					EntitlementId: mc.entitlementID,
-				}),
+				Annotations:   mc.etagAnnotations(),
 			}.Build(), nil
 		}
 		return v2.GrantsServiceListGrantsResponse_builder{
-			List: mc.secondPageGrants,
-			Annotations: annotations.New(&v2.ETag{
-				Value:         mc.etagValue,
-				EntitlementId: mc.entitlementID,
-			}),
+			List:        mc.secondPageGrants,
+			Annotations: mc.etagAnnotations(),
 		}.Build(), nil
 	}
 
@@ -1965,11 +1976,8 @@ func (mc *etagMockConnector) ListGrants(ctx context.Context, in *v2.GrantsServic
 		key = r.GetId().GetResource()
 	}
 	return v2.GrantsServiceListGrantsResponse_builder{
-		List: mc.grantDB[key],
-		Annotations: annotations.New(&v2.ETag{
-			Value:         mc.etagValue,
-			EntitlementId: mc.entitlementID,
-		}),
+		List:        mc.grantDB[key],
+		Annotations: mc.etagAnnotations(),
 	}.Build(), nil
 }
 
@@ -2048,16 +2056,19 @@ func TestSyncGrants_EtagMatchMissingPreviousEtag(t *testing.T) {
 	mc := newEtagMockConnector("etag-1")
 	mc.WithData(group, ent, grant)
 
-	// First sync: do NOT return etag (simulate connector not setting it)
-	mc.etagValue = ""
+	// First sync: connector does not return an ETag annotation on its ListGrants
+	// response, so the syncer never persists one on the resource.
+	mc.skipEtag = true
 	syncer1, err := NewSyncer(ctx, mc, WithC1ZPath(c1zPath), WithTmpDir(tempDir))
 	require.NoError(t, err)
 	require.NoError(t, syncer1.Sync(ctx))
 	require.NoError(t, syncer1.Close(ctx))
 
-	// Second sync: connector claims ETagMatch but syncer has no previous etag -> expect error
+	// Second sync: connector claims ETagMatch but syncer has no previous etag -> expect error.
+	// skipEtag stays true so the connector still omits its own ETag annotation, but it
+	// forces an ETagMatch via forceMatch — the syncer should detect the missing previous
+	// etag and refuse to proceed.
 	mc.forceMatch = true
-	mc.etagValue = "etag-1"
 	mc.callTokens = nil
 
 	syncer2, err := NewSyncer(ctx, mc, WithC1ZPath(c1zPath), WithTmpDir(tempDir))


### PR DESCRIPTION
PR #473 ("Clean up APIs to specify sync type and sync ID in more places.")
renamed *C1File.LatestFinishedSync to LatestFinishedSyncID but did not
update the locally-declared latestSyncFetcher interface in pkg/sync/syncer.go,
which still required a method named LatestFinishedSync with the same
signature.

Since that commit, the type assertion at syncer.getPreviousFullSyncID
has silently failed every time (no type satisfies the stale interface),
causing the function to return the empty string instead of the previous
full sync ID. This is used by fetchResourceForPreviousSync to look up
the previous resource's ETag; the empty sync ID short-circuits that
lookup and makes etag-based grant reuse partially ineffective.

The fix moves the capability interface to pkg/connectorstore as
LatestFinishedSyncIDFetcher with the correct method name, adds a
compile-time impl-assertion on *C1File, and deletes the stale local
declaration. Placing the interface next to the other connectorstore
types makes producer and consumer reference a single authoritative
declaration; future renames on either side become compile errors,
not silent drift.

TestSyncGrants_EtagMatchMissingPreviousEtag was written against the
broken behavior: it relied on the previous sync ID being empty to
force fetchEtaggedGrantsForResource into its "no previous sync" error
branch. With the fix, the previous sync ID is correctly resolved, so
the etag reuse path is actually reached — the test's stated intent
("no previous etag stored") requires the connector to have skipped
returning an ETag annotation on its first sync. The mock gains a
skipEtag flag that models this explicitly, and the test uses it to
genuinely reproduce the missing-etag condition.

No public behavior change: external connectors never consumed the
local latestSyncFetcher interface, and the new LatestFinishedSyncIDFetcher
interface is an additive declaration. The only observable difference
is that etag-based grant reuse now functions for partial syncs as
originally intended.
