### PR TITLE
feat(sync): emit OTel metrics for grant-expansion progress (CE-702)

### DIFF
--- a/pkg/sync/progresslog/progresslog.go
+++ b/pkg/sync/progresslog/progresslog.go
@@ -6,12 +6,22 @@ import (
 	"time"
 
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/metrics"
 	"github.com/conductorone/baton-sdk/pkg/sync/expand"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
 )
 
 const defaultMaxLogFrequency = 10 * time.Second
+
+// Metric names emitted by LogExpandProgress. Stable identifiers — operators
+// build dashboards on these, so renames are breaking changes.
+const (
+	metricActionsRemaining       = "baton.sync.expand.actions_remaining"
+	metricActionsBurnedTotal     = "baton.sync.expand.actions_burned"
+	metricDecompressedBytes      = "baton.sync.expand.decompressed_bytes"
+	metricDecompressedBytesDelta = "baton.sync.expand.decompressed_bytes_growth"
+)
 
 type rwMutex interface {
 	Lock()
@@ -54,6 +64,20 @@ type ProgressLog struct {
 	dbSize           connectorstore.DBSizeProvider
 	lastLoggedDBSize int64
 	hasLoggedDBSize  bool // false until the first successful size read; gates the delta field
+
+	// Optional OTel metrics handler. Mirrors the fields emitted by
+	// LogExpandProgress so operators don't have to back trends out of log
+	// timestamps. Initialized once in NewProgressCounts (default no-op);
+	// callers wire a real handler via WithMetricsHandler. The expand metrics
+	// are looked up lazily on first emission so the no-op path costs nothing
+	// when expand never runs (e.g. resource-only syncs).
+	metricsHandler         metrics.Handler
+	metricsExpandRemaining metrics.Int64Gauge
+	metricsExpandBurned    metrics.Int64Counter
+	metricsExpandDBSize    metrics.Int64Gauge
+	metricsExpandDBGrowth  metrics.Int64Counter
+	lastEmittedRemaining   int64
+	hasEmittedRemaining    bool // gates the burned-counter delta on the first sample
 }
 
 type Option func(*ProgressLog)
@@ -109,6 +133,22 @@ func WithDBSizeProvider(p connectorstore.DBSizeProvider) Option {
 	}
 }
 
+// WithMetricsHandler attaches an optional metrics.Handler. When set,
+// LogExpandProgress emits gauges/counters mirroring the structured log fields
+// (actions_remaining, actions_burned, decompressed_bytes, decompressed_bytes_growth)
+// so operators can build dashboards instead of scraping log timestamps.
+//
+// The handler should be pre-tagged by the caller (e.g. via Handler.WithTags
+// for connector_id / tenant_id) so emitted metrics carry the dimensions
+// operators want to slice by. nil is treated as "no metrics" (default).
+func WithMetricsHandler(h metrics.Handler) Option {
+	return func(p *ProgressLog) {
+		if h != nil {
+			p.metricsHandler = h
+		}
+	}
+}
+
 // SetDBSizeProvider updates the DBSizeProvider attached to this ProgressLog.
 // Intended for callers (notably the syncer) that construct the ProgressLog
 // before the store is known (e.g. WithC1ZPath path, where the store is
@@ -131,10 +171,34 @@ func NewProgressCounts(ctx context.Context, opts ...Option) *ProgressLog {
 		l:                    ctxzap.Extract(ctx),
 		maxLogFrequency:      defaultMaxLogFrequency,
 		mu:                   &noOpMutex{}, // Default to sequential mode for backward compatibility
+		metricsHandler:       metrics.NewNoOpHandler(ctx),
 	}
 	for _, o := range opts {
 		o(p)
 	}
+	// Resolve metric instruments after options apply. Counters/gauges are
+	// idempotent within a Handler (otelHandler caches by name), so re-resolving
+	// here is safe even if the no-op handler was replaced via WithMetricsHandler.
+	p.metricsExpandRemaining = p.metricsHandler.Int64Gauge(
+		metricActionsRemaining,
+		"Current entitlement-graph actions queued for grant expansion",
+		metrics.Dimensionless,
+	)
+	p.metricsExpandBurned = p.metricsHandler.Int64Counter(
+		metricActionsBurnedTotal,
+		"Entitlement-graph actions completed since the previous LogExpandProgress emission",
+		metrics.Dimensionless,
+	)
+	p.metricsExpandDBSize = p.metricsHandler.Int64Gauge(
+		metricDecompressedBytes,
+		"Live uncompressed c1z file size during grant expansion",
+		metrics.Bytes,
+	)
+	p.metricsExpandDBGrowth = p.metricsHandler.Int64Counter(
+		metricDecompressedBytesDelta,
+		"Uncompressed c1z growth since the previous LogExpandProgress emission",
+		metrics.Bytes,
+	)
 	return p
 }
 
@@ -288,17 +352,42 @@ func (p *ProgressLog) LogExpandProgress(ctx context.Context, actions []*expand.E
 	}
 	p.lastActionLog = time.Now()
 
-	fields := []zap.Field{zap.Int("actions_remaining", len(actions))}
+	remaining := int64(len(actions))
+	fields := []zap.Field{zap.Int64("actions_remaining", remaining)}
+
+	// Mirror the actions_remaining gauge to OTel and emit a delta counter so
+	// rate(actions_burned) over a window answers "is this connector still
+	// burning through actions?" without an operator having to scrape log
+	// timestamps. Skip the burned delta on the first sample for the same
+	// reason we skip decompressed_bytes_delta below.
+	p.metricsExpandRemaining.Observe(ctx, remaining, nil)
+	if p.hasEmittedRemaining {
+		// "Burned" is positive when the queue shrank between samples. New
+		// actions appended during this step (e.g. depth++ enqueueing the next
+		// layer) make the queue grow — count those as zero rather than
+		// negative so the counter stays monotonic. Operators interpreting
+		// rate() on a counter that goes backwards is the bigger surprise.
+		if delta := p.lastEmittedRemaining - remaining; delta > 0 {
+			p.metricsExpandBurned.Add(ctx, delta, nil)
+		}
+	}
+	p.lastEmittedRemaining = remaining
+	p.hasEmittedRemaining = true
 
 	if p.dbSize != nil {
 		if sz, err := p.dbSize.CurrentDBSizeBytes(); err == nil {
 			fields = append(fields, zap.Int64("decompressed_bytes", sz))
+			p.metricsExpandDBSize.Observe(ctx, sz, nil)
 			// Omit the delta on the very first sample — it would equal the
 			// full size and create a spurious spike in any Datadog graph of
 			// growth rate. Subsequent samples compute delta relative to the
 			// previous emitted size, which is the real signal operators want.
 			if p.hasLoggedDBSize {
-				fields = append(fields, zap.Int64("decompressed_bytes_delta", sz-p.lastLoggedDBSize))
+				delta := sz - p.lastLoggedDBSize
+				fields = append(fields, zap.Int64("decompressed_bytes_delta", delta))
+				if delta > 0 {
+					p.metricsExpandDBGrowth.Add(ctx, delta, nil)
+				}
 			}
 			p.lastLoggedDBSize = sz
 			p.hasLoggedDBSize = true

--- a/pkg/sync/progresslog/progresslog.go
+++ b/pkg/sync/progresslog/progresslog.go
@@ -14,13 +14,21 @@ import (
 
 const defaultMaxLogFrequency = 10 * time.Second
 
-// Metric names emitted by LogExpandProgress. Stable identifiers — operators
-// build dashboards on these, so renames are breaking changes.
+// Metric names emitted by LogExpandProgress. The string values are the
+// stable external contract — operators build Datadog dashboards and alert
+// rules on these names, so renames are breaking changes. The Go-level
+// constants are unexported because callers don't need them; the metric
+// names are discovered out-of-band from documentation / dashboards.
+//
+// Counter names mirror the structured-log field names emitted next to
+// each value (`actions_remaining`, `decompressed_bytes`,
+// `decompressed_bytes_delta`) so an operator who sees a field in a log
+// entry can derive the metric name by mechanical substitution.
 const (
 	metricActionsRemaining       = "baton.sync.expand.actions_remaining"
 	metricActionsBurnedTotal     = "baton.sync.expand.actions_burned"
 	metricDecompressedBytes      = "baton.sync.expand.decompressed_bytes"
-	metricDecompressedBytesDelta = "baton.sync.expand.decompressed_bytes_growth"
+	metricDecompressedBytesDelta = "baton.sync.expand.decompressed_bytes_delta"
 )
 
 type rwMutex interface {
@@ -186,7 +194,7 @@ func NewProgressCounts(ctx context.Context, opts ...Option) *ProgressLog {
 	)
 	p.metricsExpandBurned = p.metricsHandler.Int64Counter(
 		metricActionsBurnedTotal,
-		"Entitlement-graph actions completed since the previous LogExpandProgress emission",
+		"Total entitlement-graph actions completed during grant expansion (cumulative; use rate() for throughput)",
 		metrics.Dimensionless,
 	)
 	p.metricsExpandDBSize = p.metricsHandler.Int64Gauge(
@@ -196,7 +204,7 @@ func NewProgressCounts(ctx context.Context, opts ...Option) *ProgressLog {
 	)
 	p.metricsExpandDBGrowth = p.metricsHandler.Int64Counter(
 		metricDecompressedBytesDelta,
-		"Uncompressed c1z growth since the previous LogExpandProgress emission",
+		"Cumulative uncompressed c1z growth during grant expansion (use rate() for growth rate)",
 		metrics.Bytes,
 	)
 	return p

--- a/pkg/sync/progresslog/progresslog_test.go
+++ b/pkg/sync/progresslog/progresslog_test.go
@@ -12,8 +12,93 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
+	"github.com/conductorone/baton-sdk/pkg/metrics"
 	"github.com/conductorone/baton-sdk/pkg/sync/expand"
 )
+
+// fakeCounter / fakeGauge / fakeHandler capture metric emissions in-memory so
+// tests can assert on values without standing up an OTel pipeline. Mirrors the
+// shape of pkg/metrics.NoOpHandler with a recording side.
+type fakeCounter struct {
+	mu     sync.Mutex
+	values []int64
+}
+
+func (c *fakeCounter) Add(_ context.Context, value int64, _ map[string]string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.values = append(c.values, value)
+}
+
+func (c *fakeCounter) sum() int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var s int64
+	for _, v := range c.values {
+		s += v
+	}
+	return s
+}
+
+type fakeGauge struct {
+	mu     sync.Mutex
+	values []int64
+}
+
+func (g *fakeGauge) Observe(_ context.Context, value int64, _ map[string]string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.values = append(g.values, value)
+}
+
+func (g *fakeGauge) last() (int64, bool) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if len(g.values) == 0 {
+		return 0, false
+	}
+	return g.values[len(g.values)-1], true
+}
+
+type fakeHandler struct {
+	counters map[string]*fakeCounter
+	gauges   map[string]*fakeGauge
+}
+
+func newFakeHandler() *fakeHandler {
+	return &fakeHandler{
+		counters: make(map[string]*fakeCounter),
+		gauges:   make(map[string]*fakeGauge),
+	}
+}
+
+func (h *fakeHandler) Int64Counter(name string, _ string, _ metrics.Unit) metrics.Int64Counter {
+	if c, ok := h.counters[name]; ok {
+		return c
+	}
+	c := &fakeCounter{}
+	h.counters[name] = c
+	return c
+}
+
+func (h *fakeHandler) Int64Gauge(name string, _ string, _ metrics.Unit) metrics.Int64Gauge {
+	if g, ok := h.gauges[name]; ok {
+		return g
+	}
+	g := &fakeGauge{}
+	h.gauges[name] = g
+	return g
+}
+
+func (h *fakeHandler) Int64Histogram(_ string, _ string, _ metrics.Unit) metrics.Int64Histogram {
+	return &noopHistogram{}
+}
+
+func (h *fakeHandler) WithTags(_ map[string]string) metrics.Handler { return h }
+
+type noopHistogram struct{}
+
+func (*noopHistogram) Record(_ context.Context, _ int64, _ map[string]string) {}
 
 // capturingCore is a minimal zapcore.Core that records entries in-memory so
 // tests can assert on fields without depending on zaptest/observer (not vendored).
@@ -225,4 +310,79 @@ func TestLogExpandProgress_PerStepExpanderShape(t *testing.T) {
 	require.Greater(t, delta, int64(0))
 	require.Less(t, delta, size,
 		"delta must be < full size, proving the ProgressLog kept its prior sample")
+}
+
+// TestLogExpandProgress_EmitsMetrics pins the OTel metric emission contract:
+//
+//  1. actions_remaining gauge mirrors the log field on every emission.
+//  2. actions_burned counter accumulates the queue-shrink delta across
+//     emissions, but skips the first sample (no prior to delta against).
+//  3. decompressed_bytes gauge / decompressed_bytes_growth counter fire
+//     whenever the size provider returns a value.
+//  4. Queue growth between samples (e.g. depth++ enqueueing a new layer)
+//     does not produce a negative counter increment — the counter stays
+//     monotonic so rate() queries don't break.
+//
+// Without these invariants, an operator dashboard query like
+// `rate(baton.sync.expand.actions_burned)` would either be unavailable
+// (no metric) or non-monotonic (counter going backwards), neither of
+// which is acceptable for a primary "is this connector still alive?"
+// signal.
+func TestLogExpandProgress_EmitsMetrics(t *testing.T) {
+	ctx, _ := observedLogger(t)
+
+	probe := &sizeProbe{size: 100_000_000}
+	handler := newFakeHandler()
+	p := NewProgressCounts(ctx,
+		WithLogFrequency(10*time.Millisecond),
+		WithDBSizeProvider(probe),
+		WithMetricsHandler(handler),
+	)
+
+	// Sample 1: 5 actions queued. Establishes the baseline gauge value;
+	// burned counter should NOT increment (no prior remaining to delta against).
+	p.LogExpandProgress(ctx, make([]*expand.EntitlementGraphAction, 5))
+	if v, ok := handler.gauges[metricActionsRemaining].last(); !ok || v != 5 {
+		t.Fatalf("actions_remaining gauge expected 5, got %d (ok=%v)", v, ok)
+	}
+	require.Equal(t, int64(0), handler.counters[metricActionsBurnedTotal].sum(),
+		"burned counter must not increment on the first sample")
+
+	// Sample 2 (after window): 3 actions remaining → 2 burned.
+	time.Sleep(15 * time.Millisecond)
+	probe.size = 130_000_000
+	p.LogExpandProgress(ctx, make([]*expand.EntitlementGraphAction, 3))
+	if v, ok := handler.gauges[metricActionsRemaining].last(); !ok || v != 3 {
+		t.Fatalf("actions_remaining gauge expected 3, got %d (ok=%v)", v, ok)
+	}
+	require.EqualValues(t, 2, handler.counters[metricActionsBurnedTotal].sum(),
+		"5 -> 3 transition must increment burned counter by 2")
+	if v, ok := handler.gauges[metricDecompressedBytes].last(); !ok || v != 130_000_000 {
+		t.Fatalf("decompressed_bytes gauge expected 130M, got %d (ok=%v)", v, ok)
+	}
+	require.EqualValues(t, 30_000_000, handler.counters[metricDecompressedBytesDelta].sum(),
+		"100M -> 130M transition must increment growth counter by 30M")
+
+	// Sample 3 (after window): queue GREW from 3 to 7 (depth++ effect).
+	// Burned counter must not move backwards.
+	time.Sleep(15 * time.Millisecond)
+	prevBurned := handler.counters[metricActionsBurnedTotal].sum()
+	p.LogExpandProgress(ctx, make([]*expand.EntitlementGraphAction, 7))
+	require.Equal(t, prevBurned, handler.counters[metricActionsBurnedTotal].sum(),
+		"queue growth must not decrement the monotonic burned counter")
+	if v, ok := handler.gauges[metricActionsRemaining].last(); !ok || v != 7 {
+		t.Fatalf("actions_remaining gauge expected 7, got %d (ok=%v)", v, ok)
+	}
+}
+
+// TestLogExpandProgress_NoMetricsHandlerIsSafe verifies that the default
+// no-op handler path does not panic and does not produce any visible metric
+// activity. Guards against a regression where a future refactor passes a
+// nil handler instead of NoOp and panics on Observe.
+func TestLogExpandProgress_NoMetricsHandlerIsSafe(t *testing.T) {
+	ctx, _ := observedLogger(t)
+	p := NewProgressCounts(ctx, WithLogFrequency(1*time.Millisecond))
+	require.NotPanics(t, func() {
+		p.LogExpandProgress(ctx, []*expand.EntitlementGraphAction{{}, {}})
+	})
 }

--- a/pkg/sync/progresslog/progresslog_test.go
+++ b/pkg/sync/progresslog/progresslog_test.go
@@ -279,27 +279,35 @@ func TestLogExpandProgress_PerStepExpanderShape(t *testing.T) {
 	ctx, logs := observedLogger(t)
 
 	probe := &sizeProbe{size: 1_000_000}
+	// Tight window. We don't actually wait for it to elapse — we backdate
+	// p.lastActionLog between the calls we want to land. This keeps the
+	// test deterministic on coarse-clock CI runners (Windows, busy CI)
+	// where time.Sleep can return early or late by tens of ms.
 	p := NewProgressCounts(ctx,
-		WithLogFrequency(15*time.Millisecond),
+		WithLogFrequency(time.Hour),
 		WithDBSizeProvider(probe),
 	)
 
-	// Simulate ~50 steps across a ~100ms window. 2ms inter-step sleep keeps
-	// the loop well outside sub-ms clock noise on Windows while still
-	// producing enough samples to exercise rate-limiting.
+	// Simulate ~50 steps where most are rate-limited and a handful land.
+	// Land emits at step 0 (lastActionLog is zero on first call) and at
+	// step 25 (we backdate just before that one). Steps 26..49 are
+	// rate-limited by the freshly-set lastActionLog.
 	totalSteps := 50
 	for i := 0; i < totalSteps; i++ {
 		_ = expand.NewExpander(nil, nil) // throwaway, matches per-step construction
 		probe.size += 500_000            // simulate growth between steps
+		if i == 25 {
+			// Force the second emission deterministically.
+			p.expandMu.Lock()
+			p.lastActionLog = time.Time{}
+			p.expandMu.Unlock()
+		}
 		p.LogExpandProgress(ctx, nil)
-		time.Sleep(2 * time.Millisecond)
 	}
 
 	entries := logs.filterMessage("Expanding grants")
-	require.GreaterOrEqual(t, len(entries), 2,
-		"at least two logs must emit across 50 steps in a ~100ms window with 15ms rate-limit")
-	require.Less(t, len(entries), totalSteps,
-		"logs must be rate-limited, not one-per-step")
+	require.Len(t, entries, 2,
+		"backdated lastActionLog must produce exactly two emissions (step 0 and step 25); intermediate calls are rate-limited")
 
 	// Second log's delta must be growth since the first, not full size —
 	// proves state persisted across the simulated per-step calls.
@@ -333,46 +341,65 @@ func TestLogExpandProgress_EmitsMetrics(t *testing.T) {
 
 	probe := &sizeProbe{size: 100_000_000}
 	handler := newFakeHandler()
+	// Tight rate-limit window — we backdate p.lastActionLog between
+	// samples instead of sleeping, so the test is deterministic on
+	// coarse-clock CI runners.
 	p := NewProgressCounts(ctx,
-		WithLogFrequency(10*time.Millisecond),
+		WithLogFrequency(time.Hour),
 		WithDBSizeProvider(probe),
 		WithMetricsHandler(handler),
 	)
 
+	// resetWindow lets the next LogExpandProgress emit by clearing the
+	// rate-limit timestamp. Real production waits through the window;
+	// the test injects the precondition directly.
+	resetWindow := func() {
+		p.expandMu.Lock()
+		p.lastActionLog = time.Time{}
+		p.expandMu.Unlock()
+	}
+
+	gaugeLast := func(t *testing.T, name string) int64 {
+		t.Helper()
+		g := handler.gauges[name]
+		require.NotNil(t, g, "gauge %q must be registered", name)
+		v, ok := g.last()
+		require.True(t, ok, "gauge %q must have at least one observation", name)
+		return v
+	}
+	counterSum := func(t *testing.T, name string) int64 {
+		t.Helper()
+		c := handler.counters[name]
+		require.NotNil(t, c, "counter %q must be registered", name)
+		return c.sum()
+	}
+
 	// Sample 1: 5 actions queued. Establishes the baseline gauge value;
 	// burned counter should NOT increment (no prior remaining to delta against).
 	p.LogExpandProgress(ctx, make([]*expand.EntitlementGraphAction, 5))
-	if v, ok := handler.gauges[metricActionsRemaining].last(); !ok || v != 5 {
-		t.Fatalf("actions_remaining gauge expected 5, got %d (ok=%v)", v, ok)
-	}
-	require.Equal(t, int64(0), handler.counters[metricActionsBurnedTotal].sum(),
+	require.EqualValues(t, 5, gaugeLast(t, metricActionsRemaining))
+	require.EqualValues(t, 0, counterSum(t, metricActionsBurnedTotal),
 		"burned counter must not increment on the first sample")
 
-	// Sample 2 (after window): 3 actions remaining → 2 burned.
-	time.Sleep(15 * time.Millisecond)
+	// Sample 2: 3 actions remaining → 2 burned, c1z grew by 30M.
+	resetWindow()
 	probe.size = 130_000_000
 	p.LogExpandProgress(ctx, make([]*expand.EntitlementGraphAction, 3))
-	if v, ok := handler.gauges[metricActionsRemaining].last(); !ok || v != 3 {
-		t.Fatalf("actions_remaining gauge expected 3, got %d (ok=%v)", v, ok)
-	}
-	require.EqualValues(t, 2, handler.counters[metricActionsBurnedTotal].sum(),
+	require.EqualValues(t, 3, gaugeLast(t, metricActionsRemaining))
+	require.EqualValues(t, 2, counterSum(t, metricActionsBurnedTotal),
 		"5 -> 3 transition must increment burned counter by 2")
-	if v, ok := handler.gauges[metricDecompressedBytes].last(); !ok || v != 130_000_000 {
-		t.Fatalf("decompressed_bytes gauge expected 130M, got %d (ok=%v)", v, ok)
-	}
-	require.EqualValues(t, 30_000_000, handler.counters[metricDecompressedBytesDelta].sum(),
+	require.EqualValues(t, 130_000_000, gaugeLast(t, metricDecompressedBytes))
+	require.EqualValues(t, 30_000_000, counterSum(t, metricDecompressedBytesDelta),
 		"100M -> 130M transition must increment growth counter by 30M")
 
-	// Sample 3 (after window): queue GREW from 3 to 7 (depth++ effect).
-	// Burned counter must not move backwards.
-	time.Sleep(15 * time.Millisecond)
-	prevBurned := handler.counters[metricActionsBurnedTotal].sum()
+	// Sample 3: queue GREW from 3 to 7 (depth++ effect). Burned counter
+	// must not move backwards.
+	resetWindow()
+	prevBurned := counterSum(t, metricActionsBurnedTotal)
 	p.LogExpandProgress(ctx, make([]*expand.EntitlementGraphAction, 7))
-	require.Equal(t, prevBurned, handler.counters[metricActionsBurnedTotal].sum(),
+	require.EqualValues(t, prevBurned, counterSum(t, metricActionsBurnedTotal),
 		"queue growth must not decrement the monotonic burned counter")
-	if v, ok := handler.gauges[metricActionsRemaining].last(); !ok || v != 7 {
-		t.Fatalf("actions_remaining gauge expected 7, got %d (ok=%v)", v, ok)
-	}
+	require.EqualValues(t, 7, gaugeLast(t, metricActionsRemaining))
 }
 
 // TestLogExpandProgress_NoMetricsHandlerIsSafe verifies that the default


### PR DESCRIPTION
## Summary

`LogExpandProgress` already emits structured log fields (`actions_remaining`, `decompressed_bytes`, `decompressed_bytes_delta`) but no metrics. Operators end up scraping log timestamps to answer "is this connector burning through actions or wedged?". A recent prod investigation required scraping log timestamps to confirm a 12-hour grant-expansion was making progress, not stuck.

This PR adds an optional `metrics.Handler` on `ProgressLog` and mirrors the four log fields as OTel instruments so the same answer comes out of a Datadog query in seconds.

## Metrics emitted

| Name | Type | Source field |
|---|---|---|
| \`baton.sync.expand.actions_remaining\` | gauge | \`len(graph.Actions)\` |
| \`baton.sync.expand.actions_burned\` | counter | delta of remaining since previous emission |
| \`baton.sync.expand.decompressed_bytes\` | gauge | \`DBSizeProvider.CurrentDBSizeBytes()\` |
| \`baton.sync.expand.decompressed_bytes_growth\` | counter | delta of size since previous emission |

Counters are monotonic-safe: when the action queue grows between samples (depth++ enqueueing the next layer of expansion), the burned counter is held flat rather than going negative, so \`rate()\` queries on operator dashboards stay meaningful.

## Behavior

- Defaults to \`metrics.NewNoOpHandler\` so callers that don't pass \`WithMetricsHandler\` pay no cost.
- Caller is expected to pre-tag the handler via \`Handler.WithTags\` for \`connector_id\` / \`tenant_id\` so emitted metrics carry the dimensions operators slice by.
- The first sample doesn't emit a burned/growth delta — same reason \`decompressed_bytes_delta\` is omitted on the first log line: a delta against zero is a spurious spike on every dashboard.

## Tests

- \`TestLogExpandProgress_EmitsMetrics\` — pins gauge/counter values across three samples (5 → 3 → 7 actions, 100M → 130M bytes), including the queue-growth case where the burned counter must NOT go backwards.
- \`TestLogExpandProgress_NoMetricsHandlerIsSafe\` — guards against a regression where a future refactor swaps the no-op default for nil and panics on \`Observe\`.
- All existing tests still pass.

## Validation

- \`go test -count=1 ./pkg/sync/progresslog/...\` — green
- \`go vet ./pkg/sync/progresslog/...\` — clean
- \`gofmt -l pkg/sync/progresslog/\` — clean

## Linear

[CE-702](https://linear.app/ductone/issue/CE-702/add-throughput-metric-for-grant-expansion-progress)

## Follow-up

Sibling PR coming next: pre-prune duplicate \`(source, descendant)\` actions in the expander queueing loop ([CE-703](https://linear.app/ductone/issue/CE-703/pre-prune-duplicate-source-descendant-actions-in-grant-expander)). The metric added here will tell us whether that fix is meaningful by counting duplicates over real Entra-Global syncs.
