### PR TITLE
[OPS-1303] Use baton-ci app token in update-hardcoded-version workflow

### DIFF
--- a/.github/workflows/update-hardcoded-version.yaml
+++ b/.github/workflows/update-hardcoded-version.yaml
@@ -8,10 +8,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Mint baton-ci app token
+        id: ci-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.BATON_CI_CLIENT_ID }}
+          private-key: ${{ secrets.BATON_CI_SECRET_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
       - name: Checkout code
         uses: actions/checkout@v5
         with:
-          token: ${{ secrets.RELENG_GITHUB_TOKEN }}
+          token: ${{ steps.ci-token.outputs.token }}
           fetch-depth: 0
           fetch-tags: true
 


### PR DESCRIPTION
## Why

The `update-hardcoded-version.yaml` workflow uses `RELENG_GITHUB_TOKEN` to push the regenerated `pkg/sdk/version.go` back to `main` after every release. With the Connector Rules ruleset in place, that PAT path only continues to work because of the temporary org-admin mitigation.

## What

Mint a short-lived `baton-ci` app token scoped to the current repo and use it for `actions/checkout`. Credentials propagate to git, so the subsequent `EndBug/add-and-commit` push automatically runs as `baton-ci[bot]` and clears the ruleset bypass.

## Test plan

- [ ] After merge, cut a baton-sdk release and verify the auto-commit lands on main with `baton-ci[bot]` as the author.

Linear: [OPS-1303](https://linear.app/ductone/issue/OPS-1303)

🤖 Generated with [Claude Code](https://claude.com/claude-code)