### PR TITLE
fix(uotel): guard against nil system cert pool in getTLSConfig

### DIFF
--- a/pkg/uotel/config.go
+++ b/pkg/uotel/config.go
@@ -335,7 +335,7 @@ func getTLSConfig(tlsCertPath, tlsCert string) (*tls.Config, error) {
 	if tlsCertPath == "" && tlsCert == "" {
 		zap.L().Debug("otel: no certificate provided, using system certificate pool")
 		systemPool, err := x509.SystemCertPool()
-		if err != nil {
+		if err != nil || systemPool == nil {
 			return nil, fmt.Errorf("failed to load system certificate pool: %w", err)
 		}
 		return &tls.Config{


### PR DESCRIPTION
## Summary

- `getTLSConfig` in `pkg/uotel/config.go` only checked the error return from `x509.SystemCertPool()`. That call can return `(nil, nil)`, in which case the function would return a `*tls.Config` with `RootCAs: nil`.
- Two other call sites in this repo already guard against the nil pool case: `pkg/session/session_client.go:100` and `pkg/lambda/grpc/config/config.go:127`. This change matches that convention so an unexpected nil pool surfaces as the explicit error rather than being swallowed.

## Test plan

- [ ] CI builds and tests pass