### PR TITLE
Add managed runtime snapshot reload support

### DIFF
--- a/pb/c1/connectorapi/baton/v1/config.pb.go
+++ b/pb/c1/connectorapi/baton/v1/config.pb.go
@@ -151,6 +151,293 @@ func (b0 GetConnectorConfigResponse_builder) Build() *GetConnectorConfigResponse
 	return m0
 }
 
+type GetManagedRuntimeSnapshotRequest struct {
+	state         protoimpl.MessageState `protogen:"hybrid.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetManagedRuntimeSnapshotRequest) Reset() {
+	*x = GetManagedRuntimeSnapshotRequest{}
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetManagedRuntimeSnapshotRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetManagedRuntimeSnapshotRequest) ProtoMessage() {}
+
+func (x *GetManagedRuntimeSnapshotRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+type GetManagedRuntimeSnapshotRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+}
+
+func (b0 GetManagedRuntimeSnapshotRequest_builder) Build() *GetManagedRuntimeSnapshotRequest {
+	m0 := &GetManagedRuntimeSnapshotRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	return m0
+}
+
+type ManagedRuntimeAsset struct {
+	state         protoimpl.MessageState `protogen:"hybrid.v1"`
+	Role          string                 `protobuf:"bytes,1,opt,name=role,proto3" json:"role,omitempty"`
+	MediaType     string                 `protobuf:"bytes,2,opt,name=media_type,json=mediaType,proto3" json:"media_type,omitempty"`
+	Body          []byte                 `protobuf:"bytes,3,opt,name=body,proto3" json:"body,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ManagedRuntimeAsset) Reset() {
+	*x = ManagedRuntimeAsset{}
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ManagedRuntimeAsset) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ManagedRuntimeAsset) ProtoMessage() {}
+
+func (x *ManagedRuntimeAsset) ProtoReflect() protoreflect.Message {
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *ManagedRuntimeAsset) GetRole() string {
+	if x != nil {
+		return x.Role
+	}
+	return ""
+}
+
+func (x *ManagedRuntimeAsset) GetMediaType() string {
+	if x != nil {
+		return x.MediaType
+	}
+	return ""
+}
+
+func (x *ManagedRuntimeAsset) GetBody() []byte {
+	if x != nil {
+		return x.Body
+	}
+	return nil
+}
+
+func (x *ManagedRuntimeAsset) SetRole(v string) {
+	x.Role = v
+}
+
+func (x *ManagedRuntimeAsset) SetMediaType(v string) {
+	x.MediaType = v
+}
+
+func (x *ManagedRuntimeAsset) SetBody(v []byte) {
+	if v == nil {
+		v = []byte{}
+	}
+	x.Body = v
+}
+
+type ManagedRuntimeAsset_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	Role      string
+	MediaType string
+	Body      []byte
+}
+
+func (b0 ManagedRuntimeAsset_builder) Build() *ManagedRuntimeAsset {
+	m0 := &ManagedRuntimeAsset{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Role = b.Role
+	x.MediaType = b.MediaType
+	x.Body = b.Body
+	return m0
+}
+
+type ManagedRuntimeSnapshot struct {
+	state           protoimpl.MessageState `protogen:"hybrid.v1"`
+	Revision        string                 `protobuf:"bytes,1,opt,name=revision,proto3" json:"revision,omitempty"`
+	EncryptedConfig []byte                 `protobuf:"bytes,2,opt,name=encrypted_config,json=encryptedConfig,proto3" json:"encrypted_config,omitempty"`
+	Assets          []*ManagedRuntimeAsset `protobuf:"bytes,3,rep,name=assets,proto3" json:"assets,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *ManagedRuntimeSnapshot) Reset() {
+	*x = ManagedRuntimeSnapshot{}
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ManagedRuntimeSnapshot) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ManagedRuntimeSnapshot) ProtoMessage() {}
+
+func (x *ManagedRuntimeSnapshot) ProtoReflect() protoreflect.Message {
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *ManagedRuntimeSnapshot) GetRevision() string {
+	if x != nil {
+		return x.Revision
+	}
+	return ""
+}
+
+func (x *ManagedRuntimeSnapshot) GetEncryptedConfig() []byte {
+	if x != nil {
+		return x.EncryptedConfig
+	}
+	return nil
+}
+
+func (x *ManagedRuntimeSnapshot) GetAssets() []*ManagedRuntimeAsset {
+	if x != nil {
+		return x.Assets
+	}
+	return nil
+}
+
+func (x *ManagedRuntimeSnapshot) SetRevision(v string) {
+	x.Revision = v
+}
+
+func (x *ManagedRuntimeSnapshot) SetEncryptedConfig(v []byte) {
+	if v == nil {
+		v = []byte{}
+	}
+	x.EncryptedConfig = v
+}
+
+func (x *ManagedRuntimeSnapshot) SetAssets(v []*ManagedRuntimeAsset) {
+	x.Assets = v
+}
+
+type ManagedRuntimeSnapshot_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	Revision        string
+	EncryptedConfig []byte
+	Assets          []*ManagedRuntimeAsset
+}
+
+func (b0 ManagedRuntimeSnapshot_builder) Build() *ManagedRuntimeSnapshot {
+	m0 := &ManagedRuntimeSnapshot{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Revision = b.Revision
+	x.EncryptedConfig = b.EncryptedConfig
+	x.Assets = b.Assets
+	return m0
+}
+
+type GetManagedRuntimeSnapshotResponse struct {
+	state         protoimpl.MessageState  `protogen:"hybrid.v1"`
+	Snapshot      *ManagedRuntimeSnapshot `protobuf:"bytes,1,opt,name=snapshot,proto3" json:"snapshot,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetManagedRuntimeSnapshotResponse) Reset() {
+	*x = GetManagedRuntimeSnapshotResponse{}
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetManagedRuntimeSnapshotResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetManagedRuntimeSnapshotResponse) ProtoMessage() {}
+
+func (x *GetManagedRuntimeSnapshotResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *GetManagedRuntimeSnapshotResponse) GetSnapshot() *ManagedRuntimeSnapshot {
+	if x != nil {
+		return x.Snapshot
+	}
+	return nil
+}
+
+func (x *GetManagedRuntimeSnapshotResponse) SetSnapshot(v *ManagedRuntimeSnapshot) {
+	x.Snapshot = v
+}
+
+func (x *GetManagedRuntimeSnapshotResponse) HasSnapshot() bool {
+	if x == nil {
+		return false
+	}
+	return x.Snapshot != nil
+}
+
+func (x *GetManagedRuntimeSnapshotResponse) ClearSnapshot() {
+	x.Snapshot = nil
+}
+
+type GetManagedRuntimeSnapshotResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	Snapshot *ManagedRuntimeSnapshot
+}
+
+func (b0 GetManagedRuntimeSnapshotResponse_builder) Build() *GetManagedRuntimeSnapshotResponse {
+	m0 := &GetManagedRuntimeSnapshotResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Snapshot = b.Snapshot
+	return m0
+}
+
 type SignedHeader struct {
 	state         protoimpl.MessageState `protogen:"hybrid.v1"`
 	Key           string                 `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
@@ -161,7 +448,7 @@ type SignedHeader struct {
 
 func (x *SignedHeader) Reset() {
 	*x = SignedHeader{}
-	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[2]
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -173,7 +460,7 @@ func (x *SignedHeader) String() string {
 func (*SignedHeader) ProtoMessage() {}
 
 func (x *SignedHeader) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[2]
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -234,7 +521,7 @@ type Sigv4SignedRequestSTSGetCallerIdentity struct {
 
 func (x *Sigv4SignedRequestSTSGetCallerIdentity) Reset() {
 	*x = Sigv4SignedRequestSTSGetCallerIdentity{}
-	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[3]
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -246,7 +533,7 @@ func (x *Sigv4SignedRequestSTSGetCallerIdentity) String() string {
 func (*Sigv4SignedRequestSTSGetCallerIdentity) ProtoMessage() {}
 
 func (x *Sigv4SignedRequestSTSGetCallerIdentity) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[3]
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -332,7 +619,7 @@ type GetConnectorOauthTokenRequest struct {
 
 func (x *GetConnectorOauthTokenRequest) Reset() {
 	*x = GetConnectorOauthTokenRequest{}
-	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[4]
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -344,7 +631,7 @@ func (x *GetConnectorOauthTokenRequest) String() string {
 func (*GetConnectorOauthTokenRequest) ProtoMessage() {}
 
 func (x *GetConnectorOauthTokenRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[4]
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -376,7 +663,7 @@ type GetConnectorOauthTokenResponse struct {
 
 func (x *GetConnectorOauthTokenResponse) Reset() {
 	*x = GetConnectorOauthTokenResponse{}
-	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[5]
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -388,7 +675,7 @@ func (x *GetConnectorOauthTokenResponse) String() string {
 func (*GetConnectorOauthTokenResponse) ProtoMessage() {}
 
 func (x *GetConnectorOauthTokenResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[5]
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -435,7 +722,19 @@ const file_c1_connectorapi_baton_v1_config_proto_rawDesc = "" +
 	"\x19GetConnectorConfigRequest\"s\n" +
 	"\x1aGetConnectorConfigResponse\x12\x16\n" +
 	"\x06config\x18\x01 \x01(\fR\x06config\x12=\n" +
-	"\flast_updated\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\vlastUpdated\"6\n" +
+	"\flast_updated\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\vlastUpdated\"\"\n" +
+	" GetManagedRuntimeSnapshotRequest\"\\\n" +
+	"\x13ManagedRuntimeAsset\x12\x12\n" +
+	"\x04role\x18\x01 \x01(\tR\x04role\x12\x1d\n" +
+	"\n" +
+	"media_type\x18\x02 \x01(\tR\tmediaType\x12\x12\n" +
+	"\x04body\x18\x03 \x01(\fR\x04body\"\xa6\x01\n" +
+	"\x16ManagedRuntimeSnapshot\x12\x1a\n" +
+	"\brevision\x18\x01 \x01(\tR\brevision\x12)\n" +
+	"\x10encrypted_config\x18\x02 \x01(\fR\x0fencryptedConfig\x12E\n" +
+	"\x06assets\x18\x03 \x03(\v2-.c1.connectorapi.baton.v1.ManagedRuntimeAssetR\x06assets\"q\n" +
+	"!GetManagedRuntimeSnapshotResponse\x12L\n" +
+	"\bsnapshot\x18\x01 \x01(\v20.c1.connectorapi.baton.v1.ManagedRuntimeSnapshotR\bsnapshot\"6\n" +
 	"\fSignedHeader\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x03(\tR\x05value\"\xb2\x01\n" +
@@ -446,33 +745,42 @@ const file_c1_connectorapi_baton_v1_config_proto_rawDesc = "" +
 	"\x04body\x18\x04 \x01(\fR\x04body\"\x1f\n" +
 	"\x1dGetConnectorOauthTokenRequest\"6\n" +
 	"\x1eGetConnectorOauthTokenResponse\x12\x14\n" +
-	"\x05token\x18\x01 \x01(\fR\x05token2\xa7\x02\n" +
+	"\x05token\x18\x01 \x01(\fR\x05token2\xbe\x03\n" +
 	"\x16ConnectorConfigService\x12\x7f\n" +
-	"\x12GetConnectorConfig\x123.c1.connectorapi.baton.v1.GetConnectorConfigRequest\x1a4.c1.connectorapi.baton.v1.GetConnectorConfigResponse\x12\x8b\x01\n" +
+	"\x12GetConnectorConfig\x123.c1.connectorapi.baton.v1.GetConnectorConfigRequest\x1a4.c1.connectorapi.baton.v1.GetConnectorConfigResponse\x12\x94\x01\n" +
+	"\x19GetManagedRuntimeSnapshot\x12:.c1.connectorapi.baton.v1.GetManagedRuntimeSnapshotRequest\x1a;.c1.connectorapi.baton.v1.GetManagedRuntimeSnapshotResponse\x12\x8b\x01\n" +
 	"\x16GetConnectorOauthToken\x127.c1.connectorapi.baton.v1.GetConnectorOauthTokenRequest\x1a8.c1.connectorapi.baton.v1.GetConnectorOauthTokenResponseB7Z5gitlab.com/ductone/c1/pkg/pb/c1/connectorapi/baton/v1b\x06proto3"
 
-var file_c1_connectorapi_baton_v1_config_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
+var file_c1_connectorapi_baton_v1_config_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
 var file_c1_connectorapi_baton_v1_config_proto_goTypes = []any{
 	(*GetConnectorConfigRequest)(nil),              // 0: c1.connectorapi.baton.v1.GetConnectorConfigRequest
 	(*GetConnectorConfigResponse)(nil),             // 1: c1.connectorapi.baton.v1.GetConnectorConfigResponse
-	(*SignedHeader)(nil),                           // 2: c1.connectorapi.baton.v1.SignedHeader
-	(*Sigv4SignedRequestSTSGetCallerIdentity)(nil), // 3: c1.connectorapi.baton.v1.Sigv4SignedRequestSTSGetCallerIdentity
-	(*GetConnectorOauthTokenRequest)(nil),          // 4: c1.connectorapi.baton.v1.GetConnectorOauthTokenRequest
-	(*GetConnectorOauthTokenResponse)(nil),         // 5: c1.connectorapi.baton.v1.GetConnectorOauthTokenResponse
-	(*timestamppb.Timestamp)(nil),                  // 6: google.protobuf.Timestamp
+	(*GetManagedRuntimeSnapshotRequest)(nil),       // 2: c1.connectorapi.baton.v1.GetManagedRuntimeSnapshotRequest
+	(*ManagedRuntimeAsset)(nil),                    // 3: c1.connectorapi.baton.v1.ManagedRuntimeAsset
+	(*ManagedRuntimeSnapshot)(nil),                 // 4: c1.connectorapi.baton.v1.ManagedRuntimeSnapshot
+	(*GetManagedRuntimeSnapshotResponse)(nil),      // 5: c1.connectorapi.baton.v1.GetManagedRuntimeSnapshotResponse
+	(*SignedHeader)(nil),                           // 6: c1.connectorapi.baton.v1.SignedHeader
+	(*Sigv4SignedRequestSTSGetCallerIdentity)(nil), // 7: c1.connectorapi.baton.v1.Sigv4SignedRequestSTSGetCallerIdentity
+	(*GetConnectorOauthTokenRequest)(nil),          // 8: c1.connectorapi.baton.v1.GetConnectorOauthTokenRequest
+	(*GetConnectorOauthTokenResponse)(nil),         // 9: c1.connectorapi.baton.v1.GetConnectorOauthTokenResponse
+	(*timestamppb.Timestamp)(nil),                  // 10: google.protobuf.Timestamp
 }
 var file_c1_connectorapi_baton_v1_config_proto_depIdxs = []int32{
-	6, // 0: c1.connectorapi.baton.v1.GetConnectorConfigResponse.last_updated:type_name -> google.protobuf.Timestamp
-	2, // 1: c1.connectorapi.baton.v1.Sigv4SignedRequestSTSGetCallerIdentity.headers:type_name -> c1.connectorapi.baton.v1.SignedHeader
-	0, // 2: c1.connectorapi.baton.v1.ConnectorConfigService.GetConnectorConfig:input_type -> c1.connectorapi.baton.v1.GetConnectorConfigRequest
-	4, // 3: c1.connectorapi.baton.v1.ConnectorConfigService.GetConnectorOauthToken:input_type -> c1.connectorapi.baton.v1.GetConnectorOauthTokenRequest
-	1, // 4: c1.connectorapi.baton.v1.ConnectorConfigService.GetConnectorConfig:output_type -> c1.connectorapi.baton.v1.GetConnectorConfigResponse
-	5, // 5: c1.connectorapi.baton.v1.ConnectorConfigService.GetConnectorOauthToken:output_type -> c1.connectorapi.baton.v1.GetConnectorOauthTokenResponse
-	4, // [4:6] is the sub-list for method output_type
-	2, // [2:4] is the sub-list for method input_type
-	2, // [2:2] is the sub-list for extension type_name
-	2, // [2:2] is the sub-list for extension extendee
-	0, // [0:2] is the sub-list for field type_name
+	10, // 0: c1.connectorapi.baton.v1.GetConnectorConfigResponse.last_updated:type_name -> google.protobuf.Timestamp
+	3,  // 1: c1.connectorapi.baton.v1.ManagedRuntimeSnapshot.assets:type_name -> c1.connectorapi.baton.v1.ManagedRuntimeAsset
+	4,  // 2: c1.connectorapi.baton.v1.GetManagedRuntimeSnapshotResponse.snapshot:type_name -> c1.connectorapi.baton.v1.ManagedRuntimeSnapshot
+	6,  // 3: c1.connectorapi.baton.v1.Sigv4SignedRequestSTSGetCallerIdentity.headers:type_name -> c1.connectorapi.baton.v1.SignedHeader
+	0,  // 4: c1.connectorapi.baton.v1.ConnectorConfigService.GetConnectorConfig:input_type -> c1.connectorapi.baton.v1.GetConnectorConfigRequest
+	2,  // 5: c1.connectorapi.baton.v1.ConnectorConfigService.GetManagedRuntimeSnapshot:input_type -> c1.connectorapi.baton.v1.GetManagedRuntimeSnapshotRequest
+	8,  // 6: c1.connectorapi.baton.v1.ConnectorConfigService.GetConnectorOauthToken:input_type -> c1.connectorapi.baton.v1.GetConnectorOauthTokenRequest
+	1,  // 7: c1.connectorapi.baton.v1.ConnectorConfigService.GetConnectorConfig:output_type -> c1.connectorapi.baton.v1.GetConnectorConfigResponse
+	5,  // 8: c1.connectorapi.baton.v1.ConnectorConfigService.GetManagedRuntimeSnapshot:output_type -> c1.connectorapi.baton.v1.GetManagedRuntimeSnapshotResponse
+	9,  // 9: c1.connectorapi.baton.v1.ConnectorConfigService.GetConnectorOauthToken:output_type -> c1.connectorapi.baton.v1.GetConnectorOauthTokenResponse
+	7,  // [7:10] is the sub-list for method output_type
+	4,  // [4:7] is the sub-list for method input_type
+	4,  // [4:4] is the sub-list for extension type_name
+	4,  // [4:4] is the sub-list for extension extendee
+	0,  // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_c1_connectorapi_baton_v1_config_proto_init() }
@@ -486,7 +794,7 @@ func file_c1_connectorapi_baton_v1_config_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_c1_connectorapi_baton_v1_config_proto_rawDesc), len(file_c1_connectorapi_baton_v1_config_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   6,
+			NumMessages:   10,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pb/c1/connectorapi/baton/v1/config.pb.validate.go
+++ b/pb/c1/connectorapi/baton/v1/config.pb.validate.go
@@ -270,6 +270,493 @@ var _ interface {
 	ErrorName() string
 } = GetConnectorConfigResponseValidationError{}
 
+// Validate checks the field values on GetManagedRuntimeSnapshotRequest with
+// the rules defined in the proto definition for this message. If any rules
+// are violated, the first error encountered is returned, or nil if there are
+// no violations.
+func (m *GetManagedRuntimeSnapshotRequest) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on GetManagedRuntimeSnapshotRequest with
+// the rules defined in the proto definition for this message. If any rules
+// are violated, the result is a list of violation errors wrapped in
+// GetManagedRuntimeSnapshotRequestMultiError, or nil if none found.
+func (m *GetManagedRuntimeSnapshotRequest) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *GetManagedRuntimeSnapshotRequest) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	if len(errors) > 0 {
+		return GetManagedRuntimeSnapshotRequestMultiError(errors)
+	}
+
+	return nil
+}
+
+// GetManagedRuntimeSnapshotRequestMultiError is an error wrapping multiple
+// validation errors returned by
+// GetManagedRuntimeSnapshotRequest.ValidateAll() if the designated
+// constraints aren't met.
+type GetManagedRuntimeSnapshotRequestMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m GetManagedRuntimeSnapshotRequestMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m GetManagedRuntimeSnapshotRequestMultiError) AllErrors() []error { return m }
+
+// GetManagedRuntimeSnapshotRequestValidationError is the validation error
+// returned by GetManagedRuntimeSnapshotRequest.Validate if the designated
+// constraints aren't met.
+type GetManagedRuntimeSnapshotRequestValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e GetManagedRuntimeSnapshotRequestValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e GetManagedRuntimeSnapshotRequestValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e GetManagedRuntimeSnapshotRequestValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e GetManagedRuntimeSnapshotRequestValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e GetManagedRuntimeSnapshotRequestValidationError) ErrorName() string {
+	return "GetManagedRuntimeSnapshotRequestValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e GetManagedRuntimeSnapshotRequestValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sGetManagedRuntimeSnapshotRequest.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = GetManagedRuntimeSnapshotRequestValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = GetManagedRuntimeSnapshotRequestValidationError{}
+
+// Validate checks the field values on ManagedRuntimeAsset with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the first error encountered is returned, or nil if there are no violations.
+func (m *ManagedRuntimeAsset) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on ManagedRuntimeAsset with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// ManagedRuntimeAssetMultiError, or nil if none found.
+func (m *ManagedRuntimeAsset) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *ManagedRuntimeAsset) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	// no validation rules for Role
+
+	// no validation rules for MediaType
+
+	// no validation rules for Body
+
+	if len(errors) > 0 {
+		return ManagedRuntimeAssetMultiError(errors)
+	}
+
+	return nil
+}
+
+// ManagedRuntimeAssetMultiError is an error wrapping multiple validation
+// errors returned by ManagedRuntimeAsset.ValidateAll() if the designated
+// constraints aren't met.
+type ManagedRuntimeAssetMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m ManagedRuntimeAssetMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m ManagedRuntimeAssetMultiError) AllErrors() []error { return m }
+
+// ManagedRuntimeAssetValidationError is the validation error returned by
+// ManagedRuntimeAsset.Validate if the designated constraints aren't met.
+type ManagedRuntimeAssetValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e ManagedRuntimeAssetValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e ManagedRuntimeAssetValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e ManagedRuntimeAssetValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e ManagedRuntimeAssetValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e ManagedRuntimeAssetValidationError) ErrorName() string {
+	return "ManagedRuntimeAssetValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e ManagedRuntimeAssetValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sManagedRuntimeAsset.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = ManagedRuntimeAssetValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = ManagedRuntimeAssetValidationError{}
+
+// Validate checks the field values on ManagedRuntimeSnapshot with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the first error encountered is returned, or nil if there are no violations.
+func (m *ManagedRuntimeSnapshot) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on ManagedRuntimeSnapshot with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// ManagedRuntimeSnapshotMultiError, or nil if none found.
+func (m *ManagedRuntimeSnapshot) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *ManagedRuntimeSnapshot) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	// no validation rules for Revision
+
+	// no validation rules for EncryptedConfig
+
+	for idx, item := range m.GetAssets() {
+		_, _ = idx, item
+
+		if all {
+			switch v := interface{}(item).(type) {
+			case interface{ ValidateAll() error }:
+				if err := v.ValidateAll(); err != nil {
+					errors = append(errors, ManagedRuntimeSnapshotValidationError{
+						field:  fmt.Sprintf("Assets[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			case interface{ Validate() error }:
+				if err := v.Validate(); err != nil {
+					errors = append(errors, ManagedRuntimeSnapshotValidationError{
+						field:  fmt.Sprintf("Assets[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			}
+		} else if v, ok := interface{}(item).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return ManagedRuntimeSnapshotValidationError{
+					field:  fmt.Sprintf("Assets[%v]", idx),
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
+	}
+
+	if len(errors) > 0 {
+		return ManagedRuntimeSnapshotMultiError(errors)
+	}
+
+	return nil
+}
+
+// ManagedRuntimeSnapshotMultiError is an error wrapping multiple validation
+// errors returned by ManagedRuntimeSnapshot.ValidateAll() if the designated
+// constraints aren't met.
+type ManagedRuntimeSnapshotMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m ManagedRuntimeSnapshotMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m ManagedRuntimeSnapshotMultiError) AllErrors() []error { return m }
+
+// ManagedRuntimeSnapshotValidationError is the validation error returned by
+// ManagedRuntimeSnapshot.Validate if the designated constraints aren't met.
+type ManagedRuntimeSnapshotValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e ManagedRuntimeSnapshotValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e ManagedRuntimeSnapshotValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e ManagedRuntimeSnapshotValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e ManagedRuntimeSnapshotValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e ManagedRuntimeSnapshotValidationError) ErrorName() string {
+	return "ManagedRuntimeSnapshotValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e ManagedRuntimeSnapshotValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sManagedRuntimeSnapshot.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = ManagedRuntimeSnapshotValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = ManagedRuntimeSnapshotValidationError{}
+
+// Validate checks the field values on GetManagedRuntimeSnapshotResponse with
+// the rules defined in the proto definition for this message. If any rules
+// are violated, the first error encountered is returned, or nil if there are
+// no violations.
+func (m *GetManagedRuntimeSnapshotResponse) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on GetManagedRuntimeSnapshotResponse
+// with the rules defined in the proto definition for this message. If any
+// rules are violated, the result is a list of violation errors wrapped in
+// GetManagedRuntimeSnapshotResponseMultiError, or nil if none found.
+func (m *GetManagedRuntimeSnapshotResponse) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *GetManagedRuntimeSnapshotResponse) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	if all {
+		switch v := interface{}(m.GetSnapshot()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, GetManagedRuntimeSnapshotResponseValidationError{
+					field:  "Snapshot",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, GetManagedRuntimeSnapshotResponseValidationError{
+					field:  "Snapshot",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetSnapshot()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return GetManagedRuntimeSnapshotResponseValidationError{
+				field:  "Snapshot",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
+	if len(errors) > 0 {
+		return GetManagedRuntimeSnapshotResponseMultiError(errors)
+	}
+
+	return nil
+}
+
+// GetManagedRuntimeSnapshotResponseMultiError is an error wrapping multiple
+// validation errors returned by
+// GetManagedRuntimeSnapshotResponse.ValidateAll() if the designated
+// constraints aren't met.
+type GetManagedRuntimeSnapshotResponseMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m GetManagedRuntimeSnapshotResponseMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m GetManagedRuntimeSnapshotResponseMultiError) AllErrors() []error { return m }
+
+// GetManagedRuntimeSnapshotResponseValidationError is the validation error
+// returned by GetManagedRuntimeSnapshotResponse.Validate if the designated
+// constraints aren't met.
+type GetManagedRuntimeSnapshotResponseValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e GetManagedRuntimeSnapshotResponseValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e GetManagedRuntimeSnapshotResponseValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e GetManagedRuntimeSnapshotResponseValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e GetManagedRuntimeSnapshotResponseValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e GetManagedRuntimeSnapshotResponseValidationError) ErrorName() string {
+	return "GetManagedRuntimeSnapshotResponseValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e GetManagedRuntimeSnapshotResponseValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sGetManagedRuntimeSnapshotResponse.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = GetManagedRuntimeSnapshotResponseValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = GetManagedRuntimeSnapshotResponseValidationError{}
+
 // Validate checks the field values on SignedHeader with the rules defined in
 // the proto definition for this message. If any rules are violated, the first
 // error encountered is returned, or nil if there are no violations.

--- a/pb/c1/connectorapi/baton/v1/config_grpc.pb.go
+++ b/pb/c1/connectorapi/baton/v1/config_grpc.pb.go
@@ -19,8 +19,9 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	ConnectorConfigService_GetConnectorConfig_FullMethodName     = "/c1.connectorapi.baton.v1.ConnectorConfigService/GetConnectorConfig"
-	ConnectorConfigService_GetConnectorOauthToken_FullMethodName = "/c1.connectorapi.baton.v1.ConnectorConfigService/GetConnectorOauthToken"
+	ConnectorConfigService_GetConnectorConfig_FullMethodName        = "/c1.connectorapi.baton.v1.ConnectorConfigService/GetConnectorConfig"
+	ConnectorConfigService_GetManagedRuntimeSnapshot_FullMethodName = "/c1.connectorapi.baton.v1.ConnectorConfigService/GetManagedRuntimeSnapshot"
+	ConnectorConfigService_GetConnectorOauthToken_FullMethodName    = "/c1.connectorapi.baton.v1.ConnectorConfigService/GetConnectorOauthToken"
 )
 
 // ConnectorConfigServiceClient is the client API for ConnectorConfigService service.
@@ -28,6 +29,7 @@ const (
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type ConnectorConfigServiceClient interface {
 	GetConnectorConfig(ctx context.Context, in *GetConnectorConfigRequest, opts ...grpc.CallOption) (*GetConnectorConfigResponse, error)
+	GetManagedRuntimeSnapshot(ctx context.Context, in *GetManagedRuntimeSnapshotRequest, opts ...grpc.CallOption) (*GetManagedRuntimeSnapshotResponse, error)
 	GetConnectorOauthToken(ctx context.Context, in *GetConnectorOauthTokenRequest, opts ...grpc.CallOption) (*GetConnectorOauthTokenResponse, error)
 }
 
@@ -49,6 +51,16 @@ func (c *connectorConfigServiceClient) GetConnectorConfig(ctx context.Context, i
 	return out, nil
 }
 
+func (c *connectorConfigServiceClient) GetManagedRuntimeSnapshot(ctx context.Context, in *GetManagedRuntimeSnapshotRequest, opts ...grpc.CallOption) (*GetManagedRuntimeSnapshotResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetManagedRuntimeSnapshotResponse)
+	err := c.cc.Invoke(ctx, ConnectorConfigService_GetManagedRuntimeSnapshot_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *connectorConfigServiceClient) GetConnectorOauthToken(ctx context.Context, in *GetConnectorOauthTokenRequest, opts ...grpc.CallOption) (*GetConnectorOauthTokenResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(GetConnectorOauthTokenResponse)
@@ -64,6 +76,7 @@ func (c *connectorConfigServiceClient) GetConnectorOauthToken(ctx context.Contex
 // for forward compatibility.
 type ConnectorConfigServiceServer interface {
 	GetConnectorConfig(context.Context, *GetConnectorConfigRequest) (*GetConnectorConfigResponse, error)
+	GetManagedRuntimeSnapshot(context.Context, *GetManagedRuntimeSnapshotRequest) (*GetManagedRuntimeSnapshotResponse, error)
 	GetConnectorOauthToken(context.Context, *GetConnectorOauthTokenRequest) (*GetConnectorOauthTokenResponse, error)
 }
 
@@ -76,6 +89,9 @@ type UnimplementedConnectorConfigServiceServer struct{}
 
 func (UnimplementedConnectorConfigServiceServer) GetConnectorConfig(context.Context, *GetConnectorConfigRequest) (*GetConnectorConfigResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetConnectorConfig not implemented")
+}
+func (UnimplementedConnectorConfigServiceServer) GetManagedRuntimeSnapshot(context.Context, *GetManagedRuntimeSnapshotRequest) (*GetManagedRuntimeSnapshotResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetManagedRuntimeSnapshot not implemented")
 }
 func (UnimplementedConnectorConfigServiceServer) GetConnectorOauthToken(context.Context, *GetConnectorOauthTokenRequest) (*GetConnectorOauthTokenResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetConnectorOauthToken not implemented")
@@ -118,6 +134,24 @@ func _ConnectorConfigService_GetConnectorConfig_Handler(srv interface{}, ctx con
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ConnectorConfigService_GetManagedRuntimeSnapshot_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetManagedRuntimeSnapshotRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ConnectorConfigServiceServer).GetManagedRuntimeSnapshot(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ConnectorConfigService_GetManagedRuntimeSnapshot_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ConnectorConfigServiceServer).GetManagedRuntimeSnapshot(ctx, req.(*GetManagedRuntimeSnapshotRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _ConnectorConfigService_GetConnectorOauthToken_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(GetConnectorOauthTokenRequest)
 	if err := dec(in); err != nil {
@@ -146,6 +180,10 @@ var ConnectorConfigService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetConnectorConfig",
 			Handler:    _ConnectorConfigService_GetConnectorConfig_Handler,
+		},
+		{
+			MethodName: "GetManagedRuntimeSnapshot",
+			Handler:    _ConnectorConfigService_GetManagedRuntimeSnapshot_Handler,
 		},
 		{
 			MethodName: "GetConnectorOauthToken",

--- a/pb/c1/connectorapi/baton/v1/config_protoopaque.pb.go
+++ b/pb/c1/connectorapi/baton/v1/config_protoopaque.pb.go
@@ -151,6 +151,295 @@ func (b0 GetConnectorConfigResponse_builder) Build() *GetConnectorConfigResponse
 	return m0
 }
 
+type GetManagedRuntimeSnapshotRequest struct {
+	state         protoimpl.MessageState `protogen:"opaque.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetManagedRuntimeSnapshotRequest) Reset() {
+	*x = GetManagedRuntimeSnapshotRequest{}
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetManagedRuntimeSnapshotRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetManagedRuntimeSnapshotRequest) ProtoMessage() {}
+
+func (x *GetManagedRuntimeSnapshotRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+type GetManagedRuntimeSnapshotRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+}
+
+func (b0 GetManagedRuntimeSnapshotRequest_builder) Build() *GetManagedRuntimeSnapshotRequest {
+	m0 := &GetManagedRuntimeSnapshotRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	return m0
+}
+
+type ManagedRuntimeAsset struct {
+	state                protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Role      string                 `protobuf:"bytes,1,opt,name=role,proto3"`
+	xxx_hidden_MediaType string                 `protobuf:"bytes,2,opt,name=media_type,json=mediaType,proto3"`
+	xxx_hidden_Body      []byte                 `protobuf:"bytes,3,opt,name=body,proto3"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
+}
+
+func (x *ManagedRuntimeAsset) Reset() {
+	*x = ManagedRuntimeAsset{}
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ManagedRuntimeAsset) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ManagedRuntimeAsset) ProtoMessage() {}
+
+func (x *ManagedRuntimeAsset) ProtoReflect() protoreflect.Message {
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *ManagedRuntimeAsset) GetRole() string {
+	if x != nil {
+		return x.xxx_hidden_Role
+	}
+	return ""
+}
+
+func (x *ManagedRuntimeAsset) GetMediaType() string {
+	if x != nil {
+		return x.xxx_hidden_MediaType
+	}
+	return ""
+}
+
+func (x *ManagedRuntimeAsset) GetBody() []byte {
+	if x != nil {
+		return x.xxx_hidden_Body
+	}
+	return nil
+}
+
+func (x *ManagedRuntimeAsset) SetRole(v string) {
+	x.xxx_hidden_Role = v
+}
+
+func (x *ManagedRuntimeAsset) SetMediaType(v string) {
+	x.xxx_hidden_MediaType = v
+}
+
+func (x *ManagedRuntimeAsset) SetBody(v []byte) {
+	if v == nil {
+		v = []byte{}
+	}
+	x.xxx_hidden_Body = v
+}
+
+type ManagedRuntimeAsset_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	Role      string
+	MediaType string
+	Body      []byte
+}
+
+func (b0 ManagedRuntimeAsset_builder) Build() *ManagedRuntimeAsset {
+	m0 := &ManagedRuntimeAsset{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Role = b.Role
+	x.xxx_hidden_MediaType = b.MediaType
+	x.xxx_hidden_Body = b.Body
+	return m0
+}
+
+type ManagedRuntimeSnapshot struct {
+	state                      protoimpl.MessageState  `protogen:"opaque.v1"`
+	xxx_hidden_Revision        string                  `protobuf:"bytes,1,opt,name=revision,proto3"`
+	xxx_hidden_EncryptedConfig []byte                  `protobuf:"bytes,2,opt,name=encrypted_config,json=encryptedConfig,proto3"`
+	xxx_hidden_Assets          *[]*ManagedRuntimeAsset `protobuf:"bytes,3,rep,name=assets,proto3"`
+	unknownFields              protoimpl.UnknownFields
+	sizeCache                  protoimpl.SizeCache
+}
+
+func (x *ManagedRuntimeSnapshot) Reset() {
+	*x = ManagedRuntimeSnapshot{}
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ManagedRuntimeSnapshot) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ManagedRuntimeSnapshot) ProtoMessage() {}
+
+func (x *ManagedRuntimeSnapshot) ProtoReflect() protoreflect.Message {
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *ManagedRuntimeSnapshot) GetRevision() string {
+	if x != nil {
+		return x.xxx_hidden_Revision
+	}
+	return ""
+}
+
+func (x *ManagedRuntimeSnapshot) GetEncryptedConfig() []byte {
+	if x != nil {
+		return x.xxx_hidden_EncryptedConfig
+	}
+	return nil
+}
+
+func (x *ManagedRuntimeSnapshot) GetAssets() []*ManagedRuntimeAsset {
+	if x != nil {
+		if x.xxx_hidden_Assets != nil {
+			return *x.xxx_hidden_Assets
+		}
+	}
+	return nil
+}
+
+func (x *ManagedRuntimeSnapshot) SetRevision(v string) {
+	x.xxx_hidden_Revision = v
+}
+
+func (x *ManagedRuntimeSnapshot) SetEncryptedConfig(v []byte) {
+	if v == nil {
+		v = []byte{}
+	}
+	x.xxx_hidden_EncryptedConfig = v
+}
+
+func (x *ManagedRuntimeSnapshot) SetAssets(v []*ManagedRuntimeAsset) {
+	x.xxx_hidden_Assets = &v
+}
+
+type ManagedRuntimeSnapshot_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	Revision        string
+	EncryptedConfig []byte
+	Assets          []*ManagedRuntimeAsset
+}
+
+func (b0 ManagedRuntimeSnapshot_builder) Build() *ManagedRuntimeSnapshot {
+	m0 := &ManagedRuntimeSnapshot{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Revision = b.Revision
+	x.xxx_hidden_EncryptedConfig = b.EncryptedConfig
+	x.xxx_hidden_Assets = &b.Assets
+	return m0
+}
+
+type GetManagedRuntimeSnapshotResponse struct {
+	state               protoimpl.MessageState  `protogen:"opaque.v1"`
+	xxx_hidden_Snapshot *ManagedRuntimeSnapshot `protobuf:"bytes,1,opt,name=snapshot,proto3"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
+}
+
+func (x *GetManagedRuntimeSnapshotResponse) Reset() {
+	*x = GetManagedRuntimeSnapshotResponse{}
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetManagedRuntimeSnapshotResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetManagedRuntimeSnapshotResponse) ProtoMessage() {}
+
+func (x *GetManagedRuntimeSnapshotResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *GetManagedRuntimeSnapshotResponse) GetSnapshot() *ManagedRuntimeSnapshot {
+	if x != nil {
+		return x.xxx_hidden_Snapshot
+	}
+	return nil
+}
+
+func (x *GetManagedRuntimeSnapshotResponse) SetSnapshot(v *ManagedRuntimeSnapshot) {
+	x.xxx_hidden_Snapshot = v
+}
+
+func (x *GetManagedRuntimeSnapshotResponse) HasSnapshot() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_Snapshot != nil
+}
+
+func (x *GetManagedRuntimeSnapshotResponse) ClearSnapshot() {
+	x.xxx_hidden_Snapshot = nil
+}
+
+type GetManagedRuntimeSnapshotResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	Snapshot *ManagedRuntimeSnapshot
+}
+
+func (b0 GetManagedRuntimeSnapshotResponse_builder) Build() *GetManagedRuntimeSnapshotResponse {
+	m0 := &GetManagedRuntimeSnapshotResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Snapshot = b.Snapshot
+	return m0
+}
+
 type SignedHeader struct {
 	state            protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_Key   string                 `protobuf:"bytes,1,opt,name=key,proto3"`
@@ -161,7 +450,7 @@ type SignedHeader struct {
 
 func (x *SignedHeader) Reset() {
 	*x = SignedHeader{}
-	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[2]
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -173,7 +462,7 @@ func (x *SignedHeader) String() string {
 func (*SignedHeader) ProtoMessage() {}
 
 func (x *SignedHeader) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[2]
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -234,7 +523,7 @@ type Sigv4SignedRequestSTSGetCallerIdentity struct {
 
 func (x *Sigv4SignedRequestSTSGetCallerIdentity) Reset() {
 	*x = Sigv4SignedRequestSTSGetCallerIdentity{}
-	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[3]
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -246,7 +535,7 @@ func (x *Sigv4SignedRequestSTSGetCallerIdentity) String() string {
 func (*Sigv4SignedRequestSTSGetCallerIdentity) ProtoMessage() {}
 
 func (x *Sigv4SignedRequestSTSGetCallerIdentity) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[3]
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -334,7 +623,7 @@ type GetConnectorOauthTokenRequest struct {
 
 func (x *GetConnectorOauthTokenRequest) Reset() {
 	*x = GetConnectorOauthTokenRequest{}
-	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[4]
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -346,7 +635,7 @@ func (x *GetConnectorOauthTokenRequest) String() string {
 func (*GetConnectorOauthTokenRequest) ProtoMessage() {}
 
 func (x *GetConnectorOauthTokenRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[4]
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -378,7 +667,7 @@ type GetConnectorOauthTokenResponse struct {
 
 func (x *GetConnectorOauthTokenResponse) Reset() {
 	*x = GetConnectorOauthTokenResponse{}
-	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[5]
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -390,7 +679,7 @@ func (x *GetConnectorOauthTokenResponse) String() string {
 func (*GetConnectorOauthTokenResponse) ProtoMessage() {}
 
 func (x *GetConnectorOauthTokenResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[5]
+	mi := &file_c1_connectorapi_baton_v1_config_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -437,7 +726,19 @@ const file_c1_connectorapi_baton_v1_config_proto_rawDesc = "" +
 	"\x19GetConnectorConfigRequest\"s\n" +
 	"\x1aGetConnectorConfigResponse\x12\x16\n" +
 	"\x06config\x18\x01 \x01(\fR\x06config\x12=\n" +
-	"\flast_updated\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\vlastUpdated\"6\n" +
+	"\flast_updated\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\vlastUpdated\"\"\n" +
+	" GetManagedRuntimeSnapshotRequest\"\\\n" +
+	"\x13ManagedRuntimeAsset\x12\x12\n" +
+	"\x04role\x18\x01 \x01(\tR\x04role\x12\x1d\n" +
+	"\n" +
+	"media_type\x18\x02 \x01(\tR\tmediaType\x12\x12\n" +
+	"\x04body\x18\x03 \x01(\fR\x04body\"\xa6\x01\n" +
+	"\x16ManagedRuntimeSnapshot\x12\x1a\n" +
+	"\brevision\x18\x01 \x01(\tR\brevision\x12)\n" +
+	"\x10encrypted_config\x18\x02 \x01(\fR\x0fencryptedConfig\x12E\n" +
+	"\x06assets\x18\x03 \x03(\v2-.c1.connectorapi.baton.v1.ManagedRuntimeAssetR\x06assets\"q\n" +
+	"!GetManagedRuntimeSnapshotResponse\x12L\n" +
+	"\bsnapshot\x18\x01 \x01(\v20.c1.connectorapi.baton.v1.ManagedRuntimeSnapshotR\bsnapshot\"6\n" +
 	"\fSignedHeader\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x03(\tR\x05value\"\xb2\x01\n" +
@@ -448,33 +749,42 @@ const file_c1_connectorapi_baton_v1_config_proto_rawDesc = "" +
 	"\x04body\x18\x04 \x01(\fR\x04body\"\x1f\n" +
 	"\x1dGetConnectorOauthTokenRequest\"6\n" +
 	"\x1eGetConnectorOauthTokenResponse\x12\x14\n" +
-	"\x05token\x18\x01 \x01(\fR\x05token2\xa7\x02\n" +
+	"\x05token\x18\x01 \x01(\fR\x05token2\xbe\x03\n" +
 	"\x16ConnectorConfigService\x12\x7f\n" +
-	"\x12GetConnectorConfig\x123.c1.connectorapi.baton.v1.GetConnectorConfigRequest\x1a4.c1.connectorapi.baton.v1.GetConnectorConfigResponse\x12\x8b\x01\n" +
+	"\x12GetConnectorConfig\x123.c1.connectorapi.baton.v1.GetConnectorConfigRequest\x1a4.c1.connectorapi.baton.v1.GetConnectorConfigResponse\x12\x94\x01\n" +
+	"\x19GetManagedRuntimeSnapshot\x12:.c1.connectorapi.baton.v1.GetManagedRuntimeSnapshotRequest\x1a;.c1.connectorapi.baton.v1.GetManagedRuntimeSnapshotResponse\x12\x8b\x01\n" +
 	"\x16GetConnectorOauthToken\x127.c1.connectorapi.baton.v1.GetConnectorOauthTokenRequest\x1a8.c1.connectorapi.baton.v1.GetConnectorOauthTokenResponseB7Z5gitlab.com/ductone/c1/pkg/pb/c1/connectorapi/baton/v1b\x06proto3"
 
-var file_c1_connectorapi_baton_v1_config_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
+var file_c1_connectorapi_baton_v1_config_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
 var file_c1_connectorapi_baton_v1_config_proto_goTypes = []any{
 	(*GetConnectorConfigRequest)(nil),              // 0: c1.connectorapi.baton.v1.GetConnectorConfigRequest
 	(*GetConnectorConfigResponse)(nil),             // 1: c1.connectorapi.baton.v1.GetConnectorConfigResponse
-	(*SignedHeader)(nil),                           // 2: c1.connectorapi.baton.v1.SignedHeader
-	(*Sigv4SignedRequestSTSGetCallerIdentity)(nil), // 3: c1.connectorapi.baton.v1.Sigv4SignedRequestSTSGetCallerIdentity
-	(*GetConnectorOauthTokenRequest)(nil),          // 4: c1.connectorapi.baton.v1.GetConnectorOauthTokenRequest
-	(*GetConnectorOauthTokenResponse)(nil),         // 5: c1.connectorapi.baton.v1.GetConnectorOauthTokenResponse
-	(*timestamppb.Timestamp)(nil),                  // 6: google.protobuf.Timestamp
+	(*GetManagedRuntimeSnapshotRequest)(nil),       // 2: c1.connectorapi.baton.v1.GetManagedRuntimeSnapshotRequest
+	(*ManagedRuntimeAsset)(nil),                    // 3: c1.connectorapi.baton.v1.ManagedRuntimeAsset
+	(*ManagedRuntimeSnapshot)(nil),                 // 4: c1.connectorapi.baton.v1.ManagedRuntimeSnapshot
+	(*GetManagedRuntimeSnapshotResponse)(nil),      // 5: c1.connectorapi.baton.v1.GetManagedRuntimeSnapshotResponse
+	(*SignedHeader)(nil),                           // 6: c1.connectorapi.baton.v1.SignedHeader
+	(*Sigv4SignedRequestSTSGetCallerIdentity)(nil), // 7: c1.connectorapi.baton.v1.Sigv4SignedRequestSTSGetCallerIdentity
+	(*GetConnectorOauthTokenRequest)(nil),          // 8: c1.connectorapi.baton.v1.GetConnectorOauthTokenRequest
+	(*GetConnectorOauthTokenResponse)(nil),         // 9: c1.connectorapi.baton.v1.GetConnectorOauthTokenResponse
+	(*timestamppb.Timestamp)(nil),                  // 10: google.protobuf.Timestamp
 }
 var file_c1_connectorapi_baton_v1_config_proto_depIdxs = []int32{
-	6, // 0: c1.connectorapi.baton.v1.GetConnectorConfigResponse.last_updated:type_name -> google.protobuf.Timestamp
-	2, // 1: c1.connectorapi.baton.v1.Sigv4SignedRequestSTSGetCallerIdentity.headers:type_name -> c1.connectorapi.baton.v1.SignedHeader
-	0, // 2: c1.connectorapi.baton.v1.ConnectorConfigService.GetConnectorConfig:input_type -> c1.connectorapi.baton.v1.GetConnectorConfigRequest
-	4, // 3: c1.connectorapi.baton.v1.ConnectorConfigService.GetConnectorOauthToken:input_type -> c1.connectorapi.baton.v1.GetConnectorOauthTokenRequest
-	1, // 4: c1.connectorapi.baton.v1.ConnectorConfigService.GetConnectorConfig:output_type -> c1.connectorapi.baton.v1.GetConnectorConfigResponse
-	5, // 5: c1.connectorapi.baton.v1.ConnectorConfigService.GetConnectorOauthToken:output_type -> c1.connectorapi.baton.v1.GetConnectorOauthTokenResponse
-	4, // [4:6] is the sub-list for method output_type
-	2, // [2:4] is the sub-list for method input_type
-	2, // [2:2] is the sub-list for extension type_name
-	2, // [2:2] is the sub-list for extension extendee
-	0, // [0:2] is the sub-list for field type_name
+	10, // 0: c1.connectorapi.baton.v1.GetConnectorConfigResponse.last_updated:type_name -> google.protobuf.Timestamp
+	3,  // 1: c1.connectorapi.baton.v1.ManagedRuntimeSnapshot.assets:type_name -> c1.connectorapi.baton.v1.ManagedRuntimeAsset
+	4,  // 2: c1.connectorapi.baton.v1.GetManagedRuntimeSnapshotResponse.snapshot:type_name -> c1.connectorapi.baton.v1.ManagedRuntimeSnapshot
+	6,  // 3: c1.connectorapi.baton.v1.Sigv4SignedRequestSTSGetCallerIdentity.headers:type_name -> c1.connectorapi.baton.v1.SignedHeader
+	0,  // 4: c1.connectorapi.baton.v1.ConnectorConfigService.GetConnectorConfig:input_type -> c1.connectorapi.baton.v1.GetConnectorConfigRequest
+	2,  // 5: c1.connectorapi.baton.v1.ConnectorConfigService.GetManagedRuntimeSnapshot:input_type -> c1.connectorapi.baton.v1.GetManagedRuntimeSnapshotRequest
+	8,  // 6: c1.connectorapi.baton.v1.ConnectorConfigService.GetConnectorOauthToken:input_type -> c1.connectorapi.baton.v1.GetConnectorOauthTokenRequest
+	1,  // 7: c1.connectorapi.baton.v1.ConnectorConfigService.GetConnectorConfig:output_type -> c1.connectorapi.baton.v1.GetConnectorConfigResponse
+	5,  // 8: c1.connectorapi.baton.v1.ConnectorConfigService.GetManagedRuntimeSnapshot:output_type -> c1.connectorapi.baton.v1.GetManagedRuntimeSnapshotResponse
+	9,  // 9: c1.connectorapi.baton.v1.ConnectorConfigService.GetConnectorOauthToken:output_type -> c1.connectorapi.baton.v1.GetConnectorOauthTokenResponse
+	7,  // [7:10] is the sub-list for method output_type
+	4,  // [4:7] is the sub-list for method input_type
+	4,  // [4:4] is the sub-list for extension type_name
+	4,  // [4:4] is the sub-list for extension extendee
+	0,  // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_c1_connectorapi_baton_v1_config_proto_init() }
@@ -488,7 +798,7 @@ func file_c1_connectorapi_baton_v1_config_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_c1_connectorapi_baton_v1_config_proto_rawDesc), len(file_c1_connectorapi_baton_v1_config_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   6,
+			NumMessages:   10,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -16,13 +16,39 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"golang.org/x/oauth2"
+	"google.golang.org/protobuf/types/known/structpb"
 )
+
+const (
+	ManagedRuntimeRevisionHeader = "x-baton-runtime-revision"
+
+	ManagedRuntimeAssetRoleRuntimeSchema = "runtime-schema"
+	ManagedRuntimeAssetRoleRuntimeBundle = "runtime-bundle"
+	ManagedRuntimeAssetRoleRuntimePolicy = "runtime-policy"
+)
+
+type ManagedRuntimeAsset struct {
+	Role      string
+	MediaType string
+	Bytes     []byte
+}
+
+type ManagedRuntimeSnapshot struct {
+	Revision string
+	Config   *structpb.Struct
+	Assets   []ManagedRuntimeAsset
+}
+
+type ManagedRuntimeOpts struct {
+	Snapshot *ManagedRuntimeSnapshot
+}
 
 type RunTimeOpts struct {
 	SessionStore        sessions.SessionStore
 	TokenSource         oauth2.TokenSource
 	SelectedAuthMethod  string
 	SyncResourceTypeIDs []string
+	ManagedRuntime      *ManagedRuntimeOpts
 }
 
 // GetConnectorFunc is a function type that creates a connector instance.

--- a/pkg/cli/lambda_managed_runtime__added.go
+++ b/pkg/cli/lambda_managed_runtime__added.go
@@ -1,0 +1,227 @@
+//go:build baton_lambda_support
+
+package cli
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/conductorone/baton-sdk/pkg/crypto/providers/jwk"
+	c1_lambda_grpc "github.com/conductorone/baton-sdk/pkg/lambda/grpc"
+	"github.com/conductorone/baton-sdk/pkg/types"
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	v1 "github.com/conductorone/baton-sdk/pb/c1/connectorapi/baton/v1"
+)
+
+const lambdaConnectorDrainTimeout = 30 * time.Second
+
+type managedRuntimeFetcher struct {
+	client     v1.ConnectorConfigServiceClient
+	privateKey ed25519.PrivateKey
+}
+
+func newManagedRuntimeFetcher(client v1.ConnectorConfigServiceClient, privateKey ed25519.PrivateKey) *managedRuntimeFetcher {
+	return &managedRuntimeFetcher{
+		client:     client,
+		privateKey: privateKey,
+	}
+}
+
+func (f *managedRuntimeFetcher) Fetch(ctx context.Context) (*ManagedRuntimeSnapshot, error) {
+	resp, err := f.client.GetManagedRuntimeSnapshot(ctx, &v1.GetManagedRuntimeSnapshotRequest{})
+	if err != nil {
+		if status.Code(err) == codes.Unimplemented {
+			return f.fetchLegacyConfig(ctx)
+		}
+		return nil, err
+	}
+
+	snapshot := resp.GetSnapshot()
+	if snapshot == nil {
+		return nil, fmt.Errorf("managed runtime snapshot response was empty")
+	}
+
+	return f.decryptSnapshot(snapshot.GetRevision(), snapshot.GetEncryptedConfig(), snapshot.GetAssets())
+}
+
+func (f *managedRuntimeFetcher) fetchLegacyConfig(ctx context.Context) (*ManagedRuntimeSnapshot, error) {
+	resp, err := f.client.GetConnectorConfig(ctx, &v1.GetConnectorConfigRequest{})
+	if err != nil {
+		return nil, err
+	}
+
+	revision := ""
+	if ts := resp.GetLastUpdated(); ts != nil {
+		revision = ts.AsTime().UTC().Format(time.RFC3339Nano)
+	}
+
+	return f.decryptSnapshot(revision, resp.GetConfig(), nil)
+}
+
+func (f *managedRuntimeFetcher) decryptSnapshot(revision string, encryptedConfig []byte, pbAssets []*v1.ManagedRuntimeAsset) (*ManagedRuntimeSnapshot, error) {
+	decrypted, err := jwk.DecryptED25519(f.privateKey, encryptedConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decrypt config: %w", err)
+	}
+
+	configStruct := structpb.Struct{}
+	err = json.Unmarshal(decrypted, &configStruct)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal decrypted config: %w", err)
+	}
+
+	assets := make([]ManagedRuntimeAsset, 0, len(pbAssets))
+	for _, asset := range pbAssets {
+		if asset == nil {
+			continue
+		}
+		assets = append(assets, ManagedRuntimeAsset{
+			Role:      asset.GetRole(),
+			MediaType: asset.GetMediaType(),
+			Bytes:     append([]byte(nil), asset.GetBody()...),
+		})
+	}
+
+	return &ManagedRuntimeSnapshot{
+		Revision: revision,
+		Config:   &configStruct,
+		Assets:   assets,
+	}, nil
+}
+
+type lambdaConnectorGeneration struct {
+	server    *c1_lambda_grpc.Server
+	connector types.ConnectorServer
+	revision  string
+	active    sync.WaitGroup
+}
+
+type lambdaConnectorBuildFunc func(context.Context, *ManagedRuntimeSnapshot) (*lambdaConnectorGeneration, error)
+
+type lambdaConnectorReloader struct {
+	mu      sync.RWMutex
+	reload  sync.Mutex
+	current *lambdaConnectorGeneration
+
+	fetch func(context.Context) (*ManagedRuntimeSnapshot, error)
+	build lambdaConnectorBuildFunc
+}
+
+func newLambdaConnectorReloader(
+	initial *lambdaConnectorGeneration,
+	fetch func(context.Context) (*ManagedRuntimeSnapshot, error),
+	build lambdaConnectorBuildFunc,
+) *lambdaConnectorReloader {
+	return &lambdaConnectorReloader{
+		current: initial,
+		fetch:   fetch,
+		build:   build,
+	}
+}
+
+func (r *lambdaConnectorReloader) Handler(ctx context.Context, req *c1_lambda_grpc.Request) (*c1_lambda_grpc.Response, error) {
+	if revision := requestedManagedRuntimeRevision(req); revision != "" && revision != r.currentRevision() {
+		if err := r.reloadToLatest(ctx); err != nil {
+			return c1_lambda_grpc.ErrorResponse(status.Errorf(codes.Unavailable, "failed to refresh runtime snapshot: %v", err)), nil
+		}
+	}
+
+	gen := r.acquireGeneration()
+	defer gen.active.Done()
+	return gen.server.Handler(ctx, req)
+}
+
+func requestedManagedRuntimeRevision(req *c1_lambda_grpc.Request) string {
+	values := req.Headers().Get(ManagedRuntimeRevisionHeader)
+	if len(values) == 0 {
+		return ""
+	}
+	return values[0]
+}
+
+func (r *lambdaConnectorReloader) currentRevision() string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.current == nil {
+		return ""
+	}
+	return r.current.revision
+}
+
+func (r *lambdaConnectorReloader) acquireGeneration() *lambdaConnectorGeneration {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	r.current.active.Add(1)
+	return r.current
+}
+
+func (r *lambdaConnectorReloader) reloadToLatest(ctx context.Context) error {
+	r.reload.Lock()
+	defer r.reload.Unlock()
+
+	snapshot, err := r.fetch(ctx)
+	if err != nil {
+		return err
+	}
+
+	if snapshot.GetRevision() == r.currentRevision() {
+		return nil
+	}
+
+	next, err := r.build(ctx, snapshot)
+	if err != nil {
+		return err
+	}
+
+	r.mu.Lock()
+	previous := r.current
+	r.current = next
+	r.mu.Unlock()
+
+	go drainAndCloseLambdaGeneration(context.WithoutCancel(ctx), previous)
+	return nil
+}
+
+func drainAndCloseLambdaGeneration(ctx context.Context, gen *lambdaConnectorGeneration) {
+	if gen == nil || gen.connector == nil {
+		return
+	}
+
+	done := make(chan struct{})
+	go func() {
+		gen.active.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(lambdaConnectorDrainTimeout):
+		zap.L().Warn("timed out draining previous lambda connector generation", zap.String("revision", gen.revision))
+	}
+
+	closeCtx, cancel := context.WithTimeout(ctx, lambdaConnectorDrainTimeout)
+	defer cancel()
+	if err := closeManagedConnector(closeCtx, gen.connector); err != nil {
+		zap.L().Warn("failed to close previous lambda connector generation", zap.String("revision", gen.revision), zap.Error(err))
+	}
+}
+
+func closeManagedConnector(ctx context.Context, connector types.ConnectorServer) error {
+	switch c := any(connector).(type) {
+	case interface{ Close(context.Context) error }:
+		return c.Close(ctx)
+	case io.Closer:
+		return c.Close()
+	default:
+		return nil
+	}
+}

--- a/pkg/cli/lambda_server__added.go
+++ b/pkg/cli/lambda_server__added.go
@@ -18,14 +18,13 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/ugrpc"
 	"github.com/go-jose/go-jose/v4"
 	"github.com/maypok86/otter/v2"
-	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 	"golang.org/x/oauth2"
-	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/conductorone/baton-sdk/internal/connector"
+	connectorV2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	v1 "github.com/conductorone/baton-sdk/pb/c1/connectorapi/baton/v1"
 	"github.com/conductorone/baton-sdk/pkg/auth"
 	"github.com/conductorone/baton-sdk/pkg/field"
@@ -127,78 +126,14 @@ func OptionallyAddLambdaCommand[T field.Configurable](
 		// Create connector config service client using the DPoP client
 		configClient := v1.NewConnectorConfigServiceClient(grpcClient)
 
-		// Get configuration, convert it to viper flag values, then proceed.
-		config, err := configClient.GetConnectorConfig(runCtx, &v1.GetConnectorConfigRequest{})
-		if err != nil {
-			return fmt.Errorf("lambda-run: failed to get connector config: %w", err)
-		}
-
 		ed25519PrivateKey, ok := webKey.Key.(ed25519.PrivateKey)
 		if !ok {
 			return fmt.Errorf("lambda-run: failed to cast webkey to ed25519.PrivateKey")
 		}
-
-		decrypted, err := jwk.DecryptED25519(ed25519PrivateKey, config.Config)
+		snapshotFetcher := newManagedRuntimeFetcher(configClient, ed25519PrivateKey)
+		initialSnapshot, err := snapshotFetcher.Fetch(runCtx)
 		if err != nil {
-			return fmt.Errorf("lambda-run: failed to decrypt config: %w", err)
-		}
-
-		configStruct := structpb.Struct{}
-		err = json.Unmarshal(decrypted, &configStruct)
-		if err != nil {
-			return fmt.Errorf("lambda-run: failed to unmarshal decrypted config: %w", err)
-		}
-
-		// parse content directly for lambdas, don't read from file
-		readFromPath := false
-		decodeOpts := field.WithAdditionalDecodeHooks(field.FileUploadDecodeHook(readFromPath))
-		t, err := MakeGenericConfiguration[T](v, decodeOpts)
-		if err != nil {
-			return fmt.Errorf("lambda-run: failed to make generic configuration: %w", err)
-		}
-		switch cfg := any(t).(type) {
-		case *viper.Viper:
-			for k, v := range configStruct.AsMap() {
-				cfg.Set(k, v)
-			}
-		default:
-			// Use mapstructure with decode hook for file upload fields
-			decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
-				DecodeHook: field.ComposeDecodeHookFunc(decodeOpts),
-				Result:     cfg,
-			})
-			if err != nil {
-				return fmt.Errorf("lambda-run: failed to create decoder: %w", err)
-			}
-			err = decoder.Decode(configStruct.AsMap())
-			if err != nil {
-				return fmt.Errorf("lambda-run: failed to decode config: %w", err)
-			}
-		}
-
-		configStructMap := configStruct.AsMap()
-
-		var (
-			fieldOptions  []field.Option
-			schemaFields  []field.SchemaField
-			authMethodStr string
-		)
-		if authMethod, ok := configStructMap["auth-method"]; ok {
-			if authMethodStr, ok = authMethod.(string); ok {
-				fieldOptions = append(fieldOptions, field.WithAuthMethod(authMethodStr))
-			}
-		}
-		schemaFieldsMap := connectorSchema.FieldGroupFields(authMethodStr)
-		for _, field := range schemaFieldsMap {
-			schemaFields = append(schemaFields, field)
-		}
-
-		if len(schemaFields) == 0 {
-			schemaFields = connectorSchema.Fields
-		}
-
-		if err := field.Validate(connectorSchema, t, fieldOptions...); err != nil {
-			return fmt.Errorf("failed to validate config: %w", err)
+			return fmt.Errorf("lambda-run: failed to get managed runtime snapshot: %w", err)
 		}
 
 		clientSecret := v.GetString("lambda-client-secret")
@@ -218,29 +153,13 @@ func OptionallyAddLambdaCommand[T field.Configurable](
 				return &session.NoOpSessionStore{}, nil
 			}
 		}
-		ops := RunTimeOpts{
-			SessionStore: NewLazyCachingSessionStore(sessionStoreConstructor, func(otterOptions *otter.Options[string, []byte]) {
-				if sessionStoreMaximumSize <= 0 {
-					otterOptions.MaximumWeight = 0
-				} else {
-					otterOptions.MaximumWeight = uint64(sessionStoreMaximumSize)
-				}
-			}),
-			SelectedAuthMethod:  authMethodStr,
-			SyncResourceTypeIDs: v.GetStringSlice("sync-resource-types"),
-		}
-
-		if hasOauthField(schemaFields) {
-			ops.TokenSource = &lambdaTokenSource{
-				ctx:    runCtx,
-				webKey: webKey,
-				client: configClient,
+		sessionStore := NewLazyCachingSessionStore(sessionStoreConstructor, func(otterOptions *otter.Options[string, []byte]) {
+			if sessionStoreMaximumSize <= 0 {
+				otterOptions.MaximumWeight = 0
+			} else {
+				otterOptions.MaximumWeight = uint64(sessionStoreMaximumSize)
 			}
-		}
-		c, err := getconnector(runCtx, t, ops)
-		if err != nil {
-			return fmt.Errorf("failed to get connector: %w", err)
-		}
+		})
 
 		// Ensure only one auth method is provided
 		jwk := v.GetString(field.LambdaServerAuthJWTSigner.GetName())
@@ -271,10 +190,58 @@ func OptionallyAddLambdaCommand[T field.Configurable](
 
 		chain := ugrpc.ChainUnaryInterceptors(authOpt)
 
-		s := c1_lambda_grpc.NewServer(chain)
-		connector.Register(runCtx, s, c, opts)
+		buildGeneration := func(ctx context.Context, snapshot *ManagedRuntimeSnapshot) (*lambdaConnectorGeneration, error) {
+			t, cfgViper, authMethodStr, schemaFields, err := makeLambdaManagedRuntimeConfiguration[T](v, connectorSchema, snapshot)
+			if err != nil {
+				return nil, err
+			}
 
-		aws_lambda.StartWithOptions(s.Handler, aws_lambda.WithContext(runCtx))
+			ops := RunTimeOpts{
+				SessionStore:        sessionStore,
+				SelectedAuthMethod:  authMethodStr,
+				SyncResourceTypeIDs: cfgViper.GetStringSlice("sync-resource-types"),
+				ManagedRuntime: &ManagedRuntimeOpts{
+					Snapshot: snapshot,
+				},
+			}
+
+			if hasOauthField(schemaFields) {
+				ops.TokenSource = &lambdaTokenSource{
+					ctx:    runCtx,
+					webKey: webKey,
+					client: configClient,
+				}
+			}
+
+			c, err := getconnector(ctx, t, ops)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get connector: %w", err)
+			}
+
+			if _, err := c.GetMetadata(ctx, &connectorV2.ConnectorServiceGetMetadataRequest{}); err != nil {
+				closeCtx, cancel := context.WithTimeout(ctx, lambdaConnectorDrainTimeout)
+				defer cancel()
+				_ = closeManagedConnector(closeCtx, c)
+				return nil, fmt.Errorf("failed managed runtime readiness check: %w", err)
+			}
+
+			s := c1_lambda_grpc.NewServer(chain)
+			connector.Register(ctx, s, c, opts)
+
+			return &lambdaConnectorGeneration{
+				server:    s,
+				connector: c,
+				revision:  snapshot.GetRevision(),
+			}, nil
+		}
+
+		initialGeneration, err := buildGeneration(runCtx, initialSnapshot)
+		if err != nil {
+			return err
+		}
+
+		reloader := newLambdaConnectorReloader(initialGeneration, snapshotFetcher.Fetch, buildGeneration)
+		aws_lambda.StartWithOptions(reloader.Handler, aws_lambda.WithContext(runCtx))
 		return nil
 	}
 
@@ -299,7 +266,7 @@ type lambdaTokenSource struct {
 }
 
 func (s *lambdaTokenSource) Token() (*oauth2.Token, error) {
-	if s.token.Valid() {
+	if s.token != nil && s.token.Valid() {
 		return s.token, nil
 	}
 
@@ -335,4 +302,51 @@ func hasOauthField(fields []field.SchemaField) bool {
 		}
 	}
 	return false
+}
+
+func makeLambdaManagedRuntimeConfiguration[T field.Configurable](
+	base *viper.Viper,
+	connectorSchema field.Configuration,
+	snapshot *ManagedRuntimeSnapshot,
+) (T, *viper.Viper, string, []field.SchemaField, error) {
+	var zero T
+	if snapshot == nil || snapshot.Config == nil {
+		return zero, nil, "", nil, fmt.Errorf("managed runtime snapshot is missing config")
+	}
+
+	cfgViper := CloneViperSettings(base)
+	configMap := snapshot.Config.AsMap()
+	for key, value := range configMap {
+		cfgViper.Set(key, value)
+	}
+
+	decodeOpts := field.WithAdditionalDecodeHooks(field.FileUploadDecodeHook(false))
+	t, err := MakeGenericConfiguration[T](cfgViper, decodeOpts)
+	if err != nil {
+		return zero, nil, "", nil, fmt.Errorf("lambda-run: failed to make generic configuration: %w", err)
+	}
+
+	var (
+		fieldOptions  []field.Option
+		schemaFields  []field.SchemaField
+		authMethodStr string
+	)
+	if authMethod, ok := configMap["auth-method"]; ok {
+		if authMethodStr, ok = authMethod.(string); ok {
+			fieldOptions = append(fieldOptions, field.WithAuthMethod(authMethodStr))
+		}
+	}
+
+	for _, schemaField := range connectorSchema.FieldGroupFields(authMethodStr) {
+		schemaFields = append(schemaFields, schemaField)
+	}
+	if len(schemaFields) == 0 {
+		schemaFields = connectorSchema.Fields
+	}
+
+	if err := field.Validate(connectorSchema, t, fieldOptions...); err != nil {
+		return zero, nil, "", nil, fmt.Errorf("failed to validate config: %w", err)
+	}
+
+	return t, cfgViper, authMethodStr, schemaFields, nil
 }

--- a/pkg/cli/managed_runtime.go
+++ b/pkg/cli/managed_runtime.go
@@ -1,0 +1,30 @@
+package cli
+
+import "github.com/spf13/viper"
+
+func (s *ManagedRuntimeSnapshot) AssetByRole(role string) *ManagedRuntimeAsset {
+	if s == nil {
+		return nil
+	}
+	for i := range s.Assets {
+		if s.Assets[i].Role == role {
+			return &s.Assets[i]
+		}
+	}
+	return nil
+}
+
+func (s *ManagedRuntimeSnapshot) GetRevision() string {
+	if s == nil {
+		return ""
+	}
+	return s.Revision
+}
+
+func CloneViperSettings(source *viper.Viper) *viper.Viper {
+	clone := viper.New()
+	for key, value := range source.AllSettings() {
+		clone.Set(key, value)
+	}
+	return clone
+}

--- a/proto/c1/connectorapi/baton/v1/config.proto
+++ b/proto/c1/connectorapi/baton/v1/config.proto
@@ -8,6 +8,7 @@ option go_package = "gitlab.com/ductone/c1/pkg/pb/c1/connectorapi/baton/v1";
 
 service ConnectorConfigService {
   rpc GetConnectorConfig(GetConnectorConfigRequest) returns (GetConnectorConfigResponse);
+  rpc GetManagedRuntimeSnapshot(GetManagedRuntimeSnapshotRequest) returns (GetManagedRuntimeSnapshotResponse);
   rpc GetConnectorOauthToken(GetConnectorOauthTokenRequest) returns (GetConnectorOauthTokenResponse);
 }
 
@@ -16,6 +17,24 @@ message GetConnectorConfigRequest {}
 message GetConnectorConfigResponse {
   bytes config = 1;
   google.protobuf.Timestamp last_updated = 2;
+}
+
+message GetManagedRuntimeSnapshotRequest {}
+
+message ManagedRuntimeAsset {
+  string role = 1;
+  string media_type = 2;
+  bytes body = 3;
+}
+
+message ManagedRuntimeSnapshot {
+  string revision = 1;
+  bytes encrypted_config = 2;
+  repeated ManagedRuntimeAsset assets = 3;
+}
+
+message GetManagedRuntimeSnapshotResponse {
+  ManagedRuntimeSnapshot snapshot = 1;
 }
 
 message SignedHeader {


### PR DESCRIPTION
Why

Axiomatic hotload needs one SDK-level runtime contract that can carry the effective connector config and runtime assets without teaching the SDK about axiomatic-specific artifact semantics. The SDK also needs to rebuild, readiness-check, swap, and drain full connector generations when C1 reports a new effective snapshot revision.

What this changes

Adds a managed runtime snapshot API with opaque role-based assets and threads it through RunTimeOpts. Lambda mode now fetches the effective snapshot, falls back to the legacy config RPC when needed, builds connector generations from the snapshot, checks GetMetadata before serving, and swaps generations when the x-baton-runtime-revision hint changes.

Depends on follow-up C1 work to serve populated runtime assets.