### PR TITLE
Update SDK version to v0.8.28

### DIFF
--- a/pkg/sdk/version.go
+++ b/pkg/sdk/version.go
@@ -1,3 +1,3 @@
 package sdk
 
-const Version = "v0.8.26"
+const Version = "v0.8.28"


### PR DESCRIPTION
## Summary

Updates `pkg/sdk/version.go` so the next release can be tagged as v0.8.28 with a matching embedded constant.

Closes #783.

## Why

The v0.8.27 release tag was placed on the `feat(expand): periodic mid-expansion progress log` commit ([`a2bdd0c5`](https://github.com/ConductorOne/baton-sdk/commit/a2bdd0c5)) without the usual "Update SDK version to vX" preceding bump. The embedded constant at the v0.8.27 tag therefore still reads `v0.8.26`, which is cosmetically wrong on every consumer that logs `sdk.Version` at runtime.

## What about the auto-update workflow?

`update-hardcoded-version.yaml` ran on the v0.8.27 release event — workflow history shows three runs (one success, two failures). The successful run apparently no-op'd; no `Update SDK version to v0.8.27` commit appeared on main. Worth a separate look at why, but unblocking is more valuable than diagnosing here.

## Approach

Two options were possible:

1. **Cut v0.8.28 with the constant updated** (chosen here) — single small commit, no force-tag, lets v0.8.27 remain immutable.
2. Move the v0.8.27 tag to a new commit that bumps the constant to v0.8.27 — requires force-tagging an already-published release; risky for downstream consumers that pin to a specific commit SHA.

Picked option 1. Skips `v0.8.27` in the embedded constant (jumps directly to v0.8.28); the v0.8.27 tag stays where it is.

## Test plan

- [x] `make pkg/sdk/version.go VERSION=v0.8.28` produces the expected one-line diff
- [ ] CI green
- [ ] After merge: maintainer cuts v0.8.28 release, workflow optionally regenerates the constant (idempotent)

## Found via

internal platform-repo PR (bumping c1 from baton-sdk v0.8.23 → v0.8.27). The code-review bot on that PR flagged the version mismatch.
