### PR TITLE
perf(dotc1z): filter grants by has_external_match column at SQL

### DIFF
--- a/pkg/connectorstore/connectorstore.go
+++ b/pkg/connectorstore/connectorstore.go
@@ -143,6 +143,10 @@ type GrantListOptions struct {
 	// NeedsExpansionOnly filters rows to needs_expansion=1.
 	// Used by expansion-only modes.
 	NeedsExpansionOnly bool
+	// ExternalMatchOnly filters rows to grants carrying an ExternalResourceMatch
+	// annotation. Used by payload+expansion mode by processGrantsWithExternalPrincipals
+	// to skip the unmarshal work for rows the caller would otherwise discard.
+	ExternalMatchOnly bool
 
 	// PageToken and PageSize are used for pagination in all modes.
 	// SyncID is used for expansion-only modes.

--- a/pkg/dotc1z/c1file_store.go
+++ b/pkg/dotc1z/c1file_store.go
@@ -257,6 +257,41 @@ func (g c1FileGrantStore) ListWithAnnotations(ctx context.Context) iter.Seq2[Gra
 	}
 }
 
+// ListWithAnnotationsExternalMatchOnly implements GrantStore. Same shape as
+// ListWithAnnotations but filters at SQL via the has_external_match column,
+// skipping the per-row data-blob unmarshal for grants that processGrants-
+// WithExternalPrincipals would discard. Set BATON_DISABLE_EXTERNAL_MATCH_FILTER=1
+// to fall back to the unfiltered scan.
+func (g c1FileGrantStore) ListWithAnnotationsExternalMatchOnly(ctx context.Context) iter.Seq2[GrantAnnotation, error] {
+	return func(yield func(GrantAnnotation, error) bool) {
+		pageToken := ""
+		for {
+			if err := ctx.Err(); err != nil {
+				_ = yield(GrantAnnotation{}, err)
+				return
+			}
+			resp, err := g.c.listGrantsWithExpansionInternal(ctx, grantListOptions{
+				Mode:              grantListModePayloadWithExpansion,
+				ExternalMatchOnly: true,
+				PageToken:         pageToken,
+			})
+			if err != nil {
+				_ = yield(GrantAnnotation{}, err)
+				return
+			}
+			for _, ga := range grantAnnotationRowsFromInternal(resp.Rows) {
+				if !yield(ga, nil) {
+					return
+				}
+			}
+			if resp.NextPageToken == "" {
+				return
+			}
+			pageToken = resp.NextPageToken
+		}
+	}
+}
+
 // -----------------------------------------------------------------------------
 // SyncMeta
 // -----------------------------------------------------------------------------

--- a/pkg/dotc1z/clone_sync_test.go
+++ b/pkg/dotc1z/clone_sync_test.go
@@ -74,6 +74,9 @@ func TestCloneSyncMigratedColumnOrder(t *testing.T) {
 	_, err = srcFile.db.ExecContext(ctx,
 		fmt.Sprintf("ALTER TABLE %s ADD COLUMN needs_expansion integer not null default 0", grants.Name()))
 	require.NoError(t, err)
+	_, err = srcFile.db.ExecContext(ctx,
+		fmt.Sprintf("ALTER TABLE %s ADD COLUMN has_external_match integer not null default 0", grants.Name()))
+	require.NoError(t, err)
 
 	// Create partial indexes that the migration would add.
 	_, err = srcFile.db.ExecContext(ctx, fmt.Sprintf(
@@ -82,6 +85,10 @@ func TestCloneSyncMigratedColumnOrder(t *testing.T) {
 	require.NoError(t, err)
 	_, err = srcFile.db.ExecContext(ctx, fmt.Sprintf(
 		"CREATE INDEX IF NOT EXISTS idx_grants_sync_needs_expansion_v1 ON %s (sync_id) WHERE needs_expansion = 1",
+		grants.Name()))
+	require.NoError(t, err)
+	_, err = srcFile.db.ExecContext(ctx, fmt.Sprintf(
+		"CREATE INDEX IF NOT EXISTS idx_grants_sync_external_match_v1 ON %s (sync_id) WHERE has_external_match = 1",
 		grants.Name()))
 	require.NoError(t, err)
 

--- a/pkg/dotc1z/engine/pebble/adapter_grants_store.go
+++ b/pkg/dotc1z/engine/pebble/adapter_grants_store.go
@@ -256,3 +256,12 @@ func (g pebbleGrantStore) ListWithAnnotations(ctx context.Context) iter.Seq2[dot
 		}
 	}
 }
+
+// ListWithAnnotationsExternalMatchOnly implements GrantStore. The Pebble
+// engine does not maintain the has_external_match column the SQLite engine
+// uses for SQL-side filtering; fall back to the unfiltered iterator. The
+// caller (processGrantsWithExternalPrincipals) re-checks the annotation
+// in-Go, so correctness is preserved.
+func (g pebbleGrantStore) ListWithAnnotationsExternalMatchOnly(ctx context.Context) iter.Seq2[dotc1z.GrantAnnotation, error] {
+	return g.ListWithAnnotations(ctx)
+}

--- a/pkg/dotc1z/engine/pebble/register.go
+++ b/pkg/dotc1z/engine/pebble/register.go
@@ -457,6 +457,10 @@ func (g registeredStoreGrants) ListWithAnnotations(ctx context.Context) iter.Seq
 	return g.inner.ListWithAnnotations(ctx)
 }
 
+func (g registeredStoreGrants) ListWithAnnotationsExternalMatchOnly(ctx context.Context) iter.Seq2[dotc1z.GrantAnnotation, error] {
+	return g.inner.ListWithAnnotationsExternalMatchOnly(ctx)
+}
+
 func (s *registeredStore) Close(ctx context.Context) (retErr error) {
 	s.closeMu.Lock()
 	defer s.closeMu.Unlock()

--- a/pkg/dotc1z/grant_store.go
+++ b/pkg/dotc1z/grant_store.go
@@ -92,6 +92,17 @@ type GrantStore interface {
 	//
 	// Called by pkg/sync.syncer.listAllGrantsWithExpansion.
 	ListWithAnnotations(ctx context.Context) iter.Seq2[GrantAnnotation, error]
+
+	// ListWithAnnotationsExternalMatchOnly is the same shape as
+	// ListWithAnnotations but only yields grants carrying an
+	// ExternalResourceMatch{,All,ID} annotation, filtered at SQL via the
+	// has_external_match column. Used by processGrantsWithExternalPrincipals
+	// to skip the unmarshal cost for the (usually >99%) rows it would
+	// discard anyway.
+	//
+	// Set BATON_DISABLE_EXTERNAL_MATCH_FILTER=1 to fall back to the
+	// pre-filter behavior (scan all rows) without a re-release.
+	ListWithAnnotationsExternalMatchOnly(ctx context.Context) iter.Seq2[GrantAnnotation, error]
 }
 
 // PendingExpansion is a lightweight row yielded by GrantStore.PendingExpansion.

--- a/pkg/dotc1z/grants.go
+++ b/pkg/dotc1z/grants.go
@@ -26,8 +26,9 @@ create table if not exists %s (
     principal_resource_type_id text not null,
     principal_resource_id text not null,
     external_id text not null,
-    expansion blob,                             -- Serialized GrantExpandable proto; NULL if grant is not expandable.
-    needs_expansion integer not null default 0, -- 1 if grant should be processed during expansion.
+    expansion blob,                                -- Serialized GrantExpandable proto; NULL if grant is not expandable.
+    needs_expansion integer not null default 0,    -- 1 if grant should be processed during expansion.
+    has_external_match integer not null default 0, -- 1 if grant carries an ExternalResourceMatch{,All,ID} annotation.
     data blob not null,
     sync_id text not null,
     discovered_at datetime not null
@@ -85,6 +86,13 @@ func (r *grantsTable) Migrations(ctx context.Context, db *goqu.Database) error {
 		return err
 	}
 
+	// Add has_external_match column if missing (for older files).
+	if _, err := db.ExecContext(ctx, fmt.Sprintf(
+		"alter table %s add column has_external_match integer not null default 0", r.Name(),
+	)); err != nil && !isAlreadyExistsError(err) {
+		return err
+	}
+
 	// Create partial index for efficient queries on expandable grants.
 	if _, err := db.ExecContext(ctx, fmt.Sprintf(
 		"create index if not exists %s on %s (sync_id) where expansion is not null",
@@ -106,8 +114,19 @@ func (r *grantsTable) Migrations(ctx context.Context, db *goqu.Database) error {
 		return err
 	}
 
-	// Backfill expansion column from stored grant bytes.
-	return backfillGrantExpansionColumn(ctx, db, r.Name())
+	// Create partial index for grants carrying an ExternalResourceMatch annotation.
+	// Same rationale as the needs_expansion partial index: selective predicate,
+	// stays out of the general-purpose compound indexes' way.
+	if _, err := db.ExecContext(ctx, fmt.Sprintf(
+		"create index if not exists %s on %s (sync_id) where has_external_match = 1",
+		fmt.Sprintf("idx_grants_sync_external_match_v%s", r.Version()),
+		r.Name(),
+	)); err != nil {
+		return err
+	}
+
+	// Backfill expansion and has_external_match columns from stored grant bytes.
+	return backfillGrantDerivedColumns(ctx, db, r.Name())
 }
 
 func (c *C1File) ListGrants(ctx context.Context, request *v2.GrantsServiceListGrantsRequest) (*v2.GrantsServiceListGrantsResponse, error) {
@@ -256,6 +275,10 @@ func baseGrantRecord(grant *v2.Grant) goqu.Record {
 func grantExtractFields(mode connectorstore.GrantUpsertMode) func(grant *v2.Grant) (goqu.Record, error) {
 	return func(grant *v2.Grant) (goqu.Record, error) {
 		rec := baseGrantRecord(grant)
+		// has_external_match mirrors the data blob's annotation set, so it must be
+		// set in every mode (including PreserveExpansion — the data column is still
+		// replaced from EXCLUDED in executeGrantChunkedUpsert).
+		rec["has_external_match"] = hasExternalResourceMatch(grant)
 		if mode == connectorstore.GrantUpsertModePreserveExpansion {
 			return rec, nil
 		}
@@ -323,6 +346,28 @@ func hasGrantExpandable(grant *v2.Grant) bool {
 	return false
 }
 
+// externalResourceMatchSentinels are the annotation types that
+// processGrantsWithExternalPrincipals in pkg/sync filters on. hasExternalResourceMatch
+// below checks for any of these; keep in lockstep with the caller's ContainsAny.
+var externalResourceMatchSentinels = []proto.Message{
+	&v2.ExternalResourceMatchAll{},
+	&v2.ExternalResourceMatch{},
+	&v2.ExternalResourceMatchID{},
+}
+
+// hasExternalResourceMatch returns true if the grant carries any ExternalResourceMatch
+// annotation. Cheap type-url check, no unmarshal.
+func hasExternalResourceMatch(grant *v2.Grant) bool {
+	for _, a := range grant.GetAnnotations() {
+		for _, s := range externalResourceMatchSentinels {
+			if a.MessageIs(s) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // extractAndStripExpansion extracts the GrantExpandable annotation from the grant,
 // removes it from the grant's annotations, and returns the serialized proto bytes.
 // The annotation is always stripped from the grant if present, so it never leaks
@@ -366,13 +411,16 @@ func extractAndStripExpansion(grant *v2.Grant) ([]byte, bool) {
 	return data, true
 }
 
-func backfillGrantExpansionColumn(ctx context.Context, db *goqu.Database, tableName string) error {
+func backfillGrantDerivedColumns(ctx context.Context, db *goqu.Database, tableName string) error {
 	// Backfill grants only for syncs that have not yet been processed.
 	// The grants_backfilled flag is the single source of truth for whether
 	// this migration work still needs to run for a sync.
 	//
 	// We unmarshal every grant with expansion IS NULL from old syncs, extract the
-	// GrantExpandable annotation (if present), and populate the expansion column.
+	// GrantExpandable annotation (if present), populate the expansion column, and
+	// also derive has_external_match from the annotation set while we have the
+	// proto in hand — both columns track the stored data blob so backfilling them
+	// in the same pass avoids a second full scan.
 	// Non-expandable grants get an empty-blob sentinel to avoid re-processing,
 	// which is cleaned up to NULL at the end.
 	//
@@ -454,13 +502,17 @@ func backfillGrantExpansionColumn(ctx context.Context, db *goqu.Database, tableN
 		lastID = batch[len(batch)-1].id
 
 		// Split grants into expandable (need full data rewrite) and
-		// non-expandable (just need sentinel marker).
-		var sentinelIDs []any
+		// non-expandable (just need sentinel + has_external_match marker).
+		// Non-expandable rows are further split by has_external_match so each
+		// group can be updated in a single batch statement.
+		var sentinelWithMatchIDs []any
+		var sentinelNoMatchIDs []any
 		type expandableRow struct {
-			id             int64
-			expansionBytes []byte
-			needsExpansion bool
-			data           []byte
+			id               int64
+			expansionBytes   []byte
+			needsExpansion   bool
+			data             []byte
+			hasExternalMatch bool
 		}
 		var expandableRows []expandableRow
 
@@ -470,10 +522,15 @@ func backfillGrantExpansionColumn(ctx context.Context, db *goqu.Database, tableN
 				return err
 			}
 
+			hasMatch := hasExternalResourceMatch(g)
 			expansionBytes, needsExpansion := extractAndStripExpansion(g)
 
 			if expansionBytes == nil {
-				sentinelIDs = append(sentinelIDs, r.id)
+				if hasMatch {
+					sentinelWithMatchIDs = append(sentinelWithMatchIDs, r.id)
+				} else {
+					sentinelNoMatchIDs = append(sentinelNoMatchIDs, r.id)
+				}
 				continue
 			}
 
@@ -482,10 +539,11 @@ func backfillGrantExpansionColumn(ctx context.Context, db *goqu.Database, tableN
 				return err
 			}
 			expandableRows = append(expandableRows, expandableRow{
-				id:             r.id,
-				expansionBytes: expansionBytes,
-				needsExpansion: needsExpansion,
-				data:           newData,
+				id:               r.id,
+				expansionBytes:   expansionBytes,
+				needsExpansion:   needsExpansion,
+				data:             newData,
+				hasExternalMatch: hasMatch,
 			})
 		}
 
@@ -494,13 +552,24 @@ func backfillGrantExpansionColumn(ctx context.Context, db *goqu.Database, tableN
 			return err
 		}
 
-		// Batch-mark non-expandable grants with the sentinel in one statement.
-		if len(sentinelIDs) > 0 {
-			sp := strings.Repeat("?,", len(sentinelIDs))
+		// Batch-mark non-expandable grants. Split into two statements by
+		// has_external_match so we can use a simple IN(...) per group.
+		if len(sentinelNoMatchIDs) > 0 {
+			sp := strings.Repeat("?,", len(sentinelNoMatchIDs))
 			sp = sp[:len(sp)-1]
 			if _, err := tx.ExecContext(ctx, fmt.Sprintf(
 				`UPDATE %s SET expansion=X'' WHERE id IN (%s)`, tableName, sp,
-			), sentinelIDs...); err != nil {
+			), sentinelNoMatchIDs...); err != nil {
+				_ = tx.Rollback()
+				return err
+			}
+		}
+		if len(sentinelWithMatchIDs) > 0 {
+			sp := strings.Repeat("?,", len(sentinelWithMatchIDs))
+			sp = sp[:len(sp)-1]
+			if _, err := tx.ExecContext(ctx, fmt.Sprintf(
+				`UPDATE %s SET expansion=X'', has_external_match=1 WHERE id IN (%s)`, tableName, sp,
+			), sentinelWithMatchIDs...); err != nil {
 				_ = tx.Rollback()
 				return err
 			}
@@ -509,14 +578,14 @@ func backfillGrantExpansionColumn(ctx context.Context, db *goqu.Database, tableN
 		// Expandable grants need per-row updates (each has unique data).
 		if len(expandableRows) > 0 {
 			fullStmt, err := tx.PrepareContext(ctx, fmt.Sprintf(
-				`UPDATE %s SET expansion=?, needs_expansion=?, data=? WHERE id=?`, tableName,
+				`UPDATE %s SET expansion=?, needs_expansion=?, data=?, has_external_match=? WHERE id=?`, tableName,
 			))
 			if err != nil {
 				_ = tx.Rollback()
 				return err
 			}
 			for _, er := range expandableRows {
-				if _, err := fullStmt.ExecContext(ctx, er.expansionBytes, er.needsExpansion, er.data, er.id); err != nil {
+				if _, err := fullStmt.ExecContext(ctx, er.expansionBytes, er.needsExpansion, er.data, er.hasExternalMatch, er.id); err != nil {
 					_ = fullStmt.Close()
 					_ = tx.Rollback()
 					return err
@@ -588,9 +657,10 @@ func executeGrantChunkedUpsert(
 
 	buildQueryFn := func(insertDs *goqu.InsertDataset, chunkedRows []*goqu.Record) (*goqu.InsertDataset, error) {
 		update := goqu.Record{
-			"data":            goqu.I("EXCLUDED.data"),
-			"expansion":       expansionExpr,
-			"needs_expansion": needsExpansionExpr,
+			"data":               goqu.I("EXCLUDED.data"),
+			"expansion":          expansionExpr,
+			"needs_expansion":    needsExpansionExpr,
+			"has_external_match": goqu.I("EXCLUDED.has_external_match"),
 		}
 		if mode == connectorstore.GrantUpsertModeIfNewer {
 			update["discovered_at"] = goqu.I("EXCLUDED.discovered_at")

--- a/pkg/dotc1z/grants.go
+++ b/pkg/dotc1z/grants.go
@@ -140,9 +140,23 @@ func (r *grantsTable) Migrations(ctx context.Context, db *goqu.Database) (bool, 
 		return false, err
 	}
 
-	// Backfill expansion + has_external_match columns from stored grant bytes.
-	return backfillGrantDerivedColumns(ctx, db, r.Name())
+	// Backfill expansion + has_external_match columns from stored grant bytes
+	// for syncs that pre-date the expansion-column work (grants_backfilled=0).
+	migrated, err := backfillGrantDerivedColumns(ctx, db, r.Name())
+	if err != nil {
+		return false, err
+	}
 
+	// Separately, backfill has_external_match for syncs that DO have
+	// grants_backfilled=1 from the prior PR — that flag is flipped on every
+	// existing sync, so gating the new column on it would skip the entire
+	// installed base. Tracked independently via has_external_match_backfilled.
+	matchMigrated, err := backfillHasExternalMatchColumn(ctx, db, r.Name())
+	if err != nil {
+		return false, err
+	}
+
+	return migrated || matchMigrated, nil
 }
 
 func (c *C1File) ListGrants(ctx context.Context, request *v2.GrantsServiceListGrantsRequest) (*v2.GrantsServiceListGrantsResponse, error) {
@@ -897,6 +911,129 @@ func backfillGrantDerivedColumns(ctx context.Context, db *goqu.Database, tableNa
 		return false, err
 	}
 	if err := tx.Commit(); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// backfillHasExternalMatchColumn populates has_external_match for syncs that
+// pre-date this column. Gated on has_external_match_backfilled (a new
+// sync_runs flag) rather than grants_backfilled — the latter is already 1
+// on every sync after the prior expansion-column backfill PR, so reusing
+// it would silently skip the entire installed base.
+//
+// Unmarshals each grant's data blob, runs hasExternalResourceMatch, and
+// bulk-updates the matching IDs in batches keyed by sync_id. Non-matching
+// rows keep the column at its default 0. Page size matches the expansion
+// backfill above. On completion, marks the processed syncs as backfilled.
+func backfillHasExternalMatchColumn(ctx context.Context, db *goqu.Database, tableName string) (bool, error) {
+	syncRows, err := db.QueryContext(ctx, fmt.Sprintf(
+		`SELECT sync_id FROM %s WHERE has_external_match_backfilled = 0`, syncRuns.Name(),
+	))
+	if err != nil {
+		return false, err
+	}
+	var pendingSyncIDs []any
+	if err := func() error {
+		defer func() { _ = syncRows.Close() }()
+		for syncRows.Next() {
+			var sid string
+			if err := syncRows.Scan(&sid); err != nil {
+				return err
+			}
+			pendingSyncIDs = append(pendingSyncIDs, sid)
+		}
+		return syncRows.Err()
+	}(); err != nil {
+		return false, err
+	}
+	if len(pendingSyncIDs) == 0 {
+		return false, nil
+	}
+
+	placeholders := strings.Repeat("?,", len(pendingSyncIDs))
+	placeholders = placeholders[:len(placeholders)-1]
+
+	const pageSize = 1000
+	var lastID int64
+	for {
+		// Walk grants in the pending syncs that are NOT yet marked. The
+		// has_external_match=0 filter is on the column default, so this
+		// includes every row of every pending sync on the first pass.
+		args := append([]any{}, pendingSyncIDs...)
+		args = append(args, lastID, pageSize)
+		rows, err := db.QueryContext(ctx, fmt.Sprintf(
+			`SELECT id, data FROM %s WHERE sync_id IN (%s) AND id > ? ORDER BY id ASC LIMIT ?`,
+			tableName, placeholders,
+		), args...)
+		if err != nil {
+			return false, err
+		}
+
+		type row struct {
+			id   int64
+			data []byte
+		}
+		var batch []row
+		if err := func() error {
+			defer func() { _ = rows.Close() }()
+			for rows.Next() {
+				var r row
+				if err := rows.Scan(&r.id, &r.data); err != nil {
+					return err
+				}
+				batch = append(batch, r)
+			}
+			return rows.Err()
+		}(); err != nil {
+			return false, err
+		}
+		if len(batch) == 0 {
+			break
+		}
+
+		var matchIDs []any
+		for _, r := range batch {
+			g := &v2.Grant{}
+			if err := proto.Unmarshal(r.data, g); err != nil {
+				return false, fmt.Errorf("unmarshal grant %d during has_external_match backfill: %w", r.id, err)
+			}
+			if hasExternalResourceMatch(g) {
+				matchIDs = append(matchIDs, r.id)
+			}
+		}
+
+		if len(matchIDs) > 0 {
+			tx, err := db.BeginTx(ctx, nil)
+			if err != nil {
+				return false, err
+			}
+			sp := strings.Repeat("?,", len(matchIDs))
+			sp = sp[:len(sp)-1]
+			if _, err := tx.ExecContext(ctx, fmt.Sprintf(
+				`UPDATE %s SET has_external_match = 1 WHERE id IN (%s)`, tableName, sp,
+			), matchIDs...); err != nil {
+				_ = tx.Rollback()
+				return false, err
+			}
+			if err := tx.Commit(); err != nil {
+				return false, err
+			}
+		}
+
+		lastID = batch[len(batch)-1].id
+		if len(batch) < pageSize {
+			break
+		}
+	}
+
+	// Mark every pending sync as backfilled.
+	updateArgs := append([]any{}, pendingSyncIDs...)
+	if _, err := db.ExecContext(ctx, fmt.Sprintf(
+		`UPDATE %s SET has_external_match_backfilled = 1 WHERE sync_id IN (%s)`,
+		syncRuns.Name(), placeholders,
+	), updateArgs...); err != nil {
 		return false, err
 	}
 

--- a/pkg/dotc1z/grants.go
+++ b/pkg/dotc1z/grants.go
@@ -29,8 +29,9 @@ create table if not exists %s (
     principal_resource_type_id text not null,
     principal_resource_id text not null,
     external_id text not null,
-    expansion blob,                             -- Serialized GrantExpandable proto; NULL if grant is not expandable.
-    needs_expansion integer not null default 0, -- 1 if grant should be processed during expansion.
+    expansion blob,                                -- Serialized GrantExpandable proto; NULL if grant is not expandable.
+    needs_expansion integer not null default 0,    -- 1 if grant should be processed during expansion.
+    has_external_match integer not null default 0, -- 1 if grant carries an ExternalResourceMatch{,All,ID} annotation.
     data blob not null,
     sync_id text not null,
     discovered_at datetime not null
@@ -91,6 +92,13 @@ func (r *grantsTable) Migrations(ctx context.Context, db *goqu.Database) (bool, 
 		return false, err
 	}
 
+	// Add has_external_match column if missing (for older files).
+	if _, err := db.ExecContext(ctx, fmt.Sprintf(
+		"alter table %s add column has_external_match integer not null default 0", r.Name(),
+	)); err != nil && !isAlreadyExistsError(err) {
+		return false, err
+	}
+
 	// Create partial index for efficient queries on expandable grants.
 	if _, err := db.ExecContext(ctx, fmt.Sprintf(
 		"create index if not exists %s on %s (sync_id) where expansion is not null",
@@ -112,13 +120,18 @@ func (r *grantsTable) Migrations(ctx context.Context, db *goqu.Database) (bool, 
 		return false, err
 	}
 
-	// Backfill expansion column from stored grant bytes.
-	backfilled, err := backfillGrantExpansionColumn(ctx, db, r.Name())
-	if err != nil {
+	// Partial index for grants carrying an ExternalResourceMatch annotation.
+	// Same shape as the needs_expansion partial index: selective predicate that
+	// stays out of the general-purpose compound indexes' way.
+	if _, err := db.ExecContext(ctx, fmt.Sprintf(
+		"create index if not exists %s on %s (sync_id) where has_external_match = 1",
+		fmt.Sprintf("idx_grants_sync_external_match_v%s", r.Version()),
+		r.Name(),
+	)); err != nil {
 		return false, err
 	}
 
-	// Create index on entitlement_id, sync_id, and grant id.
+	// Compound index on (entitlement_id, sync_id, id) (added on main).
 	if _, err := db.ExecContext(ctx, fmt.Sprintf(
 		"create index if not exists %s on %s (entitlement_id, sync_id, id)",
 		fmt.Sprintf("idx_grants_entitlement_sync_grant_v%s", r.Version()),
@@ -127,7 +140,9 @@ func (r *grantsTable) Migrations(ctx context.Context, db *goqu.Database) (bool, 
 		return false, err
 	}
 
-	return backfilled, nil
+	// Backfill expansion + has_external_match columns from stored grant bytes.
+	return backfillGrantDerivedColumns(ctx, db, r.Name())
+
 }
 
 func (c *C1File) ListGrants(ctx context.Context, request *v2.GrantsServiceListGrantsRequest) (*v2.GrantsServiceListGrantsResponse, error) {
@@ -485,6 +500,11 @@ func unsafeForSlim(grant *v2.Grant) bool {
 func grantExtractFields(c *C1File, mode grantUpsertMode) func(grant *v2.Grant) (goqu.Record, error) {
 	return func(grant *v2.Grant) (goqu.Record, error) {
 		rec := baseGrantRecord(grant)
+		// has_external_match mirrors the data blob's annotation set; set in every
+		// upsert mode (including PreserveExpansion, where the data column is still
+		// replaced from EXCLUDED in executeGrantChunkedUpsert).
+		rec["has_external_match"] = hasExternalResourceMatch(grant)
+
 		isUnsafe := unsafeForSlim(grant)
 		slim := c.v2GrantsWriter && !isUnsafe
 		// No request ctx threaded through prepareConnectorObjectRows.
@@ -596,6 +616,28 @@ func hasGrantExpandable(grant *v2.Grant) bool {
 	return false
 }
 
+// externalResourceMatchSentinels are the annotation types that
+// processGrantsWithExternalPrincipals in pkg/sync filters on. hasExternalResourceMatch
+// below checks for any of these; keep in lockstep with the caller's ContainsAny.
+var externalResourceMatchSentinels = []proto.Message{
+	&v2.ExternalResourceMatchAll{},
+	&v2.ExternalResourceMatch{},
+	&v2.ExternalResourceMatchID{},
+}
+
+// hasExternalResourceMatch returns true if the grant carries any ExternalResourceMatch
+// annotation. Cheap type-url check, no unmarshal.
+func hasExternalResourceMatch(grant *v2.Grant) bool {
+	for _, a := range grant.GetAnnotations() {
+		for _, s := range externalResourceMatchSentinels {
+			if a.MessageIs(s) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // extractAndStripExpansion extracts the GrantExpandable annotation from the grant,
 // removes it from the grant's annotations, and returns the serialized proto bytes.
 // The annotation is always stripped from the grant if present, so it never leaks
@@ -639,13 +681,16 @@ func extractAndStripExpansion(grant *v2.Grant) ([]byte, bool) {
 	return data, true
 }
 
-func backfillGrantExpansionColumn(ctx context.Context, db *goqu.Database, tableName string) (bool, error) {
+func backfillGrantDerivedColumns(ctx context.Context, db *goqu.Database, tableName string) (bool, error) {
 	// Backfill grants only for syncs that have not yet been processed.
 	// The grants_backfilled flag is the single source of truth for whether
 	// this migration work still needs to run for a sync.
 	//
 	// We unmarshal every grant with expansion IS NULL from old syncs, extract the
-	// GrantExpandable annotation (if present), and populate the expansion column.
+	// GrantExpandable annotation (if present), populate the expansion column, and
+	// also derive has_external_match from the annotation set while we have the
+	// proto in hand — both columns track the stored data blob so backfilling them
+	// in the same pass avoids a second full scan.
 	// Non-expandable grants get an empty-blob sentinel to avoid re-processing,
 	// which is cleaned up to NULL at the end.
 	//
@@ -735,13 +780,17 @@ func backfillGrantExpansionColumn(ctx context.Context, db *goqu.Database, tableN
 		lastID = batch[len(batch)-1].id
 
 		// Split grants into expandable (need full data rewrite) and
-		// non-expandable (just need sentinel marker).
-		var sentinelIDs []any
+		// non-expandable (just need sentinel + has_external_match marker).
+		// Non-expandable rows are further split by has_external_match so each
+		// group can be updated in a single batch statement.
+		var sentinelWithMatchIDs []any
+		var sentinelNoMatchIDs []any
 		type expandableRow struct {
-			id             int64
-			expansionBytes []byte
-			needsExpansion bool
-			data           []byte
+			id               int64
+			expansionBytes   []byte
+			needsExpansion   bool
+			data             []byte
+			hasExternalMatch bool
 		}
 		var expandableRows []expandableRow
 
@@ -751,10 +800,15 @@ func backfillGrantExpansionColumn(ctx context.Context, db *goqu.Database, tableN
 				return false, err
 			}
 
+			hasMatch := hasExternalResourceMatch(g)
 			expansionBytes, needsExpansion := extractAndStripExpansion(g)
 
 			if expansionBytes == nil {
-				sentinelIDs = append(sentinelIDs, r.id)
+				if hasMatch {
+					sentinelWithMatchIDs = append(sentinelWithMatchIDs, r.id)
+				} else {
+					sentinelNoMatchIDs = append(sentinelNoMatchIDs, r.id)
+				}
 				continue
 			}
 
@@ -763,10 +817,11 @@ func backfillGrantExpansionColumn(ctx context.Context, db *goqu.Database, tableN
 				return false, err
 			}
 			expandableRows = append(expandableRows, expandableRow{
-				id:             r.id,
-				expansionBytes: expansionBytes,
-				needsExpansion: needsExpansion,
-				data:           newData,
+				id:               r.id,
+				expansionBytes:   expansionBytes,
+				needsExpansion:   needsExpansion,
+				data:             newData,
+				hasExternalMatch: hasMatch,
 			})
 		}
 
@@ -775,13 +830,24 @@ func backfillGrantExpansionColumn(ctx context.Context, db *goqu.Database, tableN
 			return false, err
 		}
 
-		// Batch-mark non-expandable grants with the sentinel in one statement.
-		if len(sentinelIDs) > 0 {
-			sp := strings.Repeat("?,", len(sentinelIDs))
+		// Batch-mark non-expandable grants. Split into two statements by
+		// has_external_match so we can use a simple IN(...) per group.
+		if len(sentinelNoMatchIDs) > 0 {
+			sp := strings.Repeat("?,", len(sentinelNoMatchIDs))
 			sp = sp[:len(sp)-1]
 			if _, err := tx.ExecContext(ctx, fmt.Sprintf(
 				`UPDATE %s SET expansion=X'' WHERE id IN (%s)`, tableName, sp,
-			), sentinelIDs...); err != nil {
+			), sentinelNoMatchIDs...); err != nil {
+				_ = tx.Rollback()
+				return false, err
+			}
+		}
+		if len(sentinelWithMatchIDs) > 0 {
+			sp := strings.Repeat("?,", len(sentinelWithMatchIDs))
+			sp = sp[:len(sp)-1]
+			if _, err := tx.ExecContext(ctx, fmt.Sprintf(
+				`UPDATE %s SET expansion=X'', has_external_match=1 WHERE id IN (%s)`, tableName, sp,
+			), sentinelWithMatchIDs...); err != nil {
 				_ = tx.Rollback()
 				return false, err
 			}
@@ -790,14 +856,14 @@ func backfillGrantExpansionColumn(ctx context.Context, db *goqu.Database, tableN
 		// Expandable grants need per-row updates (each has unique data).
 		if len(expandableRows) > 0 {
 			fullStmt, err := tx.PrepareContext(ctx, fmt.Sprintf(
-				`UPDATE %s SET expansion=?, needs_expansion=?, data=? WHERE id=?`, tableName,
+				`UPDATE %s SET expansion=?, needs_expansion=?, data=?, has_external_match=? WHERE id=?`, tableName,
 			))
 			if err != nil {
 				_ = tx.Rollback()
 				return false, err
 			}
 			for _, er := range expandableRows {
-				if _, err := fullStmt.ExecContext(ctx, er.expansionBytes, er.needsExpansion, er.data, er.id); err != nil {
+				if _, err := fullStmt.ExecContext(ctx, er.expansionBytes, er.needsExpansion, er.data, er.hasExternalMatch, er.id); err != nil {
 					_ = fullStmt.Close()
 					_ = tx.Rollback()
 					return false, err
@@ -869,9 +935,10 @@ func executeGrantChunkedUpsert(
 
 	buildQueryFn := func(insertDs *goqu.InsertDataset, chunkedRows []*goqu.Record) (*goqu.InsertDataset, error) {
 		update := goqu.Record{
-			"data":            goqu.I("EXCLUDED.data"),
-			"expansion":       expansionExpr,
-			"needs_expansion": needsExpansionExpr,
+			"data":               goqu.I("EXCLUDED.data"),
+			"expansion":          expansionExpr,
+			"needs_expansion":    needsExpansionExpr,
+			"has_external_match": goqu.I("EXCLUDED.has_external_match"),
 		}
 		return insertDs.
 			OnConflict(goqu.DoUpdate("external_id, sync_id", update)).

--- a/pkg/dotc1z/grants_bench_test.go
+++ b/pkg/dotc1z/grants_bench_test.go
@@ -8,6 +8,7 @@ import (
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	reader_v2 "github.com/conductorone/baton-sdk/pb/c1/reader/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
 	"github.com/stretchr/testify/require"
 )
@@ -94,6 +95,162 @@ func setupBenchmarkDB(b *testing.B, numGrants int) (*C1File, string, func()) {
 	}
 
 	return f, testEntitlement.Id, cleanup
+}
+
+// setupExternalMatchBenchmarkDB seeds a c1z with numGrants total grants, of which
+// approximately matchPercent percent carry an ExternalResourceMatchID annotation.
+// The syncer's processGrantsWithExternalPrincipals iterates these rows via the
+// PayloadWithExpansion internal listing mode.
+func setupExternalMatchBenchmarkDB(b *testing.B, numGrants int, matchPercent int) (*C1File, string, func()) {
+	b.Helper()
+
+	ctx := b.Context()
+	tempDir, err := os.MkdirTemp("", "grants-extmatch-bench-*")
+	require.NoError(b, err)
+
+	testFilePath := filepath.Join(tempDir, "bench.c1z")
+
+	opts := []C1ZOption{
+		WithTmpDir(tempDir),
+		WithEncoderConcurrency(0),
+		WithDecoderOptions(WithDecoderConcurrency(0)),
+	}
+
+	f, err := NewC1ZFile(ctx, testFilePath, opts...)
+	require.NoError(b, err)
+
+	syncID, _, err := f.StartOrResumeSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(b, err)
+	require.NotEmpty(b, syncID)
+
+	require.NoError(b, f.PutResourceTypes(ctx, v2.ResourceType_builder{Id: "test-type", DisplayName: "Test Type"}.Build()))
+	testResource := v2.Resource_builder{
+		Id:          v2.ResourceId_builder{ResourceType: "test-type", Resource: "test-resource"}.Build(),
+		DisplayName: "Test Resource",
+	}.Build()
+	require.NoError(b, f.PutResources(ctx, testResource))
+
+	testEntitlement := v2.Entitlement_builder{Id: "test-entitlement", Resource: testResource}.Build()
+	require.NoError(b, f.PutEntitlements(ctx, testEntitlement))
+
+	// Use a deterministic stride so matchPercent% of rows get the annotation.
+	// stride = 100/matchPercent (e.g. 5% -> every 20th grant).
+	var stride int
+	if matchPercent > 0 {
+		stride = 100 / matchPercent
+		if stride < 1 {
+			stride = 1
+		}
+	}
+
+	grants := make([]*v2.Grant, numGrants)
+	for i := range numGrants {
+		gb := v2.Grant_builder{
+			Id:          fmt.Sprintf("grant-%d", i),
+			Entitlement: testEntitlement,
+			Principal: v2.Resource_builder{
+				Id:          v2.ResourceId_builder{ResourceType: "test-type", Resource: fmt.Sprintf("principal-%d", i)}.Build(),
+				DisplayName: fmt.Sprintf("Principal %d", i),
+			}.Build(),
+		}
+		if stride > 0 && i%stride == 0 {
+			gb.Annotations = annotations.New(v2.ExternalResourceMatchID_builder{
+				Id: fmt.Sprintf("ext-%d", i),
+			}.Build())
+		}
+		grants[i] = gb.Build()
+	}
+
+	batchSize := 1000
+	for i := 0; i < len(grants); i += batchSize {
+		end := min(i+batchSize, len(grants))
+		require.NoError(b, f.PutGrants(ctx, grants[i:end]...))
+	}
+
+	cleanup := func() {
+		_ = f.Close(ctx)
+		_ = os.RemoveAll(tempDir)
+	}
+
+	return f, syncID, cleanup
+}
+
+// BenchmarkListGrantsWithExpansion_ExternalMatchOnly measures the alloc/op
+// reduction from pushing the ExternalResourceMatch annotation filter down to
+// SQL. Two sub-benchmarks per size/density: the filtered path (what production
+// now runs) and the kill-switch path (pre-fix behavior, for comparison).
+func BenchmarkListGrantsWithExpansion_ExternalMatchOnly(b *testing.B) {
+	// Paired with processGrantsWithExternalPrincipals — realistic mixes are
+	// small-fraction matches amid large grant totals. 1%/5%/20% spans the
+	// expected range; 100% pins the upper bound where filter offers no win.
+	densities := []int{1, 5, 20, 100}
+	sizes := []int{10_000, 50_000}
+
+	for _, n := range sizes {
+		for _, pct := range densities {
+			b.Run(fmt.Sprintf("n=%d/match=%d%%/filtered", n, pct), func(b *testing.B) {
+				f, _, cleanup := setupExternalMatchBenchmarkDB(b, n, pct)
+				defer cleanup()
+				ctx := b.Context()
+
+				b.ReportAllocs()
+				b.ResetTimer()
+				for b.Loop() {
+					pageToken := ""
+					total := 0
+					for {
+						resp, err := f.ListGrantsInternal(ctx, connectorstore.GrantListOptions{
+							Mode:              connectorstore.GrantListModePayloadWithExpansion,
+							ExternalMatchOnly: true,
+							PageToken:         pageToken,
+						})
+						if err != nil {
+							b.Fatal(err)
+						}
+						total += len(resp.Rows)
+						pageToken = resp.NextPageToken
+						if pageToken == "" {
+							break
+						}
+					}
+					_ = total
+				}
+			})
+
+			b.Run(fmt.Sprintf("n=%d/match=%d%%/killswitch", n, pct), func(b *testing.B) {
+				f, _, cleanup := setupExternalMatchBenchmarkDB(b, n, pct)
+				defer cleanup()
+				ctx := b.Context()
+
+				orig := externalMatchFilterDisabled
+				externalMatchFilterDisabled = true
+				defer func() { externalMatchFilterDisabled = orig }()
+
+				b.ReportAllocs()
+				b.ResetTimer()
+				for b.Loop() {
+					pageToken := ""
+					total := 0
+					for {
+						resp, err := f.ListGrantsInternal(ctx, connectorstore.GrantListOptions{
+							Mode:              connectorstore.GrantListModePayloadWithExpansion,
+							ExternalMatchOnly: true,
+							PageToken:         pageToken,
+						})
+						if err != nil {
+							b.Fatal(err)
+						}
+						total += len(resp.Rows)
+						pageToken = resp.NextPageToken
+						if pageToken == "" {
+							break
+						}
+					}
+					_ = total
+				}
+			})
+		}
+	}
 }
 
 // BenchmarkListGrantsForEntitlement benchmarks ListGrantsForEntitlement filtered by an entitlement.

--- a/pkg/dotc1z/grants_bench_test.go
+++ b/pkg/dotc1z/grants_bench_test.go
@@ -8,6 +8,7 @@ import (
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	reader_v2 "github.com/conductorone/baton-sdk/pb/c1/reader/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
 	"github.com/stretchr/testify/require"
 )
@@ -193,6 +194,134 @@ func BenchmarkListGrantsInternal_PayloadWithExpansion(b *testing.B) {
 					if totalGrants != numGrants {
 						b.Fatalf("expected %d grants, got %d", numGrants, totalGrants)
 					}
+				}
+			})
+		}
+	}
+}
+
+// setupExternalMatchBenchmarkDB seeds a c1z with numGrants total grants, of
+// which approximately matchPercent percent carry an ExternalResourceMatchID
+// annotation. This is the workload processGrantsWithExternalPrincipals walks
+// — almost always small-fraction matches against large totals.
+func setupExternalMatchBenchmarkDB(b *testing.B, numGrants int, matchPercent int) (*C1File, func()) {
+	b.Helper()
+
+	ctx := b.Context()
+	tempDir, err := os.MkdirTemp("", "grants-extmatch-bench-*")
+	require.NoError(b, err)
+
+	testFilePath := filepath.Join(tempDir, "bench.c1z")
+	opts := []C1ZOption{
+		WithTmpDir(tempDir),
+		WithEncoderConcurrency(0),
+		WithDecoderOptions(WithDecoderConcurrency(0)),
+	}
+	f, err := NewC1ZFile(ctx, testFilePath, opts...)
+	require.NoError(b, err)
+
+	_, err = f.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(b, err)
+
+	require.NoError(b, f.PutResourceTypes(ctx, v2.ResourceType_builder{Id: "test-type", DisplayName: "Test Type"}.Build()))
+	testResource := v2.Resource_builder{
+		Id:          v2.ResourceId_builder{ResourceType: "test-type", Resource: "test-resource"}.Build(),
+		DisplayName: "Test Resource",
+	}.Build()
+	require.NoError(b, f.PutResources(ctx, testResource))
+
+	testEntitlement := v2.Entitlement_builder{Id: "test-entitlement", Resource: testResource}.Build()
+	require.NoError(b, f.PutEntitlements(ctx, testEntitlement))
+
+	stride := 0
+	if matchPercent > 0 {
+		stride = 100 / matchPercent
+		if stride < 1 {
+			stride = 1
+		}
+	}
+
+	grants := make([]*v2.Grant, numGrants)
+	for i := range numGrants {
+		gb := v2.Grant_builder{
+			Id:          fmt.Sprintf("grant-%d", i),
+			Entitlement: testEntitlement,
+			Principal: v2.Resource_builder{
+				Id:          v2.ResourceId_builder{ResourceType: "test-type", Resource: fmt.Sprintf("principal-%d", i)}.Build(),
+				DisplayName: fmt.Sprintf("Principal %d", i),
+			}.Build(),
+		}
+		if stride > 0 && i%stride == 0 {
+			gb.Annotations = annotations.New(v2.ExternalResourceMatchID_builder{
+				Id: fmt.Sprintf("ext-%d", i),
+			}.Build())
+		}
+		grants[i] = gb.Build()
+	}
+
+	batchSize := 1000
+	for i := 0; i < len(grants); i += batchSize {
+		end := min(i+batchSize, len(grants))
+		require.NoError(b, f.PutGrants(ctx, grants[i:end]...))
+	}
+	require.NoError(b, f.EndSync(ctx))
+
+	cleanup := func() {
+		_ = f.Close(ctx)
+		_ = os.RemoveAll(tempDir)
+	}
+	return f, cleanup
+}
+
+// BenchmarkListGrantsExternalMatch_PRRevival compares the SQL-filtered
+// (ListWithAnnotationsExternalMatchOnly, what the PR adds) and unfiltered
+// (ListWithAnnotations, current-main behavior) paths through the
+// processGrantsWithExternalPrincipals workload. /filtered = PR's proposed
+// behavior; /unfiltered = baseline.
+func BenchmarkListGrantsExternalMatch_PRRevival(b *testing.B) {
+	densities := []int{1, 5, 20, 100}
+	sizes := []int{10_000, 50_000}
+
+	for _, n := range sizes {
+		for _, pct := range densities {
+			b.Run(fmt.Sprintf("n=%d/match=%d%%/filtered", n, pct), func(b *testing.B) {
+				f, cleanup := setupExternalMatchBenchmarkDB(b, n, pct)
+				defer cleanup()
+				ctx := b.Context()
+				b.ReportAllocs()
+				b.ResetTimer()
+				for b.Loop() {
+					total := 0
+					for ga, err := range f.Grants().ListWithAnnotationsExternalMatchOnly(ctx) {
+						if err != nil {
+							b.Fatal(err)
+						}
+						_ = ga
+						total++
+					}
+					_ = total
+				}
+			})
+
+			b.Run(fmt.Sprintf("n=%d/match=%d%%/unfiltered", n, pct), func(b *testing.B) {
+				f, cleanup := setupExternalMatchBenchmarkDB(b, n, pct)
+				defer cleanup()
+				ctx := b.Context()
+				b.ReportAllocs()
+				b.ResetTimer()
+				for b.Loop() {
+					total := 0
+					for ga, err := range f.Grants().ListWithAnnotations(ctx) {
+						if err != nil {
+							b.Fatal(err)
+						}
+						annos := annotations.Annotations(ga.Grant.GetAnnotations())
+						if !annos.ContainsAny(&v2.ExternalResourceMatchAll{}, &v2.ExternalResourceMatch{}, &v2.ExternalResourceMatchID{}) {
+							continue
+						}
+						total++
+					}
+					_ = total
 				}
 			})
 		}

--- a/pkg/dotc1z/grants_bench_test.go
+++ b/pkg/dotc1z/grants_bench_test.go
@@ -284,6 +284,7 @@ func BenchmarkListGrantsExternalMatch_PRRevival(b *testing.B) {
 
 	for _, n := range sizes {
 		for _, pct := range densities {
+			expectedMatches := n * pct / 100
 			b.Run(fmt.Sprintf("n=%d/match=%d%%/filtered", n, pct), func(b *testing.B) {
 				f, cleanup := setupExternalMatchBenchmarkDB(b, n, pct)
 				defer cleanup()
@@ -299,7 +300,9 @@ func BenchmarkListGrantsExternalMatch_PRRevival(b *testing.B) {
 						_ = ga
 						total++
 					}
-					_ = total
+					if total != expectedMatches {
+						b.Fatalf("filtered: got %d matched rows, want %d", total, expectedMatches)
+					}
 				}
 			})
 
@@ -321,7 +324,9 @@ func BenchmarkListGrantsExternalMatch_PRRevival(b *testing.B) {
 						}
 						total++
 					}
-					_ = total
+					if total != expectedMatches {
+						b.Fatalf("unfiltered: got %d matched rows, want %d", total, expectedMatches)
+					}
 				}
 			})
 		}

--- a/pkg/dotc1z/grants_expandable_query.go
+++ b/pkg/dotc1z/grants_expandable_query.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"os"
 	"strconv"
 
 	"github.com/doug-martin/goqu/v9"
@@ -12,6 +13,12 @@ import (
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
 )
+
+// externalMatchFilterDisabled is an operational kill-switch for the
+// has_external_match predicate in listGrantsWithExpansionInternal. Set
+// BATON_DISABLE_EXTERNAL_MATCH_FILTER=1 to fall back to the pre-filter behavior
+// (scan all rows) without a revert + release.
+var externalMatchFilterDisabled = os.Getenv("BATON_DISABLE_EXTERNAL_MATCH_FILTER") == "1"
 
 func parseGrantPageToken(pageToken string, tokenType string) (int64, error) {
 	id, err := strconv.ParseInt(pageToken, 10, 64)
@@ -206,6 +213,9 @@ func (c *C1File) listGrantsWithExpansionInternal(ctx context.Context, opts conne
 
 	if opts.ExpandableOnly {
 		q = q.Where(goqu.C("expansion").IsNotNull())
+	}
+	if opts.ExternalMatchOnly && !externalMatchFilterDisabled {
+		q = q.Where(goqu.C("has_external_match").Eq(1))
 	}
 	if opts.PageToken != "" {
 		id, err := parseGrantPageToken(opts.PageToken, "payload")

--- a/pkg/dotc1z/grants_expandable_query.go
+++ b/pkg/dotc1z/grants_expandable_query.go
@@ -13,11 +13,14 @@ import (
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 )
 
-// externalMatchFilterDisabled is an operational kill-switch for the
-// has_external_match predicate in listGrantsWithExpansionInternal. Set
-// BATON_DISABLE_EXTERNAL_MATCH_FILTER=1 to fall back to the pre-filter behavior
-// (scan all rows) without a revert + release.
-var externalMatchFilterDisabled = os.Getenv("BATON_DISABLE_EXTERNAL_MATCH_FILTER") == "1"
+// externalMatchFilterDisabled reports the operational kill-switch state for
+// the has_external_match predicate in listGrantsWithExpansionInternal. Set
+// BATON_DISABLE_EXTERNAL_MATCH_FILTER=1 to fall back to the pre-filter
+// behaviour (scan all rows) without a revert + release. Read per-call (cold
+// path; once per page) so tests can flip it via t.Setenv.
+func externalMatchFilterDisabled() bool {
+	return os.Getenv("BATON_DISABLE_EXTERNAL_MATCH_FILTER") == "1"
+}
 
 func parseGrantPageToken(pageToken string, tokenType string) (int64, error) {
 	id, err := strconv.ParseInt(pageToken, 10, 64)
@@ -184,7 +187,7 @@ func (c *C1File) listGrantsWithExpansionInternal(ctx context.Context, opts grant
 	if opts.ExpandableOnly {
 		q = q.Where(goqu.C("expansion").IsNotNull())
 	}
-	if opts.ExternalMatchOnly && !externalMatchFilterDisabled {
+	if opts.ExternalMatchOnly && !externalMatchFilterDisabled() {
 		q = q.Where(goqu.C("has_external_match").Eq(1))
 	}
 	if opts.PageToken != "" {

--- a/pkg/dotc1z/grants_expandable_query.go
+++ b/pkg/dotc1z/grants_expandable_query.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"os"
 	"strconv"
 
 	"github.com/doug-martin/goqu/v9"
@@ -11,6 +12,12 @@ import (
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 )
+
+// externalMatchFilterDisabled is an operational kill-switch for the
+// has_external_match predicate in listGrantsWithExpansionInternal. Set
+// BATON_DISABLE_EXTERNAL_MATCH_FILTER=1 to fall back to the pre-filter behavior
+// (scan all rows) without a revert + release.
+var externalMatchFilterDisabled = os.Getenv("BATON_DISABLE_EXTERNAL_MATCH_FILTER") == "1"
 
 func parseGrantPageToken(pageToken string, tokenType string) (int64, error) {
 	id, err := strconv.ParseInt(pageToken, 10, 64)
@@ -176,6 +183,9 @@ func (c *C1File) listGrantsWithExpansionInternal(ctx context.Context, opts grant
 
 	if opts.ExpandableOnly {
 		q = q.Where(goqu.C("expansion").IsNotNull())
+	}
+	if opts.ExternalMatchOnly && !externalMatchFilterDisabled {
+		q = q.Where(goqu.C("has_external_match").Eq(1))
 	}
 	if opts.PageToken != "" {
 		id, err := parseGrantPageToken(opts.PageToken, "payload")

--- a/pkg/dotc1z/grants_test.go
+++ b/pkg/dotc1z/grants_test.go
@@ -524,7 +524,7 @@ func TestBackfillMigration_OldSyncGetsExpansionColumn(t *testing.T) {
 	require.NoError(t, err)
 
 	// Step 3: Run the backfill explicitly (as the migration would on re-open).
-	err = backfillGrantExpansionColumn(ctx, c1f.db, grants.Name())
+	err = backfillGrantDerivedColumns(ctx, c1f.db, grants.Name())
 	require.NoError(t, err)
 
 	// Clear current sync so we can use ViewSync.
@@ -1452,4 +1452,315 @@ func TestPutGrants_ReplaceOverwritesExpansion(t *testing.T) {
 	requireExpansionSQLNullForSync(ctx, t, c1f, "grant-replace", syncID)
 	rawCleared := getRawGrantRowForSync(ctx, t, c1f, "grant-replace", syncID)
 	require.Equal(t, 0, rawCleared.needsExpansion, "needs_expansion should be 0 after clearing expansion via Replace")
+}
+
+// getRawHasExternalMatch reads the has_external_match column for a grant by external_id and sync_id.
+func getRawHasExternalMatch(ctx context.Context, t *testing.T, c1f *C1File, externalID, syncID string) int {
+	t.Helper()
+	var v int
+	err := c1f.db.QueryRowContext(ctx,
+		"SELECT has_external_match FROM "+grants.Name()+" WHERE external_id=? AND sync_id=?",
+		externalID, syncID,
+	).Scan(&v)
+	require.NoError(t, err)
+	return v
+}
+
+// TestHasExternalMatch_WriteExtraction verifies grantExtractFields sets has_external_match
+// correctly for each flavor of ExternalResourceMatch annotation (plus the negative case and
+// the co-existence-with-GrantExpandable case).
+func TestHasExternalMatch_WriteExtraction(t *testing.T) {
+	ctx := context.Background()
+	c1f, syncID, cleanup := setupTestC1Z(ctx, t)
+	defer cleanup()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build()}.Build()
+	ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1}.Build()
+
+	tests := []struct {
+		id          string
+		annotations []*anypb.Any
+		want        int
+	}{
+		{
+			id:   "grant-no-annotations",
+			want: 0,
+		},
+		{
+			id: "grant-match-all",
+			annotations: annotations.New(v2.ExternalResourceMatchAll_builder{
+				ResourceType: v2.ResourceType_TRAIT_USER,
+			}.Build()),
+			want: 1,
+		},
+		{
+			id: "grant-match-id",
+			annotations: annotations.New(v2.ExternalResourceMatchID_builder{
+				Id: "external-user-1",
+			}.Build()),
+			want: 1,
+		},
+		{
+			id: "grant-match-kv",
+			annotations: annotations.New(v2.ExternalResourceMatch_builder{
+				ResourceType: v2.ResourceType_TRAIT_USER,
+				Key:          "email",
+				Value:        "x@example.com",
+			}.Build()),
+			want: 1,
+		},
+		{
+			id: "grant-expandable-only",
+			annotations: annotations.New(v2.GrantExpandable_builder{
+				EntitlementIds: []string{"ent1"},
+			}.Build()),
+			want: 0,
+		},
+		{
+			id: "grant-match-and-expandable",
+			annotations: append(
+				annotations.New(v2.ExternalResourceMatchID_builder{Id: "external-user-2"}.Build()),
+				annotations.New(v2.GrantExpandable_builder{EntitlementIds: []string{"ent1"}}.Build())...,
+			),
+			want: 1,
+		},
+	}
+
+	var toWrite []*v2.Grant
+	for _, tc := range tests {
+		toWrite = append(toWrite, v2.Grant_builder{
+			Id:          tc.id,
+			Entitlement: ent1,
+			Principal:   u1,
+			Annotations: tc.annotations,
+		}.Build())
+	}
+	require.NoError(t, c1f.PutGrants(ctx, toWrite...))
+
+	for _, tc := range tests {
+		got := getRawHasExternalMatch(ctx, t, c1f, tc.id, syncID)
+		require.Equal(t, tc.want, got, "has_external_match for %s", tc.id)
+	}
+}
+
+// TestHasExternalMatch_PreserveExpansionUpdatesColumn verifies that upserting a grant via
+// PreserveExpansion mode refreshes has_external_match from the incoming grant's annotations,
+// even though expansion/needs_expansion are preserved.
+//
+// This guards the write-path invariant: has_external_match must track the data blob, and
+// executeGrantChunkedUpsert writes EXCLUDED.data on conflict in every mode.
+func TestHasExternalMatch_PreserveExpansionUpdatesColumn(t *testing.T) {
+	ctx := context.Background()
+	c1f, syncID, cleanup := setupTestC1Z(ctx, t)
+	defer cleanup()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build()}.Build()
+	ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1}.Build()
+
+	// Step 1: seed with NO external match annotation.
+	initial := v2.Grant_builder{
+		Id:          "grant-preserve",
+		Entitlement: ent1,
+		Principal:   u1,
+	}.Build()
+	require.NoError(t, c1f.PutGrants(ctx, initial))
+	require.Equal(t, 0, getRawHasExternalMatch(ctx, t, c1f, "grant-preserve", syncID))
+
+	// Step 2: upsert via PreserveExpansion with an ExternalResourceMatchID annotation.
+	updated := v2.Grant_builder{
+		Id:          "grant-preserve",
+		Entitlement: ent1,
+		Principal:   u1,
+		Annotations: annotations.New(v2.ExternalResourceMatchID_builder{Id: "ext-1"}.Build()),
+	}.Build()
+	require.NoError(t, c1f.UpsertGrants(ctx, connectorstore.GrantUpsertOptions{
+		Mode: connectorstore.GrantUpsertModePreserveExpansion,
+	}, updated))
+	require.Equal(t, 1, getRawHasExternalMatch(ctx, t, c1f, "grant-preserve", syncID),
+		"PreserveExpansion must refresh has_external_match from EXCLUDED")
+
+	// Step 3: upsert via PreserveExpansion removing the annotation — column must flip back.
+	cleared := v2.Grant_builder{
+		Id:          "grant-preserve",
+		Entitlement: ent1,
+		Principal:   u1,
+	}.Build()
+	require.NoError(t, c1f.UpsertGrants(ctx, connectorstore.GrantUpsertOptions{
+		Mode: connectorstore.GrantUpsertModePreserveExpansion,
+	}, cleared))
+	require.Equal(t, 0, getRawHasExternalMatch(ctx, t, c1f, "grant-preserve", syncID),
+		"PreserveExpansion must clear has_external_match when the annotation is removed")
+}
+
+// TestListGrantsInternal_ExternalMatchOnlyFilter verifies that
+// GrantListOptions.ExternalMatchOnly filters to rows with has_external_match=1.
+func TestListGrantsInternal_ExternalMatchOnlyFilter(t *testing.T) {
+	ctx := context.Background()
+	c1f, _, cleanup := setupTestC1Z(ctx, t)
+	defer cleanup()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build()}.Build()
+	ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1}.Build()
+
+	matchGrant := v2.Grant_builder{
+		Id:          "grant-match",
+		Entitlement: ent1,
+		Principal:   u1,
+		Annotations: annotations.New(v2.ExternalResourceMatchAll_builder{
+			ResourceType: v2.ResourceType_TRAIT_USER,
+		}.Build()),
+	}.Build()
+	plainGrant := v2.Grant_builder{
+		Id:          "grant-plain",
+		Entitlement: ent1,
+		Principal:   g1,
+	}.Build()
+	require.NoError(t, c1f.PutGrants(ctx, matchGrant, plainGrant))
+
+	// Unfiltered: both rows.
+	respAll, err := c1f.ListGrantsInternal(ctx, connectorstore.GrantListOptions{
+		Mode: connectorstore.GrantListModePayloadWithExpansion,
+	})
+	require.NoError(t, err)
+	require.Len(t, respAll.Rows, 2)
+
+	// ExternalMatchOnly: only the match row.
+	respFiltered, err := c1f.ListGrantsInternal(ctx, connectorstore.GrantListOptions{
+		Mode:              connectorstore.GrantListModePayloadWithExpansion,
+		ExternalMatchOnly: true,
+	})
+	require.NoError(t, err)
+	require.Len(t, respFiltered.Rows, 1)
+	require.Equal(t, "grant-match", respFiltered.Rows[0].Grant.GetId())
+}
+
+// TestBackfillMigration_PopulatesHasExternalMatch verifies the backfill path also
+// populates has_external_match when an old c1z (without the column/with it all-zero)
+// is re-opened. Covers both the expandable-row branch and the sentinel branches.
+func TestBackfillMigration_PopulatesHasExternalMatch(t *testing.T) {
+	ctx := context.Background()
+	c1f, syncID, cleanup := setupTestC1Z(ctx, t)
+	defer cleanup()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build()}.Build()
+	ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1}.Build()
+
+	// Three grants covering the relevant branches:
+	// - expandable with external match (expandableRow branch, hasExternalMatch=true)
+	// - non-expandable with external match (sentinelWithMatch branch)
+	// - non-expandable without external match (sentinelNoMatch branch, default 0)
+	expandableMatch := v2.Grant_builder{
+		Id:          "grant-expand-match",
+		Entitlement: ent1,
+		Principal:   u1,
+		Annotations: append(
+			annotations.New(v2.GrantExpandable_builder{EntitlementIds: []string{"ent1"}}.Build()),
+			annotations.New(v2.ExternalResourceMatchID_builder{Id: "ext-1"}.Build())...,
+		),
+	}.Build()
+	plainMatch := v2.Grant_builder{
+		Id:          "grant-plain-match",
+		Entitlement: ent1,
+		Principal:   u1,
+		Annotations: annotations.New(v2.ExternalResourceMatchAll_builder{
+			ResourceType: v2.ResourceType_TRAIT_USER,
+		}.Build()),
+	}.Build()
+	plainNoMatch := v2.Grant_builder{
+		Id:          "grant-plain",
+		Entitlement: ent1,
+		Principal:   g1,
+	}.Build()
+	require.NoError(t, c1f.PutGrants(ctx, expandableMatch, plainMatch, plainNoMatch))
+	require.NoError(t, c1f.EndSync(ctx))
+
+	// Simulate old-format state: clear has_external_match + expansion + needs_expansion,
+	// stuff the GrantExpandable back into the data blob, mark sync as not backfilled.
+	// This forces backfillGrantDerivedColumns through all three branches.
+	origExpandable := v2.GrantExpandable_builder{EntitlementIds: []string{"ent1"}}.Build()
+	expandableMatchOld := v2.Grant_builder{
+		Id:          "grant-expand-match",
+		Entitlement: ent1,
+		Principal:   u1,
+		Annotations: append(
+			annotations.New(origExpandable),
+			annotations.New(v2.ExternalResourceMatchID_builder{Id: "ext-1"}.Build())...,
+		),
+	}.Build()
+	oldBlob, err := proto.MarshalOptions{Deterministic: true}.Marshal(expandableMatchOld)
+	require.NoError(t, err)
+
+	_, err = c1f.db.ExecContext(ctx,
+		"UPDATE "+grants.Name()+" SET has_external_match=0",
+	)
+	require.NoError(t, err)
+	_, err = c1f.db.ExecContext(ctx,
+		"UPDATE "+grants.Name()+" SET data=?, expansion=NULL, needs_expansion=0 WHERE external_id='grant-expand-match'",
+		oldBlob,
+	)
+	require.NoError(t, err)
+	_, err = c1f.db.ExecContext(ctx,
+		"UPDATE "+grants.Name()+" SET expansion=NULL, needs_expansion=0 WHERE external_id IN ('grant-plain-match','grant-plain')",
+	)
+	require.NoError(t, err)
+	_, err = c1f.db.ExecContext(ctx, "UPDATE "+syncRuns.Name()+" SET grants_backfilled=0 WHERE sync_id=?", syncID)
+	require.NoError(t, err)
+
+	// Run the backfill directly.
+	require.NoError(t, backfillGrantDerivedColumns(ctx, c1f.db, grants.Name()))
+
+	// All three rows should have the correct has_external_match after backfill.
+	require.Equal(t, 1, getRawHasExternalMatch(ctx, t, c1f, "grant-expand-match", syncID),
+		"expandable row with match must be backfilled to has_external_match=1")
+	require.Equal(t, 1, getRawHasExternalMatch(ctx, t, c1f, "grant-plain-match", syncID),
+		"sentinel-with-match row must be backfilled to has_external_match=1")
+	require.Equal(t, 0, getRawHasExternalMatch(ctx, t, c1f, "grant-plain", syncID),
+		"sentinel-no-match row must remain has_external_match=0")
+
+	var backfilled int
+	err = c1f.db.QueryRowContext(ctx, "SELECT grants_backfilled FROM "+syncRuns.Name()+" WHERE sync_id=?", syncID).Scan(&backfilled)
+	require.NoError(t, err)
+	require.Equal(t, 1, backfilled)
+}
+
+// TestExternalMatchFilter_KillSwitch verifies that setting externalMatchFilterDisabled
+// (driven by BATON_DISABLE_EXTERNAL_MATCH_FILTER=1 at process start) makes
+// ExternalMatchOnly a no-op so all rows are returned.
+func TestExternalMatchFilter_KillSwitch(t *testing.T) {
+	ctx := context.Background()
+	c1f, _, cleanup := setupTestC1Z(ctx, t)
+	defer cleanup()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build()}.Build()
+	ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1}.Build()
+
+	matchGrant := v2.Grant_builder{
+		Id:          "grant-match",
+		Entitlement: ent1,
+		Principal:   u1,
+		Annotations: annotations.New(v2.ExternalResourceMatchID_builder{Id: "ext-1"}.Build()),
+	}.Build()
+	plainGrant := v2.Grant_builder{
+		Id:          "grant-plain",
+		Entitlement: ent1,
+		Principal:   g1,
+	}.Build()
+	require.NoError(t, c1f.PutGrants(ctx, matchGrant, plainGrant))
+
+	// Flip the kill-switch for the duration of this test.
+	orig := externalMatchFilterDisabled
+	externalMatchFilterDisabled = true
+	defer func() { externalMatchFilterDisabled = orig }()
+
+	resp, err := c1f.ListGrantsInternal(ctx, connectorstore.GrantListOptions{
+		Mode:              connectorstore.GrantListModePayloadWithExpansion,
+		ExternalMatchOnly: true,
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Rows, 2, "kill-switch must bypass the ExternalMatchOnly predicate")
 }

--- a/pkg/dotc1z/grants_test.go
+++ b/pkg/dotc1z/grants_test.go
@@ -561,6 +561,100 @@ func TestBackfillMigration_OldSyncGetsExpansionColumn(t *testing.T) {
 	require.Equal(t, 1, grantsBackfilled, "backfill should mark the sync as grants_backfilled=1")
 }
 
+// TestBackfillHasExternalMatchColumn_OldSyncWithBackfilledFlag covers the
+// critical case where a c1z opened by code AFTER the prior expansion-column
+// PR has every sync at grants_backfilled=1 already. The new
+// has_external_match column defaults to 0 on ALTER, and the legacy
+// backfillGrantDerivedColumns is gated on grants_backfilled=0 so it
+// silently no-ops. Without the dedicated has_external_match_backfilled flag,
+// processGrantsWithExternalPrincipals would filter to zero rows for the
+// entire installed base.
+func TestBackfillHasExternalMatchColumn_OldSyncWithBackfilledFlag(t *testing.T) {
+	ctx := context.Background()
+
+	tmpFile, err := os.CreateTemp("", "test-extmatch-backfill-*.c1z")
+	require.NoError(t, err)
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
+	require.NoError(t, tmpFile.Close())
+
+	c1f, err := NewC1ZFile(ctx, tmpFile.Name())
+	require.NoError(t, err)
+	defer c1f.Close(ctx)
+
+	syncID, err := c1f.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+
+	rt := v2.ResourceType_builder{Id: "user"}.Build()
+	require.NoError(t, c1f.PutResourceTypes(ctx, rt))
+	res := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "r1"}.Build()}.Build()
+	require.NoError(t, c1f.PutResources(ctx, res))
+	ent := v2.Entitlement_builder{Id: "ent1", Resource: res}.Build()
+	require.NoError(t, c1f.PutEntitlements(ctx, ent))
+
+	matchGrant := v2.Grant_builder{
+		Id:          "match",
+		Entitlement: ent,
+		Principal:   res,
+		Annotations: annotations.New(v2.ExternalResourceMatchID_builder{Id: "ext-1"}.Build()),
+	}.Build()
+	noMatchGrant := v2.Grant_builder{
+		Id:          "nomatch",
+		Entitlement: ent,
+		Principal:   res,
+	}.Build()
+	require.NoError(t, c1f.PutGrants(ctx, matchGrant, noMatchGrant))
+	require.NoError(t, c1f.EndSync(ctx))
+
+	// Simulate the "old c1z" condition: ALTER ran and added the column with
+	// default 0; the sync is already grants_backfilled=1; the new
+	// has_external_match_backfilled flag is 0 (the default for pre-existing
+	// rows after the new ALTER).
+	_, err = c1f.db.ExecContext(ctx,
+		"UPDATE "+grants.Name()+" SET has_external_match = 0 WHERE sync_id = ?", syncID)
+	require.NoError(t, err)
+	_, err = c1f.db.ExecContext(ctx,
+		"UPDATE "+syncRuns.Name()+" SET has_external_match_backfilled = 0 WHERE sync_id = ?", syncID)
+	require.NoError(t, err)
+	// Confirm grants_backfilled is 1 (the precondition that broke the legacy
+	// backfill).
+	var legacyFlag int
+	require.NoError(t, c1f.db.QueryRowContext(ctx,
+		"SELECT grants_backfilled FROM "+syncRuns.Name()+" WHERE sync_id = ?", syncID,
+	).Scan(&legacyFlag))
+	require.Equal(t, 1, legacyFlag, "precondition: grants_backfilled must already be 1")
+
+	// Run the new backfill explicitly (as InitTables would on re-open).
+	migrated, err := backfillHasExternalMatchColumn(ctx, c1f.db, grants.Name())
+	require.NoError(t, err)
+	require.True(t, migrated, "backfill must report it actually ran")
+
+	// Annotated grant should now have has_external_match=1.
+	var matchCol int
+	require.NoError(t, c1f.db.QueryRowContext(ctx,
+		"SELECT has_external_match FROM "+grants.Name()+" WHERE external_id = 'match' AND sync_id = ?", syncID,
+	).Scan(&matchCol))
+	require.Equal(t, 1, matchCol, "annotated grant must be marked has_external_match=1 by backfill")
+
+	// Non-annotated grant must stay at 0.
+	var noMatchCol int
+	require.NoError(t, c1f.db.QueryRowContext(ctx,
+		"SELECT has_external_match FROM "+grants.Name()+" WHERE external_id = 'nomatch' AND sync_id = ?", syncID,
+	).Scan(&noMatchCol))
+	require.Equal(t, 0, noMatchCol, "non-annotated grant must remain at 0")
+
+	// The sync must now be marked has_external_match_backfilled=1.
+	var newFlag int
+	require.NoError(t, c1f.db.QueryRowContext(ctx,
+		"SELECT has_external_match_backfilled FROM "+syncRuns.Name()+" WHERE sync_id = ?", syncID,
+	).Scan(&newFlag))
+	require.Equal(t, 1, newFlag, "sync must be marked has_external_match_backfilled=1 after backfill")
+
+	// Idempotent: a second run is a no-op.
+	migrated, err = backfillHasExternalMatchColumn(ctx, c1f.db, grants.Name())
+	require.NoError(t, err)
+	require.False(t, migrated, "backfill must report no-op on second run")
+}
+
 // grantRawRow holds the raw SQL column values for a grant row.
 type grantRawRow struct {
 	expansion      []byte

--- a/pkg/dotc1z/grants_test.go
+++ b/pkg/dotc1z/grants_test.go
@@ -524,7 +524,7 @@ func TestBackfillMigration_OldSyncGetsExpansionColumn(t *testing.T) {
 	require.NoError(t, err)
 
 	// Step 3: Run the backfill explicitly (as the migration would on re-open).
-	backfilled, err := backfillGrantExpansionColumn(ctx, c1f.db, grants.Name())
+	backfilled, err := backfillGrantDerivedColumns(ctx, c1f.db, grants.Name())
 	require.True(t, backfilled)
 	require.NoError(t, err)
 

--- a/pkg/dotc1z/internal_grant_options.go
+++ b/pkg/dotc1z/internal_grant_options.go
@@ -50,6 +50,11 @@ type grantListOptions struct {
 	// ExpandableOnly filters rows to grants with expansion metadata.
 	ExpandableOnly bool
 
+	// ExternalMatchOnly filters rows to grants carrying an ExternalResourceMatch
+	// annotation. Used by processGrantsWithExternalPrincipals to skip the
+	// per-row unmarshal cost for grants the caller would otherwise discard.
+	ExternalMatchOnly bool
+
 	// SyncID is used for expansion-only modes.
 	SyncID    string
 	PageToken string

--- a/pkg/dotc1z/sync_runs.go
+++ b/pkg/dotc1z/sync_runs.go
@@ -40,7 +40,8 @@ create table if not exists %s (
     linked_sync_id text not null default '',
     supports_diff integer not null default 0,
     grants_backfilled integer not null default 0,
-		stats text
+    stats text,
+    has_external_match_backfilled integer not null default 0
 );
 create unique index if not exists %s on %s (sync_id);`
 
@@ -131,6 +132,19 @@ func (r *syncRunsTable) Migrations(ctx context.Context, db *goqu.Database) (bool
 
 	// Add stats column so we can store the cached stats.
 	_, err = db.ExecContext(ctx, fmt.Sprintf("alter table %s add column stats text", r.Name()))
+	if err != nil {
+		if !isAlreadyExistsError(err) {
+			return false, err
+		}
+	} else {
+		migrated = true
+	}
+
+	// Track whether has_external_match backfill has completed for this sync.
+	// Distinct from grants_backfilled because the existing flag was already
+	// flipped to 1 for every sync at the prior backfill PR — gating the new
+	// backfill on grants_backfilled would skip every existing c1z.
+	_, err = db.ExecContext(ctx, fmt.Sprintf("alter table %s add column has_external_match_backfilled integer not null default 0", r.Name()))
 	if err != nil {
 		if !isAlreadyExistsError(err) {
 			return false, err
@@ -662,13 +676,14 @@ func (c *C1File) insertSyncRunWithLink(ctx context.Context, syncID string, syncT
 
 	q := c.db.Insert(syncRuns.Name())
 	q = q.Rows(goqu.Record{
-		"sync_id":           syncID,
-		"started_at":        time.Now().Format("2006-01-02 15:04:05.999999999"),
-		"sync_token":        "",
-		"sync_type":         syncType,
-		"parent_sync_id":    parentSyncID,
-		"linked_sync_id":    linkedSyncID,
-		"grants_backfilled": 1, // New syncs do not require grants backfill.
+		"sync_id":                       syncID,
+		"started_at":                    time.Now().Format("2006-01-02 15:04:05.999999999"),
+		"sync_token":                    "",
+		"sync_type":                     syncType,
+		"parent_sync_id":                parentSyncID,
+		"linked_sync_id":                linkedSyncID,
+		"grants_backfilled":             1, // New syncs do not require grants backfill.
+		"has_external_match_backfilled": 1, // grantExtractFields populates the column on write.
 	})
 
 	query, args, err := q.ToSQL()

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -2199,8 +2199,14 @@ func (s *syncer) listAllGrantsWithExpansion(ctx context.Context) iter.Seq2[[]*co
 		pageToken := ""
 		for {
 			internalList, err := s.store.ListGrantsInternal(ctx, connectorstore.GrantListOptions{
-				Mode:      connectorstore.GrantListModePayloadWithExpansion,
-				PageToken: pageToken,
+				Mode: connectorstore.GrantListModePayloadWithExpansion,
+				// Only iterate grants carrying an ExternalResourceMatch annotation —
+				// the sole consumer here (processGrantsWithExternalPrincipals) does an
+				// equivalent annotation check per-row and continues on mismatch.
+				// Filtering at SQL avoids the per-row columnBlob + proto.Unmarshal on
+				// rows that would be skipped anyway.
+				ExternalMatchOnly: true,
+				PageToken:         pageToken,
 			})
 			if err != nil {
 				_ = yield(nil, err)

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -2329,7 +2329,12 @@ func (s *syncer) processGrantsWithExternalPrincipals(ctx context.Context, princi
 	grantsToDelete := make([]string, 0)
 	expandedGrants := make([]*v2.Grant, 0)
 
-	for ga, err := range s.store.Grants().ListWithAnnotations(ctx) {
+	// Filter at SQL via the has_external_match column to skip the per-row
+	// data-blob unmarshal for grants that don't carry an external-match
+	// annotation (~99% for typical tenants). The in-loop annotation check
+	// stays as a correctness fallback for rows written before the backfill
+	// completed or when the kill-switch is engaged.
+	for ga, err := range s.store.Grants().ListWithAnnotationsExternalMatchOnly(ctx) {
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary

`processGrantsWithExternalPrincipals` iterates every grant in the sync but only acts on rows carrying an `ExternalResourceMatch{,All,ID}` annotation. On `be-temporal-sync`, `listGrantsWithExpansionInternal` was **20.33% flat / 23.53% cum of alloc_space** (~22 GB / 3 h), dominated by the per-row sqlite `columnBlob` copy + `proto.Unmarshal` work for rows the caller was about to skip anyway.

Push the annotation check down to SQL:

- New `has_external_match` column on `grants`, set on write from the in-memory grant's annotations via a cheap `Any.MessageIs` check (no unmarshal).
- `grantExtractFields` sets the column in **every** upsert mode — including `PreserveExpansion`, because `executeGrantChunkedUpsert` still writes `EXCLUDED.data` on conflict there; the column must track the data blob's annotation set exactly.
- Migration `ALTER`s the column in with default `0` for older c1zs, plus a partial index `(sync_id) WHERE has_external_match = 1` matching the existing `needs_expansion` index shape.
- Backfill (renamed `backfillGrantExpansionColumn` → `backfillGrantDerivedColumns`) derives `has_external_match` while the proto is already unmarshaled for the expansion backfill. Sentinel branch is split by match-presence so each group still bulk-updates in one statement.
- New `GrantListOptions.ExternalMatchOnly` opted into by `syncer.listAllGrantsWithExpansion`. The in-loop annotation check at `processGrantsWithExternalPrincipals` is kept as a defensive fallback.
- `BATON_DISABLE_EXTERNAL_MATCH_FILTER=1` kill-switch for fast revert without re-release.

Clone and attached-diff paths are schema-agnostic (column discovery via `PRAGMA table_info`) so the new column flows through automatically.

## Benchmark

`BenchmarkListGrantsWithExpansion_ExternalMatchOnly` seeds N grants at varying match densities and compares the filtered path against the pre-fix behavior via the kill-switch. `benchtime=3x` on AMD Ryzen 7 5700X3D:

**n=10,000 grants** (pre-fix: ~14.5 MB, ~380k allocs, ~37 ms regardless of density):

| match % | allocs | B/op | alloc reduction | wall time |
|---:|---:|---:|---:|---:|
| 1% | 4,374 | 266 KB | **98.8%** | 0.6 ms (60×) |
| 5% | 21,164 | 970 KB | **94.4%** | 3.4 ms (11×) |
| 20% | 84,127 | 3.6 MB | **77.9%** | 10.3 ms (3.7×) |
| 100% | 419,924 | 17.7 MB | 0% (ceiling) | 42.9 ms (parity) |

**n=50,000 grants** (pre-fix: ~72 MB, ~1.9 M allocs, ~177 ms):

| match % | allocs | B/op | alloc reduction | wall time |
|---:|---:|---:|---:|---:|
| 1% | 21,174 | 969 KB | **98.9%** | 3.3 ms (54×) |
| 5% | 105,163 | 4.5 MB | **94.5%** | 15.9 ms (11×) |
| 20% | 420,127 | 17.7 MB | **78.4%** | 49.5 ms (3.7×) |
| 100% | 2,100,784 | 88.4 MB | 0% (ceiling) | 204.8 ms (parity) |

100% match density is pinned as a regression guard — the filter imposes no measurable cost vs. the pre-fix path when every row would match anyway.

## Pressure test

Before implementing, verified (in order):

1. `grantExtractFields` is called on every upsert with the full `*v2.Grant` — cheap `Any.MessageIs` works.
2. `listGrantsWithExpansionInternal` has only one caller in-repo (the one we convert).
3. `ExternalResourceMatch*` annotations are only set by connectors pre-`PutGrants`; no in-place annotation mutation exists. `newGrantForExternalPrincipal` copies them to expanded grants, which go back through `UpsertGrants(Replace)` — extraction runs fresh.
4. `state.HasExternalResourcesGrants()` is observation-based, not eager.
5. Migrations run synchronously in `NewC1File` → `InitTables` → `Migrations` before any read can happen.
6. `PreserveExpansion` upsert rewrites `data` from `EXCLUDED.data`, so `has_external_match` must track it — covered by the update map adjustment and a targeted test.

## Test plan

- [x] `TestHasExternalMatch_WriteExtraction` — every annotation flavor + co-existence with `GrantExpandable`
- [x] `TestHasExternalMatch_PreserveExpansionUpdatesColumn` — the critical PreserveExpansion refresh case
- [x] `TestListGrantsInternal_ExternalMatchOnlyFilter` — SQL predicate returns exactly the matching rows
- [x] `TestBackfillMigration_PopulatesHasExternalMatch` — all three backfill branches (expandable+match, sentinel+match, sentinel+no-match)
- [x] `TestExternalMatchFilter_KillSwitch` — env var disables the predicate
- [x] Existing `TestExternalResourceMatchIDWithExpandableRemapping` + full sync/dotc1z/synccompactor suites pass unchanged
- [x] `TestCloneSyncMigratedColumnOrder` updated to simulate old c1z with the new ALTER
- [x] `go vet ./...` clean
- [ ] Rollout: monitor alloc on `be-temporal-sync` after deploy; if the predicate mis-plans on a customer's c1z, `BATON_DISABLE_EXTERNAL_MATCH_FILTER=1` rolls back without a re-release

🤖 Generated with [Claude Code](https://claude.com/claude-code)