### PR TITLE
expand: ExpansionFilter hook to suppress redundant derived grants

### DIFF
--- a/pkg/sync/expand/expander.go
+++ b/pkg/sync/expand/expander.go
@@ -32,19 +32,47 @@ type ExpanderStore interface {
 	UpsertGrants(ctx context.Context, opts connectorstore.GrantUpsertOptions, grants ...*v2.Grant) error
 }
 
+// ExpansionFilter is a predicate called once per candidate expansion. If it
+// returns false, the derived grant for (sourceGrant.Principal, descendant)
+// is NOT emitted — neither as a new row nor as a sources-map update on any
+// existing row. Returning true preserves the default expansion behavior.
+//
+// Use case: suppress redundant derived grants when a sparse/authoritative
+// grant model (e.g. ScopeBindingTrait) already captures the same access.
+// Filter sees the *source* grant and both entitlements so a caller can make
+// semantic decisions (e.g. "skip expansion out of role entitlements when the
+// principal already has a scope_binding grant for that role").
+type ExpansionFilter func(ctx context.Context, sourceGrant *v2.Grant, sourceEntitlement, descendantEntitlement *v2.Entitlement) bool
+
+// ExpanderOption configures an Expander at construction time.
+type ExpanderOption func(*Expander)
+
+// WithExpansionFilter installs a predicate that decides per-source-grant
+// whether expansion should emit a derived grant. See ExpansionFilter.
+func WithExpansionFilter(f ExpansionFilter) ExpanderOption {
+	return func(e *Expander) {
+		e.filter = f
+	}
+}
+
 // Expander handles the grant expansion algorithm.
 // It can be used standalone for testing or called from the syncer.
 type Expander struct {
-	store ExpanderStore
-	graph *EntitlementGraph
+	store  ExpanderStore
+	graph  *EntitlementGraph
+	filter ExpansionFilter
 }
 
 // NewExpander creates a new Expander with the given store and graph.
-func NewExpander(store ExpanderStore, graph *EntitlementGraph) *Expander {
-	return &Expander{
+func NewExpander(store ExpanderStore, graph *EntitlementGraph, opts ...ExpanderOption) *Expander {
+	e := &Expander{
 		store: store,
 		graph: graph,
 	}
+	for _, opt := range opts {
+		opt(e)
+	}
+	return e
 }
 
 // Graph returns the entitlement graph.
@@ -192,6 +220,12 @@ func (e *Expander) runAction(ctx context.Context, action *EntitlementGraphAction
 			if !foundDirectGrant {
 				continue
 			}
+		}
+
+		// Caller-provided filter. Lets a caller suppress redundant expansion
+		// (e.g. when a ScopeBindingTrait grant already captures the access).
+		if e.filter != nil && !e.filter(ctx, sourceGrant, sourceEntitlement.GetEntitlement(), descendantEntitlement.GetEntitlement()) {
+			continue
 		}
 
 		// Determine if the source grant is direct: either it has no sources (never expanded),

--- a/pkg/sync/expand/expansion_filter_test.go
+++ b/pkg/sync/expand/expansion_filter_test.go
@@ -1,0 +1,103 @@
+package expand
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExpansionFilter_Suppress demonstrates the SDK-level dedup primitive.
+//
+// Shape mirrors the pattern in baton-azure-infrastructure that motivated this work:
+//   - A role entitlement "role:StorageBlobReader:assigned" collects direct grants
+//     (one per principal who has that role on some subscription).
+//   - Storage-account action entitlements expand from the role entitlement via
+//     the existing SDK GrantExpandable machinery.
+//   - In the ScopeBinding model, the role_assignment resource already carries
+//     an authoritative grant for each (principal, role, scope) triple. The
+//     derived grants produced by expansion are therefore redundant — every
+//     piece of access they represent is also expressible through the
+//     role_assignment grants.
+//
+// Without a filter the expander creates N derived grants (one per source grant).
+// With a filter that returns false for sources on the role entitlement, the
+// expander creates zero derived grants. The source grants themselves are
+// unchanged — this is pure write-load reduction on a redundant projection.
+//
+// The SDK doesn't encode semantic knowledge about ScopeBinding here; it only
+// exposes the primitive that lets a caller (connector or syncer) pass in the
+// filter. Keeps the SDK generic and lets individual connectors opt in.
+func TestExpansionFilter_Suppress(t *testing.T) {
+	const numPrincipals = 100
+
+	run := func(t *testing.T, filter ExpansionFilter) int {
+		t.Helper()
+		ctx := context.Background()
+		store := NewMockExpanderStore()
+
+		roleResource := makeResource("role", "StorageBlobReader")
+		blobResource := makeResource("storage_account", "blob1")
+
+		sourceEnt := makeEntitlement("ent:role:StorageBlobReader:assigned", roleResource)
+		descEnt := makeEntitlement("ent:storage_account:blob1:action:read", blobResource)
+
+		store.AddEntitlement(sourceEnt)
+		store.AddEntitlement(descEnt)
+
+		for i := 0; i < numPrincipals; i++ {
+			user := makeResource("user", fmt.Sprintf("u-%03d", i))
+			g := makeGrant(fmt.Sprintf("g:assigned:u-%03d", i), sourceEnt, user)
+			store.AddGrant(g)
+		}
+
+		graph := NewEntitlementGraph(ctx)
+		graph.AddEntitlementID(sourceEnt.GetId())
+		graph.AddEntitlementID(descEnt.GetId())
+		require.NoError(t, graph.AddEdge(ctx, sourceEnt.GetId(), descEnt.GetId(), false, []string{"user"}))
+
+		var expander *Expander
+		if filter != nil {
+			expander = NewExpander(store, graph, WithExpansionFilter(filter))
+		} else {
+			expander = NewExpander(store, graph)
+		}
+		require.NoError(t, expander.Run(ctx))
+
+		return len(store.GetPutGrants())
+	}
+
+	t.Run("no_filter_emits_N_derived_grants", func(t *testing.T) {
+		derived := run(t, nil)
+		require.Equal(t, numPrincipals, derived,
+			"baseline: expander should emit one derived grant per source principal")
+	})
+
+	t.Run("filter_on_role_source_suppresses_all", func(t *testing.T) {
+		// Suppress expansion whenever the source entitlement lives on a
+		// role resource. This is the pattern a ScopeBinding-using connector
+		// would install to prevent its role→action expansion from
+		// duplicating access already captured by role_assignment grants.
+		filter := func(_ context.Context, _ *v2.Grant, src *v2.Entitlement, _ *v2.Entitlement) bool {
+			return src.GetResource().GetId().GetResourceType() != "role"
+		}
+		derived := run(t, filter)
+		require.Equal(t, 0, derived,
+			"with the role-source filter, expander should emit zero derived grants")
+	})
+
+	t.Run("filter_can_be_per_principal", func(t *testing.T) {
+		// Partial suppression: only suppress expansion for principals whose
+		// ID is even. Demonstrates the filter gets per-grant context.
+		filter := func(_ context.Context, sg *v2.Grant, _, _ *v2.Entitlement) bool {
+			id := sg.GetPrincipal().GetId().GetResource()
+			// odd-numbered principals still expand; even-numbered get suppressed
+			return len(id) > 0 && id[len(id)-1]%2 == 1
+		}
+		derived := run(t, filter)
+		// u-000 through u-099: odd last digit = 50 principals (u-001, u-003, ..., u-099)
+		require.Equal(t, 50, derived)
+	})
+}


### PR DESCRIPTION
## Summary

Adds an opt-in `ExpansionFilter` hook on the grant expander. When installed, the filter decides per-source-grant whether a derived grant should be emitted. Default (nil filter) preserves existing behavior exactly.

- Purely additive; no behavior change for any existing caller.
- No proto / schema / store-interface changes.
- Variadic options on `NewExpander` keep the signature backward compatible.

## Why

Connectors that use a sparse/authoritative grant model (e.g. anything emitting `ScopeBindingTrait`) can double-represent access when they *also* wire `GrantExpandable` edges from role entitlements to action entitlements. The expander fans those edges into derived grants, and those derived grants duplicate information the sparse grants already carry.

Today the only way for such a connector to stop emitting the duplicates is either (a) remove the `GrantExpandable` annotations and `role.Grants()` emission entirely (a large refactor per connector) or (b) add an ad-hoc early-return gate in the connector's `role.Grants`. Neither composes; both bleed policy across the connector codebase.

This primitive lets the connector express the policy once, as a predicate:

```go
expander := expand.NewExpander(store, graph, expand.WithExpansionFilter(
    func(ctx context.Context, sg *v2.Grant, src, desc *v2.Entitlement) bool {
        // Skip expansion when the source entitlement lives on a role resource,
        // because the connector's ScopeBinding grants authoritatively cover it.
        return src.GetResource().GetId().GetResourceType() != "role"
    },
))
```

The SDK intentionally encodes no semantic knowledge about ScopeBinding or any specific model — it only exposes the hook. Connectors install whatever policy they need.

## Regression surface

- `NewExpander(store, graph)` signature unchanged (variadic options).
- `filter` field defaults nil → one added nil check per source grant on the hot path, identical behavior otherwise.
- Full `pkg/sync/expand` test suite passes unchanged.

## Tests

New `expansion_filter_test.go` covers:

1. Baseline (no filter): N source grants → N derived grants.
2. Filter suppressing by source resource type: N source grants → 0 derived grants.
3. Per-principal filter: N source grants → partial emission, demonstrating the filter receives full per-grant context.

## Status

Draft. Opening for discussion on:

- Whether the right opt-in point is the expander itself (current) vs. a syncer-level option (`sync.WithExpansionFilter`) that plumbs through automatically. A syncer-level option would be additive on top of this change; happy to add in a follow-up or amend here.
- Whether a connector-facing interface (`ExpansionFilterProvider`) on the `ConnectorBuilder` side would be preferable to per-caller wiring.

No proto changes, no schema changes, no c1z format changes. Net-zero risk to existing connectors that don't adopt it.