### PR TITLE
Add reusable file upload decode helper

### DIFF
--- a/pkg/field/decode_hooks.go
+++ b/pkg/field/decode_hooks.go
@@ -11,7 +11,10 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-const defaultFileUploadMaxFileSize = 2 * 1024 * 1024
+const (
+	defaultFileUploadMaxFileSize    = 2 * 1024 * 1024
+	defaultFileUploadMaxDecodedSize = defaultFileUploadMaxFileSize
+)
 
 type DecodeHookOption func(*decodeHookConfig)
 
@@ -62,7 +65,8 @@ type fileUploadDecodeConfig struct {
 
 func defaultFileUploadDecodeConfig() *fileUploadDecodeConfig {
 	return &fileUploadDecodeConfig{
-		maxFileSize: defaultFileUploadMaxFileSize,
+		maxDecodedSize: defaultFileUploadMaxDecodedSize,
+		maxFileSize:    defaultFileUploadMaxFileSize,
 	}
 }
 
@@ -76,8 +80,10 @@ func WithFileUploadMaxDecodedSize(maxBytes int64) FileUploadDecodeOption {
 
 // DecodeFileUploadValue decodes a single file upload value using the selected mode.
 // Content-only mode supports JSON base64 data URLs, raw base64 content, and raw
-// unencoded content. Path-only mode reads the named file and never falls back to
-// content decoding.
+// unencoded content, in that order. A raw string that is also valid base64 will
+// decode as base64. Path-only mode reads the named file and never falls back to
+// content decoding. Callers that accept paths from untrusted input must validate
+// allowed paths before calling DecodeFileUploadValue.
 func DecodeFileUploadValue(value string, mode FileUploadDecodeMode, opts ...FileUploadDecodeOption) ([]byte, error) {
 	config := defaultFileUploadDecodeConfig()
 	for _, opt := range opts {
@@ -118,7 +124,7 @@ func FileUploadDecodeHook(readFromPath bool) mapstructure.DecodeHookFunc {
 			return DecodeFileUploadValue(str, FileUploadDecodeModePathOnly)
 		}
 
-		return DecodeFileUploadValue(str, FileUploadDecodeModeContentOnly)
+		return DecodeFileUploadValue(str, FileUploadDecodeModeContentOnly, WithFileUploadMaxDecodedSize(0))
 	}
 }
 
@@ -135,7 +141,7 @@ func getFileContentFromPath(path string, maxFileSize int64) ([]byte, error) {
 		return nil, fmt.Errorf("cannot access file: %w", err)
 	}
 
-	// Check file size limit (2MB)
+	// Check file size limit.
 	if maxFileSize > 0 && fileInfo.Size() > maxFileSize {
 		return nil, fmt.Errorf("file too large: %d bytes exceeds limit of %d bytes", fileInfo.Size(), maxFileSize)
 	}
@@ -157,32 +163,60 @@ func parseFileContent(data string, config *fileUploadDecodeConfig) ([]byte, erro
 
 	// Check if it's a data URL first
 	if strings.HasPrefix(data, "data:") {
-		decoded, err := parseJSONBase64DataURL(data)
-		return applyMaxDecodedSize(decoded, err, config.maxDecodedSize)
+		decoded, err := parseJSONBase64DataURL(data, config.maxDecodedSize)
+		if err != nil {
+			return nil, err
+		}
+		return checkAndReturnDecodedContent(decoded, config.maxDecodedSize)
 	}
 
 	// Check if it's a base64 encoded string
+	if err := checkBase64DecodedSize(data, config.maxDecodedSize); err != nil {
+		return nil, err
+	}
 	if decoded, err := base64.StdEncoding.DecodeString(data); err == nil {
-		return applyMaxDecodedSize(decoded, nil, config.maxDecodedSize)
+		return checkAndReturnDecodedContent(decoded, config.maxDecodedSize)
 	}
 
 	// Return the content as-is
-	return applyMaxDecodedSize([]byte(data), nil, config.maxDecodedSize)
+	return checkAndReturnDecodedContent([]byte(data), config.maxDecodedSize)
 }
 
-func applyMaxDecodedSize(data []byte, err error, maxDecodedSize int64) ([]byte, error) {
-	if err != nil {
+func checkAndReturnDecodedContent(data []byte, maxDecodedSize int64) ([]byte, error) {
+	if err := checkMaxDecodedSize(int64(len(data)), maxDecodedSize); err != nil {
 		return nil, err
-	}
-	if maxDecodedSize > 0 && int64(len(data)) > maxDecodedSize {
-		return nil, fmt.Errorf("decoded file upload content too large: %d bytes exceeds limit of %d bytes", len(data), maxDecodedSize)
 	}
 	return data, nil
 }
 
+func checkMaxDecodedSize(size int64, maxDecodedSize int64) error {
+	if maxDecodedSize > 0 && size > maxDecodedSize {
+		return fmt.Errorf("decoded file upload content too large: %d bytes exceeds limit of %d bytes", size, maxDecodedSize)
+	}
+	return nil
+}
+
+func checkBase64DecodedSize(data string, maxDecodedSize int64) error {
+	if maxDecodedSize <= 0 {
+		return nil
+	}
+
+	decodedSize := base64.StdEncoding.DecodedLen(len(data))
+	switch {
+	case strings.HasSuffix(data, "=="):
+		decodedSize -= 2
+	case strings.HasSuffix(data, "="):
+		decodedSize--
+	}
+	if decodedSize < 0 {
+		decodedSize = 0
+	}
+	return checkMaxDecodedSize(int64(decodedSize), maxDecodedSize)
+}
+
 // parseJSONBase64DataURL parses a data URL and returns the decoded content.
 // Errors if the data is not MIME type application/json and base64 encoded.
-func parseJSONBase64DataURL(dataURL string) ([]byte, error) {
+func parseJSONBase64DataURL(dataURL string, maxDecodedSize int64) ([]byte, error) {
 	parsedURL, err := url.Parse(dataURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid data URL: %w", err)
@@ -208,6 +242,9 @@ func parseJSONBase64DataURL(dataURL string) ([]byte, error) {
 		return nil, fmt.Errorf("expected MIME type application/json, got: %s", mediaType)
 	}
 
+	if err := checkBase64DecodedSize(data, maxDecodedSize); err != nil {
+		return nil, err
+	}
 	decoded, err := base64.StdEncoding.DecodeString(data)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode base64 data: %w", err)

--- a/pkg/field/decode_hooks.go
+++ b/pkg/field/decode_hooks.go
@@ -11,6 +11,8 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
+const defaultFileUploadMaxFileSize = 2 * 1024 * 1024
+
 type DecodeHookOption func(*decodeHookConfig)
 
 type decodeHookConfig struct {
@@ -39,6 +41,61 @@ func WithAdditionalDecodeHooks(funcs ...mapstructure.DecodeHookFunc) DecodeHookO
 	}
 }
 
+// FileUploadDecodeMode controls how DecodeFileUploadValue interprets the value.
+type FileUploadDecodeMode int
+
+const (
+	fileUploadDecodeModeUnspecified FileUploadDecodeMode = iota
+	// FileUploadDecodeModeContentOnly decodes the value as file content.
+	FileUploadDecodeModeContentOnly
+	// FileUploadDecodeModePathOnly reads the value as a filesystem path.
+	FileUploadDecodeModePathOnly
+)
+
+// FileUploadDecodeOption configures DecodeFileUploadValue.
+type FileUploadDecodeOption func(*fileUploadDecodeConfig)
+
+type fileUploadDecodeConfig struct {
+	maxDecodedSize int64
+	maxFileSize    int64
+}
+
+func defaultFileUploadDecodeConfig() *fileUploadDecodeConfig {
+	return &fileUploadDecodeConfig{
+		maxFileSize: defaultFileUploadMaxFileSize,
+	}
+}
+
+// WithFileUploadMaxDecodedSize limits decoded content bytes in content-only mode.
+// Values less than or equal to zero disable the limit.
+func WithFileUploadMaxDecodedSize(maxBytes int64) FileUploadDecodeOption {
+	return func(c *fileUploadDecodeConfig) {
+		c.maxDecodedSize = maxBytes
+	}
+}
+
+// DecodeFileUploadValue decodes a single file upload value using the selected mode.
+// Content-only mode supports JSON base64 data URLs, raw base64 content, and raw
+// unencoded content. Path-only mode reads the named file and never falls back to
+// content decoding.
+func DecodeFileUploadValue(value string, mode FileUploadDecodeMode, opts ...FileUploadDecodeOption) ([]byte, error) {
+	config := defaultFileUploadDecodeConfig()
+	for _, opt := range opts {
+		if opt != nil {
+			opt(config)
+		}
+	}
+
+	switch mode {
+	case FileUploadDecodeModeContentOnly:
+		return parseFileContent(value, config)
+	case FileUploadDecodeModePathOnly:
+		return getFileContentFromPath(value, config.maxFileSize)
+	default:
+		return nil, fmt.Errorf("unsupported file upload decode mode: %d", mode)
+	}
+}
+
 // FileUploadDecodeHook returns a mapstructure.DecodeHookFunc that automatically
 // converts string values to []byte for file upload fields, supporting:
 // 1. File paths (reads file content)
@@ -58,15 +115,15 @@ func FileUploadDecodeHook(readFromPath bool) mapstructure.DecodeHookFunc {
 		}
 
 		if readFromPath {
-			return getFileContentFromPath(str)
+			return DecodeFileUploadValue(str, FileUploadDecodeModePathOnly)
 		}
 
-		return parseFileContent(str)
+		return DecodeFileUploadValue(str, FileUploadDecodeModeContentOnly)
 	}
 }
 
 // getFileContentFromPath returns the file content from a path.
-func getFileContentFromPath(path string) ([]byte, error) {
+func getFileContentFromPath(path string, maxFileSize int64) ([]byte, error) {
 	if path == "" {
 		// don't error if the path is empty, leave that to the field validation rules
 		return []byte{}, nil
@@ -79,8 +136,7 @@ func getFileContentFromPath(path string) ([]byte, error) {
 	}
 
 	// Check file size limit (2MB)
-	maxFileSize := 2 * 1024 * 1024
-	if fileInfo.Size() > int64(maxFileSize) {
+	if maxFileSize > 0 && fileInfo.Size() > maxFileSize {
 		return nil, fmt.Errorf("file too large: %d bytes exceeds limit of %d bytes", fileInfo.Size(), maxFileSize)
 	}
 
@@ -93,7 +149,7 @@ func getFileContentFromPath(path string) ([]byte, error) {
 }
 
 // parseFileContent returns the file upload content from a string field value.
-func parseFileContent(data string) ([]byte, error) {
+func parseFileContent(data string, config *fileUploadDecodeConfig) ([]byte, error) {
 	if data == "" {
 		// don't error if the data is empty, leave that to the field validation rules
 		return []byte{}, nil
@@ -101,16 +157,27 @@ func parseFileContent(data string) ([]byte, error) {
 
 	// Check if it's a data URL first
 	if strings.HasPrefix(data, "data:") {
-		return parseJSONBase64DataURL(data)
+		decoded, err := parseJSONBase64DataURL(data)
+		return applyMaxDecodedSize(decoded, err, config.maxDecodedSize)
 	}
 
 	// Check if it's a base64 encoded string
 	if decoded, err := base64.StdEncoding.DecodeString(data); err == nil {
-		return decoded, nil
+		return applyMaxDecodedSize(decoded, nil, config.maxDecodedSize)
 	}
 
 	// Return the content as-is
-	return []byte(data), nil
+	return applyMaxDecodedSize([]byte(data), nil, config.maxDecodedSize)
+}
+
+func applyMaxDecodedSize(data []byte, err error, maxDecodedSize int64) ([]byte, error) {
+	if err != nil {
+		return nil, err
+	}
+	if maxDecodedSize > 0 && int64(len(data)) > maxDecodedSize {
+		return nil, fmt.Errorf("decoded file upload content too large: %d bytes exceeds limit of %d bytes", len(data), maxDecodedSize)
+	}
+	return data, nil
 }
 
 // parseJSONBase64DataURL parses a data URL and returns the decoded content.

--- a/pkg/field/decode_hooks_test.go
+++ b/pkg/field/decode_hooks_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/mitchellh/mapstructure"
@@ -223,6 +224,12 @@ func TestDecodeFileUploadValue(t *testing.T) {
 			expected: []byte(`{"key": "value"}`),
 		},
 		{
+			name:     "content-only accepts empty string",
+			value:    "",
+			mode:     FileUploadDecodeModeContentOnly,
+			expected: []byte{},
+		},
+		{
 			name:        "content-only rejects non-JSON data URL",
 			value:       "data:text/plain;base64," + base64.StdEncoding.EncodeToString([]byte("encoded content")),
 			mode:        FileUploadDecodeModeContentOnly,
@@ -234,6 +241,13 @@ func TestDecodeFileUploadValue(t *testing.T) {
 			mode:        FileUploadDecodeModeContentOnly,
 			opts:        []FileUploadDecodeOption{WithFileUploadMaxDecodedSize(4)},
 			expectError: true,
+		},
+		{
+			name:     "content-only ignores nil options",
+			value:    "content",
+			mode:     FileUploadDecodeModeContentOnly,
+			opts:     []FileUploadDecodeOption{nil},
+			expected: []byte("content"),
 		},
 		{
 			name:        "unspecified mode returns error",
@@ -254,6 +268,54 @@ func TestDecodeFileUploadValue(t *testing.T) {
 			require.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestDecodeFileUploadValueSizeLimits(t *testing.T) {
+	largeContent := strings.Repeat("!", int(defaultFileUploadMaxDecodedSize)+1)
+
+	_, err := DecodeFileUploadValue(largeContent, FileUploadDecodeModeContentOnly)
+	require.Error(t, err)
+
+	result, err := DecodeFileUploadValue(largeContent, FileUploadDecodeModeContentOnly, WithFileUploadMaxDecodedSize(0))
+	require.NoError(t, err)
+	require.Len(t, result, len(largeContent))
+
+	result, err = DecodeFileUploadValue(largeContent, FileUploadDecodeModeContentOnly, WithFileUploadMaxDecodedSize(-1))
+	require.NoError(t, err)
+	require.Len(t, result, len(largeContent))
+
+	encoded := base64.StdEncoding.EncodeToString([]byte(largeContent))
+	_, err = DecodeFileUploadValue(encoded, FileUploadDecodeModeContentOnly)
+	require.Error(t, err)
+
+	dataURL := "data:application/json;base64," + encoded
+	_, err = DecodeFileUploadValue(dataURL, FileUploadDecodeModeContentOnly)
+	require.Error(t, err)
+}
+
+func TestFileUploadDecodeHookContentModePreservesLegacySizeBehavior(t *testing.T) {
+	largeContent := strings.Repeat("!", int(defaultFileUploadMaxDecodedSize)+1)
+
+	result, err := mapstructure.DecodeHookExec(
+		FileUploadDecodeHook(false),
+		reflect.ValueOf(largeContent),
+		reflect.ValueOf([]byte{}),
+	)
+
+	require.NoError(t, err)
+	require.Len(t, result, len(largeContent))
+}
+
+func TestDecodeFileUploadValuePathSizeLimit(t *testing.T) {
+	tempDir := t.TempDir()
+	largeFilePath := filepath.Join(tempDir, "large.txt")
+	largeFileContent := []byte(strings.Repeat("!", int(defaultFileUploadMaxFileSize)+1))
+
+	err := os.WriteFile(largeFilePath, largeFileContent, 0600)
+	require.NoError(t, err)
+
+	_, err = DecodeFileUploadValue(largeFilePath, FileUploadDecodeModePathOnly)
+	require.Error(t, err)
 }
 
 func TestStringToSliceHookFunc(t *testing.T) {

--- a/pkg/field/decode_hooks_test.go
+++ b/pkg/field/decode_hooks_test.go
@@ -176,6 +176,86 @@ func TestFileUploadDecodeHook(t *testing.T) {
 	}
 }
 
+func TestDecodeFileUploadValue(t *testing.T) {
+	tempDir := t.TempDir()
+	tempFilePath := filepath.Join(tempDir, "test.txt")
+	tempFileContent := []byte("test file content")
+
+	err := os.WriteFile(tempFilePath, tempFileContent, 0600)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		value       string
+		mode        FileUploadDecodeMode
+		opts        []FileUploadDecodeOption
+		expected    []byte
+		expectError bool
+	}{
+		{
+			name:     "path-only reads file",
+			value:    tempFilePath,
+			mode:     FileUploadDecodeModePathOnly,
+			expected: tempFileContent,
+		},
+		{
+			name:        "path-only rejects missing file",
+			value:       filepath.Join(tempDir, "missing.txt"),
+			mode:        FileUploadDecodeModePathOnly,
+			expectError: true,
+		},
+		{
+			name:     "content-only keeps path string as content",
+			value:    tempFilePath,
+			mode:     FileUploadDecodeModeContentOnly,
+			expected: []byte(tempFilePath),
+		},
+		{
+			name:     "content-only decodes base64",
+			value:    base64.StdEncoding.EncodeToString([]byte("encoded content")),
+			mode:     FileUploadDecodeModeContentOnly,
+			expected: []byte("encoded content"),
+		},
+		{
+			name:     "content-only decodes JSON data URL",
+			value:    "data:application/json;base64," + base64.StdEncoding.EncodeToString([]byte(`{"key": "value"}`)),
+			mode:     FileUploadDecodeModeContentOnly,
+			expected: []byte(`{"key": "value"}`),
+		},
+		{
+			name:        "content-only rejects non-JSON data URL",
+			value:       "data:text/plain;base64," + base64.StdEncoding.EncodeToString([]byte("encoded content")),
+			mode:        FileUploadDecodeModeContentOnly,
+			expectError: true,
+		},
+		{
+			name:        "content-only enforces decoded size option",
+			value:       base64.StdEncoding.EncodeToString([]byte("12345")),
+			mode:        FileUploadDecodeModeContentOnly,
+			opts:        []FileUploadDecodeOption{WithFileUploadMaxDecodedSize(4)},
+			expectError: true,
+		},
+		{
+			name:        "unspecified mode returns error",
+			value:       "content",
+			mode:        fileUploadDecodeModeUnspecified,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := DecodeFileUploadValue(tt.value, tt.mode, tt.opts...)
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func TestStringToSliceHookFunc(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
Why

Callers outside mapstructure need the SDK's file-upload decode behavior without duplicating base64 and data URL parsing. The helper uses explicit modes so path reads are opt-in rather than inferred from arbitrary strings.

What this changes

Adds DecodeFileUploadValue with content-only and path-only modes, plus an optional decoded-size limit for content mode.
Reuses the helper from FileUploadDecodeHook to keep existing hook behavior.
Keeps data URL handling limited to application/json base64 and adds focused tests.

Validation

go test -tags=baton_lambda_support -v ./pkg/field
go vet -tags=baton_lambda_support ./pkg/field
golangci-lint run --timeout=3m ./pkg/field (blocked locally: no go files to analyze before linting)