### PR TITLE
feat(dotc1z): opt-in slim-blob grant writer with transparent reader hydration

### DIFF
--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -72,9 +72,14 @@ type C1File struct {
 
 	// v2GrantsWriter, when true, causes PutGrants/UpsertGrants to strip
 	// Grant.Entitlement and Grant.Principal from the serialized data blob.
-	// Those fields are reconstituted at read time via joins against
-	// v1_entitlements and v1_resources. Readers handle full and slim
-	// blobs transparently per row, so mixed syncs in the same table are
+	// Those fields are reconstituted at read time as minimal stubs built
+	// from the grants row's identity columns (entitlement_id,
+	// resource_type_id, resource_id, principal_resource_type_id,
+	// principal_resource_id) — no joins against v1_entitlements or
+	// v1_resources. Stubs carry identity only (Id + nested Resource.Id);
+	// DisplayName, Annotations, Purpose, Slug, traits, and other rich
+	// fields are zero-value. Readers handle full and slim blobs
+	// transparently per row, so mixed syncs in the same table are
 	// supported. Default false; enabled via WithC1FV2GrantsWriter /
 	// WithV2GrantsWriter.
 	v2GrantsWriter bool
@@ -130,9 +135,14 @@ func WithC1FSyncCountLimit(limit int) C1FOption {
 }
 
 // WithC1FV2GrantsWriter toggles the slim-blob writer path for grants.
-// When true, Grant.Entitlement and Grant.Principal are stripped from the
-// serialized data blob at write time; readers reconstitute them from
-// v1_entitlements / v1_resources. Default false. Readers always accept
+// When true, Grant.Entitlement and Grant.Principal are stripped from
+// the serialized data blob at write time; readers reconstitute them
+// as minimal identity-only stubs (Id + nested Resource.Id) using the
+// grants row's existing columns — no joins against v1_entitlements or
+// v1_resources. Stubs do NOT carry DisplayName, Annotations, Purpose,
+// Slug, traits, or any other non-identity field; callers that need
+// those must fetch the Entitlement / Resource directly via
+// GetEntitlement / GetResource. Default false. Readers always accept
 // both shapes regardless of this flag.
 func WithC1FV2GrantsWriter(enabled bool) C1FOption {
 	return func(o *C1File) {

--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -80,8 +80,14 @@ type C1File struct {
 	// DisplayName, Annotations, Purpose, Slug, traits, and other rich
 	// fields are zero-value. Readers handle full and slim blobs
 	// transparently per row, so mixed syncs in the same table are
-	// supported. Default false; enabled via WithC1FV2GrantsWriter /
-	// WithV2GrantsWriter.
+	// supported.
+	//
+	// Slim is gated per-grant: a grant carrying InsertResourceGrants or
+	// any ExternalResourceMatch* annotation stays full-blob even when
+	// this flag is on, because the syncer reads non-identity fields off
+	// its embedded Resource / Principal. See unsafeForSlim in grants.go.
+	//
+	// Default false; enabled via WithC1FV2GrantsWriter / WithV2GrantsWriter.
 	v2GrantsWriter bool
 }
 
@@ -144,6 +150,21 @@ func WithC1FSyncCountLimit(limit int) C1FOption {
 // those must fetch the Entitlement / Resource directly via
 // GetEntitlement / GetResource. Default false. Readers always accept
 // both shapes regardless of this flag.
+//
+// Slim is gated per-grant: a grant carrying any of these annotations
+// is left full-blob even when the option is on, because downstream
+// sync code reads non-identity fields off its embedded Resource /
+// Principal:
+//
+//   - v2.InsertResourceGrants  (response-level; the syncer copies it
+//     onto each grant in the batch before UpsertGrants)
+//   - v2.ExternalResourceMatchAll
+//   - v2.ExternalResourceMatch
+//   - v2.ExternalResourceMatchID
+//
+// All other grants are eligible for slim. Connectors emitting flat
+// (non-hierarchical) principals and no external-resource matching see
+// every grant slimmed.
 func WithC1FV2GrantsWriter(enabled bool) C1FOption {
 	return func(o *C1File) {
 		o.v2GrantsWriter = enabled

--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -69,6 +69,15 @@ type C1File struct {
 	// Sync cleanup settings
 	syncLimit   int
 	skipCleanup bool
+
+	// v2GrantsWriter, when true, causes PutGrants/UpsertGrants to strip
+	// Grant.Entitlement and Grant.Principal from the serialized data blob.
+	// Those fields are reconstituted at read time via joins against
+	// v1_entitlements and v1_resources. Readers handle full and slim
+	// blobs transparently per row, so mixed syncs in the same table are
+	// supported. Default false; enabled via WithC1FV2GrantsWriter /
+	// WithV2GrantsWriter.
+	v2GrantsWriter bool
 }
 
 var (
@@ -117,6 +126,17 @@ func WithC1FSkipCleanup(skip bool) C1FOption {
 func WithC1FSyncCountLimit(limit int) C1FOption {
 	return func(o *C1File) {
 		o.syncLimit = limit
+	}
+}
+
+// WithC1FV2GrantsWriter toggles the slim-blob writer path for grants.
+// When true, Grant.Entitlement and Grant.Principal are stripped from the
+// serialized data blob at write time; readers reconstitute them from
+// v1_entitlements / v1_resources. Default false. Readers always accept
+// both shapes regardless of this flag.
+func WithC1FV2GrantsWriter(enabled bool) C1FOption {
+	return func(o *C1File) {
+		o.v2GrantsWriter = enabled
 	}
 }
 
@@ -179,6 +199,7 @@ type c1zOptions struct {
 	encoderConcurrency int
 	syncLimit          int
 	skipCleanup        bool
+	v2GrantsWriter     bool
 }
 
 type C1ZOption func(*c1zOptions)
@@ -235,6 +256,14 @@ func WithSyncLimit(limit int) C1ZOption {
 	}
 }
 
+// WithV2GrantsWriter toggles the slim-blob writer path for grants.
+// See WithC1FV2GrantsWriter for details.
+func WithV2GrantsWriter(enabled bool) C1ZOption {
+	return func(o *c1zOptions) {
+		o.v2GrantsWriter = enabled
+	}
+}
+
 // Returns a new C1File instance with its state stored at the provided filename.
 func NewC1ZFile(ctx context.Context, outputFilePath string, opts ...C1ZOption) (*C1File, error) {
 	ctx, span := tracer.Start(ctx, "NewC1ZFile")
@@ -277,6 +306,9 @@ func NewC1ZFile(ctx context.Context, outputFilePath string, opts ...C1ZOption) (
 	}
 	if options.skipCleanup {
 		c1fopts = append(c1fopts, WithC1FSkipCleanup(true))
+	}
+	if options.v2GrantsWriter {
+		c1fopts = append(c1fopts, WithC1FV2GrantsWriter(true))
 	}
 
 	c1File, err := NewC1File(ctx, dbFilePath, c1fopts...)

--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -69,6 +69,26 @@ type C1File struct {
 	// Sync cleanup settings
 	syncLimit   int
 	skipCleanup bool
+
+	// v2GrantsWriter, when true, causes PutGrants/UpsertGrants to strip
+	// Grant.Entitlement and Grant.Principal from the serialized data blob.
+	// Those fields are reconstituted at read time as minimal stubs built
+	// from the grants row's identity columns (entitlement_id,
+	// resource_type_id, resource_id, principal_resource_type_id,
+	// principal_resource_id) — no joins against v1_entitlements or
+	// v1_resources. Stubs carry identity only (Id + nested Resource.Id);
+	// DisplayName, Annotations, Purpose, Slug, traits, and other rich
+	// fields are zero-value. Readers handle full and slim blobs
+	// transparently per row, so mixed syncs in the same table are
+	// supported.
+	//
+	// Slim is gated per-grant: a grant carrying InsertResourceGrants or
+	// any ExternalResourceMatch* annotation stays full-blob even when
+	// this flag is on, because the syncer reads non-identity fields off
+	// its embedded Resource / Principal. See unsafeForSlim in grants.go.
+	//
+	// Default false; enabled via WithC1FV2GrantsWriter / WithV2GrantsWriter.
+	v2GrantsWriter bool
 }
 
 // *C1File satisfies connectorstore.Writer (the connector-facing contract),
@@ -121,6 +141,37 @@ func WithC1FSkipCleanup(skip bool) C1FOption {
 func WithC1FSyncCountLimit(limit int) C1FOption {
 	return func(o *C1File) {
 		o.syncLimit = limit
+	}
+}
+
+// WithC1FV2GrantsWriter toggles the slim-blob writer path for grants.
+// When true, Grant.Entitlement and Grant.Principal are stripped from
+// the serialized data blob at write time; readers reconstitute them
+// as minimal identity-only stubs (Id + nested Resource.Id) using the
+// grants row's existing columns — no joins against v1_entitlements or
+// v1_resources. Stubs do NOT carry DisplayName, Annotations, Purpose,
+// Slug, traits, or any other non-identity field; callers that need
+// those must fetch the Entitlement / Resource directly via
+// GetEntitlement / GetResource. Default false. Readers always accept
+// both shapes regardless of this flag.
+//
+// Slim is gated per-grant: a grant carrying any of these annotations
+// is left full-blob even when the option is on, because downstream
+// sync code reads non-identity fields off its embedded Resource /
+// Principal:
+//
+//   - v2.InsertResourceGrants  (response-level; the syncer copies it
+//     onto each grant in the batch before UpsertGrants)
+//   - v2.ExternalResourceMatchAll
+//   - v2.ExternalResourceMatch
+//   - v2.ExternalResourceMatchID
+//
+// All other grants are eligible for slim. Connectors emitting flat
+// (non-hierarchical) principals and no external-resource matching see
+// every grant slimmed.
+func WithC1FV2GrantsWriter(enabled bool) C1FOption {
+	return func(o *C1File) {
+		o.v2GrantsWriter = enabled
 	}
 }
 
@@ -183,6 +234,7 @@ type c1zOptions struct {
 	encoderConcurrency int
 	syncLimit          int
 	skipCleanup        bool
+	v2GrantsWriter     bool
 }
 
 type C1ZOption func(*c1zOptions)
@@ -239,6 +291,14 @@ func WithSyncLimit(limit int) C1ZOption {
 	}
 }
 
+// WithV2GrantsWriter toggles the slim-blob writer path for grants.
+// See WithC1FV2GrantsWriter for details.
+func WithV2GrantsWriter(enabled bool) C1ZOption {
+	return func(o *c1zOptions) {
+		o.v2GrantsWriter = enabled
+	}
+}
+
 // Returns a new C1File instance with its state stored at the provided filename.
 func NewC1ZFile(ctx context.Context, outputFilePath string, opts ...C1ZOption) (*C1File, error) {
 	ctx, span := tracer.Start(ctx, "NewC1ZFile")
@@ -281,6 +341,9 @@ func NewC1ZFile(ctx context.Context, outputFilePath string, opts ...C1ZOption) (
 	}
 	if options.skipCleanup {
 		c1fopts = append(c1fopts, WithC1FSkipCleanup(true))
+	}
+	if options.v2GrantsWriter {
+		c1fopts = append(c1fopts, WithC1FV2GrantsWriter(true))
 	}
 
 	c1File, err := NewC1File(ctx, dbFilePath, c1fopts...)

--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -70,24 +70,7 @@ type C1File struct {
 	syncLimit   int
 	skipCleanup bool
 
-	// v2GrantsWriter, when true, causes PutGrants/UpsertGrants to strip
-	// Grant.Entitlement and Grant.Principal from the serialized data blob.
-	// Those fields are reconstituted at read time as minimal stubs built
-	// from the grants row's identity columns (entitlement_id,
-	// resource_type_id, resource_id, principal_resource_type_id,
-	// principal_resource_id) — no joins against v1_entitlements or
-	// v1_resources. Stubs carry identity only (Id + nested Resource.Id);
-	// DisplayName, Annotations, Purpose, Slug, traits, and other rich
-	// fields are zero-value. Readers handle full and slim blobs
-	// transparently per row, so mixed syncs in the same table are
-	// supported.
-	//
-	// Slim is gated per-grant: a grant carrying InsertResourceGrants or
-	// any ExternalResourceMatch* annotation stays full-blob even when
-	// this flag is on, because the syncer reads non-identity fields off
-	// its embedded Resource / Principal. See unsafeForSlim in grants.go.
-	//
-	// Default false; enabled via WithC1FV2GrantsWriter / WithV2GrantsWriter.
+	// See WithC1FV2GrantsWriter.
 	v2GrantsWriter bool
 }
 
@@ -144,31 +127,18 @@ func WithC1FSyncCountLimit(limit int) C1FOption {
 	}
 }
 
-// WithC1FV2GrantsWriter toggles the slim-blob writer path for grants.
-// When true, Grant.Entitlement and Grant.Principal are stripped from
-// the serialized data blob at write time; readers reconstitute them
-// as minimal identity-only stubs (Id + nested Resource.Id) using the
-// grants row's existing columns — no joins against v1_entitlements or
-// v1_resources. Stubs do NOT carry DisplayName, Annotations, Purpose,
-// Slug, traits, or any other non-identity field; callers that need
-// those must fetch the Entitlement / Resource directly via
-// GetEntitlement / GetResource. Default false. Readers always accept
-// both shapes regardless of this flag.
+// WithC1FV2GrantsWriter strips Grant.Entitlement and Grant.Principal
+// from the serialized data blob at write time. Readers rebuild them
+// as identity-only stubs (Id + nested Resource.Id) from the grants
+// row's columns. Stubs carry no DisplayName, Annotations, Purpose,
+// Slug, or traits; callers that need those must fetch the Entitlement
+// or Resource directly. Readers accept both shapes regardless of this
+// flag, so old and new rows coexist. Default false.
 //
-// Slim is gated per-grant: a grant carrying any of these annotations
-// is left full-blob even when the option is on, because downstream
-// sync code reads non-identity fields off its embedded Resource /
-// Principal:
-//
-//   - v2.InsertResourceGrants  (response-level; the syncer copies it
-//     onto each grant in the batch before UpsertGrants)
-//   - v2.ExternalResourceMatchAll
-//   - v2.ExternalResourceMatch
-//   - v2.ExternalResourceMatchID
-//
-// All other grants are eligible for slim. Connectors emitting flat
-// (non-hierarchical) principals and no external-resource matching see
-// every grant slimmed.
+// Per-grant escape hatch: see unsafeForSlim. Grants carrying
+// InsertResourceGrants or any ExternalResourceMatch* annotation stay
+// full-blob — those code paths read non-identity fields off the
+// embedded Resource / Principal.
 func WithC1FV2GrantsWriter(enabled bool) C1FOption {
 	return func(o *C1File) {
 		o.v2GrantsWriter = enabled

--- a/pkg/dotc1z/dotc1z.go
+++ b/pkg/dotc1z/dotc1z.go
@@ -7,7 +7,6 @@ import (
 	"io"
 
 	"go.opentelemetry.io/otel"
-	otelmetric "go.opentelemetry.io/otel/metric"
 	"go.uber.org/zap"
 
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
@@ -15,21 +14,6 @@ import (
 )
 
 var tracer = otel.Tracer("baton-sdk/pkg.dotc1z")
-
-var meter = otel.Meter("baton-sdk/pkg.dotc1z")
-
-// grantHydrateMissCounter counts grant rows where the reader's hydration
-// path could not resolve the Entitlement or Principal fields stripped by
-// the slim-blob writer. Emitted with a "missing" attribute of
-// "entitlement" or "principal". A non-zero count is diagnostic (orphan
-// grant rows already exist in real c1zs today): the reader returns the
-// grant with the nil field intact rather than erroring, so downstream
-// code must tolerate empty Entitlement / Principal.
-var grantHydrateMissCounter, _ = meter.Int64Counter(
-	"baton_sdk.grant_hydrate_miss",
-	otelmetric.WithDescription("Slim-grant rows whose Entitlement or Principal could not be reconstituted from joins."),
-	otelmetric.WithUnit("1"),
-)
 
 // NewC1FileReader returns a connectorstore.Reader implementation for the given sqlite db file path.
 func NewC1FileReader(ctx context.Context, dbFilePath string, opts ...C1FOption) (connectorstore.Reader, error) {

--- a/pkg/dotc1z/dotc1z.go
+++ b/pkg/dotc1z/dotc1z.go
@@ -7,6 +7,7 @@ import (
 	"io"
 
 	"go.opentelemetry.io/otel"
+	otelmetric "go.opentelemetry.io/otel/metric"
 	"go.uber.org/zap"
 
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
@@ -14,6 +15,21 @@ import (
 )
 
 var tracer = otel.Tracer("baton-sdk/pkg.dotc1z")
+
+var meter = otel.Meter("baton-sdk/pkg.dotc1z")
+
+// grantHydrateMissCounter counts grant rows where the reader's hydration
+// path could not resolve the Entitlement or Principal fields stripped by
+// the slim-blob writer. Emitted with a "missing" attribute of
+// "entitlement" or "principal". A non-zero count is diagnostic (orphan
+// grant rows already exist in real c1zs today): the reader returns the
+// grant with the nil field intact rather than erroring, so downstream
+// code must tolerate empty Entitlement / Principal.
+var grantHydrateMissCounter, _ = meter.Int64Counter(
+	"baton_sdk.grant_hydrate_miss",
+	otelmetric.WithDescription("Slim-grant rows whose Entitlement or Principal could not be reconstituted from joins."),
+	otelmetric.WithUnit("1"),
+)
 
 // NewC1FileReader returns a connectorstore.Reader implementation for the given sqlite db file path.
 func NewC1FileReader(ctx context.Context, dbFilePath string, opts ...C1FOption) (connectorstore.Reader, error) {

--- a/pkg/dotc1z/grants.go
+++ b/pkg/dotc1z/grants.go
@@ -3,7 +3,9 @@ package dotc1z
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/doug-martin/goqu/v9"
 	"google.golang.org/protobuf/proto"
@@ -115,7 +117,7 @@ func (c *C1File) ListGrants(ctx context.Context, request *v2.GrantsServiceListGr
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
-	ret, nextPageToken, err := listConnectorObjects(ctx, c, grants.Name(), request, func() *v2.Grant { return &v2.Grant{} })
+	ret, nextPageToken, err := listGrantsGeneric(ctx, c, request)
 	if err != nil {
 		return nil, fmt.Errorf("error listing grants: %w", err)
 	}
@@ -124,6 +126,184 @@ func (c *C1File) ListGrants(ctx context.Context, request *v2.GrantsServiceListGr
 		List:          ret,
 		NextPageToken: nextPageToken,
 	}.Build(), nil
+}
+
+// listGrantsGeneric is the grants-specific list implementation backing
+// ListGrants / ListGrantsFor{Entitlement,Principal,ResourceType}. It
+// mirrors the filter dispatch of the generic listConnectorObjects but
+// pulls sync_id + the three join-key columns (entitlement_id,
+// principal_resource_type_id, principal_resource_id) in the main
+// SELECT so the slim-blob hydration pass does not need a second query
+// and is always scoped to the row's own sync_id.
+//
+// Hydration short-circuits when no row on the page is slim (no nil
+// Entitlement / Principal). When a page spans multiple sync_ids (only
+// possible when the sync_id resolution cascade returns empty, which
+// leaves the query unscoped), rows are grouped by sync_id before
+// hydration so joins never cross a sync boundary.
+func listGrantsGeneric(ctx context.Context, c *C1File, req listRequest) ([]*v2.Grant, string, error) {
+	if err := c.validateDb(ctx); err != nil {
+		return nil, "", err
+	}
+
+	reqSyncID, err := resolveSyncID(ctx, c, req)
+	if err != nil {
+		return nil, "", err
+	}
+
+	tableName := grants.Name()
+	q := c.db.From(tableName).Prepared(true).Select(
+		"id",
+		"data",
+		"sync_id",
+		"entitlement_id",
+		"principal_resource_type_id",
+		"principal_resource_id",
+	)
+
+	// Filter predicates — mirrors listConnectorObjects.
+	if resourceTypeReq, ok := req.(hasResourceTypeListRequest); ok {
+		rt := resourceTypeReq.GetResourceTypeId()
+		if rt != "" {
+			q = q.Where(goqu.C("resource_type_id").Eq(rt))
+		}
+	}
+	if resourceIdReq, ok := req.(hasResourceIdListRequest); ok {
+		r := resourceIdReq.GetResourceId()
+		if r != nil && r.GetResource() != "" {
+			q = q.Where(goqu.C("resource_id").Eq(r.GetResource()))
+			q = q.Where(goqu.C("resource_type_id").Eq(r.GetResourceType()))
+		}
+	}
+	if resourceReq, ok := req.(hasResourceListRequest); ok {
+		r := resourceReq.GetResource()
+		if r != nil {
+			q = q.Where(goqu.C("resource_id").Eq(r.GetId().GetResource()))
+			q = q.Where(goqu.C("resource_type_id").Eq(r.GetId().GetResourceType()))
+		}
+	}
+	if entitlementReq, ok := req.(hasEntitlementListRequest); ok {
+		e := entitlementReq.GetEntitlement()
+		if e != nil {
+			q = q.Where(goqu.C("entitlement_id").Eq(e.GetId()))
+		}
+	}
+	if principalIdReq, ok := req.(hasPrincipalIdListRequest); ok {
+		p := principalIdReq.GetPrincipalId()
+		if p != nil {
+			q = q.Where(goqu.C("principal_resource_id").Eq(p.GetResource()))
+			q = q.Where(goqu.C("principal_resource_type_id").Eq(p.GetResourceType()))
+		}
+	}
+	if principalResourceTypeIDsReq, ok := req.(hasPrincipalResourceTypeIDsListRequest); ok {
+		p := principalResourceTypeIDsReq.GetPrincipalResourceTypeIds()
+		if len(p) > 0 {
+			q = q.Where(goqu.C("principal_resource_type_id").In(p))
+		}
+	}
+
+	if reqSyncID != "" {
+		q = q.Where(goqu.C("sync_id").Eq(reqSyncID))
+	}
+	if req.GetPageToken() != "" {
+		q = q.Where(goqu.C("id").Gte(req.GetPageToken()))
+	}
+
+	pageSize := req.GetPageSize()
+	if pageSize > maxPageSize || pageSize == 0 {
+		pageSize = maxPageSize
+	}
+	q = q.Order(goqu.C("id").Asc()).Limit(uint(pageSize + 1))
+
+	query, args, err := q.ToSQL()
+	if err != nil {
+		return nil, "", err
+	}
+
+	queryStart := time.Now()
+	rows, err := c.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, "", err
+	}
+	if dur := time.Since(queryStart); dur > c.slowQueryThreshold {
+		c.throttledWarnSlowQuery(ctx, query, dur)
+	}
+
+	unmarshal := proto.UnmarshalOptions{Merge: true, DiscardUnknown: true}
+
+	out := make([]*v2.Grant, 0, pageSize)
+	// Slim bookkeeping is only allocated on first slim row observed. On a
+	// pre-slim c1z (every existing tenant today) these stay nil and the
+	// hydration pass is skipped.
+	var slimGrants []*v2.Grant
+	var slimKeys []grantJoinKeys
+	var slimSyncIDs []string
+	var (
+		count   uint32
+		lastRow int
+	)
+	for rows.Next() {
+		count++
+		if count > pageSize {
+			break
+		}
+		var (
+			rowID         int
+			data          []byte
+			rowSyncID     string
+			entID         string
+			principalRTID string
+			principalRID  string
+		)
+		if err := rows.Scan(&rowID, &data, &rowSyncID, &entID, &principalRTID, &principalRID); err != nil {
+			rows.Close()
+			return nil, "", err
+		}
+		lastRow = rowID
+
+		g := &v2.Grant{}
+		if err := unmarshal.Unmarshal(data, g); err != nil {
+			rows.Close()
+			return nil, "", err
+		}
+		out = append(out, g)
+		if g.GetEntitlement() == nil || g.GetPrincipal() == nil {
+			if slimGrants == nil {
+				slimGrants = make([]*v2.Grant, 0, pageSize)
+				slimKeys = make([]grantJoinKeys, 0, pageSize)
+				slimSyncIDs = make([]string, 0, pageSize)
+			}
+			slimGrants = append(slimGrants, g)
+			slimKeys = append(slimKeys, grantJoinKeys{
+				EntitlementID:           entID,
+				PrincipalResourceTypeID: principalRTID,
+				PrincipalResourceID:     principalRID,
+			})
+			slimSyncIDs = append(slimSyncIDs, rowSyncID)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return nil, "", err
+	}
+	// Close rows before hydration: the DB is capped at SetMaxOpenConns(1),
+	// so any follow-up query (batchFetchEntitlements etc.) would deadlock
+	// waiting for the connection this cursor holds.
+	if err := rows.Close(); err != nil {
+		return nil, "", err
+	}
+
+	if len(slimGrants) > 0 {
+		if err := hydrateGrantsGroupedBySync(ctx, c, slimGrants, slimKeys, slimSyncIDs); err != nil {
+			return nil, "", err
+		}
+	}
+
+	nextPageToken := ""
+	if count > pageSize {
+		nextPageToken = strconv.Itoa(lastRow + 1)
+	}
+	return out, nextPageToken, nil
 }
 
 func (c *C1File) GetGrant(ctx context.Context, request *reader_v2.GrantsReaderServiceGetGrantRequest) (*reader_v2.GrantsReaderServiceGetGrantResponse, error) {
@@ -141,9 +321,53 @@ func (c *C1File) GetGrant(ctx context.Context, request *reader_v2.GrantsReaderSe
 		return nil, fmt.Errorf("error fetching grant '%s': %w", request.GetGrantId(), err)
 	}
 
+	// Hydrate Entitlement / Principal when the row was written by the
+	// slim-blob writer. Non-slim rows short-circuit. We re-resolve the
+	// sync id with the same cascade getConnectorObject used so the
+	// join-key lookup hits the same row.
+	if ret.GetEntitlement() == nil || ret.GetPrincipal() == nil {
+		resolvedSyncID, rerr := c.resolveSyncIDForGrantGet(ctx, syncId)
+		if rerr != nil {
+			return nil, fmt.Errorf("error resolving sync id for grant '%s': %w", request.GetGrantId(), rerr)
+		}
+		if herr := hydrateSingleGrant(ctx, c, resolvedSyncID, ret); herr != nil {
+			return nil, fmt.Errorf("error hydrating grant '%s': %w", request.GetGrantId(), herr)
+		}
+	}
+
 	return reader_v2.GrantsReaderServiceGetGrantResponse_builder{
 		Grant: ret,
 	}.Build(), nil
+}
+
+// resolveSyncIDForGrantGet mirrors the sync_id resolution cascade used
+// by getConnectorObject: explicit > currentSyncID > viewSyncID > latest
+// finished > latest unfinished. Needed so slim-grant hydration after
+// GetGrant queries the same row getConnectorObject saw.
+func (c *C1File) resolveSyncIDForGrantGet(ctx context.Context, explicit string) (string, error) {
+	if explicit != "" {
+		return explicit, nil
+	}
+	if c.currentSyncID != "" {
+		return c.currentSyncID, nil
+	}
+	if c.viewSyncID != "" {
+		return c.viewSyncID, nil
+	}
+	latestSyncRun, err := c.getFinishedSync(ctx, 0, connectorstore.SyncTypeAny)
+	if err != nil {
+		return "", err
+	}
+	if latestSyncRun == nil {
+		latestSyncRun, err = c.getLatestUnfinishedSync(ctx, connectorstore.SyncTypeAny)
+		if err != nil {
+			return "", err
+		}
+	}
+	if latestSyncRun == nil {
+		return "", nil
+	}
+	return latestSyncRun.ID, nil
 }
 
 func (c *C1File) ListGrantsForEntitlement(
@@ -153,7 +377,7 @@ func (c *C1File) ListGrantsForEntitlement(
 	ctx, span := tracer.Start(ctx, "C1File.ListGrantsForEntitlement")
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
-	ret, nextPageToken, err := listConnectorObjects(ctx, c, grants.Name(), request, func() *v2.Grant { return &v2.Grant{} })
+	ret, nextPageToken, err := listGrantsGeneric(ctx, c, request)
 	if err != nil {
 		return nil, fmt.Errorf("error listing grants for entitlement '%s': %w", request.GetEntitlement().GetId(), err)
 	}
@@ -172,7 +396,7 @@ func (c *C1File) ListGrantsForPrincipal(
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
-	ret, nextPageToken, err := listConnectorObjects(ctx, c, grants.Name(), request, func() *v2.Grant { return &v2.Grant{} })
+	ret, nextPageToken, err := listGrantsGeneric(ctx, c, request)
 	if err != nil {
 		return nil, fmt.Errorf("error listing grants for principal '%s': %w", request.GetPrincipalId(), err)
 	}
@@ -191,7 +415,7 @@ func (c *C1File) ListGrantsForResourceType(
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
-	ret, nextPageToken, err := listConnectorObjects(ctx, c, grants.Name(), request, func() *v2.Grant { return &v2.Grant{} })
+	ret, nextPageToken, err := listGrantsGeneric(ctx, c, request)
 	if err != nil {
 		return nil, fmt.Errorf("error listing grants for resource type '%s': %w", request.GetResourceTypeId(), err)
 	}
@@ -253,21 +477,45 @@ func baseGrantRecord(grant *v2.Grant) goqu.Record {
 	}
 }
 
-func grantExtractFields(mode connectorstore.GrantUpsertMode) func(grant *v2.Grant) (goqu.Record, error) {
+func grantExtractFields(c *C1File, mode connectorstore.GrantUpsertMode) func(grant *v2.Grant) (goqu.Record, error) {
 	return func(grant *v2.Grant) (goqu.Record, error) {
 		rec := baseGrantRecord(grant)
-		if mode == connectorstore.GrantUpsertModePreserveExpansion {
+		slim := c.v2GrantsWriter
+		preserveExpansion := mode == connectorstore.GrantUpsertModePreserveExpansion
+
+		// PreserveExpansion mode does not touch the expansion / needs_expansion
+		// columns — the UPSERT's ON CONFLICT branch keeps existing values. The
+		// data blob still needs to be slimmed when the writer option is on,
+		// otherwise slim-writer tenants would silently store full blobs for
+		// every grant that came through the expander (the majority for
+		// group-grant-heavy tenants).
+		if preserveExpansion {
+			if !slim {
+				return rec, nil
+			}
+			stripped := proto.Clone(grant).(*v2.Grant)
+			slimGrantForWrite(stripped)
+			data, err := protoMarshaler.Marshal(stripped)
+			if err != nil {
+				return nil, fmt.Errorf("error marshaling slim grant (PreserveExpansion): %w", err)
+			}
+			rec["data"] = data
 			return rec, nil
 		}
 
-		if !hasGrantExpandable(grant) {
+		hasExp := hasGrantExpandable(grant)
+		if !hasExp && !slim {
 			rec["expansion"] = nil
 			rec["needs_expansion"] = false
 			return rec, nil
 		}
 
 		stripped := proto.Clone(grant).(*v2.Grant)
-		expansionBytes, needsExpansion := extractAndStripExpansion(stripped)
+		var expansionBytes []byte
+		var needsExpansion bool
+		if hasExp {
+			expansionBytes, needsExpansion = extractAndStripExpansion(stripped)
+		}
 		// Use untyped nil for SQL NULL to avoid driver-specific []byte(nil)->X'' coercion.
 		if expansionBytes == nil {
 			rec["expansion"] = nil
@@ -276,13 +524,31 @@ func grantExtractFields(mode connectorstore.GrantUpsertMode) func(grant *v2.Gran
 		}
 		rec["needs_expansion"] = needsExpansion
 
+		if slim {
+			slimGrantForWrite(stripped)
+		}
+
 		strippedData, err := protoMarshaler.Marshal(stripped)
 		if err != nil {
-			return nil, fmt.Errorf("error marshaling grant after stripping expansion: %w", err)
+			return nil, fmt.Errorf("error marshaling grant: %w", err)
 		}
 		rec["data"] = strippedData
 		return rec, nil
 	}
+}
+
+// slimGrantForWrite zeroes Grant.Entitlement and Grant.Principal on a
+// cloned grant before it is marshaled into the data blob. The reader
+// reconstitutes both fields from v1_entitlements / v1_resources using
+// the grant row's indexed columns (entitlement_id, principal_resource_type_id,
+// principal_resource_id, sync_id).
+//
+// Grant.Id is intentionally NOT zeroed — keeping it costs ~40 B/grant (vs.
+// ~390 B savings from the two message fields) and avoids routing hydration
+// through the generic single-row getConnectorObject path that backs GetGrant.
+func slimGrantForWrite(grant *v2.Grant) {
+	grant.SetEntitlement(nil)
+	grant.SetPrincipal(nil)
 }
 
 func upsertGrantsInternal(
@@ -302,7 +568,7 @@ func upsertGrantsInternal(
 		return err
 	}
 
-	rows, err := prepareConnectorObjectRows(c, msgs, grantExtractFields(mode))
+	rows, err := prepareConnectorObjectRows(c, msgs, grantExtractFields(c, mode))
 	if err != nil {
 		return err
 	}

--- a/pkg/dotc1z/grants.go
+++ b/pkg/dotc1z/grants.go
@@ -2,6 +2,7 @@ package dotc1z
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"strconv"
 	"strings"
@@ -155,8 +156,9 @@ func listGrantsGeneric(ctx context.Context, c *C1File, req listRequest) ([]*v2.G
 	q := c.db.From(tableName).Prepared(true).Select(
 		"id",
 		"data",
-		"sync_id",
 		"entitlement_id",
+		"resource_type_id",
+		"resource_id",
 		"principal_resource_type_id",
 		"principal_resource_id",
 	)
@@ -225,6 +227,7 @@ func listGrantsGeneric(ctx context.Context, c *C1File, req listRequest) ([]*v2.G
 	if err != nil {
 		return nil, "", err
 	}
+	defer rows.Close()
 	if dur := time.Since(queryStart); dur > c.slowQueryThreshold {
 		c.throttledWarnSlowQuery(ctx, query, dur)
 	}
@@ -237,33 +240,35 @@ func listGrantsGeneric(ctx context.Context, c *C1File, req listRequest) ([]*v2.G
 	// hydration pass is skipped.
 	var slimGrants []*v2.Grant
 	var slimKeys []grantJoinKeys
-	var slimSyncIDs []string
+	// Hoist scan destinations out of the loop. data and the five identity
+	// columns use sql.RawBytes so the SQLite driver writes back into the
+	// same buffer each iteration instead of allocating a fresh []byte /
+	// string per row. We materialize Go strings only when a slim row
+	// triggers hydration bookkeeping (string(b) copies into a Go-managed
+	// buffer before the next rows.Scan invalidates the source).
 	var (
-		count   uint32
-		lastRow int
+		rowID          int
+		data           sql.RawBytes
+		entIDRaw       sql.RawBytes
+		entRTRaw       sql.RawBytes
+		entRRaw        sql.RawBytes
+		principalRTRaw sql.RawBytes
+		principalRRaw  sql.RawBytes
+		count          uint32
+		lastRow        int
 	)
 	for rows.Next() {
 		count++
 		if count > pageSize {
 			break
 		}
-		var (
-			rowID         int
-			data          []byte
-			rowSyncID     string
-			entID         string
-			principalRTID string
-			principalRID  string
-		)
-		if err := rows.Scan(&rowID, &data, &rowSyncID, &entID, &principalRTID, &principalRID); err != nil {
-			rows.Close()
+		if err := rows.Scan(&rowID, &data, &entIDRaw, &entRTRaw, &entRRaw, &principalRTRaw, &principalRRaw); err != nil {
 			return nil, "", err
 		}
 		lastRow = rowID
 
 		g := &v2.Grant{}
 		if err := unmarshal.Unmarshal(data, g); err != nil {
-			rows.Close()
 			return nil, "", err
 		}
 		out = append(out, g)
@@ -271,32 +276,23 @@ func listGrantsGeneric(ctx context.Context, c *C1File, req listRequest) ([]*v2.G
 			if slimGrants == nil {
 				slimGrants = make([]*v2.Grant, 0, pageSize)
 				slimKeys = make([]grantJoinKeys, 0, pageSize)
-				slimSyncIDs = make([]string, 0, pageSize)
 			}
 			slimGrants = append(slimGrants, g)
 			slimKeys = append(slimKeys, grantJoinKeys{
-				EntitlementID:           entID,
-				PrincipalResourceTypeID: principalRTID,
-				PrincipalResourceID:     principalRID,
+				EntitlementID:             string(entIDRaw),
+				EntitlementResourceTypeID: string(entRTRaw),
+				EntitlementResourceID:     string(entRRaw),
+				PrincipalResourceTypeID:   string(principalRTRaw),
+				PrincipalResourceID:       string(principalRRaw),
 			})
-			slimSyncIDs = append(slimSyncIDs, rowSyncID)
 		}
 	}
 	if err := rows.Err(); err != nil {
-		rows.Close()
-		return nil, "", err
-	}
-	// Close rows before hydration: the DB is capped at SetMaxOpenConns(1),
-	// so any follow-up query (batchFetchEntitlements etc.) would deadlock
-	// waiting for the connection this cursor holds.
-	if err := rows.Close(); err != nil {
 		return nil, "", err
 	}
 
 	if len(slimGrants) > 0 {
-		if err := hydrateGrantsGroupedBySync(ctx, c, slimGrants, slimKeys, slimSyncIDs); err != nil {
-			return nil, "", err
-		}
+		hydrateGrants(slimGrants, slimKeys)
 	}
 
 	nextPageToken := ""

--- a/pkg/dotc1z/grants.go
+++ b/pkg/dotc1z/grants.go
@@ -473,10 +473,42 @@ func baseGrantRecord(grant *v2.Grant) goqu.Record {
 	}
 }
 
+// unsafeForSlim returns true when a grant carries an annotation that
+// implies downstream code (in baton-sdk's syncer) reads non-identity
+// fields off the grant's embedded Entitlement.Resource or Principal.
+// Slimming such grants would silently corrupt those code paths:
+//
+//   - InsertResourceGrants: the syncer extracts grant.Entitlement.Resource
+//     and writes it to v1_resources via PutResources (syncer.go:1731-1737).
+//     Identity-only stubs from a slim re-read would overwrite the
+//     resources table with stripped data on etag-replay.
+//   - ExternalResourceMatch{All,Match,ID}: processGrantsWithExternalPrincipals
+//     uses bid.MakeBid(grant.GetPrincipal()) for a key lookup whose map
+//     keys encode ParentResourceId when set. A slim stub principal has
+//     no parent; its 2-part bid misses 4-part map keys, silently losing
+//     transitive expansion through the external-resource match.
+//
+// Note that InsertResourceGrants is canonically a response-level
+// annotation; the syncer copies it onto each grant's annotations
+// before UpsertGrants so the writer can see it per-row. The other
+// three are emitted by connectors directly on the grant.
+func unsafeForSlim(grant *v2.Grant) bool {
+	annos := annotations.Annotations(grant.GetAnnotations())
+	return annos.ContainsAny(
+		&v2.InsertResourceGrants{},
+		&v2.ExternalResourceMatchAll{},
+		&v2.ExternalResourceMatch{},
+		&v2.ExternalResourceMatchID{},
+	)
+}
+
 func grantExtractFields(c *C1File, mode connectorstore.GrantUpsertMode) func(grant *v2.Grant) (goqu.Record, error) {
 	return func(grant *v2.Grant) (goqu.Record, error) {
 		rec := baseGrantRecord(grant)
-		slim := c.v2GrantsWriter
+		// Gate slim per-grant: skip slim when the grant carries an
+		// annotation that implies the embedded Entitlement.Resource or
+		// Principal is read for non-identity fields downstream.
+		slim := c.v2GrantsWriter && !unsafeForSlim(grant)
 		preserveExpansion := mode == connectorstore.GrantUpsertModePreserveExpansion
 
 		// PreserveExpansion mode does not touch the expansion / needs_expansion

--- a/pkg/dotc1z/grants.go
+++ b/pkg/dotc1z/grants.go
@@ -2,8 +2,11 @@ package dotc1z
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/doug-martin/goqu/v9"
 	"google.golang.org/protobuf/proto"
@@ -11,6 +14,7 @@ import (
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	reader_v2 "github.com/conductorone/baton-sdk/pb/c1/reader/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
 	"github.com/conductorone/baton-sdk/pkg/uotel"
 )
 
@@ -114,7 +118,7 @@ func (c *C1File) ListGrants(ctx context.Context, request *v2.GrantsServiceListGr
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
-	ret, nextPageToken, err := listConnectorObjects(ctx, c, grants.Name(), request, func() *v2.Grant { return &v2.Grant{} })
+	ret, nextPageToken, err := listGrantsGeneric(ctx, c, request)
 	if err != nil {
 		return nil, fmt.Errorf("error listing grants: %w", err)
 	}
@@ -123,6 +127,175 @@ func (c *C1File) ListGrants(ctx context.Context, request *v2.GrantsServiceListGr
 		List:          ret,
 		NextPageToken: nextPageToken,
 	}.Build(), nil
+}
+
+// listGrantsGeneric is the grants-specific list implementation backing
+// ListGrants / ListGrantsFor{Entitlement,Principal,ResourceType}. It
+// mirrors the filter dispatch of the generic listConnectorObjects but
+// pulls the join-key columns (entitlement_id, resource_type_id,
+// resource_id, principal_resource_type_id, principal_resource_id) in
+// the main SELECT so the slim-blob hydration pass can construct
+// identity-only stubs from the row itself without a second query.
+//
+// Hydration short-circuits when no row on the page is slim (no nil
+// Entitlement / Principal). For slim rows, hydrateGrants populates
+// Entitlement and Principal from the join-key columns directly.
+func listGrantsGeneric(ctx context.Context, c *C1File, req listRequest) ([]*v2.Grant, string, error) {
+	if err := c.validateDb(ctx); err != nil {
+		return nil, "", err
+	}
+
+	reqSyncID, err := resolveSyncID(ctx, c, req)
+	if err != nil {
+		return nil, "", err
+	}
+
+	tableName := grants.Name()
+	q := c.db.From(tableName).Prepared(true).Select(
+		"id",
+		"data",
+		"entitlement_id",
+		"resource_type_id",
+		"resource_id",
+		"principal_resource_type_id",
+		"principal_resource_id",
+	)
+
+	// Filter predicates — mirrors listConnectorObjects.
+	if resourceTypeReq, ok := req.(hasResourceTypeListRequest); ok {
+		rt := resourceTypeReq.GetResourceTypeId()
+		if rt != "" {
+			q = q.Where(goqu.C("resource_type_id").Eq(rt))
+		}
+	}
+	if resourceIdReq, ok := req.(hasResourceIdListRequest); ok {
+		r := resourceIdReq.GetResourceId()
+		if r != nil && r.GetResource() != "" {
+			q = q.Where(goqu.C("resource_id").Eq(r.GetResource()))
+			q = q.Where(goqu.C("resource_type_id").Eq(r.GetResourceType()))
+		}
+	}
+	if resourceReq, ok := req.(hasResourceListRequest); ok {
+		r := resourceReq.GetResource()
+		if r != nil {
+			q = q.Where(goqu.C("resource_id").Eq(r.GetId().GetResource()))
+			q = q.Where(goqu.C("resource_type_id").Eq(r.GetId().GetResourceType()))
+		}
+	}
+	if entitlementReq, ok := req.(hasEntitlementListRequest); ok {
+		e := entitlementReq.GetEntitlement()
+		if e != nil {
+			q = q.Where(goqu.C("entitlement_id").Eq(e.GetId()))
+		}
+	}
+	if principalIdReq, ok := req.(hasPrincipalIdListRequest); ok {
+		p := principalIdReq.GetPrincipalId()
+		if p != nil {
+			q = q.Where(goqu.C("principal_resource_id").Eq(p.GetResource()))
+			q = q.Where(goqu.C("principal_resource_type_id").Eq(p.GetResourceType()))
+		}
+	}
+	if principalResourceTypeIDsReq, ok := req.(hasPrincipalResourceTypeIDsListRequest); ok {
+		p := principalResourceTypeIDsReq.GetPrincipalResourceTypeIds()
+		if len(p) > 0 {
+			q = q.Where(goqu.C("principal_resource_type_id").In(p))
+		}
+	}
+
+	if reqSyncID != "" {
+		q = q.Where(goqu.C("sync_id").Eq(reqSyncID))
+	}
+	if req.GetPageToken() != "" {
+		q = q.Where(goqu.C("id").Gte(req.GetPageToken()))
+	}
+
+	pageSize := req.GetPageSize()
+	if pageSize > maxPageSize || pageSize == 0 {
+		pageSize = maxPageSize
+	}
+	q = q.Order(goqu.C("id").Asc()).Limit(uint(pageSize + 1))
+
+	query, args, err := q.ToSQL()
+	if err != nil {
+		return nil, "", err
+	}
+
+	queryStart := time.Now()
+	rows, err := c.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, "", err
+	}
+	defer rows.Close()
+	if dur := time.Since(queryStart); dur > c.slowQueryThreshold {
+		c.throttledWarnSlowQuery(ctx, query, dur)
+	}
+
+	unmarshal := proto.UnmarshalOptions{Merge: true, DiscardUnknown: true}
+
+	// Output and slim bookkeeping slices stay nil and grow via append
+	// rather than being pre-sized to maxPageSize (10000). For 1-row
+	// queries (e.g. ListGrantsForPrincipal) the cap-hint allocation
+	// dominated the per-query cost; at scale append's doubling-grow
+	// is amortized against the per-row proto unmarshal.
+	var out []*v2.Grant
+	var slimGrants []*v2.Grant
+	var slimKeys []grantJoinKeys
+	// Hoist scan destinations out of the loop. data and the five identity
+	// columns use sql.RawBytes so the SQLite driver writes back into the
+	// same buffer each iteration instead of allocating a fresh []byte /
+	// string per row. We materialize Go strings only when a slim row
+	// triggers hydration bookkeeping (string(b) copies into a Go-managed
+	// buffer before the next rows.Scan invalidates the source).
+	var (
+		rowID          int
+		data           sql.RawBytes
+		entIDRaw       sql.RawBytes
+		entRTRaw       sql.RawBytes
+		entRRaw        sql.RawBytes
+		principalRTRaw sql.RawBytes
+		principalRRaw  sql.RawBytes
+		count          uint32
+		lastRow        int
+	)
+	for rows.Next() {
+		count++
+		if count > pageSize {
+			break
+		}
+		if err := rows.Scan(&rowID, &data, &entIDRaw, &entRTRaw, &entRRaw, &principalRTRaw, &principalRRaw); err != nil {
+			return nil, "", err
+		}
+		lastRow = rowID
+
+		g := &v2.Grant{}
+		if err := unmarshal.Unmarshal(data, g); err != nil {
+			return nil, "", err
+		}
+		out = append(out, g)
+		if g.GetEntitlement() == nil || g.GetPrincipal() == nil {
+			slimGrants = append(slimGrants, g)
+			slimKeys = append(slimKeys, grantJoinKeys{
+				EntitlementID:             string(entIDRaw),
+				EntitlementResourceTypeID: string(entRTRaw),
+				EntitlementResourceID:     string(entRRaw),
+				PrincipalResourceTypeID:   string(principalRTRaw),
+				PrincipalResourceID:       string(principalRRaw),
+			})
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, "", err
+	}
+
+	if len(slimGrants) > 0 {
+		hydrateGrants(slimGrants, slimKeys)
+	}
+
+	nextPageToken := ""
+	if count > pageSize {
+		nextPageToken = strconv.Itoa(lastRow + 1)
+	}
+	return out, nextPageToken, nil
 }
 
 func (c *C1File) GetGrant(ctx context.Context, request *reader_v2.GrantsReaderServiceGetGrantRequest) (*reader_v2.GrantsReaderServiceGetGrantResponse, error) {
@@ -140,9 +313,53 @@ func (c *C1File) GetGrant(ctx context.Context, request *reader_v2.GrantsReaderSe
 		return nil, fmt.Errorf("error fetching grant '%s': %w", request.GetGrantId(), err)
 	}
 
+	// Hydrate Entitlement / Principal when the row was written by the
+	// slim-blob writer. Non-slim rows short-circuit. We re-resolve the
+	// sync id with the same cascade getConnectorObject used so the
+	// join-key lookup hits the same row.
+	if ret.GetEntitlement() == nil || ret.GetPrincipal() == nil {
+		resolvedSyncID, rerr := c.resolveSyncIDForGrantGet(ctx, syncId)
+		if rerr != nil {
+			return nil, fmt.Errorf("error resolving sync id for grant '%s': %w", request.GetGrantId(), rerr)
+		}
+		if herr := hydrateSingleGrant(ctx, c, resolvedSyncID, ret); herr != nil {
+			return nil, fmt.Errorf("error hydrating grant '%s': %w", request.GetGrantId(), herr)
+		}
+	}
+
 	return reader_v2.GrantsReaderServiceGetGrantResponse_builder{
 		Grant: ret,
 	}.Build(), nil
+}
+
+// resolveSyncIDForGrantGet mirrors the sync_id resolution cascade used
+// by getConnectorObject: explicit > currentSyncID > viewSyncID > latest
+// finished > latest unfinished. Needed so slim-grant hydration after
+// GetGrant queries the same row getConnectorObject saw.
+func (c *C1File) resolveSyncIDForGrantGet(ctx context.Context, explicit string) (string, error) {
+	if explicit != "" {
+		return explicit, nil
+	}
+	if c.currentSyncID != "" {
+		return c.currentSyncID, nil
+	}
+	if c.viewSyncID != "" {
+		return c.viewSyncID, nil
+	}
+	latestSyncRun, err := c.getFinishedSync(ctx, 0, connectorstore.SyncTypeAny)
+	if err != nil {
+		return "", err
+	}
+	if latestSyncRun == nil {
+		latestSyncRun, err = c.getLatestUnfinishedSync(ctx, connectorstore.SyncTypeAny)
+		if err != nil {
+			return "", err
+		}
+	}
+	if latestSyncRun == nil {
+		return "", nil
+	}
+	return latestSyncRun.ID, nil
 }
 
 func (c *C1File) ListGrantsForEntitlement(
@@ -152,7 +369,7 @@ func (c *C1File) ListGrantsForEntitlement(
 	ctx, span := tracer.Start(ctx, "C1File.ListGrantsForEntitlement")
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
-	ret, nextPageToken, err := listConnectorObjects(ctx, c, grants.Name(), request, func() *v2.Grant { return &v2.Grant{} })
+	ret, nextPageToken, err := listGrantsGeneric(ctx, c, request)
 	if err != nil {
 		return nil, fmt.Errorf("error listing grants for entitlement '%s': %w", request.GetEntitlement().GetId(), err)
 	}
@@ -171,7 +388,7 @@ func (c *C1File) ListGrantsForPrincipal(
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
-	ret, nextPageToken, err := listConnectorObjects(ctx, c, grants.Name(), request, func() *v2.Grant { return &v2.Grant{} })
+	ret, nextPageToken, err := listGrantsGeneric(ctx, c, request)
 	if err != nil {
 		return nil, fmt.Errorf("error listing grants for principal '%s': %w", request.GetPrincipalId(), err)
 	}
@@ -190,7 +407,7 @@ func (c *C1File) ListGrantsForResourceType(
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
-	ret, nextPageToken, err := listConnectorObjects(ctx, c, grants.Name(), request, func() *v2.Grant { return &v2.Grant{} })
+	ret, nextPageToken, err := listGrantsGeneric(ctx, c, request)
 	if err != nil {
 		return nil, fmt.Errorf("error listing grants for resource type '%s': %w", request.GetResourceTypeId(), err)
 	}
@@ -257,21 +474,84 @@ func baseGrantRecord(grant *v2.Grant) goqu.Record {
 	}
 }
 
-func grantExtractFields(mode grantUpsertMode) func(grant *v2.Grant) (goqu.Record, error) {
+// Sentinels for unsafeForSlim's membership check. Hoisted to package
+// scope so the gate doesn't allocate four zero-value protos per grant
+// on every UpsertGrants call.
+var (
+	unsafeForSlimSentinels = []proto.Message{
+		&v2.InsertResourceGrants{},
+		&v2.ExternalResourceMatchAll{},
+		&v2.ExternalResourceMatch{},
+		&v2.ExternalResourceMatchID{},
+	}
+)
+
+// unsafeForSlim returns true when a grant carries an annotation that
+// implies downstream code (in baton-sdk's syncer) reads non-identity
+// fields off the grant's embedded Entitlement.Resource or Principal.
+// Slimming such grants would silently corrupt those code paths:
+//
+//   - InsertResourceGrants: the syncer extracts grant.Entitlement.Resource
+//     and writes it to v1_resources via PutResources (syncer.go:1731-1737).
+//     Identity-only stubs from a slim re-read would overwrite the
+//     resources table with stripped data on etag-replay.
+//   - ExternalResourceMatch{All,Match,ID}: processGrantsWithExternalPrincipals
+//     uses bid.MakeBid(grant.GetPrincipal()) for a key lookup whose map
+//     keys encode ParentResourceId when set. A slim stub principal has
+//     no parent; its 2-part bid misses 4-part map keys, silently losing
+//     transitive expansion through the external-resource match.
+//
+// Note that InsertResourceGrants is canonically a response-level
+// annotation; the syncer copies it onto each grant's annotations
+// before UpsertGrants so the writer can see it per-row. The other
+// three are emitted by connectors directly on the grant.
+func unsafeForSlim(grant *v2.Grant) bool {
+	annos := annotations.Annotations(grant.GetAnnotations())
+	return annos.ContainsAny(unsafeForSlimSentinels...)
+}
+
+func grantExtractFields(c *C1File, mode grantUpsertMode) func(grant *v2.Grant) (goqu.Record, error) {
 	return func(grant *v2.Grant) (goqu.Record, error) {
 		rec := baseGrantRecord(grant)
-		if mode == grantUpsertModePreserveExpansion {
+		// Gate slim per-grant: skip slim when the grant carries an
+		// annotation that implies the embedded Entitlement.Resource or
+		// Principal is read for non-identity fields downstream.
+		slim := c.v2GrantsWriter && !unsafeForSlim(grant)
+		preserveExpansion := mode == grantUpsertModePreserveExpansion
+
+		// PreserveExpansion mode does not touch the expansion / needs_expansion
+		// columns — the UPSERT's ON CONFLICT branch keeps existing values. The
+		// data blob still needs to be slimmed when the writer option is on,
+		// otherwise slim-writer tenants would silently store full blobs for
+		// every grant that came through the expander (the majority for
+		// group-grant-heavy tenants).
+		if preserveExpansion {
+			if !slim {
+				return rec, nil
+			}
+			stripped := proto.Clone(grant).(*v2.Grant)
+			slimGrantForWrite(stripped)
+			data, err := protoMarshaler.Marshal(stripped)
+			if err != nil {
+				return nil, fmt.Errorf("error marshaling slim grant (PreserveExpansion): %w", err)
+			}
+			rec["data"] = data
 			return rec, nil
 		}
 
-		if !hasGrantExpandable(grant) {
+		hasExp := hasGrantExpandable(grant)
+		if !hasExp && !slim {
 			rec["expansion"] = nil
 			rec["needs_expansion"] = false
 			return rec, nil
 		}
 
 		stripped := proto.Clone(grant).(*v2.Grant)
-		expansionBytes, needsExpansion := extractAndStripExpansion(stripped)
+		var expansionBytes []byte
+		var needsExpansion bool
+		if hasExp {
+			expansionBytes, needsExpansion = extractAndStripExpansion(stripped)
+		}
 		// Use untyped nil for SQL NULL to avoid driver-specific []byte(nil)->X'' coercion.
 		if expansionBytes == nil {
 			rec["expansion"] = nil
@@ -280,13 +560,32 @@ func grantExtractFields(mode grantUpsertMode) func(grant *v2.Grant) (goqu.Record
 		}
 		rec["needs_expansion"] = needsExpansion
 
+		if slim {
+			slimGrantForWrite(stripped)
+		}
+
 		strippedData, err := protoMarshaler.Marshal(stripped)
 		if err != nil {
-			return nil, fmt.Errorf("error marshaling grant after stripping expansion: %w", err)
+			return nil, fmt.Errorf("error marshaling grant: %w", err)
 		}
 		rec["data"] = strippedData
 		return rec, nil
 	}
+}
+
+// slimGrantForWrite zeroes Grant.Entitlement and Grant.Principal on a
+// cloned grant before it is marshaled into the data blob. The reader
+// reconstitutes both fields as identity-only stubs from the grant
+// row's own columns (entitlement_id, resource_type_id, resource_id,
+// principal_resource_type_id, principal_resource_id). See
+// hydrateGrants in grants_hydrate.go.
+//
+// Grant.Id is intentionally NOT zeroed — keeping it costs ~40 B/grant (vs.
+// ~390 B savings from the two message fields) and avoids routing hydration
+// through the generic single-row getConnectorObject path that backs GetGrant.
+func slimGrantForWrite(grant *v2.Grant) {
+	grant.SetEntitlement(nil)
+	grant.SetPrincipal(nil)
 }
 
 func upsertGrantsInternal(
@@ -306,7 +605,7 @@ func upsertGrantsInternal(
 		return err
 	}
 
-	rows, err := prepareConnectorObjectRows(c, msgs, grantExtractFields(mode))
+	rows, err := prepareConnectorObjectRows(c, msgs, grantExtractFields(c, mode))
 	if err != nil {
 		return err
 	}

--- a/pkg/dotc1z/grants.go
+++ b/pkg/dotc1z/grants.go
@@ -129,17 +129,8 @@ func (c *C1File) ListGrants(ctx context.Context, request *v2.GrantsServiceListGr
 	}.Build(), nil
 }
 
-// listGrantsGeneric is the grants-specific list implementation backing
-// ListGrants / ListGrantsFor{Entitlement,Principal,ResourceType}. It
-// mirrors the filter dispatch of the generic listConnectorObjects but
-// pulls the join-key columns (entitlement_id, resource_type_id,
-// resource_id, principal_resource_type_id, principal_resource_id) in
-// the main SELECT so the slim-blob hydration pass can construct
-// identity-only stubs from the row itself without a second query.
-//
-// Hydration short-circuits when no row on the page is slim (no nil
-// Entitlement / Principal). For slim rows, hydrateGrants populates
-// Entitlement and Principal from the join-key columns directly.
+// listGrantsGeneric pulls the grant identity columns inline so slim-blob
+// rows can be hydrated without a second query.
 func listGrantsGeneric(ctx context.Context, c *C1File, req listRequest) ([]*v2.Grant, string, error) {
 	if err := c.validateDb(ctx); err != nil {
 		return nil, "", err
@@ -235,12 +226,6 @@ func listGrantsGeneric(ctx context.Context, c *C1File, req listRequest) ([]*v2.G
 	var out []*v2.Grant
 	var slimGrants []*v2.Grant
 	var slimKeys []grantJoinKeys
-	// Hoist scan destinations out of the loop. data and the five identity
-	// columns use sql.RawBytes so the SQLite driver writes back into the
-	// same buffer each iteration instead of allocating a fresh []byte /
-	// string per row. We materialize Go strings only when a slim row
-	// triggers hydration bookkeeping (string(b) copies into a Go-managed
-	// buffer before the next rows.Scan invalidates the source).
 	var (
 		rowID          int
 		data           sql.RawBytes
@@ -308,10 +293,8 @@ func (c *C1File) GetGrant(ctx context.Context, request *reader_v2.GrantsReaderSe
 		return nil, fmt.Errorf("error fetching grant '%s': %w", request.GetGrantId(), err)
 	}
 
-	// Hydrate Entitlement / Principal when the row was written by the
-	// slim-blob writer. Non-slim rows short-circuit. We re-resolve the
-	// sync id with the same cascade getConnectorObject used so the
-	// join-key lookup hits the same row.
+	// Re-resolve sync_id with the same cascade as getConnectorObject so
+	// hydration hits the same row.
 	if ret.GetEntitlement() == nil || ret.GetPrincipal() == nil {
 		resolvedSyncID, rerr := c.resolveSyncIDForGrantGet(ctx, syncId)
 		if rerr != nil {
@@ -327,10 +310,8 @@ func (c *C1File) GetGrant(ctx context.Context, request *reader_v2.GrantsReaderSe
 	}.Build(), nil
 }
 
-// resolveSyncIDForGrantGet mirrors the sync_id resolution cascade used
-// by getConnectorObject: explicit > currentSyncID > viewSyncID > latest
-// finished > latest unfinished. Needed so slim-grant hydration after
-// GetGrant queries the same row getConnectorObject saw.
+// resolveSyncIDForGrantGet mirrors getConnectorObject's sync_id cascade
+// so slim-grant hydration queries the same row.
 func (c *C1File) resolveSyncIDForGrantGet(ctx context.Context, explicit string) (string, error) {
 	if explicit != "" {
 		return explicit, nil
@@ -469,9 +450,8 @@ func baseGrantRecord(grant *v2.Grant) goqu.Record {
 	}
 }
 
-// Sentinels for unsafeForSlim's membership check. Hoisted to package
-// scope so the gate doesn't allocate four zero-value protos per grant
-// on every UpsertGrants call.
+// Hoisted so the per-grant gate doesn't allocate four zero-value
+// protos per UpsertGrants call.
 var (
 	unsafeForSlimSentinels = []proto.Message{
 		&v2.InsertResourceGrants{},
@@ -481,25 +461,18 @@ var (
 	}
 )
 
-// unsafeForSlim returns true when a grant carries an annotation that
-// implies downstream code (in baton-sdk's syncer) reads non-identity
-// fields off the grant's embedded Entitlement.Resource or Principal.
-// Slimming such grants would silently corrupt those code paths:
+// unsafeForSlim returns true when a grant's annotations imply the
+// syncer reads non-identity fields off its embedded Entitlement.Resource
+// or Principal. Slimming silently corrupts those paths.
 //
-//   - InsertResourceGrants: the syncer extracts grant.Entitlement.Resource
-//     and writes it to v1_resources via PutResources (syncer.go:1731-1737).
-//     Identity-only stubs from a slim re-read would overwrite the
-//     resources table with stripped data on etag-replay.
-//   - ExternalResourceMatch{All,Match,ID}: processGrantsWithExternalPrincipals
-//     uses bid.MakeBid(grant.GetPrincipal()) for a key lookup whose map
-//     keys encode ParentResourceId when set. A slim stub principal has
-//     no parent; its 2-part bid misses 4-part map keys, silently losing
-//     transitive expansion through the external-resource match.
+// InsertResourceGrants — the syncer extracts grant.Entitlement.Resource
+// and writes it to v1_resources via PutResources. Stubs would overwrite
+// the resources table with stripped data on etag-replay.
 //
-// Note that InsertResourceGrants is canonically a response-level
-// annotation; the syncer copies it onto each grant's annotations
-// before UpsertGrants so the writer can see it per-row. The other
-// three are emitted by connectors directly on the grant.
+// ExternalResourceMatch{All,Match,ID} — processGrantsWithExternalPrincipals
+// builds a bid key from grant.GetPrincipal() that encodes ParentResourceId.
+// A slim stub principal has no parent, so its bid misses keys and loses
+// transitive expansion through the external-resource match.
 func unsafeForSlim(grant *v2.Grant) bool {
 	annos := annotations.Annotations(grant.GetAnnotations())
 	return annos.ContainsAny(unsafeForSlimSentinels...)
@@ -508,18 +481,12 @@ func unsafeForSlim(grant *v2.Grant) bool {
 func grantExtractFields(c *C1File, mode grantUpsertMode) func(grant *v2.Grant) (goqu.Record, error) {
 	return func(grant *v2.Grant) (goqu.Record, error) {
 		rec := baseGrantRecord(grant)
-		// Gate slim per-grant: skip slim when the grant carries an
-		// annotation that implies the embedded Entitlement.Resource or
-		// Principal is read for non-identity fields downstream.
 		slim := c.v2GrantsWriter && !unsafeForSlim(grant)
 		preserveExpansion := mode == grantUpsertModePreserveExpansion
 
-		// PreserveExpansion mode does not touch the expansion / needs_expansion
-		// columns — the UPSERT's ON CONFLICT branch keeps existing values. The
-		// data blob still needs to be slimmed when the writer option is on,
-		// otherwise slim-writer tenants would silently store full blobs for
-		// every grant that came through the expander (the majority for
-		// group-grant-heavy tenants).
+		// PreserveExpansion still must slim the data blob — otherwise
+		// expanded grants (the majority for group-heavy tenants) silently
+		// stay full-blob.
 		if preserveExpansion {
 			if !slim {
 				return rec, nil
@@ -568,16 +535,8 @@ func grantExtractFields(c *C1File, mode grantUpsertMode) func(grant *v2.Grant) (
 	}
 }
 
-// slimGrantForWrite zeroes Grant.Entitlement and Grant.Principal on a
-// cloned grant before it is marshaled into the data blob. The reader
-// reconstitutes both fields as identity-only stubs from the grant
-// row's own columns (entitlement_id, resource_type_id, resource_id,
-// principal_resource_type_id, principal_resource_id). See
-// hydrateGrants in grants_hydrate.go.
-//
-// Grant.Id is intentionally NOT zeroed — keeping it costs ~40 B/grant (vs.
-// ~390 B savings from the two message fields) and avoids routing hydration
-// through the generic single-row getConnectorObject path that backs GetGrant.
+// Id is intentionally kept — stripping it would force GetGrant through
+// the slow generic single-row hydration path.
 func slimGrantForWrite(grant *v2.Grant) {
 	grant.SetEntitlement(nil)
 	grant.SetPrincipal(nil)

--- a/pkg/dotc1z/grants.go
+++ b/pkg/dotc1z/grants.go
@@ -227,7 +227,7 @@ func listGrantsGeneric(ctx context.Context, c *C1File, req listRequest) ([]*v2.G
 	var slimGrants []*v2.Grant
 	var slimKeys []grantJoinKeys
 	var (
-		rowID          int
+		rowID          int64
 		data           sql.RawBytes
 		entIDRaw       sql.RawBytes
 		entRTRaw       sql.RawBytes
@@ -235,7 +235,7 @@ func listGrantsGeneric(ctx context.Context, c *C1File, req listRequest) ([]*v2.G
 		principalRTRaw sql.RawBytes
 		principalRRaw  sql.RawBytes
 		count          uint32
-		lastRow        int
+		lastRow        int64
 	)
 	for rows.Next() {
 		count++
@@ -273,7 +273,7 @@ func listGrantsGeneric(ctx context.Context, c *C1File, req listRequest) ([]*v2.G
 
 	nextPageToken := ""
 	if count > pageSize {
-		nextPageToken = strconv.Itoa(lastRow + 1)
+		nextPageToken = strconv.FormatInt(lastRow+1, 10)
 	}
 	return out, nextPageToken, nil
 }

--- a/pkg/dotc1z/grants.go
+++ b/pkg/dotc1z/grants.go
@@ -232,11 +232,6 @@ func listGrantsGeneric(ctx context.Context, c *C1File, req listRequest) ([]*v2.G
 
 	unmarshal := proto.UnmarshalOptions{Merge: true, DiscardUnknown: true}
 
-	// Output and slim bookkeeping slices stay nil and grow via append
-	// rather than being pre-sized to maxPageSize (10000). For 1-row
-	// queries (e.g. ListGrantsForPrincipal) the cap-hint allocation
-	// dominated the per-query cost; at scale append's doubling-grow
-	// is amortized against the per-row proto unmarshal.
 	var out []*v2.Grant
 	var slimGrants []*v2.Grant
 	var slimKeys []grantJoinKeys

--- a/pkg/dotc1z/grants_bench_test.go
+++ b/pkg/dotc1z/grants_bench_test.go
@@ -14,8 +14,11 @@ import (
 
 var grantCounts = []int{100, 1000, 10000, 100000}
 
-// setupBenchmarkDB creates a test database with the specified number of grants.
-func setupBenchmarkDB(b *testing.B, numGrants int) (*C1File, string, func()) {
+// setupBenchmarkDB creates a test database with the specified number of
+// grants. When slim=true, the slim-blob writer is enabled; reads must
+// then go through the hydration path to reconstitute Entitlement /
+// Principal.
+func setupBenchmarkDB(b *testing.B, numGrants int, slim bool) (*C1File, string, func()) {
 	b.Helper()
 
 	ctx := b.Context()
@@ -28,6 +31,9 @@ func setupBenchmarkDB(b *testing.B, numGrants int) (*C1File, string, func()) {
 		WithTmpDir(tempDir),
 		WithEncoderConcurrency(0),
 		WithDecoderOptions(WithDecoderConcurrency(0)),
+	}
+	if slim {
+		opts = append(opts, WithV2GrantsWriter(true))
 	}
 
 	f, err := NewC1ZFile(ctx, testFilePath, opts...)
@@ -98,44 +104,99 @@ func setupBenchmarkDB(b *testing.B, numGrants int) (*C1File, string, func()) {
 
 // BenchmarkListGrantsForEntitlement benchmarks ListGrantsForEntitlement filtered by an entitlement.
 func BenchmarkListGrantsForEntitlement(b *testing.B) {
-	for _, numGrants := range grantCounts {
-		b.Run(fmt.Sprintf("grants=%d", numGrants), func(b *testing.B) {
-			f, entitlementID, cleanup := setupBenchmarkDB(b, numGrants)
-			defer cleanup()
+	for _, slim := range []bool{false, true} {
+		writer := "full"
+		if slim {
+			writer = "slim"
+		}
+		for _, numGrants := range grantCounts {
+			b.Run(fmt.Sprintf("writer=%s/grants=%d", writer, numGrants), func(b *testing.B) {
+				f, entitlementID, cleanup := setupBenchmarkDB(b, numGrants, slim)
+				defer cleanup()
 
-			ctx := b.Context()
+				ctx := b.Context()
 
-			// Get the entitlement for the request
-			entResp, err := f.GetEntitlement(ctx, reader_v2.EntitlementsReaderServiceGetEntitlementRequest_builder{
-				EntitlementId: entitlementID,
-			}.Build())
-			require.NoError(b, err)
+				entResp, err := f.GetEntitlement(ctx, reader_v2.EntitlementsReaderServiceGetEntitlementRequest_builder{
+					EntitlementId: entitlementID,
+				}.Build())
+				require.NoError(b, err)
 
-			req := reader_v2.GrantsReaderServiceListGrantsForEntitlementRequest_builder{
-				Entitlement: entResp.GetEntitlement(),
-			}.Build()
+				req := reader_v2.GrantsReaderServiceListGrantsForEntitlementRequest_builder{
+					Entitlement: entResp.GetEntitlement(),
+				}.Build()
 
-			b.ReportAllocs()
+				b.ReportAllocs()
 
-			for b.Loop() {
-				pageToken := ""
-				totalGrants := 0
-				for {
-					req.SetPageToken(pageToken)
-					resp, err := f.ListGrantsForEntitlement(ctx, req)
-					if err != nil {
-						b.Fatal(err)
+				for b.Loop() {
+					pageToken := ""
+					totalGrants := 0
+					for {
+						req.SetPageToken(pageToken)
+						resp, err := f.ListGrantsForEntitlement(ctx, req)
+						if err != nil {
+							b.Fatal(err)
+						}
+						totalGrants += len(resp.GetList())
+						pageToken = resp.GetNextPageToken()
+						if pageToken == "" {
+							break
+						}
 					}
-					totalGrants += len(resp.GetList())
-					pageToken = resp.GetNextPageToken()
-					if pageToken == "" {
-						break
+					if totalGrants != numGrants {
+						b.Fatalf("expected %d grants, got %d", numGrants, totalGrants)
 					}
 				}
-				if totalGrants != numGrants {
-					b.Fatalf("expected %d grants, got %d", numGrants, totalGrants)
+			})
+		}
+	}
+}
+
+// BenchmarkListGrantsInternal_PayloadWithExpansion mirrors the c1 uplift read
+// path: c1 wraps the SDK in fileClientWrapper.ListGrants, which routes to
+// ListGrantsInternal(GrantListModePayloadWithExpansion) so expansion
+// annotations are preserved on the returned grants. This is the hottest
+// read path on the c1 side at scale (uplift reads every grant in a c1z),
+// and the one most affected by the slim-blob hydration changes.
+//
+// Run with both writer modes so we can measure the hydration cost vs. the
+// pre-slim full-blob baseline.
+func BenchmarkListGrantsInternal_PayloadWithExpansion(b *testing.B) {
+	for _, slim := range []bool{false, true} {
+		writer := "full"
+		if slim {
+			writer = "slim"
+		}
+		for _, numGrants := range grantCounts {
+			b.Run(fmt.Sprintf("writer=%s/grants=%d", writer, numGrants), func(b *testing.B) {
+				f, _, cleanup := setupBenchmarkDB(b, numGrants, slim)
+				defer cleanup()
+
+				ctx := b.Context()
+
+				b.ReportAllocs()
+
+				for b.Loop() {
+					pageToken := ""
+					totalGrants := 0
+					for {
+						resp, err := f.ListGrantsInternal(ctx, connectorstore.GrantListOptions{
+							Mode:      connectorstore.GrantListModePayloadWithExpansion,
+							PageToken: pageToken,
+						})
+						if err != nil {
+							b.Fatal(err)
+						}
+						totalGrants += len(resp.Rows)
+						pageToken = resp.NextPageToken
+						if pageToken == "" {
+							break
+						}
+					}
+					if totalGrants != numGrants {
+						b.Fatalf("expected %d grants, got %d", numGrants, totalGrants)
+					}
 				}
-			}
-		})
+			})
+		}
 	}
 }

--- a/pkg/dotc1z/grants_bench_test.go
+++ b/pkg/dotc1z/grants_bench_test.go
@@ -14,8 +14,11 @@ import (
 
 var grantCounts = []int{100, 1000, 10000, 100000}
 
-// setupBenchmarkDB creates a test database with the specified number of grants.
-func setupBenchmarkDB(b *testing.B, numGrants int) (*C1File, string, func()) {
+// setupBenchmarkDB creates a test database with the specified number of
+// grants. When slim=true, the slim-blob writer is enabled; reads must
+// then go through the hydration path to reconstitute Entitlement /
+// Principal.
+func setupBenchmarkDB(b *testing.B, numGrants int, slim bool) (*C1File, string, func()) {
 	b.Helper()
 
 	ctx := b.Context()
@@ -28,6 +31,9 @@ func setupBenchmarkDB(b *testing.B, numGrants int) (*C1File, string, func()) {
 		WithTmpDir(tempDir),
 		WithEncoderConcurrency(0),
 		WithDecoderOptions(WithDecoderConcurrency(0)),
+	}
+	if slim {
+		opts = append(opts, WithV2GrantsWriter(true))
 	}
 
 	f, err := NewC1ZFile(ctx, testFilePath, opts...)
@@ -98,44 +104,97 @@ func setupBenchmarkDB(b *testing.B, numGrants int) (*C1File, string, func()) {
 
 // BenchmarkListGrantsForEntitlement benchmarks ListGrantsForEntitlement filtered by an entitlement.
 func BenchmarkListGrantsForEntitlement(b *testing.B) {
-	for _, numGrants := range grantCounts {
-		b.Run(fmt.Sprintf("grants=%d", numGrants), func(b *testing.B) {
-			f, entitlementID, cleanup := setupBenchmarkDB(b, numGrants)
-			defer cleanup()
+	for _, slim := range []bool{false, true} {
+		writer := "full"
+		if slim {
+			writer = "slim"
+		}
+		for _, numGrants := range grantCounts {
+			b.Run(fmt.Sprintf("writer=%s/grants=%d", writer, numGrants), func(b *testing.B) {
+				f, entitlementID, cleanup := setupBenchmarkDB(b, numGrants, slim)
+				defer cleanup()
 
-			ctx := b.Context()
+				ctx := b.Context()
 
-			// Get the entitlement for the request
-			entResp, err := f.GetEntitlement(ctx, reader_v2.EntitlementsReaderServiceGetEntitlementRequest_builder{
-				EntitlementId: entitlementID,
-			}.Build())
-			require.NoError(b, err)
+				entResp, err := f.GetEntitlement(ctx, reader_v2.EntitlementsReaderServiceGetEntitlementRequest_builder{
+					EntitlementId: entitlementID,
+				}.Build())
+				require.NoError(b, err)
 
-			req := reader_v2.GrantsReaderServiceListGrantsForEntitlementRequest_builder{
-				Entitlement: entResp.GetEntitlement(),
-			}.Build()
+				req := reader_v2.GrantsReaderServiceListGrantsForEntitlementRequest_builder{
+					Entitlement: entResp.GetEntitlement(),
+				}.Build()
 
-			b.ReportAllocs()
+				b.ReportAllocs()
 
-			for b.Loop() {
-				pageToken := ""
-				totalGrants := 0
-				for {
-					req.SetPageToken(pageToken)
-					resp, err := f.ListGrantsForEntitlement(ctx, req)
-					if err != nil {
-						b.Fatal(err)
+				for b.Loop() {
+					pageToken := ""
+					totalGrants := 0
+					for {
+						req.SetPageToken(pageToken)
+						resp, err := f.ListGrantsForEntitlement(ctx, req)
+						if err != nil {
+							b.Fatal(err)
+						}
+						totalGrants += len(resp.GetList())
+						pageToken = resp.GetNextPageToken()
+						if pageToken == "" {
+							break
+						}
 					}
-					totalGrants += len(resp.GetList())
-					pageToken = resp.GetNextPageToken()
-					if pageToken == "" {
-						break
+					if totalGrants != numGrants {
+						b.Fatalf("expected %d grants, got %d", numGrants, totalGrants)
 					}
 				}
-				if totalGrants != numGrants {
-					b.Fatalf("expected %d grants, got %d", numGrants, totalGrants)
+			})
+		}
+	}
+}
+
+// BenchmarkListGrantsInternal_PayloadWithExpansion mirrors the c1 uplift read
+// path: c1 wraps the SDK in fileClientWrapper.ListGrants, which routes to
+// the GrantStore.ListWithAnnotationsPage path (post-RFC-0002 replacement
+// for ListGrantsInternal(PayloadWithExpansion)) so expansion annotations
+// are preserved on the returned grants. This is the hottest read path on
+// the c1 side at scale (uplift reads every grant in a c1z), and the one
+// most affected by the slim-blob hydration changes.
+//
+// Run with both writer modes so we can measure the hydration cost vs. the
+// pre-slim full-blob baseline.
+func BenchmarkListGrantsInternal_PayloadWithExpansion(b *testing.B) {
+	for _, slim := range []bool{false, true} {
+		writer := "full"
+		if slim {
+			writer = "slim"
+		}
+		for _, numGrants := range grantCounts {
+			b.Run(fmt.Sprintf("writer=%s/grants=%d", writer, numGrants), func(b *testing.B) {
+				f, _, cleanup := setupBenchmarkDB(b, numGrants, slim)
+				defer cleanup()
+
+				ctx := b.Context()
+
+				b.ReportAllocs()
+
+				for b.Loop() {
+					pageToken := ""
+					totalGrants := 0
+					for {
+						rows, nextPageToken, err := f.Grants().ListWithAnnotationsPage(ctx, pageToken)
+						if err != nil {
+							b.Fatal(err)
+						}
+						totalGrants += len(rows)
+						pageToken = nextPageToken
+						if pageToken == "" {
+							break
+						}
+					}
+					if totalGrants != numGrants {
+						b.Fatalf("expected %d grants, got %d", numGrants, totalGrants)
+					}
 				}
-			}
-		})
+			})
+		}
 	}
 }

--- a/pkg/dotc1z/grants_expandable_query.go
+++ b/pkg/dotc1z/grants_expandable_query.go
@@ -189,6 +189,8 @@ func (c *C1File) listGrantsWithExpansionInternal(ctx context.Context, opts conne
 			"data",
 			"external_id",
 			"entitlement_id",
+			"resource_type_id",
+			"resource_id",
 			"principal_resource_type_id",
 			"principal_resource_id",
 			"expansion",
@@ -230,15 +232,31 @@ func (c *C1File) listGrantsWithExpansionInternal(ctx context.Context, opts conne
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 
 	unmarshalerOptions := proto.UnmarshalOptions{
 		Merge:          true,
 		DiscardUnknown: true,
 	}
 
+	// Hoist scan destinations and reuse RawBytes buffers across rows so the
+	// SQLite driver doesn't allocate fresh slices/strings every iteration.
+	// Strings are only materialized when we need them downstream (expansion
+	// def populated, or slim row triggers hydration bookkeeping); RawBytes
+	// contents are invalidated on the next rows.Scan.
 	var (
-		count   uint32
-		lastRow int64
+		rowID          int64
+		grantData      sql.RawBytes
+		externalIDRaw  sql.RawBytes
+		entIDRaw       sql.RawBytes
+		entRTRaw       sql.RawBytes
+		entRRaw        sql.RawBytes
+		principalRTRaw sql.RawBytes
+		principalRRaw  sql.RawBytes
+		expansionBlob  sql.RawBytes
+		needsExp       int
+		count          uint32
+		lastRow        int64
 	)
 	result := make([]*connectorstore.InternalGrantRow, 0, pageSize)
 	// Only populated when a slim row is observed — on pre-slim c1zs
@@ -254,34 +272,24 @@ func (c *C1File) listGrantsWithExpansionInternal(ctx context.Context, opts conne
 			break
 		}
 
-		var (
-			rowID         int64
-			grantData     []byte
-			externalID    string
-			entID         string
-			principalRTID string
-			principalRID  string
-			expansionBlob []byte
-			needsExp      int
-		)
 		if err := rows.Scan(
 			&rowID,
 			&grantData,
-			&externalID,
-			&entID,
-			&principalRTID,
-			&principalRID,
+			&externalIDRaw,
+			&entIDRaw,
+			&entRTRaw,
+			&entRRaw,
+			&principalRTRaw,
+			&principalRRaw,
 			&expansionBlob,
 			&needsExp,
 		); err != nil {
-			rows.Close()
 			return nil, err
 		}
 		lastRow = rowID
 
 		grant := &v2.Grant{}
 		if err := unmarshalerOptions.Unmarshal(grantData, grant); err != nil {
-			rows.Close()
 			return nil, err
 		}
 
@@ -289,14 +297,13 @@ func (c *C1File) listGrantsWithExpansionInternal(ctx context.Context, opts conne
 		if len(expansionBlob) > 0 {
 			ge := &v2.GrantExpandable{}
 			if err := proto.Unmarshal(expansionBlob, ge); err != nil {
-				rows.Close()
-				return nil, fmt.Errorf("failed to unmarshal grant expansion for %s: %w", externalID, err)
+				return nil, fmt.Errorf("failed to unmarshal grant expansion for %s: %w", string(externalIDRaw), err)
 			}
 			expansion = &connectorstore.ExpandableGrantDef{
-				GrantExternalID:         externalID,
-				TargetEntitlementID:     entID,
-				PrincipalResourceTypeID: principalRTID,
-				PrincipalResourceID:     principalRID,
+				GrantExternalID:         string(externalIDRaw),
+				TargetEntitlementID:     string(entIDRaw),
+				PrincipalResourceTypeID: string(principalRTRaw),
+				PrincipalResourceID:     string(principalRRaw),
 				SourceEntitlementIDs:    ge.GetEntitlementIds(),
 				Shallow:                 ge.GetShallow(),
 				ResourceTypeIDs:         ge.GetResourceTypeIds(),
@@ -316,26 +323,20 @@ func (c *C1File) listGrantsWithExpansionInternal(ctx context.Context, opts conne
 			}
 			pageGrants = append(pageGrants, grant)
 			pageKeys = append(pageKeys, grantJoinKeys{
-				EntitlementID:           entID,
-				PrincipalResourceTypeID: principalRTID,
-				PrincipalResourceID:     principalRID,
+				EntitlementID:             string(entIDRaw),
+				EntitlementResourceTypeID: string(entRTRaw),
+				EntitlementResourceID:     string(entRRaw),
+				PrincipalResourceTypeID:   string(principalRTRaw),
+				PrincipalResourceID:       string(principalRRaw),
 			})
 		}
 	}
 	if err := rows.Err(); err != nil {
-		rows.Close()
-		return nil, err
-	}
-	// Close rows before hydration to release the pooled SQLite connection —
-	// SetMaxOpenConns(1) would otherwise deadlock any follow-up query.
-	if err := rows.Close(); err != nil {
 		return nil, err
 	}
 
 	if sawSlim {
-		if err := hydrateGrants(ctx, c, syncID, pageGrants, pageKeys); err != nil {
-			return nil, err
-		}
+		hydrateGrants(pageGrants, pageKeys)
 	}
 
 	nextPageToken := ""
@@ -363,6 +364,8 @@ func (c *C1File) listGrantsPayloadInternal(ctx context.Context, opts connectorst
 		"id",
 		"data",
 		"entitlement_id",
+		"resource_type_id",
+		"resource_id",
 		"principal_resource_type_id",
 		"principal_resource_id",
 	)
@@ -395,6 +398,7 @@ func (c *C1File) listGrantsPayloadInternal(ctx context.Context, opts connectorst
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 
 	unmarshalerOptions := proto.UnmarshalOptions{
 		Merge:          true,
@@ -403,10 +407,21 @@ func (c *C1File) listGrantsPayloadInternal(ctx context.Context, opts connectorst
 	result := make([]*connectorstore.InternalGrantRow, 0, pageSize)
 	var pageGrants []*v2.Grant
 	var pageKeys []grantJoinKeys
+	// Hoist scan destinations out of the loop and use sql.RawBytes for the
+	// per-row data + the five identity columns. The driver reuses the
+	// same buffer each iteration; we only allocate Go strings when a slim
+	// row triggers hydration bookkeeping.
 	var (
-		count   uint32
-		lastRow int64
-		sawSlim bool
+		rowID          int64
+		grantData      sql.RawBytes
+		entIDRaw       sql.RawBytes
+		entRTRaw       sql.RawBytes
+		entRRaw        sql.RawBytes
+		principalRTRaw sql.RawBytes
+		principalRRaw  sql.RawBytes
+		count          uint32
+		lastRow        int64
+		sawSlim        bool
 	)
 	for rows.Next() {
 		count++
@@ -414,22 +429,13 @@ func (c *C1File) listGrantsPayloadInternal(ctx context.Context, opts connectorst
 			break
 		}
 
-		var (
-			rowID         int64
-			grantData     []byte
-			entID         string
-			principalRTID string
-			principalRID  string
-		)
-		if err := rows.Scan(&rowID, &grantData, &entID, &principalRTID, &principalRID); err != nil {
-			rows.Close()
+		if err := rows.Scan(&rowID, &grantData, &entIDRaw, &entRTRaw, &entRRaw, &principalRTRaw, &principalRRaw); err != nil {
 			return nil, err
 		}
 		lastRow = rowID
 
 		grant := &v2.Grant{}
 		if err := unmarshalerOptions.Unmarshal(grantData, grant); err != nil {
-			rows.Close()
 			return nil, err
 		}
 		result = append(result, &connectorstore.InternalGrantRow{Grant: grant})
@@ -441,26 +447,20 @@ func (c *C1File) listGrantsPayloadInternal(ctx context.Context, opts connectorst
 			}
 			pageGrants = append(pageGrants, grant)
 			pageKeys = append(pageKeys, grantJoinKeys{
-				EntitlementID:           entID,
-				PrincipalResourceTypeID: principalRTID,
-				PrincipalResourceID:     principalRID,
+				EntitlementID:             string(entIDRaw),
+				EntitlementResourceTypeID: string(entRTRaw),
+				EntitlementResourceID:     string(entRRaw),
+				PrincipalResourceTypeID:   string(principalRTRaw),
+				PrincipalResourceID:       string(principalRRaw),
 			})
 		}
 	}
 	if err := rows.Err(); err != nil {
-		rows.Close()
-		return nil, err
-	}
-	// Release the pooled connection before hydration — see comment in
-	// listGrantsWithExpansionInternal above.
-	if err := rows.Close(); err != nil {
 		return nil, err
 	}
 
 	if sawSlim {
-		if err := hydrateGrants(ctx, c, syncID, pageGrants, pageKeys); err != nil {
-			return nil, err
-		}
+		hydrateGrants(pageGrants, pageKeys)
 	}
 
 	nextPageToken := ""

--- a/pkg/dotc1z/grants_expandable_query.go
+++ b/pkg/dotc1z/grants_expandable_query.go
@@ -230,7 +230,6 @@ func (c *C1File) listGrantsWithExpansionInternal(ctx context.Context, opts conne
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
 
 	unmarshalerOptions := proto.UnmarshalOptions{
 		Merge:          true,
@@ -242,6 +241,12 @@ func (c *C1File) listGrantsWithExpansionInternal(ctx context.Context, opts conne
 		lastRow int64
 	)
 	result := make([]*connectorstore.InternalGrantRow, 0, pageSize)
+	// Only populated when a slim row is observed — on pre-slim c1zs
+	// (every existing tenant today) these slices stay nil and the
+	// hydration pass is skipped entirely.
+	var pageGrants []*v2.Grant
+	var pageKeys []grantJoinKeys
+	var sawSlim bool
 
 	for rows.Next() {
 		count++
@@ -269,12 +274,14 @@ func (c *C1File) listGrantsWithExpansionInternal(ctx context.Context, opts conne
 			&expansionBlob,
 			&needsExp,
 		); err != nil {
+			rows.Close()
 			return nil, err
 		}
 		lastRow = rowID
 
 		grant := &v2.Grant{}
 		if err := unmarshalerOptions.Unmarshal(grantData, grant); err != nil {
+			rows.Close()
 			return nil, err
 		}
 
@@ -282,6 +289,7 @@ func (c *C1File) listGrantsWithExpansionInternal(ctx context.Context, opts conne
 		if len(expansionBlob) > 0 {
 			ge := &v2.GrantExpandable{}
 			if err := proto.Unmarshal(expansionBlob, ge); err != nil {
+				rows.Close()
 				return nil, fmt.Errorf("failed to unmarshal grant expansion for %s: %w", externalID, err)
 			}
 			expansion = &connectorstore.ExpandableGrantDef{
@@ -300,9 +308,34 @@ func (c *C1File) listGrantsWithExpansionInternal(ctx context.Context, opts conne
 			Grant:     grant,
 			Expansion: expansion,
 		})
+		if grant.GetEntitlement() == nil || grant.GetPrincipal() == nil {
+			if !sawSlim {
+				pageGrants = make([]*v2.Grant, 0, pageSize)
+				pageKeys = make([]grantJoinKeys, 0, pageSize)
+				sawSlim = true
+			}
+			pageGrants = append(pageGrants, grant)
+			pageKeys = append(pageKeys, grantJoinKeys{
+				EntitlementID:           entID,
+				PrincipalResourceTypeID: principalRTID,
+				PrincipalResourceID:     principalRID,
+			})
+		}
 	}
 	if err := rows.Err(); err != nil {
+		rows.Close()
 		return nil, err
+	}
+	// Close rows before hydration to release the pooled SQLite connection —
+	// SetMaxOpenConns(1) would otherwise deadlock any follow-up query.
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+
+	if sawSlim {
+		if err := hydrateGrants(ctx, c, syncID, pageGrants, pageKeys); err != nil {
+			return nil, err
+		}
 	}
 
 	nextPageToken := ""
@@ -326,7 +359,13 @@ func (c *C1File) listGrantsPayloadInternal(ctx context.Context, opts connectorst
 		return nil, err
 	}
 
-	q := c.db.From(grants.Name()).Prepared(true).Select("id", "data")
+	q := c.db.From(grants.Name()).Prepared(true).Select(
+		"id",
+		"data",
+		"entitlement_id",
+		"principal_resource_type_id",
+		"principal_resource_id",
+	)
 	if opts.Resource != nil {
 		q = q.Where(goqu.C("resource_id").Eq(opts.Resource.GetId().GetResource()))
 		q = q.Where(goqu.C("resource_type_id").Eq(opts.Resource.GetId().GetResourceType()))
@@ -356,16 +395,18 @@ func (c *C1File) listGrantsPayloadInternal(ctx context.Context, opts connectorst
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
 
 	unmarshalerOptions := proto.UnmarshalOptions{
 		Merge:          true,
 		DiscardUnknown: true,
 	}
 	result := make([]*connectorstore.InternalGrantRow, 0, pageSize)
+	var pageGrants []*v2.Grant
+	var pageKeys []grantJoinKeys
 	var (
 		count   uint32
 		lastRow int64
+		sawSlim bool
 	)
 	for rows.Next() {
 		count++
@@ -374,22 +415,52 @@ func (c *C1File) listGrantsPayloadInternal(ctx context.Context, opts connectorst
 		}
 
 		var (
-			rowID     int64
-			grantData []byte
+			rowID         int64
+			grantData     []byte
+			entID         string
+			principalRTID string
+			principalRID  string
 		)
-		if err := rows.Scan(&rowID, &grantData); err != nil {
+		if err := rows.Scan(&rowID, &grantData, &entID, &principalRTID, &principalRID); err != nil {
+			rows.Close()
 			return nil, err
 		}
 		lastRow = rowID
 
 		grant := &v2.Grant{}
 		if err := unmarshalerOptions.Unmarshal(grantData, grant); err != nil {
+			rows.Close()
 			return nil, err
 		}
 		result = append(result, &connectorstore.InternalGrantRow{Grant: grant})
+		if grant.GetEntitlement() == nil || grant.GetPrincipal() == nil {
+			if !sawSlim {
+				pageGrants = make([]*v2.Grant, 0, pageSize)
+				pageKeys = make([]grantJoinKeys, 0, pageSize)
+				sawSlim = true
+			}
+			pageGrants = append(pageGrants, grant)
+			pageKeys = append(pageKeys, grantJoinKeys{
+				EntitlementID:           entID,
+				PrincipalResourceTypeID: principalRTID,
+				PrincipalResourceID:     principalRID,
+			})
+		}
 	}
 	if err := rows.Err(); err != nil {
+		rows.Close()
 		return nil, err
+	}
+	// Release the pooled connection before hydration — see comment in
+	// listGrantsWithExpansionInternal above.
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+
+	if sawSlim {
+		if err := hydrateGrants(ctx, c, syncID, pageGrants, pageKeys); err != nil {
+			return nil, err
+		}
 	}
 
 	nextPageToken := ""

--- a/pkg/dotc1z/grants_expandable_query.go
+++ b/pkg/dotc1z/grants_expandable_query.go
@@ -226,10 +226,6 @@ func (c *C1File) listGrantsWithExpansionInternal(ctx context.Context, opts grant
 		count          uint32
 		lastRow        int64
 	)
-	// Result and slim-row bookkeeping start nil and grow via append.
-	// Pre-sizing to maxPageSize is wasteful for queries that return
-	// few rows; at scale append's doubling-grow is amortized against
-	// per-row proto unmarshal.
 	var result []*internalGrantRow
 	var pageGrants []*v2.Grant
 	var pageKeys []grantJoinKeys

--- a/pkg/dotc1z/grants_expandable_query.go
+++ b/pkg/dotc1z/grants_expandable_query.go
@@ -207,11 +207,6 @@ func (c *C1File) listGrantsWithExpansionInternal(ctx context.Context, opts grant
 		DiscardUnknown: true,
 	}
 
-	// Hoist scan destinations and reuse RawBytes buffers across rows so the
-	// SQLite driver doesn't allocate fresh slices/strings every iteration.
-	// Strings are only materialized when we need them downstream (expansion
-	// def populated, or slim row triggers hydration bookkeeping); RawBytes
-	// contents are invalidated on the next rows.Scan.
 	var (
 		rowID          int64
 		grantData      sql.RawBytes

--- a/pkg/dotc1z/grants_expandable_query.go
+++ b/pkg/dotc1z/grants_expandable_query.go
@@ -157,6 +157,8 @@ func (c *C1File) listGrantsWithExpansionInternal(ctx context.Context, opts grant
 			"data",
 			"external_id",
 			"entitlement_id",
+			"resource_type_id",
+			"resource_id",
 			"principal_resource_type_id",
 			"principal_resource_id",
 			"expansion",
@@ -205,11 +207,32 @@ func (c *C1File) listGrantsWithExpansionInternal(ctx context.Context, opts grant
 		DiscardUnknown: true,
 	}
 
+	// Hoist scan destinations and reuse RawBytes buffers across rows so the
+	// SQLite driver doesn't allocate fresh slices/strings every iteration.
+	// Strings are only materialized when we need them downstream (expansion
+	// def populated, or slim row triggers hydration bookkeeping); RawBytes
+	// contents are invalidated on the next rows.Scan.
 	var (
-		count   uint32
-		lastRow int64
+		rowID          int64
+		grantData      sql.RawBytes
+		externalIDRaw  sql.RawBytes
+		entIDRaw       sql.RawBytes
+		entRTRaw       sql.RawBytes
+		entRRaw        sql.RawBytes
+		principalRTRaw sql.RawBytes
+		principalRRaw  sql.RawBytes
+		expansionBlob  sql.RawBytes
+		needsExp       int
+		count          uint32
+		lastRow        int64
 	)
-	result := make([]*internalGrantRow, 0, pageSize)
+	// Result and slim-row bookkeeping start nil and grow via append.
+	// Pre-sizing to maxPageSize is wasteful for queries that return
+	// few rows; at scale append's doubling-grow is amortized against
+	// per-row proto unmarshal.
+	var result []*internalGrantRow
+	var pageGrants []*v2.Grant
+	var pageKeys []grantJoinKeys
 
 	for rows.Next() {
 		count++
@@ -217,23 +240,15 @@ func (c *C1File) listGrantsWithExpansionInternal(ctx context.Context, opts grant
 			break
 		}
 
-		var (
-			rowID         int64
-			grantData     []byte
-			externalID    string
-			entID         string
-			principalRTID string
-			principalRID  string
-			expansionBlob []byte
-			needsExp      int
-		)
 		if err := rows.Scan(
 			&rowID,
 			&grantData,
-			&externalID,
-			&entID,
-			&principalRTID,
-			&principalRID,
+			&externalIDRaw,
+			&entIDRaw,
+			&entRTRaw,
+			&entRRaw,
+			&principalRTRaw,
+			&principalRRaw,
 			&expansionBlob,
 			&needsExp,
 		); err != nil {
@@ -250,13 +265,13 @@ func (c *C1File) listGrantsWithExpansionInternal(ctx context.Context, opts grant
 		if len(expansionBlob) > 0 {
 			ge := &v2.GrantExpandable{}
 			if err := proto.Unmarshal(expansionBlob, ge); err != nil {
-				return nil, fmt.Errorf("failed to unmarshal grant expansion for %s: %w", externalID, err)
+				return nil, fmt.Errorf("failed to unmarshal grant expansion for %s: %w", string(externalIDRaw), err)
 			}
 			expansion = &expandableGrantDef{
-				GrantExternalID:         externalID,
-				TargetEntitlementID:     entID,
-				PrincipalResourceTypeID: principalRTID,
-				PrincipalResourceID:     principalRID,
+				GrantExternalID:         string(externalIDRaw),
+				TargetEntitlementID:     string(entIDRaw),
+				PrincipalResourceTypeID: string(principalRTRaw),
+				PrincipalResourceID:     string(principalRRaw),
 				SourceEntitlementIDs:    ge.GetEntitlementIds(),
 				Shallow:                 ge.GetShallow(),
 				ResourceTypeIDs:         ge.GetResourceTypeIds(),
@@ -268,9 +283,23 @@ func (c *C1File) listGrantsWithExpansionInternal(ctx context.Context, opts grant
 			Grant:     grant,
 			Expansion: expansion,
 		})
+		if grant.GetEntitlement() == nil || grant.GetPrincipal() == nil {
+			pageGrants = append(pageGrants, grant)
+			pageKeys = append(pageKeys, grantJoinKeys{
+				EntitlementID:             string(entIDRaw),
+				EntitlementResourceTypeID: string(entRTRaw),
+				EntitlementResourceID:     string(entRRaw),
+				PrincipalResourceTypeID:   string(principalRTRaw),
+				PrincipalResourceID:       string(principalRRaw),
+			})
+		}
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
+	}
+
+	if len(pageGrants) > 0 {
+		hydrateGrants(pageGrants, pageKeys)
 	}
 
 	nextPageToken := ""

--- a/pkg/dotc1z/grants_hydrate.go
+++ b/pkg/dotc1z/grants_hydrate.go
@@ -1,0 +1,332 @@
+package dotc1z
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/doug-martin/goqu/v9"
+	"go.opentelemetry.io/otel/attribute"
+	otelmetric "go.opentelemetry.io/otel/metric"
+	"google.golang.org/protobuf/proto"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+)
+
+// resourceKey uniquely identifies a resource for hydration lookups.
+type resourceKey struct {
+	ResourceTypeID string
+	ResourceID     string
+}
+
+// grantJoinKeys is the per-row data needed to hydrate a slim grant —
+// i.e. the three grants-table columns that are stripped from the
+// serialized data blob when WithV2GrantsWriter is on.
+type grantJoinKeys struct {
+	EntitlementID           string
+	PrincipalResourceTypeID string
+	PrincipalResourceID     string
+}
+
+// hydrateGrants reconstitutes Grant.Entitlement and/or Grant.Principal
+// on any grants that have nil values for those fields (slim-blob writes).
+// Grants with both fields already populated are left unchanged.
+//
+// grantKeys must be index-aligned with grants: each entry holds the
+// (entitlement_id, principal_resource_type_id, principal_resource_id)
+// columns for the corresponding row. Non-slim entries in grantKeys are
+// ignored.
+//
+// Missing joins are not errors: the grant is returned with the nil field
+// intact and a dotc1z.grant_hydrate_miss counter increment (tagged
+// "entitlement" or "principal"). Orphan grants are a real present-day
+// scenario — pre-slim readers succeeded on them because the fields were
+// embedded, so a hard-erroring reader would regress every caller.
+func hydrateGrants(
+	ctx context.Context,
+	c *C1File,
+	syncID string,
+	grants []*v2.Grant,
+	grantKeys []grantJoinKeys,
+) error {
+	if len(grants) == 0 {
+		return nil
+	}
+	if len(grantKeys) != len(grants) {
+		return fmt.Errorf("hydrateGrants: len(grantKeys)=%d does not match len(grants)=%d", len(grantKeys), len(grants))
+	}
+
+	needEnt := make(map[string]struct{}, len(grants))
+	needRes := make(map[resourceKey]struct{}, len(grants))
+	slimIndices := make([]int, 0, len(grants))
+
+	for i, g := range grants {
+		entNil := g.GetEntitlement() == nil
+		princNil := g.GetPrincipal() == nil
+		if !entNil && !princNil {
+			continue
+		}
+		slimIndices = append(slimIndices, i)
+		k := grantKeys[i]
+		if entNil && k.EntitlementID != "" {
+			needEnt[k.EntitlementID] = struct{}{}
+		}
+		// Both columns must be populated to form a valid resource lookup key.
+		// Writer invariants guarantee this (baseGrantRecord sets both from
+		// the same ResourceId), so a partial key is an orphan signal.
+		if princNil && k.PrincipalResourceID != "" && k.PrincipalResourceTypeID != "" {
+			needRes[resourceKey{k.PrincipalResourceTypeID, k.PrincipalResourceID}] = struct{}{}
+		}
+	}
+	if len(slimIndices) == 0 {
+		return nil
+	}
+
+	entMap, err := batchFetchEntitlements(ctx, c, syncID, needEnt)
+	if err != nil {
+		return fmt.Errorf("hydrateGrants: batch fetch entitlements: %w", err)
+	}
+	resMap, err := batchFetchResources(ctx, c, syncID, needRes)
+	if err != nil {
+		return fmt.Errorf("hydrateGrants: batch fetch resources: %w", err)
+	}
+
+	for _, i := range slimIndices {
+		g := grants[i]
+		k := grantKeys[i]
+		if g.GetEntitlement() == nil {
+			if ent, ok := entMap[k.EntitlementID]; ok {
+				g.SetEntitlement(ent)
+			}
+		}
+		if g.GetPrincipal() == nil {
+			if res, ok := resMap[resourceKey{k.PrincipalResourceTypeID, k.PrincipalResourceID}]; ok {
+				g.SetPrincipal(res)
+			}
+		}
+		// If either side is still nil after the lookup, count it as a miss.
+		if g.GetEntitlement() == nil || g.GetPrincipal() == nil {
+			recordHydrateMiss(ctx, g)
+		}
+	}
+	return nil
+}
+
+// batchFetchEntitlements returns a map external_id -> Entitlement for
+// the given entitlement IDs, scoped by sync_id. Missing IDs are simply
+// absent from the map. An empty input returns an empty map.
+func batchFetchEntitlements(ctx context.Context, c *C1File, syncID string, ids map[string]struct{}) (map[string]*v2.Entitlement, error) {
+	out := make(map[string]*v2.Entitlement, len(ids))
+	if len(ids) == 0 {
+		return out, nil
+	}
+	args := make([]any, 0, len(ids))
+	for id := range ids {
+		args = append(args, id)
+	}
+
+	q := c.db.From(entitlements.Name()).Prepared(true).
+		Select("external_id", "data").
+		Where(goqu.C("external_id").In(args...))
+	if syncID != "" {
+		q = q.Where(goqu.C("sync_id").Eq(syncID))
+	}
+
+	query, qargs, err := q.ToSQL()
+	if err != nil {
+		return nil, err
+	}
+	rows, err := c.db.QueryContext(ctx, query, qargs...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	unmarshal := proto.UnmarshalOptions{Merge: true, DiscardUnknown: true}
+	for rows.Next() {
+		var (
+			externalID string
+			data       []byte
+		)
+		if err := rows.Scan(&externalID, &data); err != nil {
+			return nil, err
+		}
+		ent := &v2.Entitlement{}
+		if err := unmarshal.Unmarshal(data, ent); err != nil {
+			return nil, fmt.Errorf("batchFetchEntitlements: unmarshal %q: %w", externalID, err)
+		}
+		out[externalID] = ent
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// batchFetchResources returns a map (resource_type_id, resource_id) ->
+// Resource for the given keys, scoped by sync_id.
+//
+// NOTE: the resources table stores external_id as the composite
+// "<resource_type>:<resource_id>" (see putResourcesInternal). We build
+// composite keys for the IN clause and recover the raw resource_id from
+// the unmarshaled Resource's proto fields — that's the identity the
+// caller passed in as resourceKey.ResourceID.
+func batchFetchResources(ctx context.Context, c *C1File, syncID string, keys map[resourceKey]struct{}) (map[resourceKey]*v2.Resource, error) {
+	out := make(map[resourceKey]*v2.Resource, len(keys))
+	if len(keys) == 0 {
+		return out, nil
+	}
+
+	// Group composite IDs by resource_type_id so we can emit one
+	// (resource_type_id=? AND external_id IN (...)) clause per type.
+	byType := make(map[string][]any, 4)
+	for k := range keys {
+		byType[k.ResourceTypeID] = append(byType[k.ResourceTypeID], k.ResourceTypeID+":"+k.ResourceID)
+	}
+
+	// Build: (resource_type_id = ? AND external_id IN (...)) OR (...) OR ...
+	var ors []goqu.Expression
+	for rtID, ids := range byType {
+		ors = append(ors,
+			goqu.And(
+				goqu.C("resource_type_id").Eq(rtID),
+				goqu.C("external_id").In(ids...),
+			),
+		)
+	}
+	q := c.db.From(resources.Name()).Prepared(true).
+		Select("data").
+		Where(goqu.Or(ors...))
+	if syncID != "" {
+		q = q.Where(goqu.C("sync_id").Eq(syncID))
+	}
+
+	query, args, err := q.ToSQL()
+	if err != nil {
+		return nil, err
+	}
+	rows, err := c.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	unmarshal := proto.UnmarshalOptions{Merge: true, DiscardUnknown: true}
+	for rows.Next() {
+		var data []byte
+		if err := rows.Scan(&data); err != nil {
+			return nil, err
+		}
+		res := &v2.Resource{}
+		if err := unmarshal.Unmarshal(data, res); err != nil {
+			return nil, fmt.Errorf("batchFetchResources: unmarshal: %w", err)
+		}
+		id := res.GetId()
+		out[resourceKey{ResourceTypeID: id.GetResourceType(), ResourceID: id.GetResource()}] = res
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// hydrateGrantsGroupedBySync hydrates slim grants where each row's
+// sync_id is independently known (via the main SELECT that produced the
+// rows). Grants are grouped by sync_id so hydration joins are always
+// scoped to the originating sync — essential when the list query went
+// unscoped because the caller's sync_id resolution cascaded to empty.
+//
+// grants / keys / syncIDs must be index-aligned and the same length.
+// Common case is a single sync_id across the page (scoped list query);
+// the per-sync loop then runs exactly once.
+func hydrateGrantsGroupedBySync(
+	ctx context.Context,
+	c *C1File,
+	grantList []*v2.Grant,
+	keys []grantJoinKeys,
+	syncIDs []string,
+) error {
+	if len(grantList) != len(keys) || len(grantList) != len(syncIDs) {
+		return fmt.Errorf("hydrateGrantsGroupedBySync: len mismatch grants=%d keys=%d syncIDs=%d", len(grantList), len(keys), len(syncIDs))
+	}
+
+	// Fast path: all rows share one sync_id.
+	if len(grantList) > 0 {
+		first := syncIDs[0]
+		sameSync := true
+		for i := 1; i < len(syncIDs); i++ {
+			if syncIDs[i] != first {
+				sameSync = false
+				break
+			}
+		}
+		if sameSync {
+			return hydrateGrants(ctx, c, first, grantList, keys)
+		}
+	}
+
+	// Mixed page: group by sync_id and hydrate each group.
+	bySync := make(map[string][]int, 2)
+	for i, sid := range syncIDs {
+		bySync[sid] = append(bySync[sid], i)
+	}
+	for sid, indices := range bySync {
+		subGrants := make([]*v2.Grant, len(indices))
+		subKeys := make([]grantJoinKeys, len(indices))
+		for j, idx := range indices {
+			subGrants[j] = grantList[idx]
+			subKeys[j] = keys[idx]
+		}
+		if err := hydrateGrants(ctx, c, sid, subGrants, subKeys); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// hydrateSingleGrant hydrates one slim grant by fetching its join keys
+// from v1_grants and running batch joins. The sync_id scopes both the
+// join-key fetch and the entitlement / resource lookups — callers must
+// pass the same sync_id that getConnectorObject used to retrieve the
+// grant.
+//
+// Orphan contract mirrors the batch path (hydrateGrants): when the row
+// cannot be resolved (empty sync_id or the grant row vanished between
+// getConnectorObject and this call — possible under a concurrent sync
+// completion race), the grant is returned with its nil fields intact
+// and the grant_hydrate_miss counter is bumped per side. Never errors
+// on misses — a hard-erroring reader would regress any caller that
+// tolerates orphan grants today.
+func hydrateSingleGrant(ctx context.Context, c *C1File, syncID string, g *v2.Grant) error {
+	if syncID == "" {
+		recordHydrateMiss(ctx, g)
+		return nil
+	}
+
+	row := c.db.QueryRowContext(ctx, fmt.Sprintf(
+		`SELECT entitlement_id, principal_resource_type_id, principal_resource_id
+		 FROM %s WHERE external_id = ? AND sync_id = ?`, grants.Name(),
+	), g.GetId(), syncID)
+	var k grantJoinKeys
+	if err := row.Scan(&k.EntitlementID, &k.PrincipalResourceTypeID, &k.PrincipalResourceID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			recordHydrateMiss(ctx, g)
+			return nil
+		}
+		return fmt.Errorf("hydrateSingleGrant: fetch join keys for %q: %w", g.GetId(), err)
+	}
+	return hydrateGrants(ctx, c, syncID, []*v2.Grant{g}, []grantJoinKeys{k})
+}
+
+// recordHydrateMiss bumps the grant_hydrate_miss counter for each nil
+// side on g. Consolidates the empty-syncID / ErrNoRows / batch-miss
+// paths that all share the "grant is effectively orphan" contract.
+func recordHydrateMiss(ctx context.Context, g *v2.Grant) {
+	if g.GetEntitlement() == nil {
+		grantHydrateMissCounter.Add(ctx, 1, otelmetric.WithAttributes(attribute.String("missing", "entitlement")))
+	}
+	if g.GetPrincipal() == nil {
+		grantHydrateMissCounter.Add(ctx, 1, otelmetric.WithAttributes(attribute.String("missing", "principal")))
+	}
+}

--- a/pkg/dotc1z/grants_hydrate.go
+++ b/pkg/dotc1z/grants_hydrate.go
@@ -1,0 +1,108 @@
+package dotc1z
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+)
+
+// grantJoinKeys is the per-row identity data needed to construct stub
+// Entitlement / Principal protos for a slim grant. Every field maps
+// directly to a column on the grants row — no joins required.
+//
+// Stubs carry only identity (Id + nested Resource.Id). DisplayName,
+// Annotations, Purpose, Slug, traits, and any other non-identity field
+// on the original Entitlement / Resource are zero-value. This is the
+// documented contract of the slim writer (see WithC1FV2GrantsWriter).
+type grantJoinKeys struct {
+	EntitlementID             string
+	EntitlementResourceTypeID string
+	EntitlementResourceID     string
+	PrincipalResourceTypeID   string
+	PrincipalResourceID       string
+}
+
+// hydrateGrants fills in Grant.Entitlement and Grant.Principal on any
+// slim row (one with a nil Entitlement or Principal after unmarshal)
+// by constructing minimal stubs from the row's own column data. Grants
+// that already have both fields populated are left unchanged.
+//
+// Pure function. No DB access, no network, no errors. grantKeys must
+// be index-aligned with grants.
+func hydrateGrants(grants []*v2.Grant, grantKeys []grantJoinKeys) {
+	for i, g := range grants {
+		entNil := g.GetEntitlement() == nil
+		princNil := g.GetPrincipal() == nil
+		if !entNil && !princNil {
+			continue
+		}
+		k := grantKeys[i]
+		if entNil {
+			g.SetEntitlement(stubEntitlement(k))
+		}
+		if princNil {
+			g.SetPrincipal(stubPrincipal(k))
+		}
+	}
+}
+
+func stubEntitlement(k grantJoinKeys) *v2.Entitlement {
+	return v2.Entitlement_builder{
+		Id: k.EntitlementID,
+		Resource: v2.Resource_builder{
+			Id: v2.ResourceId_builder{
+				ResourceType: k.EntitlementResourceTypeID,
+				Resource:     k.EntitlementResourceID,
+			}.Build(),
+		}.Build(),
+	}.Build()
+}
+
+func stubPrincipal(k grantJoinKeys) *v2.Resource {
+	return v2.Resource_builder{
+		Id: v2.ResourceId_builder{
+			ResourceType: k.PrincipalResourceTypeID,
+			Resource:     k.PrincipalResourceID,
+		}.Build(),
+	}.Build()
+}
+
+// hydrateSingleGrant fills in Entitlement / Principal on a single slim
+// grant returned by GetGrant. Unlike the list paths, GetGrant's caller
+// (getConnectorObject) only retrieves the data blob, so we still need
+// a small SQL round-trip to read the row's identity columns. Once we
+// have them, stub construction is pure.
+//
+// Concurrent-write race contract: if the row vanished between
+// getConnectorObject and this call (sql.ErrNoRows), or if syncID is
+// empty (no resolvable sync context), we leave nil fields intact and
+// return nil — same as a row whose columns are all empty strings.
+// Callers downstream tolerate empty identity per existing behavior.
+func hydrateSingleGrant(ctx context.Context, c *C1File, syncID string, g *v2.Grant) error {
+	if syncID == "" {
+		return nil
+	}
+
+	row := c.db.QueryRowContext(ctx, fmt.Sprintf(
+		`SELECT entitlement_id, resource_type_id, resource_id, principal_resource_type_id, principal_resource_id
+		 FROM %s WHERE external_id = ? AND sync_id = ?`, grants.Name(),
+	), g.GetId(), syncID)
+	var k grantJoinKeys
+	if err := row.Scan(
+		&k.EntitlementID,
+		&k.EntitlementResourceTypeID,
+		&k.EntitlementResourceID,
+		&k.PrincipalResourceTypeID,
+		&k.PrincipalResourceID,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil
+		}
+		return fmt.Errorf("hydrateSingleGrant: fetch identity columns for %q: %w", g.GetId(), err)
+	}
+	hydrateGrants([]*v2.Grant{g}, []grantJoinKeys{k})
+	return nil
+}

--- a/pkg/dotc1z/grants_hydrate.go
+++ b/pkg/dotc1z/grants_hydrate.go
@@ -6,327 +6,103 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/doug-martin/goqu/v9"
-	"go.opentelemetry.io/otel/attribute"
-	otelmetric "go.opentelemetry.io/otel/metric"
-	"google.golang.org/protobuf/proto"
-
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 )
 
-// resourceKey uniquely identifies a resource for hydration lookups.
-type resourceKey struct {
-	ResourceTypeID string
-	ResourceID     string
-}
-
-// grantJoinKeys is the per-row data needed to hydrate a slim grant —
-// i.e. the three grants-table columns that are stripped from the
-// serialized data blob when WithV2GrantsWriter is on.
+// grantJoinKeys is the per-row identity data needed to construct stub
+// Entitlement / Principal protos for a slim grant. Every field maps
+// directly to a column on the grants row — no joins required.
+//
+// Stubs carry only identity (Id + nested Resource.Id). DisplayName,
+// Annotations, Purpose, Slug, traits, and any other non-identity field
+// on the original Entitlement / Resource are zero-value. This is the
+// documented contract of the slim writer (see WithC1FV2GrantsWriter).
 type grantJoinKeys struct {
-	EntitlementID           string
-	PrincipalResourceTypeID string
-	PrincipalResourceID     string
+	EntitlementID             string
+	EntitlementResourceTypeID string
+	EntitlementResourceID     string
+	PrincipalResourceTypeID   string
+	PrincipalResourceID       string
 }
 
-// hydrateGrants reconstitutes Grant.Entitlement and/or Grant.Principal
-// on any grants that have nil values for those fields (slim-blob writes).
-// Grants with both fields already populated are left unchanged.
+// hydrateGrants fills in Grant.Entitlement and Grant.Principal on any
+// slim row (one with a nil Entitlement or Principal after unmarshal)
+// by constructing minimal stubs from the row's own column data. Grants
+// that already have both fields populated are left unchanged.
 //
-// grantKeys must be index-aligned with grants: each entry holds the
-// (entitlement_id, principal_resource_type_id, principal_resource_id)
-// columns for the corresponding row. Non-slim entries in grantKeys are
-// ignored.
-//
-// Missing joins are not errors: the grant is returned with the nil field
-// intact and a dotc1z.grant_hydrate_miss counter increment (tagged
-// "entitlement" or "principal"). Orphan grants are a real present-day
-// scenario — pre-slim readers succeeded on them because the fields were
-// embedded, so a hard-erroring reader would regress every caller.
-func hydrateGrants(
-	ctx context.Context,
-	c *C1File,
-	syncID string,
-	grants []*v2.Grant,
-	grantKeys []grantJoinKeys,
-) error {
-	if len(grants) == 0 {
-		return nil
-	}
-	if len(grantKeys) != len(grants) {
-		return fmt.Errorf("hydrateGrants: len(grantKeys)=%d does not match len(grants)=%d", len(grantKeys), len(grants))
-	}
-
-	needEnt := make(map[string]struct{}, len(grants))
-	needRes := make(map[resourceKey]struct{}, len(grants))
-	slimIndices := make([]int, 0, len(grants))
-
+// Pure function. No DB access, no network, no errors. grantKeys must
+// be index-aligned with grants.
+func hydrateGrants(grants []*v2.Grant, grantKeys []grantJoinKeys) {
 	for i, g := range grants {
 		entNil := g.GetEntitlement() == nil
 		princNil := g.GetPrincipal() == nil
 		if !entNil && !princNil {
 			continue
 		}
-		slimIndices = append(slimIndices, i)
 		k := grantKeys[i]
-		if entNil && k.EntitlementID != "" {
-			needEnt[k.EntitlementID] = struct{}{}
+		if entNil {
+			g.SetEntitlement(stubEntitlement(k))
 		}
-		// Both columns must be populated to form a valid resource lookup key.
-		// Writer invariants guarantee this (baseGrantRecord sets both from
-		// the same ResourceId), so a partial key is an orphan signal.
-		if princNil && k.PrincipalResourceID != "" && k.PrincipalResourceTypeID != "" {
-			needRes[resourceKey{k.PrincipalResourceTypeID, k.PrincipalResourceID}] = struct{}{}
+		if princNil {
+			g.SetPrincipal(stubPrincipal(k))
 		}
 	}
-	if len(slimIndices) == 0 {
-		return nil
-	}
-
-	entMap, err := batchFetchEntitlements(ctx, c, syncID, needEnt)
-	if err != nil {
-		return fmt.Errorf("hydrateGrants: batch fetch entitlements: %w", err)
-	}
-	resMap, err := batchFetchResources(ctx, c, syncID, needRes)
-	if err != nil {
-		return fmt.Errorf("hydrateGrants: batch fetch resources: %w", err)
-	}
-
-	for _, i := range slimIndices {
-		g := grants[i]
-		k := grantKeys[i]
-		if g.GetEntitlement() == nil {
-			if ent, ok := entMap[k.EntitlementID]; ok {
-				g.SetEntitlement(ent)
-			}
-		}
-		if g.GetPrincipal() == nil {
-			if res, ok := resMap[resourceKey{k.PrincipalResourceTypeID, k.PrincipalResourceID}]; ok {
-				g.SetPrincipal(res)
-			}
-		}
-		// If either side is still nil after the lookup, count it as a miss.
-		if g.GetEntitlement() == nil || g.GetPrincipal() == nil {
-			recordHydrateMiss(ctx, g)
-		}
-	}
-	return nil
 }
 
-// batchFetchEntitlements returns a map external_id -> Entitlement for
-// the given entitlement IDs, scoped by sync_id. Missing IDs are simply
-// absent from the map. An empty input returns an empty map.
-func batchFetchEntitlements(ctx context.Context, c *C1File, syncID string, ids map[string]struct{}) (map[string]*v2.Entitlement, error) {
-	out := make(map[string]*v2.Entitlement, len(ids))
-	if len(ids) == 0 {
-		return out, nil
-	}
-	args := make([]any, 0, len(ids))
-	for id := range ids {
-		args = append(args, id)
-	}
-
-	q := c.db.From(entitlements.Name()).Prepared(true).
-		Select("external_id", "data").
-		Where(goqu.C("external_id").In(args...))
-	if syncID != "" {
-		q = q.Where(goqu.C("sync_id").Eq(syncID))
-	}
-
-	query, qargs, err := q.ToSQL()
-	if err != nil {
-		return nil, err
-	}
-	rows, err := c.db.QueryContext(ctx, query, qargs...)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	unmarshal := proto.UnmarshalOptions{Merge: true, DiscardUnknown: true}
-	for rows.Next() {
-		var (
-			externalID string
-			data       []byte
-		)
-		if err := rows.Scan(&externalID, &data); err != nil {
-			return nil, err
-		}
-		ent := &v2.Entitlement{}
-		if err := unmarshal.Unmarshal(data, ent); err != nil {
-			return nil, fmt.Errorf("batchFetchEntitlements: unmarshal %q: %w", externalID, err)
-		}
-		out[externalID] = ent
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return out, nil
+func stubEntitlement(k grantJoinKeys) *v2.Entitlement {
+	return v2.Entitlement_builder{
+		Id: k.EntitlementID,
+		Resource: v2.Resource_builder{
+			Id: v2.ResourceId_builder{
+				ResourceType: k.EntitlementResourceTypeID,
+				Resource:     k.EntitlementResourceID,
+			}.Build(),
+		}.Build(),
+	}.Build()
 }
 
-// batchFetchResources returns a map (resource_type_id, resource_id) ->
-// Resource for the given keys, scoped by sync_id.
+func stubPrincipal(k grantJoinKeys) *v2.Resource {
+	return v2.Resource_builder{
+		Id: v2.ResourceId_builder{
+			ResourceType: k.PrincipalResourceTypeID,
+			Resource:     k.PrincipalResourceID,
+		}.Build(),
+	}.Build()
+}
+
+// hydrateSingleGrant fills in Entitlement / Principal on a single slim
+// grant returned by GetGrant. Unlike the list paths, GetGrant's caller
+// (getConnectorObject) only retrieves the data blob, so we still need
+// a small SQL round-trip to read the row's identity columns. Once we
+// have them, stub construction is pure.
 //
-// NOTE: the resources table stores external_id as the composite
-// "<resource_type>:<resource_id>" (see putResourcesInternal). We build
-// composite keys for the IN clause and recover the raw resource_id from
-// the unmarshaled Resource's proto fields — that's the identity the
-// caller passed in as resourceKey.ResourceID.
-func batchFetchResources(ctx context.Context, c *C1File, syncID string, keys map[resourceKey]struct{}) (map[resourceKey]*v2.Resource, error) {
-	out := make(map[resourceKey]*v2.Resource, len(keys))
-	if len(keys) == 0 {
-		return out, nil
-	}
-
-	// Group composite IDs by resource_type_id so we can emit one
-	// (resource_type_id=? AND external_id IN (...)) clause per type.
-	byType := make(map[string][]any, 4)
-	for k := range keys {
-		byType[k.ResourceTypeID] = append(byType[k.ResourceTypeID], k.ResourceTypeID+":"+k.ResourceID)
-	}
-
-	// Build: (resource_type_id = ? AND external_id IN (...)) OR (...) OR ...
-	var ors []goqu.Expression
-	for rtID, ids := range byType {
-		ors = append(ors,
-			goqu.And(
-				goqu.C("resource_type_id").Eq(rtID),
-				goqu.C("external_id").In(ids...),
-			),
-		)
-	}
-	q := c.db.From(resources.Name()).Prepared(true).
-		Select("data").
-		Where(goqu.Or(ors...))
-	if syncID != "" {
-		q = q.Where(goqu.C("sync_id").Eq(syncID))
-	}
-
-	query, args, err := q.ToSQL()
-	if err != nil {
-		return nil, err
-	}
-	rows, err := c.db.QueryContext(ctx, query, args...)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	unmarshal := proto.UnmarshalOptions{Merge: true, DiscardUnknown: true}
-	for rows.Next() {
-		var data []byte
-		if err := rows.Scan(&data); err != nil {
-			return nil, err
-		}
-		res := &v2.Resource{}
-		if err := unmarshal.Unmarshal(data, res); err != nil {
-			return nil, fmt.Errorf("batchFetchResources: unmarshal: %w", err)
-		}
-		id := res.GetId()
-		out[resourceKey{ResourceTypeID: id.GetResourceType(), ResourceID: id.GetResource()}] = res
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-// hydrateGrantsGroupedBySync hydrates slim grants where each row's
-// sync_id is independently known (via the main SELECT that produced the
-// rows). Grants are grouped by sync_id so hydration joins are always
-// scoped to the originating sync — essential when the list query went
-// unscoped because the caller's sync_id resolution cascaded to empty.
-//
-// grants / keys / syncIDs must be index-aligned and the same length.
-// Common case is a single sync_id across the page (scoped list query);
-// the per-sync loop then runs exactly once.
-func hydrateGrantsGroupedBySync(
-	ctx context.Context,
-	c *C1File,
-	grantList []*v2.Grant,
-	keys []grantJoinKeys,
-	syncIDs []string,
-) error {
-	if len(grantList) != len(keys) || len(grantList) != len(syncIDs) {
-		return fmt.Errorf("hydrateGrantsGroupedBySync: len mismatch grants=%d keys=%d syncIDs=%d", len(grantList), len(keys), len(syncIDs))
-	}
-
-	// Fast path: all rows share one sync_id.
-	if len(grantList) > 0 {
-		first := syncIDs[0]
-		sameSync := true
-		for i := 1; i < len(syncIDs); i++ {
-			if syncIDs[i] != first {
-				sameSync = false
-				break
-			}
-		}
-		if sameSync {
-			return hydrateGrants(ctx, c, first, grantList, keys)
-		}
-	}
-
-	// Mixed page: group by sync_id and hydrate each group.
-	bySync := make(map[string][]int, 2)
-	for i, sid := range syncIDs {
-		bySync[sid] = append(bySync[sid], i)
-	}
-	for sid, indices := range bySync {
-		subGrants := make([]*v2.Grant, len(indices))
-		subKeys := make([]grantJoinKeys, len(indices))
-		for j, idx := range indices {
-			subGrants[j] = grantList[idx]
-			subKeys[j] = keys[idx]
-		}
-		if err := hydrateGrants(ctx, c, sid, subGrants, subKeys); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// hydrateSingleGrant hydrates one slim grant by fetching its join keys
-// from v1_grants and running batch joins. The sync_id scopes both the
-// join-key fetch and the entitlement / resource lookups — callers must
-// pass the same sync_id that getConnectorObject used to retrieve the
-// grant.
-//
-// Orphan contract mirrors the batch path (hydrateGrants): when the row
-// cannot be resolved (empty sync_id or the grant row vanished between
-// getConnectorObject and this call — possible under a concurrent sync
-// completion race), the grant is returned with its nil fields intact
-// and the grant_hydrate_miss counter is bumped per side. Never errors
-// on misses — a hard-erroring reader would regress any caller that
-// tolerates orphan grants today.
+// Concurrent-write race contract: if the row vanished between
+// getConnectorObject and this call (sql.ErrNoRows), or if syncID is
+// empty (no resolvable sync context), we leave nil fields intact and
+// return nil — same as a row whose columns are all empty strings.
+// Callers downstream tolerate empty identity per existing behavior.
 func hydrateSingleGrant(ctx context.Context, c *C1File, syncID string, g *v2.Grant) error {
 	if syncID == "" {
-		recordHydrateMiss(ctx, g)
 		return nil
 	}
 
 	row := c.db.QueryRowContext(ctx, fmt.Sprintf(
-		`SELECT entitlement_id, principal_resource_type_id, principal_resource_id
+		`SELECT entitlement_id, resource_type_id, resource_id, principal_resource_type_id, principal_resource_id
 		 FROM %s WHERE external_id = ? AND sync_id = ?`, grants.Name(),
 	), g.GetId(), syncID)
 	var k grantJoinKeys
-	if err := row.Scan(&k.EntitlementID, &k.PrincipalResourceTypeID, &k.PrincipalResourceID); err != nil {
+	if err := row.Scan(
+		&k.EntitlementID,
+		&k.EntitlementResourceTypeID,
+		&k.EntitlementResourceID,
+		&k.PrincipalResourceTypeID,
+		&k.PrincipalResourceID,
+	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			recordHydrateMiss(ctx, g)
 			return nil
 		}
-		return fmt.Errorf("hydrateSingleGrant: fetch join keys for %q: %w", g.GetId(), err)
+		return fmt.Errorf("hydrateSingleGrant: fetch identity columns for %q: %w", g.GetId(), err)
 	}
-	return hydrateGrants(ctx, c, syncID, []*v2.Grant{g}, []grantJoinKeys{k})
-}
-
-// recordHydrateMiss bumps the grant_hydrate_miss counter for each nil
-// side on g. Consolidates the empty-syncID / ErrNoRows / batch-miss
-// paths that all share the "grant is effectively orphan" contract.
-func recordHydrateMiss(ctx context.Context, g *v2.Grant) {
-	if g.GetEntitlement() == nil {
-		grantHydrateMissCounter.Add(ctx, 1, otelmetric.WithAttributes(attribute.String("missing", "entitlement")))
-	}
-	if g.GetPrincipal() == nil {
-		grantHydrateMissCounter.Add(ctx, 1, otelmetric.WithAttributes(attribute.String("missing", "principal")))
-	}
+	hydrateGrants([]*v2.Grant{g}, []grantJoinKeys{k})
+	return nil
 }

--- a/pkg/dotc1z/grants_hydrate.go
+++ b/pkg/dotc1z/grants_hydrate.go
@@ -9,14 +9,6 @@ import (
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 )
 
-// grantJoinKeys is the per-row identity data needed to construct stub
-// Entitlement / Principal protos for a slim grant. Every field maps
-// directly to a column on the grants row — no joins required.
-//
-// Stubs carry only identity (Id + nested Resource.Id). DisplayName,
-// Annotations, Purpose, Slug, traits, and any other non-identity field
-// on the original Entitlement / Resource are zero-value. This is the
-// documented contract of the slim writer (see WithC1FV2GrantsWriter).
 type grantJoinKeys struct {
 	EntitlementID             string
 	EntitlementResourceTypeID string
@@ -25,13 +17,7 @@ type grantJoinKeys struct {
 	PrincipalResourceID       string
 }
 
-// hydrateGrants fills in Grant.Entitlement and Grant.Principal on any
-// slim row (one with a nil Entitlement or Principal after unmarshal)
-// by constructing minimal stubs from the row's own column data. Grants
-// that already have both fields populated are left unchanged.
-//
-// Pure function. No DB access, no network, no errors. grantKeys must
-// be index-aligned with grants.
+// grantKeys must be index-aligned with grants.
 func hydrateGrants(grants []*v2.Grant, grantKeys []grantJoinKeys) {
 	for i, g := range grants {
 		entNil := g.GetEntitlement() == nil
@@ -70,17 +56,9 @@ func stubPrincipal(k grantJoinKeys) *v2.Resource {
 	}.Build()
 }
 
-// hydrateSingleGrant fills in Entitlement / Principal on a single slim
-// grant returned by GetGrant. Unlike the list paths, GetGrant's caller
-// (getConnectorObject) only retrieves the data blob, so we still need
-// a small SQL round-trip to read the row's identity columns. Once we
-// have them, stub construction is pure.
-//
-// Concurrent-write race contract: if the row vanished between
-// getConnectorObject and this call (sql.ErrNoRows), or if syncID is
-// empty (no resolvable sync context), we leave nil fields intact and
-// return nil — same as a row whose columns are all empty strings.
-// Callers downstream tolerate empty identity per existing behavior.
+// Treats sql.ErrNoRows and empty syncID as soft misses — leaves nil
+// fields intact and returns nil. The row may have been deleted between
+// GetGrant and this call.
 func hydrateSingleGrant(ctx context.Context, c *C1File, syncID string, g *v2.Grant) error {
 	if syncID == "" {
 		return nil

--- a/pkg/dotc1z/grants_hydrate.go
+++ b/pkg/dotc1z/grants_hydrate.go
@@ -17,7 +17,7 @@ type grantJoinKeys struct {
 	PrincipalResourceID       string
 }
 
-// grantKeys must be index-aligned with grants.
+// grantKeys[i] must describe grants[i] — same length, same order.
 func hydrateGrants(grants []*v2.Grant, grantKeys []grantJoinKeys) {
 	for i, g := range grants {
 		entNil := g.GetEntitlement() == nil

--- a/pkg/dotc1z/grants_listing_bench_test.go
+++ b/pkg/dotc1z/grants_listing_bench_test.go
@@ -1,0 +1,359 @@
+package dotc1z
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	reader_v2 "github.com/conductorone/baton-sdk/pb/c1/reader/v2"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/stretchr/testify/require"
+)
+
+// listGrantsFixture bundles everything the BenchmarkListGrants* benches
+// need from setupListGrantsBench, so each bench can construct its
+// request without re-fetching the entitlement/resource.
+type listGrantsFixture struct {
+	F               *C1File
+	EntitlementID   string
+	Resource        *v2.Resource // resource the entitlement is on, used for the resource-filtered ListGrants
+	PrincipalSample *v2.Resource // one of the N principals, used for ListGrantsForPrincipal
+	ResourceTypeID  string       // "test-type"
+}
+
+// setupListGrantsBench constructs a fresh c1z with numGrants grants,
+// 1 entitlement, and N unique principals — same fixture shape as
+// setupBenchmarkDB, but returns additional fields the new benches
+// need (the resource for filtered ListGrants, a sample principal for
+// ListGrantsForPrincipal, the resource-type id).
+//
+// extraOpts are appended to the default C1ZOptions and let callers
+// flip writer modes (e.g. WithV2GrantsWriter(true) for the slim
+// sub-benches). The default — no extra opts — is the full-blob
+// writer, equivalent to the bench code on origin/main.
+func setupListGrantsBench(b *testing.B, numGrants int, extraOpts ...C1ZOption) (*listGrantsFixture, func()) {
+	b.Helper()
+
+	ctx := b.Context()
+	tempDir, err := os.MkdirTemp("", "grants-listing-bench-*")
+	require.NoError(b, err)
+
+	testFilePath := filepath.Join(tempDir, "bench.c1z")
+
+	opts := []C1ZOption{
+		WithTmpDir(tempDir),
+		WithEncoderConcurrency(0),
+		WithDecoderOptions(WithDecoderConcurrency(0)),
+	}
+	opts = append(opts, extraOpts...)
+
+	f, err := NewC1ZFile(ctx, testFilePath, opts...)
+	require.NoError(b, err)
+
+	syncID, _, err := f.StartOrResumeSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(b, err)
+	require.NotEmpty(b, syncID)
+
+	require.NoError(b, f.PutResourceTypes(ctx, &v2.ResourceType{
+		Id:          "test-type",
+		DisplayName: "Test Type",
+	}))
+
+	testResource := &v2.Resource{
+		Id: &v2.ResourceId{
+			ResourceType: "test-type",
+			Resource:     "test-resource",
+		},
+		DisplayName: "Test Resource",
+	}
+	require.NoError(b, f.PutResources(ctx, testResource))
+
+	testEntitlement := &v2.Entitlement{
+		Id:       "test-entitlement",
+		Resource: testResource,
+	}
+	require.NoError(b, f.PutEntitlements(ctx, testEntitlement))
+
+	grants := make([]*v2.Grant, numGrants)
+	var principalSample *v2.Resource
+	for i := range numGrants {
+		principal := &v2.Resource{
+			Id: &v2.ResourceId{
+				ResourceType: "test-type",
+				Resource:     fmt.Sprintf("principal-%d", i),
+			},
+			DisplayName: fmt.Sprintf("Principal %d", i),
+		}
+		grants[i] = &v2.Grant{
+			Id:          fmt.Sprintf("grant-%d", i),
+			Entitlement: testEntitlement,
+			Principal:   principal,
+		}
+		if i == 0 {
+			principalSample = principal
+		}
+	}
+
+	batchSize := 1000
+	for i := 0; i < len(grants); i += batchSize {
+		end := min(i+batchSize, len(grants))
+		require.NoError(b, f.PutGrants(ctx, grants[i:end]...))
+	}
+
+	cleanup := func() {
+		_ = f.Close(ctx)
+		_ = os.RemoveAll(tempDir)
+	}
+
+	return &listGrantsFixture{
+		F:               f,
+		EntitlementID:   testEntitlement.Id,
+		Resource:        testResource,
+		PrincipalSample: principalSample,
+		ResourceTypeID:  "test-type",
+	}, cleanup
+}
+
+// drainPaginatedListGrants paginates ListGrants until exhaustion and
+// returns the total row count. Used by the unfiltered + resource-
+// filtered ListGrants benches.
+func drainPaginatedListGrants(b *testing.B, fix *listGrantsFixture, withResourceFilter bool) int {
+	b.Helper()
+	ctx := b.Context()
+
+	total := 0
+	pageToken := ""
+	for {
+		req := v2.GrantsServiceListGrantsRequest_builder{PageToken: pageToken}
+		if withResourceFilter {
+			req.Resource = fix.Resource
+		}
+		resp, err := fix.F.ListGrants(ctx, req.Build())
+		if err != nil {
+			b.Fatal(err)
+		}
+		total += len(resp.GetList())
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			break
+		}
+	}
+	return total
+}
+
+// BenchmarkListGrants benchmarks the unfiltered public ListGrants
+// reader — the path baton CLI's default `baton grants` invocation
+// hits, and the c1 uplift fallback path when the store does not
+// implement InternalWriter.
+func BenchmarkListGrants(b *testing.B) {
+	for _, numGrants := range grantCounts {
+		b.Run(fmt.Sprintf("grants=%d", numGrants), func(b *testing.B) {
+			b.Run("writer=full", func(b *testing.B) {
+				fix, cleanup := setupListGrantsBench(b, numGrants)
+				defer cleanup()
+
+				b.ReportAllocs()
+				for b.Loop() {
+					if got := drainPaginatedListGrants(b, fix, false); got != numGrants {
+						b.Fatalf("expected %d grants, got %d", numGrants, got)
+					}
+				}
+			})
+			b.Run("writer=slim", func(b *testing.B) {
+				fix, cleanup := setupListGrantsBench(b, numGrants, WithV2GrantsWriter(true))
+				defer cleanup()
+
+				b.ReportAllocs()
+				for b.Loop() {
+					if got := drainPaginatedListGrants(b, fix, false); got != numGrants {
+						b.Fatalf("expected %d grants, got %d", numGrants, got)
+					}
+				}
+			})
+		})
+	}
+}
+
+// BenchmarkListGrants_ResourceFilter exercises ListGrants with the
+// Resource filter set — the UI drill-down path for "grants on this
+// resource". Same SQL backbone, different filter.
+func BenchmarkListGrants_ResourceFilter(b *testing.B) {
+	for _, numGrants := range grantCounts {
+		b.Run(fmt.Sprintf("grants=%d", numGrants), func(b *testing.B) {
+			b.Run("writer=full", func(b *testing.B) {
+				fix, cleanup := setupListGrantsBench(b, numGrants)
+				defer cleanup()
+
+				b.ReportAllocs()
+				for b.Loop() {
+					if got := drainPaginatedListGrants(b, fix, true); got != numGrants {
+						b.Fatalf("expected %d grants, got %d", numGrants, got)
+					}
+				}
+			})
+			b.Run("writer=slim", func(b *testing.B) {
+				fix, cleanup := setupListGrantsBench(b, numGrants, WithV2GrantsWriter(true))
+				defer cleanup()
+
+				b.ReportAllocs()
+				for b.Loop() {
+					if got := drainPaginatedListGrants(b, fix, true); got != numGrants {
+						b.Fatalf("expected %d grants, got %d", numGrants, got)
+					}
+				}
+			})
+		})
+	}
+}
+
+// BenchmarkListGrantsForPrincipal benchmarks the principal-filtered
+// reader path used by UI "what does this user have?" lookups. Note
+// the request type is GrantsReaderServiceListGrantsForEntitlementRequest
+// with the PrincipalId field set — not a separately-named
+// principal-request struct. The fixture has unique principals, so
+// each call returns exactly 1 row.
+func BenchmarkListGrantsForPrincipal(b *testing.B) {
+	runForPrincipal := func(b *testing.B, numGrants int, extraOpts ...C1ZOption) {
+		fix, cleanup := setupListGrantsBench(b, numGrants, extraOpts...)
+		defer cleanup()
+
+		ctx := b.Context()
+
+		req := reader_v2.GrantsReaderServiceListGrantsForEntitlementRequest_builder{
+			PrincipalId: fix.PrincipalSample.Id,
+		}.Build()
+
+		b.ReportAllocs()
+		for b.Loop() {
+			pageToken := ""
+			total := 0
+			for {
+				req.SetPageToken(pageToken)
+				resp, err := fix.F.ListGrantsForPrincipal(ctx, req)
+				if err != nil {
+					b.Fatal(err)
+				}
+				total += len(resp.GetList())
+				pageToken = resp.GetNextPageToken()
+				if pageToken == "" {
+					break
+				}
+			}
+			if total != 1 {
+				b.Fatalf("expected 1 grant for sample principal, got %d", total)
+			}
+		}
+	}
+
+	for _, numGrants := range grantCounts {
+		b.Run(fmt.Sprintf("grants=%d", numGrants), func(b *testing.B) {
+			b.Run("writer=full", func(b *testing.B) {
+				runForPrincipal(b, numGrants)
+			})
+			b.Run("writer=slim", func(b *testing.B) {
+				runForPrincipal(b, numGrants, WithV2GrantsWriter(true))
+			})
+		})
+	}
+}
+
+// BenchmarkListGrantsForResourceType benchmarks the resource-type-
+// filtered reader path used by admin/audit views ("all grants on
+// resources of type X"). The fixture's entitlement and all
+// principals share resource-type "test-type", so the filter matches
+// every row.
+func BenchmarkListGrantsForResourceType(b *testing.B) {
+	runForResourceType := func(b *testing.B, numGrants int, extraOpts ...C1ZOption) {
+		fix, cleanup := setupListGrantsBench(b, numGrants, extraOpts...)
+		defer cleanup()
+
+		ctx := b.Context()
+
+		req := reader_v2.GrantsReaderServiceListGrantsForResourceTypeRequest_builder{
+			ResourceTypeId: fix.ResourceTypeID,
+		}.Build()
+
+		b.ReportAllocs()
+		for b.Loop() {
+			pageToken := ""
+			total := 0
+			for {
+				req.SetPageToken(pageToken)
+				resp, err := fix.F.ListGrantsForResourceType(ctx, req)
+				if err != nil {
+					b.Fatal(err)
+				}
+				total += len(resp.GetList())
+				pageToken = resp.GetNextPageToken()
+				if pageToken == "" {
+					break
+				}
+			}
+			if total != numGrants {
+				b.Fatalf("expected %d grants, got %d", numGrants, total)
+			}
+		}
+	}
+
+	for _, numGrants := range grantCounts {
+		b.Run(fmt.Sprintf("grants=%d", numGrants), func(b *testing.B) {
+			b.Run("writer=full", func(b *testing.B) {
+				runForResourceType(b, numGrants)
+			})
+			b.Run("writer=slim", func(b *testing.B) {
+				runForResourceType(b, numGrants, WithV2GrantsWriter(true))
+			})
+		})
+	}
+}
+
+// BenchmarkListGrants_Payload benchmarks the gRPC ListGrants surface
+// (the closest remaining payload-shaped reader after RFC 0002 removed
+// the internal payload-only mode). It is a sibling to
+// BenchmarkListGrantsInternal_PayloadWithExpansion in grants_bench_test.go;
+// ListGrants routes through listGrantsGeneric, a narrower SELECT than
+// the with-expansion path because it skips the expansion column
+// projection and the per-row expansion unmarshal.
+func BenchmarkListGrants_Payload(b *testing.B) {
+	runPayload := func(b *testing.B, numGrants int, extraOpts ...C1ZOption) {
+		fix, cleanup := setupListGrantsBench(b, numGrants, extraOpts...)
+		defer cleanup()
+
+		ctx := b.Context()
+
+		b.ReportAllocs()
+		for b.Loop() {
+			pageToken := ""
+			total := 0
+			for {
+				resp, err := fix.F.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{
+					PageToken: pageToken,
+				}.Build())
+				if err != nil {
+					b.Fatal(err)
+				}
+				total += len(resp.GetList())
+				pageToken = resp.GetNextPageToken()
+				if pageToken == "" {
+					break
+				}
+			}
+			if total != numGrants {
+				b.Fatalf("expected %d grants, got %d", numGrants, total)
+			}
+		}
+	}
+
+	for _, numGrants := range grantCounts {
+		b.Run(fmt.Sprintf("grants=%d", numGrants), func(b *testing.B) {
+			b.Run("writer=full", func(b *testing.B) {
+				runPayload(b, numGrants)
+			})
+			b.Run("writer=slim", func(b *testing.B) {
+				runPayload(b, numGrants, WithV2GrantsWriter(true))
+			})
+		})
+	}
+}

--- a/pkg/dotc1z/grants_v2_writer_test.go
+++ b/pkg/dotc1z/grants_v2_writer_test.go
@@ -1,0 +1,630 @@
+package dotc1z
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	reader_v2 "github.com/conductorone/baton-sdk/pb/c1/reader/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+)
+
+// newTestC1z constructs a fresh c1z in t.TempDir(), starts a full sync,
+// and seeds two resource types (group, user), two resources (g1, u1),
+// and two entitlements (ent1, ent2 on g1). Returns the file, sync id,
+// and a cleanup that closes the c1z. Extra C1ZOptions (e.g.
+// WithV2GrantsWriter) are forwarded to NewC1ZFile.
+//
+// No binary .c1z files live on disk beyond the test process — fixtures
+// are generated at test-setup time (2026-04-22 orchestration decision).
+func newTestC1z(ctx context.Context, t *testing.T, opts ...C1ZOption) (*C1File, string, func()) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "test.c1z")
+
+	c1f, err := NewC1ZFile(ctx, path, opts...)
+	require.NoError(t, err)
+
+	syncID, err := c1f.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+
+	groupRT := v2.ResourceType_builder{Id: "group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user"}.Build()
+	require.NoError(t, c1f.PutResourceTypes(ctx, groupRT, userRT))
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "Group 1"}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "User 1"}.Build()
+	require.NoError(t, c1f.PutResources(ctx, g1, u1))
+
+	ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1, DisplayName: "Ent 1"}.Build()
+	ent2 := v2.Entitlement_builder{Id: "ent2", Resource: g1, DisplayName: "Ent 2"}.Build()
+	require.NoError(t, c1f.PutEntitlements(ctx, ent1, ent2))
+
+	cleanup := func() {
+		require.NoError(t, c1f.Close(ctx))
+	}
+	return c1f, syncID, cleanup
+}
+
+// readRawGrantBlob returns the raw data blob stored for a grant row,
+// bypassing the reader's hydration path.
+func readRawGrantBlob(ctx context.Context, t *testing.T, c1f *C1File, externalID string) []byte {
+	t.Helper()
+	var data []byte
+	err := c1f.db.QueryRowContext(ctx,
+		fmt.Sprintf("SELECT data FROM %s WHERE external_id = ?", grants.Name()),
+		externalID,
+	).Scan(&data)
+	require.NoError(t, err)
+	return data
+}
+
+func TestV2GrantsWriter_RoundTrip(t *testing.T) {
+	ctx := context.Background()
+	c1f, _, cleanup := newTestC1z(ctx, t, WithV2GrantsWriter(true))
+	defer cleanup()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "Group 1"}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "User 1"}.Build()
+	ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1, DisplayName: "Ent 1"}.Build()
+
+	grant := v2.Grant_builder{
+		Id:          "grant-1",
+		Entitlement: ent1,
+		Principal:   u1,
+	}.Build()
+	require.NoError(t, c1f.PutGrants(ctx, grant))
+
+	// The on-disk blob must not contain Entitlement or Principal.
+	raw := readRawGrantBlob(ctx, t, c1f, "grant-1")
+	bare := &v2.Grant{}
+	require.NoError(t, proto.Unmarshal(raw, bare))
+	require.Nil(t, bare.GetEntitlement(), "slim blob should have nil Entitlement on disk")
+	require.Nil(t, bare.GetPrincipal(), "slim blob should have nil Principal on disk")
+	require.Equal(t, "grant-1", bare.GetId(), "Grant.Id is preserved in the blob")
+
+	// The reader must reconstitute both fields via hydration.
+	resp, err := c1f.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{}.Build())
+	require.NoError(t, err)
+	require.Len(t, resp.GetList(), 1)
+	got := resp.GetList()[0]
+	require.Equal(t, "grant-1", got.GetId())
+	require.Equal(t, "ent1", got.GetEntitlement().GetId())
+	require.Equal(t, "Ent 1", got.GetEntitlement().GetDisplayName())
+	require.Equal(t, "user", got.GetPrincipal().GetId().GetResourceType())
+	require.Equal(t, "u1", got.GetPrincipal().GetId().GetResource())
+	require.Equal(t, "User 1", got.GetPrincipal().GetDisplayName())
+}
+
+func TestV2GrantsWriter_DefaultWritesFullBlob(t *testing.T) {
+	ctx := context.Background()
+	c1f, _, cleanup := newTestC1z(ctx, t)
+	defer cleanup()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build()}.Build()
+	ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1}.Build()
+
+	require.NoError(t, c1f.PutGrants(ctx, v2.Grant_builder{
+		Id:          "grant-full",
+		Entitlement: ent1,
+		Principal:   u1,
+	}.Build()))
+
+	raw := readRawGrantBlob(ctx, t, c1f, "grant-full")
+	bare := &v2.Grant{}
+	require.NoError(t, proto.Unmarshal(raw, bare))
+	require.NotNil(t, bare.GetEntitlement(), "default writer must embed Entitlement in blob")
+	require.NotNil(t, bare.GetPrincipal(), "default writer must embed Principal in blob")
+	require.Equal(t, "ent1", bare.GetEntitlement().GetId())
+}
+
+// TestV2GrantsReader_FullBlobPassThrough confirms that when the reader
+// encounters a row that already has Entitlement / Principal populated,
+// it does not overwrite them or issue unnecessary hydration queries.
+func TestV2GrantsReader_FullBlobPassThrough(t *testing.T) {
+	ctx := context.Background()
+	// Writer off — rows are full blobs.
+	c1f, _, cleanup := newTestC1z(ctx, t)
+	defer cleanup()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "Original U1"}.Build()
+	ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1, DisplayName: "Original Ent 1"}.Build()
+
+	require.NoError(t, c1f.PutGrants(ctx, v2.Grant_builder{
+		Id:          "grant-full",
+		Entitlement: ent1,
+		Principal:   u1,
+	}.Build()))
+
+	// Mutate the entitlement/resource rows so a hydration pass would be
+	// observably different. If the reader hydrates, we'd see "Changed".
+	mutatedEnt := v2.Entitlement_builder{Id: "ent1", Resource: g1, DisplayName: "Changed Ent"}.Build()
+	require.NoError(t, c1f.PutEntitlements(ctx, mutatedEnt))
+	mutatedU1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "Changed U1"}.Build()
+	require.NoError(t, c1f.PutResources(ctx, mutatedU1))
+
+	resp, err := c1f.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{}.Build())
+	require.NoError(t, err)
+	require.Len(t, resp.GetList(), 1)
+	got := resp.GetList()[0]
+	require.Equal(t, "Original Ent 1", got.GetEntitlement().GetDisplayName(), "full blob must pass through unchanged")
+	require.Equal(t, "Original U1", got.GetPrincipal().GetDisplayName(), "full blob must pass through unchanged")
+}
+
+// TestV2GrantsReader_MixedBlobs writes some rows with the slim writer
+// and some with the full writer into the same v1_grants table, then
+// verifies the reader returns correct Grants for each. Rows are
+// distinguished per-blob (proto3 nil field detection), no schema marker.
+func TestV2GrantsReader_MixedBlobs(t *testing.T) {
+	ctx := context.Background()
+	c1f, _, cleanup := newTestC1z(ctx, t)
+	defer cleanup()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "Group 1"}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "User 1"}.Build()
+	ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1, DisplayName: "Ent 1"}.Build()
+	ent2 := v2.Entitlement_builder{Id: "ent2", Resource: g1, DisplayName: "Ent 2"}.Build()
+
+	// First grant written with slim disabled (full blob).
+	c1f.v2GrantsWriter = false
+	require.NoError(t, c1f.PutGrants(ctx, v2.Grant_builder{
+		Id:          "grant-full",
+		Entitlement: ent1,
+		Principal:   u1,
+	}.Build()))
+
+	// Second grant written with slim enabled (stripped blob).
+	c1f.v2GrantsWriter = true
+	require.NoError(t, c1f.PutGrants(ctx, v2.Grant_builder{
+		Id:          "grant-slim",
+		Entitlement: ent2,
+		Principal:   u1,
+	}.Build()))
+
+	// On-disk: one full, one slim.
+	fullBare := &v2.Grant{}
+	require.NoError(t, proto.Unmarshal(readRawGrantBlob(ctx, t, c1f, "grant-full"), fullBare))
+	require.NotNil(t, fullBare.GetEntitlement(), "grant-full row should be full blob")
+
+	slimBare := &v2.Grant{}
+	require.NoError(t, proto.Unmarshal(readRawGrantBlob(ctx, t, c1f, "grant-slim"), slimBare))
+	require.Nil(t, slimBare.GetEntitlement(), "grant-slim row should be slim blob")
+	require.Nil(t, slimBare.GetPrincipal(), "grant-slim row should be slim blob")
+
+	// Reader returns both correctly.
+	resp, err := c1f.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{}.Build())
+	require.NoError(t, err)
+	require.Len(t, resp.GetList(), 2)
+	byID := map[string]*v2.Grant{}
+	for _, g := range resp.GetList() {
+		byID[g.GetId()] = g
+	}
+	require.Equal(t, "ent1", byID["grant-full"].GetEntitlement().GetId())
+	require.Equal(t, "u1", byID["grant-full"].GetPrincipal().GetId().GetResource())
+	require.Equal(t, "ent2", byID["grant-slim"].GetEntitlement().GetId())
+	require.Equal(t, "u1", byID["grant-slim"].GetPrincipal().GetId().GetResource())
+}
+
+// TestV2GrantsReader_MissingEntitlement covers the orphan-grant contract:
+// a slim grant whose entitlement_id has no matching v1_entitlements row.
+// The reader must return the grant with Entitlement nil (not error).
+func TestV2GrantsReader_MissingEntitlement(t *testing.T) {
+	ctx := context.Background()
+	c1f, _, cleanup := newTestC1z(ctx, t, WithV2GrantsWriter(true))
+	defer cleanup()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build()}.Build()
+	// Reference an entitlement id that does not exist in v1_entitlements.
+	orphanEnt := v2.Entitlement_builder{Id: "ent-does-not-exist", Resource: g1}.Build()
+
+	require.NoError(t, c1f.PutGrants(ctx, v2.Grant_builder{
+		Id:          "grant-orphan-ent",
+		Entitlement: orphanEnt,
+		Principal:   u1,
+	}.Build()))
+
+	resp, err := c1f.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{}.Build())
+	require.NoError(t, err, "orphan grant must not cause reader to error")
+	require.Len(t, resp.GetList(), 1)
+	got := resp.GetList()[0]
+	require.Equal(t, "grant-orphan-ent", got.GetId())
+	require.Nil(t, got.GetEntitlement(), "unresolved entitlement should remain nil, not fabricated")
+	require.NotNil(t, got.GetPrincipal(), "principal should still be hydrated")
+	require.Equal(t, "u1", got.GetPrincipal().GetId().GetResource())
+}
+
+// TestV2GrantsReader_MissingPrincipal is the mirror of MissingEntitlement
+// for the principal side.
+func TestV2GrantsReader_MissingPrincipal(t *testing.T) {
+	ctx := context.Background()
+	c1f, _, cleanup := newTestC1z(ctx, t, WithV2GrantsWriter(true))
+	defer cleanup()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1}.Build()
+	// Reference a principal that does not exist in v1_resources.
+	orphanPrincipal := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "nope"}.Build()}.Build()
+
+	require.NoError(t, c1f.PutGrants(ctx, v2.Grant_builder{
+		Id:          "grant-orphan-principal",
+		Entitlement: ent1,
+		Principal:   orphanPrincipal,
+	}.Build()))
+
+	resp, err := c1f.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{}.Build())
+	require.NoError(t, err, "orphan grant must not cause reader to error")
+	require.Len(t, resp.GetList(), 1)
+	got := resp.GetList()[0]
+	require.Equal(t, "grant-orphan-principal", got.GetId())
+	require.NotNil(t, got.GetEntitlement())
+	require.Equal(t, "ent1", got.GetEntitlement().GetId())
+	require.Nil(t, got.GetPrincipal(), "unresolved principal should remain nil, not fabricated")
+}
+
+// TestV2GrantsReader_BatchFetch confirms hydration uses batched joins,
+// not a per-row fetch. We measure by inserting many grants that share a
+// handful of (entitlement, principal) targets and then verifying a
+// single ListGrants call returns all of them with correct hydration.
+func TestV2GrantsReader_BatchFetch(t *testing.T) {
+	ctx := context.Background()
+	c1f, _, cleanup := newTestC1z(ctx, t, WithV2GrantsWriter(true))
+	defer cleanup()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1, DisplayName: "Ent 1"}.Build()
+	ent2 := v2.Entitlement_builder{Id: "ent2", Resource: g1, DisplayName: "Ent 2"}.Build()
+
+	// Seed a pool of users so hydration has to fan out.
+	const nUsers = 50
+	users := make([]*v2.Resource, nUsers)
+	for i := range users {
+		u := v2.Resource_builder{
+			Id:          v2.ResourceId_builder{ResourceType: "user", Resource: fmt.Sprintf("u%d", i)}.Build(),
+			DisplayName: fmt.Sprintf("User %d", i),
+		}.Build()
+		users[i] = u
+	}
+	require.NoError(t, c1f.PutResources(ctx, users...))
+
+	// Write 500 slim grants: each user touched 10 times, alternating entitlements.
+	var grantsOut []*v2.Grant
+	for i := range 500 {
+		user := users[i%nUsers]
+		ent := ent1
+		if i%2 == 1 {
+			ent = ent2
+		}
+		g := v2.Grant_builder{
+			Id:          fmt.Sprintf("grant-%d", i),
+			Entitlement: ent,
+			Principal:   user,
+		}.Build()
+		grantsOut = append(grantsOut, g)
+	}
+	require.NoError(t, c1f.PutGrants(ctx, grantsOut...))
+
+	// Page through everything. Each page must hydrate every slim row.
+	seen := 0
+	pageToken := ""
+	for {
+		resp, err := c1f.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{
+			PageSize:  100,
+			PageToken: pageToken,
+		}.Build())
+		require.NoError(t, err)
+		for _, g := range resp.GetList() {
+			require.NotNil(t, g.GetEntitlement(), "grant %s entitlement not hydrated", g.GetId())
+			require.NotNil(t, g.GetPrincipal(), "grant %s principal not hydrated", g.GetId())
+			require.Contains(t, []string{"ent1", "ent2"}, g.GetEntitlement().GetId())
+			require.Equal(t, "user", g.GetPrincipal().GetId().GetResourceType())
+			seen++
+		}
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			break
+		}
+	}
+	require.Equal(t, 500, seen)
+}
+
+// TestV2GetGrant_Hydrates confirms the single-row GetGrant path also
+// hydrates slim blobs.
+func TestV2GetGrant_Hydrates(t *testing.T) {
+	ctx := context.Background()
+	c1f, _, cleanup := newTestC1z(ctx, t, WithV2GrantsWriter(true))
+	defer cleanup()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "User 1"}.Build()
+	ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1, DisplayName: "Ent 1"}.Build()
+
+	require.NoError(t, c1f.PutGrants(ctx, v2.Grant_builder{
+		Id:          "grant-get",
+		Entitlement: ent1,
+		Principal:   u1,
+	}.Build()))
+
+	// Blob is slim.
+	bare := &v2.Grant{}
+	require.NoError(t, proto.Unmarshal(readRawGrantBlob(ctx, t, c1f, "grant-get"), bare))
+	require.Nil(t, bare.GetEntitlement())
+	require.Nil(t, bare.GetPrincipal())
+
+	// GetGrant resolves sync via the currentSyncID cascade (sync is still open).
+	req := reader_v2.GrantsReaderServiceGetGrantRequest_builder{GrantId: "grant-get"}.Build()
+	resp, err := c1f.GetGrant(ctx, req)
+	require.NoError(t, err)
+	got := resp.GetGrant()
+	require.Equal(t, "grant-get", got.GetId())
+	require.Equal(t, "ent1", got.GetEntitlement().GetId())
+	require.Equal(t, "Ent 1", got.GetEntitlement().GetDisplayName())
+	require.Equal(t, "u1", got.GetPrincipal().GetId().GetResource())
+}
+
+// TestExpandableGrants_Unchanged confirms that the expansion reader path
+// still works identically with full vs. slim input rows. Expansion is
+// stored in the `expansion` column (not in the data blob), so the slim
+// writer must not affect it.
+func TestExpandableGrants_Unchanged(t *testing.T) {
+	ctx := context.Background()
+	c1f, _, cleanup := newTestC1z(ctx, t, WithV2GrantsWriter(true))
+	defer cleanup()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build()}.Build()
+	ent2 := v2.Entitlement_builder{Id: "ent2", Resource: g1}.Build()
+
+	expandableGrant := v2.Grant_builder{
+		Id:          "grant-expandable-slim",
+		Entitlement: ent2,
+		Principal:   u1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{"ent1"},
+			Shallow:         true,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	require.NoError(t, c1f.PutGrants(ctx, expandableGrant))
+
+	// Expansion column is populated regardless of slim writer.
+	var expansionBytes []byte
+	require.NoError(t, c1f.db.QueryRowContext(ctx,
+		fmt.Sprintf("SELECT expansion FROM %s WHERE external_id=?", grants.Name()),
+		"grant-expandable-slim",
+	).Scan(&expansionBytes))
+	require.NotEmpty(t, expansionBytes, "expansion column must be populated for slim grants with expandable annotation")
+
+	// The expansion-aware list reader hydrates the slim grant AND returns
+	// the expansion def.
+	resp, err := c1f.ListGrantsInternal(ctx, connectorstore.GrantListOptions{
+		Mode: connectorstore.GrantListModePayloadWithExpansion,
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Rows, 1)
+	row := resp.Rows[0]
+	require.NotNil(t, row.Grant)
+	require.Equal(t, "ent2", row.Grant.GetEntitlement().GetId(), "expansion-aware reader must hydrate slim grants")
+	require.NotNil(t, row.Expansion)
+	require.Equal(t, []string{"ent1"}, row.Expansion.SourceEntitlementIDs)
+	require.True(t, row.Expansion.Shallow)
+}
+
+// Ensure the newTestC1z helper path does not leave files behind.
+func TestNewTestC1z_Cleanup(t *testing.T) {
+	ctx := context.Background()
+	c1f, _, cleanup := newTestC1z(ctx, t)
+	path, err := c1f.OutputFilepath()
+	require.NoError(t, err)
+	cleanup()
+	// Close must have written the file out; the TempDir cleanup handled
+	// by *testing.T removes it after the test.
+	_, statErr := os.Stat(path)
+	require.NoError(t, statErr, "expected c1z written on close; got %v", statErr)
+}
+
+// TestV2GrantsReader_ListGrantsForEntitlement_Slim exercises the
+// entitlement-filter branch of listGrantsGeneric against slim rows.
+// The filter is a different request type than plain ListGrants, and
+// before the multi-reviewer pass the filter paths had no slim coverage.
+func TestV2GrantsReader_ListGrantsForEntitlement_Slim(t *testing.T) {
+	ctx := context.Background()
+	c1f, _, cleanup := newTestC1z(ctx, t, WithV2GrantsWriter(true))
+	defer cleanup()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "User 1"}.Build()
+	ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1, DisplayName: "Ent 1"}.Build()
+	ent2 := v2.Entitlement_builder{Id: "ent2", Resource: g1}.Build()
+
+	require.NoError(t, c1f.PutGrants(ctx,
+		v2.Grant_builder{Id: "g-on-ent1", Entitlement: ent1, Principal: u1}.Build(),
+		v2.Grant_builder{Id: "g-on-ent2", Entitlement: ent2, Principal: u1}.Build(),
+	))
+
+	resp, err := c1f.ListGrantsForEntitlement(ctx, reader_v2.GrantsReaderServiceListGrantsForEntitlementRequest_builder{
+		Entitlement: ent1,
+	}.Build())
+	require.NoError(t, err)
+	require.Len(t, resp.GetList(), 1)
+	got := resp.GetList()[0]
+	require.Equal(t, "g-on-ent1", got.GetId())
+	require.Equal(t, "ent1", got.GetEntitlement().GetId(), "hydration must fire on the filter path")
+	require.Equal(t, "Ent 1", got.GetEntitlement().GetDisplayName())
+	require.Equal(t, "User 1", got.GetPrincipal().GetDisplayName())
+}
+
+// TestV2GrantsReader_ListGrantsForPrincipal_Slim covers the
+// principal-filter branch of listGrantsGeneric.
+func TestV2GrantsReader_ListGrantsForPrincipal_Slim(t *testing.T) {
+	ctx := context.Background()
+	c1f, _, cleanup := newTestC1z(ctx, t, WithV2GrantsWriter(true))
+	defer cleanup()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "User 1"}.Build()
+	u2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u2"}.Build(), DisplayName: "User 2"}.Build()
+	require.NoError(t, c1f.PutResources(ctx, u2))
+	ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1}.Build()
+
+	require.NoError(t, c1f.PutGrants(ctx,
+		v2.Grant_builder{Id: "g-u1", Entitlement: ent1, Principal: u1}.Build(),
+		v2.Grant_builder{Id: "g-u2", Entitlement: ent1, Principal: u2}.Build(),
+	))
+
+	resp, err := c1f.ListGrantsForPrincipal(ctx, reader_v2.GrantsReaderServiceListGrantsForEntitlementRequest_builder{
+		PrincipalId: v2.ResourceId_builder{ResourceType: "user", Resource: "u2"}.Build(),
+	}.Build())
+	require.NoError(t, err)
+	require.Len(t, resp.GetList(), 1)
+	got := resp.GetList()[0]
+	require.Equal(t, "g-u2", got.GetId())
+	require.Equal(t, "User 2", got.GetPrincipal().GetDisplayName(), "hydration must resolve the filtered principal")
+	require.Equal(t, "ent1", got.GetEntitlement().GetId())
+}
+
+// TestV2GrantsReader_ListGrantsForResourceType_Slim covers the
+// resource-type-filter branch of listGrantsGeneric.
+func TestV2GrantsReader_ListGrantsForResourceType_Slim(t *testing.T) {
+	ctx := context.Background()
+	c1f, _, cleanup := newTestC1z(ctx, t, WithV2GrantsWriter(true))
+	defer cleanup()
+
+	roleRT := v2.ResourceType_builder{Id: "role"}.Build()
+	require.NoError(t, c1f.PutResourceTypes(ctx, roleRT))
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	r1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "role", Resource: "r1"}.Build()}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build()}.Build()
+	require.NoError(t, c1f.PutResources(ctx, r1))
+
+	entG := v2.Entitlement_builder{Id: "ent-group", Resource: g1}.Build()
+	entR := v2.Entitlement_builder{Id: "ent-role", Resource: r1}.Build()
+	require.NoError(t, c1f.PutEntitlements(ctx, entR))
+
+	require.NoError(t, c1f.PutGrants(ctx,
+		v2.Grant_builder{Id: "g-group", Entitlement: entG, Principal: u1}.Build(),
+		v2.Grant_builder{Id: "g-role", Entitlement: entR, Principal: u1}.Build(),
+	))
+
+	resp, err := c1f.ListGrantsForResourceType(ctx, reader_v2.GrantsReaderServiceListGrantsForResourceTypeRequest_builder{
+		ResourceTypeId: "role",
+	}.Build())
+	require.NoError(t, err)
+	require.Len(t, resp.GetList(), 1)
+	got := resp.GetList()[0]
+	require.Equal(t, "g-role", got.GetId())
+	require.Equal(t, "ent-role", got.GetEntitlement().GetId())
+	require.Equal(t, "role", got.GetEntitlement().GetResource().GetId().GetResourceType())
+}
+
+// TestV2GrantsReader_ListGrantsInternalPayload_Slim exercises the
+// GrantListModePayload branch of listGrantsPayloadInternal, which was
+// uncovered (only the WithExpansion branch had slim-path coverage).
+func TestV2GrantsReader_ListGrantsInternalPayload_Slim(t *testing.T) {
+	ctx := context.Background()
+	c1f, _, cleanup := newTestC1z(ctx, t, WithV2GrantsWriter(true))
+	defer cleanup()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "User 1"}.Build()
+	ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1, DisplayName: "Ent 1"}.Build()
+
+	require.NoError(t, c1f.PutGrants(ctx, v2.Grant_builder{
+		Id:          "g-payload",
+		Entitlement: ent1,
+		Principal:   u1,
+	}.Build()))
+
+	// EndSync so resolveSyncIDForPayloadQuery takes the viewSyncID path.
+	require.NoError(t, c1f.EndSync(ctx))
+
+	resp, err := c1f.ListGrantsInternal(ctx, connectorstore.GrantListOptions{
+		Mode: connectorstore.GrantListModePayload,
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Rows, 1)
+	got := resp.Rows[0].Grant
+	require.Equal(t, "g-payload", got.GetId())
+	require.Equal(t, "ent1", got.GetEntitlement().GetId(), "payload-mode internal reader must hydrate slim rows")
+	require.Equal(t, "User 1", got.GetPrincipal().GetDisplayName())
+}
+
+// TestV2GrantsWriter_PreserveExpansionMode_Slim guards against
+// regression: the slim writer must still strip Entitlement / Principal
+// from the data blob when grants are upserted in PreserveExpansion
+// mode. That mode is how the sync expander (pkg/sync/expand) writes
+// every expansion-generated grant — the exact population the feature
+// was built for. A prior iteration early-returned for PreserveExpansion
+// before the slim step, silently storing full blobs for the majority
+// of grants on expansion-heavy tenants.
+func TestV2GrantsWriter_PreserveExpansionMode_Slim(t *testing.T) {
+	ctx := context.Background()
+	c1f, _, cleanup := newTestC1z(ctx, t, WithV2GrantsWriter(true))
+	defer cleanup()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "User 1"}.Build()
+	ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1, DisplayName: "Ent 1"}.Build()
+
+	err := c1f.UpsertGrants(ctx, connectorstore.GrantUpsertOptions{
+		Mode: connectorstore.GrantUpsertModePreserveExpansion,
+	}, v2.Grant_builder{
+		Id:          "grant-preserve",
+		Entitlement: ent1,
+		Principal:   u1,
+	}.Build())
+	require.NoError(t, err)
+
+	// Data blob must be slim.
+	bare := &v2.Grant{}
+	require.NoError(t, proto.Unmarshal(readRawGrantBlob(ctx, t, c1f, "grant-preserve"), bare))
+	require.Nil(t, bare.GetEntitlement(), "PreserveExpansion + slim must strip Entitlement from the blob")
+	require.Nil(t, bare.GetPrincipal(), "PreserveExpansion + slim must strip Principal from the blob")
+
+	// Reader round-trips correctly.
+	resp, err := c1f.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{}.Build())
+	require.NoError(t, err)
+	require.Len(t, resp.GetList(), 1)
+	got := resp.GetList()[0]
+	require.Equal(t, "ent1", got.GetEntitlement().GetId())
+	require.Equal(t, "Ent 1", got.GetEntitlement().GetDisplayName())
+	require.Equal(t, "u1", got.GetPrincipal().GetId().GetResource())
+}
+
+// TestV2GrantsReader_EmptyTable_NoHydrationWork confirms the
+// sawSlim / empty-list short-circuit paths don't error and don't do
+// hydration work when there are no grants.
+func TestV2GrantsReader_EmptyTable_NoHydrationWork(t *testing.T) {
+	ctx := context.Background()
+	c1f, _, cleanup := newTestC1z(ctx, t, WithV2GrantsWriter(true))
+	defer cleanup()
+
+	// ListGrants with no grants written.
+	resp, err := c1f.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{}.Build())
+	require.NoError(t, err)
+	require.Empty(t, resp.GetList())
+	require.Equal(t, "", resp.GetNextPageToken())
+
+	// Internal paths.
+	payloadResp, err := c1f.ListGrantsInternal(ctx, connectorstore.GrantListOptions{
+		Mode: connectorstore.GrantListModePayload,
+	})
+	require.NoError(t, err)
+	require.Empty(t, payloadResp.Rows)
+
+	exResp, err := c1f.ListGrantsInternal(ctx, connectorstore.GrantListOptions{
+		Mode: connectorstore.GrantListModePayloadWithExpansion,
+	})
+	require.NoError(t, err)
+	require.Empty(t, exResp.Rows)
+}

--- a/pkg/dotc1z/grants_v2_writer_test.go
+++ b/pkg/dotc1z/grants_v2_writer_test.go
@@ -617,3 +617,86 @@ func TestV2GrantsReader_EmptyTable_NoHydrationWork(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, exResp.Rows)
 }
+
+// TestV2GrantsWriter_GateSkipsSlimForUnsafeAnnotations verifies that
+// the per-grant gate keeps grants full-blob when they carry an
+// annotation that implies downstream code reads non-identity fields
+// off the embedded Resource / Principal. Each subtest writes one
+// grant with the named annotation under WithV2GrantsWriter(true)
+// and asserts the on-disk blob is full (Entitlement and Principal
+// present), not slim.
+func TestV2GrantsWriter_GateSkipsSlimForUnsafeAnnotations(t *testing.T) {
+	ctx := context.Background()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build()}.Build()
+	ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1, DisplayName: "Ent 1"}.Build()
+
+	cases := []struct {
+		name string
+		anno proto.Message
+	}{
+		{"InsertResourceGrants", &v2.InsertResourceGrants{}},
+		{"ExternalResourceMatchAll", &v2.ExternalResourceMatchAll{}},
+		{"ExternalResourceMatch", &v2.ExternalResourceMatch{}},
+		{"ExternalResourceMatchID", &v2.ExternalResourceMatchID{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c1f, _, cleanup := newTestC1z(ctx, t, WithV2GrantsWriter(true))
+			defer cleanup()
+
+			grant := v2.Grant_builder{
+				Id:          "grant-gated",
+				Entitlement: ent1,
+				Principal:   u1,
+				Annotations: annotations.New(tc.anno),
+			}.Build()
+			require.NoError(t, c1f.PutGrants(ctx, grant))
+
+			// Blob must be full despite slim writer being on.
+			raw := readRawGrantBlob(ctx, t, c1f, "grant-gated")
+			bare := &v2.Grant{}
+			require.NoError(t, proto.Unmarshal(raw, bare))
+			require.NotNil(t, bare.GetEntitlement(), "%s gate must keep Entitlement in the blob", tc.name)
+			require.NotNil(t, bare.GetPrincipal(), "%s gate must keep Principal in the blob", tc.name)
+			require.Equal(t, "ent1", bare.GetEntitlement().GetId())
+			require.Equal(t, "Ent 1", bare.GetEntitlement().GetDisplayName(),
+				"%s gate must preserve DisplayName (proves full blob, not stub)", tc.name)
+
+			// Reader returns the full Grant (no stub).
+			resp, err := c1f.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{}.Build())
+			require.NoError(t, err)
+			require.Len(t, resp.GetList(), 1)
+			got := resp.GetList()[0]
+			require.Equal(t, "Ent 1", got.GetEntitlement().GetDisplayName(),
+				"%s gate-preserved blob must round-trip DisplayName", tc.name)
+		})
+	}
+}
+
+// TestV2GrantsWriter_GateAllowsSlimWhenAnnotationsAbsent guards
+// against a regression where the gate fires on grants that don't
+// actually carry any unsafe annotation. With slim on and no unsafe
+// annotation, the writer must still slim.
+func TestV2GrantsWriter_GateAllowsSlimWhenAnnotationsAbsent(t *testing.T) {
+	ctx := context.Background()
+	c1f, _, cleanup := newTestC1z(ctx, t, WithV2GrantsWriter(true))
+	defer cleanup()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build()}.Build()
+	ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1, DisplayName: "Ent 1"}.Build()
+
+	require.NoError(t, c1f.PutGrants(ctx, v2.Grant_builder{
+		Id:          "grant-no-anno",
+		Entitlement: ent1,
+		Principal:   u1,
+	}.Build()))
+
+	raw := readRawGrantBlob(ctx, t, c1f, "grant-no-anno")
+	bare := &v2.Grant{}
+	require.NoError(t, proto.Unmarshal(raw, bare))
+	require.Nil(t, bare.GetEntitlement(), "no unsafe annotation: blob must be slim")
+	require.Nil(t, bare.GetPrincipal(), "no unsafe annotation: blob must be slim")
+}

--- a/pkg/dotc1z/grants_v2_writer_test.go
+++ b/pkg/dotc1z/grants_v2_writer_test.go
@@ -89,17 +89,22 @@ func TestV2GrantsWriter_RoundTrip(t *testing.T) {
 	require.Nil(t, bare.GetPrincipal(), "slim blob should have nil Principal on disk")
 	require.Equal(t, "grant-1", bare.GetId(), "Grant.Id is preserved in the blob")
 
-	// The reader must reconstitute both fields via hydration.
+	// The reader must reconstitute identity via stub-from-columns. Stubs
+	// carry only Id + nested Resource.Id — DisplayName and other rich
+	// fields are zero-value (documented contract; callers needing rich
+	// data fetch via GetEntitlement / GetResource).
 	resp, err := c1f.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{}.Build())
 	require.NoError(t, err)
 	require.Len(t, resp.GetList(), 1)
 	got := resp.GetList()[0]
 	require.Equal(t, "grant-1", got.GetId())
 	require.Equal(t, "ent1", got.GetEntitlement().GetId())
-	require.Equal(t, "Ent 1", got.GetEntitlement().GetDisplayName())
+	require.Equal(t, "group", got.GetEntitlement().GetResource().GetId().GetResourceType())
+	require.Equal(t, "g1", got.GetEntitlement().GetResource().GetId().GetResource())
 	require.Equal(t, "user", got.GetPrincipal().GetId().GetResourceType())
 	require.Equal(t, "u1", got.GetPrincipal().GetId().GetResource())
-	require.Equal(t, "User 1", got.GetPrincipal().GetDisplayName())
+	require.Empty(t, got.GetEntitlement().GetDisplayName(), "stub Entitlement carries no DisplayName")
+	require.Empty(t, got.GetPrincipal().GetDisplayName(), "stub Principal carries no DisplayName")
 }
 
 func TestV2GrantsWriter_DefaultWritesFullBlob(t *testing.T) {
@@ -213,68 +218,52 @@ func TestV2GrantsReader_MixedBlobs(t *testing.T) {
 	require.Equal(t, "u1", byID["grant-slim"].GetPrincipal().GetId().GetResource())
 }
 
-// TestV2GrantsReader_MissingEntitlement covers the orphan-grant contract:
-// a slim grant whose entitlement_id has no matching v1_entitlements row.
-// The reader must return the grant with Entitlement nil (not error).
-func TestV2GrantsReader_MissingEntitlement(t *testing.T) {
+// TestV2GrantsReader_StubsIgnoreEntitlementTable proves that slim-row
+// hydration does not depend on v1_entitlements or v1_resources existing.
+// We write slim grants, manually wipe both tables, then read the grants
+// back and verify identity is intact on the hydrated stubs. If the
+// reader were still joining (the pre-stub design), this test would fail
+// with empty IDs.
+func TestV2GrantsReader_StubsIgnoreEntitlementTable(t *testing.T) {
 	ctx := context.Background()
 	c1f, _, cleanup := newTestC1z(ctx, t, WithV2GrantsWriter(true))
 	defer cleanup()
 
 	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
 	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build()}.Build()
-	// Reference an entitlement id that does not exist in v1_entitlements.
-	orphanEnt := v2.Entitlement_builder{Id: "ent-does-not-exist", Resource: g1}.Build()
+	ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1}.Build()
 
 	require.NoError(t, c1f.PutGrants(ctx, v2.Grant_builder{
-		Id:          "grant-orphan-ent",
-		Entitlement: orphanEnt,
+		Id:          "grant-stub",
+		Entitlement: ent1,
 		Principal:   u1,
 	}.Build()))
 
+	// Wipe both join targets — stubs should be unaffected.
+	_, err := c1f.db.ExecContext(ctx, fmt.Sprintf("DELETE FROM %s", entitlements.Name()))
+	require.NoError(t, err)
+	_, err = c1f.db.ExecContext(ctx, fmt.Sprintf("DELETE FROM %s", resources.Name()))
+	require.NoError(t, err)
+
 	resp, err := c1f.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{}.Build())
-	require.NoError(t, err, "orphan grant must not cause reader to error")
+	require.NoError(t, err)
 	require.Len(t, resp.GetList(), 1)
 	got := resp.GetList()[0]
-	require.Equal(t, "grant-orphan-ent", got.GetId())
-	require.Nil(t, got.GetEntitlement(), "unresolved entitlement should remain nil, not fabricated")
-	require.NotNil(t, got.GetPrincipal(), "principal should still be hydrated")
+	require.Equal(t, "grant-stub", got.GetId())
+	// Identity must round-trip from the grants row's columns.
+	require.Equal(t, "ent1", got.GetEntitlement().GetId())
+	require.Equal(t, "group", got.GetEntitlement().GetResource().GetId().GetResourceType())
+	require.Equal(t, "g1", got.GetEntitlement().GetResource().GetId().GetResource())
+	require.Equal(t, "user", got.GetPrincipal().GetId().GetResourceType())
 	require.Equal(t, "u1", got.GetPrincipal().GetId().GetResource())
 }
 
-// TestV2GrantsReader_MissingPrincipal is the mirror of MissingEntitlement
-// for the principal side.
-func TestV2GrantsReader_MissingPrincipal(t *testing.T) {
-	ctx := context.Background()
-	c1f, _, cleanup := newTestC1z(ctx, t, WithV2GrantsWriter(true))
-	defer cleanup()
-
-	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
-	ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1}.Build()
-	// Reference a principal that does not exist in v1_resources.
-	orphanPrincipal := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "nope"}.Build()}.Build()
-
-	require.NoError(t, c1f.PutGrants(ctx, v2.Grant_builder{
-		Id:          "grant-orphan-principal",
-		Entitlement: ent1,
-		Principal:   orphanPrincipal,
-	}.Build()))
-
-	resp, err := c1f.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{}.Build())
-	require.NoError(t, err, "orphan grant must not cause reader to error")
-	require.Len(t, resp.GetList(), 1)
-	got := resp.GetList()[0]
-	require.Equal(t, "grant-orphan-principal", got.GetId())
-	require.NotNil(t, got.GetEntitlement())
-	require.Equal(t, "ent1", got.GetEntitlement().GetId())
-	require.Nil(t, got.GetPrincipal(), "unresolved principal should remain nil, not fabricated")
-}
-
-// TestV2GrantsReader_BatchFetch confirms hydration uses batched joins,
-// not a per-row fetch. We measure by inserting many grants that share a
-// handful of (entitlement, principal) targets and then verifying a
-// single ListGrants call returns all of them with correct hydration.
-func TestV2GrantsReader_BatchFetch(t *testing.T) {
+// TestV2GrantsReader_PaginatedSlim verifies that paged reads of slim
+// rows reconstitute identity correctly across page boundaries. With
+// stub-from-columns hydration there's no batched join; this test
+// catches regressions in the per-row stub construction or the
+// pageToken handoff between pages.
+func TestV2GrantsReader_PaginatedSlim(t *testing.T) {
 	ctx := context.Background()
 	c1f, _, cleanup := newTestC1z(ctx, t, WithV2GrantsWriter(true))
 	defer cleanup()
@@ -366,8 +355,8 @@ func TestV2GetGrant_Hydrates(t *testing.T) {
 	got := resp.GetGrant()
 	require.Equal(t, "grant-get", got.GetId())
 	require.Equal(t, "ent1", got.GetEntitlement().GetId())
-	require.Equal(t, "Ent 1", got.GetEntitlement().GetDisplayName())
 	require.Equal(t, "u1", got.GetPrincipal().GetId().GetResource())
+	require.Empty(t, got.GetEntitlement().GetDisplayName(), "stub carries identity only")
 }
 
 // TestExpandableGrants_Unchanged confirms that the expansion reader path
@@ -458,9 +447,8 @@ func TestV2GrantsReader_ListGrantsForEntitlement_Slim(t *testing.T) {
 	require.Len(t, resp.GetList(), 1)
 	got := resp.GetList()[0]
 	require.Equal(t, "g-on-ent1", got.GetId())
-	require.Equal(t, "ent1", got.GetEntitlement().GetId(), "hydration must fire on the filter path")
-	require.Equal(t, "Ent 1", got.GetEntitlement().GetDisplayName())
-	require.Equal(t, "User 1", got.GetPrincipal().GetDisplayName())
+	require.Equal(t, "ent1", got.GetEntitlement().GetId(), "stub hydration must fire on the filter path")
+	require.Equal(t, "u1", got.GetPrincipal().GetId().GetResource())
 }
 
 // TestV2GrantsReader_ListGrantsForPrincipal_Slim covers the
@@ -488,7 +476,8 @@ func TestV2GrantsReader_ListGrantsForPrincipal_Slim(t *testing.T) {
 	require.Len(t, resp.GetList(), 1)
 	got := resp.GetList()[0]
 	require.Equal(t, "g-u2", got.GetId())
-	require.Equal(t, "User 2", got.GetPrincipal().GetDisplayName(), "hydration must resolve the filtered principal")
+	require.Equal(t, "u2", got.GetPrincipal().GetId().GetResource(), "stub hydration must resolve the filtered principal")
+	require.Equal(t, "user", got.GetPrincipal().GetId().GetResourceType())
 	require.Equal(t, "ent1", got.GetEntitlement().GetId())
 }
 
@@ -555,8 +544,9 @@ func TestV2GrantsReader_ListGrantsInternalPayload_Slim(t *testing.T) {
 	require.Len(t, resp.Rows, 1)
 	got := resp.Rows[0].Grant
 	require.Equal(t, "g-payload", got.GetId())
-	require.Equal(t, "ent1", got.GetEntitlement().GetId(), "payload-mode internal reader must hydrate slim rows")
-	require.Equal(t, "User 1", got.GetPrincipal().GetDisplayName())
+	require.Equal(t, "ent1", got.GetEntitlement().GetId(), "payload-mode internal reader must stub-hydrate slim rows")
+	require.Equal(t, "u1", got.GetPrincipal().GetId().GetResource())
+	require.Equal(t, "user", got.GetPrincipal().GetId().GetResourceType())
 }
 
 // TestV2GrantsWriter_PreserveExpansionMode_Slim guards against
@@ -591,13 +581,12 @@ func TestV2GrantsWriter_PreserveExpansionMode_Slim(t *testing.T) {
 	require.Nil(t, bare.GetEntitlement(), "PreserveExpansion + slim must strip Entitlement from the blob")
 	require.Nil(t, bare.GetPrincipal(), "PreserveExpansion + slim must strip Principal from the blob")
 
-	// Reader round-trips correctly.
+	// Reader round-trips correctly via stub-from-columns.
 	resp, err := c1f.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{}.Build())
 	require.NoError(t, err)
 	require.Len(t, resp.GetList(), 1)
 	got := resp.GetList()[0]
 	require.Equal(t, "ent1", got.GetEntitlement().GetId())
-	require.Equal(t, "Ent 1", got.GetEntitlement().GetDisplayName())
 	require.Equal(t, "u1", got.GetPrincipal().GetId().GetResource())
 }
 

--- a/pkg/dotc1z/grants_v2_writer_test.go
+++ b/pkg/dotc1z/grants_v2_writer_test.go
@@ -1,0 +1,723 @@
+package dotc1z
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	reader_v2 "github.com/conductorone/baton-sdk/pb/c1/reader/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+)
+
+// newTestC1z constructs a fresh c1z in t.TempDir(), starts a full sync,
+// and seeds two resource types (group, user), two resources (g1, u1),
+// and two entitlements (ent1, ent2 on g1). Returns the file, sync id,
+// and a cleanup that closes the c1z. Extra C1ZOptions (e.g.
+// WithV2GrantsWriter) are forwarded to NewC1ZFile.
+//
+// No binary .c1z files live on disk beyond the test process — fixtures
+// are generated at test-setup time (2026-04-22 orchestration decision).
+func newTestC1z(ctx context.Context, t *testing.T, opts ...C1ZOption) (*C1File, string, func()) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "test.c1z")
+
+	c1f, err := NewC1ZFile(ctx, path, opts...)
+	require.NoError(t, err)
+
+	syncID, err := c1f.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+
+	groupRT := v2.ResourceType_builder{Id: "group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user"}.Build()
+	require.NoError(t, c1f.PutResourceTypes(ctx, groupRT, userRT))
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "Group 1"}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "User 1"}.Build()
+	require.NoError(t, c1f.PutResources(ctx, g1, u1))
+
+	ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1, DisplayName: "Ent 1"}.Build()
+	ent2 := v2.Entitlement_builder{Id: "ent2", Resource: g1, DisplayName: "Ent 2"}.Build()
+	require.NoError(t, c1f.PutEntitlements(ctx, ent1, ent2))
+
+	cleanup := func() {
+		require.NoError(t, c1f.Close(ctx))
+	}
+	return c1f, syncID, cleanup
+}
+
+// readRawGrantBlob returns the raw data blob stored for a grant row,
+// bypassing the reader's hydration path.
+func readRawGrantBlob(ctx context.Context, t *testing.T, c1f *C1File, externalID string) []byte {
+	t.Helper()
+	var data []byte
+	err := c1f.db.QueryRowContext(ctx,
+		fmt.Sprintf("SELECT data FROM %s WHERE external_id = ?", grants.Name()),
+		externalID,
+	).Scan(&data)
+	require.NoError(t, err)
+	return data
+}
+
+func TestV2GrantsWriter_RoundTrip(t *testing.T) {
+	ctx := context.Background()
+	c1f, _, cleanup := newTestC1z(ctx, t, WithV2GrantsWriter(true))
+	defer cleanup()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "Group 1"}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "User 1"}.Build()
+	ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1, DisplayName: "Ent 1"}.Build()
+
+	grant := v2.Grant_builder{
+		Id:          "grant-1",
+		Entitlement: ent1,
+		Principal:   u1,
+	}.Build()
+	require.NoError(t, c1f.PutGrants(ctx, grant))
+
+	// The on-disk blob must not contain Entitlement or Principal.
+	raw := readRawGrantBlob(ctx, t, c1f, "grant-1")
+	bare := &v2.Grant{}
+	require.NoError(t, proto.Unmarshal(raw, bare))
+	require.Nil(t, bare.GetEntitlement(), "slim blob should have nil Entitlement on disk")
+	require.Nil(t, bare.GetPrincipal(), "slim blob should have nil Principal on disk")
+	require.Equal(t, "grant-1", bare.GetId(), "Grant.Id is preserved in the blob")
+
+	// The reader must reconstitute identity via stub-from-columns. Stubs
+	// carry only Id + nested Resource.Id — DisplayName and other rich
+	// fields are zero-value (documented contract; callers needing rich
+	// data fetch via GetEntitlement / GetResource).
+	resp, err := c1f.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{}.Build())
+	require.NoError(t, err)
+	require.Len(t, resp.GetList(), 1)
+	got := resp.GetList()[0]
+	require.Equal(t, "grant-1", got.GetId())
+	require.Equal(t, "ent1", got.GetEntitlement().GetId())
+	require.Equal(t, "group", got.GetEntitlement().GetResource().GetId().GetResourceType())
+	require.Equal(t, "g1", got.GetEntitlement().GetResource().GetId().GetResource())
+	require.Equal(t, "user", got.GetPrincipal().GetId().GetResourceType())
+	require.Equal(t, "u1", got.GetPrincipal().GetId().GetResource())
+	require.Empty(t, got.GetEntitlement().GetDisplayName(), "stub Entitlement carries no DisplayName")
+	require.Empty(t, got.GetPrincipal().GetDisplayName(), "stub Principal carries no DisplayName")
+}
+
+func TestV2GrantsWriter_DefaultWritesFullBlob(t *testing.T) {
+	ctx := context.Background()
+	c1f, _, cleanup := newTestC1z(ctx, t)
+	defer cleanup()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build()}.Build()
+	ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1}.Build()
+
+	require.NoError(t, c1f.PutGrants(ctx, v2.Grant_builder{
+		Id:          "grant-full",
+		Entitlement: ent1,
+		Principal:   u1,
+	}.Build()))
+
+	raw := readRawGrantBlob(ctx, t, c1f, "grant-full")
+	bare := &v2.Grant{}
+	require.NoError(t, proto.Unmarshal(raw, bare))
+	require.NotNil(t, bare.GetEntitlement(), "default writer must embed Entitlement in blob")
+	require.NotNil(t, bare.GetPrincipal(), "default writer must embed Principal in blob")
+	require.Equal(t, "ent1", bare.GetEntitlement().GetId())
+}
+
+// TestV2GrantsReader_FullBlobPassThrough confirms that when the reader
+// encounters a row that already has Entitlement / Principal populated,
+// it does not overwrite them or issue unnecessary hydration queries.
+func TestV2GrantsReader_FullBlobPassThrough(t *testing.T) {
+	ctx := context.Background()
+	// Writer off — rows are full blobs.
+	c1f, _, cleanup := newTestC1z(ctx, t)
+	defer cleanup()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "Original U1"}.Build()
+	ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1, DisplayName: "Original Ent 1"}.Build()
+
+	require.NoError(t, c1f.PutGrants(ctx, v2.Grant_builder{
+		Id:          "grant-full",
+		Entitlement: ent1,
+		Principal:   u1,
+	}.Build()))
+
+	// Mutate the entitlement/resource rows so a hydration pass would be
+	// observably different. If the reader hydrates, we'd see "Changed".
+	mutatedEnt := v2.Entitlement_builder{Id: "ent1", Resource: g1, DisplayName: "Changed Ent"}.Build()
+	require.NoError(t, c1f.PutEntitlements(ctx, mutatedEnt))
+	mutatedU1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "Changed U1"}.Build()
+	require.NoError(t, c1f.PutResources(ctx, mutatedU1))
+
+	resp, err := c1f.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{}.Build())
+	require.NoError(t, err)
+	require.Len(t, resp.GetList(), 1)
+	got := resp.GetList()[0]
+	require.Equal(t, "Original Ent 1", got.GetEntitlement().GetDisplayName(), "full blob must pass through unchanged")
+	require.Equal(t, "Original U1", got.GetPrincipal().GetDisplayName(), "full blob must pass through unchanged")
+}
+
+// TestV2GrantsReader_MixedBlobs writes some rows with the slim writer
+// and some with the full writer into the same v1_grants table, then
+// verifies the reader returns correct Grants for each. Rows are
+// distinguished per-blob (proto3 nil field detection), no schema marker.
+func TestV2GrantsReader_MixedBlobs(t *testing.T) {
+	ctx := context.Background()
+	c1f, _, cleanup := newTestC1z(ctx, t)
+	defer cleanup()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "Group 1"}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "User 1"}.Build()
+	ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1, DisplayName: "Ent 1"}.Build()
+	ent2 := v2.Entitlement_builder{Id: "ent2", Resource: g1, DisplayName: "Ent 2"}.Build()
+
+	// First grant written with slim disabled (full blob).
+	c1f.v2GrantsWriter = false
+	require.NoError(t, c1f.PutGrants(ctx, v2.Grant_builder{
+		Id:          "grant-full",
+		Entitlement: ent1,
+		Principal:   u1,
+	}.Build()))
+
+	// Second grant written with slim enabled (stripped blob).
+	c1f.v2GrantsWriter = true
+	require.NoError(t, c1f.PutGrants(ctx, v2.Grant_builder{
+		Id:          "grant-slim",
+		Entitlement: ent2,
+		Principal:   u1,
+	}.Build()))
+
+	// On-disk: one full, one slim.
+	fullBare := &v2.Grant{}
+	require.NoError(t, proto.Unmarshal(readRawGrantBlob(ctx, t, c1f, "grant-full"), fullBare))
+	require.NotNil(t, fullBare.GetEntitlement(), "grant-full row should be full blob")
+
+	slimBare := &v2.Grant{}
+	require.NoError(t, proto.Unmarshal(readRawGrantBlob(ctx, t, c1f, "grant-slim"), slimBare))
+	require.Nil(t, slimBare.GetEntitlement(), "grant-slim row should be slim blob")
+	require.Nil(t, slimBare.GetPrincipal(), "grant-slim row should be slim blob")
+
+	// Reader returns both correctly.
+	resp, err := c1f.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{}.Build())
+	require.NoError(t, err)
+	require.Len(t, resp.GetList(), 2)
+	byID := map[string]*v2.Grant{}
+	for _, g := range resp.GetList() {
+		byID[g.GetId()] = g
+	}
+	require.Equal(t, "ent1", byID["grant-full"].GetEntitlement().GetId())
+	require.Equal(t, "u1", byID["grant-full"].GetPrincipal().GetId().GetResource())
+	require.Equal(t, "ent2", byID["grant-slim"].GetEntitlement().GetId())
+	require.Equal(t, "u1", byID["grant-slim"].GetPrincipal().GetId().GetResource())
+}
+
+// TestV2GrantsReader_StubsIgnoreEntitlementTable proves that slim-row
+// hydration does not depend on v1_entitlements or v1_resources existing.
+// We write slim grants, manually wipe both tables, then read the grants
+// back and verify identity is intact on the hydrated stubs. If the
+// reader were still joining (the pre-stub design), this test would fail
+// with empty IDs.
+func TestV2GrantsReader_StubsIgnoreEntitlementTable(t *testing.T) {
+	ctx := context.Background()
+	c1f, _, cleanup := newTestC1z(ctx, t, WithV2GrantsWriter(true))
+	defer cleanup()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build()}.Build()
+	ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1}.Build()
+
+	require.NoError(t, c1f.PutGrants(ctx, v2.Grant_builder{
+		Id:          "grant-stub",
+		Entitlement: ent1,
+		Principal:   u1,
+	}.Build()))
+
+	// Wipe both join targets — stubs should be unaffected.
+	_, err := c1f.db.ExecContext(ctx, fmt.Sprintf("DELETE FROM %s", entitlements.Name()))
+	require.NoError(t, err)
+	_, err = c1f.db.ExecContext(ctx, fmt.Sprintf("DELETE FROM %s", resources.Name()))
+	require.NoError(t, err)
+
+	resp, err := c1f.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{}.Build())
+	require.NoError(t, err)
+	require.Len(t, resp.GetList(), 1)
+	got := resp.GetList()[0]
+	require.Equal(t, "grant-stub", got.GetId())
+	// Identity must round-trip from the grants row's columns.
+	require.Equal(t, "ent1", got.GetEntitlement().GetId())
+	require.Equal(t, "group", got.GetEntitlement().GetResource().GetId().GetResourceType())
+	require.Equal(t, "g1", got.GetEntitlement().GetResource().GetId().GetResource())
+	require.Equal(t, "user", got.GetPrincipal().GetId().GetResourceType())
+	require.Equal(t, "u1", got.GetPrincipal().GetId().GetResource())
+}
+
+// TestV2GrantsReader_PaginatedSlim verifies that paged reads of slim
+// rows reconstitute identity correctly across page boundaries. With
+// stub-from-columns hydration there's no batched join; this test
+// catches regressions in the per-row stub construction or the
+// pageToken handoff between pages.
+func TestV2GrantsReader_PaginatedSlim(t *testing.T) {
+	ctx := context.Background()
+	c1f, _, cleanup := newTestC1z(ctx, t, WithV2GrantsWriter(true))
+	defer cleanup()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1, DisplayName: "Ent 1"}.Build()
+	ent2 := v2.Entitlement_builder{Id: "ent2", Resource: g1, DisplayName: "Ent 2"}.Build()
+
+	// Seed a pool of users so hydration has to fan out.
+	const nUsers = 50
+	users := make([]*v2.Resource, nUsers)
+	for i := range users {
+		u := v2.Resource_builder{
+			Id:          v2.ResourceId_builder{ResourceType: "user", Resource: fmt.Sprintf("u%d", i)}.Build(),
+			DisplayName: fmt.Sprintf("User %d", i),
+		}.Build()
+		users[i] = u
+	}
+	require.NoError(t, c1f.PutResources(ctx, users...))
+
+	// Write 500 slim grants: each user touched 10 times, alternating entitlements.
+	var grantsOut []*v2.Grant
+	for i := range 500 {
+		user := users[i%nUsers]
+		ent := ent1
+		if i%2 == 1 {
+			ent = ent2
+		}
+		g := v2.Grant_builder{
+			Id:          fmt.Sprintf("grant-%d", i),
+			Entitlement: ent,
+			Principal:   user,
+		}.Build()
+		grantsOut = append(grantsOut, g)
+	}
+	require.NoError(t, c1f.PutGrants(ctx, grantsOut...))
+
+	// Page through everything. Each page must hydrate every slim row.
+	seen := 0
+	pageToken := ""
+	for {
+		resp, err := c1f.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{
+			PageSize:  100,
+			PageToken: pageToken,
+		}.Build())
+		require.NoError(t, err)
+		for _, g := range resp.GetList() {
+			require.NotNil(t, g.GetEntitlement(), "grant %s entitlement not hydrated", g.GetId())
+			require.NotNil(t, g.GetPrincipal(), "grant %s principal not hydrated", g.GetId())
+			require.Contains(t, []string{"ent1", "ent2"}, g.GetEntitlement().GetId())
+			require.Equal(t, "user", g.GetPrincipal().GetId().GetResourceType())
+			seen++
+		}
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			break
+		}
+	}
+	require.Equal(t, 500, seen)
+}
+
+// TestV2GetGrant_Hydrates confirms the single-row GetGrant path also
+// hydrates slim blobs.
+func TestV2GetGrant_Hydrates(t *testing.T) {
+	ctx := context.Background()
+	c1f, _, cleanup := newTestC1z(ctx, t, WithV2GrantsWriter(true))
+	defer cleanup()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "User 1"}.Build()
+	ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1, DisplayName: "Ent 1"}.Build()
+
+	require.NoError(t, c1f.PutGrants(ctx, v2.Grant_builder{
+		Id:          "grant-get",
+		Entitlement: ent1,
+		Principal:   u1,
+	}.Build()))
+
+	// Blob is slim.
+	bare := &v2.Grant{}
+	require.NoError(t, proto.Unmarshal(readRawGrantBlob(ctx, t, c1f, "grant-get"), bare))
+	require.Nil(t, bare.GetEntitlement())
+	require.Nil(t, bare.GetPrincipal())
+
+	// GetGrant resolves sync via the currentSyncID cascade (sync is still open).
+	req := reader_v2.GrantsReaderServiceGetGrantRequest_builder{GrantId: "grant-get"}.Build()
+	resp, err := c1f.GetGrant(ctx, req)
+	require.NoError(t, err)
+	got := resp.GetGrant()
+	require.Equal(t, "grant-get", got.GetId())
+	require.Equal(t, "ent1", got.GetEntitlement().GetId())
+	require.Equal(t, "u1", got.GetPrincipal().GetId().GetResource())
+	require.Empty(t, got.GetEntitlement().GetDisplayName(), "stub carries identity only")
+}
+
+// TestExpandableGrants_Unchanged confirms that the expansion reader path
+// still works identically with full vs. slim input rows. Expansion is
+// stored in the `expansion` column (not in the data blob), so the slim
+// writer must not affect it.
+func TestExpandableGrants_Unchanged(t *testing.T) {
+	ctx := context.Background()
+	c1f, _, cleanup := newTestC1z(ctx, t, WithV2GrantsWriter(true))
+	defer cleanup()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build()}.Build()
+	ent2 := v2.Entitlement_builder{Id: "ent2", Resource: g1}.Build()
+
+	expandableGrant := v2.Grant_builder{
+		Id:          "grant-expandable-slim",
+		Entitlement: ent2,
+		Principal:   u1,
+		Annotations: annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{"ent1"},
+			Shallow:         true,
+			ResourceTypeIds: []string{"user"},
+		}.Build()),
+	}.Build()
+
+	require.NoError(t, c1f.PutGrants(ctx, expandableGrant))
+
+	// Expansion column is populated regardless of slim writer.
+	var expansionBytes []byte
+	require.NoError(t, c1f.db.QueryRowContext(ctx,
+		fmt.Sprintf("SELECT expansion FROM %s WHERE external_id=?", grants.Name()),
+		"grant-expandable-slim",
+	).Scan(&expansionBytes))
+	require.NotEmpty(t, expansionBytes, "expansion column must be populated for slim grants with expandable annotation")
+
+	// The expansion-aware list reader hydrates the slim grant AND returns
+	// the expansion annotation.
+	rows, _, err := c1f.Grants().ListWithAnnotationsPage(ctx, "")
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	row := rows[0]
+	require.NotNil(t, row.Grant)
+	require.Equal(t, "ent2", row.Grant.GetEntitlement().GetId(), "expansion-aware reader must hydrate slim grants")
+	require.NotNil(t, row.Annotation)
+	require.Equal(t, []string{"ent1"}, row.Annotation.GetEntitlementIds())
+	require.True(t, row.Annotation.GetShallow())
+}
+
+// Ensure the newTestC1z helper path does not leave files behind.
+func TestNewTestC1z_Cleanup(t *testing.T) {
+	ctx := context.Background()
+	c1f, _, cleanup := newTestC1z(ctx, t)
+	path, err := c1f.OutputFilepath()
+	require.NoError(t, err)
+	cleanup()
+	// Close must have written the file out; the TempDir cleanup handled
+	// by *testing.T removes it after the test.
+	_, statErr := os.Stat(path)
+	require.NoError(t, statErr, "expected c1z written on close; got %v", statErr)
+}
+
+// TestV2GrantsReader_ListGrantsForEntitlement_Slim exercises the
+// entitlement-filter branch of listGrantsGeneric against slim rows.
+// The filter is a different request type than plain ListGrants, and
+// before the multi-reviewer pass the filter paths had no slim coverage.
+func TestV2GrantsReader_ListGrantsForEntitlement_Slim(t *testing.T) {
+	ctx := context.Background()
+	c1f, _, cleanup := newTestC1z(ctx, t, WithV2GrantsWriter(true))
+	defer cleanup()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "User 1"}.Build()
+	ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1, DisplayName: "Ent 1"}.Build()
+	ent2 := v2.Entitlement_builder{Id: "ent2", Resource: g1}.Build()
+
+	require.NoError(t, c1f.PutGrants(ctx,
+		v2.Grant_builder{Id: "g-on-ent1", Entitlement: ent1, Principal: u1}.Build(),
+		v2.Grant_builder{Id: "g-on-ent2", Entitlement: ent2, Principal: u1}.Build(),
+	))
+
+	resp, err := c1f.ListGrantsForEntitlement(ctx, reader_v2.GrantsReaderServiceListGrantsForEntitlementRequest_builder{
+		Entitlement: ent1,
+	}.Build())
+	require.NoError(t, err)
+	require.Len(t, resp.GetList(), 1)
+	got := resp.GetList()[0]
+	require.Equal(t, "g-on-ent1", got.GetId())
+	require.Equal(t, "ent1", got.GetEntitlement().GetId(), "stub hydration must fire on the filter path")
+	require.Equal(t, "u1", got.GetPrincipal().GetId().GetResource())
+}
+
+// TestV2GrantsReader_ListGrantsForPrincipal_Slim covers the
+// principal-filter branch of listGrantsGeneric.
+func TestV2GrantsReader_ListGrantsForPrincipal_Slim(t *testing.T) {
+	ctx := context.Background()
+	c1f, _, cleanup := newTestC1z(ctx, t, WithV2GrantsWriter(true))
+	defer cleanup()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "User 1"}.Build()
+	u2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u2"}.Build(), DisplayName: "User 2"}.Build()
+	require.NoError(t, c1f.PutResources(ctx, u2))
+	ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1}.Build()
+
+	require.NoError(t, c1f.PutGrants(ctx,
+		v2.Grant_builder{Id: "g-u1", Entitlement: ent1, Principal: u1}.Build(),
+		v2.Grant_builder{Id: "g-u2", Entitlement: ent1, Principal: u2}.Build(),
+	))
+
+	resp, err := c1f.ListGrantsForPrincipal(ctx, reader_v2.GrantsReaderServiceListGrantsForEntitlementRequest_builder{
+		PrincipalId: v2.ResourceId_builder{ResourceType: "user", Resource: "u2"}.Build(),
+	}.Build())
+	require.NoError(t, err)
+	require.Len(t, resp.GetList(), 1)
+	got := resp.GetList()[0]
+	require.Equal(t, "g-u2", got.GetId())
+	require.Equal(t, "u2", got.GetPrincipal().GetId().GetResource(), "stub hydration must resolve the filtered principal")
+	require.Equal(t, "user", got.GetPrincipal().GetId().GetResourceType())
+	require.Equal(t, "ent1", got.GetEntitlement().GetId())
+}
+
+// TestV2GrantsReader_ListGrantsForResourceType_Slim covers the
+// resource-type-filter branch of listGrantsGeneric.
+func TestV2GrantsReader_ListGrantsForResourceType_Slim(t *testing.T) {
+	ctx := context.Background()
+	c1f, _, cleanup := newTestC1z(ctx, t, WithV2GrantsWriter(true))
+	defer cleanup()
+
+	roleRT := v2.ResourceType_builder{Id: "role"}.Build()
+	require.NoError(t, c1f.PutResourceTypes(ctx, roleRT))
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	r1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "role", Resource: "r1"}.Build()}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build()}.Build()
+	require.NoError(t, c1f.PutResources(ctx, r1))
+
+	entG := v2.Entitlement_builder{Id: "ent-group", Resource: g1}.Build()
+	entR := v2.Entitlement_builder{Id: "ent-role", Resource: r1}.Build()
+	require.NoError(t, c1f.PutEntitlements(ctx, entR))
+
+	require.NoError(t, c1f.PutGrants(ctx,
+		v2.Grant_builder{Id: "g-group", Entitlement: entG, Principal: u1}.Build(),
+		v2.Grant_builder{Id: "g-role", Entitlement: entR, Principal: u1}.Build(),
+	))
+
+	resp, err := c1f.ListGrantsForResourceType(ctx, reader_v2.GrantsReaderServiceListGrantsForResourceTypeRequest_builder{
+		ResourceTypeId: "role",
+	}.Build())
+	require.NoError(t, err)
+	require.Len(t, resp.GetList(), 1)
+	got := resp.GetList()[0]
+	require.Equal(t, "g-role", got.GetId())
+	require.Equal(t, "ent-role", got.GetEntitlement().GetId())
+	require.Equal(t, "role", got.GetEntitlement().GetResource().GetId().GetResourceType())
+}
+
+// TestV2GrantsWriter_PreserveExpansionMode_Slim guards against
+// regression: the slim writer must still strip Entitlement / Principal
+// from the data blob when grants are upserted in PreserveExpansion
+// mode. That mode is how the sync expander (pkg/sync/expand) writes
+// every expansion-generated grant — the exact population the feature
+// was built for. A prior iteration early-returned for PreserveExpansion
+// before the slim step, silently storing full blobs for the majority
+// of grants on expansion-heavy tenants.
+//
+// StoreExpandedGrants is the public PreserveExpansion entry point
+// post-RFC-0002. The grant in this test carries no GrantExpandable
+// annotation, so StoreExpandedGrants's defensive strip is a no-op and
+// the slim-write assertions still measure what they intend.
+func TestV2GrantsWriter_PreserveExpansionMode_Slim(t *testing.T) {
+	ctx := context.Background()
+	c1f, _, cleanup := newTestC1z(ctx, t, WithV2GrantsWriter(true))
+	defer cleanup()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "User 1"}.Build()
+	ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1, DisplayName: "Ent 1"}.Build()
+
+	err := c1f.StoreExpandedGrants(ctx, v2.Grant_builder{
+		Id:          "grant-preserve",
+		Entitlement: ent1,
+		Principal:   u1,
+	}.Build())
+	require.NoError(t, err)
+
+	// Data blob must be slim.
+	bare := &v2.Grant{}
+	require.NoError(t, proto.Unmarshal(readRawGrantBlob(ctx, t, c1f, "grant-preserve"), bare))
+	require.Nil(t, bare.GetEntitlement(), "PreserveExpansion + slim must strip Entitlement from the blob")
+	require.Nil(t, bare.GetPrincipal(), "PreserveExpansion + slim must strip Principal from the blob")
+
+	// Reader round-trips correctly via stub-from-columns.
+	resp, err := c1f.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{}.Build())
+	require.NoError(t, err)
+	require.Len(t, resp.GetList(), 1)
+	got := resp.GetList()[0]
+	require.Equal(t, "ent1", got.GetEntitlement().GetId())
+	require.Equal(t, "u1", got.GetPrincipal().GetId().GetResource())
+}
+
+// TestV2GrantsReader_EmptyTable_NoHydrationWork confirms the
+// empty-list short-circuit paths don't error and don't do hydration
+// work when there are no grants. Post-RFC-0002 the only public
+// payload-shaped reader is the gRPC ListGrants surface plus the
+// expansion-aware ListWithAnnotationsPage; both must short-circuit.
+func TestV2GrantsReader_EmptyTable_NoHydrationWork(t *testing.T) {
+	ctx := context.Background()
+	c1f, _, cleanup := newTestC1z(ctx, t, WithV2GrantsWriter(true))
+	defer cleanup()
+
+	// ListGrants with no grants written.
+	resp, err := c1f.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{}.Build())
+	require.NoError(t, err)
+	require.Empty(t, resp.GetList())
+	require.Equal(t, "", resp.GetNextPageToken())
+
+	// The expansion-aware internal path must also short-circuit cleanly.
+	annRows, _, err := c1f.Grants().ListWithAnnotationsPage(ctx, "")
+	require.NoError(t, err)
+	require.Empty(t, annRows)
+}
+
+// TestV2GrantsWriter_GateSkipsSlimForUnsafeAnnotations verifies that
+// the per-grant gate keeps grants full-blob when they carry an
+// annotation that implies downstream code reads non-identity fields
+// off the embedded Resource / Principal. Each subtest writes one
+// grant with the named annotation under WithV2GrantsWriter(true)
+// and asserts the on-disk blob is full (Entitlement and Principal
+// present), not slim.
+func TestV2GrantsWriter_GateSkipsSlimForUnsafeAnnotations(t *testing.T) {
+	ctx := context.Background()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build()}.Build()
+	ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1, DisplayName: "Ent 1"}.Build()
+
+	cases := []struct {
+		name string
+		anno proto.Message
+	}{
+		{"InsertResourceGrants", &v2.InsertResourceGrants{}},
+		{"ExternalResourceMatchAll", &v2.ExternalResourceMatchAll{}},
+		{"ExternalResourceMatch", &v2.ExternalResourceMatch{}},
+		{"ExternalResourceMatchID", &v2.ExternalResourceMatchID{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c1f, _, cleanup := newTestC1z(ctx, t, WithV2GrantsWriter(true))
+			defer cleanup()
+
+			grant := v2.Grant_builder{
+				Id:          "grant-gated",
+				Entitlement: ent1,
+				Principal:   u1,
+				Annotations: annotations.New(tc.anno),
+			}.Build()
+			require.NoError(t, c1f.PutGrants(ctx, grant))
+
+			// Blob must be full despite slim writer being on.
+			raw := readRawGrantBlob(ctx, t, c1f, "grant-gated")
+			bare := &v2.Grant{}
+			require.NoError(t, proto.Unmarshal(raw, bare))
+			require.NotNil(t, bare.GetEntitlement(), "%s gate must keep Entitlement in the blob", tc.name)
+			require.NotNil(t, bare.GetPrincipal(), "%s gate must keep Principal in the blob", tc.name)
+			require.Equal(t, "ent1", bare.GetEntitlement().GetId())
+			require.Equal(t, "Ent 1", bare.GetEntitlement().GetDisplayName(),
+				"%s gate must preserve DisplayName (proves full blob, not stub)", tc.name)
+
+			// Reader returns the full Grant (no stub).
+			resp, err := c1f.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{}.Build())
+			require.NoError(t, err)
+			require.Len(t, resp.GetList(), 1)
+			got := resp.GetList()[0]
+			require.Equal(t, "Ent 1", got.GetEntitlement().GetDisplayName(),
+				"%s gate-preserved blob must round-trip DisplayName", tc.name)
+		})
+	}
+}
+
+// TestV2GrantsWriter_GateAllowsSlimWhenAnnotationsAbsent guards
+// against a regression where the gate fires on grants that don't
+// actually carry any unsafe annotation. With slim on and no unsafe
+// annotation, the writer must still slim.
+func TestV2GrantsWriter_GateAllowsSlimWhenAnnotationsAbsent(t *testing.T) {
+	ctx := context.Background()
+	c1f, _, cleanup := newTestC1z(ctx, t, WithV2GrantsWriter(true))
+	defer cleanup()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build()}.Build()
+	ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1, DisplayName: "Ent 1"}.Build()
+
+	require.NoError(t, c1f.PutGrants(ctx, v2.Grant_builder{
+		Id:          "grant-no-anno",
+		Entitlement: ent1,
+		Principal:   u1,
+	}.Build()))
+
+	raw := readRawGrantBlob(ctx, t, c1f, "grant-no-anno")
+	bare := &v2.Grant{}
+	require.NoError(t, proto.Unmarshal(raw, bare))
+	require.Nil(t, bare.GetEntitlement(), "no unsafe annotation: blob must be slim")
+	require.Nil(t, bare.GetPrincipal(), "no unsafe annotation: blob must be slim")
+}
+
+// TestV2GetGrant_HydratesAfterCloseReopen exercises the cascade
+// fall-through in resolveSyncIDForGrantGet: after Close + reopen,
+// neither currentSyncID nor viewSyncID is set, so resolution falls
+// through to the latest finished sync. Slim grants fetched via
+// GetGrant on the reopened c1z must still hydrate.
+//
+// This is the read path that baton CLI's `baton grants` and any
+// post-sync analyzer hits (open the c1z, no current sync, no view
+// sync set), and it was previously untested.
+func TestV2GetGrant_HydratesAfterCloseReopen(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "reopen.c1z")
+
+	// Phase 1: write slim grants and finalize the sync.
+	c1f, err := NewC1ZFile(ctx, path, WithV2GrantsWriter(true))
+	require.NoError(t, err)
+
+	_, err = c1f.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+
+	groupRT := v2.ResourceType_builder{Id: "group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user"}.Build()
+	require.NoError(t, c1f.PutResourceTypes(ctx, groupRT, userRT))
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "Group 1"}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "User 1"}.Build()
+	require.NoError(t, c1f.PutResources(ctx, g1, u1))
+
+	ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1, DisplayName: "Ent 1"}.Build()
+	require.NoError(t, c1f.PutEntitlements(ctx, ent1))
+
+	require.NoError(t, c1f.PutGrants(ctx, v2.Grant_builder{
+		Id:          "grant-reopen",
+		Entitlement: ent1,
+		Principal:   u1,
+	}.Build()))
+
+	require.NoError(t, c1f.EndSync(ctx))
+	require.NoError(t, c1f.Close(ctx))
+
+	// Phase 2: reopen the c1z. Neither currentSyncID nor viewSyncID
+	// is set on the freshly reopened file — resolveSyncIDForGrantGet
+	// must fall through to getFinishedSync.
+	c1f2, err := NewC1ZFile(ctx, path)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, c1f2.Close(ctx)) }()
+
+	resp, err := c1f2.GetGrant(ctx, reader_v2.GrantsReaderServiceGetGrantRequest_builder{
+		GrantId: "grant-reopen",
+	}.Build())
+	require.NoError(t, err)
+	got := resp.GetGrant()
+	require.Equal(t, "grant-reopen", got.GetId())
+	require.Equal(t, "ent1", got.GetEntitlement().GetId(),
+		"GetGrant must hydrate via the latest-finished-sync cascade branch")
+	require.Equal(t, "u1", got.GetPrincipal().GetId().GetResource())
+	require.Equal(t, "user", got.GetPrincipal().GetId().GetResourceType())
+}

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -1719,6 +1719,21 @@ func (s *syncer) syncGrantsForResource(ctx context.Context, action *Action) erro
 	respAnnos := annotations.Annotations(resp.GetAnnotations())
 	insertResourceGrants := respAnnos.Contains(&v2.InsertResourceGrants{})
 
+	// InsertResourceGrants is canonically a response-level annotation but
+	// the slim-blob writer's per-grant safety gate (grantExtractFields →
+	// unsafeForSlim) needs to see it per-row to avoid stripping the
+	// embedded Resource that this code path will subsequently extract via
+	// grant.GetEntitlement().GetResource() and write to v1_resources.
+	// Stamp the marker onto each grant so the writer treats them as
+	// full-blob.
+	if insertResourceGrants {
+		for _, g := range grants {
+			gAnnos := annotations.Annotations(g.GetAnnotations())
+			gAnnos.Update(&v2.InsertResourceGrants{})
+			g.SetAnnotations(gAnnos)
+		}
+	}
+
 	for _, grant := range grants {
 		grantAnnos := annotations.Annotations(grant.GetAnnotations())
 		if !s.dontExpandGrants && grantAnnos.Contains(&v2.GrantExpandable{}) {

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -1734,18 +1734,14 @@ func (s *syncer) syncGrantsForResource(ctx context.Context, action *Action) erro
 	respAnnos := annotations.Annotations(resp.GetAnnotations())
 	insertResourceGrants := respAnnos.Contains(&v2.InsertResourceGrants{})
 
-	// InsertResourceGrants is canonically a response-level annotation but
-	// the slim-blob writer's per-grant safety gate (grantExtractFields →
-	// unsafeForSlim) needs to see it per-row to avoid stripping the
-	// embedded Resource that this code path will subsequently extract via
-	// grant.GetEntitlement().GetResource() and write to v1_resources.
-	// Stamp the marker onto each grant so the writer treats them as
-	// full-blob.
+	// Stamp InsertResourceGrants per-grant so the slim-blob writer's
+	// gate sees it. The annotation is response-level, but the writer
+	// needs it per-row to avoid stripping the Resource this path
+	// subsequently writes to v1_resources.
 	//
-	// Marshal the *anypb.Any once and append the shared pointer to each
-	// grant — Any is treated as immutable downstream, so aliasing is
-	// safe and avoids per-grant proto-marshal + slice rebuild that
-	// annotations.Update would do.
+	// Aliasing the same *anypb.Any across grants is safe — Any is
+	// treated as immutable downstream. Avoids the per-grant proto
+	// marshal that annotations.Update would do.
 	if insertResourceGrants {
 		insertResourceGrantsSentinel := &v2.InsertResourceGrants{}
 		var insertAny *anypb.Any

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -35,6 +35,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
 
 	c1zpb "github.com/conductorone/baton-sdk/pb/c1/c1z/v1"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
@@ -1732,6 +1733,34 @@ func (s *syncer) syncGrantsForResource(ctx context.Context, action *Action) erro
 	resourcesToInsertMap := make(map[string]*v2.Resource, 0)
 	respAnnos := annotations.Annotations(resp.GetAnnotations())
 	insertResourceGrants := respAnnos.Contains(&v2.InsertResourceGrants{})
+
+	// InsertResourceGrants is canonically a response-level annotation but
+	// the slim-blob writer's per-grant safety gate (grantExtractFields →
+	// unsafeForSlim) needs to see it per-row to avoid stripping the
+	// embedded Resource that this code path will subsequently extract via
+	// grant.GetEntitlement().GetResource() and write to v1_resources.
+	// Stamp the marker onto each grant so the writer treats them as
+	// full-blob.
+	//
+	// Marshal the *anypb.Any once and append the shared pointer to each
+	// grant — Any is treated as immutable downstream, so aliasing is
+	// safe and avoids per-grant proto-marshal + slice rebuild that
+	// annotations.Update would do.
+	if insertResourceGrants {
+		insertResourceGrantsSentinel := &v2.InsertResourceGrants{}
+		var insertAny *anypb.Any
+		insertAny, err = anypb.New(insertResourceGrantsSentinel)
+		if err != nil {
+			return fmt.Errorf("error marshaling InsertResourceGrants annotation: %w", err)
+		}
+		for _, g := range grants {
+			annos := annotations.Annotations(g.GetAnnotations())
+			if annos.Contains(insertResourceGrantsSentinel) {
+				continue
+			}
+			g.SetAnnotations(append(annos, insertAny))
+		}
+	}
 
 	for _, grant := range grants {
 		grantAnnos := annotations.Annotations(grant.GetAnnotations())

--- a/pkg/sync/syncer_test.go
+++ b/pkg/sync/syncer_test.go
@@ -2144,3 +2144,128 @@ func TestSyncGrants_NoMatchPaginates(t *testing.T) {
 
 	require.Equal(t, []string{"", "next"}, mc.callTokens)
 }
+
+// insertResourceGrantsMockConnector returns InsertResourceGrants on its
+// ListGrants response when emitInsertResourceGrants is set. Used to
+// exercise the syncer's per-grant annotation propagation in
+// syncGrantsForResource (the writer's slim-blob safety gate depends on
+// the per-row annotation being present).
+type insertResourceGrantsMockConnector struct {
+	*mockConnector
+	emitInsertResourceGrants bool
+}
+
+func newInsertResourceGrantsMockConnector(emit bool) *insertResourceGrantsMockConnector {
+	mc := &insertResourceGrantsMockConnector{
+		mockConnector:            newMockConnector(),
+		emitInsertResourceGrants: emit,
+	}
+	mc.rtDB = append(mc.rtDB, groupResourceType, userResourceType)
+	return mc
+}
+
+func (mc *insertResourceGrantsMockConnector) ListGrants(
+	ctx context.Context,
+	in *v2.GrantsServiceListGrantsRequest,
+	opts ...grpc.CallOption,
+) (*v2.GrantsServiceListGrantsResponse, error) {
+	var key string
+	if r := in.GetResource(); r != nil {
+		key = r.GetId().GetResource()
+	}
+	resp := v2.GrantsServiceListGrantsResponse_builder{List: mc.grantDB[key]}
+	if mc.emitInsertResourceGrants {
+		resp.Annotations = annotations.New(&v2.InsertResourceGrants{})
+	}
+	return resp.Build(), nil
+}
+
+// TestSyncGrants_PropagatesInsertResourceGrantsAnnotation verifies that
+// when the connector returns InsertResourceGrants on the ListGrants
+// response, syncGrantsForResource stamps the annotation onto each
+// grant in the batch. This is load-bearing: the slim-blob writer's
+// per-grant gate (unsafeForSlim) reads the annotation off each Grant,
+// not off the response — without this propagation, slim writes would
+// strip Entitlement.Resource from grants that the syncer subsequently
+// extracts and writes to v1_resources via PutResources, corrupting
+// the resources table on etag-replay.
+func TestSyncGrants_PropagatesInsertResourceGrantsAnnotation(t *testing.T) {
+	ctx := t.Context()
+	tempDir := t.TempDir()
+	c1zPath := filepath.Join(tempDir, "insert-resource-grants.c1z")
+
+	group, err := rs.NewGroupResource("g1", groupResourceType, "g1", nil)
+	require.NoError(t, err)
+	ent := et.NewAssignmentEntitlement(group, "member", et.WithGrantableTo(groupResourceType, userResourceType))
+	ent.SetSlug("member")
+	user, err := rs.NewUserResource("u1", userResourceType, "u1", nil, rs.WithAnnotation(&v2.SkipEntitlementsAndGrants{}))
+	require.NoError(t, err)
+	grant := gt.NewGrant(group, "member", user)
+
+	mc := newInsertResourceGrantsMockConnector(true)
+	mc.entDB[group.GetId().GetResource()] = []*v2.Entitlement{ent}
+	mc.grantDB[group.GetId().GetResource()] = []*v2.Grant{grant}
+	mc.AddResource(ctx, group)
+
+	syncer, err := NewSyncer(ctx, mc, WithC1ZPath(c1zPath), WithTmpDir(tempDir))
+	require.NoError(t, err)
+	require.NoError(t, syncer.Sync(ctx))
+	require.NoError(t, syncer.Close(ctx))
+
+	c1zManager, err := manager.New(ctx, c1zPath)
+	require.NoError(t, err)
+	store, err := c1zManager.LoadC1Z(ctx)
+	require.NoError(t, err)
+
+	resp, err := store.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{}.Build())
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.GetList(), "expected at least one stored grant")
+	for _, g := range resp.GetList() {
+		annos := annotations.Annotations(g.GetAnnotations())
+		require.True(t, annos.Contains(&v2.InsertResourceGrants{}),
+			"grant %s missing InsertResourceGrants annotation after sync", g.GetId())
+	}
+}
+
+// TestSyncGrants_DoesNotPropagateAnnotationWhenAbsent is the negative
+// case for the propagation: when the response does not carry
+// InsertResourceGrants, syncGrantsForResource must not stamp it onto
+// grants. Otherwise the slim-blob writer's gate would always treat
+// every grant as full-blob, defeating the storage savings.
+func TestSyncGrants_DoesNotPropagateAnnotationWhenAbsent(t *testing.T) {
+	ctx := t.Context()
+	tempDir := t.TempDir()
+	c1zPath := filepath.Join(tempDir, "no-insert-resource-grants.c1z")
+
+	group, err := rs.NewGroupResource("g1", groupResourceType, "g1", nil)
+	require.NoError(t, err)
+	ent := et.NewAssignmentEntitlement(group, "member", et.WithGrantableTo(groupResourceType, userResourceType))
+	ent.SetSlug("member")
+	user, err := rs.NewUserResource("u1", userResourceType, "u1", nil, rs.WithAnnotation(&v2.SkipEntitlementsAndGrants{}))
+	require.NoError(t, err)
+	grant := gt.NewGrant(group, "member", user)
+
+	mc := newInsertResourceGrantsMockConnector(false)
+	mc.entDB[group.GetId().GetResource()] = []*v2.Entitlement{ent}
+	mc.grantDB[group.GetId().GetResource()] = []*v2.Grant{grant}
+	mc.AddResource(ctx, group)
+
+	syncer, err := NewSyncer(ctx, mc, WithC1ZPath(c1zPath), WithTmpDir(tempDir))
+	require.NoError(t, err)
+	require.NoError(t, syncer.Sync(ctx))
+	require.NoError(t, syncer.Close(ctx))
+
+	c1zManager, err := manager.New(ctx, c1zPath)
+	require.NoError(t, err)
+	store, err := c1zManager.LoadC1Z(ctx)
+	require.NoError(t, err)
+
+	resp, err := store.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{}.Build())
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.GetList(), "expected at least one stored grant")
+	for _, g := range resp.GetList() {
+		annos := annotations.Annotations(g.GetAnnotations())
+		require.False(t, annos.Contains(&v2.InsertResourceGrants{}),
+			"grant %s carries InsertResourceGrants annotation but response did not", g.GetId())
+	}
+}


### PR DESCRIPTION
## One-sentence summary

Opt-in writer mode that strips `Entitlement` and `Principal` from the
grant data blob and rebuilds them as identity-only stubs at read time,
to keep large-tenant `.c1z` files under the decoder's max-size cap.

## The problem

Large tenants — particularly group-grant-heavy ones — hit the c1z
decoder's `ErrMaxSizeExceeded` cap. The biggest contributor is grant
expansion: every expanded grant row duplicates the embedded `Entitlement`
and `Principal` protos. On a tenant with thousands of group memberships
expanded across thousands of users, this is millions of redundant
copies of the same Resource and Entitlement data.

## The fix

At **write time**, strip the embedded `Entitlement` and `Principal`
from `Grant.data`. Save ~390 B per grant.

At **read time**, rebuild both fields as identity-only stubs from
columns that already exist on the grants row:

- `entitlement_id`
- `resource_type_id` (entitlement's resource)
- `resource_id` (entitlement's resource)
- `principal_resource_type_id`
- `principal_resource_id`

No joins. No second query. The hydration is a pure function: SELECT
those five columns alongside the data blob, build a stub if either
field came back nil after unmarshal.

## What "stub" means

A stub carries identity only:

- `Entitlement.Id` + `Entitlement.Resource.Id` (resource type + resource)
- `Resource.Id` (principal's resource type + resource)

Everything else is zero-value: `DisplayName`, `Annotations`, `Purpose`,
`Slug`, `Traits`, `ParentResourceId`, etc. Callers that need rich
fields must fetch the `Entitlement` or `Resource` directly.

## Why it's safe

Cross-repo audit (baton-sdk, c1, baton CLI) found no consumer reading
non-identity fields off a grant's embedded `Entitlement` or `Principal`.
Everyone uses `.Id`, `.Resource.Id`, or `.GetResource().GetId()`.

Then two cases inside baton-sdk's syncer were found that *do* read
non-identity fields. Both are now gated:

1. **`InsertResourceGrants`** — the syncer extracts
   `grant.Entitlement.Resource` and writes it to `v1_resources` via
   `PutResources`. Stubs would overwrite the resources table with
   stripped data on etag-replay.
2. **`ExternalResourceMatch{All,Match,ID}`** —
   `processGrantsWithExternalPrincipals` builds a bid key from
   `grant.GetPrincipal()` whose map keys encode `ParentResourceId`.
   A stub principal has no parent; its 2-part bid would silently miss
   4-part map keys, losing transitive expansion.

`unsafeForSlim()` checks for any of these four annotations. If
present, the grant stays full-blob even when the writer flag is on.

## What's opt-in vs always-on

- **Writer**: opt-in. Default off. Toggle with `WithV2GrantsWriter(true)`
  or `WithC1FV2GrantsWriter(true)`.
- **Reader**: always on. Full and slim rows coexist transparently in
  the same table. Old `.c1z` files keep working unchanged.

## Files changed

- `pkg/dotc1z/c1file.go` — option plumbing.
- `pkg/dotc1z/dotc1z.go` — top-level option.
- `pkg/dotc1z/grants.go` — `slimGrantForWrite` (writer), `unsafeForSlim`
  (gate), `listGrantsGeneric` (grant-specific list with identity
  columns inline), `resolveSyncIDForGrantGet`.
- `pkg/dotc1z/grants_hydrate.go` — `hydrateGrants` (pure stub builder),
  `hydrateSingleGrant` (one-row variant for `GetGrant`).
- `pkg/dotc1z/grants_expandable_query.go` — same identity-column
  treatment for the expansion reader.
- `pkg/sync/syncer.go` — stamps `InsertResourceGrants` per-grant so
  the writer's gate sees it (it's normally response-level only).

## Performance

- 62% wall-clock improvement on `ListGrantsForEntitlement` at 10k
  slim grants vs the original batch-join hydration approach.
- At 100k grants, slim beats the pre-slim full-blob baseline — 543ms
  vs 661ms — *with* the size win on top.

Validation against a real customer target (baton-microsoft-entra
`.c1z`, 489 grants): 0 grants carry any unsafe annotation, all 489
are slim-eligible.

See `BENCHMARKS.md` for how to reproduce.

## Likely questions

**Why not normalize the grants table?**
The schema already has the identity columns we need. A normalized
schema would mean a migration, joins on every read, and breaking
changes. Stripping the blob is a write-only change; the read path
stays a single SELECT.

**Why opt-in?**
Gradual rollout. Customers who hit the cap turn it on; everyone else
keeps the unchanged behavior. Once the gate is proven in production,
defaulting on is reasonable.

**What if a future syncer change reads non-identity fields off these
embedded protos?**
That's the trust contract. The audit was point-in-time. New code that
reads non-identity fields off `grant.GetEntitlement()` or
`grant.GetPrincipal()` must either annotate the grant with one of the
unsafe markers or accept that slim-mode tenants get zero-value fields.
There's no compiler-level enforcement; reviewers have to know.

**What about a race in `GetGrant`?**
`GetGrant` does the SELECT, then a second SELECT via `hydrateSingleGrant`
to fetch identity columns. If a sync finishes in the microsecond gap,
the cascade *could* resolve to a different sync_id. The failure mode
is soft: `sql.ErrNoRows` returns nil and the grant comes back with
nil-fields rather than mismatched data. `resolveSyncIDForGrantGet`
replays the same cascade `getConnectorObject` used to keep the window
small.

**Why does `resolveSyncIDForGrantGet` exist at all?**
`getConnectorObject` resolves the sync_id internally but doesn't
return which one it picked. The slim hydration query needs the same
sync_id to land on the same row. Cleaner alternatives exist (return
the resolved sync_id from `getConnectorObject`, or pull identity
columns inside it for the grants table) — they'd touch more code, so
this PR took the workaround path.

**Why does `listGrantsGeneric` exist alongside `listConnectorObjects`?**
The generic version only reads the data blob. Slim hydration needs
five additional columns in the same SELECT. Forking the generic path
for grants only — same dispatch idiom, wider column set.

**What's the size win per grant?**
~390 B saved by stripping `Entitlement` and `Principal`. `Grant.Id` is
intentionally kept (~40 B cost) because stripping it would force
`GetGrant` through a slower generic single-row path.

**Does this break any existing consumers?**
No. Readers transparently handle both shapes. Connectors emit grants
the same way as before. The flag is a writer-side toggle; nothing in
the wire format changed.

## Impact
Using insulator entra sync:

```
 table                          rows    bytes (total)     avg blob
     ---------------------- ------------ ---------------- ------------
     v1_grants                       893           73,128         81.9   [slim]
                                     897          741,515        826.7   [full]
                                      -4          -668387       -90.1%   [delta]

     v1_resources                    768          434,921        566.3   [slim]
                                     768          434,921        566.3   [full]
                                      +0               +0        +0.0%   [delta]

     v1_entitlements               1,127          833,743        739.8   [slim]
                                   1,127          833,743        739.8   [full]
                                      +0               +0        +0.0%   [delta]

     v1_resource_types                 6              243         40.5   [slim]
                                       6              243         40.5   [full]
                                      +0               +0        +0.0%   [delta]

     file sizes:
       3.7M  /Users/btipling/projects/full.db
       2.9M  /Users/btipling/projects/slim.db
```
Compressed c1z:
```
baton on  bt/slim-grants-smoke [!?] via 🐹 v1.25.2 with 🐃 v1.66.1 on ☁️  bjorn.tipling@batonc1.com
❯ ls -lah ~/projects/slim.c1z ~/projects/full.c1z
-rw-r--r--@ 1 btipling  staff   257K May 13 14:15 /Users/btipling/projects/full.c1z
-rw-r--r--@ 1 btipling  staff   244K May 13 13:55 /Users/btipling/projects/slim.c1z
```

## Benchmarks

```sh
git checkout main
go test -tags=baton_lambda_support -run=^$ -bench=. -benchmem -benchtime=3s -count=6 ./pkg/dotc1z > /tmp/main.txt
git checkout bt/v2-grants-slim-blob
go test -tags=baton_lambda_support -run=^$ -bench=. -benchmem -benchtime=3s -count=6 ./pkg/dotc1z > /tmp/branch.txt
benchstat /tmp/main.txt /tmp/branch.txt
```

```
goos: darwin
goarch: arm64
pkg: github.com/conductorone/baton-sdk/pkg/dotc1z
cpu: Apple M2 Max
                                                                     │ /tmp/main.txt │            /tmp/branch.txt            │
                                                                     │    sec/op     │    sec/op      vs base                │
StatsSmall-12                                                           46.96m ±  5%   45.40m ±   4%  -3.32% (p=0.026 n=6)
StatsMedium-12                                                          59.82m ±  2%   58.85m ±   2%       ~ (p=0.240 n=6)
CloneSyncSmall-12                                                        4.178 ±  5%    4.224 ±   7%       ~ (p=0.485 n=6)
CloneSyncSmallMedium-12                                                  5.492 ±  7%    5.282 ±   9%       ~ (p=0.699 n=6)
ListGrantsForEntitlement/grants=100-12                                  190.8µ ±  1%
ListGrantsForEntitlement/grants=1000-12                                 1.640m ±  3%
ListGrantsForEntitlement/grants=10000-12                                17.48m ±  2%
ListGrantsForEntitlement/grants=100000-12                               483.4m ±  3%
EncoderPoolAllocs/pooled_encoder-12                                     6.084m ±  6%   6.351m ±   6%  +4.40% (p=0.026 n=6)
EncoderPoolAllocs/new_encoder_each_time-12                              4.816m ±  6%   4.789m ±   4%       ~ (p=0.589 n=6)
EncoderAllocationOnly/pooled-12                                         817.6n ±  1%   822.1n ±   2%       ~ (p=0.485 n=6)
EncoderAllocationOnly/new_each_time-12                                  79.02µ ± 96%   85.18µ ± 113%  +7.80% (p=0.041 n=6)
DecoderPoolAllocs/pooled_decoder-12                                     32.64µ ±  8%   34.04µ ±  10%       ~ (p=0.132 n=6)
DecoderPoolAllocs/new_decoder_each_time-12                              42.20µ ±  5%   44.70µ ±   4%  +5.92% (p=0.026 n=6)
PutResources/500-12                                                     2.833m ±  2%   2.762m ±   3%  -2.51% (p=0.041 n=6)
PutResources/1k-12                                                      5.631m ±  1%   5.755m ±   6%  +2.19% (p=0.009 n=6)
PutResources/10k-12                                                     66.88m ±  5%   65.54m ±   2%       ~ (p=0.065 n=6)
PutResources/50k-12                                                     470.0m ±  9%   486.7m ±   7%       ~ (p=0.699 n=6)
ListGrantsForEntitlement/writer=full/grants=100-12                                     273.9µ ±   3%
ListGrantsForEntitlement/writer=full/grants=1000-12                                    2.475m ±   1%
ListGrantsForEntitlement/writer=full/grants=10000-12                                   27.62m ±   2%
ListGrantsForEntitlement/writer=full/grants=100000-12                                  597.8m ±   6%
ListGrantsForEntitlement/writer=slim/grants=100-12                                     249.4µ ±   4%
ListGrantsForEntitlement/writer=slim/grants=1000-12                                    2.078m ±   2%
ListGrantsForEntitlement/writer=slim/grants=10000-12                                   21.36m ±   1%
ListGrantsForEntitlement/writer=slim/grants=100000-12                                  511.1m ±   7%
ListGrantsInternal_PayloadWithExpansion/writer=full/grants=100-12                      233.7µ ±   1%
ListGrantsInternal_PayloadWithExpansion/writer=full/grants=1000-12                     1.942m ±   1%
ListGrantsInternal_PayloadWithExpansion/writer=full/grants=10000-12                    20.18m ±   2%
ListGrantsInternal_PayloadWithExpansion/writer=full/grants=100000-12                   206.6m ±   2%
ListGrantsInternal_PayloadWithExpansion/writer=slim/grants=100-12                      209.0µ ±   0%
ListGrantsInternal_PayloadWithExpansion/writer=slim/grants=1000-12                     1.664m ±   1%
ListGrantsInternal_PayloadWithExpansion/writer=slim/grants=10000-12                    16.60m ±   1%
ListGrantsInternal_PayloadWithExpansion/writer=slim/grants=100000-12                   173.2m ±   2%
ListGrants/grants=100/writer=full-12                                                   194.7µ ±   1%
ListGrants/grants=100/writer=slim-12                                                   179.7µ ±   1%
ListGrants/grants=1000/writer=full-12                                                  1.670m ±   5%
ListGrants/grants=1000/writer=slim-12                                                  1.437m ±   1%
ListGrants/grants=10000/writer=full-12                                                 17.37m ±   4%
ListGrants/grants=10000/writer=slim-12                                                 14.22m ±   2%
ListGrants/grants=100000/writer=full-12                                                176.6m ±   2%
ListGrants/grants=100000/writer=slim-12                                                150.7m ±  17%
ListGrants_ResourceFilter/grants=100/writer=full-12                                    212.0µ ±   2%
ListGrants_ResourceFilter/grants=100/writer=slim-12                                    195.9µ ±   1%
ListGrants_ResourceFilter/grants=1000/writer=full-12                                   1.740m ±   6%
ListGrants_ResourceFilter/grants=1000/writer=slim-12                                   1.513m ±   1%
ListGrants_ResourceFilter/grants=10000/writer=full-12                                  18.14m ±   9%
ListGrants_ResourceFilter/grants=10000/writer=slim-12                                  14.74m ±   4%
ListGrants_ResourceFilter/grants=100000/writer=full-12                                 182.4m ±   4%
ListGrants_ResourceFilter/grants=100000/writer=slim-12                                 156.7m ± 102%
ListGrantsForPrincipal/grants=100/writer=full-12                                       36.71µ ±   4%
ListGrantsForPrincipal/grants=100/writer=slim-12                                       36.30µ ±   3%
ListGrantsForPrincipal/grants=1000/writer=full-12                                      36.91µ ±   3%
ListGrantsForPrincipal/grants=1000/writer=slim-12                                      37.08µ ±   2%
ListGrantsForPrincipal/grants=10000/writer=full-12                                     37.94µ ±   2%
ListGrantsForPrincipal/grants=10000/writer=slim-12                                     37.50µ ±   4%
ListGrantsForPrincipal/grants=100000/writer=full-12                                    38.34µ ±   1%
ListGrantsForPrincipal/grants=100000/writer=slim-12                                    37.77µ ±   1%
ListGrantsForResourceType/grants=100/writer=full-12                                    275.5µ ±   1%
ListGrantsForResourceType/grants=100/writer=slim-12                                    248.9µ ±   1%
ListGrantsForResourceType/grants=1000/writer=full-12                                   2.407m ±   3%
ListGrantsForResourceType/grants=1000/writer=slim-12                                   2.066m ±   2%
ListGrantsForResourceType/grants=10000/writer=full-12                                  25.82m ±   3%
ListGrantsForResourceType/grants=10000/writer=slim-12                                  20.09m ±   2%
ListGrantsForResourceType/grants=100000/writer=full-12                                 552.6m ±   3%
ListGrantsForResourceType/grants=100000/writer=slim-12                                 467.3m ±   1%
ListGrants_Payload/grants=100/writer=full-12                                           204.6µ ±   2%
ListGrants_Payload/grants=100/writer=slim-12                                           185.9µ ±   2%
ListGrants_Payload/grants=1000/writer=full-12                                          1.763m ±   3%
ListGrants_Payload/grants=1000/writer=slim-12                                          1.492m ±   3%
ListGrants_Payload/grants=10000/writer=full-12                                         17.69m ±   1%
ListGrants_Payload/grants=10000/writer=slim-12                                         14.56m ±   2%
ListGrants_Payload/grants=100000/writer=full-12                                        181.1m ±   2%
ListGrants_Payload/grants=100000/writer=slim-12                                        151.9m ±   5%
geomean                                                                 6.268m         3.586m         +1.08%               ¹
¹ benchmark set differs from baseline; geomeans may not be comparable

                        │ /tmp/main.txt │          /tmp/branch.txt           │
                        │      B/s      │     B/s       vs base              │
StatsSmall-12              395.6Mi ± 5%   409.2Mi ± 3%  +3.44% (p=0.026 n=6)
StatsMedium-12             392.1Mi ± 2%   398.6Mi ± 2%       ~ (p=0.240 n=6)
CloneSyncSmall-12          4.444Mi ± 5%   4.396Mi ± 8%       ~ (p=0.485 n=6)
CloneSyncSmallMedium-12    4.268Mi ± 7%   4.439Mi ± 8%       ~ (p=0.563 n=6)
geomean                    41.42Mi        42.24Mi       +1.99%

                                                                     │ /tmp/main.txt │            /tmp/branch.txt            │
                                                                     │     B/op      │     B/op       vs base                │
StatsSmall-12                                                          25.41Ki ±  0%   25.40Ki ±  0%       ~ (p=0.667 n=6)
StatsMedium-12                                                         25.42Ki ±  0%   25.39Ki ±  0%       ~ (p=0.078 n=6)
CloneSyncSmall-12                                                      18.07Mi ±  0%   18.07Mi ±  0%       ~ (p=0.310 n=6)
CloneSyncSmallMedium-12                                                18.08Mi ±  0%   18.08Mi ±  0%       ~ (p=0.937 n=6)
ListGrantsForEntitlement/grants=100-12                                 106.9Ki ±  0%
ListGrantsForEntitlement/grants=1000-12                                1.003Mi ±  0%
ListGrantsForEntitlement/grants=10000-12                               10.14Mi ±  0%
ListGrantsForEntitlement/grants=100000-12                              101.5Mi ±  0%
EncoderPoolAllocs/pooled_encoder-12                                    66.53Ki ± 97%   90.02Ki ± 30%       ~ (p=0.240 n=6)
EncoderPoolAllocs/new_encoder_each_time-12                             17.69Mi ±  0%   17.69Mi ±  0%  +0.00% (p=0.004 n=6)
EncoderAllocationOnly/pooled-12                                          113.0 ±  1%     112.5 ±  1%       ~ (p=0.545 n=6)
EncoderAllocationOnly/new_each_time-12                                 1.677Mi ±  0%   1.677Mi ±  0%       ~ (p=0.727 n=6)
DecoderPoolAllocs/pooled_decoder-12                                    66.37Ki ±  0%   66.44Ki ±  0%  +0.10% (p=0.002 n=6)
DecoderPoolAllocs/new_decoder_each_time-12                             113.4Ki ±  0%   113.4Ki ±  0%  +0.01% (p=0.004 n=6)
PutResources/500-12                                                    1.178Mi ±  0%   1.178Mi ±  0%  -0.00% (p=0.050 n=6)
PutResources/1k-12                                                     2.512Mi ±  0%   2.512Mi ±  0%       ~ (p=0.260 n=6)
PutResources/10k-12                                                    25.10Mi ±  0%   25.10Mi ±  0%       ~ (p=0.240 n=6)
PutResources/50k-12                                                    125.5Mi ±  0%   125.5Mi ±  0%       ~ (p=0.937 n=6)
ListGrantsForEntitlement/writer=full/grants=100-12                                     124.7Ki ±  0%
ListGrantsForEntitlement/writer=full/grants=1000-12                                    1.172Mi ±  0%
ListGrantsForEntitlement/writer=full/grants=10000-12                                   11.82Mi ±  0%
ListGrantsForEntitlement/writer=full/grants=100000-12                                  118.3Mi ±  0%
ListGrantsForEntitlement/writer=slim/grants=100-12                                     136.4Ki ±  0%
ListGrantsForEntitlement/writer=slim/grants=1000-12                                    1.222Mi ±  0%
ListGrantsForEntitlement/writer=slim/grants=10000-12                                   14.16Mi ±  0%
ListGrantsForEntitlement/writer=slim/grants=100000-12                                  141.6Mi ±  0%
ListGrantsInternal_PayloadWithExpansion/writer=full/grants=100-12                      138.3Ki ±  0%
ListGrantsInternal_PayloadWithExpansion/writer=full/grants=1000-12                     1.297Mi ±  0%
ListGrantsInternal_PayloadWithExpansion/writer=full/grants=10000-12                    13.05Mi ±  0%
ListGrantsInternal_PayloadWithExpansion/writer=full/grants=100000-12                   130.5Mi ±  0%
ListGrantsInternal_PayloadWithExpansion/writer=slim/grants=100-12                      149.9Ki ±  0%
ListGrantsInternal_PayloadWithExpansion/writer=slim/grants=1000-12                     1.348Mi ±  0%
ListGrantsInternal_PayloadWithExpansion/writer=slim/grants=10000-12                    15.38Mi ±  0%
ListGrantsInternal_PayloadWithExpansion/writer=slim/grants=100000-12                   153.9Mi ±  0%
ListGrants/grants=100/writer=full-12                                                   124.0Ki ±  0%
ListGrants/grants=100/writer=slim-12                                                   135.7Ki ±  0%
ListGrants/grants=1000/writer=full-12                                                  1.171Mi ±  0%
ListGrants/grants=1000/writer=slim-12                                                  1.222Mi ±  0%
ListGrants/grants=10000/writer=full-12                                                 11.82Mi ±  0%
ListGrants/grants=10000/writer=slim-12                                                 14.16Mi ±  0%
ListGrants/grants=100000/writer=full-12                                                118.3Mi ±  0%
ListGrants/grants=100000/writer=slim-12                                                141.6Mi ±  0%
ListGrants_ResourceFilter/grants=100/writer=full-12                                    125.8Ki ±  0%
ListGrants_ResourceFilter/grants=100/writer=slim-12                                    137.4Ki ±  0%
ListGrants_ResourceFilter/grants=1000/writer=full-12                                   1.173Mi ±  0%
ListGrants_ResourceFilter/grants=1000/writer=slim-12                                   1.223Mi ±  0%
ListGrants_ResourceFilter/grants=10000/writer=full-12                                  11.82Mi ±  0%
ListGrants_ResourceFilter/grants=10000/writer=slim-12                                  14.16Mi ±  0%
ListGrants_ResourceFilter/grants=100000/writer=full-12                                 118.3Mi ±  0%
ListGrants_ResourceFilter/grants=100000/writer=slim-12                                 141.6Mi ±  0%
ListGrantsForPrincipal/grants=100/writer=full-12                                       10.15Ki ±  0%
ListGrantsForPrincipal/grants=100/writer=slim-12                                       10.10Ki ±  0%
ListGrantsForPrincipal/grants=1000/writer=full-12                                      10.15Ki ±  0%
ListGrantsForPrincipal/grants=1000/writer=slim-12                                      10.10Ki ±  0%
ListGrantsForPrincipal/grants=10000/writer=full-12                                     10.15Ki ±  0%
ListGrantsForPrincipal/grants=10000/writer=slim-12                                     10.10Ki ±  0%
ListGrantsForPrincipal/grants=100000/writer=full-12                                    10.15Ki ±  0%
ListGrantsForPrincipal/grants=100000/writer=slim-12                                    10.10Ki ±  0%
ListGrantsForResourceType/grants=100/writer=full-12                                    124.7Ki ±  0%
ListGrantsForResourceType/grants=100/writer=slim-12                                    136.4Ki ±  0%
ListGrantsForResourceType/grants=1000/writer=full-12                                   1.172Mi ±  0%
ListGrantsForResourceType/grants=1000/writer=slim-12                                   1.222Mi ±  0%
ListGrantsForResourceType/grants=10000/writer=full-12                                  11.82Mi ±  0%
ListGrantsForResourceType/grants=10000/writer=slim-12                                  14.16Mi ±  0%
ListGrantsForResourceType/grants=100000/writer=full-12                                 118.3Mi ±  0%
ListGrantsForResourceType/grants=100000/writer=slim-12                                 141.6Mi ±  0%
ListGrants_Payload/grants=100/writer=full-12                                           124.0Ki ±  0%
ListGrants_Payload/grants=100/writer=slim-12                                           135.7Ki ±  0%
ListGrants_Payload/grants=1000/writer=full-12                                          1.171Mi ±  0%
ListGrants_Payload/grants=1000/writer=slim-12                                          1.222Mi ±  0%
ListGrants_Payload/grants=10000/writer=full-12                                         11.82Mi ±  0%
ListGrants_Payload/grants=10000/writer=slim-12                                         14.16Mi ±  0%
ListGrants_Payload/grants=100000/writer=full-12                                        118.3Mi ±  0%
ListGrants_Payload/grants=100000/writer=slim-12                                        141.6Mi ±  0%
geomean                                                                958.0Ki         1.424Mi        +2.14%               ¹
¹ benchmark set differs from baseline; geomeans may not be comparable

                                                                     │ /tmp/main.txt │           /tmp/branch.txt           │
                                                                     │   allocs/op   │  allocs/op   vs base                │
StatsSmall-12                                                             706.0 ± 0%    706.0 ± 0%       ~ (p=1.000 n=6) ¹
StatsMedium-12                                                            706.0 ± 0%    706.0 ± 0%       ~ (p=1.000 n=6) ¹
CloneSyncSmall-12                                                        2.487k ± 1%   2.484k ± 0%       ~ (p=0.554 n=6)
CloneSyncSmallMedium-12                                                  2.486k ± 1%   2.487k ± 0%       ~ (p=0.909 n=6)
ListGrantsForEntitlement/grants=100-12                                   1.747k ± 0%
ListGrantsForEntitlement/grants=1000-12                                  17.80k ± 0%
ListGrantsForEntitlement/grants=10000-12                                 179.8k ± 0%
ListGrantsForEntitlement/grants=100000-12                                1.801M ± 0%
EncoderPoolAllocs/pooled_encoder-12                                       19.00 ± 0%    19.00 ± 0%       ~ (p=1.000 n=6) ¹
EncoderPoolAllocs/new_encoder_each_time-12                                35.00 ± 0%    35.00 ± 0%       ~ (p=1.000 n=6) ¹
EncoderAllocationOnly/pooled-12                                           2.000 ± 0%    2.000 ± 0%       ~ (p=1.000 n=6) ¹
EncoderAllocationOnly/new_each_time-12                                    19.00 ± 0%    19.00 ± 0%       ~ (p=1.000 n=6) ¹
DecoderPoolAllocs/pooled_decoder-12                                       19.00 ± 0%    19.00 ± 0%       ~ (p=1.000 n=6) ¹
DecoderPoolAllocs/new_decoder_each_time-12                                27.00 ± 0%    27.00 ± 0%       ~ (p=1.000 n=6) ¹
PutResources/500-12                                                      25.70k ± 0%   25.70k ± 0%       ~ (p=1.000 n=6) ¹
PutResources/1k-12                                                       51.22k ± 0%   51.22k ± 0%       ~ (p=1.000 n=6) ¹
PutResources/10k-12                                                      511.9k ± 0%   511.9k ± 0%       ~ (p=1.000 n=6)
PutResources/50k-12                                                      2.559M ± 0%   2.559M ± 0%       ~ (p=0.937 n=6)
ListGrantsForEntitlement/writer=full/grants=100-12                                     3.295k ± 0%
ListGrantsForEntitlement/writer=full/grants=1000-12                                    32.84k ± 0%
ListGrantsForEntitlement/writer=full/grants=10000-12                                   329.9k ± 0%
ListGrantsForEntitlement/writer=full/grants=100000-12                                  3.302M ± 0%
ListGrantsForEntitlement/writer=slim/grants=100-12                                     3.108k ± 0%
ListGrantsForEntitlement/writer=slim/grants=1000-12                                    30.86k ± 0%
ListGrantsForEntitlement/writer=slim/grants=10000-12                                   309.9k ± 0%
ListGrantsForEntitlement/writer=slim/grants=100000-12                                  3.102M ± 0%
ListGrantsInternal_PayloadWithExpansion/writer=full/grants=100-12                      3.696k ± 0%
ListGrantsInternal_PayloadWithExpansion/writer=full/grants=1000-12                     35.95k ± 0%
ListGrantsInternal_PayloadWithExpansion/writer=full/grants=10000-12                    360.0k ± 0%
ListGrantsInternal_PayloadWithExpansion/writer=full/grants=100000-12                   3.602M ± 0%
ListGrantsInternal_PayloadWithExpansion/writer=slim/grants=100-12                      3.509k ± 0%
ListGrantsInternal_PayloadWithExpansion/writer=slim/grants=1000-12                     33.97k ± 0%
ListGrantsInternal_PayloadWithExpansion/writer=slim/grants=10000-12                    340.0k ± 0%
ListGrantsInternal_PayloadWithExpansion/writer=slim/grants=100000-12                   3.403M ± 0%
ListGrants/grants=100/writer=full-12                                                   3.273k ± 0%
ListGrants/grants=100/writer=slim-12                                                   3.086k ± 0%
ListGrants/grants=1000/writer=full-12                                                  32.82k ± 0%
ListGrants/grants=1000/writer=slim-12                                                  30.84k ± 0%
ListGrants/grants=10000/writer=full-12                                                 329.8k ± 0%
ListGrants/grants=10000/writer=slim-12                                                 309.9k ± 0%
ListGrants/grants=100000/writer=full-12                                                3.302M ± 0%
ListGrants/grants=100000/writer=slim-12                                                3.102M ± 0%
ListGrants_ResourceFilter/grants=100/writer=full-12                                    3.318k ± 0%
ListGrants_ResourceFilter/grants=100/writer=slim-12                                    3.131k ± 0%
ListGrants_ResourceFilter/grants=1000/writer=full-12                                   32.87k ± 0%
ListGrants_ResourceFilter/grants=1000/writer=slim-12                                   30.89k ± 0%
ListGrants_ResourceFilter/grants=10000/writer=full-12                                  329.9k ± 0%
ListGrants_ResourceFilter/grants=10000/writer=slim-12                                  309.9k ± 0%
ListGrants_ResourceFilter/grants=100000/writer=full-12                                 3.302M ± 0%
ListGrants_ResourceFilter/grants=100000/writer=slim-12                                 3.103M ± 0%
ListGrantsForPrincipal/grants=100/writer=full-12                                        240.0 ± 0%
ListGrantsForPrincipal/grants=100/writer=slim-12                                        239.0 ± 0%
ListGrantsForPrincipal/grants=1000/writer=full-12                                       240.0 ± 0%
ListGrantsForPrincipal/grants=1000/writer=slim-12                                       239.0 ± 0%
ListGrantsForPrincipal/grants=10000/writer=full-12                                      240.0 ± 0%
ListGrantsForPrincipal/grants=10000/writer=slim-12                                      239.0 ± 0%
ListGrantsForPrincipal/grants=100000/writer=full-12                                     240.0 ± 0%
ListGrantsForPrincipal/grants=100000/writer=slim-12                                     239.0 ± 0%
ListGrantsForResourceType/grants=100/writer=full-12                                    3.295k ± 0%
ListGrantsForResourceType/grants=100/writer=slim-12                                    3.108k ± 0%
ListGrantsForResourceType/grants=1000/writer=full-12                                   32.84k ± 0%
ListGrantsForResourceType/grants=1000/writer=slim-12                                   30.86k ± 0%
ListGrantsForResourceType/grants=10000/writer=full-12                                  329.9k ± 0%
ListGrantsForResourceType/grants=10000/writer=slim-12                                  309.9k ± 0%
ListGrantsForResourceType/grants=100000/writer=full-12                                 3.302M ± 0%
ListGrantsForResourceType/grants=100000/writer=slim-12                                 3.102M ± 0%
ListGrants_Payload/grants=100/writer=full-12                                           3.273k ± 0%
ListGrants_Payload/grants=100/writer=slim-12                                           3.086k ± 0%
ListGrants_Payload/grants=1000/writer=full-12                                          32.82k ± 0%
ListGrants_Payload/grants=1000/writer=slim-12                                          30.84k ± 0%
ListGrants_Payload/grants=10000/writer=full-12                                         329.8k ± 0%
ListGrants_Payload/grants=10000/writer=slim-12                                         309.9k ± 0%
ListGrants_Payload/grants=100000/writer=full-12                                        3.302M ± 0%
ListGrants_Payload/grants=100000/writer=slim-12                                        3.102M ± 0%
geomean                                                                  2.111k        19.58k       -0.01%               ²
¹ all samples are equal
² benchmark set differs from baseline; geomeans may not be comparable

```