### PR TITLE
[CE-416] baton-sdk: use reuseTokenSOurce

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/aws/smithy-go v1.24.0
 	github.com/conductorone/dpop v0.2.3
 	github.com/conductorone/dpop/integrations/dpop_grpc v0.2.3
-	github.com/conductorone/dpop/integrations/dpop_oauth2 v0.2.3
+	github.com/conductorone/dpop/integrations/dpop_oauth2 v0.2.5
 	github.com/deckarep/golang-set/v2 v2.7.0
 	github.com/doug-martin/goqu/v9 v9.19.0
 	github.com/envoyproxy/protoc-gen-validate v1.2.1
@@ -60,6 +60,7 @@ require (
 	google.golang.org/grpc v1.78.0
 	google.golang.org/protobuf v1.36.10
 	gopkg.in/yaml.v2 v2.4.0
+	modernc.org/sqlite v1.34.5
 )
 
 require (
@@ -123,7 +124,6 @@ require (
 	modernc.org/libc v1.61.10 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.8.2 // indirect
-	modernc.org/sqlite v1.34.5 // indirect
 )
 
 // Remove once https://github.com/doug-martin/goqu/pull/440 merges

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/conductorone/dpop v0.2.3 h1:s91U3845GHQ6P6FWrdNr2SEOy1ES/jcFs1JtKSl2S
 github.com/conductorone/dpop v0.2.3/go.mod h1:gyo8TtzB9SCFCsjsICH4IaLZ7y64CcrDXMOPBwfq/3s=
 github.com/conductorone/dpop/integrations/dpop_grpc v0.2.3 h1:kLMCNIh0Mo2vbvvkCmJ3ixsPbXEJ6HPcW53Ku9yje3s=
 github.com/conductorone/dpop/integrations/dpop_grpc v0.2.3/go.mod h1:LYNoUc1lkvozk9HBio+xI2w8YyfYy0v2cAJtIgrkj8o=
-github.com/conductorone/dpop/integrations/dpop_oauth2 v0.2.3 h1:KhFaxiTzj9FteI9IE2tIGdSjJKyFW5ZcUF2SrgLnA28=
-github.com/conductorone/dpop/integrations/dpop_oauth2 v0.2.3/go.mod h1:2eI0qv+XaEhoCw0GKFF1yH4X8Mp4KLVEVnQKRFEy4zs=
+github.com/conductorone/dpop/integrations/dpop_oauth2 v0.2.5 h1:x/ZtD0YLNwlmoSv9SE4OBPJB9Hj2cpwyE5BAfia7aY8=
+github.com/conductorone/dpop/integrations/dpop_oauth2 v0.2.5/go.mod h1:2eI0qv+XaEhoCw0GKFF1yH4X8Mp4KLVEVnQKRFEy4zs=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/lambda/grpc/config/config.go
+++ b/pkg/lambda/grpc/config/config.go
@@ -96,7 +96,9 @@ func NewDPoPClient(ctx context.Context, clientID string, clientSecret string) (g
 		return nil, nil, nil, fmt.Errorf("new-dpop-client: failed to create token source: %w", err)
 	}
 
-	creds, err := dpop_grpc.NewDPoPCredentials(proofer, tokenSource, configurationHost, []dpop.ProofOption{
+	reuseTokenSource := oauth2.ReuseTokenSource(nil, tokenSource)
+
+	creds, err := dpop_grpc.NewDPoPCredentials(proofer, reuseTokenSource, configurationHost, []dpop.ProofOption{
 		dpop.WithValidityDuration(time.Minute * 5),
 		dpop.WithProofNowFunc(time.Now),
 	})
@@ -117,7 +119,7 @@ func NewDPoPClient(ctx context.Context, clientID string, clientSecret string) (g
 		return nil, nil, nil, fmt.Errorf("new-dpop-client: failed to create client: %w", err)
 	}
 
-	return client, jwk, tokenSource, nil
+	return client, jwk, reuseTokenSource, nil
 }
 
 func lambdaTLSConfig() (*tls.Config, error) {

--- a/pkg/lambda/grpc/config/config.go
+++ b/pkg/lambda/grpc/config/config.go
@@ -78,7 +78,9 @@ func NewDPoPClient(ctx context.Context, clientID string, clientSecret string) (g
 		return nil, nil, nil, fmt.Errorf("new-dpop-client: failed to create token source: %w", err)
 	}
 
-	creds, err := dpop_grpc.NewDPoPCredentials(proofer, tokenSource, tokenHost, []dpop.ProofOption{
+	reuseTokenSource := oauth2.ReuseTokenSource(nil, tokenSource)
+
+	creds, err := dpop_grpc.NewDPoPCredentials(proofer, reuseTokenSource, tokenHost, []dpop.ProofOption{
 		dpop.WithValidityDuration(time.Minute * 5),
 		dpop.WithProofNowFunc(time.Now),
 	})
@@ -106,7 +108,7 @@ func NewDPoPClient(ctx context.Context, clientID string, clientSecret string) (g
 		return nil, nil, nil, fmt.Errorf("new-dpop-client: failed to create client: %w", err)
 	}
 
-	return client, jwk, tokenSource, nil
+	return client, jwk, reuseTokenSource, nil
 }
 
 func parseClientID(input string) (string, string, error) {

--- a/vendor/github.com/conductorone/dpop/integrations/dpop_oauth2/token_client_assertion.go
+++ b/vendor/github.com/conductorone/dpop/integrations/dpop_oauth2/token_client_assertion.go
@@ -322,6 +322,13 @@ func (c *tokenSource) tryToken(ctx context.Context, firstAttempt bool) (*oauth2.
 		return nil, fmt.Errorf("%w: empty access token", ErrInvalidToken)
 	}
 
+	if token.Expiry.IsZero() {
+		token.Expiry = time.Now()
+		if token.ExpiresIn > 0 {
+			token.Expiry = time.Now().Add(time.Duration(token.ExpiresIn-10) * time.Second) // 10 seconds before the token expires
+		}
+	}
+
 	// Accept both DPoP and Bearer tokens
 	// If we sent a DPoP proof but got a Bearer token, that means the AS doesn't support DPoP
 	if !strings.EqualFold(token.TokenType, "DPoP") && !strings.EqualFold(token.TokenType, "Bearer") {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -168,7 +168,7 @@ github.com/conductorone/dpop/pkg/dpop
 # github.com/conductorone/dpop/integrations/dpop_grpc v0.2.3
 ## explicit; go 1.23.4
 github.com/conductorone/dpop/integrations/dpop_grpc
-# github.com/conductorone/dpop/integrations/dpop_oauth2 v0.2.3
+# github.com/conductorone/dpop/integrations/dpop_oauth2 v0.2.5
 ## explicit; go 1.23.4
 github.com/conductorone/dpop/integrations/dpop_oauth2
 # github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc


### PR DESCRIPTION
see a lot of token exchange from lambda connector. see [here](https://us3.datadoghq.com/logs?query=%40http.url_details.route%3A%22%2Fauth%2Fv1%2Ftoken%22%20%22Token%3A%20Completed%20token%20exchange%22&agg_m=count&agg_m_source=base&agg_q=%40http.url_details.host&agg_t=count&analyticsOptions=%5B%22bars%22%2C%22dog_classic%22%2Cnull%2Cnull%2C%22value%22%5D&clustering_pattern_field_path=message&cols=service%2C%40http.url_details.host&flat_group_bys=true&fromUser=true&messageDisplay=inline&panel=%7B%22queryString%22%3A%22%40http.url_details.host%3Aplume.conductor.one%22%2C%22filters%22%3A%5B%7B%22isClicked%22%3Atrue%2C%22source%22%3A%22log%22%2C%22path%22%3A%22http.url_details.host%22%2C%22value%22%3A%22plume.conductor.one%22%7D%5D%2C%22queryId%22%3A%22a%22%2C%22timeRange%22%3A%7B%22from%22%3A1775766476000%2C%22to%22%3A1777062476000%2C%22live%22%3Atrue%7D%7D&refresh_mode=sliding&sort_m=count&sort_t=count&storage=hot&stream_sort=%40grpc.method%2Casc&top_n=500&top_o=top&viz=toplist&x_missing=true&from_ts=1770566143674&to_ts=1771862143674&live=true)

looks like we don't use `reuseTokenSource` in DPoPClient. 

## test. 
1. test with `expireIn: nil`. 
<img width="1112" height="622" alt="image" src="https://github.com/user-attachments/assets/09419371-249c-4a5d-a0e7-fa050863ca61" />

2. test with normal `reuseTokenSource` 
one `oauth token exchange` request saw on the support dashboard.
<img width="1122" height="200" alt="image" src="https://github.com/user-attachments/assets/b756911e-0c39-4d0e-8f8e-1ea58710473a" />

