### PR TITLE
support hot loading configs for lambdas

### DIFF
--- a/pb/c1/connectorapi/baton/v1/config.pb.go
+++ b/pb/c1/connectorapi/baton/v1/config.pb.go
@@ -24,9 +24,10 @@ const (
 )
 
 type GetConnectorConfigRequest struct {
-	state         protoimpl.MessageState `protogen:"hybrid.v1"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state            protoimpl.MessageState `protogen:"hybrid.v1"`
+	RequestedVersion string                 `protobuf:"bytes,1,opt,name=requested_version,json=requestedVersion,proto3" json:"requested_version,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *GetConnectorConfigRequest) Reset() {
@@ -54,15 +55,28 @@ func (x *GetConnectorConfigRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
+func (x *GetConnectorConfigRequest) GetRequestedVersion() string {
+	if x != nil {
+		return x.RequestedVersion
+	}
+	return ""
+}
+
+func (x *GetConnectorConfigRequest) SetRequestedVersion(v string) {
+	x.RequestedVersion = v
+}
+
 type GetConnectorConfigRequest_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
+	RequestedVersion string
 }
 
 func (b0 GetConnectorConfigRequest_builder) Build() *GetConnectorConfigRequest {
 	m0 := &GetConnectorConfigRequest{}
 	b, x := &b0, m0
 	_, _ = b, x
+	x.RequestedVersion = b.RequestedVersion
 	return m0
 }
 
@@ -431,8 +445,9 @@ var File_c1_connectorapi_baton_v1_config_proto protoreflect.FileDescriptor
 
 const file_c1_connectorapi_baton_v1_config_proto_rawDesc = "" +
 	"\n" +
-	"%c1/connectorapi/baton/v1/config.proto\x12\x18c1.connectorapi.baton.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\x1b\n" +
-	"\x19GetConnectorConfigRequest\"s\n" +
+	"%c1/connectorapi/baton/v1/config.proto\x12\x18c1.connectorapi.baton.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"H\n" +
+	"\x19GetConnectorConfigRequest\x12+\n" +
+	"\x11requested_version\x18\x01 \x01(\tR\x10requestedVersion\"s\n" +
 	"\x1aGetConnectorConfigResponse\x12\x16\n" +
 	"\x06config\x18\x01 \x01(\fR\x06config\x12=\n" +
 	"\flast_updated\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\vlastUpdated\"6\n" +

--- a/pb/c1/connectorapi/baton/v1/config.pb.validate.go
+++ b/pb/c1/connectorapi/baton/v1/config.pb.validate.go
@@ -57,6 +57,8 @@ func (m *GetConnectorConfigRequest) validate(all bool) error {
 
 	var errors []error
 
+	// no validation rules for RequestedVersion
+
 	if len(errors) > 0 {
 		return GetConnectorConfigRequestMultiError(errors)
 	}

--- a/pb/c1/connectorapi/baton/v1/config_protoopaque.pb.go
+++ b/pb/c1/connectorapi/baton/v1/config_protoopaque.pb.go
@@ -24,9 +24,10 @@ const (
 )
 
 type GetConnectorConfigRequest struct {
-	state         protoimpl.MessageState `protogen:"opaque.v1"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state                       protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_RequestedVersion string                 `protobuf:"bytes,1,opt,name=requested_version,json=requestedVersion,proto3"`
+	unknownFields               protoimpl.UnknownFields
+	sizeCache                   protoimpl.SizeCache
 }
 
 func (x *GetConnectorConfigRequest) Reset() {
@@ -54,15 +55,28 @@ func (x *GetConnectorConfigRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
+func (x *GetConnectorConfigRequest) GetRequestedVersion() string {
+	if x != nil {
+		return x.xxx_hidden_RequestedVersion
+	}
+	return ""
+}
+
+func (x *GetConnectorConfigRequest) SetRequestedVersion(v string) {
+	x.xxx_hidden_RequestedVersion = v
+}
+
 type GetConnectorConfigRequest_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
+	RequestedVersion string
 }
 
 func (b0 GetConnectorConfigRequest_builder) Build() *GetConnectorConfigRequest {
 	m0 := &GetConnectorConfigRequest{}
 	b, x := &b0, m0
 	_, _ = b, x
+	x.xxx_hidden_RequestedVersion = b.RequestedVersion
 	return m0
 }
 
@@ -433,8 +447,9 @@ var File_c1_connectorapi_baton_v1_config_proto protoreflect.FileDescriptor
 
 const file_c1_connectorapi_baton_v1_config_proto_rawDesc = "" +
 	"\n" +
-	"%c1/connectorapi/baton/v1/config.proto\x12\x18c1.connectorapi.baton.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\x1b\n" +
-	"\x19GetConnectorConfigRequest\"s\n" +
+	"%c1/connectorapi/baton/v1/config.proto\x12\x18c1.connectorapi.baton.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"H\n" +
+	"\x19GetConnectorConfigRequest\x12+\n" +
+	"\x11requested_version\x18\x01 \x01(\tR\x10requestedVersion\"s\n" +
 	"\x1aGetConnectorConfigResponse\x12\x16\n" +
 	"\x06config\x18\x01 \x01(\fR\x06config\x12=\n" +
 	"\flast_updated\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\vlastUpdated\"6\n" +

--- a/pkg/cli/lambda_server__added.go
+++ b/pkg/cli/lambda_server__added.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sync"
 	"time"
 
 	aws_lambda "github.com/aws/aws-lambda-go/lambda"
@@ -15,14 +16,16 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/crypto/providers/jwk"
 	"github.com/conductorone/baton-sdk/pkg/logging"
 	"github.com/conductorone/baton-sdk/pkg/session"
+	"github.com/conductorone/baton-sdk/pkg/types"
 	"github.com/conductorone/baton-sdk/pkg/ugrpc"
 	"github.com/go-jose/go-jose/v4"
 	"github.com/maypok86/otter/v2"
-	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 	"golang.org/x/oauth2"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/conductorone/baton-sdk/internal/connector"
@@ -35,6 +38,84 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/types/sessions"
 	"google.golang.org/grpc"
 )
+
+const lambdaConnectorConfigVersionHeader = "x-baton-connector-config-version"
+
+type lambdaConnectorGeneration struct {
+	version   string
+	connector types.ConnectorServer
+}
+
+type lambdaConnectorCloser interface {
+	Close(context.Context) error
+}
+
+type lambdaConnectorReloader struct {
+	mu      sync.Mutex
+	server  *c1_lambda_grpc.Server
+	current *lambdaConnectorGeneration
+	build   func(context.Context, string) (*lambdaConnectorGeneration, error)
+}
+
+func (r *lambdaConnectorReloader) Handler(ctx context.Context, req *c1_lambda_grpc.Request) (*c1_lambda_grpc.Response, error) {
+	requestedVersion := ""
+	if values := req.Headers().Get(lambdaConnectorConfigVersionHeader); len(values) > 0 {
+		requestedVersion = values[0]
+	}
+
+	if requestedVersion != "" {
+		if err := r.reloadIfNeeded(ctx, requestedVersion); err != nil {
+			return c1_lambda_grpc.ErrorResponse(status.Errorf(codes.Unavailable, "lambda-run: failed to reload connector config: %v", err)), nil
+		}
+	}
+
+	return r.server.Handler(ctx, req)
+}
+
+func (r *lambdaConnectorReloader) reloadIfNeeded(ctx context.Context, requestedVersion string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.current != nil && r.current.version == requestedVersion {
+		return nil
+	}
+	if r.current == nil {
+		return fmt.Errorf("no current connector generation is registered")
+	}
+
+	next, err := r.build(ctx, requestedVersion)
+	if err != nil {
+		return err
+	}
+	previous := r.current
+	replaced, drained, err := r.server.ReplaceServiceImplementation(previous.connector, next.connector)
+	if err != nil {
+		return err
+	}
+	if replaced == 0 {
+		return fmt.Errorf("no registered services matched the current connector generation")
+	}
+
+	r.current = next
+	closeCtx := context.WithoutCancel(ctx)
+	go closeConnectorGenerationAfterDrain(closeCtx, previous, drained)
+	return nil
+}
+
+func closeConnectorGenerationAfterDrain(ctx context.Context, generation *lambdaConnectorGeneration, drained <-chan struct{}) {
+	if generation == nil {
+		return
+	}
+	closer, ok := generation.connector.(lambdaConnectorCloser)
+	if !ok {
+		return
+	}
+
+	<-drained
+	if err := closer.Close(ctx); err != nil {
+		zap.L().Warn("error closing stale lambda connector generation", zap.String("config_version", generation.version), zap.Error(err))
+	}
+}
 
 func OptionallyAddLambdaCommand[T field.Configurable](
 	ctx context.Context,
@@ -127,78 +208,9 @@ func OptionallyAddLambdaCommand[T field.Configurable](
 		// Create connector config service client using the DPoP client
 		configClient := v1.NewConnectorConfigServiceClient(grpcClient)
 
-		// Get configuration, convert it to viper flag values, then proceed.
-		config, err := configClient.GetConnectorConfig(runCtx, &v1.GetConnectorConfigRequest{})
-		if err != nil {
-			return fmt.Errorf("lambda-run: failed to get connector config: %w", err)
-		}
-
 		ed25519PrivateKey, ok := webKey.Key.(ed25519.PrivateKey)
 		if !ok {
 			return fmt.Errorf("lambda-run: failed to cast webkey to ed25519.PrivateKey")
-		}
-
-		decrypted, err := jwk.DecryptED25519(ed25519PrivateKey, config.Config)
-		if err != nil {
-			return fmt.Errorf("lambda-run: failed to decrypt config: %w", err)
-		}
-
-		configStruct := structpb.Struct{}
-		err = json.Unmarshal(decrypted, &configStruct)
-		if err != nil {
-			return fmt.Errorf("lambda-run: failed to unmarshal decrypted config: %w", err)
-		}
-
-		// parse content directly for lambdas, don't read from file
-		readFromPath := false
-		decodeOpts := field.WithAdditionalDecodeHooks(field.FileUploadDecodeHook(readFromPath))
-		t, err := MakeGenericConfiguration[T](v, decodeOpts)
-		if err != nil {
-			return fmt.Errorf("lambda-run: failed to make generic configuration: %w", err)
-		}
-		switch cfg := any(t).(type) {
-		case *viper.Viper:
-			for k, v := range configStruct.AsMap() {
-				cfg.Set(k, v)
-			}
-		default:
-			// Use mapstructure with decode hook for file upload fields
-			decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
-				DecodeHook: field.ComposeDecodeHookFunc(decodeOpts),
-				Result:     cfg,
-			})
-			if err != nil {
-				return fmt.Errorf("lambda-run: failed to create decoder: %w", err)
-			}
-			err = decoder.Decode(configStruct.AsMap())
-			if err != nil {
-				return fmt.Errorf("lambda-run: failed to decode config: %w", err)
-			}
-		}
-
-		configStructMap := configStruct.AsMap()
-
-		var (
-			fieldOptions  []field.Option
-			schemaFields  []field.SchemaField
-			authMethodStr string
-		)
-		if authMethod, ok := configStructMap["auth-method"]; ok {
-			if authMethodStr, ok = authMethod.(string); ok {
-				fieldOptions = append(fieldOptions, field.WithAuthMethod(authMethodStr))
-			}
-		}
-		schemaFieldsMap := connectorSchema.FieldGroupFields(authMethodStr)
-		for _, field := range schemaFieldsMap {
-			schemaFields = append(schemaFields, field)
-		}
-
-		if len(schemaFields) == 0 {
-			schemaFields = connectorSchema.Fields
-		}
-
-		if err := field.Validate(connectorSchema, t, fieldOptions...); err != nil {
-			return fmt.Errorf("failed to validate config: %w", err)
 		}
 
 		clientSecret := v.GetString("lambda-client-secret")
@@ -209,6 +221,11 @@ func OptionallyAddLambdaCommand[T field.Configurable](
 			}
 			runCtx = context.WithValue(runCtx, crypto.ContextClientSecretKey, secretJwk)
 		}
+
+		// parse content directly for lambdas, don't read from file
+		readFromPath := false
+		decodeOpts := field.WithAdditionalDecodeHooks(field.FileUploadDecodeHook(readFromPath))
+
 		sessionStoreMaximumSize := v.GetInt(field.ServerSessionStoreMaximumSizeField.GetName())
 		var sessionStoreConstructor sessions.SessionStoreConstructor
 		if sessionStoreEnabled {
@@ -218,28 +235,94 @@ func OptionallyAddLambdaCommand[T field.Configurable](
 				return &session.NoOpSessionStore{}, nil
 			}
 		}
-		ops := RunTimeOpts{
-			SessionStore: NewLazyCachingSessionStore(sessionStoreConstructor, func(otterOptions *otter.Options[string, []byte]) {
-				if sessionStoreMaximumSize <= 0 {
-					otterOptions.MaximumWeight = 0
-				} else {
-					otterOptions.MaximumWeight = uint64(sessionStoreMaximumSize)
+
+		buildConnectorGeneration := func(ctx context.Context, requestedVersion string) (*lambdaConnectorGeneration, error) {
+			// Get configuration, convert it to viper flag values, then proceed.
+			config, err := configClient.GetConnectorConfig(ctx, &v1.GetConnectorConfigRequest{})
+			if err != nil {
+				return nil, fmt.Errorf("lambda-run: failed to get connector config: %w", err)
+			}
+
+			decrypted, err := jwk.DecryptED25519(ed25519PrivateKey, config.GetConfig())
+			if err != nil {
+				return nil, fmt.Errorf("lambda-run: failed to decrypt config: %w", err)
+			}
+
+			configStruct := structpb.Struct{}
+			err = json.Unmarshal(decrypted, &configStruct)
+			if err != nil {
+				return nil, fmt.Errorf("lambda-run: failed to unmarshal decrypted config: %w", err)
+			}
+
+			effectiveConfig := cloneViperSettings(v)
+			for key, value := range configStruct.AsMap() {
+				effectiveConfig.Set(key, value)
+			}
+
+			t, err := MakeGenericConfiguration[T](effectiveConfig, decodeOpts)
+			if err != nil {
+				return nil, fmt.Errorf("lambda-run: failed to make generic configuration: %w", err)
+			}
+
+			var (
+				fieldOptions  []field.Option
+				schemaFields  []field.SchemaField
+				authMethodStr string
+			)
+			authMethodStr = effectiveConfig.GetString("auth-method")
+			if authMethodStr != "" {
+				fieldOptions = append(fieldOptions, field.WithAuthMethod(authMethodStr))
+			}
+			schemaFieldsMap := connectorSchema.FieldGroupFields(authMethodStr)
+			for _, field := range schemaFieldsMap {
+				schemaFields = append(schemaFields, field)
+			}
+
+			if len(schemaFields) == 0 {
+				schemaFields = connectorSchema.Fields
+			}
+
+			if err := field.Validate(connectorSchema, t, fieldOptions...); err != nil {
+				return nil, fmt.Errorf("failed to validate config: %w", err)
+			}
+
+			ops := RunTimeOpts{
+				SessionStore: NewLazyCachingSessionStore(sessionStoreConstructor, func(otterOptions *otter.Options[string, []byte]) {
+					if sessionStoreMaximumSize <= 0 {
+						otterOptions.MaximumWeight = 0
+					} else {
+						otterOptions.MaximumWeight = uint64(sessionStoreMaximumSize)
+					}
+				}),
+				SelectedAuthMethod:  authMethodStr,
+				SyncResourceTypeIDs: effectiveConfig.GetStringSlice("sync-resource-types"),
+			}
+
+			if hasOauthField(schemaFields) {
+				ops.TokenSource = &lambdaTokenSource{
+					ctx:    runCtx,
+					webKey: webKey,
+					client: configClient,
 				}
-			}),
-			SelectedAuthMethod:  authMethodStr,
-			SyncResourceTypeIDs: v.GetStringSlice("sync-resource-types"),
+			}
+			c, err := getconnector(runCtx, t, ops)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get connector: %w", err)
+			}
+
+			version := requestedVersion
+			if version == "" {
+				version = lambdaConnectorConfigVersion(config)
+			}
+			return &lambdaConnectorGeneration{
+				version:   version,
+				connector: c,
+			}, nil
 		}
 
-		if hasOauthField(schemaFields) {
-			ops.TokenSource = &lambdaTokenSource{
-				ctx:    runCtx,
-				webKey: webKey,
-				client: configClient,
-			}
-		}
-		c, err := getconnector(runCtx, t, ops)
+		initialGeneration, err := buildConnectorGeneration(runCtx, "")
 		if err != nil {
-			return fmt.Errorf("failed to get connector: %w", err)
+			return err
 		}
 
 		// Ensure only one auth method is provided
@@ -272,13 +355,37 @@ func OptionallyAddLambdaCommand[T field.Configurable](
 		chain := ugrpc.ChainUnaryInterceptors(authOpt)
 
 		s := c1_lambda_grpc.NewServer(chain)
-		connector.Register(runCtx, s, c, opts)
+		connector.Register(runCtx, s, initialGeneration.connector, opts)
 
-		aws_lambda.StartWithOptions(s.Handler, aws_lambda.WithContext(runCtx))
+		reloader := &lambdaConnectorReloader{
+			server:  s,
+			current: initialGeneration,
+			build:   buildConnectorGeneration,
+		}
+
+		aws_lambda.StartWithOptions(reloader.Handler, aws_lambda.WithContext(runCtx))
 		return nil
 	}
 
 	return nil
+}
+
+func lambdaConnectorConfigVersion(config *v1.GetConnectorConfigResponse) string {
+	if config == nil || config.GetLastUpdated() == nil {
+		return ""
+	}
+	return config.GetLastUpdated().AsTime().UTC().Format(time.RFC3339Nano)
+}
+
+func cloneViperSettings(v *viper.Viper) *viper.Viper {
+	cloned := viper.New()
+	if v == nil {
+		return cloned
+	}
+	for key, value := range v.AllSettings() {
+		cloned.Set(key, value)
+	}
+	return cloned
 }
 
 // createSessionCacheConstructor creates a session cache constructor function that uses the provided gRPC client.

--- a/pkg/cli/lambda_server__added.go
+++ b/pkg/cli/lambda_server__added.go
@@ -48,6 +48,19 @@ const (
 type lambdaConnectorGeneration struct {
 	version   string
 	connector types.ConnectorServer
+	logging   lambdaLogLevelConfig
+}
+
+type lambdaLogLevelConfig struct {
+	level              string
+	debugModeExpiresAt time.Time
+}
+
+func (c lambdaLogLevelConfig) effective(now time.Time) string {
+	if c.level == "debug" && !c.debugModeExpiresAt.IsZero() && now.After(c.debugModeExpiresAt) {
+		return "info"
+	}
+	return c.level
 }
 
 type lambdaConnectorCloserWithContext interface {
@@ -77,7 +90,21 @@ func (r *lambdaConnectorReloader) Handler(ctx context.Context, req *c1_lambda_gr
 		}
 	}
 
+	if err := r.applyCurrentLogLevel(time.Now()); err != nil {
+		return c1_lambda_grpc.ErrorResponse(status.Errorf(codes.Unavailable, "lambda-run: failed to apply log level: %v", err)), nil
+	}
+
 	return r.server.Handler(ctx, req)
+}
+
+func (r *lambdaConnectorReloader) applyCurrentLogLevel(now time.Time) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.current == nil {
+		return nil
+	}
+	return applyLambdaLogLevel(r.current.logging, now)
 }
 
 func (r *lambdaConnectorReloader) reloadIfNeeded(ctx context.Context, requestedVersion string) error {
@@ -105,6 +132,9 @@ func (r *lambdaConnectorReloader) reloadIfNeeded(ctx context.Context, requestedV
 	}
 
 	r.current = next
+	if err := applyLambdaLogLevel(next.logging, time.Now()); err != nil {
+		return err
+	}
 	closeCtx := context.WithoutCancel(ctx)
 	go closeConnectorGenerationAfterDrain(closeCtx, previous, drained, lambdaConnectorDrainTimeout, lambdaConnectorCloseTimeout)
 	return nil
@@ -182,11 +212,9 @@ func OptionallyAddLambdaCommand[T field.Configurable](
 			return err
 		}
 
-		logLevel := v.GetString("log-level")
-		// Downgrade log level to "info" if debug mode has expired
-		debugModeExpiresAt := v.GetTime("log-level-debug-expires-at")
-		if logLevel == "debug" && !debugModeExpiresAt.IsZero() && time.Now().After(debugModeExpiresAt) {
-			logLevel = "info"
+		startupLogLevel, err := lambdaLogLevelConfigFromViper(v)
+		if err != nil {
+			return err
 		}
 
 		initialLogFields := map[string]interface{}{
@@ -205,7 +233,7 @@ func OptionallyAddLambdaCommand[T field.Configurable](
 			ctx,
 			name,
 			logging.WithLogFormat(v.GetString("log-format")),
-			logging.WithLogLevel(logLevel),
+			logging.WithLogLevel(startupLogLevel.effective(time.Now())),
 			logging.WithInitialFields(initialLogFields),
 		)
 		if err != nil {
@@ -295,6 +323,10 @@ func OptionallyAddLambdaCommand[T field.Configurable](
 			for key, value := range configStruct.AsMap() {
 				effectiveConfig.Set(key, value)
 			}
+			logLevelConfig, err := lambdaLogLevelConfigFromViper(effectiveConfig)
+			if err != nil {
+				return nil, err
+			}
 
 			t, err := MakeGenericConfiguration[T](effectiveConfig, decodeOpts)
 			if err != nil {
@@ -354,11 +386,15 @@ func OptionallyAddLambdaCommand[T field.Configurable](
 			return &lambdaConnectorGeneration{
 				version:   version,
 				connector: c,
+				logging:   logLevelConfig,
 			}, nil
 		}
 
 		initialGeneration, err := buildConnectorGeneration(runCtx, "")
 		if err != nil {
+			return err
+		}
+		if err := applyLambdaLogLevel(initialGeneration.logging, time.Now()); err != nil {
 			return err
 		}
 
@@ -412,6 +448,21 @@ func lambdaConnectorConfigVersion(config *v1.GetConnectorConfigResponse) string 
 		return ""
 	}
 	return config.GetLastUpdated().AsTime().UTC().Format(time.RFC3339Nano)
+}
+
+func lambdaLogLevelConfigFromViper(v *viper.Viper) (lambdaLogLevelConfig, error) {
+	level, err := logging.NormalizeLogLevel(v.GetString("log-level"))
+	if err != nil {
+		return lambdaLogLevelConfig{}, fmt.Errorf("lambda-run: invalid log level: %w", err)
+	}
+	return lambdaLogLevelConfig{
+		level:              level,
+		debugModeExpiresAt: v.GetTime("log-level-debug-expires-at"),
+	}, nil
+}
+
+func applyLambdaLogLevel(config lambdaLogLevelConfig, now time.Time) error {
+	return logging.SetLogLevel(config.effective(now))
 }
 
 func cloneViperSettings(v *viper.Viper) *viper.Viper {

--- a/pkg/cli/lambda_server__added.go
+++ b/pkg/cli/lambda_server__added.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sync"
 	"time"
 
 	aws_lambda "github.com/aws/aws-lambda-go/lambda"
@@ -15,14 +16,16 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/crypto/providers/jwk"
 	"github.com/conductorone/baton-sdk/pkg/logging"
 	"github.com/conductorone/baton-sdk/pkg/session"
+	"github.com/conductorone/baton-sdk/pkg/types"
 	"github.com/conductorone/baton-sdk/pkg/ugrpc"
 	"github.com/go-jose/go-jose/v4"
 	"github.com/maypok86/otter/v2"
-	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 	"golang.org/x/oauth2"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/conductorone/baton-sdk/internal/connector"
@@ -35,6 +38,84 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/types/sessions"
 	"google.golang.org/grpc"
 )
+
+const lambdaConnectorConfigVersionHeader = "x-baton-connector-config-version"
+
+type lambdaConnectorGeneration struct {
+	version   string
+	connector types.ConnectorServer
+}
+
+type lambdaConnectorCloser interface {
+	Close(context.Context) error
+}
+
+type lambdaConnectorReloader struct {
+	mu      sync.Mutex
+	server  *c1_lambda_grpc.Server
+	current *lambdaConnectorGeneration
+	build   func(context.Context, string) (*lambdaConnectorGeneration, error)
+}
+
+func (r *lambdaConnectorReloader) Handler(ctx context.Context, req *c1_lambda_grpc.Request) (*c1_lambda_grpc.Response, error) {
+	requestedVersion := ""
+	if values := req.Headers().Get(lambdaConnectorConfigVersionHeader); len(values) > 0 {
+		requestedVersion = values[0]
+	}
+
+	if requestedVersion != "" {
+		if err := r.reloadIfNeeded(ctx, requestedVersion); err != nil {
+			return c1_lambda_grpc.ErrorResponse(status.Errorf(codes.Unavailable, "lambda-run: failed to reload connector config: %v", err)), nil
+		}
+	}
+
+	return r.server.Handler(ctx, req)
+}
+
+func (r *lambdaConnectorReloader) reloadIfNeeded(ctx context.Context, requestedVersion string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.current != nil && r.current.version == requestedVersion {
+		return nil
+	}
+	if r.current == nil {
+		return fmt.Errorf("no current connector generation is registered")
+	}
+
+	next, err := r.build(ctx, requestedVersion)
+	if err != nil {
+		return err
+	}
+	previous := r.current
+	replaced, drained, err := r.server.ReplaceServiceImplementation(previous.connector, next.connector)
+	if err != nil {
+		return err
+	}
+	if replaced == 0 {
+		return fmt.Errorf("no registered services matched the current connector generation")
+	}
+
+	r.current = next
+	closeCtx := context.WithoutCancel(ctx)
+	go closeConnectorGenerationAfterDrain(closeCtx, previous, drained)
+	return nil
+}
+
+func closeConnectorGenerationAfterDrain(ctx context.Context, generation *lambdaConnectorGeneration, drained <-chan struct{}) {
+	if generation == nil {
+		return
+	}
+	closer, ok := generation.connector.(lambdaConnectorCloser)
+	if !ok {
+		return
+	}
+
+	<-drained
+	if err := closer.Close(ctx); err != nil {
+		zap.L().Warn("error closing stale lambda connector generation", zap.String("config_version", generation.version), zap.Error(err))
+	}
+}
 
 func OptionallyAddLambdaCommand[T field.Configurable](
 	ctx context.Context,
@@ -127,79 +208,9 @@ func OptionallyAddLambdaCommand[T field.Configurable](
 		// Create connector config service client using the DPoP client
 		configClient := v1.NewConnectorConfigServiceClient(grpcClient)
 
-		// Get configuration, convert it to viper flag values, then proceed.
-		config, err := configClient.GetConnectorConfig(runCtx, &v1.GetConnectorConfigRequest{})
-		if err != nil {
-			return fmt.Errorf("lambda-run: failed to get connector config: %w", err)
-		}
-
 		ed25519PrivateKey, ok := webKey.Key.(ed25519.PrivateKey)
 		if !ok {
 			return fmt.Errorf("lambda-run: failed to cast webkey to ed25519.PrivateKey")
-		}
-
-		decrypted, err := jwk.DecryptED25519(ed25519PrivateKey, config.Config)
-		if err != nil {
-			return fmt.Errorf("lambda-run: failed to decrypt config: %w", err)
-		}
-
-		configStruct := structpb.Struct{}
-		err = json.Unmarshal(decrypted, &configStruct)
-		if err != nil {
-			return fmt.Errorf("lambda-run: failed to unmarshal decrypted config: %w", err)
-		}
-
-		// parse content directly for lambdas, don't read from file
-		readFromPath := false
-		decodeOpts := field.WithAdditionalDecodeHooks(field.FileUploadDecodeHook(readFromPath))
-		t, err := MakeGenericConfiguration[T](v, decodeOpts)
-		if err != nil {
-			return fmt.Errorf("lambda-run: failed to make generic configuration: %w", err)
-		}
-		switch cfg := any(t).(type) {
-		case *viper.Viper:
-			for k, v := range configStruct.AsMap() {
-				cfg.Set(k, v)
-			}
-		default:
-			// Use mapstructure with decode hook for file upload fields
-			decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
-				DecodeHook: field.ComposeDecodeHookFunc(decodeOpts),
-				Result:     cfg,
-			})
-			if err != nil {
-				return fmt.Errorf("lambda-run: failed to create decoder: %w", err)
-			}
-			err = decoder.Decode(configStruct.AsMap())
-			if err != nil {
-				return fmt.Errorf("lambda-run: failed to decode config: %w", err)
-			}
-		}
-
-		configStructMap := configStruct.AsMap()
-
-		var (
-			fieldOptions  []field.Option
-			schemaFields  []field.SchemaField
-			authMethodStr string
-		)
-		if authMethod, ok := configStructMap["auth-method"]; ok {
-			if authMethodStr, ok = authMethod.(string); ok {
-				fieldOptions = append(fieldOptions, field.WithAuthMethod(authMethodStr))
-			}
-		}
-		syncResourceTypeIDs := parseSyncResourceTypeIDs(configStructMap)
-		schemaFieldsMap := connectorSchema.FieldGroupFields(authMethodStr)
-		for _, field := range schemaFieldsMap {
-			schemaFields = append(schemaFields, field)
-		}
-
-		if len(schemaFields) == 0 {
-			schemaFields = connectorSchema.Fields
-		}
-
-		if err := field.Validate(connectorSchema, t, fieldOptions...); err != nil {
-			return fmt.Errorf("failed to validate config: %w", err)
 		}
 
 		clientSecret := v.GetString("lambda-client-secret")
@@ -210,6 +221,11 @@ func OptionallyAddLambdaCommand[T field.Configurable](
 			}
 			runCtx = context.WithValue(runCtx, crypto.ContextClientSecretKey, secretJwk)
 		}
+
+		// parse content directly for lambdas, don't read from file
+		readFromPath := false
+		decodeOpts := field.WithAdditionalDecodeHooks(field.FileUploadDecodeHook(readFromPath))
+
 		sessionStoreMaximumSize := v.GetInt(field.ServerSessionStoreMaximumSizeField.GetName())
 		var sessionStoreConstructor sessions.SessionStoreConstructor
 		if sessionStoreEnabled {
@@ -219,28 +235,94 @@ func OptionallyAddLambdaCommand[T field.Configurable](
 				return &session.NoOpSessionStore{}, nil
 			}
 		}
-		ops := RunTimeOpts{
-			SessionStore: NewLazyCachingSessionStore(sessionStoreConstructor, func(otterOptions *otter.Options[string, []byte]) {
-				if sessionStoreMaximumSize <= 0 {
-					otterOptions.MaximumWeight = 0
-				} else {
-					otterOptions.MaximumWeight = uint64(sessionStoreMaximumSize)
+
+		buildConnectorGeneration := func(ctx context.Context, requestedVersion string) (*lambdaConnectorGeneration, error) {
+			// Get configuration, convert it to viper flag values, then proceed.
+			config, err := configClient.GetConnectorConfig(ctx, &v1.GetConnectorConfigRequest{})
+			if err != nil {
+				return nil, fmt.Errorf("lambda-run: failed to get connector config: %w", err)
+			}
+
+			decrypted, err := jwk.DecryptED25519(ed25519PrivateKey, config.GetConfig())
+			if err != nil {
+				return nil, fmt.Errorf("lambda-run: failed to decrypt config: %w", err)
+			}
+
+			configStruct := structpb.Struct{}
+			err = json.Unmarshal(decrypted, &configStruct)
+			if err != nil {
+				return nil, fmt.Errorf("lambda-run: failed to unmarshal decrypted config: %w", err)
+			}
+
+			effectiveConfig := cloneViperSettings(v)
+			for key, value := range configStruct.AsMap() {
+				effectiveConfig.Set(key, value)
+			}
+
+			t, err := MakeGenericConfiguration[T](effectiveConfig, decodeOpts)
+			if err != nil {
+				return nil, fmt.Errorf("lambda-run: failed to make generic configuration: %w", err)
+			}
+
+			var (
+				fieldOptions  []field.Option
+				schemaFields  []field.SchemaField
+				authMethodStr string
+			)
+			authMethodStr = effectiveConfig.GetString("auth-method")
+			if authMethodStr != "" {
+				fieldOptions = append(fieldOptions, field.WithAuthMethod(authMethodStr))
+			}
+			schemaFieldsMap := connectorSchema.FieldGroupFields(authMethodStr)
+			for _, field := range schemaFieldsMap {
+				schemaFields = append(schemaFields, field)
+			}
+
+			if len(schemaFields) == 0 {
+				schemaFields = connectorSchema.Fields
+			}
+
+			if err := field.Validate(connectorSchema, t, fieldOptions...); err != nil {
+				return nil, fmt.Errorf("failed to validate config: %w", err)
+			}
+
+			ops := RunTimeOpts{
+				SessionStore: NewLazyCachingSessionStore(sessionStoreConstructor, func(otterOptions *otter.Options[string, []byte]) {
+					if sessionStoreMaximumSize <= 0 {
+						otterOptions.MaximumWeight = 0
+					} else {
+						otterOptions.MaximumWeight = uint64(sessionStoreMaximumSize)
+					}
+				}),
+				SelectedAuthMethod:  authMethodStr,
+				SyncResourceTypeIDs: effectiveConfig.GetStringSlice("sync-resource-types"),
+			}
+
+			if hasOauthField(schemaFields) {
+				ops.TokenSource = &lambdaTokenSource{
+					ctx:    runCtx,
+					webKey: webKey,
+					client: configClient,
 				}
-			}),
-			SelectedAuthMethod:  authMethodStr,
-			SyncResourceTypeIDs: syncResourceTypeIDs,
+			}
+			c, err := getconnector(runCtx, t, ops)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get connector: %w", err)
+			}
+
+			version := requestedVersion
+			if version == "" {
+				version = lambdaConnectorConfigVersion(config)
+			}
+			return &lambdaConnectorGeneration{
+				version:   version,
+				connector: c,
+			}, nil
 		}
 
-		if hasOauthField(schemaFields) {
-			ops.TokenSource = &lambdaTokenSource{
-				ctx:    runCtx,
-				webKey: webKey,
-				client: configClient,
-			}
-		}
-		c, err := getconnector(runCtx, t, ops)
+		initialGeneration, err := buildConnectorGeneration(runCtx, "")
 		if err != nil {
-			return fmt.Errorf("failed to get connector: %w", err)
+			return err
 		}
 
 		// Ensure only one auth method is provided
@@ -273,13 +355,37 @@ func OptionallyAddLambdaCommand[T field.Configurable](
 		chain := ugrpc.ChainUnaryInterceptors(authOpt)
 
 		s := c1_lambda_grpc.NewServer(chain)
-		connector.Register(runCtx, s, c, opts)
+		connector.Register(runCtx, s, initialGeneration.connector, opts)
 
-		aws_lambda.StartWithOptions(s.Handler, aws_lambda.WithContext(runCtx))
+		reloader := &lambdaConnectorReloader{
+			server:  s,
+			current: initialGeneration,
+			build:   buildConnectorGeneration,
+		}
+
+		aws_lambda.StartWithOptions(reloader.Handler, aws_lambda.WithContext(runCtx))
 		return nil
 	}
 
 	return nil
+}
+
+func lambdaConnectorConfigVersion(config *v1.GetConnectorConfigResponse) string {
+	if config == nil || config.GetLastUpdated() == nil {
+		return ""
+	}
+	return config.GetLastUpdated().AsTime().UTC().Format(time.RFC3339Nano)
+}
+
+func cloneViperSettings(v *viper.Viper) *viper.Viper {
+	cloned := viper.New()
+	if v == nil {
+		return cloned
+	}
+	for key, value := range v.AllSettings() {
+		cloned.Set(key, value)
+	}
+	return cloned
 }
 
 // createSessionCacheConstructor creates a session cache constructor function that uses the provided gRPC client.
@@ -336,24 +442,4 @@ func hasOauthField(fields []field.SchemaField) bool {
 		}
 	}
 	return false
-}
-
-// parseSyncResourceTypeIDs extracts the "sync-resource-types" string slice from
-// a structpb-decoded config map. Returns nil when the key is absent.
-func parseSyncResourceTypeIDs(configMap map[string]interface{}) []string {
-	v, ok := configMap["sync-resource-types"]
-	if !ok {
-		return nil
-	}
-	raw, ok := v.([]interface{})
-	if !ok {
-		return nil
-	}
-	ids := make([]string, 0, len(raw))
-	for _, item := range raw {
-		if s, ok := item.(string); ok {
-			ids = append(ids, s)
-		}
-	}
-	return ids
 }

--- a/pkg/cli/lambda_server__added.go
+++ b/pkg/cli/lambda_server__added.go
@@ -39,15 +39,23 @@ import (
 	"google.golang.org/grpc"
 )
 
-const lambdaConnectorConfigVersionHeader = "x-baton-connector-config-version"
+const (
+	lambdaConnectorConfigVersionHeader = "x-baton-connector-config-version"
+	lambdaConnectorDrainTimeout        = 30 * time.Second
+	lambdaConnectorCloseTimeout        = 10 * time.Second
+)
 
 type lambdaConnectorGeneration struct {
 	version   string
 	connector types.ConnectorServer
 }
 
-type lambdaConnectorCloser interface {
+type lambdaConnectorCloserWithContext interface {
 	Close(context.Context) error
+}
+
+type lambdaConnectorCloser interface {
+	Close() error
 }
 
 type lambdaConnectorReloader struct {
@@ -98,22 +106,51 @@ func (r *lambdaConnectorReloader) reloadIfNeeded(ctx context.Context, requestedV
 
 	r.current = next
 	closeCtx := context.WithoutCancel(ctx)
-	go closeConnectorGenerationAfterDrain(closeCtx, previous, drained)
+	go closeConnectorGenerationAfterDrain(closeCtx, previous, drained, lambdaConnectorDrainTimeout, lambdaConnectorCloseTimeout)
 	return nil
 }
 
-func closeConnectorGenerationAfterDrain(ctx context.Context, generation *lambdaConnectorGeneration, drained <-chan struct{}) {
+func closeConnectorGenerationAfterDrain(ctx context.Context, generation *lambdaConnectorGeneration, drained <-chan struct{}, drainTimeout time.Duration, closeTimeout time.Duration) {
 	if generation == nil {
 		return
 	}
-	closer, ok := generation.connector.(lambdaConnectorCloser)
-	if !ok {
-		return
+
+	drainTimer := time.NewTimer(drainTimeout)
+	defer drainTimer.Stop()
+
+	select {
+	case <-drained:
+	case <-drainTimer.C:
+		zap.L().Warn("timed out waiting for stale lambda connector generation to drain", zap.String("config_version", generation.version), zap.Duration("timeout", drainTimeout))
 	}
 
-	<-drained
-	if err := closer.Close(ctx); err != nil {
+	closeCtx, cancel := context.WithTimeout(ctx, closeTimeout)
+	defer cancel()
+
+	if err := closeLambdaConnectorGeneration(closeCtx, generation.connector); err != nil {
 		zap.L().Warn("error closing stale lambda connector generation", zap.String("config_version", generation.version), zap.Error(err))
+	}
+}
+
+func closeLambdaConnectorGeneration(ctx context.Context, connector types.ConnectorServer) error {
+	errCh := make(chan error, 1)
+	if closer, ok := connector.(lambdaConnectorCloserWithContext); ok {
+		go func() {
+			errCh <- closer.Close(ctx)
+		}()
+	} else if closer, ok := connector.(lambdaConnectorCloser); ok {
+		go func() {
+			errCh <- closer.Close()
+		}()
+	} else {
+		return nil
+	}
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 

--- a/pkg/cli/lambda_server__added.go
+++ b/pkg/cli/lambda_server__added.go
@@ -321,10 +321,7 @@ func OptionallyAddLambdaCommand[T field.Configurable](
 				return nil, fmt.Errorf("lambda-run: failed to unmarshal decrypted config: %w", err)
 			}
 
-			effectiveConfig := cloneViperSettings(v)
-			for key, value := range configStruct.AsMap() {
-				effectiveConfig.Set(key, value)
-			}
+			effectiveConfig := effectiveLambdaConfig(v, configStruct.AsMap())
 			logLevelConfig, err := lambdaLogLevelConfigFromViper(effectiveConfig)
 			if err != nil {
 				return nil, err
@@ -476,6 +473,14 @@ func cloneViperSettings(v *viper.Viper) *viper.Viper {
 		cloned.Set(key, value)
 	}
 	return cloned
+}
+
+func effectiveLambdaConfig(v *viper.Viper, connectorConfig map[string]any) *viper.Viper {
+	effectiveConfig := cloneViperSettings(v)
+	for key, value := range connectorConfig {
+		effectiveConfig.Set(key, value)
+	}
+	return effectiveConfig
 }
 
 // createSessionCacheConstructor creates a session cache constructor function that uses the provided gRPC client.

--- a/pkg/cli/lambda_server__added.go
+++ b/pkg/cli/lambda_server__added.go
@@ -303,7 +303,9 @@ func OptionallyAddLambdaCommand[T field.Configurable](
 
 		buildConnectorGeneration := func(ctx context.Context, requestedVersion string) (*lambdaConnectorGeneration, error) {
 			// Get configuration, convert it to viper flag values, then proceed.
-			config, err := configClient.GetConnectorConfig(ctx, &v1.GetConnectorConfigRequest{})
+			config, err := configClient.GetConnectorConfig(ctx, &v1.GetConnectorConfigRequest{
+				RequestedVersion: requestedVersion,
+			})
 			if err != nil {
 				return nil, fmt.Errorf("lambda-run: failed to get connector config: %w", err)
 			}

--- a/pkg/cli/lambda_server__added_test.go
+++ b/pkg/cli/lambda_server__added_test.go
@@ -1,0 +1,55 @@
+//go:build baton_lambda_support
+
+package cli
+
+import (
+	"testing"
+	"time"
+
+	"github.com/spf13/viper"
+)
+
+func TestLambdaLogLevelConfigExpiresDebug(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	v := viper.New()
+	v.Set("log-level", "debug")
+	v.Set("log-level-debug-expires-at", now.Add(-time.Minute).Format(time.RFC3339))
+
+	config, err := lambdaLogLevelConfigFromViper(v)
+	if err != nil {
+		t.Fatalf("lambdaLogLevelConfigFromViper: %v", err)
+	}
+	if got := config.effective(now); got != "info" {
+		t.Fatalf("effective log level = %q, want info", got)
+	}
+}
+
+func TestLambdaLogLevelConfigKeepsUnexpiredDebug(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	v := viper.New()
+	v.Set("log-level", "debug")
+	v.Set("log-level-debug-expires-at", now.Add(time.Minute).Format(time.RFC3339))
+
+	config, err := lambdaLogLevelConfigFromViper(v)
+	if err != nil {
+		t.Fatalf("lambdaLogLevelConfigFromViper: %v", err)
+	}
+	if got := config.effective(now); got != "debug" {
+		t.Fatalf("effective log level = %q, want debug", got)
+	}
+}
+
+func TestLambdaLogLevelConfigRejectsInvalidLevel(t *testing.T) {
+	t.Parallel()
+
+	v := viper.New()
+	v.Set("log-level", "verbose")
+
+	if _, err := lambdaLogLevelConfigFromViper(v); err == nil {
+		t.Fatal("expected invalid log level to fail")
+	}
+}

--- a/pkg/cli/lambda_server_test.go
+++ b/pkg/cli/lambda_server_test.go
@@ -3,36 +3,68 @@
 package cli
 
 import (
+	"context"
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 )
 
-func TestParseSyncResourceTypeIDs(t *testing.T) {
-	t.Run("key absent returns nil", func(t *testing.T) {
-		require.Nil(t, parseSyncResourceTypeIDs(map[string]interface{}{}))
-	})
+type testLambdaConnectorServer struct {
+	v2.UnimplementedConnectorServiceServer
+	v2.UnimplementedResourceTypesServiceServer
+	v2.UnimplementedResourcesServiceServer
+	v2.UnimplementedEntitlementsServiceServer
+	v2.UnimplementedGrantsServiceServer
+	v2.UnimplementedAssetServiceServer
+	v2.UnimplementedGrantManagerServiceServer
+	v2.UnimplementedResourceManagerServiceServer
+	v2.UnimplementedResourceDeleterServiceServer
+	v2.UnimplementedAccountManagerServiceServer
+	v2.UnimplementedCredentialManagerServiceServer
+	v2.UnimplementedEventServiceServer
+	v2.UnimplementedTicketsServiceServer
+	v2.UnimplementedActionServiceServer
+	v2.UnimplementedResourceGetterServiceServer
+}
 
-	t.Run("key present with values returns ids", func(t *testing.T) {
-		m := map[string]interface{}{
-			"sync-resource-types": []interface{}{"user", "group"},
-		}
-		got := parseSyncResourceTypeIDs(m)
-		require.Equal(t, []string{"user", "group"}, got)
-	})
+type testLambdaConnectorCloseWithoutContext struct {
+	testLambdaConnectorServer
+	closed bool
+}
 
-	t.Run("key present with empty slice returns empty", func(t *testing.T) {
-		m := map[string]interface{}{
-			"sync-resource-types": []interface{}{},
-		}
-		got := parseSyncResourceTypeIDs(m)
-		require.Empty(t, got)
-	})
+func (c *testLambdaConnectorCloseWithoutContext) Close() error {
+	c.closed = true
+	return nil
+}
 
-	t.Run("non-slice value is ignored", func(t *testing.T) {
-		m := map[string]interface{}{
-			"sync-resource-types": "user",
-		}
-		require.Nil(t, parseSyncResourceTypeIDs(m))
-	})
+type testLambdaConnectorCloseWithContext struct {
+	testLambdaConnectorServer
+	closed bool
+}
+
+func (c *testLambdaConnectorCloseWithContext) Close(context.Context) error {
+	c.closed = true
+	return nil
+}
+
+func TestCloseLambdaConnectorGenerationSupportsCloseWithoutContext(t *testing.T) {
+	connector := &testLambdaConnectorCloseWithoutContext{}
+
+	if err := closeLambdaConnectorGeneration(context.Background(), connector); err != nil {
+		t.Fatalf("closeLambdaConnectorGeneration: %v", err)
+	}
+	if !connector.closed {
+		t.Fatal("expected Close() to be called")
+	}
+}
+
+func TestCloseLambdaConnectorGenerationSupportsCloseWithContext(t *testing.T) {
+	connector := &testLambdaConnectorCloseWithContext{}
+
+	if err := closeLambdaConnectorGeneration(context.Background(), connector); err != nil {
+		t.Fatalf("closeLambdaConnectorGeneration: %v", err)
+	}
+	if !connector.closed {
+		t.Fatal("expected Close(context.Context) to be called")
+	}
 }

--- a/pkg/cli/lambda_server_test.go
+++ b/pkg/cli/lambda_server_test.go
@@ -4,9 +4,11 @@ package cli
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/spf13/viper"
 )
 
 type testLambdaConnectorServer struct {
@@ -66,5 +68,23 @@ func TestCloseLambdaConnectorGenerationSupportsCloseWithContext(t *testing.T) {
 	}
 	if !connector.closed {
 		t.Fatal("expected Close(context.Context) to be called")
+	}
+}
+
+func TestEffectiveLambdaConfigSyncResourceTypeIDs(t *testing.T) {
+	t.Parallel()
+
+	base := viper.New()
+	base.Set("sync-resource-types", []string{"fallback"})
+	connectorConfig := map[string]any{
+		"sync-resource-types": []any{"user", "group"},
+	}
+
+	effectiveConfig := effectiveLambdaConfig(base, connectorConfig)
+
+	got := effectiveConfig.GetStringSlice("sync-resource-types")
+	want := []string{"user", "group"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("sync-resource-types = %#v, want %#v", got, want)
 	}
 }

--- a/pkg/connectorbuilder/connectorbuilder.go
+++ b/pkg/connectorbuilder/connectorbuilder.go
@@ -60,6 +60,16 @@ type ConnectorBuilderV2 interface {
 	ResourceSyncers(ctx context.Context) []ResourceSyncerV2
 }
 
+type closeHook func(context.Context) error
+
+type closeWithContext interface {
+	Close(context.Context) error
+}
+
+type closeWithoutContext interface {
+	Close() error
+}
+
 type builder struct {
 	ticketingEnabled        bool
 	m                       *metrics.M
@@ -78,6 +88,7 @@ type builder struct {
 	eventFeeds              map[string]EventFeed
 	accountManagers         map[string]AccountManagerLimited
 	actionManager           ActionManager // Unified action manager for all actions
+	closeHook               closeHook
 }
 
 // NewConnector creates a new ConnectorServer for a new resource.
@@ -116,6 +127,7 @@ func NewConnector(ctx context.Context, in interface{}, opts ...Opt) (types.Conne
 		eventFeeds:              make(map[string]EventFeed),
 		accountManagers:         make(map[string]AccountManagerLimited),
 		actionManager:           actionMgr,
+		closeHook:               closeHookFor(in),
 	}
 
 	// WithTicketingEnabled checks for the ticketManager
@@ -253,6 +265,29 @@ func (b *builder) addConnectorBuilderProviders(_ context.Context, in interface{}
 	}
 
 	return nil
+}
+
+func closeHookFor(in any) closeHook {
+	if in == nil {
+		return nil
+	}
+
+	if closer, ok := in.(closeWithContext); ok {
+		return closer.Close
+	}
+	if closer, ok := in.(closeWithoutContext); ok {
+		return func(context.Context) error {
+			return closer.Close()
+		}
+	}
+	return nil
+}
+
+func (b *builder) Close(ctx context.Context) error {
+	if b.closeHook == nil {
+		return nil
+	}
+	return b.closeHook(ctx)
 }
 
 // GetMetadata gets all metadata for a connector.

--- a/pkg/lambda/grpc/config/config.go
+++ b/pkg/lambda/grpc/config/config.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -29,15 +30,24 @@ var (
 	ErrInvalidClientID = errors.New("invalid client id")
 )
 
+const (
+	lambdaTokenHostEnv         = "BATON_LAMBDA_TOKEN_HOST" //nolint:gosec // Environment variable name, not a credential value.
+	lambdaConfigurationHostEnv = "BATON_LAMBDA_CONFIGURATION_HOST"
+	lambdaCACertPathEnv        = "BATON_LAMBDA_CA_CERT_PATH"
+)
+
 // NewDPoPClient creates a gRPC client with DPoP authentication.
 func NewDPoPClient(ctx context.Context, clientID string, clientSecret string) (grpc.ClientConnInterface, *jose.JSONWebKey, oauth2.TokenSource, error) {
 	_, tokenHost, err := parseClientID(clientID)
 	if err != nil {
 		return nil, nil, nil, err
 	}
-
-	if envHost, ok := os.LookupEnv("BATON_LAMBDA_TOKEN_HOST"); ok {
+	if envHost, ok := os.LookupEnv(lambdaTokenHostEnv); ok {
 		tokenHost = envHost
+	}
+	configurationHost := tokenHost
+	if envHost, ok := os.LookupEnv(lambdaConfigurationHostEnv); ok {
+		configurationHost = envHost
 	}
 
 	tokenURL := &url.URL{
@@ -68,17 +78,25 @@ func NewDPoPClient(ctx context.Context, clientID string, clientSecret string) (g
 		return nil, nil, nil, fmt.Errorf("new-dpop-client: failed to create proofer: %w", err)
 	}
 
+	tlsConfig, err := lambdaTLSConfig()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
 	idAttMarshaller, err := NewIdAttMarshaller(ctx)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("new-dpop-client: failed to create claims adjuster: %w", err)
 	}
-	opts := dpop_oauth.WithRequestOption(dpop_oauth.WithCustomMarshaler(idAttMarshaller.Marshal))
-	tokenSource, err := dpop_oauth.NewTokenSource(proofer, tokenURL, clientID, clientSecretJWK, opts)
+	opts := []dpop_oauth.TokenSourceOption{
+		dpop_oauth.WithRequestOption(dpop_oauth.WithCustomMarshaler(idAttMarshaller.Marshal)),
+		dpop_oauth.WithHTTPClient(lambdaHTTPClient(tlsConfig)),
+	}
+	tokenSource, err := dpop_oauth.NewTokenSource(proofer, tokenURL, clientID, clientSecretJWK, opts...)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("new-dpop-client: failed to create token source: %w", err)
 	}
 
-	creds, err := dpop_grpc.NewDPoPCredentials(proofer, tokenSource, tokenHost, []dpop.ProofOption{
+	creds, err := dpop_grpc.NewDPoPCredentials(proofer, tokenSource, configurationHost, []dpop.ProofOption{
 		dpop.WithValidityDuration(time.Minute * 5),
 		dpop.WithProofNowFunc(time.Now),
 	})
@@ -86,14 +104,7 @@ func NewDPoPClient(ctx context.Context, clientID string, clientSecret string) (g
 		return nil, nil, nil, fmt.Errorf("new-dpop-client: failed to create dpop credentials: %w", err)
 	}
 
-	systemCertPool, err := x509.SystemCertPool()
-	if err != nil || systemCertPool == nil {
-		return nil, nil, nil, fmt.Errorf("new-dpop-client: failed to load system cert pool: %w", err)
-	}
-	transportCreds := credentials.NewTLS(&tls.Config{
-		RootCAs:    systemCertPool,
-		MinVersion: tls.VersionTLS12,
-	})
+	transportCreds := credentials.NewTLS(tlsConfig)
 
 	dialOpts := []grpc.DialOption{
 		grpc.WithTransportCredentials(transportCreds),
@@ -101,12 +112,38 @@ func NewDPoPClient(ctx context.Context, clientID string, clientSecret string) (g
 		grpc.WithPerRPCCredentials(creds),
 	}
 
-	client, err := grpc.NewClient(tokenHost, dialOpts...)
+	client, err := grpc.NewClient(configurationHost, dialOpts...)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("new-dpop-client: failed to create client: %w", err)
 	}
 
 	return client, jwk, tokenSource, nil
+}
+
+func lambdaTLSConfig() (*tls.Config, error) {
+	systemCertPool, err := x509.SystemCertPool()
+	if err != nil || systemCertPool == nil {
+		return nil, fmt.Errorf("new-dpop-client: failed to load system cert pool: %w", err)
+	}
+	if certPath := strings.TrimSpace(os.Getenv(lambdaCACertPathEnv)); certPath != "" {
+		pemBytes, err := os.ReadFile(certPath) //nolint:gosec // Operator-provided CA bundle path for lambda-hosted connector configuration.
+		if err != nil {
+			return nil, fmt.Errorf("new-dpop-client: failed to read %s: %w", lambdaCACertPathEnv, err)
+		}
+		if ok := systemCertPool.AppendCertsFromPEM(pemBytes); !ok {
+			return nil, fmt.Errorf("new-dpop-client: failed to append CA certificates from %s", lambdaCACertPathEnv)
+		}
+	}
+	return &tls.Config{
+		RootCAs:    systemCertPool,
+		MinVersion: tls.VersionTLS12,
+	}, nil
+}
+
+func lambdaHTTPClient(tlsConfig *tls.Config) *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = tlsConfig.Clone()
+	return &http.Client{Transport: transport}
 }
 
 func parseClientID(input string) (string, string, error) {

--- a/pkg/lambda/grpc/config/config_test.go
+++ b/pkg/lambda/grpc/config/config_test.go
@@ -1,0 +1,55 @@
+package config
+
+import (
+	"context"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLambdaTLSConfigTrustsConfiguredCA(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	certPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: server.Certificate().Raw,
+	})
+	certPath := filepath.Join(t.TempDir(), "ca.pem")
+	if err := os.WriteFile(certPath, certPEM, 0o600); err != nil {
+		t.Fatalf("write CA cert: %v", err)
+	}
+	t.Setenv(lambdaCACertPathEnv, certPath)
+
+	tlsConfig, err := lambdaTLSConfig()
+	if err != nil {
+		t.Fatalf("lambdaTLSConfig: %v", err)
+	}
+	client := lambdaHTTPClient(tlsConfig)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequestWithContext: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("GET with configured CA: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusNoContent)
+	}
+}
+
+func TestLambdaTLSConfigRejectsInvalidCAPath(t *testing.T) {
+	t.Setenv(lambdaCACertPathEnv, filepath.Join(t.TempDir(), "missing.pem"))
+
+	_, err := lambdaTLSConfig()
+	if err == nil {
+		t.Fatal("expected error for missing CA path")
+	}
+}

--- a/pkg/lambda/grpc/server.go
+++ b/pkg/lambda/grpc/server.go
@@ -140,23 +140,36 @@ func NewTransportStream(method *grpc.MethodDesc) *TransportStream {
 func NewServer(unaryInterceptor grpc.UnaryServerInterceptor,
 ) *Server {
 	return &Server{
-		unaryInterceptor: unaryInterceptor,
-		services:         make(map[string]*serviceInfo),
+		unaryInterceptor:       unaryInterceptor,
+		services:               make(map[string]*serviceInfo),
+		activeServiceInstances: make(map[serviceImplementationKey]*serviceImplementationState),
 	}
 }
 
 type serviceInfo struct {
 	serviceImpl any
+	handlerType reflect.Type
 	methods     map[string]*grpc.MethodDesc
 	streams     map[string]*grpc.StreamDesc
 	mdata       any
 }
 
 type Server struct {
-	mu               sync.Mutex
-	unaryInterceptor grpc.UnaryServerInterceptor
+	mu                     sync.Mutex
+	unaryInterceptor       grpc.UnaryServerInterceptor
+	activeServiceInstances map[serviceImplementationKey]*serviceImplementationState
 
 	services map[string]*serviceInfo
+}
+
+type serviceImplementationKey struct {
+	typ reflect.Type
+	ptr uintptr
+}
+
+type serviceImplementationState struct {
+	active  int
+	drained chan struct{}
 }
 
 func MetadataForRequest(req *Request) metadata.MD {
@@ -213,14 +226,22 @@ func (s *Server) Handler(ctx context.Context, req *Request) (*Response, error) {
 	if err != nil {
 		return ErrorResponse(err), nil
 	}
+
+	s.mu.Lock()
 	service, ok := s.services[serviceName]
 	if !ok {
+		s.mu.Unlock()
 		return ErrorResponse(status.Errorf(codes.Unimplemented, "unknown service %v", serviceName)), nil
 	}
 	method, ok := service.methods[methodName]
 	if !ok {
+		s.mu.Unlock()
 		return ErrorResponse(status.Errorf(codes.Unimplemented, "unknown method %v for service %v", method, service)), nil
 	}
+	serviceImpl := service.serviceImpl
+	releaseServiceImpl := s.acquireServiceImplementationLocked(serviceImpl)
+	s.mu.Unlock()
+	defer releaseServiceImpl()
 
 	md := MetadataForRequest(req)
 	p := PeerForRequest(req)
@@ -248,7 +269,7 @@ func (s *Server) Handler(ctx context.Context, req *Request) (*Response, error) {
 		return nil
 	}
 
-	resp, err := method.Handler(service.serviceImpl, ctx, df, s.unaryInterceptor)
+	resp, err := method.Handler(serviceImpl, ctx, df, s.unaryInterceptor)
 	if err != nil {
 		appStatus, ok := status.FromError(err)
 		if ok {
@@ -292,6 +313,7 @@ func (s *Server) register(sd *grpc.ServiceDesc, ss any) {
 	}
 	info := &serviceInfo{
 		serviceImpl: ss,
+		handlerType: reflect.TypeOf(sd.HandlerType).Elem(),
 		methods:     make(map[string]*grpc.MethodDesc),
 		streams:     make(map[string]*grpc.StreamDesc),
 		mdata:       sd.Metadata,
@@ -305,4 +327,109 @@ func (s *Server) register(sd *grpc.ServiceDesc, ss any) {
 		info.streams[d.StreamName] = d
 	}
 	s.services[sd.ServiceName] = info
+}
+
+// ReplaceServiceImplementation swaps all services currently registered with oldImpl to
+// newImpl and returns a channel that closes when requests using oldImpl have drained.
+// It is intended for lambda connector generation reloads where the service
+// descriptors stay fixed but connector-owned state must be discarded wholesale.
+func (s *Server) ReplaceServiceImplementation(oldImpl any, newImpl any) (int, <-chan struct{}, error) {
+	if newImpl == nil {
+		return 0, closedChannel(), fmt.Errorf("grpc: replacement service implementation is nil")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var replacements []*serviceInfo
+	for serviceName, service := range s.services {
+		if !sameServiceImplementation(service.serviceImpl, oldImpl) {
+			continue
+		}
+		if service.handlerType != nil && !reflect.TypeOf(newImpl).Implements(service.handlerType) {
+			return 0, closedChannel(), fmt.Errorf("grpc: replacement service implementation of type %v does not satisfy %v for service %q", reflect.TypeOf(newImpl), service.handlerType, serviceName)
+		}
+		replacements = append(replacements, service)
+	}
+
+	for _, service := range replacements {
+		service.serviceImpl = newImpl
+	}
+
+	drained := closedChannel()
+	if key, ok := serviceImplementationKeyFor(oldImpl); ok {
+		if state, ok := s.activeServiceInstances[key]; ok {
+			drained = state.drained
+		}
+	}
+
+	return len(replacements), drained, nil
+}
+
+func sameServiceImplementation(a any, b any) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+	if av.Kind() == reflect.Pointer && bv.Kind() == reflect.Pointer {
+		return av.Pointer() == bv.Pointer()
+	}
+	if !av.Type().Comparable() || !bv.Type().Comparable() {
+		return false
+	}
+
+	return a == b
+}
+
+func (s *Server) acquireServiceImplementationLocked(impl any) func() {
+	key, ok := serviceImplementationKeyFor(impl)
+	if !ok {
+		return func() {}
+	}
+
+	state, ok := s.activeServiceInstances[key]
+	if !ok {
+		state = &serviceImplementationState{drained: make(chan struct{})}
+		s.activeServiceInstances[key] = state
+	}
+	state.active++
+
+	return func() {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+
+		state := s.activeServiceInstances[key]
+		if state == nil {
+			return
+		}
+		state.active--
+		if state.active == 0 {
+			close(state.drained)
+			delete(s.activeServiceInstances, key)
+		}
+	}
+}
+
+func serviceImplementationKeyFor(impl any) (serviceImplementationKey, bool) {
+	if impl == nil {
+		return serviceImplementationKey{}, false
+	}
+
+	v := reflect.ValueOf(impl)
+	if v.Kind() != reflect.Pointer {
+		return serviceImplementationKey{}, false
+	}
+
+	return serviceImplementationKey{
+		typ: v.Type(),
+		ptr: v.Pointer(),
+	}, true
+}
+
+func closedChannel() <-chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
 }

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -2,6 +2,9 @@ package logging
 
 import (
 	"context"
+	"fmt"
+	"strings"
+	"sync"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
@@ -15,12 +18,55 @@ const (
 
 type Option func(*zap.Config)
 
+var (
+	activeLevelMu sync.RWMutex
+	activeLevel   *zap.AtomicLevel
+)
+
 func WithLogLevel(level string) Option {
 	return func(c *zap.Config) {
-		ll := zapcore.DebugLevel
-		_ = ll.Set(level)
+		ll, err := ParseLogLevel(level)
+		if err != nil {
+			return
+		}
 		c.Level.SetLevel(ll)
 	}
+}
+
+func ParseLogLevel(level string) (zapcore.Level, error) {
+	level = strings.TrimSpace(level)
+	if level == "" {
+		level = "info"
+	}
+	var parsed zapcore.Level
+	if err := parsed.Set(level); err != nil {
+		return zapcore.InfoLevel, fmt.Errorf("invalid log level %q: %w", level, err)
+	}
+	return parsed, nil
+}
+
+func NormalizeLogLevel(level string) (string, error) {
+	parsed, err := ParseLogLevel(level)
+	if err != nil {
+		return "", err
+	}
+	return parsed.String(), nil
+}
+
+func SetLogLevel(level string) error {
+	parsed, err := ParseLogLevel(level)
+	if err != nil {
+		return err
+	}
+
+	activeLevelMu.RLock()
+	levelHandle := activeLevel
+	activeLevelMu.RUnlock()
+	if levelHandle == nil {
+		return nil
+	}
+	levelHandle.SetLevel(parsed)
+	return nil
 }
 
 func WithLogFormat(format string) Option {
@@ -65,6 +111,9 @@ func Init(ctx context.Context, opts ...Option) (context.Context, error) {
 	if err != nil {
 		return nil, err
 	}
+	activeLevelMu.Lock()
+	activeLevel = &zc.Level
+	activeLevelMu.Unlock()
 	zap.ReplaceGlobals(l)
 
 	l.Debug("Logger created!", zap.String("log_level", zc.Level.String()))

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -1,0 +1,37 @@
+package logging
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
+)
+
+func TestSetLogLevelUpdatesActiveLogger(t *testing.T) {
+	t.Parallel()
+
+	ctx, err := Init(context.Background(), WithLogLevel("info"))
+	if err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	logger := ctxzap.Extract(ctx)
+	if checked := logger.Check(zap.DebugLevel, "debug"); checked != nil {
+		t.Fatal("debug should be disabled at info level")
+	}
+
+	if err := SetLogLevel("debug"); err != nil {
+		t.Fatalf("SetLogLevel: %v", err)
+	}
+	if checked := logger.Check(zap.DebugLevel, "debug"); checked == nil {
+		t.Fatal("debug should be enabled after SetLogLevel")
+	}
+}
+
+func TestSetLogLevelRejectsInvalidLevel(t *testing.T) {
+	t.Parallel()
+
+	if err := SetLogLevel("verbose"); err == nil {
+		t.Fatal("expected invalid log level to fail")
+	}
+}

--- a/proto/c1/connectorapi/baton/v1/config.proto
+++ b/proto/c1/connectorapi/baton/v1/config.proto
@@ -11,7 +11,9 @@ service ConnectorConfigService {
   rpc GetConnectorOauthToken(GetConnectorOauthTokenRequest) returns (GetConnectorOauthTokenResponse);
 }
 
-message GetConnectorConfigRequest {}
+message GetConnectorConfigRequest {
+  string requested_version = 1;
+}
 
 message GetConnectorConfigResponse {
   bytes config = 1;


### PR DESCRIPTION
## Summary

- Adds lambda connector config hot loading keyed by the `x-baton-connector-config-version` request header.
- Rebuilds the full connector generation on version changes so connector-local caches/state are discarded instead of reused.
- Swaps registered lambda gRPC service implementations in place and waits for in-flight requests using the old generation to drain before closing it.
- Adds connector close forwarding in `connectorbuilder` for connectors that implement `Close(context.Context) error` or `Close() error`.
- Adds shared lambda client secret context wiring used by downstream credential flows.