### PR TITLE
feat(dotc1z): record decompressed db size on save (zstd FCS + Info log)

### DIFF
--- a/pkg/dotc1z/c1file_test.go
+++ b/pkg/dotc1z/c1file_test.go
@@ -224,15 +224,13 @@ func TestC1ZDecoder(t *testing.T) {
 	err = d.Close()
 	require.NoError(t, err)
 
-	// Test lower mem usage
-	d, err = NewDecoder(c1zf, WithDecoderMaxMemory(1*1024*1024))
-	require.NoError(t, err)
-	_, err = io.Copy(io.Discard, d)
-	require.ErrorIs(t, err, ErrWindowSizeExceeded)
-	err = d.Close()
-	require.NoError(t, err)
+	// Window-size-exceeded coverage is in TestC1ZDecoder_WindowSizeExceeded,
+	// which constructs a sufficiently large c1z. With the FCS-aware encoder,
+	// small c1z frames use SingleSegment mode and fit inside a 1 MiB decoder
+	// memory budget — so this decoder's small content cannot be used to
+	// exercise ErrWindowSizeExceeded here.
 
-	// Test lower mem usage
+	// 8 MiB memory budget is large enough to decode the small test c1z.
 	d, err = NewDecoder(c1zf, WithDecoderMaxMemory(8*1024*1024))
 	require.NoError(t, err)
 	_, err = io.Copy(b, d)

--- a/pkg/dotc1z/decoder.go
+++ b/pkg/dotc1z/decoder.go
@@ -275,24 +275,38 @@ func (d *decoder) Read(p []byte) (int, error) {
 		return 0, d.o.ctx.Err()
 	}
 
-	// Check we have not exceeded our max decoded size. When the frame declared
-	// its size and was within the cap, this overrun path is effectively
-	// unreachable; it remains as defense against a mismatched FCS.
+	// Enforce max decoded size at both ends of the underlying Read:
+	// - Top-of-call: short-circuit subsequent Reads after we've already tripped.
+	// - Post-call: clip `n` so bytes beyond the cap never reach the caller,
+	//   even when a single zstd read straddles the cap boundary.
+	// When FCS is present and within the cap the post-call branch is
+	// unreachable; it's defense against a missing or mismatched FCS.
 	maxDecodedSize := d.getMaxDecodedSize()
 	if d.decodedBytes > maxDecodedSize {
-		if d.hasDeclaredSize {
-			return 0, fmt.Errorf(
-				"c1z: max decoded size exceeded: %d > %d (declared: %d): %w",
-				d.decodedBytes, maxDecodedSize, d.declaredSize, ErrMaxSizeExceeded,
-			)
-		}
-		return 0, fmt.Errorf("c1z: max decoded size exceeded: %d > %d: %w", d.decodedBytes, maxDecodedSize, ErrMaxSizeExceeded)
+		return 0, d.maxSizeExceededErr()
 	}
 
 	// Do underlying read
 	n, err := d.zd.Read(p)
 	//nolint:gosec // No risk of overflow/underflow because n is always >= 0.
 	d.decodedBytes += uint64(n)
+
+	// Clip any bytes that crossed the cap in this single Read so we never
+	// return data past maxDecodedSize, and surface the error immediately
+	// instead of waiting for the next Read.
+	if d.decodedBytes > maxDecodedSize {
+		overrun := d.decodedBytes - maxDecodedSize
+		//nolint:gosec // overrun <= n by construction (we just added n and went over).
+		if uint64(n) >= overrun {
+			n -= int(overrun)
+		} else {
+			n = 0
+		}
+		// Leave d.decodedBytes at its true post-read value so subsequent
+		// Reads hit the top-of-call guard above.
+		return n, d.maxSizeExceededErr()
+	}
+
 	if err != nil {
 		// NOTE(morgabra) This happens if you set a small DecoderMaxMemory
 		if errors.Is(err, zstd.ErrWindowSizeExceeded) {
@@ -301,6 +315,21 @@ func (d *decoder) Read(p []byte) (int, error) {
 		return n, err
 	}
 	return n, nil
+}
+
+// maxSizeExceededErr builds the ErrMaxSizeExceeded wrap emitted from both the
+// top-of-Read guard and the in-Read clip path. Includes the declared size
+// when FCS was advertised so callers see the exact stream size without
+// decompressing further.
+func (d *decoder) maxSizeExceededErr() error {
+	maxDecodedSize := d.getMaxDecodedSize()
+	if d.hasDeclaredSize {
+		return fmt.Errorf(
+			"c1z: max decoded size exceeded: %d > %d (declared: %d): %w",
+			d.decodedBytes, maxDecodedSize, d.declaredSize, ErrMaxSizeExceeded,
+		)
+	}
+	return fmt.Errorf("c1z: max decoded size exceeded: %d > %d: %w", d.decodedBytes, maxDecodedSize, ErrMaxSizeExceeded)
 }
 
 func (d *decoder) Close() error {

--- a/pkg/dotc1z/decoder.go
+++ b/pkg/dotc1z/decoder.go
@@ -19,7 +19,19 @@ const (
 	defaultDecoderMaxMemory = 128 * 1024 * 1024      // 128MiB
 	maxDecodedSizeEnvVar    = "BATON_DECODER_MAX_DECODED_SIZE_MB"
 	maxDecoderMemorySizeEnv = "BATON_DECODER_MAX_MEMORY_MB"
+
+	// fcsFailFastDisableEnvVar, when set to "1", disables the fail-fast path
+	// that rejects c1zs whose declared Frame_Content_Size already exceeds the
+	// configured DecoderMaxDecodedSize. Disabling falls back to the pre-FCS
+	// behavior of running the decoder until decoded bytes exceed the cap.
+	// Intended as an operational kill-switch if an FCS-induced false positive
+	// surfaces in production; zero behavior change when unset.
+	fcsFailFastDisableEnvVar = "BATON_DISABLE_FCS_FAIL_FAST"
 )
+
+// fcsFailFastDisabled is read once at package init to avoid per-Read env
+// lookups. Matches the pattern used by BATON_ZSTD_POOL_DISABLE in pool.go.
+var fcsFailFastDisabled = os.Getenv(fcsFailFastDisableEnvVar) == "1"
 
 var C1ZFileHeader = []byte("C1ZF\x00")
 
@@ -194,8 +206,10 @@ func (d *decoder) ensureInit() {
 		// no need to instantiate a zstd decoder for a c1z we can't accept.
 		// The error wraps ErrMaxSizeExceeded and carries the declared size
 		// explicitly so callers can surface "this c1z wants to decode to N
-		// bytes" without running the decoder.
-		if d.hasDeclaredSize {
+		// bytes" without running the decoder. BATON_DISABLE_FCS_FAIL_FAST=1
+		// skips the pre-check and falls back to the decoded-bytes-over-cap
+		// path inside Read (pre-FCS behavior).
+		if d.hasDeclaredSize && !fcsFailFastDisabled {
 			maxDecodedSize := d.getMaxDecodedSize()
 			if d.declaredSize > maxDecodedSize {
 				d.decoderInitErr = fmt.Errorf(

--- a/pkg/dotc1z/decoder.go
+++ b/pkg/dotc1z/decoder.go
@@ -1,6 +1,7 @@
 package dotc1z
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"errors"
@@ -123,6 +124,12 @@ type decoder struct {
 	decodedBytes   uint64
 	poolCompatible bool // true if zd has pool-compatible settings and should be returned to pool
 
+	// declaredSize is the Frame_Content_Size from the zstd frame header, if
+	// advertised. Populated lazily during init (alongside header validation),
+	// before any decompression happens.
+	declaredSize    uint64
+	hasDeclaredSize bool
+
 	initOnce       sync.Once
 	headerCheckErr error
 	decoderInitErr error
@@ -136,13 +143,67 @@ func (d *decoder) getMaxMemSize() uint64 {
 	return maxMemSize
 }
 
-func (d *decoder) Read(p []byte) (int, error) {
-	// Init
+func (d *decoder) getMaxDecodedSize() uint64 {
+	v := d.o.maxDecodedSize
+	if v == 0 {
+		v = defaultMaxDecodedSize
+	}
+	return v
+}
+
+// DeclaredDecodedSize returns the decompressed size advertised in the zstd
+// Frame_Content_Size field of the c1z's frame header, if present. It triggers
+// header parsing on first call without starting decompression.
+//
+// Returns (size, true) when FCS is advertised — this is the exact number of
+// bytes the stream will produce. Returns (0, false) for c1zs saved before the
+// producer started recording FCS, or when header parsing failed (in which case
+// Read will surface the underlying error).
+//
+// Safe to call before, during, or instead of Read; subsequent Read calls
+// continue to work normally.
+func (d *decoder) DeclaredDecodedSize() (uint64, bool) {
+	d.ensureInit()
+	return d.declaredSize, d.hasDeclaredSize
+}
+
+// ensureInit runs decoder initialization at most once: header check, FCS peek,
+// fail-fast on declared-size cap, then zstd decoder setup (from pool or fresh).
+// Called from both Read and DeclaredDecodedSize.
+func (d *decoder) ensureInit() {
 	d.initOnce.Do(func() {
 		err := ReadHeader(d.f)
 		if err != nil {
 			d.headerCheckErr = err
 			return
+		}
+
+		// Wrap the post-magic reader so we can peek the zstd frame header
+		// without consuming those bytes — the zstd decoder still reads them
+		// from the bufio buffer when it starts.
+		br := bufio.NewReader(d.f)
+		if peek, perr := br.Peek(zstd.HeaderMaxSize); perr == nil || errors.Is(perr, io.EOF) {
+			var hdr zstd.Header
+			if decErr := hdr.Decode(peek); decErr == nil && hdr.HasFCS {
+				d.declaredSize = hdr.FrameContentSize
+				d.hasDeclaredSize = true
+			}
+		}
+
+		// Fail fast when the declared size already exceeds the caller's cap:
+		// no need to instantiate a zstd decoder for a c1z we can't accept.
+		// The error wraps ErrMaxSizeExceeded and carries the declared size
+		// explicitly so callers can surface "this c1z wants to decode to N
+		// bytes" without running the decoder.
+		if d.hasDeclaredSize {
+			maxDecodedSize := d.getMaxDecodedSize()
+			if d.declaredSize > maxDecodedSize {
+				d.decoderInitErr = fmt.Errorf(
+					"c1z: declared decoded size %d exceeds cap %d: %w",
+					d.declaredSize, maxDecodedSize, ErrMaxSizeExceeded,
+				)
+				return
+			}
 		}
 
 		// Try to use a pooled decoder if options match the pool's defaults.
@@ -151,7 +212,7 @@ func (d *decoder) Read(p []byte) (int, error) {
 		if usePool {
 			zd, _ := getDecoder()
 			if zd != nil {
-				if err := zd.Reset(d.f); err != nil {
+				if err := zd.Reset(br); err != nil {
 					// Reset failed, return decoder to pool and fall through to create new one.
 					putDecoder(zd)
 				} else {
@@ -171,10 +232,7 @@ func (d *decoder) Read(p []byte) (int, error) {
 			zstdOpts = append(zstdOpts, zstd.WithDecoderConcurrency(d.o.decoderConcurrency))
 		}
 
-		zd, err := zstd.NewReader(
-			d.f,
-			zstdOpts...,
-		)
+		zd, err := zstd.NewReader(br, zstdOpts...)
 		if err != nil {
 			d.decoderInitErr = err
 			return
@@ -183,6 +241,10 @@ func (d *decoder) Read(p []byte) (int, error) {
 		// If settings are pool-compatible, mark for return to pool on Close()
 		d.poolCompatible = usePool
 	})
+}
+
+func (d *decoder) Read(p []byte) (int, error) {
+	d.ensureInit()
 
 	// Check header
 	if d.headerCheckErr != nil {
@@ -199,12 +261,17 @@ func (d *decoder) Read(p []byte) (int, error) {
 		return 0, d.o.ctx.Err()
 	}
 
-	// Check we have not exceeded our max decoded size
-	maxDecodedSize := d.o.maxDecodedSize
-	if maxDecodedSize == 0 {
-		maxDecodedSize = defaultMaxDecodedSize
-	}
+	// Check we have not exceeded our max decoded size. When the frame declared
+	// its size and was within the cap, this overrun path is effectively
+	// unreachable; it remains as defense against a mismatched FCS.
+	maxDecodedSize := d.getMaxDecodedSize()
 	if d.decodedBytes > maxDecodedSize {
+		if d.hasDeclaredSize {
+			return 0, fmt.Errorf(
+				"c1z: max decoded size exceeded: %d > %d (declared: %d): %w",
+				d.decodedBytes, maxDecodedSize, d.declaredSize, ErrMaxSizeExceeded,
+			)
+		}
 		return 0, fmt.Errorf("c1z: max decoded size exceeded: %d > %d: %w", d.decodedBytes, maxDecodedSize, ErrMaxSizeExceeded)
 	}
 

--- a/pkg/dotc1z/file.go
+++ b/pkg/dotc1z/file.go
@@ -113,6 +113,19 @@ func saveC1z(dbFilePath string, outputFilePath string, encoderConcurrency int) e
 		}
 	}()
 
+	// Capture the decompressed db file size up front. It is used for two
+	// purposes:
+	//   1. Embedded into the zstd frame header as Frame_Content_Size (FCS),
+	//      making the decoded size discoverable to any zstd reader without
+	//      having to decompress the stream.
+	//   2. Logged alongside the resulting compressed size so operators can
+	//      observe the decompressed size of every c1z we produce.
+	dbStat, err := dbFile.Stat()
+	if err != nil {
+		return fmt.Errorf("failed to stat db file: %w", err)
+	}
+	dbSize := dbStat.Size()
+
 	// Write to a temporary file first to ensure atomic writes.
 	// This prevents file corruption if the process crashes mid-write,
 	// since the original file remains intact until the rename succeeds.
@@ -158,12 +171,12 @@ func saveC1z(dbFilePath string, outputFilePath string, encoderConcurrency int) e
 	if encoderConcurrency == pooledEncoderConcurrency {
 		c1z, _ = getEncoder()
 	}
-	if c1z != nil {
-		c1z.Reset(outFile)
-	} else {
+	if c1z == nil {
 		// Non-default concurrency or pool returned nil: create new encoder.
+		// The writer passed here is replaced by ResetContentSize below, so
+		// io.Discard is only used as a placeholder during construction.
 		var err error
-		c1z, err = zstd.NewWriter(outFile,
+		c1z, err = zstd.NewWriter(io.Discard,
 			zstd.WithEncoderConcurrency(encoderConcurrency),
 		)
 		if err != nil {
@@ -171,11 +184,21 @@ func saveC1z(dbFilePath string, outputFilePath string, encoderConcurrency int) e
 		}
 	}
 
-	_, err = io.Copy(c1z, dbFile)
+	// Reset the encoder onto outFile and record the decompressed size in the
+	// zstd Frame_Content_Size field. This is upstream-spec-compatible — old
+	// decoders ignore FCS and continue to stream as today. New decoders (and
+	// the zstd CLI) can observe the decoded size from the frame header
+	// without having to decompress the stream.
+	//
+	// Note: ResetContentSize requires the number of bytes written to equal
+	// the advertised size at Close() time. We enforce this with io.CopyN.
+	c1z.ResetContentSize(outFile, dbSize)
+
+	_, err = io.CopyN(c1z, dbFile, dbSize)
 	if err != nil {
 		// Always close encoder to release resources. Don't return to pool - may be in bad state.
 		_ = c1z.Close()
-		return err
+		return fmt.Errorf("failed to copy db file into encoder: %w", err)
 	}
 
 	err = c1z.Flush()
@@ -220,6 +243,19 @@ func saveC1z(dbFilePath string, outputFilePath string, encoderConcurrency int) e
 		return fmt.Errorf("failed to rename temp file to output file: %w", err)
 	}
 	success = true
+
+	// Record the decompressed and compressed sizes for every saved c1z.
+	// Operators rely on this line to track c1z growth per tenant/connector
+	// and to detect bloat before decoders hit the max-decoded-size cap.
+	compressedSize := int64(-1)
+	if outStat, statErr := os.Stat(outputFilePath); statErr == nil {
+		compressedSize = outStat.Size()
+	}
+	zap.L().Info("c1z: saved",
+		zap.String("output_path", outputFilePath),
+		zap.Int64("decompressed_bytes", dbSize),
+		zap.Int64("compressed_bytes", compressedSize),
+	)
 
 	return nil
 }

--- a/pkg/dotc1z/file_fcs_test.go
+++ b/pkg/dotc1z/file_fcs_test.go
@@ -1,6 +1,7 @@
 package dotc1z
 
 import (
+	"bytes"
 	"errors"
 	"io"
 	"math/rand"
@@ -254,4 +255,54 @@ func TestDecoder_FCSFailFastKillSwitch(t *testing.T) {
 	require.ErrorIs(t, err, ErrMaxSizeExceeded)
 	require.NotContains(t, err.Error(), "declared decoded size",
 		"kill-switch must route through the overrun path, not the pre-check")
+}
+
+// TestDecoder_ReadClipsBytesAtCap verifies that no bytes past
+// DecoderMaxDecodedSize are returned to the caller, even when a single
+// underlying zstd read would straddle the cap boundary. Addresses the
+// "what if the subsequent read sends us over the limit?" case: we enforce
+// the cap within the Read call instead of only at the start of the next one.
+func TestDecoder_ReadClipsBytesAtCap(t *testing.T) {
+	tmpDir := t.TempDir()
+	const dbSize = 1 << 20 // 1 MiB
+	dbPath := filepath.Join(tmpDir, "src.db")
+	data := make([]byte, dbSize)
+	for i := range data {
+		data[i] = byte(i * 13 % 251)
+	}
+	require.NoError(t, os.WriteFile(dbPath, data, 0600))
+
+	c1zPath := filepath.Join(tmpDir, "out.c1z")
+	require.NoError(t, saveC1z(dbPath, c1zPath, 1))
+
+	f, err := os.Open(c1zPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = f.Close() })
+
+	// Disable the init-time pre-check so we exercise the in-Read clip path:
+	// the decoder has to actually run and decide what to do when a single
+	// read would cross the cap.
+	orig := fcsFailFastDisabled
+	fcsFailFastDisabled = true
+	defer func() { fcsFailFastDisabled = orig }()
+
+	// Pick a cap mid-stream so the clip logic has to fire on some Read call.
+	const cap = dbSize/2 + 37
+	d, err := NewDecoder(f, WithDecoderMaxDecodedSize(cap))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = d.Close() })
+
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, d)
+	require.ErrorIs(t, err, ErrMaxSizeExceeded)
+
+	// The caller must never receive more bytes than the cap — the decoder
+	// should clip the straddling read and surface the error in the same call.
+	require.LessOrEqual(t, uint64(buf.Len()), uint64(cap),
+		"bytes past the cap leaked to the caller")
+
+	// And the bytes we did receive must match the leading prefix of the
+	// original db — proving we clipped the end, not some arbitrary middle.
+	require.Equal(t, data[:buf.Len()], buf.Bytes(),
+		"clipped bytes must be the leading prefix of the stream")
 }

--- a/pkg/dotc1z/file_fcs_test.go
+++ b/pkg/dotc1z/file_fcs_test.go
@@ -43,4 +43,3 @@ func TestSaveC1z_SetsFrameContentSize(t *testing.T) {
 	require.Equal(t, uint64(dbSize), header.FrameContentSize,
 		"FCS in header must equal the decompressed db size")
 }
-

--- a/pkg/dotc1z/file_fcs_test.go
+++ b/pkg/dotc1z/file_fcs_test.go
@@ -286,9 +286,10 @@ func TestDecoder_ReadClipsBytesAtCap(t *testing.T) {
 	fcsFailFastDisabled = true
 	defer func() { fcsFailFastDisabled = orig }()
 
-	// Pick a cap mid-stream so the clip logic has to fire on some Read call.
-	const cap = dbSize/2 + 37
-	d, err := NewDecoder(f, WithDecoderMaxDecodedSize(cap))
+	// Pick a ceiling mid-stream so the clip logic has to fire on some Read
+	// call. Named sizeCap to avoid shadowing the built-in cap().
+	const sizeCap uint64 = dbSize/2 + 37
+	d, err := NewDecoder(f, WithDecoderMaxDecodedSize(sizeCap))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = d.Close() })
 
@@ -298,7 +299,7 @@ func TestDecoder_ReadClipsBytesAtCap(t *testing.T) {
 
 	// The caller must never receive more bytes than the cap — the decoder
 	// should clip the straddling read and surface the error in the same call.
-	require.LessOrEqual(t, uint64(buf.Len()), uint64(cap),
+	require.LessOrEqual(t, buf.Len(), int(sizeCap),
 		"bytes past the cap leaked to the caller")
 
 	// And the bytes we did receive must match the leading prefix of the

--- a/pkg/dotc1z/file_fcs_test.go
+++ b/pkg/dotc1z/file_fcs_test.go
@@ -64,6 +64,7 @@ func TestC1ZDecoder_WindowSizeExceeded(t *testing.T) {
 	const dbSize = 16 * 1024 * 1024
 	dbPath := filepath.Join(tmpDir, "large.db")
 	data := make([]byte, dbSize)
+	//nolint:gosec // deterministic test fixture; no security context.
 	rng := rand.New(rand.NewSource(42))
 	_, err := rng.Read(data)
 	require.NoError(t, err)

--- a/pkg/dotc1z/file_fcs_test.go
+++ b/pkg/dotc1z/file_fcs_test.go
@@ -1,0 +1,46 @@
+package dotc1z
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSaveC1z_SetsFrameContentSize verifies that saveC1z records the
+// decompressed db size in the zstd Frame_Content_Size (FCS) field. This lets
+// readers learn the decoded size without decompressing the stream — which
+// closes the gap that forced us to run the decoder against the max-size cap
+// to discover how big a c1z actually is.
+func TestSaveC1z_SetsFrameContentSize(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Write a non-trivial db file so the size is distinguishable.
+	const dbSize = 123_456
+	dbPath := filepath.Join(tmpDir, "src.db")
+	data := make([]byte, dbSize)
+	for i := range data {
+		data[i] = byte(i % 251)
+	}
+	require.NoError(t, os.WriteFile(dbPath, data, 0600))
+
+	c1zPath := filepath.Join(tmpDir, "out.c1z")
+	require.NoError(t, saveC1z(dbPath, c1zPath, 1))
+
+	// Open the c1z, skip the 5-byte C1ZF magic, and parse the zstd frame
+	// header directly. FCS should now be populated with the exact db size.
+	raw, err := os.ReadFile(c1zPath)
+	require.NoError(t, err)
+	require.Greater(t, len(raw), len(C1ZFileHeader))
+	zstdStream := raw[len(C1ZFileHeader):]
+
+	header := zstd.Header{}
+	require.NoError(t, header.Decode(zstdStream))
+
+	require.True(t, header.HasFCS, "zstd frame must advertise Frame_Content_Size after save")
+	require.Equal(t, uint64(dbSize), header.FrameContentSize,
+		"FCS in header must equal the decompressed db size")
+}
+

--- a/pkg/dotc1z/file_fcs_test.go
+++ b/pkg/dotc1z/file_fcs_test.go
@@ -1,6 +1,7 @@
 package dotc1z
 
 import (
+	"errors"
 	"io"
 	"math/rand"
 	"os"
@@ -84,4 +85,125 @@ func TestC1ZDecoder_WindowSizeExceeded(t *testing.T) {
 
 	_, err = io.Copy(io.Discard, d)
 	require.ErrorIs(t, err, ErrWindowSizeExceeded)
+}
+
+// TestDecoder_DeclaredDecodedSize verifies the consumer-side FCS peek:
+// DeclaredDecodedSize() returns the exact db size advertised in the frame
+// header for c1zs saved by the current producer, without decompressing.
+func TestDecoder_DeclaredDecodedSize(t *testing.T) {
+	tmpDir := t.TempDir()
+	const dbSize = 271_828 // non-round, distinguishable from any default
+	dbPath := filepath.Join(tmpDir, "src.db")
+	data := make([]byte, dbSize)
+	for i := range data {
+		data[i] = byte(i % 251)
+	}
+	require.NoError(t, os.WriteFile(dbPath, data, 0600))
+
+	c1zPath := filepath.Join(tmpDir, "out.c1z")
+	require.NoError(t, saveC1z(dbPath, c1zPath, 1))
+
+	f, err := os.Open(c1zPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = f.Close() })
+
+	d, err := NewDecoder(f)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = d.Close() })
+
+	// No Read yet — DeclaredDecodedSize must trigger header parsing.
+	size, ok := d.DeclaredDecodedSize()
+	require.True(t, ok, "FCS must be declared for c1zs saved by the current producer")
+	require.Equal(t, uint64(dbSize), size)
+
+	// Subsequent Read must still decompress the full stream.
+	decoded, err := io.ReadAll(d)
+	require.NoError(t, err)
+	require.Equal(t, data, decoded)
+
+	// Second call returns the same value (idempotent).
+	size2, ok2 := d.DeclaredDecodedSize()
+	require.True(t, ok2)
+	require.Equal(t, size, size2)
+}
+
+// TestDecoder_DeclaredDecodedSize_LegacyWithoutFCS verifies the backward-compat
+// path: a c1z produced before the FCS change (hand-built here without
+// ResetContentSize) returns (0, false) from DeclaredDecodedSize, and reads
+// normally.
+func TestDecoder_DeclaredDecodedSize_LegacyWithoutFCS(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Build a legacy-format c1z directly: C1ZF magic + zstd frame WITHOUT
+	// FCS. The default klauspost encoder (no ResetContentSize call) produces
+	// exactly this layout.
+	payload := []byte("legacy c1z payload without FCS")
+	c1zPath := filepath.Join(tmpDir, "legacy.c1z")
+	f, err := os.Create(c1zPath)
+	require.NoError(t, err)
+	_, err = f.Write(C1ZFileHeader)
+	require.NoError(t, err)
+	enc, err := zstd.NewWriter(f, zstd.WithEncoderConcurrency(1))
+	require.NoError(t, err)
+	_, err = enc.Write(payload)
+	require.NoError(t, err)
+	require.NoError(t, enc.Close())
+	require.NoError(t, f.Close())
+
+	rf, err := os.Open(c1zPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rf.Close() })
+
+	d, err := NewDecoder(rf)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = d.Close() })
+
+	size, ok := d.DeclaredDecodedSize()
+	require.False(t, ok, "legacy c1z must not advertise FCS")
+	require.Zero(t, size)
+
+	decoded, err := io.ReadAll(d)
+	require.NoError(t, err)
+	require.Equal(t, payload, decoded)
+}
+
+// TestDecoder_DeclaredSizeExceedsCap_FailsFast verifies the fail-fast path: if
+// the frame's declared size exceeds the caller's DecoderMaxDecodedSize, the
+// very first Read returns ErrMaxSizeExceeded with the declared size embedded
+// in the error message, before any decompression happens.
+func TestDecoder_DeclaredSizeExceedsCap_FailsFast(t *testing.T) {
+	tmpDir := t.TempDir()
+	const dbSize = 1 << 20 // 1 MiB
+	dbPath := filepath.Join(tmpDir, "src.db")
+	data := make([]byte, dbSize)
+	for i := range data {
+		data[i] = byte(i * 7 % 251)
+	}
+	require.NoError(t, os.WriteFile(dbPath, data, 0600))
+
+	c1zPath := filepath.Join(tmpDir, "out.c1z")
+	require.NoError(t, saveC1z(dbPath, c1zPath, 1))
+
+	f, err := os.Open(c1zPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = f.Close() })
+
+	// Cap set below the declared size — init should surface the error on the
+	// very first Read without the decoder ever producing a byte.
+	d, err := NewDecoder(f, WithDecoderMaxDecodedSize(dbSize/2))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = d.Close() })
+
+	// DeclaredDecodedSize still reports the declared size — the inspection
+	// path is still useful even when the cap rejects the stream.
+	size, ok := d.DeclaredDecodedSize()
+	require.True(t, ok)
+	require.Equal(t, uint64(dbSize), size)
+
+	var buf [64]byte
+	n, err := d.Read(buf[:])
+	require.Equal(t, 0, n, "no bytes must be produced when the cap rejects declared size")
+	require.ErrorIs(t, err, ErrMaxSizeExceeded)
+	require.True(t, errors.Is(err, ErrMaxSizeExceeded))
+	require.Contains(t, err.Error(), "declared decoded size")
 }

--- a/pkg/dotc1z/file_fcs_test.go
+++ b/pkg/dotc1z/file_fcs_test.go
@@ -207,3 +207,51 @@ func TestDecoder_DeclaredSizeExceedsCap_FailsFast(t *testing.T) {
 	require.True(t, errors.Is(err, ErrMaxSizeExceeded))
 	require.Contains(t, err.Error(), "declared decoded size")
 }
+
+// TestDecoder_FCSFailFastKillSwitch verifies that flipping
+// fcsFailFastDisabled (driven by BATON_DISABLE_FCS_FAIL_FAST=1 at process
+// start) bypasses the init-time pre-check and falls back to the pre-FCS
+// behavior: Read runs the decoder and trips ErrMaxSizeExceeded only after
+// decoded bytes pass the cap.
+func TestDecoder_FCSFailFastKillSwitch(t *testing.T) {
+	tmpDir := t.TempDir()
+	const dbSize = 1 << 20 // 1 MiB
+	dbPath := filepath.Join(tmpDir, "src.db")
+	data := make([]byte, dbSize)
+	for i := range data {
+		data[i] = byte(i * 11 % 251)
+	}
+	require.NoError(t, os.WriteFile(dbPath, data, 0600))
+
+	c1zPath := filepath.Join(tmpDir, "out.c1z")
+	require.NoError(t, saveC1z(dbPath, c1zPath, 1))
+
+	f, err := os.Open(c1zPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = f.Close() })
+
+	// Flip the switch for the duration of this test.
+	orig := fcsFailFastDisabled
+	fcsFailFastDisabled = true
+	defer func() { fcsFailFastDisabled = orig }()
+
+	// Cap below declared size — with fail-fast disabled, init must succeed
+	// and Read must decode until decodedBytes > cap.
+	d, err := NewDecoder(f, WithDecoderMaxDecodedSize(dbSize/2))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = d.Close() })
+
+	// DeclaredDecodedSize still works — the kill-switch only gates the
+	// pre-check, not the header peek.
+	size, ok := d.DeclaredDecodedSize()
+	require.True(t, ok)
+	require.Equal(t, uint64(dbSize), size)
+
+	// Streaming into io.Discard must eventually fail with the overrun error,
+	// and the error must NOT contain the fail-fast "declared decoded size"
+	// phrase (that only appears on the init-time pre-check).
+	_, err = io.Copy(io.Discard, d)
+	require.ErrorIs(t, err, ErrMaxSizeExceeded)
+	require.NotContains(t, err.Error(), "declared decoded size",
+		"kill-switch must route through the overrun path, not the pre-check")
+}

--- a/pkg/dotc1z/file_fcs_test.go
+++ b/pkg/dotc1z/file_fcs_test.go
@@ -1,6 +1,8 @@
 package dotc1z
 
 import (
+	"io"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"testing"
@@ -42,4 +44,43 @@ func TestSaveC1z_SetsFrameContentSize(t *testing.T) {
 	require.True(t, header.HasFCS, "zstd frame must advertise Frame_Content_Size after save")
 	require.Equal(t, uint64(dbSize), header.FrameContentSize,
 		"FCS in header must equal the decompressed db size")
+}
+
+// TestC1ZDecoder_WindowSizeExceeded verifies that a sufficiently large c1z
+// triggers ErrWindowSizeExceeded when the decoder memory budget is too small
+// for the encoder's sliding window. This previously lived inline in
+// TestC1ZDecoder but moved here after saveC1z started setting FCS — small c1z
+// frames now use SingleSegment mode and fit inside modest memory budgets, so
+// exercising the window-size limit requires a content larger than the
+// encoder's max single-segment size (128 MiB spec limit, but klauspost
+// switches to a sliding window at ~8 MiB by default).
+func TestC1ZDecoder_WindowSizeExceeded(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Write ~16 MiB of semi-random data — random enough to not fully
+	// compress to nothing, and large enough to force the encoder off of
+	// single-segment mode and onto a sliding window that a 1 MiB decoder
+	// memory budget cannot hold.
+	const dbSize = 16 * 1024 * 1024
+	dbPath := filepath.Join(tmpDir, "large.db")
+	data := make([]byte, dbSize)
+	rng := rand.New(rand.NewSource(42))
+	_, err := rng.Read(data)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(dbPath, data, 0600))
+
+	c1zPath := filepath.Join(tmpDir, "large.c1z")
+	require.NoError(t, saveC1z(dbPath, c1zPath, 1))
+
+	f, err := os.Open(c1zPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = f.Close() })
+
+	// 1 MiB decoder memory budget — too small for the encoder's window.
+	d, err := NewDecoder(f, WithDecoderMaxMemory(1*1024*1024))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = d.Close() })
+
+	_, err = io.Copy(io.Discard, d)
+	require.ErrorIs(t, err, ErrWindowSizeExceeded)
 }

--- a/pkg/dotc1z/pool_test.go
+++ b/pkg/dotc1z/pool_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"sync"
 	"testing"
 
@@ -193,13 +194,21 @@ func TestDecoderPool(t *testing.T) {
 // sync.Pool values for the duration of the test. Needed because sync.Pool can
 // evict entries via GC between Gets, and because concurrent tests in the same
 // package could otherwise race with exact-membership assertions.
+//
+// Also disables GC during the test. sync.Pool drops items when the runtime
+// runs a GC cycle between Put and Get, which makes exact-membership
+// assertions (e.g. "did putEncoder put one in the pool?") flaky under CI
+// memory pressure. Restoring the prior GOGC on teardown keeps the rest of
+// the package suite unaffected.
 func withIsolatedPools(t *testing.T) {
 	t.Helper()
 	origEnc := encoderPool
 	origDec := decoderPool
 	encoderPool = &sync.Pool{}
 	decoderPool = &sync.Pool{}
+	origGCPercent := debug.SetGCPercent(-1)
 	t.Cleanup(func() {
+		debug.SetGCPercent(origGCPercent)
 		encoderPool = origEnc
 		decoderPool = origDec
 	})


### PR DESCRIPTION
## Summary

Two changes, one feature:

1. **Producer side** — `saveC1z` now writes the decompressed db size into the zstd frame header (Frame_Content_Size / FCS) and logs it at Info alongside the resulting compressed size. Upstream-spec-compatible — every existing zstd decoder ignores FCS and continues to stream exactly as today.
2. **Consumer side** — the dotc1z `decoder` peeks the frame header during init and exposes `DeclaredDecodedSize() (uint64, bool)`. When the declared size already exceeds `DecoderMaxDecodedSize`, the first `Read` returns `ErrMaxSizeExceeded` with the exact declared size embedded in the message — no bytes decompressed, no decoder warmed up.

## Why

The hit today isn't at sync time — it's during **grant expansion**. Expansion materializes one grant per (member, inherited access) tuple from the annotations the connector emits, and on some tenants that's enough to push the c1z past the 3 GiB decoder cap (observed: >200 GB decompressed). When downstream reopens the post-expansion c1z, it trips `ErrMaxSizeExceeded` with no signal about how much more data is in the stream. The only way to find the true size today is to download the c1z and re-decompress with a raised cap — operationally expensive, often not possible during an incident.

`saveC1z` runs once per `C1File.Close()`, so the final post-expansion save records the final post-expansion size. With FCS now in the header, any reader can learn that size directly — either via the 14-byte frame header (no dependency on this SDK) or via `DeclaredDecodedSize()` (this SDK). Fail-fast on cap means the next bad c1z reports its declared size in the error instead of a generic "cap exceeded".

## What changed

### Producer (`pkg/dotc1z/file.go`)
- Stat the db file before encoding so we know its exact size.
- Initialize the zstd encoder, then call `ResetContentSize(outFile, dbSize)` so the frame header carries FCS. `ResetContentSize` requires the written byte count to equal the advertised size at `Close()`, so the `io.Copy` is replaced with `io.CopyN(..., dbSize)` to make that invariant explicit.
- After successful rename, log `c1z: saved` at Info with `decompressed_bytes` + `compressed_bytes` for operational visibility.

### Consumer (`pkg/dotc1z/decoder.go`)
- `decoder` grows `declaredSize` / `hasDeclaredSize` fields populated lazily during init.
- Init logic extracted into `ensureInit()`, called from both `Read` and the new `DeclaredDecodedSize()`.
- After `ReadHeader` strips the 5-byte C1ZF magic, wrap the post-magic reader in `bufio.Reader` so we can `Peek(zstd.HeaderMaxSize)` the zstd frame header without consuming those bytes — the zstd decoder reads them back from bufio's buffer when it starts.
- If FCS is advertised and `declaredSize > maxDecodedSize`, init stores an `ErrMaxSizeExceeded`-wrapped error with `"declared decoded size N exceeds cap M"`. The pooled / fresh zstd decoder is never even constructed in this case.
- Legacy c1zs (saved before this PR) don't advertise FCS — `DeclaredDecodedSize` returns `(0, false)`, and `Read` behaves exactly as before.

## Tests

Producer:
- `TestSaveC1z_SetsFrameContentSize` — decodes the frame header of a freshly-saved c1z, asserts `header.HasFCS` and `header.FrameContentSize == dbSize`.
- All existing `TestSaveC1z` / `TestLoadC1z` subtests pass (including the empty-db edge case).

Consumer:
- `TestDecoder_DeclaredDecodedSize` — `DeclaredDecodedSize` returns exact FCS before any `Read`; `Read` then streams the full payload; second call is idempotent.
- `TestDecoder_DeclaredDecodedSize_LegacyWithoutFCS` — hand-built legacy c1z (C1ZF magic + zstd frame without `ResetContentSize`) returns `(0, false)` and still decodes cleanly.
- `TestDecoder_DeclaredSizeExceedsCap_FailsFast` — cap set below declared size; first `Read` returns `ErrMaxSizeExceeded` with `"declared decoded size"` in the message; zero bytes produced.
- `TestC1ZDecoder_WindowSizeExceeded` (16 MiB random payload) — moved here from `TestC1ZDecoder`, since FCS-aware SingleSegment frames make small-payload window-exceeded checks impossible. Preserves coverage of `ErrWindowSizeExceeded`.

## Compat

- No c1z format change — the 5-byte `C1ZF\x00` magic and zstd stream layout are unchanged; FCS is an optional field inside the zstd frame header.
- Older decoders (baton-sdk ≤ v0.8.25) ignore FCS — no behavioral change for any existing reader.
- Callers that rely on `errors.Is(err, ErrMaxSizeExceeded)` keep working. The message now carries the declared size when known.

## Follow-ups (separate PRs, not in scope)

- Consumer-side (c1 repo): surface `DeclaredDecodedSize()` in the `ErrMaxSizeExceeded` log line at the fetch site so per-tenant c1z-growth is queryable; add an OTel metric (e.g. `c1z.size.decompressed_bytes` histogram) keyed on tenant.
- Optional: expose an `Inspect` helper on `dotc1z` that returns FCS without constructing a decoder, so ops tooling can parse the 14-byte header without any zstd setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)