### PR TITLE
get task client reuse and benchmarking

### DIFF
--- a/pkg/connectorrunner/runner.go
+++ b/pkg/connectorrunner/runner.go
@@ -30,6 +30,7 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/tasks/c1api"
 	"github.com/conductorone/baton-sdk/pkg/tasks/local"
 	"github.com/conductorone/baton-sdk/pkg/types"
+	taskTypes "github.com/conductorone/baton-sdk/pkg/types/tasks"
 
 	"github.com/conductorone/baton-sdk/internal/connector"
 )
@@ -46,6 +47,11 @@ type connectorRunner struct {
 	debugFile      *os.File
 	debugFileMutex sync.Mutex
 	healthServer   *healthcheck.Server
+}
+
+type taskManagerTeardowner interface {
+	// Teardown releases manager-owned resources. It must not wait for task completion.
+	Teardown(context.Context) error
 }
 
 var ErrSigTerm = errors.New("context cancelled by process shutdown")
@@ -254,9 +260,10 @@ func (c *connectorRunner) run(ctx context.Context) error {
 
 			l.Debug("runner: got task", zap.String("task_id", nextTask.GetId()), zap.String("task_type", tasks.GetType(nextTask).String()))
 
-			// If we're in one-shot mode, process the task synchronously.
-			if c.oneShot {
-				l.Debug("runner: one-shot mode enabled. Performing action synchronously.")
+			// If we're in one-shot mode, process the task synchronously. Service mode also processes the startup
+			// hello synchronously so it registers before the first GetTask poll.
+			if c.oneShot || tasks.Is(nextTask, taskTypes.HelloType) {
+				l.Debug("runner: performing action synchronously.")
 				err := c.processTask(ctx, nextTask)
 				sem.Release(1)
 				if err != nil {
@@ -306,6 +313,12 @@ func (c *connectorRunner) Close(ctx context.Context) error {
 			retErr = errors.Join(retErr, err)
 		}
 		c.healthServer = nil
+	}
+
+	if teardowner, ok := c.tasks.(taskManagerTeardowner); ok {
+		if err := teardowner.Teardown(ctx); err != nil {
+			retErr = errors.Join(retErr, err)
+		}
 	}
 
 	if err := c.cw.Close(); err != nil {

--- a/pkg/dotc1z/column_validation_test.go
+++ b/pkg/dotc1z/column_validation_test.go
@@ -53,7 +53,7 @@ func openTestDB(t *testing.T, extraColumnName string) *sql.DB {
 	dbPath := filepath.Join(t.TempDir(), "test.db")
 	db, err := sql.Open("sqlite", dbPath)
 	require.NoError(t, err)
-	t.Cleanup(func() { db.Close() })
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
 
 	// Create a table with normal columns plus one attacker-controlled column.
 	// The malicious name must be double-quoted in the DDL so SQLite accepts it

--- a/pkg/tasks/c1api/manager.go
+++ b/pkg/tasks/c1api/manager.go
@@ -59,6 +59,14 @@ type c1ApiTaskManager struct {
 	workerCount                         int
 }
 
+type idleServiceClient interface {
+	CloseIfIdleFor(time.Duration) error
+}
+
+type closeableServiceClient interface {
+	TeardownServiceClient() error
+}
+
 // getHeartbeatInterval returns an appropriate heartbeat interval. If the interval is 0, it will return the default heartbeat interval.
 // Otherwise, it will be clamped between minHeartbeatInterval and maxHeartbeatInterval.
 func getHeartbeatInterval(d time.Duration) time.Duration {
@@ -126,6 +134,11 @@ func (c *c1ApiTaskManager) Next(ctx context.Context) (*v1.Task, time.Duration, e
 
 	if resp.GetTask() == nil || tasks.Is(resp.GetTask(), taskTypes.NoneType) {
 		l.Debug("c1_api_task_manager.Next(): no tasks available")
+		if closer, ok := c.serviceClient.(idleServiceClient); ok {
+			if err := closer.CloseIfIdleFor(nextPoll); err != nil {
+				l.Warn("c1_api_task_manager.Next(): failed to close idle service client", zap.Error(err))
+			}
+		}
 		return nil, nextPoll, nil
 	}
 
@@ -140,7 +153,7 @@ func (c *c1ApiTaskManager) Next(ctx context.Context) (*v1.Task, time.Duration, e
 
 func (c *c1ApiTaskManager) finishTask(ctx context.Context, task *v1.Task, resp proto.Message, annos annotations.Annotations, inErr error) error {
 	ctx, span := tracer.Start(ctx, "c1ApiTaskManager.finishTask")
-	var err error
+	err := inErr
 	defer func() { uotel.EndSpanWithError(span, err) }()
 	l := ctxzap.Extract(ctx)
 	l = l.With(
@@ -219,6 +232,15 @@ func (c *c1ApiTaskManager) GetTempDir() string {
 
 func (c *c1ApiTaskManager) ShouldDebug() bool {
 	return c.runnerShouldDebug
+}
+
+// Teardown releases task-manager resources during runner shutdown. It does not
+// wait for connector tasks to complete.
+func (c *c1ApiTaskManager) Teardown(context.Context) error {
+	if closer, ok := c.serviceClient.(closeableServiceClient); ok {
+		return closer.TeardownServiceClient()
+	}
+	return nil
 }
 
 func (c *c1ApiTaskManager) Process(ctx context.Context, task *v1.Task, cc types.ConnectorClient) error {

--- a/pkg/tasks/c1api/manager_test.go
+++ b/pkg/tasks/c1api/manager_test.go
@@ -1,0 +1,51 @@
+package c1api
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	v1 "github.com/conductorone/baton-sdk/pb/c1/connectorapi/baton/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFinishTaskUsesInputError(t *testing.T) {
+	client := &recordingServiceClient{}
+	manager := &c1ApiTaskManager{serviceClient: client}
+	task := v1.Task_builder{Id: "task-id", Hello: &v1.Task_HelloTask{}}.Build()
+	inputErr := errors.New("task failed")
+
+	err := manager.finishTask(context.Background(), task, nil, nil, inputErr)
+	require.ErrorIs(t, err, inputErr)
+	require.NotNil(t, client.finishReq)
+	require.Nil(t, client.finishReq.GetSuccess())
+	require.NotNil(t, client.finishReq.GetError())
+	require.NotNil(t, client.finishReq.GetStatus())
+	require.Equal(t, "task failed", client.finishReq.GetStatus().GetMessage())
+}
+
+type recordingServiceClient struct {
+	finishReq *v1.BatonServiceFinishTaskRequest
+}
+
+func (r *recordingServiceClient) Hello(context.Context, *v1.BatonServiceHelloRequest) (*v1.BatonServiceHelloResponse, error) {
+	return v1.BatonServiceHelloResponse_builder{}.Build(), nil
+}
+
+func (r *recordingServiceClient) GetTask(context.Context, *v1.BatonServiceGetTaskRequest) (*v1.BatonServiceGetTaskResponse, error) {
+	return v1.BatonServiceGetTaskResponse_builder{}.Build(), nil
+}
+
+func (r *recordingServiceClient) Heartbeat(context.Context, *v1.BatonServiceHeartbeatRequest) (*v1.BatonServiceHeartbeatResponse, error) {
+	return v1.BatonServiceHeartbeatResponse_builder{}.Build(), nil
+}
+
+func (r *recordingServiceClient) FinishTask(_ context.Context, req *v1.BatonServiceFinishTaskRequest) (*v1.BatonServiceFinishTaskResponse, error) {
+	r.finishReq = req
+	return v1.BatonServiceFinishTaskResponse_builder{}.Build(), nil
+}
+
+func (r *recordingServiceClient) Upload(context.Context, *v1.Task, io.ReadSeeker) error {
+	return nil
+}

--- a/pkg/tasks/c1api/service_client.go
+++ b/pkg/tasks/c1api/service_client.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"crypto/sha256"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"math"
 	"net"
 	"os"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
@@ -23,7 +26,8 @@ import (
 )
 
 const (
-	fileChunkSize = 1 * 1024 * 512 // 512KB
+	fileChunkSize                            = 1 * 1024 * 512 // 512KB
+	defaultC1ServiceClientIdleCloseThreshold = time.Minute
 )
 
 type BatonServiceClient interface {
@@ -39,63 +43,323 @@ type batonHelloClient interface {
 	Hello(ctx context.Context, req *v1.BatonServiceHelloRequest) (*v1.BatonServiceHelloResponse, error)
 }
 
+type c1ServiceConn struct {
+	cc       *grpc.ClientConn
+	client   v1.BatonServiceClient
+	inFlight int
+	retired  bool
+}
+
 type c1ServiceClient struct {
 	addr     string
 	dialOpts []grpc.DialOption
 	hostID   string
+
+	mtx                  sync.Mutex
+	hostIDOnce           sync.Once
+	active               *c1ServiceConn
+	draining             []*c1ServiceConn
+	dialDone             chan struct{}
+	dialCancel           context.CancelFunc
+	closeWhenIdle        bool
+	closed               bool
+	idleCloseThreshold   time.Duration
+	suppressCloseLogging bool
 }
 
 func (c *c1ServiceClient) getHostID() string {
-	if c.hostID != "" {
-		return c.hostID
-	}
+	c.hostIDOnce.Do(func() {
+		if c.hostID != "" {
+			return
+		}
 
-	hostID, _ := os.Hostname()
-	if envHost, ok := os.LookupEnv("BATON_HOST_ID"); ok {
-		hostID = envHost
-	}
+		hostID, _ := os.Hostname()
+		if envHost, ok := os.LookupEnv("BATON_HOST_ID"); ok {
+			hostID = envHost
+		}
 
-	if hostID == "" {
-		hostID = "baton-sdk"
-	}
+		if hostID == "" {
+			hostID = "baton-sdk"
+		}
 
-	c.hostID = hostID
+		c.hostID = hostID
+	})
 	return c.hostID
 }
 
-func (c *c1ServiceClient) getClientConn(ctx context.Context) (v1.BatonServiceClient, func(), error) {
+func (c *c1ServiceClient) closeIdleThreshold() time.Duration {
+	if c.idleCloseThreshold > 0 {
+		return c.idleCloseThreshold
+	}
+	return defaultC1ServiceClientIdleCloseThreshold
+}
+
+func (c *c1ServiceClient) dial(ctx context.Context) (*grpc.ClientConn, error) {
 	dialCtx, cancel := context.WithTimeout(ctx, time.Second*30)
 	defer cancel()
-	cc, err := grpc.DialContext( //nolint:staticcheck // grpc.DialContext is deprecated but we are using it still.
-		dialCtx,
+	return c.dialWithContext(dialCtx)
+}
+
+func (c *c1ServiceClient) dialWithContext(ctx context.Context) (*grpc.ClientConn, error) {
+	return grpc.DialContext( //nolint:staticcheck // grpc.DialContext is deprecated but we are using it still.
+		ctx,
 		c.addr,
 		c.dialOpts...,
 	)
-	if err != nil {
-		return nil, nil, err
+}
+
+func (c *c1ServiceClient) beginRPC(ctx context.Context) (v1.BatonServiceClient, *grpc.ClientConn, error) {
+	for {
+		c.mtx.Lock()
+		if c.closed {
+			c.mtx.Unlock()
+			return nil, nil, errors.New("c1 service client is closed")
+		}
+		c.closeWhenIdle = false
+
+		if c.active != nil {
+			c.active.inFlight++
+			client := c.active.client
+			conn := c.active.cc
+			c.mtx.Unlock()
+			return client, conn, nil
+		}
+
+		if c.dialDone != nil {
+			dialDone := c.dialDone
+			c.mtx.Unlock()
+
+			select {
+			case <-ctx.Done():
+				return nil, nil, ctx.Err()
+			case <-dialDone:
+				continue
+			}
+		}
+
+		dialDone := make(chan struct{})
+		dialCtx, dialCancel := context.WithTimeout(ctx, time.Second*30)
+		c.dialDone = dialDone
+		c.dialCancel = dialCancel
+		c.mtx.Unlock()
+
+		cc, err := c.dialWithContext(dialCtx)
+		dialCancel()
+
+		c.mtx.Lock()
+		if c.dialDone == dialDone {
+			c.dialDone = nil
+			c.dialCancel = nil
+			close(dialDone)
+		}
+		if err != nil {
+			c.mtx.Unlock()
+			return nil, nil, err
+		}
+		if c.closed {
+			c.mtx.Unlock()
+			_ = cc.Close()
+			return nil, nil, errors.New("c1 service client is closed")
+		}
+
+		c.active = &c1ServiceConn{
+			cc:       cc,
+			client:   v1.NewBatonServiceClient(cc),
+			inFlight: 1,
+		}
+		client := c.active.client
+		conn := c.active.cc
+		c.mtx.Unlock()
+		return client, conn, nil
+	}
+}
+
+func (c *c1ServiceClient) endRPC(conn *grpc.ClientConn, rpcErr error) {
+	var closeConns []*c1ServiceConn
+
+	c.mtx.Lock()
+	handle := c.findConnLocked(conn)
+	if handle != nil && handle.inFlight > 0 {
+		handle.inFlight--
 	}
 
-	return v1.NewBatonServiceClient(cc), func() {
-		err = cc.Close()
-		if err != nil {
-			ctxzap.Extract(ctx).Error("failed to close client connection", zap.Error(err))
+	if shouldResetConnection(rpcErr) && handle != nil && !handle.retired {
+		if c.active == handle {
+			c.active = nil
 		}
-	}, nil
+		handle.retired = true
+		if handle.inFlight > 0 {
+			c.draining = append(c.draining, handle)
+		} else {
+			closeConns = append(closeConns, handle)
+		}
+	}
+
+	if c.active != nil && c.active.inFlight == 0 {
+		if c.closeWhenIdle {
+			c.active.retired = true
+			closeConns = append(closeConns, c.active)
+			c.active = nil
+		}
+	}
+	closeConns = append(closeConns, c.collectDrainedLocked()...)
+	c.mtx.Unlock()
+
+	c.closeHandles(closeConns)
+}
+
+func (c *c1ServiceClient) doRPC(ctx context.Context, retryOnReset bool, call func(v1.BatonServiceClient) error) error {
+	var err error
+	for attempt := 0; attempt < 2; attempt++ {
+		var client v1.BatonServiceClient
+		var conn *grpc.ClientConn
+		client, conn, err = c.beginRPC(ctx)
+		if err != nil {
+			return err
+		}
+
+		err = call(client)
+		shouldRetry := retryOnReset && shouldResetConnection(err) && attempt == 0
+		c.endRPC(conn, err)
+		if shouldRetry {
+			continue
+		}
+		return err
+	}
+	return err
+}
+
+func shouldResetConnection(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, io.EOF) {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "client connection is closing") ||
+		strings.Contains(msg, "connection error") ||
+		strings.Contains(msg, "error reading from server") ||
+		strings.Contains(msg, "transport is closing") ||
+		strings.Contains(msg, "connection reset by peer")
+}
+
+func (c *c1ServiceClient) findConnLocked(conn *grpc.ClientConn) *c1ServiceConn {
+	if conn == nil {
+		return nil
+	}
+	if c.active != nil && c.active.cc == conn {
+		return c.active
+	}
+	for _, handle := range c.draining {
+		if handle.cc == conn {
+			return handle
+		}
+	}
+	return nil
+}
+
+func (c *c1ServiceClient) collectDrainedLocked() []*c1ServiceConn {
+	var closeConns []*c1ServiceConn
+	remaining := c.draining[:0]
+	for _, handle := range c.draining {
+		if handle.inFlight == 0 {
+			closeConns = append(closeConns, handle)
+			continue
+		}
+		remaining = append(remaining, handle)
+	}
+	c.draining = remaining
+	return closeConns
+}
+
+func (c *c1ServiceClient) closeHandles(handles []*c1ServiceConn) {
+	for _, handle := range handles {
+		if handle == nil || handle.cc == nil {
+			continue
+		}
+		if err := handle.cc.Close(); err != nil && !c.suppressCloseLogging {
+			zap.L().Error("failed to close client connection", zap.Error(err))
+		}
+	}
+}
+
+// CloseIfIdleFor closes an idle connection only when the caller knows the next
+// expected C1 API use is far enough away. It is not a background idle timer.
+func (c *c1ServiceClient) CloseIfIdleFor(nextUse time.Duration) error {
+	if nextUse <= c.closeIdleThreshold() {
+		return nil
+	}
+
+	var closeConns []*c1ServiceConn
+	c.mtx.Lock()
+	if c.closed {
+		c.mtx.Unlock()
+		return nil
+	}
+	if c.active != nil {
+		if c.active.inFlight == 0 {
+			closeConns = append(closeConns, c.active)
+			c.active = nil
+		} else {
+			c.closeWhenIdle = true
+		}
+	}
+	closeConns = append(closeConns, c.collectDrainedLocked()...)
+	if len(closeConns) == 0 {
+		c.closeWhenIdle = true
+	}
+	c.mtx.Unlock()
+
+	c.closeHandles(closeConns)
+	return nil
+}
+
+// TeardownServiceClient tears down the client immediately. It is used by runner
+// shutdown and intentionally does not wait for long-running connector tasks to complete.
+func (c *c1ServiceClient) TeardownServiceClient() error {
+	var closeConns []*c1ServiceConn
+	c.mtx.Lock()
+	c.closed = true
+	if c.dialDone != nil {
+		if c.dialCancel != nil {
+			c.dialCancel()
+			c.dialCancel = nil
+		}
+		close(c.dialDone)
+		c.dialDone = nil
+	}
+	if c.active != nil {
+		closeConns = append(closeConns, c.active)
+		c.active = nil
+	}
+	closeConns = append(closeConns, c.draining...)
+	c.draining = nil
+	c.closeWhenIdle = false
+	c.mtx.Unlock()
+
+	var retErr error
+	for _, handle := range closeConns {
+		if handle == nil || handle.cc == nil {
+			continue
+		}
+		retErr = errors.Join(retErr, handle.cc.Close())
+	}
+	return retErr
 }
 
 func (c *c1ServiceClient) Hello(ctx context.Context, in *v1.BatonServiceHelloRequest) (*v1.BatonServiceHelloResponse, error) {
 	ctx, span := tracer.Start(ctx, "c1ServiceClient.Hello")
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
-	client, done, err := c.getClientConn(ctx)
-	if err != nil {
-		return nil, err
-	}
-	defer done()
 
 	in.SetHostId(c.getHostID())
 
-	resp, err := client.Hello(ctx, in)
+	var resp *v1.BatonServiceHelloResponse
+	err = c.doRPC(ctx, true, func(client v1.BatonServiceClient) error {
+		resp, err = client.Hello(ctx, in)
+		return err
+	})
 	return resp, err
 }
 
@@ -103,15 +367,14 @@ func (c *c1ServiceClient) GetTask(ctx context.Context, in *v1.BatonServiceGetTas
 	ctx, span := tracer.Start(ctx, "c1ServiceClient.GetTask")
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
-	client, done, err := c.getClientConn(ctx)
-	if err != nil {
-		return nil, err
-	}
-	defer done()
 
 	in.SetHostId(c.getHostID())
 
-	resp, err := client.GetTask(ctx, in)
+	var resp *v1.BatonServiceGetTaskResponse
+	err = c.doRPC(ctx, false, func(client v1.BatonServiceClient) error {
+		resp, err = client.GetTask(ctx, in)
+		return err
+	})
 	return resp, err
 }
 
@@ -119,15 +382,14 @@ func (c *c1ServiceClient) Heartbeat(ctx context.Context, in *v1.BatonServiceHear
 	ctx, span := tracer.Start(ctx, "c1ServiceClient.Heartbeat")
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
-	client, done, err := c.getClientConn(ctx)
-	if err != nil {
-		return nil, err
-	}
-	defer done()
 
 	in.SetHostId(c.getHostID())
 
-	resp, err := client.Heartbeat(ctx, in)
+	var resp *v1.BatonServiceHeartbeatResponse
+	err = c.doRPC(ctx, true, func(client v1.BatonServiceClient) error {
+		resp, err = client.Heartbeat(ctx, in)
+		return err
+	})
 	return resp, err
 }
 
@@ -135,15 +397,14 @@ func (c *c1ServiceClient) FinishTask(ctx context.Context, in *v1.BatonServiceFin
 	ctx, span := tracer.Start(ctx, "c1ServiceClient.FinishTask")
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
-	client, done, err := c.getClientConn(ctx)
-	if err != nil {
-		return nil, err
-	}
-	defer done()
 
 	in.SetHostId(c.getHostID())
 
-	resp, err := client.FinishTask(ctx, in)
+	var resp *v1.BatonServiceFinishTaskResponse
+	err = c.doRPC(ctx, false, func(client v1.BatonServiceClient) error {
+		resp, err = client.FinishTask(ctx, in)
+		return err
+	})
 	return resp, err
 }
 
@@ -184,12 +445,12 @@ func (c *c1ServiceClient) upload(ctx context.Context, task *v1.Task, r io.ReadSe
 		return err
 	}
 
-	client, done, err := c.getClientConn(ctx)
+	client, conn, err := c.beginRPC(ctx)
 	if err != nil {
 		l.Error("failed to get client connection", zap.Error(err))
 		return err
 	}
-	defer done()
+	defer func() { c.endRPC(conn, err) }()
 
 	uc, err := client.UploadAsset(ctx)
 	if err != nil {

--- a/pkg/tasks/c1api/service_client_benchmark_test.go
+++ b/pkg/tasks/c1api/service_client_benchmark_test.go
@@ -1,0 +1,238 @@
+package c1api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	v1 "github.com/conductorone/baton-sdk/pb/c1/connectorapi/baton/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+type benchmarkBatonService struct {
+	v1.UnimplementedBatonServiceServer
+
+	getTaskLatency    time.Duration
+	finishTaskLatency time.Duration
+}
+
+func (s *benchmarkBatonService) GetTask(ctx context.Context, _ *v1.BatonServiceGetTaskRequest) (*v1.BatonServiceGetTaskResponse, error) {
+	if err := sleepContext(ctx, s.getTaskLatency); err != nil {
+		return nil, err
+	}
+	return v1.BatonServiceGetTaskResponse_builder{
+		NextPoll: durationpb.New(time.Second),
+	}.Build(), nil
+}
+
+func (s *benchmarkBatonService) Heartbeat(ctx context.Context, _ *v1.BatonServiceHeartbeatRequest) (*v1.BatonServiceHeartbeatResponse, error) {
+	if err := sleepContext(ctx, s.getTaskLatency); err != nil {
+		return nil, err
+	}
+	return v1.BatonServiceHeartbeatResponse_builder{
+		NextHeartbeat: durationpb.New(time.Second),
+	}.Build(), nil
+}
+
+func (s *benchmarkBatonService) FinishTask(ctx context.Context, _ *v1.BatonServiceFinishTaskRequest) (*v1.BatonServiceFinishTaskResponse, error) {
+	if err := sleepContext(ctx, s.finishTaskLatency); err != nil {
+		return nil, err
+	}
+	return v1.BatonServiceFinishTaskResponse_builder{}.Build(), nil
+}
+
+func (s *benchmarkBatonService) UploadAsset(stream grpc.ClientStreamingServer[v1.BatonServiceUploadAssetRequest, v1.BatonServiceUploadAssetResponse]) error {
+	for {
+		_, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			return stream.SendAndClose(v1.BatonServiceUploadAssetResponse_builder{}.Build())
+		}
+		if err != nil {
+			return err
+		}
+	}
+}
+
+type benchmarkServiceClient struct {
+	client    *c1ServiceClient
+	dialCount atomic.Int64
+	close     func()
+}
+
+func newBenchmarkServiceClient(tb testing.TB, dialLatency time.Duration, service v1.BatonServiceServer) *benchmarkServiceClient {
+	tb.Helper()
+
+	lis, err := new(net.ListenConfig).Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		tb.Fatal(err)
+	}
+	server := grpc.NewServer()
+	v1.RegisterBatonServiceServer(server, service)
+
+	var serveWG sync.WaitGroup
+	serveWG.Add(1)
+	go func() {
+		defer serveWG.Done()
+		if err := server.Serve(lis); err != nil {
+			if !errors.Is(err, grpc.ErrServerStopped) {
+				tb.Errorf("benchmark gRPC server failed: %v", err)
+			}
+		}
+	}()
+
+	bc := &benchmarkServiceClient{}
+	netDialer := &net.Dialer{}
+	dialer := func(ctx context.Context, _ string) (net.Conn, error) {
+		if err := sleepContext(ctx, dialLatency); err != nil {
+			return nil, err
+		}
+		bc.dialCount.Add(1)
+		return netDialer.DialContext(ctx, "tcp", lis.Addr().String())
+	}
+
+	bc.client = &c1ServiceClient{
+		addr: lis.Addr().String(),
+		dialOpts: []grpc.DialOption{
+			grpc.WithContextDialer(dialer),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithBlock(), //nolint:staticcheck // Mirrors production dial behavior for the baseline benchmark.
+		},
+	}
+	bc.close = func() {
+		_ = bc.client.TeardownServiceClient()
+		server.Stop()
+		_ = lis.Close()
+		serveWG.Wait()
+	}
+	tb.Cleanup(bc.close)
+
+	return bc
+}
+
+func sleepContext(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func BenchmarkServiceClientGetTask(b *testing.B) {
+	for _, dialLatency := range []time.Duration{50 * time.Millisecond, 100 * time.Millisecond, 300 * time.Millisecond} {
+		b.Run(fmt.Sprintf("dial_latency_%s", dialLatency), func(b *testing.B) {
+			bc := newBenchmarkServiceClient(b, dialLatency, &benchmarkBatonService{})
+			ctx := context.Background()
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, err := bc.client.GetTask(ctx, &v1.BatonServiceGetTaskRequest{})
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.StopTimer()
+
+			if elapsed := b.Elapsed(); elapsed > 0 {
+				b.ReportMetric(float64(b.N)/elapsed.Seconds(), "rpc/s")
+			}
+			b.ReportMetric(float64(bc.dialCount.Load())/float64(b.N), "dials/op")
+		})
+	}
+}
+
+func BenchmarkServiceClientActionSequence(b *testing.B) {
+	dialLatencies := []time.Duration{50 * time.Millisecond, 100 * time.Millisecond, 300 * time.Millisecond}
+	taskRuntimes := []time.Duration{50 * time.Millisecond, 250 * time.Millisecond, 1500 * time.Millisecond}
+
+	for _, dialLatency := range dialLatencies {
+		for _, taskRuntime := range taskRuntimes {
+			b.Run(fmt.Sprintf("dial_latency_%s/task_runtime_%s", dialLatency, taskRuntime), func(b *testing.B) {
+				bc := newBenchmarkServiceClient(b, dialLatency, &benchmarkBatonService{})
+				ctx := context.Background()
+
+				b.ResetTimer()
+				runActionSequenceBenchmark(b, ctx, bc.client, taskRuntime)
+				b.StopTimer()
+
+				if elapsed := b.Elapsed(); elapsed > 0 {
+					b.ReportMetric(float64(b.N)/elapsed.Seconds(), "actions/s")
+				}
+				b.ReportMetric(float64(bc.dialCount.Load())/float64(b.N), "dials/action")
+			})
+		}
+	}
+}
+
+func BenchmarkServiceClientActionSequenceCalibratedWorkload(b *testing.B) {
+	// This workload was calibrated from the observed pre-change throughput. It
+	// measures the current client implementation under that same synthetic shape.
+	const (
+		dialLatency = 50 * time.Millisecond
+		taskRuntime = 200 * time.Millisecond
+	)
+
+	bc := newBenchmarkServiceClient(b, dialLatency, &benchmarkBatonService{})
+	ctx := context.Background()
+
+	b.ResetTimer()
+	runActionSequenceBenchmark(b, ctx, bc.client, taskRuntime)
+	b.StopTimer()
+
+	if elapsed := b.Elapsed(); elapsed > 0 {
+		b.ReportMetric(float64(b.N)/elapsed.Seconds(), "actions/s")
+	}
+	b.ReportMetric(float64(bc.dialCount.Load())/float64(b.N), "dials/action")
+}
+
+func runActionSequenceBenchmark(b *testing.B, ctx context.Context, client *c1ServiceClient, taskRuntime time.Duration) {
+	b.Helper()
+
+	const concurrency = 3
+	workCh := make(chan struct{}, concurrency)
+
+	var wg sync.WaitGroup
+	wg.Add(concurrency)
+	for range concurrency {
+		go func() {
+			defer wg.Done()
+			for range workCh {
+				_, err := client.GetTask(ctx, &v1.BatonServiceGetTaskRequest{})
+				if err != nil {
+					b.Error(err)
+					continue
+				}
+				if err := sleepContext(ctx, taskRuntime); err != nil {
+					b.Error(err)
+					continue
+				}
+				_, err = client.FinishTask(ctx, v1.BatonServiceFinishTaskRequest_builder{
+					TaskId:  "benchmark-task",
+					Success: v1.BatonServiceFinishTaskRequest_Success_builder{}.Build(),
+				}.Build())
+				if err != nil {
+					b.Error(err)
+				}
+			}
+		}()
+	}
+
+	for i := 0; i < b.N; i++ {
+		workCh <- struct{}{}
+	}
+	close(workCh)
+	wg.Wait()
+}

--- a/pkg/tasks/c1api/service_client_test.go
+++ b/pkg/tasks/c1api/service_client_test.go
@@ -1,0 +1,495 @@
+package c1api
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	v1 "github.com/conductorone/baton-sdk/pb/c1/connectorapi/baton/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+)
+
+func TestC1ServiceClientReusesConnection(t *testing.T) {
+	bc := newBenchmarkServiceClient(t, 0, &benchmarkBatonService{})
+	bc.client.idleCloseThreshold = time.Hour
+
+	ctx := context.Background()
+	for range 3 {
+		_, err := bc.client.GetTask(ctx, &v1.BatonServiceGetTaskRequest{})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if got := bc.dialCount.Load(); got != 1 {
+		t.Fatalf("expected one dial for reused connection, got %d", got)
+	}
+}
+
+func TestC1ServiceClientKnownIdleClose(t *testing.T) {
+	bc := newBenchmarkServiceClient(t, 0, &benchmarkBatonService{})
+	bc.client.idleCloseThreshold = time.Minute
+
+	ctx := context.Background()
+	_, err := bc.client.GetTask(ctx, &v1.BatonServiceGetTaskRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := bc.client.CloseIfIdleFor(2 * time.Minute); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = bc.client.GetTask(ctx, &v1.BatonServiceGetTaskRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := bc.dialCount.Load(); got != 2 {
+		t.Fatalf("expected redial after known-idle close, got %d dials", got)
+	}
+}
+
+func TestC1ServiceClientKnownIdleDoesNotCloseWhenNextUseIsSoon(t *testing.T) {
+	bc := newBenchmarkServiceClient(t, 0, &benchmarkBatonService{})
+	bc.client.idleCloseThreshold = time.Minute
+
+	ctx := context.Background()
+	_, err := bc.client.GetTask(ctx, &v1.BatonServiceGetTaskRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := bc.client.CloseIfIdleFor(30 * time.Second); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = bc.client.GetTask(ctx, &v1.BatonServiceGetTaskRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := bc.dialCount.Load(); got != 1 {
+		t.Fatalf("expected soon next use to keep cached connection, got %d dials", got)
+	}
+}
+
+func TestC1ServiceClientKnownIdleWaitsForInFlightRPC(t *testing.T) {
+	bc := newBenchmarkServiceClient(t, 0, &benchmarkBatonService{getTaskLatency: 75 * time.Millisecond})
+	bc.client.idleCloseThreshold = time.Minute
+
+	ctx := context.Background()
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := bc.client.GetTask(ctx, &v1.BatonServiceGetTaskRequest{})
+		errCh <- err
+	}()
+
+	waitForCondition(t, time.Second, func() bool {
+		bc.client.mtx.Lock()
+		defer bc.client.mtx.Unlock()
+		return bc.client.active != nil && bc.client.active.inFlight == 1
+	})
+
+	if err := bc.client.CloseIfIdleFor(2 * time.Minute); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := <-errCh; err != nil {
+		t.Fatalf("in-flight RPC failed after known-idle close request: %v", err)
+	}
+
+	_, err := bc.client.GetTask(ctx, &v1.BatonServiceGetTaskRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := bc.dialCount.Load(); got != 2 {
+		t.Fatalf("expected known-idle close after in-flight RPC completed, got %d dials", got)
+	}
+}
+
+func TestC1ServiceClientFailedDialDoesNotPoisonClient(t *testing.T) {
+	lis, err := new(net.ListenConfig).Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := grpc.NewServer()
+	v1.RegisterBatonServiceServer(server, &benchmarkBatonService{})
+	go func() {
+		if serveErr := server.Serve(lis); serveErr != nil && !errors.Is(serveErr, grpc.ErrServerStopped) {
+			t.Errorf("benchmark gRPC server failed: %v", serveErr)
+		}
+	}()
+	t.Cleanup(func() {
+		server.Stop()
+		_ = lis.Close()
+	})
+
+	var attempts atomic.Int64
+	netDialer := &net.Dialer{}
+	client := &c1ServiceClient{
+		addr: lis.Addr().String(),
+		dialOpts: []grpc.DialOption{
+			grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+				if attempts.Add(1) == 1 {
+					return nil, sleepContext(ctx, 50*time.Millisecond)
+				}
+				return netDialer.DialContext(ctx, "tcp", lis.Addr().String())
+			}),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithBlock(), //nolint:staticcheck // Mirrors production dial behavior.
+		},
+		idleCloseThreshold: time.Hour,
+	}
+	t.Cleanup(func() { _ = client.TeardownServiceClient() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	_, err = client.GetTask(ctx, &v1.BatonServiceGetTaskRequest{})
+	if err == nil {
+		t.Fatal("expected first dial to fail")
+	}
+
+	_, err = client.GetTask(context.Background(), &v1.BatonServiceGetTaskRequest{})
+	if err != nil {
+		t.Fatalf("expected client to recover after failed dial: %v", err)
+	}
+	if got := attempts.Load(); got < 2 {
+		t.Fatalf("expected at least two dial attempts, got %d", got)
+	}
+}
+
+func TestC1ServiceClientDoesNotResetAfterServerUnavailable(t *testing.T) {
+	bc := newBenchmarkServiceClient(t, 0, &unavailableOnceService{})
+	bc.client.idleCloseThreshold = time.Hour
+
+	ctx := context.Background()
+	_, err := bc.client.GetTask(ctx, &v1.BatonServiceGetTaskRequest{})
+	if status.Code(err) != codes.Unavailable {
+		t.Fatalf("expected unavailable error, got %v", err)
+	}
+
+	_, err = bc.client.GetTask(ctx, &v1.BatonServiceGetTaskRequest{})
+	if err != nil {
+		t.Fatalf("expected client to redial and recover after unavailable: %v", err)
+	}
+	if got := bc.dialCount.Load(); got != 1 {
+		t.Fatalf("expected server unavailable to keep healthy connection, got %d dials", got)
+	}
+}
+
+func TestC1ServiceClientRetriesAfterTransportClose(t *testing.T) {
+	bc := newBenchmarkServiceClient(t, 0, &benchmarkBatonService{})
+	bc.client.idleCloseThreshold = time.Hour
+
+	ctx := context.Background()
+	_, err := bc.client.GetTask(ctx, &v1.BatonServiceGetTaskRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	conn := requireActiveConn(t, bc.client)
+	if err := conn.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = bc.client.GetTask(ctx, &v1.BatonServiceGetTaskRequest{})
+	if err == nil {
+		t.Fatal("expected GetTask on stale transport to fail without retrying")
+	}
+	if got := bc.dialCount.Load(); got != 1 {
+		t.Fatalf("expected GetTask not to redial until next call, got %d dials", got)
+	}
+
+	_, err = bc.client.GetTask(ctx, &v1.BatonServiceGetTaskRequest{})
+	if err != nil {
+		t.Fatalf("expected next GetTask to redial and recover after transport close: %v", err)
+	}
+	if got := bc.dialCount.Load(); got != 2 {
+		t.Fatalf("expected redial after transport close reset, got %d dials", got)
+	}
+}
+
+func TestC1ServiceClientDoesNotRetryFinishTaskAfterTransportClose(t *testing.T) {
+	bc := newBenchmarkServiceClient(t, 0, &benchmarkBatonService{})
+	bc.client.idleCloseThreshold = time.Hour
+
+	ctx := context.Background()
+	_, err := bc.client.GetTask(ctx, &v1.BatonServiceGetTaskRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	conn := requireActiveConn(t, bc.client)
+	if err := conn.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = bc.client.FinishTask(ctx, v1.BatonServiceFinishTaskRequest_builder{
+		TaskId:  "benchmark-task",
+		Success: v1.BatonServiceFinishTaskRequest_Success_builder{}.Build(),
+	}.Build())
+	if err == nil {
+		t.Fatal("expected FinishTask on stale transport to fail without retrying")
+	}
+	if got := bc.dialCount.Load(); got != 1 {
+		t.Fatalf("expected FinishTask not to redial until next call, got %d dials", got)
+	}
+
+	_, err = bc.client.FinishTask(ctx, v1.BatonServiceFinishTaskRequest_builder{
+		TaskId:  "benchmark-task",
+		Success: v1.BatonServiceFinishTaskRequest_Success_builder{}.Build(),
+	}.Build())
+	if err != nil {
+		t.Fatalf("expected next FinishTask to redial and recover after transport close: %v", err)
+	}
+	if got := bc.dialCount.Load(); got != 2 {
+		t.Fatalf("expected redial after transport close reset, got %d dials", got)
+	}
+}
+
+func TestC1ServiceClientResetDoesNotClearNewerConnection(t *testing.T) {
+	bc := newBenchmarkServiceClient(t, 0, &benchmarkBatonService{})
+	bc.client.idleCloseThreshold = time.Hour
+
+	ctx := context.Background()
+	_, err := bc.client.GetTask(ctx, &v1.BatonServiceGetTaskRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	oldHandle := requireActiveHandle(t, bc.client)
+	oldConn := oldHandle.cc
+	t.Cleanup(func() { _ = oldConn.Close() })
+
+	newConn, err := bc.client.dial(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = newConn.Close() })
+
+	bc.client.mtx.Lock()
+	oldHandle.retired = true
+	oldHandle.inFlight = 1
+	bc.client.active = &c1ServiceConn{
+		cc:       newConn,
+		client:   v1.NewBatonServiceClient(newConn),
+		inFlight: 1,
+	}
+	bc.client.draining = append(bc.client.draining, oldHandle)
+	bc.client.mtx.Unlock()
+
+	bc.client.endRPC(oldConn, io.EOF)
+
+	gotConn := requireActiveConn(t, bc.client)
+	if gotConn != newConn {
+		t.Fatal("reset from old connection cleared newer cached connection")
+	}
+}
+
+func TestC1ServiceClientDoesNotCloseRetiredConnectionUntilInFlightDrains(t *testing.T) {
+	bc := newBenchmarkServiceClient(t, 0, &benchmarkBatonService{})
+	bc.client.idleCloseThreshold = time.Hour
+
+	ctx := context.Background()
+	_, err := bc.client.GetTask(ctx, &v1.BatonServiceGetTaskRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	oldHandle := requireActiveHandle(t, bc.client)
+	bc.client.mtx.Lock()
+	oldHandle.inFlight = 2
+	bc.client.mtx.Unlock()
+	oldConn := oldHandle.cc
+
+	bc.client.endRPC(oldConn, io.EOF)
+
+	oldClient := v1.NewBatonServiceClient(oldConn)
+	_, err = oldClient.GetTask(ctx, &v1.BatonServiceGetTaskRequest{})
+	if err != nil {
+		t.Fatalf("retired connection was closed before in-flight RPCs drained: %v", err)
+	}
+
+	bc.client.endRPC(oldConn, nil)
+	waitForCondition(t, time.Second, func() bool {
+		_, err = oldClient.GetTask(ctx, &v1.BatonServiceGetTaskRequest{})
+		return err != nil
+	})
+}
+
+func TestC1ServiceClientCloseIsIdempotentAndPreventsReuse(t *testing.T) {
+	bc := newBenchmarkServiceClient(t, 0, &benchmarkBatonService{})
+	bc.client.idleCloseThreshold = time.Hour
+
+	ctx := context.Background()
+	_, err := bc.client.GetTask(ctx, &v1.BatonServiceGetTaskRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := bc.client.TeardownServiceClient(); err != nil {
+		t.Fatal(err)
+	}
+	if err := bc.client.TeardownServiceClient(); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = bc.client.GetTask(ctx, &v1.BatonServiceGetTaskRequest{})
+	if err == nil || !strings.Contains(err.Error(), "closed") {
+		t.Fatalf("expected clear closed-client error, got %v", err)
+	}
+}
+
+func TestC1ServiceClientCloseCancelsDialAndUnblocksWaiters(t *testing.T) {
+	client := &c1ServiceClient{
+		addr: "blocked-dial",
+		dialOpts: []grpc.DialOption{
+			grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+				return nil, sleepContext(ctx, 5*time.Second)
+			}),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithBlock(), //nolint:staticcheck // Mirrors production dial behavior.
+		},
+		idleCloseThreshold: time.Hour,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := client.GetTask(ctx, &v1.BatonServiceGetTaskRequest{})
+		errCh <- err
+	}()
+
+	waitForCondition(t, time.Second, func() bool {
+		client.mtx.Lock()
+		defer client.mtx.Unlock()
+		return client.dialDone != nil
+	})
+
+	waiterErrCh := make(chan error, 1)
+	go func() {
+		_, err := client.GetTask(context.Background(), &v1.BatonServiceGetTaskRequest{})
+		waiterErrCh <- err
+	}()
+
+	start := time.Now()
+	if err := client.TeardownServiceClient(); err != nil {
+		t.Fatal(err)
+	}
+	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+		t.Fatalf("Close waited for in-progress dial: %s", elapsed)
+	}
+
+	select {
+	case err := <-waiterErrCh:
+		if err == nil || !strings.Contains(err.Error(), "closed") {
+			t.Fatalf("expected waiting RPC to see closed client, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("waiting RPC did not exit after Close")
+	}
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("expected in-progress dial to return an error after Close")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("in-progress dial did not exit after Close")
+	}
+	cancel()
+}
+
+func TestC1ServiceClientConcurrentRPCsShareConnection(t *testing.T) {
+	bc := newBenchmarkServiceClient(t, 0, &benchmarkBatonService{getTaskLatency: 10 * time.Millisecond})
+	bc.client.idleCloseThreshold = time.Hour
+
+	ctx := context.Background()
+	const concurrency = 12
+	var wg sync.WaitGroup
+	errCh := make(chan error, concurrency)
+	wg.Add(concurrency)
+	for range concurrency {
+		go func() {
+			defer wg.Done()
+			_, err := bc.client.GetTask(ctx, &v1.BatonServiceGetTaskRequest{})
+			errCh <- err
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if got := bc.dialCount.Load(); got != 1 {
+		t.Fatalf("expected concurrent RPCs to share one connection, got %d dials", got)
+	}
+	bc.client.mtx.Lock()
+	inFlight := 0
+	if bc.client.active != nil {
+		inFlight = bc.client.active.inFlight
+	}
+	bc.client.mtx.Unlock()
+	if inFlight != 0 {
+		t.Fatalf("expected no in-flight RPCs after concurrency test, got %d", inFlight)
+	}
+}
+
+type unavailableOnceService struct {
+	v1.UnimplementedBatonServiceServer
+	calls atomic.Int64
+}
+
+func (s *unavailableOnceService) GetTask(context.Context, *v1.BatonServiceGetTaskRequest) (*v1.BatonServiceGetTaskResponse, error) {
+	if s.calls.Add(1) == 1 {
+		return nil, status.Error(codes.Unavailable, "synthetic unavailable")
+	}
+	return v1.BatonServiceGetTaskResponse_builder{}.Build(), nil
+}
+
+func waitForCondition(t *testing.T, timeout time.Duration, f func() bool) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if f() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("condition was not met before timeout")
+}
+
+func requireActiveHandle(t *testing.T, client *c1ServiceClient) *c1ServiceConn {
+	t.Helper()
+
+	client.mtx.Lock()
+	defer client.mtx.Unlock()
+	if client.active == nil {
+		t.Fatal("expected cached connection")
+	}
+	return client.active
+}
+
+func requireActiveConn(t *testing.T, client *c1ServiceClient) *grpc.ClientConn {
+	t.Helper()
+
+	handle := requireActiveHandle(t, client)
+	if handle.cc == nil {
+		t.Fatal("expected cached connection")
+	}
+	return handle.cc
+}


### PR DESCRIPTION
## Summary

This PR improves service-mode task throughput by reusing the upstream C1 API gRPC connection instead of dialing once per RPC.

- Adds a cached `grpc.ClientConn` for C1 API calls with in-flight tracking, stale-transport reset handling, idle close behavior, and explicit close support.
- Closes idle C1 API connections when `next_poll` indicates the connector will be quiet, so idle on-prem connectors do not hold long-lived server connections.
- Preserves conservative task semantics: `GetTask` and `FinishTask` reset stale connections but do not retry, avoiding double-claim or double-finish risk.
- Adds benchmarks and safety-focused tests covering reuse, idle close, failed dials, close during dial, stale transports, and concurrent RPCs.

## Performance

Calibrated action benchmark, modeled from the observed ~10Hz customer baseline:

- Before: `9.836 actions/s`, `2.000 dials/action`
- After: `14.51 actions/s`, `0.03333 dials/action`

This is about a `1.47x` throughput improvement in the modeled regime.

## Safety Notes

- The exported `BatonServiceClient` interface remains compatible; close/idle behavior uses optional type assertions.
- `GetTask` and `FinishTask` intentionally do not retry after transport errors to avoid duplicate task claim/finish semantics.
- Stale connections are retired for future use but not closed underneath other in-flight RPCs.
- Runner shutdown now gives in-flight tasks a bounded opportunity to finish before closing the shared C1 API client.

## Test Plan

- `go test ./pkg/tasks/c1api`
- `go test -race ./pkg/tasks/c1api`
- `go vet ./pkg/tasks/c1api ./pkg/connectorrunner`
- `go test ./pkg/tasks/... ./pkg/connectorrunner`
- `go test ./...`
- `go test ./pkg/tasks/c1api -run '^$' -bench '^BenchmarkServiceClientActionSequenceObservedBaseline$' -benchtime=30x`