### PR TITLE
Use Get Tasks

### DIFF
--- a/pb/c1/connectorapi/baton/v1/baton.pb.go
+++ b/pb/c1/connectorapi/baton/v1/baton.pb.go
@@ -1522,6 +1522,226 @@ func (b0 BatonServiceGetTaskRequest_builder) Build() *BatonServiceGetTaskRequest
 	return m0
 }
 
+type BatonServiceGetTasksRequest struct {
+	state         protoimpl.MessageState `protogen:"hybrid.v1"`
+	HostId        string                 `protobuf:"bytes,1,opt,name=host_id,json=hostId,proto3" json:"host_id,omitempty"`
+	PageSize      uint32                 `protobuf:"varint,2,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
+	KnownTaskIds  []string               `protobuf:"bytes,3,rep,name=known_task_ids,json=knownTaskIds,proto3" json:"known_task_ids,omitempty"`
+	Annotations   []*anypb.Any           `protobuf:"bytes,4,rep,name=annotations,proto3" json:"annotations,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BatonServiceGetTasksRequest) Reset() {
+	*x = BatonServiceGetTasksRequest{}
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BatonServiceGetTasksRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BatonServiceGetTasksRequest) ProtoMessage() {}
+
+func (x *BatonServiceGetTasksRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *BatonServiceGetTasksRequest) GetHostId() string {
+	if x != nil {
+		return x.HostId
+	}
+	return ""
+}
+
+func (x *BatonServiceGetTasksRequest) GetPageSize() uint32 {
+	if x != nil {
+		return x.PageSize
+	}
+	return 0
+}
+
+func (x *BatonServiceGetTasksRequest) GetKnownTaskIds() []string {
+	if x != nil {
+		return x.KnownTaskIds
+	}
+	return nil
+}
+
+func (x *BatonServiceGetTasksRequest) GetAnnotations() []*anypb.Any {
+	if x != nil {
+		return x.Annotations
+	}
+	return nil
+}
+
+func (x *BatonServiceGetTasksRequest) SetHostId(v string) {
+	x.HostId = v
+}
+
+func (x *BatonServiceGetTasksRequest) SetPageSize(v uint32) {
+	x.PageSize = v
+}
+
+func (x *BatonServiceGetTasksRequest) SetKnownTaskIds(v []string) {
+	x.KnownTaskIds = v
+}
+
+func (x *BatonServiceGetTasksRequest) SetAnnotations(v []*anypb.Any) {
+	x.Annotations = v
+}
+
+type BatonServiceGetTasksRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	HostId       string
+	PageSize     uint32
+	KnownTaskIds []string
+	Annotations  []*anypb.Any
+}
+
+func (b0 BatonServiceGetTasksRequest_builder) Build() *BatonServiceGetTasksRequest {
+	m0 := &BatonServiceGetTasksRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.HostId = b.HostId
+	x.PageSize = b.PageSize
+	x.KnownTaskIds = b.KnownTaskIds
+	x.Annotations = b.Annotations
+	return m0
+}
+
+type BatonServiceGetTasksResponse struct {
+	state         protoimpl.MessageState `protogen:"hybrid.v1"`
+	Tasks         []*Task                `protobuf:"bytes,1,rep,name=tasks,proto3" json:"tasks,omitempty"`
+	NextPoll      *durationpb.Duration   `protobuf:"bytes,2,opt,name=next_poll,json=nextPoll,proto3" json:"next_poll,omitempty"`
+	NextHeartbeat *durationpb.Duration   `protobuf:"bytes,3,opt,name=next_heartbeat,json=nextHeartbeat,proto3" json:"next_heartbeat,omitempty"`
+	Annotations   []*anypb.Any           `protobuf:"bytes,4,rep,name=annotations,proto3" json:"annotations,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BatonServiceGetTasksResponse) Reset() {
+	*x = BatonServiceGetTasksResponse{}
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BatonServiceGetTasksResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BatonServiceGetTasksResponse) ProtoMessage() {}
+
+func (x *BatonServiceGetTasksResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *BatonServiceGetTasksResponse) GetTasks() []*Task {
+	if x != nil {
+		return x.Tasks
+	}
+	return nil
+}
+
+func (x *BatonServiceGetTasksResponse) GetNextPoll() *durationpb.Duration {
+	if x != nil {
+		return x.NextPoll
+	}
+	return nil
+}
+
+func (x *BatonServiceGetTasksResponse) GetNextHeartbeat() *durationpb.Duration {
+	if x != nil {
+		return x.NextHeartbeat
+	}
+	return nil
+}
+
+func (x *BatonServiceGetTasksResponse) GetAnnotations() []*anypb.Any {
+	if x != nil {
+		return x.Annotations
+	}
+	return nil
+}
+
+func (x *BatonServiceGetTasksResponse) SetTasks(v []*Task) {
+	x.Tasks = v
+}
+
+func (x *BatonServiceGetTasksResponse) SetNextPoll(v *durationpb.Duration) {
+	x.NextPoll = v
+}
+
+func (x *BatonServiceGetTasksResponse) SetNextHeartbeat(v *durationpb.Duration) {
+	x.NextHeartbeat = v
+}
+
+func (x *BatonServiceGetTasksResponse) SetAnnotations(v []*anypb.Any) {
+	x.Annotations = v
+}
+
+func (x *BatonServiceGetTasksResponse) HasNextPoll() bool {
+	if x == nil {
+		return false
+	}
+	return x.NextPoll != nil
+}
+
+func (x *BatonServiceGetTasksResponse) HasNextHeartbeat() bool {
+	if x == nil {
+		return false
+	}
+	return x.NextHeartbeat != nil
+}
+
+func (x *BatonServiceGetTasksResponse) ClearNextPoll() {
+	x.NextPoll = nil
+}
+
+func (x *BatonServiceGetTasksResponse) ClearNextHeartbeat() {
+	x.NextHeartbeat = nil
+}
+
+type BatonServiceGetTasksResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	Tasks         []*Task
+	NextPoll      *durationpb.Duration
+	NextHeartbeat *durationpb.Duration
+	Annotations   []*anypb.Any
+}
+
+func (b0 BatonServiceGetTasksResponse_builder) Build() *BatonServiceGetTasksResponse {
+	m0 := &BatonServiceGetTasksResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Tasks = b.Tasks
+	x.NextPoll = b.NextPoll
+	x.NextHeartbeat = b.NextHeartbeat
+	x.Annotations = b.Annotations
+	return m0
+}
+
 type BatonServiceGetTaskResponse struct {
 	state         protoimpl.MessageState `protogen:"hybrid.v1"`
 	Task          *Task                  `protobuf:"bytes,1,opt,name=task,proto3" json:"task,omitempty"`
@@ -1534,7 +1754,7 @@ type BatonServiceGetTaskResponse struct {
 
 func (x *BatonServiceGetTaskResponse) Reset() {
 	*x = BatonServiceGetTaskResponse{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[4]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1546,7 +1766,7 @@ func (x *BatonServiceGetTaskResponse) String() string {
 func (*BatonServiceGetTaskResponse) ProtoMessage() {}
 
 func (x *BatonServiceGetTaskResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[4]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1655,17 +1875,19 @@ func (b0 BatonServiceGetTaskResponse_builder) Build() *BatonServiceGetTaskRespon
 }
 
 type BatonServiceHeartbeatRequest struct {
-	state         protoimpl.MessageState `protogen:"hybrid.v1"`
-	HostId        string                 `protobuf:"bytes,1,opt,name=host_id,json=hostId,proto3" json:"host_id,omitempty"`
-	TaskId        string                 `protobuf:"bytes,2,opt,name=task_id,json=taskId,proto3" json:"task_id,omitempty"`
-	Annotations   []*anypb.Any           `protobuf:"bytes,3,rep,name=annotations,proto3" json:"annotations,omitempty"` // Useful for returning status updates on the task
+	state       protoimpl.MessageState `protogen:"hybrid.v1"`
+	HostId      string                 `protobuf:"bytes,1,opt,name=host_id,json=hostId,proto3" json:"host_id,omitempty"`
+	TaskId      string                 `protobuf:"bytes,2,opt,name=task_id,json=taskId,proto3" json:"task_id,omitempty"`
+	Annotations []*anypb.Any           `protobuf:"bytes,3,rep,name=annotations,proto3" json:"annotations,omitempty"` // Useful for returning status updates on the task
+	// New batch heartbeat path.
+	TaskIds       []string `protobuf:"bytes,4,rep,name=task_ids,json=taskIds,proto3" json:"task_ids,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *BatonServiceHeartbeatRequest) Reset() {
 	*x = BatonServiceHeartbeatRequest{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[5]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1677,7 +1899,7 @@ func (x *BatonServiceHeartbeatRequest) String() string {
 func (*BatonServiceHeartbeatRequest) ProtoMessage() {}
 
 func (x *BatonServiceHeartbeatRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[5]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1709,6 +1931,13 @@ func (x *BatonServiceHeartbeatRequest) GetAnnotations() []*anypb.Any {
 	return nil
 }
 
+func (x *BatonServiceHeartbeatRequest) GetTaskIds() []string {
+	if x != nil {
+		return x.TaskIds
+	}
+	return nil
+}
+
 func (x *BatonServiceHeartbeatRequest) SetHostId(v string) {
 	x.HostId = v
 }
@@ -1721,12 +1950,18 @@ func (x *BatonServiceHeartbeatRequest) SetAnnotations(v []*anypb.Any) {
 	x.Annotations = v
 }
 
+func (x *BatonServiceHeartbeatRequest) SetTaskIds(v []string) {
+	x.TaskIds = v
+}
+
 type BatonServiceHeartbeatRequest_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
 	HostId      string
 	TaskId      string
 	Annotations []*anypb.Any
+	// New batch heartbeat path.
+	TaskIds []string
 }
 
 func (b0 BatonServiceHeartbeatRequest_builder) Build() *BatonServiceHeartbeatRequest {
@@ -1736,21 +1971,23 @@ func (b0 BatonServiceHeartbeatRequest_builder) Build() *BatonServiceHeartbeatReq
 	x.HostId = b.HostId
 	x.TaskId = b.TaskId
 	x.Annotations = b.Annotations
+	x.TaskIds = b.TaskIds
 	return m0
 }
 
 type BatonServiceHeartbeatResponse struct {
-	state         protoimpl.MessageState `protogen:"hybrid.v1"`
-	NextHeartbeat *durationpb.Duration   `protobuf:"bytes,1,opt,name=next_heartbeat,json=nextHeartbeat,proto3" json:"next_heartbeat,omitempty"`
-	Cancelled     bool                   `protobuf:"varint,2,opt,name=cancelled,proto3" json:"cancelled,omitempty"` // Backend has decided that we should stop working on this
-	Annotations   []*anypb.Any           `protobuf:"bytes,3,rep,name=annotations,proto3" json:"annotations,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state            protoimpl.MessageState `protogen:"hybrid.v1"`
+	NextHeartbeat    *durationpb.Duration   `protobuf:"bytes,1,opt,name=next_heartbeat,json=nextHeartbeat,proto3" json:"next_heartbeat,omitempty"`
+	Cancelled        bool                   `protobuf:"varint,2,opt,name=cancelled,proto3" json:"cancelled,omitempty"` // Backend has decided that we should stop working on this
+	Annotations      []*anypb.Any           `protobuf:"bytes,3,rep,name=annotations,proto3" json:"annotations,omitempty"`
+	CancelledTaskIds []string               `protobuf:"bytes,4,rep,name=cancelled_task_ids,json=cancelledTaskIds,proto3" json:"cancelled_task_ids,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *BatonServiceHeartbeatResponse) Reset() {
 	*x = BatonServiceHeartbeatResponse{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[6]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1762,7 +1999,7 @@ func (x *BatonServiceHeartbeatResponse) String() string {
 func (*BatonServiceHeartbeatResponse) ProtoMessage() {}
 
 func (x *BatonServiceHeartbeatResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[6]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1794,6 +2031,13 @@ func (x *BatonServiceHeartbeatResponse) GetAnnotations() []*anypb.Any {
 	return nil
 }
 
+func (x *BatonServiceHeartbeatResponse) GetCancelledTaskIds() []string {
+	if x != nil {
+		return x.CancelledTaskIds
+	}
+	return nil
+}
+
 func (x *BatonServiceHeartbeatResponse) SetNextHeartbeat(v *durationpb.Duration) {
 	x.NextHeartbeat = v
 }
@@ -1804,6 +2048,10 @@ func (x *BatonServiceHeartbeatResponse) SetCancelled(v bool) {
 
 func (x *BatonServiceHeartbeatResponse) SetAnnotations(v []*anypb.Any) {
 	x.Annotations = v
+}
+
+func (x *BatonServiceHeartbeatResponse) SetCancelledTaskIds(v []string) {
+	x.CancelledTaskIds = v
 }
 
 func (x *BatonServiceHeartbeatResponse) HasNextHeartbeat() bool {
@@ -1820,9 +2068,10 @@ func (x *BatonServiceHeartbeatResponse) ClearNextHeartbeat() {
 type BatonServiceHeartbeatResponse_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	NextHeartbeat *durationpb.Duration
-	Cancelled     bool
-	Annotations   []*anypb.Any
+	NextHeartbeat    *durationpb.Duration
+	Cancelled        bool
+	Annotations      []*anypb.Any
+	CancelledTaskIds []string
 }
 
 func (b0 BatonServiceHeartbeatResponse_builder) Build() *BatonServiceHeartbeatResponse {
@@ -1832,6 +2081,7 @@ func (b0 BatonServiceHeartbeatResponse_builder) Build() *BatonServiceHeartbeatRe
 	x.NextHeartbeat = b.NextHeartbeat
 	x.Cancelled = b.Cancelled
 	x.Annotations = b.Annotations
+	x.CancelledTaskIds = b.CancelledTaskIds
 	return m0
 }
 
@@ -1849,7 +2099,7 @@ type BatonServiceUploadAssetRequest struct {
 
 func (x *BatonServiceUploadAssetRequest) Reset() {
 	*x = BatonServiceUploadAssetRequest{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[7]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1861,7 +2111,7 @@ func (x *BatonServiceUploadAssetRequest) String() string {
 func (*BatonServiceUploadAssetRequest) ProtoMessage() {}
 
 func (x *BatonServiceUploadAssetRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[7]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2033,7 +2283,7 @@ func (b0 BatonServiceUploadAssetRequest_builder) Build() *BatonServiceUploadAsse
 type case_BatonServiceUploadAssetRequest_Msg protoreflect.FieldNumber
 
 func (x case_BatonServiceUploadAssetRequest_Msg) String() string {
-	md := file_c1_connectorapi_baton_v1_baton_proto_msgTypes[7].Descriptor()
+	md := file_c1_connectorapi_baton_v1_baton_proto_msgTypes[9].Descriptor()
 	if x == 0 {
 		return "not set"
 	}
@@ -2071,7 +2321,7 @@ type BatonServiceUploadAssetResponse struct {
 
 func (x *BatonServiceUploadAssetResponse) Reset() {
 	*x = BatonServiceUploadAssetResponse{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[8]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2083,7 +2333,7 @@ func (x *BatonServiceUploadAssetResponse) String() string {
 func (*BatonServiceUploadAssetResponse) ProtoMessage() {}
 
 func (x *BatonServiceUploadAssetResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[8]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2136,7 +2386,7 @@ type BatonServiceFinishTaskRequest struct {
 
 func (x *BatonServiceFinishTaskRequest) Reset() {
 	*x = BatonServiceFinishTaskRequest{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[9]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2148,7 +2398,7 @@ func (x *BatonServiceFinishTaskRequest) String() string {
 func (*BatonServiceFinishTaskRequest) ProtoMessage() {}
 
 func (x *BatonServiceFinishTaskRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[9]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2332,7 +2582,7 @@ func (b0 BatonServiceFinishTaskRequest_builder) Build() *BatonServiceFinishTaskR
 type case_BatonServiceFinishTaskRequest_FinalState protoreflect.FieldNumber
 
 func (x case_BatonServiceFinishTaskRequest_FinalState) String() string {
-	md := file_c1_connectorapi_baton_v1_baton_proto_msgTypes[9].Descriptor()
+	md := file_c1_connectorapi_baton_v1_baton_proto_msgTypes[11].Descriptor()
 	if x == 0 {
 		return "not set"
 	}
@@ -2364,7 +2614,7 @@ type BatonServiceFinishTaskResponse struct {
 
 func (x *BatonServiceFinishTaskResponse) Reset() {
 	*x = BatonServiceFinishTaskResponse{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[10]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2376,7 +2626,7 @@ func (x *BatonServiceFinishTaskResponse) String() string {
 func (*BatonServiceFinishTaskResponse) ProtoMessage() {}
 
 func (x *BatonServiceFinishTaskResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[10]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2420,7 +2670,7 @@ type StartDebuggingRequest struct {
 
 func (x *StartDebuggingRequest) Reset() {
 	*x = StartDebuggingRequest{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[11]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2432,7 +2682,7 @@ func (x *StartDebuggingRequest) String() string {
 func (*StartDebuggingRequest) ProtoMessage() {}
 
 func (x *StartDebuggingRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[11]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2464,7 +2714,7 @@ type StartDebuggingResponse struct {
 
 func (x *StartDebuggingResponse) Reset() {
 	*x = StartDebuggingResponse{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[12]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2476,7 +2726,7 @@ func (x *StartDebuggingResponse) String() string {
 func (*StartDebuggingResponse) ProtoMessage() {}
 
 func (x *StartDebuggingResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[12]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2521,7 +2771,7 @@ type Task_NoneTask struct {
 
 func (x *Task_NoneTask) Reset() {
 	*x = Task_NoneTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[13]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2533,7 +2783,7 @@ func (x *Task_NoneTask) String() string {
 func (*Task_NoneTask) ProtoMessage() {}
 
 func (x *Task_NoneTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[13]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2578,7 +2828,7 @@ type Task_HelloTask struct {
 
 func (x *Task_HelloTask) Reset() {
 	*x = Task_HelloTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[14]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2590,7 +2840,7 @@ func (x *Task_HelloTask) String() string {
 func (*Task_HelloTask) ProtoMessage() {}
 
 func (x *Task_HelloTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[14]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2639,7 +2889,7 @@ type Task_SyncFullTask struct {
 
 func (x *Task_SyncFullTask) Reset() {
 	*x = Task_SyncFullTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[15]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2651,7 +2901,7 @@ func (x *Task_SyncFullTask) String() string {
 func (*Task_SyncFullTask) ProtoMessage() {}
 
 func (x *Task_SyncFullTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[15]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2749,7 +2999,7 @@ type Task_EventFeedTask struct {
 
 func (x *Task_EventFeedTask) Reset() {
 	*x = Task_EventFeedTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[16]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2761,7 +3011,7 @@ func (x *Task_EventFeedTask) String() string {
 func (*Task_EventFeedTask) ProtoMessage() {}
 
 func (x *Task_EventFeedTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[16]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2834,7 +3084,7 @@ type Task_ListEventsTask struct {
 
 func (x *Task_ListEventsTask) Reset() {
 	*x = Task_ListEventsTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[17]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2846,7 +3096,7 @@ func (x *Task_ListEventsTask) String() string {
 func (*Task_ListEventsTask) ProtoMessage() {}
 
 func (x *Task_ListEventsTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[17]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2954,7 +3204,7 @@ type Task_ListEventFeedsTask struct {
 
 func (x *Task_ListEventFeedsTask) Reset() {
 	*x = Task_ListEventFeedsTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[18]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2966,7 +3216,7 @@ func (x *Task_ListEventFeedsTask) String() string {
 func (*Task_ListEventFeedsTask) ProtoMessage() {}
 
 func (x *Task_ListEventFeedsTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[18]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3014,7 +3264,7 @@ type Task_GrantTask struct {
 
 func (x *Task_GrantTask) Reset() {
 	*x = Task_GrantTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[19]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3026,7 +3276,7 @@ func (x *Task_GrantTask) String() string {
 func (*Task_GrantTask) ProtoMessage() {}
 
 func (x *Task_GrantTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[19]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3144,7 +3394,7 @@ type Task_RevokeTask struct {
 
 func (x *Task_RevokeTask) Reset() {
 	*x = Task_RevokeTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[20]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3156,7 +3406,7 @@ func (x *Task_RevokeTask) String() string {
 func (*Task_RevokeTask) ProtoMessage() {}
 
 func (x *Task_RevokeTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[20]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3228,7 +3478,7 @@ type Task_CreateAccountTask struct {
 
 func (x *Task_CreateAccountTask) Reset() {
 	*x = Task_CreateAccountTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[21]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3240,7 +3490,7 @@ func (x *Task_CreateAccountTask) String() string {
 func (*Task_CreateAccountTask) ProtoMessage() {}
 
 func (x *Task_CreateAccountTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[21]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3346,7 +3596,7 @@ type Task_CreateResourceTask struct {
 
 func (x *Task_CreateResourceTask) Reset() {
 	*x = Task_CreateResourceTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[22]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3358,7 +3608,7 @@ func (x *Task_CreateResourceTask) String() string {
 func (*Task_CreateResourceTask) ProtoMessage() {}
 
 func (x *Task_CreateResourceTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[22]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3415,7 +3665,7 @@ type Task_DeleteResourceTask struct {
 
 func (x *Task_DeleteResourceTask) Reset() {
 	*x = Task_DeleteResourceTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[23]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3427,7 +3677,7 @@ func (x *Task_DeleteResourceTask) String() string {
 func (*Task_DeleteResourceTask) ProtoMessage() {}
 
 func (x *Task_DeleteResourceTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[23]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3509,7 +3759,7 @@ type Task_RotateCredentialsTask struct {
 
 func (x *Task_RotateCredentialsTask) Reset() {
 	*x = Task_RotateCredentialsTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[24]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3521,7 +3771,7 @@ func (x *Task_RotateCredentialsTask) String() string {
 func (*Task_RotateCredentialsTask) ProtoMessage() {}
 
 func (x *Task_RotateCredentialsTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[24]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3616,7 +3866,7 @@ type Task_CreateTicketTask struct {
 
 func (x *Task_CreateTicketTask) Reset() {
 	*x = Task_CreateTicketTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[25]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3628,7 +3878,7 @@ func (x *Task_CreateTicketTask) String() string {
 func (*Task_CreateTicketTask) ProtoMessage() {}
 
 func (x *Task_CreateTicketTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[25]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3721,7 +3971,7 @@ type Task_BulkCreateTicketsTask struct {
 
 func (x *Task_BulkCreateTicketsTask) Reset() {
 	*x = Task_BulkCreateTicketsTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[26]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3733,7 +3983,7 @@ func (x *Task_BulkCreateTicketsTask) String() string {
 func (*Task_BulkCreateTicketsTask) ProtoMessage() {}
 
 func (x *Task_BulkCreateTicketsTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[26]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3778,7 +4028,7 @@ type Task_BulkGetTicketsTask struct {
 
 func (x *Task_BulkGetTicketsTask) Reset() {
 	*x = Task_BulkGetTicketsTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[27]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3790,7 +4040,7 @@ func (x *Task_BulkGetTicketsTask) String() string {
 func (*Task_BulkGetTicketsTask) ProtoMessage() {}
 
 func (x *Task_BulkGetTicketsTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[27]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3835,7 +4085,7 @@ type Task_ListTicketSchemasTask struct {
 
 func (x *Task_ListTicketSchemasTask) Reset() {
 	*x = Task_ListTicketSchemasTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[28]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3847,7 +4097,7 @@ func (x *Task_ListTicketSchemasTask) String() string {
 func (*Task_ListTicketSchemasTask) ProtoMessage() {}
 
 func (x *Task_ListTicketSchemasTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[28]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3893,7 +4143,7 @@ type Task_GetTicketTask struct {
 
 func (x *Task_GetTicketTask) Reset() {
 	*x = Task_GetTicketTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[29]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3905,7 +4155,7 @@ func (x *Task_GetTicketTask) String() string {
 func (*Task_GetTicketTask) ProtoMessage() {}
 
 func (x *Task_GetTicketTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[29]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3965,7 +4215,7 @@ type Task_ActionListSchemasTask struct {
 
 func (x *Task_ActionListSchemasTask) Reset() {
 	*x = Task_ActionListSchemasTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[30]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3977,7 +4227,7 @@ func (x *Task_ActionListSchemasTask) String() string {
 func (*Task_ActionListSchemasTask) ProtoMessage() {}
 
 func (x *Task_ActionListSchemasTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[30]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4037,7 +4287,7 @@ type Task_ActionGetSchemaTask struct {
 
 func (x *Task_ActionGetSchemaTask) Reset() {
 	*x = Task_ActionGetSchemaTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[31]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4049,7 +4299,7 @@ func (x *Task_ActionGetSchemaTask) String() string {
 func (*Task_ActionGetSchemaTask) ProtoMessage() {}
 
 func (x *Task_ActionGetSchemaTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[31]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4111,7 +4361,7 @@ type Task_ActionInvokeTask struct {
 
 func (x *Task_ActionInvokeTask) Reset() {
 	*x = Task_ActionInvokeTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[32]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4123,7 +4373,7 @@ func (x *Task_ActionInvokeTask) String() string {
 func (*Task_ActionInvokeTask) ProtoMessage() {}
 
 func (x *Task_ActionInvokeTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[32]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4221,7 +4471,7 @@ type Task_ActionStatusTask struct {
 
 func (x *Task_ActionStatusTask) Reset() {
 	*x = Task_ActionStatusTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[33]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4233,7 +4483,7 @@ func (x *Task_ActionStatusTask) String() string {
 func (*Task_ActionStatusTask) ProtoMessage() {}
 
 func (x *Task_ActionStatusTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[33]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4307,7 +4557,7 @@ type Task_CreateSyncDiffTask struct {
 
 func (x *Task_CreateSyncDiffTask) Reset() {
 	*x = Task_CreateSyncDiffTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[34]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4319,7 +4569,7 @@ func (x *Task_CreateSyncDiffTask) String() string {
 func (*Task_CreateSyncDiffTask) ProtoMessage() {}
 
 func (x *Task_CreateSyncDiffTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[34]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4392,7 +4642,7 @@ type Task_CompactSyncs struct {
 
 func (x *Task_CompactSyncs) Reset() {
 	*x = Task_CompactSyncs{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[35]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4404,7 +4654,7 @@ func (x *Task_CompactSyncs) String() string {
 func (*Task_CompactSyncs) ProtoMessage() {}
 
 func (x *Task_CompactSyncs) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[35]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4463,7 +4713,7 @@ type Task_CompactSyncs_CompactableSync struct {
 
 func (x *Task_CompactSyncs_CompactableSync) Reset() {
 	*x = Task_CompactSyncs_CompactableSync{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[36]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4475,7 +4725,7 @@ func (x *Task_CompactSyncs_CompactableSync) String() string {
 func (*Task_CompactSyncs_CompactableSync) ProtoMessage() {}
 
 func (x *Task_CompactSyncs_CompactableSync) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[36]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4535,7 +4785,7 @@ type BatonServiceHelloRequest_BuildInfo struct {
 
 func (x *BatonServiceHelloRequest_BuildInfo) Reset() {
 	*x = BatonServiceHelloRequest_BuildInfo{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[37]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4547,7 +4797,7 @@ func (x *BatonServiceHelloRequest_BuildInfo) String() string {
 func (*BatonServiceHelloRequest_BuildInfo) ProtoMessage() {}
 
 func (x *BatonServiceHelloRequest_BuildInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[37]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4625,7 +4875,7 @@ type BatonServiceHelloRequest_OSInfo struct {
 
 func (x *BatonServiceHelloRequest_OSInfo) Reset() {
 	*x = BatonServiceHelloRequest_OSInfo{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[38]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4637,7 +4887,7 @@ func (x *BatonServiceHelloRequest_OSInfo) String() string {
 func (*BatonServiceHelloRequest_OSInfo) ProtoMessage() {}
 
 func (x *BatonServiceHelloRequest_OSInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[38]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4775,7 +5025,7 @@ type BatonServiceUploadAssetRequest_UploadMetadata struct {
 
 func (x *BatonServiceUploadAssetRequest_UploadMetadata) Reset() {
 	*x = BatonServiceUploadAssetRequest_UploadMetadata{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[39]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4787,7 +5037,7 @@ func (x *BatonServiceUploadAssetRequest_UploadMetadata) String() string {
 func (*BatonServiceUploadAssetRequest_UploadMetadata) ProtoMessage() {}
 
 func (x *BatonServiceUploadAssetRequest_UploadMetadata) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[39]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4859,7 +5109,7 @@ type BatonServiceUploadAssetRequest_UploadData struct {
 
 func (x *BatonServiceUploadAssetRequest_UploadData) Reset() {
 	*x = BatonServiceUploadAssetRequest_UploadData{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[40]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4871,7 +5121,7 @@ func (x *BatonServiceUploadAssetRequest_UploadData) String() string {
 func (*BatonServiceUploadAssetRequest_UploadData) ProtoMessage() {}
 
 func (x *BatonServiceUploadAssetRequest_UploadData) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[40]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4921,7 +5171,7 @@ type BatonServiceUploadAssetRequest_UploadEOF struct {
 
 func (x *BatonServiceUploadAssetRequest_UploadEOF) Reset() {
 	*x = BatonServiceUploadAssetRequest_UploadEOF{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[41]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4933,7 +5183,7 @@ func (x *BatonServiceUploadAssetRequest_UploadEOF) String() string {
 func (*BatonServiceUploadAssetRequest_UploadEOF) ProtoMessage() {}
 
 func (x *BatonServiceUploadAssetRequest_UploadEOF) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[41]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4997,7 +5247,7 @@ type BatonServiceFinishTaskRequest_Error struct {
 
 func (x *BatonServiceFinishTaskRequest_Error) Reset() {
 	*x = BatonServiceFinishTaskRequest_Error{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[42]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5009,7 +5259,7 @@ func (x *BatonServiceFinishTaskRequest_Error) String() string {
 func (*BatonServiceFinishTaskRequest_Error) ProtoMessage() {}
 
 func (x *BatonServiceFinishTaskRequest_Error) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[42]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5094,7 +5344,7 @@ type BatonServiceFinishTaskRequest_Success struct {
 
 func (x *BatonServiceFinishTaskRequest_Success) Reset() {
 	*x = BatonServiceFinishTaskRequest_Success{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[43]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5106,7 +5356,7 @@ func (x *BatonServiceFinishTaskRequest_Success) String() string {
 func (*BatonServiceFinishTaskRequest_Success) ProtoMessage() {}
 
 func (x *BatonServiceFinishTaskRequest_Success) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[43]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5323,21 +5573,34 @@ const file_c1_connectorapi_baton_v1_baton_proto_rawDesc = "" +
 	"\vannotations\x18\x01 \x03(\v2\x14.google.protobuf.AnyR\vannotations\"A\n" +
 	"\x1aBatonServiceGetTaskRequest\x12#\n" +
 	"\ahost_id\x18\x01 \x01(\tB\n" +
-	"\xfaB\ar\x05\x10\x01\x18\x80\x02R\x06hostId\"\x83\x02\n" +
+	"\xfaB\ar\x05\x10\x01\x18\x80\x02R\x06hostId\"\xf1\x01\n" +
+	"\x1bBatonServiceGetTasksRequest\x12#\n" +
+	"\ahost_id\x18\x01 \x01(\tB\n" +
+	"\xfaB\ar\x05\x10\x01\x18\x80\x02R\x06hostId\x12&\n" +
+	"\tpage_size\x18\x02 \x01(\rB\t\xfaB\x06*\x04\x18d \x00R\bpageSize\x12C\n" +
+	"\x0eknown_task_ids\x18\x03 \x03(\tB\x1d\xfaB\x1a\x92\x01\x17\"\x15r\x132\x11^[a-zA-Z0-9]{27}$R\fknownTaskIds\x12@\n" +
+	"\vannotations\x18\x04 \x03(\v2\x14.google.protobuf.AnyB\b\xfaB\x05\x92\x01\x02\x10\x10R\vannotations\"\x90\x02\n" +
+	"\x1cBatonServiceGetTasksResponse\x12>\n" +
+	"\x05tasks\x18\x01 \x03(\v2\x1e.c1.connectorapi.baton.v1.TaskB\b\xfaB\x05\x92\x01\x02\x10dR\x05tasks\x126\n" +
+	"\tnext_poll\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\bnextPoll\x12@\n" +
+	"\x0enext_heartbeat\x18\x03 \x01(\v2\x19.google.protobuf.DurationR\rnextHeartbeat\x126\n" +
+	"\vannotations\x18\x04 \x03(\v2\x14.google.protobuf.AnyR\vannotations\"\x83\x02\n" +
 	"\x1bBatonServiceGetTaskResponse\x122\n" +
 	"\x04task\x18\x01 \x01(\v2\x1e.c1.connectorapi.baton.v1.TaskR\x04task\x126\n" +
 	"\tnext_poll\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\bnextPoll\x12@\n" +
 	"\x0enext_heartbeat\x18\x03 \x01(\v2\x19.google.protobuf.DurationR\rnextHeartbeat\x126\n" +
-	"\vannotations\x18\x04 \x03(\v2\x14.google.protobuf.AnyR\vannotations\"\xb8\x01\n" +
+	"\vannotations\x18\x04 \x03(\v2\x14.google.protobuf.AnyR\vannotations\"\xf4\x01\n" +
 	"\x1cBatonServiceHeartbeatRequest\x12#\n" +
 	"\ahost_id\x18\x01 \x01(\tB\n" +
 	"\xfaB\ar\x05\x10\x01\x18\x80\x02R\x06hostId\x121\n" +
 	"\atask_id\x18\x02 \x01(\tB\x18\xfaB\x15r\x132\x11^[a-zA-Z0-9]{27}$R\x06taskId\x12@\n" +
-	"\vannotations\x18\x03 \x03(\v2\x14.google.protobuf.AnyB\b\xfaB\x05\x92\x01\x02\x10\x10R\vannotations\"\xb7\x01\n" +
+	"\vannotations\x18\x03 \x03(\v2\x14.google.protobuf.AnyB\b\xfaB\x05\x92\x01\x02\x10\x10R\vannotations\x12:\n" +
+	"\btask_ids\x18\x04 \x03(\tB\x1f\xfaB\x1c\x92\x01\x19\x10d\"\x15r\x132\x11^[a-zA-Z0-9]{27}$R\ataskIds\"\xe5\x01\n" +
 	"\x1dBatonServiceHeartbeatResponse\x12@\n" +
 	"\x0enext_heartbeat\x18\x01 \x01(\v2\x19.google.protobuf.DurationR\rnextHeartbeat\x12\x1c\n" +
 	"\tcancelled\x18\x02 \x01(\bR\tcancelled\x126\n" +
-	"\vannotations\x18\x03 \x03(\v2\x14.google.protobuf.AnyR\vannotations\"\xa3\x05\n" +
+	"\vannotations\x18\x03 \x03(\v2\x14.google.protobuf.AnyR\vannotations\x12,\n" +
+	"\x12cancelled_task_ids\x18\x04 \x03(\tR\x10cancelledTaskIds\"\xa3\x05\n" +
 	"\x1eBatonServiceUploadAssetRequest\x12e\n" +
 	"\bmetadata\x18d \x01(\v2G.c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadMetadataH\x00R\bmetadata\x12Y\n" +
 	"\x04data\x18e \x01(\v2C.c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadDataH\x00R\x04data\x12V\n" +
@@ -5376,10 +5639,11 @@ const file_c1_connectorapi_baton_v1_baton_proto_rawDesc = "" +
 	"\vannotations\x18\x01 \x03(\v2\x14.google.protobuf.AnyR\vannotations\"\x17\n" +
 	"\x15StartDebuggingRequest\"0\n" +
 	"\x16StartDebuggingResponse\x12\x16\n" +
-	"\x06status\x18\x01 \x01(\bR\x06status2\x80\x06\n" +
+	"\x06status\x18\x01 \x01(\bR\x06status2\xfd\x06\n" +
 	"\fBatonService\x12r\n" +
 	"\x05Hello\x122.c1.connectorapi.baton.v1.BatonServiceHelloRequest\x1a3.c1.connectorapi.baton.v1.BatonServiceHelloResponse\"\x00\x12x\n" +
-	"\aGetTask\x124.c1.connectorapi.baton.v1.BatonServiceGetTaskRequest\x1a5.c1.connectorapi.baton.v1.BatonServiceGetTaskResponse\"\x00\x12~\n" +
+	"\aGetTask\x124.c1.connectorapi.baton.v1.BatonServiceGetTaskRequest\x1a5.c1.connectorapi.baton.v1.BatonServiceGetTaskResponse\"\x00\x12{\n" +
+	"\bGetTasks\x125.c1.connectorapi.baton.v1.BatonServiceGetTasksRequest\x1a6.c1.connectorapi.baton.v1.BatonServiceGetTasksResponse\"\x00\x12~\n" +
 	"\tHeartbeat\x126.c1.connectorapi.baton.v1.BatonServiceHeartbeatRequest\x1a7.c1.connectorapi.baton.v1.BatonServiceHeartbeatResponse\"\x00\x12\x81\x01\n" +
 	"\n" +
 	"FinishTask\x127.c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest\x1a8.c1.connectorapi.baton.v1.BatonServiceFinishTaskResponse\"\x00\x12\x86\x01\n" +
@@ -5387,176 +5651,185 @@ const file_c1_connectorapi_baton_v1_baton_proto_rawDesc = "" +
 	"\x0eStartDebugging\x12/.c1.connectorapi.baton.v1.StartDebuggingRequest\x1a0.c1.connectorapi.baton.v1.StartDebuggingResponse\"\x00B7Z5gitlab.com/ductone/c1/pkg/pb/c1/connectorapi/baton/v1b\x06proto3"
 
 var file_c1_connectorapi_baton_v1_baton_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_c1_connectorapi_baton_v1_baton_proto_msgTypes = make([]protoimpl.MessageInfo, 44)
+var file_c1_connectorapi_baton_v1_baton_proto_msgTypes = make([]protoimpl.MessageInfo, 46)
 var file_c1_connectorapi_baton_v1_baton_proto_goTypes = []any{
 	(Task_Status)(0),                                      // 0: c1.connectorapi.baton.v1.Task.Status
 	(*Task)(nil),                                          // 1: c1.connectorapi.baton.v1.Task
 	(*BatonServiceHelloRequest)(nil),                      // 2: c1.connectorapi.baton.v1.BatonServiceHelloRequest
 	(*BatonServiceHelloResponse)(nil),                     // 3: c1.connectorapi.baton.v1.BatonServiceHelloResponse
 	(*BatonServiceGetTaskRequest)(nil),                    // 4: c1.connectorapi.baton.v1.BatonServiceGetTaskRequest
-	(*BatonServiceGetTaskResponse)(nil),                   // 5: c1.connectorapi.baton.v1.BatonServiceGetTaskResponse
-	(*BatonServiceHeartbeatRequest)(nil),                  // 6: c1.connectorapi.baton.v1.BatonServiceHeartbeatRequest
-	(*BatonServiceHeartbeatResponse)(nil),                 // 7: c1.connectorapi.baton.v1.BatonServiceHeartbeatResponse
-	(*BatonServiceUploadAssetRequest)(nil),                // 8: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest
-	(*BatonServiceUploadAssetResponse)(nil),               // 9: c1.connectorapi.baton.v1.BatonServiceUploadAssetResponse
-	(*BatonServiceFinishTaskRequest)(nil),                 // 10: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest
-	(*BatonServiceFinishTaskResponse)(nil),                // 11: c1.connectorapi.baton.v1.BatonServiceFinishTaskResponse
-	(*StartDebuggingRequest)(nil),                         // 12: c1.connectorapi.baton.v1.StartDebuggingRequest
-	(*StartDebuggingResponse)(nil),                        // 13: c1.connectorapi.baton.v1.StartDebuggingResponse
-	(*Task_NoneTask)(nil),                                 // 14: c1.connectorapi.baton.v1.Task.NoneTask
-	(*Task_HelloTask)(nil),                                // 15: c1.connectorapi.baton.v1.Task.HelloTask
-	(*Task_SyncFullTask)(nil),                             // 16: c1.connectorapi.baton.v1.Task.SyncFullTask
-	(*Task_EventFeedTask)(nil),                            // 17: c1.connectorapi.baton.v1.Task.EventFeedTask
-	(*Task_ListEventsTask)(nil),                           // 18: c1.connectorapi.baton.v1.Task.ListEventsTask
-	(*Task_ListEventFeedsTask)(nil),                       // 19: c1.connectorapi.baton.v1.Task.ListEventFeedsTask
-	(*Task_GrantTask)(nil),                                // 20: c1.connectorapi.baton.v1.Task.GrantTask
-	(*Task_RevokeTask)(nil),                               // 21: c1.connectorapi.baton.v1.Task.RevokeTask
-	(*Task_CreateAccountTask)(nil),                        // 22: c1.connectorapi.baton.v1.Task.CreateAccountTask
-	(*Task_CreateResourceTask)(nil),                       // 23: c1.connectorapi.baton.v1.Task.CreateResourceTask
-	(*Task_DeleteResourceTask)(nil),                       // 24: c1.connectorapi.baton.v1.Task.DeleteResourceTask
-	(*Task_RotateCredentialsTask)(nil),                    // 25: c1.connectorapi.baton.v1.Task.RotateCredentialsTask
-	(*Task_CreateTicketTask)(nil),                         // 26: c1.connectorapi.baton.v1.Task.CreateTicketTask
-	(*Task_BulkCreateTicketsTask)(nil),                    // 27: c1.connectorapi.baton.v1.Task.BulkCreateTicketsTask
-	(*Task_BulkGetTicketsTask)(nil),                       // 28: c1.connectorapi.baton.v1.Task.BulkGetTicketsTask
-	(*Task_ListTicketSchemasTask)(nil),                    // 29: c1.connectorapi.baton.v1.Task.ListTicketSchemasTask
-	(*Task_GetTicketTask)(nil),                            // 30: c1.connectorapi.baton.v1.Task.GetTicketTask
-	(*Task_ActionListSchemasTask)(nil),                    // 31: c1.connectorapi.baton.v1.Task.ActionListSchemasTask
-	(*Task_ActionGetSchemaTask)(nil),                      // 32: c1.connectorapi.baton.v1.Task.ActionGetSchemaTask
-	(*Task_ActionInvokeTask)(nil),                         // 33: c1.connectorapi.baton.v1.Task.ActionInvokeTask
-	(*Task_ActionStatusTask)(nil),                         // 34: c1.connectorapi.baton.v1.Task.ActionStatusTask
-	(*Task_CreateSyncDiffTask)(nil),                       // 35: c1.connectorapi.baton.v1.Task.CreateSyncDiffTask
-	(*Task_CompactSyncs)(nil),                             // 36: c1.connectorapi.baton.v1.Task.CompactSyncs
-	(*Task_CompactSyncs_CompactableSync)(nil),             // 37: c1.connectorapi.baton.v1.Task.CompactSyncs.CompactableSync
-	(*BatonServiceHelloRequest_BuildInfo)(nil),            // 38: c1.connectorapi.baton.v1.BatonServiceHelloRequest.BuildInfo
-	(*BatonServiceHelloRequest_OSInfo)(nil),               // 39: c1.connectorapi.baton.v1.BatonServiceHelloRequest.OSInfo
-	(*BatonServiceUploadAssetRequest_UploadMetadata)(nil), // 40: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadMetadata
-	(*BatonServiceUploadAssetRequest_UploadData)(nil),     // 41: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadData
-	(*BatonServiceUploadAssetRequest_UploadEOF)(nil),      // 42: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadEOF
-	(*BatonServiceFinishTaskRequest_Error)(nil),           // 43: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Error
-	(*BatonServiceFinishTaskRequest_Success)(nil),         // 44: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Success
-	(*v2.ConnectorMetadata)(nil),                          // 45: c1.connector.v2.ConnectorMetadata
-	(*anypb.Any)(nil),                                     // 46: google.protobuf.Any
-	(*durationpb.Duration)(nil),                           // 47: google.protobuf.Duration
-	(*status.Status)(nil),                                 // 48: google.rpc.Status
-	(*v2.Resource)(nil),                                   // 49: c1.connector.v2.Resource
-	(*timestamppb.Timestamp)(nil),                         // 50: google.protobuf.Timestamp
-	(*v2.Entitlement)(nil),                                // 51: c1.connector.v2.Entitlement
-	(*v2.Grant)(nil),                                      // 52: c1.connector.v2.Grant
-	(*v2.AccountInfo)(nil),                                // 53: c1.connector.v2.AccountInfo
-	(*v2.CredentialOptions)(nil),                          // 54: c1.connector.v2.CredentialOptions
-	(*v2.EncryptionConfig)(nil),                           // 55: c1.connector.v2.EncryptionConfig
-	(*v2.ResourceId)(nil),                                 // 56: c1.connector.v2.ResourceId
-	(*v2.TicketRequest)(nil),                              // 57: c1.connector.v2.TicketRequest
-	(*v2.TicketSchema)(nil),                               // 58: c1.connector.v2.TicketSchema
-	(*structpb.Struct)(nil),                               // 59: google.protobuf.Struct
+	(*BatonServiceGetTasksRequest)(nil),                   // 5: c1.connectorapi.baton.v1.BatonServiceGetTasksRequest
+	(*BatonServiceGetTasksResponse)(nil),                  // 6: c1.connectorapi.baton.v1.BatonServiceGetTasksResponse
+	(*BatonServiceGetTaskResponse)(nil),                   // 7: c1.connectorapi.baton.v1.BatonServiceGetTaskResponse
+	(*BatonServiceHeartbeatRequest)(nil),                  // 8: c1.connectorapi.baton.v1.BatonServiceHeartbeatRequest
+	(*BatonServiceHeartbeatResponse)(nil),                 // 9: c1.connectorapi.baton.v1.BatonServiceHeartbeatResponse
+	(*BatonServiceUploadAssetRequest)(nil),                // 10: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest
+	(*BatonServiceUploadAssetResponse)(nil),               // 11: c1.connectorapi.baton.v1.BatonServiceUploadAssetResponse
+	(*BatonServiceFinishTaskRequest)(nil),                 // 12: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest
+	(*BatonServiceFinishTaskResponse)(nil),                // 13: c1.connectorapi.baton.v1.BatonServiceFinishTaskResponse
+	(*StartDebuggingRequest)(nil),                         // 14: c1.connectorapi.baton.v1.StartDebuggingRequest
+	(*StartDebuggingResponse)(nil),                        // 15: c1.connectorapi.baton.v1.StartDebuggingResponse
+	(*Task_NoneTask)(nil),                                 // 16: c1.connectorapi.baton.v1.Task.NoneTask
+	(*Task_HelloTask)(nil),                                // 17: c1.connectorapi.baton.v1.Task.HelloTask
+	(*Task_SyncFullTask)(nil),                             // 18: c1.connectorapi.baton.v1.Task.SyncFullTask
+	(*Task_EventFeedTask)(nil),                            // 19: c1.connectorapi.baton.v1.Task.EventFeedTask
+	(*Task_ListEventsTask)(nil),                           // 20: c1.connectorapi.baton.v1.Task.ListEventsTask
+	(*Task_ListEventFeedsTask)(nil),                       // 21: c1.connectorapi.baton.v1.Task.ListEventFeedsTask
+	(*Task_GrantTask)(nil),                                // 22: c1.connectorapi.baton.v1.Task.GrantTask
+	(*Task_RevokeTask)(nil),                               // 23: c1.connectorapi.baton.v1.Task.RevokeTask
+	(*Task_CreateAccountTask)(nil),                        // 24: c1.connectorapi.baton.v1.Task.CreateAccountTask
+	(*Task_CreateResourceTask)(nil),                       // 25: c1.connectorapi.baton.v1.Task.CreateResourceTask
+	(*Task_DeleteResourceTask)(nil),                       // 26: c1.connectorapi.baton.v1.Task.DeleteResourceTask
+	(*Task_RotateCredentialsTask)(nil),                    // 27: c1.connectorapi.baton.v1.Task.RotateCredentialsTask
+	(*Task_CreateTicketTask)(nil),                         // 28: c1.connectorapi.baton.v1.Task.CreateTicketTask
+	(*Task_BulkCreateTicketsTask)(nil),                    // 29: c1.connectorapi.baton.v1.Task.BulkCreateTicketsTask
+	(*Task_BulkGetTicketsTask)(nil),                       // 30: c1.connectorapi.baton.v1.Task.BulkGetTicketsTask
+	(*Task_ListTicketSchemasTask)(nil),                    // 31: c1.connectorapi.baton.v1.Task.ListTicketSchemasTask
+	(*Task_GetTicketTask)(nil),                            // 32: c1.connectorapi.baton.v1.Task.GetTicketTask
+	(*Task_ActionListSchemasTask)(nil),                    // 33: c1.connectorapi.baton.v1.Task.ActionListSchemasTask
+	(*Task_ActionGetSchemaTask)(nil),                      // 34: c1.connectorapi.baton.v1.Task.ActionGetSchemaTask
+	(*Task_ActionInvokeTask)(nil),                         // 35: c1.connectorapi.baton.v1.Task.ActionInvokeTask
+	(*Task_ActionStatusTask)(nil),                         // 36: c1.connectorapi.baton.v1.Task.ActionStatusTask
+	(*Task_CreateSyncDiffTask)(nil),                       // 37: c1.connectorapi.baton.v1.Task.CreateSyncDiffTask
+	(*Task_CompactSyncs)(nil),                             // 38: c1.connectorapi.baton.v1.Task.CompactSyncs
+	(*Task_CompactSyncs_CompactableSync)(nil),             // 39: c1.connectorapi.baton.v1.Task.CompactSyncs.CompactableSync
+	(*BatonServiceHelloRequest_BuildInfo)(nil),            // 40: c1.connectorapi.baton.v1.BatonServiceHelloRequest.BuildInfo
+	(*BatonServiceHelloRequest_OSInfo)(nil),               // 41: c1.connectorapi.baton.v1.BatonServiceHelloRequest.OSInfo
+	(*BatonServiceUploadAssetRequest_UploadMetadata)(nil), // 42: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadMetadata
+	(*BatonServiceUploadAssetRequest_UploadData)(nil),     // 43: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadData
+	(*BatonServiceUploadAssetRequest_UploadEOF)(nil),      // 44: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadEOF
+	(*BatonServiceFinishTaskRequest_Error)(nil),           // 45: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Error
+	(*BatonServiceFinishTaskRequest_Success)(nil),         // 46: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Success
+	(*v2.ConnectorMetadata)(nil),                          // 47: c1.connector.v2.ConnectorMetadata
+	(*anypb.Any)(nil),                                     // 48: google.protobuf.Any
+	(*durationpb.Duration)(nil),                           // 49: google.protobuf.Duration
+	(*status.Status)(nil),                                 // 50: google.rpc.Status
+	(*v2.Resource)(nil),                                   // 51: c1.connector.v2.Resource
+	(*timestamppb.Timestamp)(nil),                         // 52: google.protobuf.Timestamp
+	(*v2.Entitlement)(nil),                                // 53: c1.connector.v2.Entitlement
+	(*v2.Grant)(nil),                                      // 54: c1.connector.v2.Grant
+	(*v2.AccountInfo)(nil),                                // 55: c1.connector.v2.AccountInfo
+	(*v2.CredentialOptions)(nil),                          // 56: c1.connector.v2.CredentialOptions
+	(*v2.EncryptionConfig)(nil),                           // 57: c1.connector.v2.EncryptionConfig
+	(*v2.ResourceId)(nil),                                 // 58: c1.connector.v2.ResourceId
+	(*v2.TicketRequest)(nil),                              // 59: c1.connector.v2.TicketRequest
+	(*v2.TicketSchema)(nil),                               // 60: c1.connector.v2.TicketSchema
+	(*structpb.Struct)(nil),                               // 61: google.protobuf.Struct
 }
 var file_c1_connectorapi_baton_v1_baton_proto_depIdxs = []int32{
-	0,  // 0: c1.connectorapi.baton.v1.Task.status:type_name -> c1.connectorapi.baton.v1.Task.Status
-	14, // 1: c1.connectorapi.baton.v1.Task.none:type_name -> c1.connectorapi.baton.v1.Task.NoneTask
-	15, // 2: c1.connectorapi.baton.v1.Task.hello:type_name -> c1.connectorapi.baton.v1.Task.HelloTask
-	16, // 3: c1.connectorapi.baton.v1.Task.sync_full:type_name -> c1.connectorapi.baton.v1.Task.SyncFullTask
-	20, // 4: c1.connectorapi.baton.v1.Task.grant:type_name -> c1.connectorapi.baton.v1.Task.GrantTask
-	21, // 5: c1.connectorapi.baton.v1.Task.revoke:type_name -> c1.connectorapi.baton.v1.Task.RevokeTask
-	22, // 6: c1.connectorapi.baton.v1.Task.create_account:type_name -> c1.connectorapi.baton.v1.Task.CreateAccountTask
-	23, // 7: c1.connectorapi.baton.v1.Task.create_resource:type_name -> c1.connectorapi.baton.v1.Task.CreateResourceTask
-	24, // 8: c1.connectorapi.baton.v1.Task.delete_resource:type_name -> c1.connectorapi.baton.v1.Task.DeleteResourceTask
-	25, // 9: c1.connectorapi.baton.v1.Task.rotate_credentials:type_name -> c1.connectorapi.baton.v1.Task.RotateCredentialsTask
-	17, // 10: c1.connectorapi.baton.v1.Task.event_feed:type_name -> c1.connectorapi.baton.v1.Task.EventFeedTask
-	26, // 11: c1.connectorapi.baton.v1.Task.create_ticket_task:type_name -> c1.connectorapi.baton.v1.Task.CreateTicketTask
-	29, // 12: c1.connectorapi.baton.v1.Task.list_ticket_schemas:type_name -> c1.connectorapi.baton.v1.Task.ListTicketSchemasTask
-	30, // 13: c1.connectorapi.baton.v1.Task.get_ticket:type_name -> c1.connectorapi.baton.v1.Task.GetTicketTask
-	27, // 14: c1.connectorapi.baton.v1.Task.bulk_create_tickets:type_name -> c1.connectorapi.baton.v1.Task.BulkCreateTicketsTask
-	28, // 15: c1.connectorapi.baton.v1.Task.bulk_get_tickets:type_name -> c1.connectorapi.baton.v1.Task.BulkGetTicketsTask
-	31, // 16: c1.connectorapi.baton.v1.Task.action_list_schemas:type_name -> c1.connectorapi.baton.v1.Task.ActionListSchemasTask
-	32, // 17: c1.connectorapi.baton.v1.Task.action_get_schema:type_name -> c1.connectorapi.baton.v1.Task.ActionGetSchemaTask
-	33, // 18: c1.connectorapi.baton.v1.Task.action_invoke:type_name -> c1.connectorapi.baton.v1.Task.ActionInvokeTask
-	34, // 19: c1.connectorapi.baton.v1.Task.action_status:type_name -> c1.connectorapi.baton.v1.Task.ActionStatusTask
-	35, // 20: c1.connectorapi.baton.v1.Task.create_sync_diff:type_name -> c1.connectorapi.baton.v1.Task.CreateSyncDiffTask
-	36, // 21: c1.connectorapi.baton.v1.Task.compact_syncs:type_name -> c1.connectorapi.baton.v1.Task.CompactSyncs
-	19, // 22: c1.connectorapi.baton.v1.Task.list_event_feeds:type_name -> c1.connectorapi.baton.v1.Task.ListEventFeedsTask
-	18, // 23: c1.connectorapi.baton.v1.Task.list_events:type_name -> c1.connectorapi.baton.v1.Task.ListEventsTask
-	38, // 24: c1.connectorapi.baton.v1.BatonServiceHelloRequest.build_info:type_name -> c1.connectorapi.baton.v1.BatonServiceHelloRequest.BuildInfo
-	39, // 25: c1.connectorapi.baton.v1.BatonServiceHelloRequest.os_info:type_name -> c1.connectorapi.baton.v1.BatonServiceHelloRequest.OSInfo
-	45, // 26: c1.connectorapi.baton.v1.BatonServiceHelloRequest.connector_metadata:type_name -> c1.connector.v2.ConnectorMetadata
-	46, // 27: c1.connectorapi.baton.v1.BatonServiceHelloRequest.annotations:type_name -> google.protobuf.Any
-	46, // 28: c1.connectorapi.baton.v1.BatonServiceHelloResponse.annotations:type_name -> google.protobuf.Any
-	1,  // 29: c1.connectorapi.baton.v1.BatonServiceGetTaskResponse.task:type_name -> c1.connectorapi.baton.v1.Task
-	47, // 30: c1.connectorapi.baton.v1.BatonServiceGetTaskResponse.next_poll:type_name -> google.protobuf.Duration
-	47, // 31: c1.connectorapi.baton.v1.BatonServiceGetTaskResponse.next_heartbeat:type_name -> google.protobuf.Duration
-	46, // 32: c1.connectorapi.baton.v1.BatonServiceGetTaskResponse.annotations:type_name -> google.protobuf.Any
-	46, // 33: c1.connectorapi.baton.v1.BatonServiceHeartbeatRequest.annotations:type_name -> google.protobuf.Any
-	47, // 34: c1.connectorapi.baton.v1.BatonServiceHeartbeatResponse.next_heartbeat:type_name -> google.protobuf.Duration
-	46, // 35: c1.connectorapi.baton.v1.BatonServiceHeartbeatResponse.annotations:type_name -> google.protobuf.Any
-	40, // 36: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.metadata:type_name -> c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadMetadata
-	41, // 37: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.data:type_name -> c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadData
-	42, // 38: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.eof:type_name -> c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadEOF
-	46, // 39: c1.connectorapi.baton.v1.BatonServiceUploadAssetResponse.annotations:type_name -> google.protobuf.Any
-	48, // 40: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.status:type_name -> google.rpc.Status
-	43, // 41: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.error:type_name -> c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Error
-	44, // 42: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.success:type_name -> c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Success
-	46, // 43: c1.connectorapi.baton.v1.BatonServiceFinishTaskResponse.annotations:type_name -> google.protobuf.Any
-	46, // 44: c1.connectorapi.baton.v1.Task.NoneTask.annotations:type_name -> google.protobuf.Any
-	46, // 45: c1.connectorapi.baton.v1.Task.HelloTask.annotations:type_name -> google.protobuf.Any
-	46, // 46: c1.connectorapi.baton.v1.Task.SyncFullTask.annotations:type_name -> google.protobuf.Any
-	49, // 47: c1.connectorapi.baton.v1.Task.SyncFullTask.targeted_sync_resources:type_name -> c1.connector.v2.Resource
-	46, // 48: c1.connectorapi.baton.v1.Task.EventFeedTask.annotations:type_name -> google.protobuf.Any
-	50, // 49: c1.connectorapi.baton.v1.Task.EventFeedTask.start_at:type_name -> google.protobuf.Timestamp
-	46, // 50: c1.connectorapi.baton.v1.Task.ListEventsTask.annotations:type_name -> google.protobuf.Any
-	50, // 51: c1.connectorapi.baton.v1.Task.ListEventsTask.start_at:type_name -> google.protobuf.Timestamp
-	46, // 52: c1.connectorapi.baton.v1.Task.ListEventFeedsTask.annotations:type_name -> google.protobuf.Any
-	51, // 53: c1.connectorapi.baton.v1.Task.GrantTask.entitlement:type_name -> c1.connector.v2.Entitlement
-	49, // 54: c1.connectorapi.baton.v1.Task.GrantTask.principal:type_name -> c1.connector.v2.Resource
-	46, // 55: c1.connectorapi.baton.v1.Task.GrantTask.annotations:type_name -> google.protobuf.Any
-	47, // 56: c1.connectorapi.baton.v1.Task.GrantTask.duration:type_name -> google.protobuf.Duration
-	52, // 57: c1.connectorapi.baton.v1.Task.RevokeTask.grant:type_name -> c1.connector.v2.Grant
-	46, // 58: c1.connectorapi.baton.v1.Task.RevokeTask.annotations:type_name -> google.protobuf.Any
-	53, // 59: c1.connectorapi.baton.v1.Task.CreateAccountTask.account_info:type_name -> c1.connector.v2.AccountInfo
-	54, // 60: c1.connectorapi.baton.v1.Task.CreateAccountTask.credential_options:type_name -> c1.connector.v2.CredentialOptions
-	55, // 61: c1.connectorapi.baton.v1.Task.CreateAccountTask.encryption_configs:type_name -> c1.connector.v2.EncryptionConfig
-	49, // 62: c1.connectorapi.baton.v1.Task.CreateResourceTask.resource:type_name -> c1.connector.v2.Resource
-	56, // 63: c1.connectorapi.baton.v1.Task.DeleteResourceTask.resource_id:type_name -> c1.connector.v2.ResourceId
-	56, // 64: c1.connectorapi.baton.v1.Task.DeleteResourceTask.parent_resource_id:type_name -> c1.connector.v2.ResourceId
-	56, // 65: c1.connectorapi.baton.v1.Task.RotateCredentialsTask.resource_id:type_name -> c1.connector.v2.ResourceId
-	54, // 66: c1.connectorapi.baton.v1.Task.RotateCredentialsTask.credential_options:type_name -> c1.connector.v2.CredentialOptions
-	55, // 67: c1.connectorapi.baton.v1.Task.RotateCredentialsTask.encryption_configs:type_name -> c1.connector.v2.EncryptionConfig
-	57, // 68: c1.connectorapi.baton.v1.Task.CreateTicketTask.ticket_request:type_name -> c1.connector.v2.TicketRequest
-	58, // 69: c1.connectorapi.baton.v1.Task.CreateTicketTask.ticket_schema:type_name -> c1.connector.v2.TicketSchema
-	46, // 70: c1.connectorapi.baton.v1.Task.CreateTicketTask.annotations:type_name -> google.protobuf.Any
-	26, // 71: c1.connectorapi.baton.v1.Task.BulkCreateTicketsTask.ticket_requests:type_name -> c1.connectorapi.baton.v1.Task.CreateTicketTask
-	30, // 72: c1.connectorapi.baton.v1.Task.BulkGetTicketsTask.ticket_requests:type_name -> c1.connectorapi.baton.v1.Task.GetTicketTask
-	46, // 73: c1.connectorapi.baton.v1.Task.ListTicketSchemasTask.annotations:type_name -> google.protobuf.Any
-	46, // 74: c1.connectorapi.baton.v1.Task.GetTicketTask.annotations:type_name -> google.protobuf.Any
-	46, // 75: c1.connectorapi.baton.v1.Task.ActionListSchemasTask.annotations:type_name -> google.protobuf.Any
-	46, // 76: c1.connectorapi.baton.v1.Task.ActionGetSchemaTask.annotations:type_name -> google.protobuf.Any
-	59, // 77: c1.connectorapi.baton.v1.Task.ActionInvokeTask.args:type_name -> google.protobuf.Struct
-	46, // 78: c1.connectorapi.baton.v1.Task.ActionInvokeTask.annotations:type_name -> google.protobuf.Any
-	46, // 79: c1.connectorapi.baton.v1.Task.ActionStatusTask.annotations:type_name -> google.protobuf.Any
-	46, // 80: c1.connectorapi.baton.v1.Task.CreateSyncDiffTask.annotations:type_name -> google.protobuf.Any
-	37, // 81: c1.connectorapi.baton.v1.Task.CompactSyncs.compactable_syncs:type_name -> c1.connectorapi.baton.v1.Task.CompactSyncs.CompactableSync
-	46, // 82: c1.connectorapi.baton.v1.Task.CompactSyncs.annotations:type_name -> google.protobuf.Any
-	46, // 83: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadMetadata.annotations:type_name -> google.protobuf.Any
-	46, // 84: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadEOF.annotations:type_name -> google.protobuf.Any
-	46, // 85: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Error.annotations:type_name -> google.protobuf.Any
-	46, // 86: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Error.response:type_name -> google.protobuf.Any
-	46, // 87: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Success.annotations:type_name -> google.protobuf.Any
-	46, // 88: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Success.response:type_name -> google.protobuf.Any
-	2,  // 89: c1.connectorapi.baton.v1.BatonService.Hello:input_type -> c1.connectorapi.baton.v1.BatonServiceHelloRequest
-	4,  // 90: c1.connectorapi.baton.v1.BatonService.GetTask:input_type -> c1.connectorapi.baton.v1.BatonServiceGetTaskRequest
-	6,  // 91: c1.connectorapi.baton.v1.BatonService.Heartbeat:input_type -> c1.connectorapi.baton.v1.BatonServiceHeartbeatRequest
-	10, // 92: c1.connectorapi.baton.v1.BatonService.FinishTask:input_type -> c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest
-	8,  // 93: c1.connectorapi.baton.v1.BatonService.UploadAsset:input_type -> c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest
-	12, // 94: c1.connectorapi.baton.v1.BatonService.StartDebugging:input_type -> c1.connectorapi.baton.v1.StartDebuggingRequest
-	3,  // 95: c1.connectorapi.baton.v1.BatonService.Hello:output_type -> c1.connectorapi.baton.v1.BatonServiceHelloResponse
-	5,  // 96: c1.connectorapi.baton.v1.BatonService.GetTask:output_type -> c1.connectorapi.baton.v1.BatonServiceGetTaskResponse
-	7,  // 97: c1.connectorapi.baton.v1.BatonService.Heartbeat:output_type -> c1.connectorapi.baton.v1.BatonServiceHeartbeatResponse
-	11, // 98: c1.connectorapi.baton.v1.BatonService.FinishTask:output_type -> c1.connectorapi.baton.v1.BatonServiceFinishTaskResponse
-	9,  // 99: c1.connectorapi.baton.v1.BatonService.UploadAsset:output_type -> c1.connectorapi.baton.v1.BatonServiceUploadAssetResponse
-	13, // 100: c1.connectorapi.baton.v1.BatonService.StartDebugging:output_type -> c1.connectorapi.baton.v1.StartDebuggingResponse
-	95, // [95:101] is the sub-list for method output_type
-	89, // [89:95] is the sub-list for method input_type
-	89, // [89:89] is the sub-list for extension type_name
-	89, // [89:89] is the sub-list for extension extendee
-	0,  // [0:89] is the sub-list for field type_name
+	0,   // 0: c1.connectorapi.baton.v1.Task.status:type_name -> c1.connectorapi.baton.v1.Task.Status
+	16,  // 1: c1.connectorapi.baton.v1.Task.none:type_name -> c1.connectorapi.baton.v1.Task.NoneTask
+	17,  // 2: c1.connectorapi.baton.v1.Task.hello:type_name -> c1.connectorapi.baton.v1.Task.HelloTask
+	18,  // 3: c1.connectorapi.baton.v1.Task.sync_full:type_name -> c1.connectorapi.baton.v1.Task.SyncFullTask
+	22,  // 4: c1.connectorapi.baton.v1.Task.grant:type_name -> c1.connectorapi.baton.v1.Task.GrantTask
+	23,  // 5: c1.connectorapi.baton.v1.Task.revoke:type_name -> c1.connectorapi.baton.v1.Task.RevokeTask
+	24,  // 6: c1.connectorapi.baton.v1.Task.create_account:type_name -> c1.connectorapi.baton.v1.Task.CreateAccountTask
+	25,  // 7: c1.connectorapi.baton.v1.Task.create_resource:type_name -> c1.connectorapi.baton.v1.Task.CreateResourceTask
+	26,  // 8: c1.connectorapi.baton.v1.Task.delete_resource:type_name -> c1.connectorapi.baton.v1.Task.DeleteResourceTask
+	27,  // 9: c1.connectorapi.baton.v1.Task.rotate_credentials:type_name -> c1.connectorapi.baton.v1.Task.RotateCredentialsTask
+	19,  // 10: c1.connectorapi.baton.v1.Task.event_feed:type_name -> c1.connectorapi.baton.v1.Task.EventFeedTask
+	28,  // 11: c1.connectorapi.baton.v1.Task.create_ticket_task:type_name -> c1.connectorapi.baton.v1.Task.CreateTicketTask
+	31,  // 12: c1.connectorapi.baton.v1.Task.list_ticket_schemas:type_name -> c1.connectorapi.baton.v1.Task.ListTicketSchemasTask
+	32,  // 13: c1.connectorapi.baton.v1.Task.get_ticket:type_name -> c1.connectorapi.baton.v1.Task.GetTicketTask
+	29,  // 14: c1.connectorapi.baton.v1.Task.bulk_create_tickets:type_name -> c1.connectorapi.baton.v1.Task.BulkCreateTicketsTask
+	30,  // 15: c1.connectorapi.baton.v1.Task.bulk_get_tickets:type_name -> c1.connectorapi.baton.v1.Task.BulkGetTicketsTask
+	33,  // 16: c1.connectorapi.baton.v1.Task.action_list_schemas:type_name -> c1.connectorapi.baton.v1.Task.ActionListSchemasTask
+	34,  // 17: c1.connectorapi.baton.v1.Task.action_get_schema:type_name -> c1.connectorapi.baton.v1.Task.ActionGetSchemaTask
+	35,  // 18: c1.connectorapi.baton.v1.Task.action_invoke:type_name -> c1.connectorapi.baton.v1.Task.ActionInvokeTask
+	36,  // 19: c1.connectorapi.baton.v1.Task.action_status:type_name -> c1.connectorapi.baton.v1.Task.ActionStatusTask
+	37,  // 20: c1.connectorapi.baton.v1.Task.create_sync_diff:type_name -> c1.connectorapi.baton.v1.Task.CreateSyncDiffTask
+	38,  // 21: c1.connectorapi.baton.v1.Task.compact_syncs:type_name -> c1.connectorapi.baton.v1.Task.CompactSyncs
+	21,  // 22: c1.connectorapi.baton.v1.Task.list_event_feeds:type_name -> c1.connectorapi.baton.v1.Task.ListEventFeedsTask
+	20,  // 23: c1.connectorapi.baton.v1.Task.list_events:type_name -> c1.connectorapi.baton.v1.Task.ListEventsTask
+	40,  // 24: c1.connectorapi.baton.v1.BatonServiceHelloRequest.build_info:type_name -> c1.connectorapi.baton.v1.BatonServiceHelloRequest.BuildInfo
+	41,  // 25: c1.connectorapi.baton.v1.BatonServiceHelloRequest.os_info:type_name -> c1.connectorapi.baton.v1.BatonServiceHelloRequest.OSInfo
+	47,  // 26: c1.connectorapi.baton.v1.BatonServiceHelloRequest.connector_metadata:type_name -> c1.connector.v2.ConnectorMetadata
+	48,  // 27: c1.connectorapi.baton.v1.BatonServiceHelloRequest.annotations:type_name -> google.protobuf.Any
+	48,  // 28: c1.connectorapi.baton.v1.BatonServiceHelloResponse.annotations:type_name -> google.protobuf.Any
+	48,  // 29: c1.connectorapi.baton.v1.BatonServiceGetTasksRequest.annotations:type_name -> google.protobuf.Any
+	1,   // 30: c1.connectorapi.baton.v1.BatonServiceGetTasksResponse.tasks:type_name -> c1.connectorapi.baton.v1.Task
+	49,  // 31: c1.connectorapi.baton.v1.BatonServiceGetTasksResponse.next_poll:type_name -> google.protobuf.Duration
+	49,  // 32: c1.connectorapi.baton.v1.BatonServiceGetTasksResponse.next_heartbeat:type_name -> google.protobuf.Duration
+	48,  // 33: c1.connectorapi.baton.v1.BatonServiceGetTasksResponse.annotations:type_name -> google.protobuf.Any
+	1,   // 34: c1.connectorapi.baton.v1.BatonServiceGetTaskResponse.task:type_name -> c1.connectorapi.baton.v1.Task
+	49,  // 35: c1.connectorapi.baton.v1.BatonServiceGetTaskResponse.next_poll:type_name -> google.protobuf.Duration
+	49,  // 36: c1.connectorapi.baton.v1.BatonServiceGetTaskResponse.next_heartbeat:type_name -> google.protobuf.Duration
+	48,  // 37: c1.connectorapi.baton.v1.BatonServiceGetTaskResponse.annotations:type_name -> google.protobuf.Any
+	48,  // 38: c1.connectorapi.baton.v1.BatonServiceHeartbeatRequest.annotations:type_name -> google.protobuf.Any
+	49,  // 39: c1.connectorapi.baton.v1.BatonServiceHeartbeatResponse.next_heartbeat:type_name -> google.protobuf.Duration
+	48,  // 40: c1.connectorapi.baton.v1.BatonServiceHeartbeatResponse.annotations:type_name -> google.protobuf.Any
+	42,  // 41: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.metadata:type_name -> c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadMetadata
+	43,  // 42: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.data:type_name -> c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadData
+	44,  // 43: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.eof:type_name -> c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadEOF
+	48,  // 44: c1.connectorapi.baton.v1.BatonServiceUploadAssetResponse.annotations:type_name -> google.protobuf.Any
+	50,  // 45: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.status:type_name -> google.rpc.Status
+	45,  // 46: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.error:type_name -> c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Error
+	46,  // 47: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.success:type_name -> c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Success
+	48,  // 48: c1.connectorapi.baton.v1.BatonServiceFinishTaskResponse.annotations:type_name -> google.protobuf.Any
+	48,  // 49: c1.connectorapi.baton.v1.Task.NoneTask.annotations:type_name -> google.protobuf.Any
+	48,  // 50: c1.connectorapi.baton.v1.Task.HelloTask.annotations:type_name -> google.protobuf.Any
+	48,  // 51: c1.connectorapi.baton.v1.Task.SyncFullTask.annotations:type_name -> google.protobuf.Any
+	51,  // 52: c1.connectorapi.baton.v1.Task.SyncFullTask.targeted_sync_resources:type_name -> c1.connector.v2.Resource
+	48,  // 53: c1.connectorapi.baton.v1.Task.EventFeedTask.annotations:type_name -> google.protobuf.Any
+	52,  // 54: c1.connectorapi.baton.v1.Task.EventFeedTask.start_at:type_name -> google.protobuf.Timestamp
+	48,  // 55: c1.connectorapi.baton.v1.Task.ListEventsTask.annotations:type_name -> google.protobuf.Any
+	52,  // 56: c1.connectorapi.baton.v1.Task.ListEventsTask.start_at:type_name -> google.protobuf.Timestamp
+	48,  // 57: c1.connectorapi.baton.v1.Task.ListEventFeedsTask.annotations:type_name -> google.protobuf.Any
+	53,  // 58: c1.connectorapi.baton.v1.Task.GrantTask.entitlement:type_name -> c1.connector.v2.Entitlement
+	51,  // 59: c1.connectorapi.baton.v1.Task.GrantTask.principal:type_name -> c1.connector.v2.Resource
+	48,  // 60: c1.connectorapi.baton.v1.Task.GrantTask.annotations:type_name -> google.protobuf.Any
+	49,  // 61: c1.connectorapi.baton.v1.Task.GrantTask.duration:type_name -> google.protobuf.Duration
+	54,  // 62: c1.connectorapi.baton.v1.Task.RevokeTask.grant:type_name -> c1.connector.v2.Grant
+	48,  // 63: c1.connectorapi.baton.v1.Task.RevokeTask.annotations:type_name -> google.protobuf.Any
+	55,  // 64: c1.connectorapi.baton.v1.Task.CreateAccountTask.account_info:type_name -> c1.connector.v2.AccountInfo
+	56,  // 65: c1.connectorapi.baton.v1.Task.CreateAccountTask.credential_options:type_name -> c1.connector.v2.CredentialOptions
+	57,  // 66: c1.connectorapi.baton.v1.Task.CreateAccountTask.encryption_configs:type_name -> c1.connector.v2.EncryptionConfig
+	51,  // 67: c1.connectorapi.baton.v1.Task.CreateResourceTask.resource:type_name -> c1.connector.v2.Resource
+	58,  // 68: c1.connectorapi.baton.v1.Task.DeleteResourceTask.resource_id:type_name -> c1.connector.v2.ResourceId
+	58,  // 69: c1.connectorapi.baton.v1.Task.DeleteResourceTask.parent_resource_id:type_name -> c1.connector.v2.ResourceId
+	58,  // 70: c1.connectorapi.baton.v1.Task.RotateCredentialsTask.resource_id:type_name -> c1.connector.v2.ResourceId
+	56,  // 71: c1.connectorapi.baton.v1.Task.RotateCredentialsTask.credential_options:type_name -> c1.connector.v2.CredentialOptions
+	57,  // 72: c1.connectorapi.baton.v1.Task.RotateCredentialsTask.encryption_configs:type_name -> c1.connector.v2.EncryptionConfig
+	59,  // 73: c1.connectorapi.baton.v1.Task.CreateTicketTask.ticket_request:type_name -> c1.connector.v2.TicketRequest
+	60,  // 74: c1.connectorapi.baton.v1.Task.CreateTicketTask.ticket_schema:type_name -> c1.connector.v2.TicketSchema
+	48,  // 75: c1.connectorapi.baton.v1.Task.CreateTicketTask.annotations:type_name -> google.protobuf.Any
+	28,  // 76: c1.connectorapi.baton.v1.Task.BulkCreateTicketsTask.ticket_requests:type_name -> c1.connectorapi.baton.v1.Task.CreateTicketTask
+	32,  // 77: c1.connectorapi.baton.v1.Task.BulkGetTicketsTask.ticket_requests:type_name -> c1.connectorapi.baton.v1.Task.GetTicketTask
+	48,  // 78: c1.connectorapi.baton.v1.Task.ListTicketSchemasTask.annotations:type_name -> google.protobuf.Any
+	48,  // 79: c1.connectorapi.baton.v1.Task.GetTicketTask.annotations:type_name -> google.protobuf.Any
+	48,  // 80: c1.connectorapi.baton.v1.Task.ActionListSchemasTask.annotations:type_name -> google.protobuf.Any
+	48,  // 81: c1.connectorapi.baton.v1.Task.ActionGetSchemaTask.annotations:type_name -> google.protobuf.Any
+	61,  // 82: c1.connectorapi.baton.v1.Task.ActionInvokeTask.args:type_name -> google.protobuf.Struct
+	48,  // 83: c1.connectorapi.baton.v1.Task.ActionInvokeTask.annotations:type_name -> google.protobuf.Any
+	48,  // 84: c1.connectorapi.baton.v1.Task.ActionStatusTask.annotations:type_name -> google.protobuf.Any
+	48,  // 85: c1.connectorapi.baton.v1.Task.CreateSyncDiffTask.annotations:type_name -> google.protobuf.Any
+	39,  // 86: c1.connectorapi.baton.v1.Task.CompactSyncs.compactable_syncs:type_name -> c1.connectorapi.baton.v1.Task.CompactSyncs.CompactableSync
+	48,  // 87: c1.connectorapi.baton.v1.Task.CompactSyncs.annotations:type_name -> google.protobuf.Any
+	48,  // 88: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadMetadata.annotations:type_name -> google.protobuf.Any
+	48,  // 89: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadEOF.annotations:type_name -> google.protobuf.Any
+	48,  // 90: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Error.annotations:type_name -> google.protobuf.Any
+	48,  // 91: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Error.response:type_name -> google.protobuf.Any
+	48,  // 92: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Success.annotations:type_name -> google.protobuf.Any
+	48,  // 93: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Success.response:type_name -> google.protobuf.Any
+	2,   // 94: c1.connectorapi.baton.v1.BatonService.Hello:input_type -> c1.connectorapi.baton.v1.BatonServiceHelloRequest
+	4,   // 95: c1.connectorapi.baton.v1.BatonService.GetTask:input_type -> c1.connectorapi.baton.v1.BatonServiceGetTaskRequest
+	5,   // 96: c1.connectorapi.baton.v1.BatonService.GetTasks:input_type -> c1.connectorapi.baton.v1.BatonServiceGetTasksRequest
+	8,   // 97: c1.connectorapi.baton.v1.BatonService.Heartbeat:input_type -> c1.connectorapi.baton.v1.BatonServiceHeartbeatRequest
+	12,  // 98: c1.connectorapi.baton.v1.BatonService.FinishTask:input_type -> c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest
+	10,  // 99: c1.connectorapi.baton.v1.BatonService.UploadAsset:input_type -> c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest
+	14,  // 100: c1.connectorapi.baton.v1.BatonService.StartDebugging:input_type -> c1.connectorapi.baton.v1.StartDebuggingRequest
+	3,   // 101: c1.connectorapi.baton.v1.BatonService.Hello:output_type -> c1.connectorapi.baton.v1.BatonServiceHelloResponse
+	7,   // 102: c1.connectorapi.baton.v1.BatonService.GetTask:output_type -> c1.connectorapi.baton.v1.BatonServiceGetTaskResponse
+	6,   // 103: c1.connectorapi.baton.v1.BatonService.GetTasks:output_type -> c1.connectorapi.baton.v1.BatonServiceGetTasksResponse
+	9,   // 104: c1.connectorapi.baton.v1.BatonService.Heartbeat:output_type -> c1.connectorapi.baton.v1.BatonServiceHeartbeatResponse
+	13,  // 105: c1.connectorapi.baton.v1.BatonService.FinishTask:output_type -> c1.connectorapi.baton.v1.BatonServiceFinishTaskResponse
+	11,  // 106: c1.connectorapi.baton.v1.BatonService.UploadAsset:output_type -> c1.connectorapi.baton.v1.BatonServiceUploadAssetResponse
+	15,  // 107: c1.connectorapi.baton.v1.BatonService.StartDebugging:output_type -> c1.connectorapi.baton.v1.StartDebuggingResponse
+	101, // [101:108] is the sub-list for method output_type
+	94,  // [94:101] is the sub-list for method input_type
+	94,  // [94:94] is the sub-list for extension type_name
+	94,  // [94:94] is the sub-list for extension extendee
+	0,   // [0:94] is the sub-list for field type_name
 }
 
 func init() { file_c1_connectorapi_baton_v1_baton_proto_init() }
@@ -5589,12 +5862,12 @@ func file_c1_connectorapi_baton_v1_baton_proto_init() {
 		(*Task_ListEventFeeds)(nil),
 		(*Task_ListEvents)(nil),
 	}
-	file_c1_connectorapi_baton_v1_baton_proto_msgTypes[7].OneofWrappers = []any{
+	file_c1_connectorapi_baton_v1_baton_proto_msgTypes[9].OneofWrappers = []any{
 		(*BatonServiceUploadAssetRequest_Metadata)(nil),
 		(*BatonServiceUploadAssetRequest_Data)(nil),
 		(*BatonServiceUploadAssetRequest_Eof)(nil),
 	}
-	file_c1_connectorapi_baton_v1_baton_proto_msgTypes[9].OneofWrappers = []any{
+	file_c1_connectorapi_baton_v1_baton_proto_msgTypes[11].OneofWrappers = []any{
 		(*BatonServiceFinishTaskRequest_Error_)(nil),
 		(*BatonServiceFinishTaskRequest_Success_)(nil),
 	}
@@ -5604,7 +5877,7 @@ func file_c1_connectorapi_baton_v1_baton_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_c1_connectorapi_baton_v1_baton_proto_rawDesc), len(file_c1_connectorapi_baton_v1_baton_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   44,
+			NumMessages:   46,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pb/c1/connectorapi/baton/v1/baton.pb.validate.go
+++ b/pb/c1/connectorapi/baton/v1/baton.pb.validate.go
@@ -1605,6 +1605,434 @@ var _ interface {
 	ErrorName() string
 } = BatonServiceGetTaskRequestValidationError{}
 
+// Validate checks the field values on BatonServiceGetTasksRequest with the
+// rules defined in the proto definition for this message. If any rules are
+// violated, the first error encountered is returned, or nil if there are no violations.
+func (m *BatonServiceGetTasksRequest) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on BatonServiceGetTasksRequest with the
+// rules defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// BatonServiceGetTasksRequestMultiError, or nil if none found.
+func (m *BatonServiceGetTasksRequest) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *BatonServiceGetTasksRequest) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	if l := utf8.RuneCountInString(m.GetHostId()); l < 1 || l > 256 {
+		err := BatonServiceGetTasksRequestValidationError{
+			field:  "HostId",
+			reason: "value length must be between 1 and 256 runes, inclusive",
+		}
+		if !all {
+			return err
+		}
+		errors = append(errors, err)
+	}
+
+	if val := m.GetPageSize(); val <= 0 || val > 100 {
+		err := BatonServiceGetTasksRequestValidationError{
+			field:  "PageSize",
+			reason: "value must be inside range (0, 100]",
+		}
+		if !all {
+			return err
+		}
+		errors = append(errors, err)
+	}
+
+	for idx, item := range m.GetKnownTaskIds() {
+		_, _ = idx, item
+
+		if !_BatonServiceGetTasksRequest_KnownTaskIds_Pattern.MatchString(item) {
+			err := BatonServiceGetTasksRequestValidationError{
+				field:  fmt.Sprintf("KnownTaskIds[%v]", idx),
+				reason: "value does not match regex pattern \"^[a-zA-Z0-9]{27}$\"",
+			}
+			if !all {
+				return err
+			}
+			errors = append(errors, err)
+		}
+
+	}
+
+	if len(m.GetAnnotations()) > 16 {
+		err := BatonServiceGetTasksRequestValidationError{
+			field:  "Annotations",
+			reason: "value must contain no more than 16 item(s)",
+		}
+		if !all {
+			return err
+		}
+		errors = append(errors, err)
+	}
+
+	for idx, item := range m.GetAnnotations() {
+		_, _ = idx, item
+
+		if all {
+			switch v := interface{}(item).(type) {
+			case interface{ ValidateAll() error }:
+				if err := v.ValidateAll(); err != nil {
+					errors = append(errors, BatonServiceGetTasksRequestValidationError{
+						field:  fmt.Sprintf("Annotations[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			case interface{ Validate() error }:
+				if err := v.Validate(); err != nil {
+					errors = append(errors, BatonServiceGetTasksRequestValidationError{
+						field:  fmt.Sprintf("Annotations[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			}
+		} else if v, ok := interface{}(item).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return BatonServiceGetTasksRequestValidationError{
+					field:  fmt.Sprintf("Annotations[%v]", idx),
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
+	}
+
+	if len(errors) > 0 {
+		return BatonServiceGetTasksRequestMultiError(errors)
+	}
+
+	return nil
+}
+
+// BatonServiceGetTasksRequestMultiError is an error wrapping multiple
+// validation errors returned by BatonServiceGetTasksRequest.ValidateAll() if
+// the designated constraints aren't met.
+type BatonServiceGetTasksRequestMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m BatonServiceGetTasksRequestMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m BatonServiceGetTasksRequestMultiError) AllErrors() []error { return m }
+
+// BatonServiceGetTasksRequestValidationError is the validation error returned
+// by BatonServiceGetTasksRequest.Validate if the designated constraints
+// aren't met.
+type BatonServiceGetTasksRequestValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e BatonServiceGetTasksRequestValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e BatonServiceGetTasksRequestValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e BatonServiceGetTasksRequestValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e BatonServiceGetTasksRequestValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e BatonServiceGetTasksRequestValidationError) ErrorName() string {
+	return "BatonServiceGetTasksRequestValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e BatonServiceGetTasksRequestValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sBatonServiceGetTasksRequest.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = BatonServiceGetTasksRequestValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = BatonServiceGetTasksRequestValidationError{}
+
+var _BatonServiceGetTasksRequest_KnownTaskIds_Pattern = regexp.MustCompile("^[a-zA-Z0-9]{27}$")
+
+// Validate checks the field values on BatonServiceGetTasksResponse with the
+// rules defined in the proto definition for this message. If any rules are
+// violated, the first error encountered is returned, or nil if there are no violations.
+func (m *BatonServiceGetTasksResponse) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on BatonServiceGetTasksResponse with the
+// rules defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// BatonServiceGetTasksResponseMultiError, or nil if none found.
+func (m *BatonServiceGetTasksResponse) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *BatonServiceGetTasksResponse) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	if len(m.GetTasks()) > 100 {
+		err := BatonServiceGetTasksResponseValidationError{
+			field:  "Tasks",
+			reason: "value must contain no more than 100 item(s)",
+		}
+		if !all {
+			return err
+		}
+		errors = append(errors, err)
+	}
+
+	for idx, item := range m.GetTasks() {
+		_, _ = idx, item
+
+		if all {
+			switch v := interface{}(item).(type) {
+			case interface{ ValidateAll() error }:
+				if err := v.ValidateAll(); err != nil {
+					errors = append(errors, BatonServiceGetTasksResponseValidationError{
+						field:  fmt.Sprintf("Tasks[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			case interface{ Validate() error }:
+				if err := v.Validate(); err != nil {
+					errors = append(errors, BatonServiceGetTasksResponseValidationError{
+						field:  fmt.Sprintf("Tasks[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			}
+		} else if v, ok := interface{}(item).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return BatonServiceGetTasksResponseValidationError{
+					field:  fmt.Sprintf("Tasks[%v]", idx),
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
+	}
+
+	if all {
+		switch v := interface{}(m.GetNextPoll()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, BatonServiceGetTasksResponseValidationError{
+					field:  "NextPoll",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, BatonServiceGetTasksResponseValidationError{
+					field:  "NextPoll",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetNextPoll()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return BatonServiceGetTasksResponseValidationError{
+				field:  "NextPoll",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetNextHeartbeat()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, BatonServiceGetTasksResponseValidationError{
+					field:  "NextHeartbeat",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, BatonServiceGetTasksResponseValidationError{
+					field:  "NextHeartbeat",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetNextHeartbeat()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return BatonServiceGetTasksResponseValidationError{
+				field:  "NextHeartbeat",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
+	for idx, item := range m.GetAnnotations() {
+		_, _ = idx, item
+
+		if all {
+			switch v := interface{}(item).(type) {
+			case interface{ ValidateAll() error }:
+				if err := v.ValidateAll(); err != nil {
+					errors = append(errors, BatonServiceGetTasksResponseValidationError{
+						field:  fmt.Sprintf("Annotations[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			case interface{ Validate() error }:
+				if err := v.Validate(); err != nil {
+					errors = append(errors, BatonServiceGetTasksResponseValidationError{
+						field:  fmt.Sprintf("Annotations[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			}
+		} else if v, ok := interface{}(item).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return BatonServiceGetTasksResponseValidationError{
+					field:  fmt.Sprintf("Annotations[%v]", idx),
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
+	}
+
+	if len(errors) > 0 {
+		return BatonServiceGetTasksResponseMultiError(errors)
+	}
+
+	return nil
+}
+
+// BatonServiceGetTasksResponseMultiError is an error wrapping multiple
+// validation errors returned by BatonServiceGetTasksResponse.ValidateAll() if
+// the designated constraints aren't met.
+type BatonServiceGetTasksResponseMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m BatonServiceGetTasksResponseMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m BatonServiceGetTasksResponseMultiError) AllErrors() []error { return m }
+
+// BatonServiceGetTasksResponseValidationError is the validation error returned
+// by BatonServiceGetTasksResponse.Validate if the designated constraints
+// aren't met.
+type BatonServiceGetTasksResponseValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e BatonServiceGetTasksResponseValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e BatonServiceGetTasksResponseValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e BatonServiceGetTasksResponseValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e BatonServiceGetTasksResponseValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e BatonServiceGetTasksResponseValidationError) ErrorName() string {
+	return "BatonServiceGetTasksResponseValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e BatonServiceGetTasksResponseValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sBatonServiceGetTasksResponse.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = BatonServiceGetTasksResponseValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = BatonServiceGetTasksResponseValidationError{}
+
 // Validate checks the field values on BatonServiceGetTaskResponse with the
 // rules defined in the proto definition for this message. If any rules are
 // violated, the first error encountered is returned, or nil if there are no violations.
@@ -1918,6 +2346,33 @@ func (m *BatonServiceHeartbeatRequest) validate(all bool) error {
 
 	}
 
+	if len(m.GetTaskIds()) > 100 {
+		err := BatonServiceHeartbeatRequestValidationError{
+			field:  "TaskIds",
+			reason: "value must contain no more than 100 item(s)",
+		}
+		if !all {
+			return err
+		}
+		errors = append(errors, err)
+	}
+
+	for idx, item := range m.GetTaskIds() {
+		_, _ = idx, item
+
+		if !_BatonServiceHeartbeatRequest_TaskIds_Pattern.MatchString(item) {
+			err := BatonServiceHeartbeatRequestValidationError{
+				field:  fmt.Sprintf("TaskIds[%v]", idx),
+				reason: "value does not match regex pattern \"^[a-zA-Z0-9]{27}$\"",
+			}
+			if !all {
+				return err
+			}
+			errors = append(errors, err)
+		}
+
+	}
+
 	if len(errors) > 0 {
 		return BatonServiceHeartbeatRequestMultiError(errors)
 	}
@@ -2000,6 +2455,8 @@ var _ interface {
 } = BatonServiceHeartbeatRequestValidationError{}
 
 var _BatonServiceHeartbeatRequest_TaskId_Pattern = regexp.MustCompile("^[a-zA-Z0-9]{27}$")
+
+var _BatonServiceHeartbeatRequest_TaskIds_Pattern = regexp.MustCompile("^[a-zA-Z0-9]{27}$")
 
 // Validate checks the field values on BatonServiceHeartbeatResponse with the
 // rules defined in the proto definition for this message. If any rules are

--- a/pb/c1/connectorapi/baton/v1/baton_grpc.pb.go
+++ b/pb/c1/connectorapi/baton/v1/baton_grpc.pb.go
@@ -21,6 +21,7 @@ const _ = grpc.SupportPackageIsVersion9
 const (
 	BatonService_Hello_FullMethodName          = "/c1.connectorapi.baton.v1.BatonService/Hello"
 	BatonService_GetTask_FullMethodName        = "/c1.connectorapi.baton.v1.BatonService/GetTask"
+	BatonService_GetTasks_FullMethodName       = "/c1.connectorapi.baton.v1.BatonService/GetTasks"
 	BatonService_Heartbeat_FullMethodName      = "/c1.connectorapi.baton.v1.BatonService/Heartbeat"
 	BatonService_FinishTask_FullMethodName     = "/c1.connectorapi.baton.v1.BatonService/FinishTask"
 	BatonService_UploadAsset_FullMethodName    = "/c1.connectorapi.baton.v1.BatonService/UploadAsset"
@@ -33,6 +34,7 @@ const (
 type BatonServiceClient interface {
 	Hello(ctx context.Context, in *BatonServiceHelloRequest, opts ...grpc.CallOption) (*BatonServiceHelloResponse, error)
 	GetTask(ctx context.Context, in *BatonServiceGetTaskRequest, opts ...grpc.CallOption) (*BatonServiceGetTaskResponse, error)
+	GetTasks(ctx context.Context, in *BatonServiceGetTasksRequest, opts ...grpc.CallOption) (*BatonServiceGetTasksResponse, error)
 	Heartbeat(ctx context.Context, in *BatonServiceHeartbeatRequest, opts ...grpc.CallOption) (*BatonServiceHeartbeatResponse, error)
 	FinishTask(ctx context.Context, in *BatonServiceFinishTaskRequest, opts ...grpc.CallOption) (*BatonServiceFinishTaskResponse, error)
 	UploadAsset(ctx context.Context, opts ...grpc.CallOption) (grpc.ClientStreamingClient[BatonServiceUploadAssetRequest, BatonServiceUploadAssetResponse], error)
@@ -61,6 +63,16 @@ func (c *batonServiceClient) GetTask(ctx context.Context, in *BatonServiceGetTas
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(BatonServiceGetTaskResponse)
 	err := c.cc.Invoke(ctx, BatonService_GetTask_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *batonServiceClient) GetTasks(ctx context.Context, in *BatonServiceGetTasksRequest, opts ...grpc.CallOption) (*BatonServiceGetTasksResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(BatonServiceGetTasksResponse)
+	err := c.cc.Invoke(ctx, BatonService_GetTasks_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -116,6 +128,7 @@ func (c *batonServiceClient) StartDebugging(ctx context.Context, in *StartDebugg
 type BatonServiceServer interface {
 	Hello(context.Context, *BatonServiceHelloRequest) (*BatonServiceHelloResponse, error)
 	GetTask(context.Context, *BatonServiceGetTaskRequest) (*BatonServiceGetTaskResponse, error)
+	GetTasks(context.Context, *BatonServiceGetTasksRequest) (*BatonServiceGetTasksResponse, error)
 	Heartbeat(context.Context, *BatonServiceHeartbeatRequest) (*BatonServiceHeartbeatResponse, error)
 	FinishTask(context.Context, *BatonServiceFinishTaskRequest) (*BatonServiceFinishTaskResponse, error)
 	UploadAsset(grpc.ClientStreamingServer[BatonServiceUploadAssetRequest, BatonServiceUploadAssetResponse]) error
@@ -134,6 +147,9 @@ func (UnimplementedBatonServiceServer) Hello(context.Context, *BatonServiceHello
 }
 func (UnimplementedBatonServiceServer) GetTask(context.Context, *BatonServiceGetTaskRequest) (*BatonServiceGetTaskResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetTask not implemented")
+}
+func (UnimplementedBatonServiceServer) GetTasks(context.Context, *BatonServiceGetTasksRequest) (*BatonServiceGetTasksResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetTasks not implemented")
 }
 func (UnimplementedBatonServiceServer) Heartbeat(context.Context, *BatonServiceHeartbeatRequest) (*BatonServiceHeartbeatResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Heartbeat not implemented")
@@ -199,6 +215,24 @@ func _BatonService_GetTask_Handler(srv interface{}, ctx context.Context, dec fun
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(BatonServiceServer).GetTask(ctx, req.(*BatonServiceGetTaskRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _BatonService_GetTasks_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(BatonServiceGetTasksRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(BatonServiceServer).GetTasks(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: BatonService_GetTasks_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(BatonServiceServer).GetTasks(ctx, req.(*BatonServiceGetTasksRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -278,6 +312,10 @@ var BatonService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetTask",
 			Handler:    _BatonService_GetTask_Handler,
+		},
+		{
+			MethodName: "GetTasks",
+			Handler:    _BatonService_GetTasks_Handler,
 		},
 		{
 			MethodName: "Heartbeat",

--- a/pb/c1/connectorapi/baton/v1/baton_protoopaque.pb.go
+++ b/pb/c1/connectorapi/baton/v1/baton_protoopaque.pb.go
@@ -1494,6 +1494,232 @@ func (b0 BatonServiceGetTaskRequest_builder) Build() *BatonServiceGetTaskRequest
 	return m0
 }
 
+type BatonServiceGetTasksRequest struct {
+	state                   protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_HostId       string                 `protobuf:"bytes,1,opt,name=host_id,json=hostId,proto3"`
+	xxx_hidden_PageSize     uint32                 `protobuf:"varint,2,opt,name=page_size,json=pageSize,proto3"`
+	xxx_hidden_KnownTaskIds []string               `protobuf:"bytes,3,rep,name=known_task_ids,json=knownTaskIds,proto3"`
+	xxx_hidden_Annotations  *[]*anypb.Any          `protobuf:"bytes,4,rep,name=annotations,proto3"`
+	unknownFields           protoimpl.UnknownFields
+	sizeCache               protoimpl.SizeCache
+}
+
+func (x *BatonServiceGetTasksRequest) Reset() {
+	*x = BatonServiceGetTasksRequest{}
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BatonServiceGetTasksRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BatonServiceGetTasksRequest) ProtoMessage() {}
+
+func (x *BatonServiceGetTasksRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *BatonServiceGetTasksRequest) GetHostId() string {
+	if x != nil {
+		return x.xxx_hidden_HostId
+	}
+	return ""
+}
+
+func (x *BatonServiceGetTasksRequest) GetPageSize() uint32 {
+	if x != nil {
+		return x.xxx_hidden_PageSize
+	}
+	return 0
+}
+
+func (x *BatonServiceGetTasksRequest) GetKnownTaskIds() []string {
+	if x != nil {
+		return x.xxx_hidden_KnownTaskIds
+	}
+	return nil
+}
+
+func (x *BatonServiceGetTasksRequest) GetAnnotations() []*anypb.Any {
+	if x != nil {
+		if x.xxx_hidden_Annotations != nil {
+			return *x.xxx_hidden_Annotations
+		}
+	}
+	return nil
+}
+
+func (x *BatonServiceGetTasksRequest) SetHostId(v string) {
+	x.xxx_hidden_HostId = v
+}
+
+func (x *BatonServiceGetTasksRequest) SetPageSize(v uint32) {
+	x.xxx_hidden_PageSize = v
+}
+
+func (x *BatonServiceGetTasksRequest) SetKnownTaskIds(v []string) {
+	x.xxx_hidden_KnownTaskIds = v
+}
+
+func (x *BatonServiceGetTasksRequest) SetAnnotations(v []*anypb.Any) {
+	x.xxx_hidden_Annotations = &v
+}
+
+type BatonServiceGetTasksRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	HostId       string
+	PageSize     uint32
+	KnownTaskIds []string
+	Annotations  []*anypb.Any
+}
+
+func (b0 BatonServiceGetTasksRequest_builder) Build() *BatonServiceGetTasksRequest {
+	m0 := &BatonServiceGetTasksRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_HostId = b.HostId
+	x.xxx_hidden_PageSize = b.PageSize
+	x.xxx_hidden_KnownTaskIds = b.KnownTaskIds
+	x.xxx_hidden_Annotations = &b.Annotations
+	return m0
+}
+
+type BatonServiceGetTasksResponse struct {
+	state                    protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Tasks         *[]*Task               `protobuf:"bytes,1,rep,name=tasks,proto3"`
+	xxx_hidden_NextPoll      *durationpb.Duration   `protobuf:"bytes,2,opt,name=next_poll,json=nextPoll,proto3"`
+	xxx_hidden_NextHeartbeat *durationpb.Duration   `protobuf:"bytes,3,opt,name=next_heartbeat,json=nextHeartbeat,proto3"`
+	xxx_hidden_Annotations   *[]*anypb.Any          `protobuf:"bytes,4,rep,name=annotations,proto3"`
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
+}
+
+func (x *BatonServiceGetTasksResponse) Reset() {
+	*x = BatonServiceGetTasksResponse{}
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BatonServiceGetTasksResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BatonServiceGetTasksResponse) ProtoMessage() {}
+
+func (x *BatonServiceGetTasksResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *BatonServiceGetTasksResponse) GetTasks() []*Task {
+	if x != nil {
+		if x.xxx_hidden_Tasks != nil {
+			return *x.xxx_hidden_Tasks
+		}
+	}
+	return nil
+}
+
+func (x *BatonServiceGetTasksResponse) GetNextPoll() *durationpb.Duration {
+	if x != nil {
+		return x.xxx_hidden_NextPoll
+	}
+	return nil
+}
+
+func (x *BatonServiceGetTasksResponse) GetNextHeartbeat() *durationpb.Duration {
+	if x != nil {
+		return x.xxx_hidden_NextHeartbeat
+	}
+	return nil
+}
+
+func (x *BatonServiceGetTasksResponse) GetAnnotations() []*anypb.Any {
+	if x != nil {
+		if x.xxx_hidden_Annotations != nil {
+			return *x.xxx_hidden_Annotations
+		}
+	}
+	return nil
+}
+
+func (x *BatonServiceGetTasksResponse) SetTasks(v []*Task) {
+	x.xxx_hidden_Tasks = &v
+}
+
+func (x *BatonServiceGetTasksResponse) SetNextPoll(v *durationpb.Duration) {
+	x.xxx_hidden_NextPoll = v
+}
+
+func (x *BatonServiceGetTasksResponse) SetNextHeartbeat(v *durationpb.Duration) {
+	x.xxx_hidden_NextHeartbeat = v
+}
+
+func (x *BatonServiceGetTasksResponse) SetAnnotations(v []*anypb.Any) {
+	x.xxx_hidden_Annotations = &v
+}
+
+func (x *BatonServiceGetTasksResponse) HasNextPoll() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_NextPoll != nil
+}
+
+func (x *BatonServiceGetTasksResponse) HasNextHeartbeat() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_NextHeartbeat != nil
+}
+
+func (x *BatonServiceGetTasksResponse) ClearNextPoll() {
+	x.xxx_hidden_NextPoll = nil
+}
+
+func (x *BatonServiceGetTasksResponse) ClearNextHeartbeat() {
+	x.xxx_hidden_NextHeartbeat = nil
+}
+
+type BatonServiceGetTasksResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	Tasks         []*Task
+	NextPoll      *durationpb.Duration
+	NextHeartbeat *durationpb.Duration
+	Annotations   []*anypb.Any
+}
+
+func (b0 BatonServiceGetTasksResponse_builder) Build() *BatonServiceGetTasksResponse {
+	m0 := &BatonServiceGetTasksResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Tasks = &b.Tasks
+	x.xxx_hidden_NextPoll = b.NextPoll
+	x.xxx_hidden_NextHeartbeat = b.NextHeartbeat
+	x.xxx_hidden_Annotations = &b.Annotations
+	return m0
+}
+
 type BatonServiceGetTaskResponse struct {
 	state                    protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_Task          *Task                  `protobuf:"bytes,1,opt,name=task,proto3"`
@@ -1506,7 +1732,7 @@ type BatonServiceGetTaskResponse struct {
 
 func (x *BatonServiceGetTaskResponse) Reset() {
 	*x = BatonServiceGetTaskResponse{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[4]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1518,7 +1744,7 @@ func (x *BatonServiceGetTaskResponse) String() string {
 func (*BatonServiceGetTaskResponse) ProtoMessage() {}
 
 func (x *BatonServiceGetTaskResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[4]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1633,13 +1859,14 @@ type BatonServiceHeartbeatRequest struct {
 	xxx_hidden_HostId      string                 `protobuf:"bytes,1,opt,name=host_id,json=hostId,proto3"`
 	xxx_hidden_TaskId      string                 `protobuf:"bytes,2,opt,name=task_id,json=taskId,proto3"`
 	xxx_hidden_Annotations *[]*anypb.Any          `protobuf:"bytes,3,rep,name=annotations,proto3"`
+	xxx_hidden_TaskIds     []string               `protobuf:"bytes,4,rep,name=task_ids,json=taskIds,proto3"`
 	unknownFields          protoimpl.UnknownFields
 	sizeCache              protoimpl.SizeCache
 }
 
 func (x *BatonServiceHeartbeatRequest) Reset() {
 	*x = BatonServiceHeartbeatRequest{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[5]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1651,7 +1878,7 @@ func (x *BatonServiceHeartbeatRequest) String() string {
 func (*BatonServiceHeartbeatRequest) ProtoMessage() {}
 
 func (x *BatonServiceHeartbeatRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[5]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1685,6 +1912,13 @@ func (x *BatonServiceHeartbeatRequest) GetAnnotations() []*anypb.Any {
 	return nil
 }
 
+func (x *BatonServiceHeartbeatRequest) GetTaskIds() []string {
+	if x != nil {
+		return x.xxx_hidden_TaskIds
+	}
+	return nil
+}
+
 func (x *BatonServiceHeartbeatRequest) SetHostId(v string) {
 	x.xxx_hidden_HostId = v
 }
@@ -1697,12 +1931,18 @@ func (x *BatonServiceHeartbeatRequest) SetAnnotations(v []*anypb.Any) {
 	x.xxx_hidden_Annotations = &v
 }
 
+func (x *BatonServiceHeartbeatRequest) SetTaskIds(v []string) {
+	x.xxx_hidden_TaskIds = v
+}
+
 type BatonServiceHeartbeatRequest_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
 	HostId      string
 	TaskId      string
 	Annotations []*anypb.Any
+	// New batch heartbeat path.
+	TaskIds []string
 }
 
 func (b0 BatonServiceHeartbeatRequest_builder) Build() *BatonServiceHeartbeatRequest {
@@ -1712,21 +1952,23 @@ func (b0 BatonServiceHeartbeatRequest_builder) Build() *BatonServiceHeartbeatReq
 	x.xxx_hidden_HostId = b.HostId
 	x.xxx_hidden_TaskId = b.TaskId
 	x.xxx_hidden_Annotations = &b.Annotations
+	x.xxx_hidden_TaskIds = b.TaskIds
 	return m0
 }
 
 type BatonServiceHeartbeatResponse struct {
-	state                    protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_NextHeartbeat *durationpb.Duration   `protobuf:"bytes,1,opt,name=next_heartbeat,json=nextHeartbeat,proto3"`
-	xxx_hidden_Cancelled     bool                   `protobuf:"varint,2,opt,name=cancelled,proto3"`
-	xxx_hidden_Annotations   *[]*anypb.Any          `protobuf:"bytes,3,rep,name=annotations,proto3"`
-	unknownFields            protoimpl.UnknownFields
-	sizeCache                protoimpl.SizeCache
+	state                       protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_NextHeartbeat    *durationpb.Duration   `protobuf:"bytes,1,opt,name=next_heartbeat,json=nextHeartbeat,proto3"`
+	xxx_hidden_Cancelled        bool                   `protobuf:"varint,2,opt,name=cancelled,proto3"`
+	xxx_hidden_Annotations      *[]*anypb.Any          `protobuf:"bytes,3,rep,name=annotations,proto3"`
+	xxx_hidden_CancelledTaskIds []string               `protobuf:"bytes,4,rep,name=cancelled_task_ids,json=cancelledTaskIds,proto3"`
+	unknownFields               protoimpl.UnknownFields
+	sizeCache                   protoimpl.SizeCache
 }
 
 func (x *BatonServiceHeartbeatResponse) Reset() {
 	*x = BatonServiceHeartbeatResponse{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[6]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1738,7 +1980,7 @@ func (x *BatonServiceHeartbeatResponse) String() string {
 func (*BatonServiceHeartbeatResponse) ProtoMessage() {}
 
 func (x *BatonServiceHeartbeatResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[6]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1772,6 +2014,13 @@ func (x *BatonServiceHeartbeatResponse) GetAnnotations() []*anypb.Any {
 	return nil
 }
 
+func (x *BatonServiceHeartbeatResponse) GetCancelledTaskIds() []string {
+	if x != nil {
+		return x.xxx_hidden_CancelledTaskIds
+	}
+	return nil
+}
+
 func (x *BatonServiceHeartbeatResponse) SetNextHeartbeat(v *durationpb.Duration) {
 	x.xxx_hidden_NextHeartbeat = v
 }
@@ -1782,6 +2031,10 @@ func (x *BatonServiceHeartbeatResponse) SetCancelled(v bool) {
 
 func (x *BatonServiceHeartbeatResponse) SetAnnotations(v []*anypb.Any) {
 	x.xxx_hidden_Annotations = &v
+}
+
+func (x *BatonServiceHeartbeatResponse) SetCancelledTaskIds(v []string) {
+	x.xxx_hidden_CancelledTaskIds = v
 }
 
 func (x *BatonServiceHeartbeatResponse) HasNextHeartbeat() bool {
@@ -1798,9 +2051,10 @@ func (x *BatonServiceHeartbeatResponse) ClearNextHeartbeat() {
 type BatonServiceHeartbeatResponse_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	NextHeartbeat *durationpb.Duration
-	Cancelled     bool
-	Annotations   []*anypb.Any
+	NextHeartbeat    *durationpb.Duration
+	Cancelled        bool
+	Annotations      []*anypb.Any
+	CancelledTaskIds []string
 }
 
 func (b0 BatonServiceHeartbeatResponse_builder) Build() *BatonServiceHeartbeatResponse {
@@ -1810,6 +2064,7 @@ func (b0 BatonServiceHeartbeatResponse_builder) Build() *BatonServiceHeartbeatRe
 	x.xxx_hidden_NextHeartbeat = b.NextHeartbeat
 	x.xxx_hidden_Cancelled = b.Cancelled
 	x.xxx_hidden_Annotations = &b.Annotations
+	x.xxx_hidden_CancelledTaskIds = b.CancelledTaskIds
 	return m0
 }
 
@@ -1822,7 +2077,7 @@ type BatonServiceUploadAssetRequest struct {
 
 func (x *BatonServiceUploadAssetRequest) Reset() {
 	*x = BatonServiceUploadAssetRequest{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[7]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1834,7 +2089,7 @@ func (x *BatonServiceUploadAssetRequest) String() string {
 func (*BatonServiceUploadAssetRequest) ProtoMessage() {}
 
 func (x *BatonServiceUploadAssetRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[7]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1999,7 +2254,7 @@ func (b0 BatonServiceUploadAssetRequest_builder) Build() *BatonServiceUploadAsse
 type case_BatonServiceUploadAssetRequest_Msg protoreflect.FieldNumber
 
 func (x case_BatonServiceUploadAssetRequest_Msg) String() string {
-	md := file_c1_connectorapi_baton_v1_baton_proto_msgTypes[7].Descriptor()
+	md := file_c1_connectorapi_baton_v1_baton_proto_msgTypes[9].Descriptor()
 	if x == 0 {
 		return "not set"
 	}
@@ -2037,7 +2292,7 @@ type BatonServiceUploadAssetResponse struct {
 
 func (x *BatonServiceUploadAssetResponse) Reset() {
 	*x = BatonServiceUploadAssetResponse{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[8]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2049,7 +2304,7 @@ func (x *BatonServiceUploadAssetResponse) String() string {
 func (*BatonServiceUploadAssetResponse) ProtoMessage() {}
 
 func (x *BatonServiceUploadAssetResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[8]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2100,7 +2355,7 @@ type BatonServiceFinishTaskRequest struct {
 
 func (x *BatonServiceFinishTaskRequest) Reset() {
 	*x = BatonServiceFinishTaskRequest{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[9]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2112,7 +2367,7 @@ func (x *BatonServiceFinishTaskRequest) String() string {
 func (*BatonServiceFinishTaskRequest) ProtoMessage() {}
 
 func (x *BatonServiceFinishTaskRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[9]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2289,7 +2544,7 @@ func (b0 BatonServiceFinishTaskRequest_builder) Build() *BatonServiceFinishTaskR
 type case_BatonServiceFinishTaskRequest_FinalState protoreflect.FieldNumber
 
 func (x case_BatonServiceFinishTaskRequest_FinalState) String() string {
-	md := file_c1_connectorapi_baton_v1_baton_proto_msgTypes[9].Descriptor()
+	md := file_c1_connectorapi_baton_v1_baton_proto_msgTypes[11].Descriptor()
 	if x == 0 {
 		return "not set"
 	}
@@ -2321,7 +2576,7 @@ type BatonServiceFinishTaskResponse struct {
 
 func (x *BatonServiceFinishTaskResponse) Reset() {
 	*x = BatonServiceFinishTaskResponse{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[10]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2333,7 +2588,7 @@ func (x *BatonServiceFinishTaskResponse) String() string {
 func (*BatonServiceFinishTaskResponse) ProtoMessage() {}
 
 func (x *BatonServiceFinishTaskResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[10]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2379,7 +2634,7 @@ type StartDebuggingRequest struct {
 
 func (x *StartDebuggingRequest) Reset() {
 	*x = StartDebuggingRequest{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[11]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2391,7 +2646,7 @@ func (x *StartDebuggingRequest) String() string {
 func (*StartDebuggingRequest) ProtoMessage() {}
 
 func (x *StartDebuggingRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[11]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2423,7 +2678,7 @@ type StartDebuggingResponse struct {
 
 func (x *StartDebuggingResponse) Reset() {
 	*x = StartDebuggingResponse{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[12]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2435,7 +2690,7 @@ func (x *StartDebuggingResponse) String() string {
 func (*StartDebuggingResponse) ProtoMessage() {}
 
 func (x *StartDebuggingResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[12]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2480,7 +2735,7 @@ type Task_NoneTask struct {
 
 func (x *Task_NoneTask) Reset() {
 	*x = Task_NoneTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[13]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2492,7 +2747,7 @@ func (x *Task_NoneTask) String() string {
 func (*Task_NoneTask) ProtoMessage() {}
 
 func (x *Task_NoneTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[13]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2539,7 +2794,7 @@ type Task_HelloTask struct {
 
 func (x *Task_HelloTask) Reset() {
 	*x = Task_HelloTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[14]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2551,7 +2806,7 @@ func (x *Task_HelloTask) String() string {
 func (*Task_HelloTask) ProtoMessage() {}
 
 func (x *Task_HelloTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[14]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2602,7 +2857,7 @@ type Task_SyncFullTask struct {
 
 func (x *Task_SyncFullTask) Reset() {
 	*x = Task_SyncFullTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[15]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2614,7 +2869,7 @@ func (x *Task_SyncFullTask) String() string {
 func (*Task_SyncFullTask) ProtoMessage() {}
 
 func (x *Task_SyncFullTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[15]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2716,7 +2971,7 @@ type Task_EventFeedTask struct {
 
 func (x *Task_EventFeedTask) Reset() {
 	*x = Task_EventFeedTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[16]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2728,7 +2983,7 @@ func (x *Task_EventFeedTask) String() string {
 func (*Task_EventFeedTask) ProtoMessage() {}
 
 func (x *Task_EventFeedTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[16]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2803,7 +3058,7 @@ type Task_ListEventsTask struct {
 
 func (x *Task_ListEventsTask) Reset() {
 	*x = Task_ListEventsTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[17]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2815,7 +3070,7 @@ func (x *Task_ListEventsTask) String() string {
 func (*Task_ListEventsTask) ProtoMessage() {}
 
 func (x *Task_ListEventsTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[17]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2925,7 +3180,7 @@ type Task_ListEventFeedsTask struct {
 
 func (x *Task_ListEventFeedsTask) Reset() {
 	*x = Task_ListEventFeedsTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[18]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2937,7 +3192,7 @@ func (x *Task_ListEventFeedsTask) String() string {
 func (*Task_ListEventFeedsTask) ProtoMessage() {}
 
 func (x *Task_ListEventFeedsTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[18]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2987,7 +3242,7 @@ type Task_GrantTask struct {
 
 func (x *Task_GrantTask) Reset() {
 	*x = Task_GrantTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[19]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2999,7 +3254,7 @@ func (x *Task_GrantTask) String() string {
 func (*Task_GrantTask) ProtoMessage() {}
 
 func (x *Task_GrantTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[19]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3119,7 +3374,7 @@ type Task_RevokeTask struct {
 
 func (x *Task_RevokeTask) Reset() {
 	*x = Task_RevokeTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[20]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3131,7 +3386,7 @@ func (x *Task_RevokeTask) String() string {
 func (*Task_RevokeTask) ProtoMessage() {}
 
 func (x *Task_RevokeTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[20]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3205,7 +3460,7 @@ type Task_CreateAccountTask struct {
 
 func (x *Task_CreateAccountTask) Reset() {
 	*x = Task_CreateAccountTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[21]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3217,7 +3472,7 @@ func (x *Task_CreateAccountTask) String() string {
 func (*Task_CreateAccountTask) ProtoMessage() {}
 
 func (x *Task_CreateAccountTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[21]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3325,7 +3580,7 @@ type Task_CreateResourceTask struct {
 
 func (x *Task_CreateResourceTask) Reset() {
 	*x = Task_CreateResourceTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[22]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3337,7 +3592,7 @@ func (x *Task_CreateResourceTask) String() string {
 func (*Task_CreateResourceTask) ProtoMessage() {}
 
 func (x *Task_CreateResourceTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[22]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3394,7 +3649,7 @@ type Task_DeleteResourceTask struct {
 
 func (x *Task_DeleteResourceTask) Reset() {
 	*x = Task_DeleteResourceTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[23]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3406,7 +3661,7 @@ func (x *Task_DeleteResourceTask) String() string {
 func (*Task_DeleteResourceTask) ProtoMessage() {}
 
 func (x *Task_DeleteResourceTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[23]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3488,7 +3743,7 @@ type Task_RotateCredentialsTask struct {
 
 func (x *Task_RotateCredentialsTask) Reset() {
 	*x = Task_RotateCredentialsTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[24]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3500,7 +3755,7 @@ func (x *Task_RotateCredentialsTask) String() string {
 func (*Task_RotateCredentialsTask) ProtoMessage() {}
 
 func (x *Task_RotateCredentialsTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[24]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3597,7 +3852,7 @@ type Task_CreateTicketTask struct {
 
 func (x *Task_CreateTicketTask) Reset() {
 	*x = Task_CreateTicketTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[25]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3609,7 +3864,7 @@ func (x *Task_CreateTicketTask) String() string {
 func (*Task_CreateTicketTask) ProtoMessage() {}
 
 func (x *Task_CreateTicketTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[25]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3704,7 +3959,7 @@ type Task_BulkCreateTicketsTask struct {
 
 func (x *Task_BulkCreateTicketsTask) Reset() {
 	*x = Task_BulkCreateTicketsTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[26]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3716,7 +3971,7 @@ func (x *Task_BulkCreateTicketsTask) String() string {
 func (*Task_BulkCreateTicketsTask) ProtoMessage() {}
 
 func (x *Task_BulkCreateTicketsTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[26]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3763,7 +4018,7 @@ type Task_BulkGetTicketsTask struct {
 
 func (x *Task_BulkGetTicketsTask) Reset() {
 	*x = Task_BulkGetTicketsTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[27]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3775,7 +4030,7 @@ func (x *Task_BulkGetTicketsTask) String() string {
 func (*Task_BulkGetTicketsTask) ProtoMessage() {}
 
 func (x *Task_BulkGetTicketsTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[27]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3822,7 +4077,7 @@ type Task_ListTicketSchemasTask struct {
 
 func (x *Task_ListTicketSchemasTask) Reset() {
 	*x = Task_ListTicketSchemasTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[28]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3834,7 +4089,7 @@ func (x *Task_ListTicketSchemasTask) String() string {
 func (*Task_ListTicketSchemasTask) ProtoMessage() {}
 
 func (x *Task_ListTicketSchemasTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[28]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3882,7 +4137,7 @@ type Task_GetTicketTask struct {
 
 func (x *Task_GetTicketTask) Reset() {
 	*x = Task_GetTicketTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[29]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3894,7 +4149,7 @@ func (x *Task_GetTicketTask) String() string {
 func (*Task_GetTicketTask) ProtoMessage() {}
 
 func (x *Task_GetTicketTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[29]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3955,7 +4210,7 @@ type Task_ActionListSchemasTask struct {
 
 func (x *Task_ActionListSchemasTask) Reset() {
 	*x = Task_ActionListSchemasTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[30]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3967,7 +4222,7 @@ func (x *Task_ActionListSchemasTask) String() string {
 func (*Task_ActionListSchemasTask) ProtoMessage() {}
 
 func (x *Task_ActionListSchemasTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[30]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4029,7 +4284,7 @@ type Task_ActionGetSchemaTask struct {
 
 func (x *Task_ActionGetSchemaTask) Reset() {
 	*x = Task_ActionGetSchemaTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[31]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4041,7 +4296,7 @@ func (x *Task_ActionGetSchemaTask) String() string {
 func (*Task_ActionGetSchemaTask) ProtoMessage() {}
 
 func (x *Task_ActionGetSchemaTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[31]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4104,7 +4359,7 @@ type Task_ActionInvokeTask struct {
 
 func (x *Task_ActionInvokeTask) Reset() {
 	*x = Task_ActionInvokeTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[32]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4116,7 +4371,7 @@ func (x *Task_ActionInvokeTask) String() string {
 func (*Task_ActionInvokeTask) ProtoMessage() {}
 
 func (x *Task_ActionInvokeTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[32]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4216,7 +4471,7 @@ type Task_ActionStatusTask struct {
 
 func (x *Task_ActionStatusTask) Reset() {
 	*x = Task_ActionStatusTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[33]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4228,7 +4483,7 @@ func (x *Task_ActionStatusTask) String() string {
 func (*Task_ActionStatusTask) ProtoMessage() {}
 
 func (x *Task_ActionStatusTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[33]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4303,7 +4558,7 @@ type Task_CreateSyncDiffTask struct {
 
 func (x *Task_CreateSyncDiffTask) Reset() {
 	*x = Task_CreateSyncDiffTask{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[34]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4315,7 +4570,7 @@ func (x *Task_CreateSyncDiffTask) String() string {
 func (*Task_CreateSyncDiffTask) ProtoMessage() {}
 
 func (x *Task_CreateSyncDiffTask) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[34]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4390,7 +4645,7 @@ type Task_CompactSyncs struct {
 
 func (x *Task_CompactSyncs) Reset() {
 	*x = Task_CompactSyncs{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[35]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4402,7 +4657,7 @@ func (x *Task_CompactSyncs) String() string {
 func (*Task_CompactSyncs) ProtoMessage() {}
 
 func (x *Task_CompactSyncs) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[35]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4465,7 +4720,7 @@ type Task_CompactSyncs_CompactableSync struct {
 
 func (x *Task_CompactSyncs_CompactableSync) Reset() {
 	*x = Task_CompactSyncs_CompactableSync{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[36]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4477,7 +4732,7 @@ func (x *Task_CompactSyncs_CompactableSync) String() string {
 func (*Task_CompactSyncs_CompactableSync) ProtoMessage() {}
 
 func (x *Task_CompactSyncs_CompactableSync) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[36]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4537,7 +4792,7 @@ type BatonServiceHelloRequest_BuildInfo struct {
 
 func (x *BatonServiceHelloRequest_BuildInfo) Reset() {
 	*x = BatonServiceHelloRequest_BuildInfo{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[37]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4549,7 +4804,7 @@ func (x *BatonServiceHelloRequest_BuildInfo) String() string {
 func (*BatonServiceHelloRequest_BuildInfo) ProtoMessage() {}
 
 func (x *BatonServiceHelloRequest_BuildInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[37]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4627,7 +4882,7 @@ type BatonServiceHelloRequest_OSInfo struct {
 
 func (x *BatonServiceHelloRequest_OSInfo) Reset() {
 	*x = BatonServiceHelloRequest_OSInfo{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[38]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4639,7 +4894,7 @@ func (x *BatonServiceHelloRequest_OSInfo) String() string {
 func (*BatonServiceHelloRequest_OSInfo) ProtoMessage() {}
 
 func (x *BatonServiceHelloRequest_OSInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[38]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4777,7 +5032,7 @@ type BatonServiceUploadAssetRequest_UploadMetadata struct {
 
 func (x *BatonServiceUploadAssetRequest_UploadMetadata) Reset() {
 	*x = BatonServiceUploadAssetRequest_UploadMetadata{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[39]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4789,7 +5044,7 @@ func (x *BatonServiceUploadAssetRequest_UploadMetadata) String() string {
 func (*BatonServiceUploadAssetRequest_UploadMetadata) ProtoMessage() {}
 
 func (x *BatonServiceUploadAssetRequest_UploadMetadata) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[39]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4862,7 +5117,7 @@ type BatonServiceUploadAssetRequest_UploadData struct {
 
 func (x *BatonServiceUploadAssetRequest_UploadData) Reset() {
 	*x = BatonServiceUploadAssetRequest_UploadData{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[40]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4874,7 +5129,7 @@ func (x *BatonServiceUploadAssetRequest_UploadData) String() string {
 func (*BatonServiceUploadAssetRequest_UploadData) ProtoMessage() {}
 
 func (x *BatonServiceUploadAssetRequest_UploadData) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[40]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4924,7 +5179,7 @@ type BatonServiceUploadAssetRequest_UploadEOF struct {
 
 func (x *BatonServiceUploadAssetRequest_UploadEOF) Reset() {
 	*x = BatonServiceUploadAssetRequest_UploadEOF{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[41]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4936,7 +5191,7 @@ func (x *BatonServiceUploadAssetRequest_UploadEOF) String() string {
 func (*BatonServiceUploadAssetRequest_UploadEOF) ProtoMessage() {}
 
 func (x *BatonServiceUploadAssetRequest_UploadEOF) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[41]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5001,7 +5256,7 @@ type BatonServiceFinishTaskRequest_Error struct {
 
 func (x *BatonServiceFinishTaskRequest_Error) Reset() {
 	*x = BatonServiceFinishTaskRequest_Error{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[42]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5013,7 +5268,7 @@ func (x *BatonServiceFinishTaskRequest_Error) String() string {
 func (*BatonServiceFinishTaskRequest_Error) ProtoMessage() {}
 
 func (x *BatonServiceFinishTaskRequest_Error) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[42]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5099,7 +5354,7 @@ type BatonServiceFinishTaskRequest_Success struct {
 
 func (x *BatonServiceFinishTaskRequest_Success) Reset() {
 	*x = BatonServiceFinishTaskRequest_Success{}
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[43]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5111,7 +5366,7 @@ func (x *BatonServiceFinishTaskRequest_Success) String() string {
 func (*BatonServiceFinishTaskRequest_Success) ProtoMessage() {}
 
 func (x *BatonServiceFinishTaskRequest_Success) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[43]
+	mi := &file_c1_connectorapi_baton_v1_baton_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5330,21 +5585,34 @@ const file_c1_connectorapi_baton_v1_baton_proto_rawDesc = "" +
 	"\vannotations\x18\x01 \x03(\v2\x14.google.protobuf.AnyR\vannotations\"A\n" +
 	"\x1aBatonServiceGetTaskRequest\x12#\n" +
 	"\ahost_id\x18\x01 \x01(\tB\n" +
-	"\xfaB\ar\x05\x10\x01\x18\x80\x02R\x06hostId\"\x83\x02\n" +
+	"\xfaB\ar\x05\x10\x01\x18\x80\x02R\x06hostId\"\xf1\x01\n" +
+	"\x1bBatonServiceGetTasksRequest\x12#\n" +
+	"\ahost_id\x18\x01 \x01(\tB\n" +
+	"\xfaB\ar\x05\x10\x01\x18\x80\x02R\x06hostId\x12&\n" +
+	"\tpage_size\x18\x02 \x01(\rB\t\xfaB\x06*\x04\x18d \x00R\bpageSize\x12C\n" +
+	"\x0eknown_task_ids\x18\x03 \x03(\tB\x1d\xfaB\x1a\x92\x01\x17\"\x15r\x132\x11^[a-zA-Z0-9]{27}$R\fknownTaskIds\x12@\n" +
+	"\vannotations\x18\x04 \x03(\v2\x14.google.protobuf.AnyB\b\xfaB\x05\x92\x01\x02\x10\x10R\vannotations\"\x90\x02\n" +
+	"\x1cBatonServiceGetTasksResponse\x12>\n" +
+	"\x05tasks\x18\x01 \x03(\v2\x1e.c1.connectorapi.baton.v1.TaskB\b\xfaB\x05\x92\x01\x02\x10dR\x05tasks\x126\n" +
+	"\tnext_poll\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\bnextPoll\x12@\n" +
+	"\x0enext_heartbeat\x18\x03 \x01(\v2\x19.google.protobuf.DurationR\rnextHeartbeat\x126\n" +
+	"\vannotations\x18\x04 \x03(\v2\x14.google.protobuf.AnyR\vannotations\"\x83\x02\n" +
 	"\x1bBatonServiceGetTaskResponse\x122\n" +
 	"\x04task\x18\x01 \x01(\v2\x1e.c1.connectorapi.baton.v1.TaskR\x04task\x126\n" +
 	"\tnext_poll\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\bnextPoll\x12@\n" +
 	"\x0enext_heartbeat\x18\x03 \x01(\v2\x19.google.protobuf.DurationR\rnextHeartbeat\x126\n" +
-	"\vannotations\x18\x04 \x03(\v2\x14.google.protobuf.AnyR\vannotations\"\xb8\x01\n" +
+	"\vannotations\x18\x04 \x03(\v2\x14.google.protobuf.AnyR\vannotations\"\xf4\x01\n" +
 	"\x1cBatonServiceHeartbeatRequest\x12#\n" +
 	"\ahost_id\x18\x01 \x01(\tB\n" +
 	"\xfaB\ar\x05\x10\x01\x18\x80\x02R\x06hostId\x121\n" +
 	"\atask_id\x18\x02 \x01(\tB\x18\xfaB\x15r\x132\x11^[a-zA-Z0-9]{27}$R\x06taskId\x12@\n" +
-	"\vannotations\x18\x03 \x03(\v2\x14.google.protobuf.AnyB\b\xfaB\x05\x92\x01\x02\x10\x10R\vannotations\"\xb7\x01\n" +
+	"\vannotations\x18\x03 \x03(\v2\x14.google.protobuf.AnyB\b\xfaB\x05\x92\x01\x02\x10\x10R\vannotations\x12:\n" +
+	"\btask_ids\x18\x04 \x03(\tB\x1f\xfaB\x1c\x92\x01\x19\x10d\"\x15r\x132\x11^[a-zA-Z0-9]{27}$R\ataskIds\"\xe5\x01\n" +
 	"\x1dBatonServiceHeartbeatResponse\x12@\n" +
 	"\x0enext_heartbeat\x18\x01 \x01(\v2\x19.google.protobuf.DurationR\rnextHeartbeat\x12\x1c\n" +
 	"\tcancelled\x18\x02 \x01(\bR\tcancelled\x126\n" +
-	"\vannotations\x18\x03 \x03(\v2\x14.google.protobuf.AnyR\vannotations\"\xa3\x05\n" +
+	"\vannotations\x18\x03 \x03(\v2\x14.google.protobuf.AnyR\vannotations\x12,\n" +
+	"\x12cancelled_task_ids\x18\x04 \x03(\tR\x10cancelledTaskIds\"\xa3\x05\n" +
 	"\x1eBatonServiceUploadAssetRequest\x12e\n" +
 	"\bmetadata\x18d \x01(\v2G.c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadMetadataH\x00R\bmetadata\x12Y\n" +
 	"\x04data\x18e \x01(\v2C.c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadDataH\x00R\x04data\x12V\n" +
@@ -5383,10 +5651,11 @@ const file_c1_connectorapi_baton_v1_baton_proto_rawDesc = "" +
 	"\vannotations\x18\x01 \x03(\v2\x14.google.protobuf.AnyR\vannotations\"\x17\n" +
 	"\x15StartDebuggingRequest\"0\n" +
 	"\x16StartDebuggingResponse\x12\x16\n" +
-	"\x06status\x18\x01 \x01(\bR\x06status2\x80\x06\n" +
+	"\x06status\x18\x01 \x01(\bR\x06status2\xfd\x06\n" +
 	"\fBatonService\x12r\n" +
 	"\x05Hello\x122.c1.connectorapi.baton.v1.BatonServiceHelloRequest\x1a3.c1.connectorapi.baton.v1.BatonServiceHelloResponse\"\x00\x12x\n" +
-	"\aGetTask\x124.c1.connectorapi.baton.v1.BatonServiceGetTaskRequest\x1a5.c1.connectorapi.baton.v1.BatonServiceGetTaskResponse\"\x00\x12~\n" +
+	"\aGetTask\x124.c1.connectorapi.baton.v1.BatonServiceGetTaskRequest\x1a5.c1.connectorapi.baton.v1.BatonServiceGetTaskResponse\"\x00\x12{\n" +
+	"\bGetTasks\x125.c1.connectorapi.baton.v1.BatonServiceGetTasksRequest\x1a6.c1.connectorapi.baton.v1.BatonServiceGetTasksResponse\"\x00\x12~\n" +
 	"\tHeartbeat\x126.c1.connectorapi.baton.v1.BatonServiceHeartbeatRequest\x1a7.c1.connectorapi.baton.v1.BatonServiceHeartbeatResponse\"\x00\x12\x81\x01\n" +
 	"\n" +
 	"FinishTask\x127.c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest\x1a8.c1.connectorapi.baton.v1.BatonServiceFinishTaskResponse\"\x00\x12\x86\x01\n" +
@@ -5394,176 +5663,185 @@ const file_c1_connectorapi_baton_v1_baton_proto_rawDesc = "" +
 	"\x0eStartDebugging\x12/.c1.connectorapi.baton.v1.StartDebuggingRequest\x1a0.c1.connectorapi.baton.v1.StartDebuggingResponse\"\x00B7Z5gitlab.com/ductone/c1/pkg/pb/c1/connectorapi/baton/v1b\x06proto3"
 
 var file_c1_connectorapi_baton_v1_baton_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_c1_connectorapi_baton_v1_baton_proto_msgTypes = make([]protoimpl.MessageInfo, 44)
+var file_c1_connectorapi_baton_v1_baton_proto_msgTypes = make([]protoimpl.MessageInfo, 46)
 var file_c1_connectorapi_baton_v1_baton_proto_goTypes = []any{
 	(Task_Status)(0),                                      // 0: c1.connectorapi.baton.v1.Task.Status
 	(*Task)(nil),                                          // 1: c1.connectorapi.baton.v1.Task
 	(*BatonServiceHelloRequest)(nil),                      // 2: c1.connectorapi.baton.v1.BatonServiceHelloRequest
 	(*BatonServiceHelloResponse)(nil),                     // 3: c1.connectorapi.baton.v1.BatonServiceHelloResponse
 	(*BatonServiceGetTaskRequest)(nil),                    // 4: c1.connectorapi.baton.v1.BatonServiceGetTaskRequest
-	(*BatonServiceGetTaskResponse)(nil),                   // 5: c1.connectorapi.baton.v1.BatonServiceGetTaskResponse
-	(*BatonServiceHeartbeatRequest)(nil),                  // 6: c1.connectorapi.baton.v1.BatonServiceHeartbeatRequest
-	(*BatonServiceHeartbeatResponse)(nil),                 // 7: c1.connectorapi.baton.v1.BatonServiceHeartbeatResponse
-	(*BatonServiceUploadAssetRequest)(nil),                // 8: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest
-	(*BatonServiceUploadAssetResponse)(nil),               // 9: c1.connectorapi.baton.v1.BatonServiceUploadAssetResponse
-	(*BatonServiceFinishTaskRequest)(nil),                 // 10: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest
-	(*BatonServiceFinishTaskResponse)(nil),                // 11: c1.connectorapi.baton.v1.BatonServiceFinishTaskResponse
-	(*StartDebuggingRequest)(nil),                         // 12: c1.connectorapi.baton.v1.StartDebuggingRequest
-	(*StartDebuggingResponse)(nil),                        // 13: c1.connectorapi.baton.v1.StartDebuggingResponse
-	(*Task_NoneTask)(nil),                                 // 14: c1.connectorapi.baton.v1.Task.NoneTask
-	(*Task_HelloTask)(nil),                                // 15: c1.connectorapi.baton.v1.Task.HelloTask
-	(*Task_SyncFullTask)(nil),                             // 16: c1.connectorapi.baton.v1.Task.SyncFullTask
-	(*Task_EventFeedTask)(nil),                            // 17: c1.connectorapi.baton.v1.Task.EventFeedTask
-	(*Task_ListEventsTask)(nil),                           // 18: c1.connectorapi.baton.v1.Task.ListEventsTask
-	(*Task_ListEventFeedsTask)(nil),                       // 19: c1.connectorapi.baton.v1.Task.ListEventFeedsTask
-	(*Task_GrantTask)(nil),                                // 20: c1.connectorapi.baton.v1.Task.GrantTask
-	(*Task_RevokeTask)(nil),                               // 21: c1.connectorapi.baton.v1.Task.RevokeTask
-	(*Task_CreateAccountTask)(nil),                        // 22: c1.connectorapi.baton.v1.Task.CreateAccountTask
-	(*Task_CreateResourceTask)(nil),                       // 23: c1.connectorapi.baton.v1.Task.CreateResourceTask
-	(*Task_DeleteResourceTask)(nil),                       // 24: c1.connectorapi.baton.v1.Task.DeleteResourceTask
-	(*Task_RotateCredentialsTask)(nil),                    // 25: c1.connectorapi.baton.v1.Task.RotateCredentialsTask
-	(*Task_CreateTicketTask)(nil),                         // 26: c1.connectorapi.baton.v1.Task.CreateTicketTask
-	(*Task_BulkCreateTicketsTask)(nil),                    // 27: c1.connectorapi.baton.v1.Task.BulkCreateTicketsTask
-	(*Task_BulkGetTicketsTask)(nil),                       // 28: c1.connectorapi.baton.v1.Task.BulkGetTicketsTask
-	(*Task_ListTicketSchemasTask)(nil),                    // 29: c1.connectorapi.baton.v1.Task.ListTicketSchemasTask
-	(*Task_GetTicketTask)(nil),                            // 30: c1.connectorapi.baton.v1.Task.GetTicketTask
-	(*Task_ActionListSchemasTask)(nil),                    // 31: c1.connectorapi.baton.v1.Task.ActionListSchemasTask
-	(*Task_ActionGetSchemaTask)(nil),                      // 32: c1.connectorapi.baton.v1.Task.ActionGetSchemaTask
-	(*Task_ActionInvokeTask)(nil),                         // 33: c1.connectorapi.baton.v1.Task.ActionInvokeTask
-	(*Task_ActionStatusTask)(nil),                         // 34: c1.connectorapi.baton.v1.Task.ActionStatusTask
-	(*Task_CreateSyncDiffTask)(nil),                       // 35: c1.connectorapi.baton.v1.Task.CreateSyncDiffTask
-	(*Task_CompactSyncs)(nil),                             // 36: c1.connectorapi.baton.v1.Task.CompactSyncs
-	(*Task_CompactSyncs_CompactableSync)(nil),             // 37: c1.connectorapi.baton.v1.Task.CompactSyncs.CompactableSync
-	(*BatonServiceHelloRequest_BuildInfo)(nil),            // 38: c1.connectorapi.baton.v1.BatonServiceHelloRequest.BuildInfo
-	(*BatonServiceHelloRequest_OSInfo)(nil),               // 39: c1.connectorapi.baton.v1.BatonServiceHelloRequest.OSInfo
-	(*BatonServiceUploadAssetRequest_UploadMetadata)(nil), // 40: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadMetadata
-	(*BatonServiceUploadAssetRequest_UploadData)(nil),     // 41: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadData
-	(*BatonServiceUploadAssetRequest_UploadEOF)(nil),      // 42: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadEOF
-	(*BatonServiceFinishTaskRequest_Error)(nil),           // 43: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Error
-	(*BatonServiceFinishTaskRequest_Success)(nil),         // 44: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Success
-	(*v2.ConnectorMetadata)(nil),                          // 45: c1.connector.v2.ConnectorMetadata
-	(*anypb.Any)(nil),                                     // 46: google.protobuf.Any
-	(*durationpb.Duration)(nil),                           // 47: google.protobuf.Duration
-	(*status.Status)(nil),                                 // 48: google.rpc.Status
-	(*v2.Resource)(nil),                                   // 49: c1.connector.v2.Resource
-	(*timestamppb.Timestamp)(nil),                         // 50: google.protobuf.Timestamp
-	(*v2.Entitlement)(nil),                                // 51: c1.connector.v2.Entitlement
-	(*v2.Grant)(nil),                                      // 52: c1.connector.v2.Grant
-	(*v2.AccountInfo)(nil),                                // 53: c1.connector.v2.AccountInfo
-	(*v2.CredentialOptions)(nil),                          // 54: c1.connector.v2.CredentialOptions
-	(*v2.EncryptionConfig)(nil),                           // 55: c1.connector.v2.EncryptionConfig
-	(*v2.ResourceId)(nil),                                 // 56: c1.connector.v2.ResourceId
-	(*v2.TicketRequest)(nil),                              // 57: c1.connector.v2.TicketRequest
-	(*v2.TicketSchema)(nil),                               // 58: c1.connector.v2.TicketSchema
-	(*structpb.Struct)(nil),                               // 59: google.protobuf.Struct
+	(*BatonServiceGetTasksRequest)(nil),                   // 5: c1.connectorapi.baton.v1.BatonServiceGetTasksRequest
+	(*BatonServiceGetTasksResponse)(nil),                  // 6: c1.connectorapi.baton.v1.BatonServiceGetTasksResponse
+	(*BatonServiceGetTaskResponse)(nil),                   // 7: c1.connectorapi.baton.v1.BatonServiceGetTaskResponse
+	(*BatonServiceHeartbeatRequest)(nil),                  // 8: c1.connectorapi.baton.v1.BatonServiceHeartbeatRequest
+	(*BatonServiceHeartbeatResponse)(nil),                 // 9: c1.connectorapi.baton.v1.BatonServiceHeartbeatResponse
+	(*BatonServiceUploadAssetRequest)(nil),                // 10: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest
+	(*BatonServiceUploadAssetResponse)(nil),               // 11: c1.connectorapi.baton.v1.BatonServiceUploadAssetResponse
+	(*BatonServiceFinishTaskRequest)(nil),                 // 12: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest
+	(*BatonServiceFinishTaskResponse)(nil),                // 13: c1.connectorapi.baton.v1.BatonServiceFinishTaskResponse
+	(*StartDebuggingRequest)(nil),                         // 14: c1.connectorapi.baton.v1.StartDebuggingRequest
+	(*StartDebuggingResponse)(nil),                        // 15: c1.connectorapi.baton.v1.StartDebuggingResponse
+	(*Task_NoneTask)(nil),                                 // 16: c1.connectorapi.baton.v1.Task.NoneTask
+	(*Task_HelloTask)(nil),                                // 17: c1.connectorapi.baton.v1.Task.HelloTask
+	(*Task_SyncFullTask)(nil),                             // 18: c1.connectorapi.baton.v1.Task.SyncFullTask
+	(*Task_EventFeedTask)(nil),                            // 19: c1.connectorapi.baton.v1.Task.EventFeedTask
+	(*Task_ListEventsTask)(nil),                           // 20: c1.connectorapi.baton.v1.Task.ListEventsTask
+	(*Task_ListEventFeedsTask)(nil),                       // 21: c1.connectorapi.baton.v1.Task.ListEventFeedsTask
+	(*Task_GrantTask)(nil),                                // 22: c1.connectorapi.baton.v1.Task.GrantTask
+	(*Task_RevokeTask)(nil),                               // 23: c1.connectorapi.baton.v1.Task.RevokeTask
+	(*Task_CreateAccountTask)(nil),                        // 24: c1.connectorapi.baton.v1.Task.CreateAccountTask
+	(*Task_CreateResourceTask)(nil),                       // 25: c1.connectorapi.baton.v1.Task.CreateResourceTask
+	(*Task_DeleteResourceTask)(nil),                       // 26: c1.connectorapi.baton.v1.Task.DeleteResourceTask
+	(*Task_RotateCredentialsTask)(nil),                    // 27: c1.connectorapi.baton.v1.Task.RotateCredentialsTask
+	(*Task_CreateTicketTask)(nil),                         // 28: c1.connectorapi.baton.v1.Task.CreateTicketTask
+	(*Task_BulkCreateTicketsTask)(nil),                    // 29: c1.connectorapi.baton.v1.Task.BulkCreateTicketsTask
+	(*Task_BulkGetTicketsTask)(nil),                       // 30: c1.connectorapi.baton.v1.Task.BulkGetTicketsTask
+	(*Task_ListTicketSchemasTask)(nil),                    // 31: c1.connectorapi.baton.v1.Task.ListTicketSchemasTask
+	(*Task_GetTicketTask)(nil),                            // 32: c1.connectorapi.baton.v1.Task.GetTicketTask
+	(*Task_ActionListSchemasTask)(nil),                    // 33: c1.connectorapi.baton.v1.Task.ActionListSchemasTask
+	(*Task_ActionGetSchemaTask)(nil),                      // 34: c1.connectorapi.baton.v1.Task.ActionGetSchemaTask
+	(*Task_ActionInvokeTask)(nil),                         // 35: c1.connectorapi.baton.v1.Task.ActionInvokeTask
+	(*Task_ActionStatusTask)(nil),                         // 36: c1.connectorapi.baton.v1.Task.ActionStatusTask
+	(*Task_CreateSyncDiffTask)(nil),                       // 37: c1.connectorapi.baton.v1.Task.CreateSyncDiffTask
+	(*Task_CompactSyncs)(nil),                             // 38: c1.connectorapi.baton.v1.Task.CompactSyncs
+	(*Task_CompactSyncs_CompactableSync)(nil),             // 39: c1.connectorapi.baton.v1.Task.CompactSyncs.CompactableSync
+	(*BatonServiceHelloRequest_BuildInfo)(nil),            // 40: c1.connectorapi.baton.v1.BatonServiceHelloRequest.BuildInfo
+	(*BatonServiceHelloRequest_OSInfo)(nil),               // 41: c1.connectorapi.baton.v1.BatonServiceHelloRequest.OSInfo
+	(*BatonServiceUploadAssetRequest_UploadMetadata)(nil), // 42: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadMetadata
+	(*BatonServiceUploadAssetRequest_UploadData)(nil),     // 43: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadData
+	(*BatonServiceUploadAssetRequest_UploadEOF)(nil),      // 44: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadEOF
+	(*BatonServiceFinishTaskRequest_Error)(nil),           // 45: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Error
+	(*BatonServiceFinishTaskRequest_Success)(nil),         // 46: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Success
+	(*v2.ConnectorMetadata)(nil),                          // 47: c1.connector.v2.ConnectorMetadata
+	(*anypb.Any)(nil),                                     // 48: google.protobuf.Any
+	(*durationpb.Duration)(nil),                           // 49: google.protobuf.Duration
+	(*status.Status)(nil),                                 // 50: google.rpc.Status
+	(*v2.Resource)(nil),                                   // 51: c1.connector.v2.Resource
+	(*timestamppb.Timestamp)(nil),                         // 52: google.protobuf.Timestamp
+	(*v2.Entitlement)(nil),                                // 53: c1.connector.v2.Entitlement
+	(*v2.Grant)(nil),                                      // 54: c1.connector.v2.Grant
+	(*v2.AccountInfo)(nil),                                // 55: c1.connector.v2.AccountInfo
+	(*v2.CredentialOptions)(nil),                          // 56: c1.connector.v2.CredentialOptions
+	(*v2.EncryptionConfig)(nil),                           // 57: c1.connector.v2.EncryptionConfig
+	(*v2.ResourceId)(nil),                                 // 58: c1.connector.v2.ResourceId
+	(*v2.TicketRequest)(nil),                              // 59: c1.connector.v2.TicketRequest
+	(*v2.TicketSchema)(nil),                               // 60: c1.connector.v2.TicketSchema
+	(*structpb.Struct)(nil),                               // 61: google.protobuf.Struct
 }
 var file_c1_connectorapi_baton_v1_baton_proto_depIdxs = []int32{
-	0,  // 0: c1.connectorapi.baton.v1.Task.status:type_name -> c1.connectorapi.baton.v1.Task.Status
-	14, // 1: c1.connectorapi.baton.v1.Task.none:type_name -> c1.connectorapi.baton.v1.Task.NoneTask
-	15, // 2: c1.connectorapi.baton.v1.Task.hello:type_name -> c1.connectorapi.baton.v1.Task.HelloTask
-	16, // 3: c1.connectorapi.baton.v1.Task.sync_full:type_name -> c1.connectorapi.baton.v1.Task.SyncFullTask
-	20, // 4: c1.connectorapi.baton.v1.Task.grant:type_name -> c1.connectorapi.baton.v1.Task.GrantTask
-	21, // 5: c1.connectorapi.baton.v1.Task.revoke:type_name -> c1.connectorapi.baton.v1.Task.RevokeTask
-	22, // 6: c1.connectorapi.baton.v1.Task.create_account:type_name -> c1.connectorapi.baton.v1.Task.CreateAccountTask
-	23, // 7: c1.connectorapi.baton.v1.Task.create_resource:type_name -> c1.connectorapi.baton.v1.Task.CreateResourceTask
-	24, // 8: c1.connectorapi.baton.v1.Task.delete_resource:type_name -> c1.connectorapi.baton.v1.Task.DeleteResourceTask
-	25, // 9: c1.connectorapi.baton.v1.Task.rotate_credentials:type_name -> c1.connectorapi.baton.v1.Task.RotateCredentialsTask
-	17, // 10: c1.connectorapi.baton.v1.Task.event_feed:type_name -> c1.connectorapi.baton.v1.Task.EventFeedTask
-	26, // 11: c1.connectorapi.baton.v1.Task.create_ticket_task:type_name -> c1.connectorapi.baton.v1.Task.CreateTicketTask
-	29, // 12: c1.connectorapi.baton.v1.Task.list_ticket_schemas:type_name -> c1.connectorapi.baton.v1.Task.ListTicketSchemasTask
-	30, // 13: c1.connectorapi.baton.v1.Task.get_ticket:type_name -> c1.connectorapi.baton.v1.Task.GetTicketTask
-	27, // 14: c1.connectorapi.baton.v1.Task.bulk_create_tickets:type_name -> c1.connectorapi.baton.v1.Task.BulkCreateTicketsTask
-	28, // 15: c1.connectorapi.baton.v1.Task.bulk_get_tickets:type_name -> c1.connectorapi.baton.v1.Task.BulkGetTicketsTask
-	31, // 16: c1.connectorapi.baton.v1.Task.action_list_schemas:type_name -> c1.connectorapi.baton.v1.Task.ActionListSchemasTask
-	32, // 17: c1.connectorapi.baton.v1.Task.action_get_schema:type_name -> c1.connectorapi.baton.v1.Task.ActionGetSchemaTask
-	33, // 18: c1.connectorapi.baton.v1.Task.action_invoke:type_name -> c1.connectorapi.baton.v1.Task.ActionInvokeTask
-	34, // 19: c1.connectorapi.baton.v1.Task.action_status:type_name -> c1.connectorapi.baton.v1.Task.ActionStatusTask
-	35, // 20: c1.connectorapi.baton.v1.Task.create_sync_diff:type_name -> c1.connectorapi.baton.v1.Task.CreateSyncDiffTask
-	36, // 21: c1.connectorapi.baton.v1.Task.compact_syncs:type_name -> c1.connectorapi.baton.v1.Task.CompactSyncs
-	19, // 22: c1.connectorapi.baton.v1.Task.list_event_feeds:type_name -> c1.connectorapi.baton.v1.Task.ListEventFeedsTask
-	18, // 23: c1.connectorapi.baton.v1.Task.list_events:type_name -> c1.connectorapi.baton.v1.Task.ListEventsTask
-	38, // 24: c1.connectorapi.baton.v1.BatonServiceHelloRequest.build_info:type_name -> c1.connectorapi.baton.v1.BatonServiceHelloRequest.BuildInfo
-	39, // 25: c1.connectorapi.baton.v1.BatonServiceHelloRequest.os_info:type_name -> c1.connectorapi.baton.v1.BatonServiceHelloRequest.OSInfo
-	45, // 26: c1.connectorapi.baton.v1.BatonServiceHelloRequest.connector_metadata:type_name -> c1.connector.v2.ConnectorMetadata
-	46, // 27: c1.connectorapi.baton.v1.BatonServiceHelloRequest.annotations:type_name -> google.protobuf.Any
-	46, // 28: c1.connectorapi.baton.v1.BatonServiceHelloResponse.annotations:type_name -> google.protobuf.Any
-	1,  // 29: c1.connectorapi.baton.v1.BatonServiceGetTaskResponse.task:type_name -> c1.connectorapi.baton.v1.Task
-	47, // 30: c1.connectorapi.baton.v1.BatonServiceGetTaskResponse.next_poll:type_name -> google.protobuf.Duration
-	47, // 31: c1.connectorapi.baton.v1.BatonServiceGetTaskResponse.next_heartbeat:type_name -> google.protobuf.Duration
-	46, // 32: c1.connectorapi.baton.v1.BatonServiceGetTaskResponse.annotations:type_name -> google.protobuf.Any
-	46, // 33: c1.connectorapi.baton.v1.BatonServiceHeartbeatRequest.annotations:type_name -> google.protobuf.Any
-	47, // 34: c1.connectorapi.baton.v1.BatonServiceHeartbeatResponse.next_heartbeat:type_name -> google.protobuf.Duration
-	46, // 35: c1.connectorapi.baton.v1.BatonServiceHeartbeatResponse.annotations:type_name -> google.protobuf.Any
-	40, // 36: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.metadata:type_name -> c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadMetadata
-	41, // 37: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.data:type_name -> c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadData
-	42, // 38: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.eof:type_name -> c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadEOF
-	46, // 39: c1.connectorapi.baton.v1.BatonServiceUploadAssetResponse.annotations:type_name -> google.protobuf.Any
-	48, // 40: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.status:type_name -> google.rpc.Status
-	43, // 41: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.error:type_name -> c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Error
-	44, // 42: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.success:type_name -> c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Success
-	46, // 43: c1.connectorapi.baton.v1.BatonServiceFinishTaskResponse.annotations:type_name -> google.protobuf.Any
-	46, // 44: c1.connectorapi.baton.v1.Task.NoneTask.annotations:type_name -> google.protobuf.Any
-	46, // 45: c1.connectorapi.baton.v1.Task.HelloTask.annotations:type_name -> google.protobuf.Any
-	46, // 46: c1.connectorapi.baton.v1.Task.SyncFullTask.annotations:type_name -> google.protobuf.Any
-	49, // 47: c1.connectorapi.baton.v1.Task.SyncFullTask.targeted_sync_resources:type_name -> c1.connector.v2.Resource
-	46, // 48: c1.connectorapi.baton.v1.Task.EventFeedTask.annotations:type_name -> google.protobuf.Any
-	50, // 49: c1.connectorapi.baton.v1.Task.EventFeedTask.start_at:type_name -> google.protobuf.Timestamp
-	46, // 50: c1.connectorapi.baton.v1.Task.ListEventsTask.annotations:type_name -> google.protobuf.Any
-	50, // 51: c1.connectorapi.baton.v1.Task.ListEventsTask.start_at:type_name -> google.protobuf.Timestamp
-	46, // 52: c1.connectorapi.baton.v1.Task.ListEventFeedsTask.annotations:type_name -> google.protobuf.Any
-	51, // 53: c1.connectorapi.baton.v1.Task.GrantTask.entitlement:type_name -> c1.connector.v2.Entitlement
-	49, // 54: c1.connectorapi.baton.v1.Task.GrantTask.principal:type_name -> c1.connector.v2.Resource
-	46, // 55: c1.connectorapi.baton.v1.Task.GrantTask.annotations:type_name -> google.protobuf.Any
-	47, // 56: c1.connectorapi.baton.v1.Task.GrantTask.duration:type_name -> google.protobuf.Duration
-	52, // 57: c1.connectorapi.baton.v1.Task.RevokeTask.grant:type_name -> c1.connector.v2.Grant
-	46, // 58: c1.connectorapi.baton.v1.Task.RevokeTask.annotations:type_name -> google.protobuf.Any
-	53, // 59: c1.connectorapi.baton.v1.Task.CreateAccountTask.account_info:type_name -> c1.connector.v2.AccountInfo
-	54, // 60: c1.connectorapi.baton.v1.Task.CreateAccountTask.credential_options:type_name -> c1.connector.v2.CredentialOptions
-	55, // 61: c1.connectorapi.baton.v1.Task.CreateAccountTask.encryption_configs:type_name -> c1.connector.v2.EncryptionConfig
-	49, // 62: c1.connectorapi.baton.v1.Task.CreateResourceTask.resource:type_name -> c1.connector.v2.Resource
-	56, // 63: c1.connectorapi.baton.v1.Task.DeleteResourceTask.resource_id:type_name -> c1.connector.v2.ResourceId
-	56, // 64: c1.connectorapi.baton.v1.Task.DeleteResourceTask.parent_resource_id:type_name -> c1.connector.v2.ResourceId
-	56, // 65: c1.connectorapi.baton.v1.Task.RotateCredentialsTask.resource_id:type_name -> c1.connector.v2.ResourceId
-	54, // 66: c1.connectorapi.baton.v1.Task.RotateCredentialsTask.credential_options:type_name -> c1.connector.v2.CredentialOptions
-	55, // 67: c1.connectorapi.baton.v1.Task.RotateCredentialsTask.encryption_configs:type_name -> c1.connector.v2.EncryptionConfig
-	57, // 68: c1.connectorapi.baton.v1.Task.CreateTicketTask.ticket_request:type_name -> c1.connector.v2.TicketRequest
-	58, // 69: c1.connectorapi.baton.v1.Task.CreateTicketTask.ticket_schema:type_name -> c1.connector.v2.TicketSchema
-	46, // 70: c1.connectorapi.baton.v1.Task.CreateTicketTask.annotations:type_name -> google.protobuf.Any
-	26, // 71: c1.connectorapi.baton.v1.Task.BulkCreateTicketsTask.ticket_requests:type_name -> c1.connectorapi.baton.v1.Task.CreateTicketTask
-	30, // 72: c1.connectorapi.baton.v1.Task.BulkGetTicketsTask.ticket_requests:type_name -> c1.connectorapi.baton.v1.Task.GetTicketTask
-	46, // 73: c1.connectorapi.baton.v1.Task.ListTicketSchemasTask.annotations:type_name -> google.protobuf.Any
-	46, // 74: c1.connectorapi.baton.v1.Task.GetTicketTask.annotations:type_name -> google.protobuf.Any
-	46, // 75: c1.connectorapi.baton.v1.Task.ActionListSchemasTask.annotations:type_name -> google.protobuf.Any
-	46, // 76: c1.connectorapi.baton.v1.Task.ActionGetSchemaTask.annotations:type_name -> google.protobuf.Any
-	59, // 77: c1.connectorapi.baton.v1.Task.ActionInvokeTask.args:type_name -> google.protobuf.Struct
-	46, // 78: c1.connectorapi.baton.v1.Task.ActionInvokeTask.annotations:type_name -> google.protobuf.Any
-	46, // 79: c1.connectorapi.baton.v1.Task.ActionStatusTask.annotations:type_name -> google.protobuf.Any
-	46, // 80: c1.connectorapi.baton.v1.Task.CreateSyncDiffTask.annotations:type_name -> google.protobuf.Any
-	37, // 81: c1.connectorapi.baton.v1.Task.CompactSyncs.compactable_syncs:type_name -> c1.connectorapi.baton.v1.Task.CompactSyncs.CompactableSync
-	46, // 82: c1.connectorapi.baton.v1.Task.CompactSyncs.annotations:type_name -> google.protobuf.Any
-	46, // 83: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadMetadata.annotations:type_name -> google.protobuf.Any
-	46, // 84: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadEOF.annotations:type_name -> google.protobuf.Any
-	46, // 85: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Error.annotations:type_name -> google.protobuf.Any
-	46, // 86: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Error.response:type_name -> google.protobuf.Any
-	46, // 87: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Success.annotations:type_name -> google.protobuf.Any
-	46, // 88: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Success.response:type_name -> google.protobuf.Any
-	2,  // 89: c1.connectorapi.baton.v1.BatonService.Hello:input_type -> c1.connectorapi.baton.v1.BatonServiceHelloRequest
-	4,  // 90: c1.connectorapi.baton.v1.BatonService.GetTask:input_type -> c1.connectorapi.baton.v1.BatonServiceGetTaskRequest
-	6,  // 91: c1.connectorapi.baton.v1.BatonService.Heartbeat:input_type -> c1.connectorapi.baton.v1.BatonServiceHeartbeatRequest
-	10, // 92: c1.connectorapi.baton.v1.BatonService.FinishTask:input_type -> c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest
-	8,  // 93: c1.connectorapi.baton.v1.BatonService.UploadAsset:input_type -> c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest
-	12, // 94: c1.connectorapi.baton.v1.BatonService.StartDebugging:input_type -> c1.connectorapi.baton.v1.StartDebuggingRequest
-	3,  // 95: c1.connectorapi.baton.v1.BatonService.Hello:output_type -> c1.connectorapi.baton.v1.BatonServiceHelloResponse
-	5,  // 96: c1.connectorapi.baton.v1.BatonService.GetTask:output_type -> c1.connectorapi.baton.v1.BatonServiceGetTaskResponse
-	7,  // 97: c1.connectorapi.baton.v1.BatonService.Heartbeat:output_type -> c1.connectorapi.baton.v1.BatonServiceHeartbeatResponse
-	11, // 98: c1.connectorapi.baton.v1.BatonService.FinishTask:output_type -> c1.connectorapi.baton.v1.BatonServiceFinishTaskResponse
-	9,  // 99: c1.connectorapi.baton.v1.BatonService.UploadAsset:output_type -> c1.connectorapi.baton.v1.BatonServiceUploadAssetResponse
-	13, // 100: c1.connectorapi.baton.v1.BatonService.StartDebugging:output_type -> c1.connectorapi.baton.v1.StartDebuggingResponse
-	95, // [95:101] is the sub-list for method output_type
-	89, // [89:95] is the sub-list for method input_type
-	89, // [89:89] is the sub-list for extension type_name
-	89, // [89:89] is the sub-list for extension extendee
-	0,  // [0:89] is the sub-list for field type_name
+	0,   // 0: c1.connectorapi.baton.v1.Task.status:type_name -> c1.connectorapi.baton.v1.Task.Status
+	16,  // 1: c1.connectorapi.baton.v1.Task.none:type_name -> c1.connectorapi.baton.v1.Task.NoneTask
+	17,  // 2: c1.connectorapi.baton.v1.Task.hello:type_name -> c1.connectorapi.baton.v1.Task.HelloTask
+	18,  // 3: c1.connectorapi.baton.v1.Task.sync_full:type_name -> c1.connectorapi.baton.v1.Task.SyncFullTask
+	22,  // 4: c1.connectorapi.baton.v1.Task.grant:type_name -> c1.connectorapi.baton.v1.Task.GrantTask
+	23,  // 5: c1.connectorapi.baton.v1.Task.revoke:type_name -> c1.connectorapi.baton.v1.Task.RevokeTask
+	24,  // 6: c1.connectorapi.baton.v1.Task.create_account:type_name -> c1.connectorapi.baton.v1.Task.CreateAccountTask
+	25,  // 7: c1.connectorapi.baton.v1.Task.create_resource:type_name -> c1.connectorapi.baton.v1.Task.CreateResourceTask
+	26,  // 8: c1.connectorapi.baton.v1.Task.delete_resource:type_name -> c1.connectorapi.baton.v1.Task.DeleteResourceTask
+	27,  // 9: c1.connectorapi.baton.v1.Task.rotate_credentials:type_name -> c1.connectorapi.baton.v1.Task.RotateCredentialsTask
+	19,  // 10: c1.connectorapi.baton.v1.Task.event_feed:type_name -> c1.connectorapi.baton.v1.Task.EventFeedTask
+	28,  // 11: c1.connectorapi.baton.v1.Task.create_ticket_task:type_name -> c1.connectorapi.baton.v1.Task.CreateTicketTask
+	31,  // 12: c1.connectorapi.baton.v1.Task.list_ticket_schemas:type_name -> c1.connectorapi.baton.v1.Task.ListTicketSchemasTask
+	32,  // 13: c1.connectorapi.baton.v1.Task.get_ticket:type_name -> c1.connectorapi.baton.v1.Task.GetTicketTask
+	29,  // 14: c1.connectorapi.baton.v1.Task.bulk_create_tickets:type_name -> c1.connectorapi.baton.v1.Task.BulkCreateTicketsTask
+	30,  // 15: c1.connectorapi.baton.v1.Task.bulk_get_tickets:type_name -> c1.connectorapi.baton.v1.Task.BulkGetTicketsTask
+	33,  // 16: c1.connectorapi.baton.v1.Task.action_list_schemas:type_name -> c1.connectorapi.baton.v1.Task.ActionListSchemasTask
+	34,  // 17: c1.connectorapi.baton.v1.Task.action_get_schema:type_name -> c1.connectorapi.baton.v1.Task.ActionGetSchemaTask
+	35,  // 18: c1.connectorapi.baton.v1.Task.action_invoke:type_name -> c1.connectorapi.baton.v1.Task.ActionInvokeTask
+	36,  // 19: c1.connectorapi.baton.v1.Task.action_status:type_name -> c1.connectorapi.baton.v1.Task.ActionStatusTask
+	37,  // 20: c1.connectorapi.baton.v1.Task.create_sync_diff:type_name -> c1.connectorapi.baton.v1.Task.CreateSyncDiffTask
+	38,  // 21: c1.connectorapi.baton.v1.Task.compact_syncs:type_name -> c1.connectorapi.baton.v1.Task.CompactSyncs
+	21,  // 22: c1.connectorapi.baton.v1.Task.list_event_feeds:type_name -> c1.connectorapi.baton.v1.Task.ListEventFeedsTask
+	20,  // 23: c1.connectorapi.baton.v1.Task.list_events:type_name -> c1.connectorapi.baton.v1.Task.ListEventsTask
+	40,  // 24: c1.connectorapi.baton.v1.BatonServiceHelloRequest.build_info:type_name -> c1.connectorapi.baton.v1.BatonServiceHelloRequest.BuildInfo
+	41,  // 25: c1.connectorapi.baton.v1.BatonServiceHelloRequest.os_info:type_name -> c1.connectorapi.baton.v1.BatonServiceHelloRequest.OSInfo
+	47,  // 26: c1.connectorapi.baton.v1.BatonServiceHelloRequest.connector_metadata:type_name -> c1.connector.v2.ConnectorMetadata
+	48,  // 27: c1.connectorapi.baton.v1.BatonServiceHelloRequest.annotations:type_name -> google.protobuf.Any
+	48,  // 28: c1.connectorapi.baton.v1.BatonServiceHelloResponse.annotations:type_name -> google.protobuf.Any
+	48,  // 29: c1.connectorapi.baton.v1.BatonServiceGetTasksRequest.annotations:type_name -> google.protobuf.Any
+	1,   // 30: c1.connectorapi.baton.v1.BatonServiceGetTasksResponse.tasks:type_name -> c1.connectorapi.baton.v1.Task
+	49,  // 31: c1.connectorapi.baton.v1.BatonServiceGetTasksResponse.next_poll:type_name -> google.protobuf.Duration
+	49,  // 32: c1.connectorapi.baton.v1.BatonServiceGetTasksResponse.next_heartbeat:type_name -> google.protobuf.Duration
+	48,  // 33: c1.connectorapi.baton.v1.BatonServiceGetTasksResponse.annotations:type_name -> google.protobuf.Any
+	1,   // 34: c1.connectorapi.baton.v1.BatonServiceGetTaskResponse.task:type_name -> c1.connectorapi.baton.v1.Task
+	49,  // 35: c1.connectorapi.baton.v1.BatonServiceGetTaskResponse.next_poll:type_name -> google.protobuf.Duration
+	49,  // 36: c1.connectorapi.baton.v1.BatonServiceGetTaskResponse.next_heartbeat:type_name -> google.protobuf.Duration
+	48,  // 37: c1.connectorapi.baton.v1.BatonServiceGetTaskResponse.annotations:type_name -> google.protobuf.Any
+	48,  // 38: c1.connectorapi.baton.v1.BatonServiceHeartbeatRequest.annotations:type_name -> google.protobuf.Any
+	49,  // 39: c1.connectorapi.baton.v1.BatonServiceHeartbeatResponse.next_heartbeat:type_name -> google.protobuf.Duration
+	48,  // 40: c1.connectorapi.baton.v1.BatonServiceHeartbeatResponse.annotations:type_name -> google.protobuf.Any
+	42,  // 41: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.metadata:type_name -> c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadMetadata
+	43,  // 42: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.data:type_name -> c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadData
+	44,  // 43: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.eof:type_name -> c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadEOF
+	48,  // 44: c1.connectorapi.baton.v1.BatonServiceUploadAssetResponse.annotations:type_name -> google.protobuf.Any
+	50,  // 45: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.status:type_name -> google.rpc.Status
+	45,  // 46: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.error:type_name -> c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Error
+	46,  // 47: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.success:type_name -> c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Success
+	48,  // 48: c1.connectorapi.baton.v1.BatonServiceFinishTaskResponse.annotations:type_name -> google.protobuf.Any
+	48,  // 49: c1.connectorapi.baton.v1.Task.NoneTask.annotations:type_name -> google.protobuf.Any
+	48,  // 50: c1.connectorapi.baton.v1.Task.HelloTask.annotations:type_name -> google.protobuf.Any
+	48,  // 51: c1.connectorapi.baton.v1.Task.SyncFullTask.annotations:type_name -> google.protobuf.Any
+	51,  // 52: c1.connectorapi.baton.v1.Task.SyncFullTask.targeted_sync_resources:type_name -> c1.connector.v2.Resource
+	48,  // 53: c1.connectorapi.baton.v1.Task.EventFeedTask.annotations:type_name -> google.protobuf.Any
+	52,  // 54: c1.connectorapi.baton.v1.Task.EventFeedTask.start_at:type_name -> google.protobuf.Timestamp
+	48,  // 55: c1.connectorapi.baton.v1.Task.ListEventsTask.annotations:type_name -> google.protobuf.Any
+	52,  // 56: c1.connectorapi.baton.v1.Task.ListEventsTask.start_at:type_name -> google.protobuf.Timestamp
+	48,  // 57: c1.connectorapi.baton.v1.Task.ListEventFeedsTask.annotations:type_name -> google.protobuf.Any
+	53,  // 58: c1.connectorapi.baton.v1.Task.GrantTask.entitlement:type_name -> c1.connector.v2.Entitlement
+	51,  // 59: c1.connectorapi.baton.v1.Task.GrantTask.principal:type_name -> c1.connector.v2.Resource
+	48,  // 60: c1.connectorapi.baton.v1.Task.GrantTask.annotations:type_name -> google.protobuf.Any
+	49,  // 61: c1.connectorapi.baton.v1.Task.GrantTask.duration:type_name -> google.protobuf.Duration
+	54,  // 62: c1.connectorapi.baton.v1.Task.RevokeTask.grant:type_name -> c1.connector.v2.Grant
+	48,  // 63: c1.connectorapi.baton.v1.Task.RevokeTask.annotations:type_name -> google.protobuf.Any
+	55,  // 64: c1.connectorapi.baton.v1.Task.CreateAccountTask.account_info:type_name -> c1.connector.v2.AccountInfo
+	56,  // 65: c1.connectorapi.baton.v1.Task.CreateAccountTask.credential_options:type_name -> c1.connector.v2.CredentialOptions
+	57,  // 66: c1.connectorapi.baton.v1.Task.CreateAccountTask.encryption_configs:type_name -> c1.connector.v2.EncryptionConfig
+	51,  // 67: c1.connectorapi.baton.v1.Task.CreateResourceTask.resource:type_name -> c1.connector.v2.Resource
+	58,  // 68: c1.connectorapi.baton.v1.Task.DeleteResourceTask.resource_id:type_name -> c1.connector.v2.ResourceId
+	58,  // 69: c1.connectorapi.baton.v1.Task.DeleteResourceTask.parent_resource_id:type_name -> c1.connector.v2.ResourceId
+	58,  // 70: c1.connectorapi.baton.v1.Task.RotateCredentialsTask.resource_id:type_name -> c1.connector.v2.ResourceId
+	56,  // 71: c1.connectorapi.baton.v1.Task.RotateCredentialsTask.credential_options:type_name -> c1.connector.v2.CredentialOptions
+	57,  // 72: c1.connectorapi.baton.v1.Task.RotateCredentialsTask.encryption_configs:type_name -> c1.connector.v2.EncryptionConfig
+	59,  // 73: c1.connectorapi.baton.v1.Task.CreateTicketTask.ticket_request:type_name -> c1.connector.v2.TicketRequest
+	60,  // 74: c1.connectorapi.baton.v1.Task.CreateTicketTask.ticket_schema:type_name -> c1.connector.v2.TicketSchema
+	48,  // 75: c1.connectorapi.baton.v1.Task.CreateTicketTask.annotations:type_name -> google.protobuf.Any
+	28,  // 76: c1.connectorapi.baton.v1.Task.BulkCreateTicketsTask.ticket_requests:type_name -> c1.connectorapi.baton.v1.Task.CreateTicketTask
+	32,  // 77: c1.connectorapi.baton.v1.Task.BulkGetTicketsTask.ticket_requests:type_name -> c1.connectorapi.baton.v1.Task.GetTicketTask
+	48,  // 78: c1.connectorapi.baton.v1.Task.ListTicketSchemasTask.annotations:type_name -> google.protobuf.Any
+	48,  // 79: c1.connectorapi.baton.v1.Task.GetTicketTask.annotations:type_name -> google.protobuf.Any
+	48,  // 80: c1.connectorapi.baton.v1.Task.ActionListSchemasTask.annotations:type_name -> google.protobuf.Any
+	48,  // 81: c1.connectorapi.baton.v1.Task.ActionGetSchemaTask.annotations:type_name -> google.protobuf.Any
+	61,  // 82: c1.connectorapi.baton.v1.Task.ActionInvokeTask.args:type_name -> google.protobuf.Struct
+	48,  // 83: c1.connectorapi.baton.v1.Task.ActionInvokeTask.annotations:type_name -> google.protobuf.Any
+	48,  // 84: c1.connectorapi.baton.v1.Task.ActionStatusTask.annotations:type_name -> google.protobuf.Any
+	48,  // 85: c1.connectorapi.baton.v1.Task.CreateSyncDiffTask.annotations:type_name -> google.protobuf.Any
+	39,  // 86: c1.connectorapi.baton.v1.Task.CompactSyncs.compactable_syncs:type_name -> c1.connectorapi.baton.v1.Task.CompactSyncs.CompactableSync
+	48,  // 87: c1.connectorapi.baton.v1.Task.CompactSyncs.annotations:type_name -> google.protobuf.Any
+	48,  // 88: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadMetadata.annotations:type_name -> google.protobuf.Any
+	48,  // 89: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadEOF.annotations:type_name -> google.protobuf.Any
+	48,  // 90: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Error.annotations:type_name -> google.protobuf.Any
+	48,  // 91: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Error.response:type_name -> google.protobuf.Any
+	48,  // 92: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Success.annotations:type_name -> google.protobuf.Any
+	48,  // 93: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Success.response:type_name -> google.protobuf.Any
+	2,   // 94: c1.connectorapi.baton.v1.BatonService.Hello:input_type -> c1.connectorapi.baton.v1.BatonServiceHelloRequest
+	4,   // 95: c1.connectorapi.baton.v1.BatonService.GetTask:input_type -> c1.connectorapi.baton.v1.BatonServiceGetTaskRequest
+	5,   // 96: c1.connectorapi.baton.v1.BatonService.GetTasks:input_type -> c1.connectorapi.baton.v1.BatonServiceGetTasksRequest
+	8,   // 97: c1.connectorapi.baton.v1.BatonService.Heartbeat:input_type -> c1.connectorapi.baton.v1.BatonServiceHeartbeatRequest
+	12,  // 98: c1.connectorapi.baton.v1.BatonService.FinishTask:input_type -> c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest
+	10,  // 99: c1.connectorapi.baton.v1.BatonService.UploadAsset:input_type -> c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest
+	14,  // 100: c1.connectorapi.baton.v1.BatonService.StartDebugging:input_type -> c1.connectorapi.baton.v1.StartDebuggingRequest
+	3,   // 101: c1.connectorapi.baton.v1.BatonService.Hello:output_type -> c1.connectorapi.baton.v1.BatonServiceHelloResponse
+	7,   // 102: c1.connectorapi.baton.v1.BatonService.GetTask:output_type -> c1.connectorapi.baton.v1.BatonServiceGetTaskResponse
+	6,   // 103: c1.connectorapi.baton.v1.BatonService.GetTasks:output_type -> c1.connectorapi.baton.v1.BatonServiceGetTasksResponse
+	9,   // 104: c1.connectorapi.baton.v1.BatonService.Heartbeat:output_type -> c1.connectorapi.baton.v1.BatonServiceHeartbeatResponse
+	13,  // 105: c1.connectorapi.baton.v1.BatonService.FinishTask:output_type -> c1.connectorapi.baton.v1.BatonServiceFinishTaskResponse
+	11,  // 106: c1.connectorapi.baton.v1.BatonService.UploadAsset:output_type -> c1.connectorapi.baton.v1.BatonServiceUploadAssetResponse
+	15,  // 107: c1.connectorapi.baton.v1.BatonService.StartDebugging:output_type -> c1.connectorapi.baton.v1.StartDebuggingResponse
+	101, // [101:108] is the sub-list for method output_type
+	94,  // [94:101] is the sub-list for method input_type
+	94,  // [94:94] is the sub-list for extension type_name
+	94,  // [94:94] is the sub-list for extension extendee
+	0,   // [0:94] is the sub-list for field type_name
 }
 
 func init() { file_c1_connectorapi_baton_v1_baton_proto_init() }
@@ -5596,12 +5874,12 @@ func file_c1_connectorapi_baton_v1_baton_proto_init() {
 		(*task_ListEventFeeds)(nil),
 		(*task_ListEvents)(nil),
 	}
-	file_c1_connectorapi_baton_v1_baton_proto_msgTypes[7].OneofWrappers = []any{
+	file_c1_connectorapi_baton_v1_baton_proto_msgTypes[9].OneofWrappers = []any{
 		(*batonServiceUploadAssetRequest_Metadata)(nil),
 		(*batonServiceUploadAssetRequest_Data)(nil),
 		(*batonServiceUploadAssetRequest_Eof)(nil),
 	}
-	file_c1_connectorapi_baton_v1_baton_proto_msgTypes[9].OneofWrappers = []any{
+	file_c1_connectorapi_baton_v1_baton_proto_msgTypes[11].OneofWrappers = []any{
 		(*batonServiceFinishTaskRequest_Error_)(nil),
 		(*batonServiceFinishTaskRequest_Success_)(nil),
 	}
@@ -5611,7 +5889,7 @@ func file_c1_connectorapi_baton_v1_baton_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_c1_connectorapi_baton_v1_baton_proto_rawDesc), len(file_c1_connectorapi_baton_v1_baton_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   44,
+			NumMessages:   46,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/connectorrunner/runner.go
+++ b/pkg/connectorrunner/runner.go
@@ -210,7 +210,7 @@ func (c *connectorRunner) run(ctx context.Context) error {
 
 	sem := semaphore.NewWeighted(int64(c.taskConcurrency))
 
-	waitDuration := time.Second * 0
+	nextCheckAfter := time.Second * 0
 	errCount := 0
 	stopForLoop := false
 	var err error
@@ -218,7 +218,7 @@ func (c *connectorRunner) run(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			return c.handleContextCancel(ctx)
-		case <-time.After(waitDuration):
+		case <-time.After(nextCheckAfter):
 			l.Debug("runner: claiming worker")
 			// Acquire a worker slot before we call Next() so we don't claim a task before we can actually process it.
 			err = sem.Acquire(ctx, 1)
@@ -228,24 +228,25 @@ func (c *connectorRunner) run(ctx context.Context) error {
 			}
 			l.Debug("runner: worker claimed, checking for next task")
 
-			// Fetch the next task.
-			nextTask, nextWaitDuration, err := c.tasks.Next(ctx)
+			// Ask the manager for local or remote work. With batched task managers,
+			// the manager owns remote poll deadlines while it buffers local tasks.
+			nextTask, nextCheckAfterFromManager, err := c.tasks.Next(ctx)
 			if err != nil {
 				// TODO(morgabra) Use a library with jitter for this?
 				errCount++
-				waitDuration = c.backoff(ctx, errCount)
-				l.Error("runner: error getting next task", zap.Error(err), zap.Int("err_count", errCount), zap.Duration("wait_duration", waitDuration))
+				nextCheckAfter = c.backoff(ctx, errCount)
+				l.Error("runner: error getting next task", zap.Error(err), zap.Int("err_count", errCount), zap.Duration("next_check_after", nextCheckAfter))
 				sem.Release(1)
 				continue
 			}
 
 			errCount = 0
-			waitDuration = nextWaitDuration
+			nextCheckAfter = nextCheckAfterFromManager
 
 			// nil tasks mean there are no tasks to process.
 			if nextTask == nil {
 				sem.Release(1)
-				l.Debug("runner: no tasks to process", zap.Duration("wait_duration", waitDuration))
+				l.Debug("runner: no tasks to process", zap.Duration("next_check_after", nextCheckAfter))
 				if c.oneShot {
 					l.Debug("runner: one-shot mode enabled. Exiting.")
 					return nil
@@ -287,7 +288,7 @@ func (c *connectorRunner) run(ctx context.Context) error {
 				l.Debug("runner: task processed", zap.String("task_id", t.GetId()), zap.String("task_type", tasks.GetType(t).String()))
 			}(nextTask)
 
-			l.Debug("runner: dispatched task, waiting for next task", zap.Duration("wait_duration", waitDuration))
+			l.Debug("runner: dispatched task, asking manager again after delay", zap.Duration("next_check_after", nextCheckAfter))
 		}
 	}
 
@@ -1036,6 +1037,7 @@ func NewConnectorRunner(ctx context.Context, c types.ConnectorServer, opts ...Op
 		resources,
 		cfg.syncResourceTypeIDs,
 		cfg.workerCount,
+		runner.taskConcurrency,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/tasks/c1api/manager.go
+++ b/pkg/tasks/c1api/manager.go
@@ -1,8 +1,11 @@
 package c1api
 
 import (
+	"cmp"
 	"context"
 	"errors"
+	"os"
+	"strconv"
 	"sync/atomic"
 	"time"
 
@@ -50,8 +53,12 @@ var (
 	maxHelloBackoff     = 5 * time.Minute
 )
 
+const getTasksEnv = "BATON_GET_TASKS"
+
 type c1ApiTaskManager struct {
 	serviceClient                       BatonServiceClient
+	taskQueue                           *taskQueue
+	getTasksEnabled                     bool
 	tempDir                             string
 	skipFullSync                        bool
 	externalResourceC1Z                 string
@@ -197,28 +204,91 @@ func (c *c1ApiTaskManager) Next(ctx context.Context) (*v1.Task, time.Duration, e
 	defer func() { uotel.EndSpanWithError(span, err) }()
 	l := ctxzap.Extract(ctx)
 
-	l.Debug("c1_api_task_manager.Next(): checking for new tasks")
+	if !c.getTasksEnabled {
+		l.Debug("c1_api_task_manager.Next(): checking for new task")
+		resp, err := c.serviceClient.GetTask(ctx, &v1.BatonServiceGetTaskRequest{})
+		if err != nil {
+			return nil, 0, err
+		}
 
-	resp, err := c.serviceClient.GetTask(ctx, &v1.BatonServiceGetTaskRequest{})
+		nextPoll := getNextPoll(resp.GetNextPoll().AsDuration())
+		l = l.With(zap.Duration("next_poll", nextPoll))
+
+		if resp.GetTask() == nil || tasks.Is(resp.GetTask(), taskTypes.NoneType) {
+			l.Debug("c1_api_task_manager.Next(): no tasks available")
+			return nil, nextPoll, nil
+		}
+
+		l = l.With(
+			zap.String("task_id", resp.GetTask().GetId()),
+			zap.Stringer("task_type", tasks.GetType(resp.GetTask())),
+		)
+
+		l.Debug("c1_api_task_manager.Next(): got task", zap.Duration("next_poll", nextPoll))
+		return resp.GetTask(), nextPoll, nil
+	}
+
+	// Bulk fetch & queue path.
+	task := c.taskQueue.take()
+	wait := time.Duration(0)
+	decision := c.taskQueue.pollDecision()
+	// Can we do any work right now?
+	if decision.action == pollActionWait {
+		if task == nil {
+			// no tasks in our queue, so bubble up the mandatory wait time (or default to 100ms to avoid a spinlock).
+			wait = cmp.Or(decision.wait, 100*time.Millisecond)
+		}
+		l.Debug("c1_api_task_manager.Next(): returning queued task", zap.String("task_id", task.GetId()), zap.Stringer("task_type", tasks.GetType(task)))
+		return task, wait, nil
+	}
+
+	// Should we do work now?
+	if decision.action == pollActionFetch {
+		knownTaskIDs, pageSize := c.taskQueue.fetchParams()
+
+		resp, err := c.serviceClient.GetTasks(ctx, &v1.BatonServiceGetTasksRequest{
+			PageSize:     pageSize,
+			KnownTaskIds: knownTaskIDs,
+		})
+
+		if err == nil {
+			nextPoll := getNextPoll(resp.GetNextPoll().AsDuration())
+			l.Debug("c1_api_task_manager.Next(): fetched task batch", zap.Duration("next_poll", nextPoll), zap.Int("tasks", len(resp.GetTasks())), zap.Uint32("page_size", pageSize))
+			c.taskQueue.setNextPoll(nextPoll)
+			c.taskQueue.enqueue(resp.GetTasks())
+		} else {
+			l.Error("c1_api_task_manager.Next(): failed to top up task batch", zap.Error(err))
+			if task == nil {
+				// our queue is empty, and we can't fetch more, thats an error.
+				return nil, 0, err
+			}
+			// swallow error, maybe the next one will work.
+		}
+	}
+
+	// Maybe we don't have a task but fetched one...
+	if task == nil {
+		task = c.taskQueue.take()
+	}
+
+	if task == nil {
+		// Maybe we fetched tasks and there were none, so use a fresh wait time.
+		wait = cmp.Or(c.taskQueue.pollDecision().wait, 100*time.Millisecond)
+	}
+
+	return task, wait, nil
+}
+
+func getTasksEnabledFromEnv() bool {
+	raw, ok := os.LookupEnv(getTasksEnv)
+	if !ok {
+		return false
+	}
+	enabled, err := strconv.ParseBool(raw)
 	if err != nil {
-		return nil, 0, err
+		return false
 	}
-
-	nextPoll := getNextPoll(resp.GetNextPoll().AsDuration())
-	l = l.With(zap.Duration("next_poll", nextPoll))
-
-	if resp.GetTask() == nil || tasks.Is(resp.GetTask(), taskTypes.NoneType) {
-		l.Debug("c1_api_task_manager.Next(): no tasks available")
-		return nil, nextPoll, nil
-	}
-
-	l = l.With(
-		zap.String("task_id", resp.GetTask().GetId()),
-		zap.Stringer("task_type", tasks.GetType(resp.GetTask())),
-	)
-
-	l.Debug("c1_api_task_manager.Next(): got task", zap.Duration("next_poll", nextPoll))
-	return resp.GetTask(), nextPoll, nil
+	return enabled
 }
 
 func (c *c1ApiTaskManager) finishTask(ctx context.Context, task *v1.Task, resp proto.Message, annos annotations.Annotations, taskError error) error {
@@ -313,6 +383,7 @@ func (c *c1ApiTaskManager) Process(ctx context.Context, task *v1.Task, cc types.
 		l.Debug("c1_api_task_manager.Process(): process called with nil task -- continuing")
 		return nil
 	}
+	defer c.taskQueue.markDone(task)
 
 	l = l.With(
 		zap.String("task_id", task.GetId()),
@@ -410,6 +481,7 @@ func NewC1TaskManager(
 	targetedSyncResources []*v2.Resource,
 	syncResourceTypeIDs []string,
 	workerCount int,
+	taskConcurrency int,
 ) (BootstrappingTaskManager, error) {
 	serviceClient, err := newServiceClient(ctx, clientID, clientSecret)
 	if err != nil {
@@ -418,6 +490,8 @@ func NewC1TaskManager(
 
 	return &c1ApiTaskManager{
 		serviceClient:                       serviceClient,
+		taskQueue:                           newTaskQueue(taskConcurrency),
+		getTasksEnabled:                     getTasksEnabledFromEnv(),
 		tempDir:                             tempDir,
 		skipFullSync:                        skipFullSync,
 		externalResourceC1Z:                 externalC1Z,

--- a/pkg/tasks/c1api/manager_test.go
+++ b/pkg/tasks/c1api/manager_test.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	v1 "github.com/conductorone/baton-sdk/pb/c1/connectorapi/baton/v1"
@@ -25,6 +26,10 @@ type fakeBatonServiceClient struct {
 
 	helloResponses []error
 	helloCalls     int
+	getTasksReqs   []*v1.BatonServiceGetTasksRequest
+	getTasksResp   *v1.BatonServiceGetTasksResponse
+	getTasksErr    error
+	getTaskCalls   int
 }
 
 func newFakeBatonServiceClient(helloResponses []error) *fakeBatonServiceClient {
@@ -48,7 +53,23 @@ func (f *fakeBatonServiceClient) Hello(ctx context.Context, req *v1.BatonService
 }
 
 func (f *fakeBatonServiceClient) GetTask(context.Context, *v1.BatonServiceGetTaskRequest) (*v1.BatonServiceGetTaskResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.getTaskCalls++
 	return v1.BatonServiceGetTaskResponse_builder{}.Build(), nil
+}
+
+func (f *fakeBatonServiceClient) GetTasks(_ context.Context, req *v1.BatonServiceGetTasksRequest) (*v1.BatonServiceGetTasksResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.getTasksReqs = append(f.getTasksReqs, req)
+	if f.getTasksErr != nil {
+		return nil, f.getTasksErr
+	}
+	if f.getTasksResp != nil {
+		return f.getTasksResp, nil
+	}
+	return v1.BatonServiceGetTasksResponse_builder{}.Build(), nil
 }
 
 func (f *fakeBatonServiceClient) Heartbeat(context.Context, *v1.BatonServiceHeartbeatRequest) (*v1.BatonServiceHeartbeatResponse, error) {
@@ -100,7 +121,16 @@ func withFastBackoff(t *testing.T) {
 }
 
 func newTestManager(sc BatonServiceClient) *c1ApiTaskManager {
-	return &c1ApiTaskManager{serviceClient: sc}
+	return &c1ApiTaskManager{
+		serviceClient:   sc,
+		taskQueue:       newTaskQueue(3),
+		getTasksEnabled: getTasksEnabledFromEnv(),
+	}
+}
+
+func enableGetTasks(t *testing.T) {
+	t.Helper()
+	t.Setenv(getTasksEnv, "true")
 }
 
 func TestBootstrapSucceedsOnFirstAttempt(t *testing.T) {
@@ -205,7 +235,7 @@ func TestBootstrapPropagatesGetMetadataError(t *testing.T) {
 
 func TestNextDoesNotSelfQueueHello(t *testing.T) {
 	// With Bootstrap owning the startup handshake, Next() must no longer
-	// self-enqueue a Hello task. First Next() call should just go to GetTask.
+	// self-enqueue a Hello task. First Next() call should just poll C1.
 	sc := newFakeBatonServiceClient(nil)
 	mgr := newTestManager(sc)
 
@@ -216,6 +246,256 @@ func TestNextDoesNotSelfQueueHello(t *testing.T) {
 	if task != nil && task.GetHello() != nil {
 		t.Fatalf("Next must not self-queue a Hello task, got %+v", task)
 	}
+	if sc.getTaskCalls != 1 {
+		t.Fatalf("expected default path to use GetTask once, got %d calls", sc.getTaskCalls)
+	}
+	if len(sc.getTasksReqs) != 0 {
+		t.Fatalf("expected default path not to use GetTasks, got %d calls", len(sc.getTasksReqs))
+	}
+}
+
+func TestNextUsesGetTasksAndQueuesBatch(t *testing.T) {
+	enableGetTasks(t)
+	task1 := v1.Task_builder{Id: "aaaaaaaaaaaaaaaaaaaaaaaaaaa", Hello: &v1.Task_HelloTask{}}.Build()
+	task2 := v1.Task_builder{Id: "bbbbbbbbbbbbbbbbbbbbbbbbbbb", Hello: &v1.Task_HelloTask{}}.Build()
+	sc := newFakeBatonServiceClient(nil)
+	sc.getTasksResp = v1.BatonServiceGetTasksResponse_builder{
+		Tasks:    []*v1.Task{task1, task2},
+		NextPoll: durationpb.New(time.Hour),
+	}.Build()
+	mgr := newTestManager(sc)
+
+	got1, _, err := mgr.Next(context.Background())
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	if got1.GetId() != task1.GetId() {
+		t.Fatalf("first task id = %q, want %q", got1.GetId(), task1.GetId())
+	}
+
+	got2, _, err := mgr.Next(context.Background())
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	if got2.GetId() != task2.GetId() {
+		t.Fatalf("second task id = %q, want %q", got2.GetId(), task2.GetId())
+	}
+	if len(sc.getTasksReqs) != 1 {
+		t.Fatalf("expected one GetTasks call, got %d", len(sc.getTasksReqs))
+	}
+}
+
+func TestNextSendsKnownTaskIDs(t *testing.T) {
+	enableGetTasks(t)
+	task1 := v1.Task_builder{Id: "aaaaaaaaaaaaaaaaaaaaaaaaaaa", Hello: &v1.Task_HelloTask{}}.Build()
+	task2 := v1.Task_builder{Id: "bbbbbbbbbbbbbbbbbbbbbbbbbbb", Hello: &v1.Task_HelloTask{}}.Build()
+	sc := newFakeBatonServiceClient(nil)
+	sc.getTasksResp = v1.BatonServiceGetTasksResponse_builder{
+		Tasks: []*v1.Task{task1, task2},
+	}.Build()
+	mgr := newTestManager(sc)
+
+	got1, _, err := mgr.Next(context.Background())
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	sc.getTasksResp = v1.BatonServiceGetTasksResponse_builder{}.Build()
+
+	_, _, err = mgr.Next(context.Background())
+	if err != nil {
+		t.Fatalf("Next queued: %v", err)
+	}
+
+	if len(sc.getTasksReqs) != 2 {
+		t.Fatalf("expected two GetTasks calls, got %d", len(sc.getTasksReqs))
+	}
+	known := sc.getTasksReqs[1].GetKnownTaskIds()
+	if !containsString(known, got1.GetId()) {
+		t.Fatalf("known task IDs %v did not include in-flight task %q", known, got1.GetId())
+	}
+}
+
+func TestNextRequestsOnlyEnoughTasksToReachKnownTarget(t *testing.T) {
+	enableGetTasks(t)
+	task1 := v1.Task_builder{Id: "aaaaaaaaaaaaaaaaaaaaaaaaaaa", Hello: &v1.Task_HelloTask{}}.Build()
+	task2 := v1.Task_builder{Id: "bbbbbbbbbbbbbbbbbbbbbbbbbbb", Hello: &v1.Task_HelloTask{}}.Build()
+	sc := newFakeBatonServiceClient(nil)
+	sc.getTasksResp = v1.BatonServiceGetTasksResponse_builder{
+		Tasks: []*v1.Task{task1, task2},
+	}.Build()
+	mgr := newTestManager(sc)
+
+	if _, _, err := mgr.Next(context.Background()); err != nil {
+		t.Fatalf("Next first fetch: %v", err)
+	}
+	sc.getTasksResp = v1.BatonServiceGetTasksResponse_builder{}.Build()
+	if _, _, err := mgr.Next(context.Background()); err != nil {
+		t.Fatalf("Next queued: %v", err)
+	}
+
+	if len(sc.getTasksReqs) != 2 {
+		t.Fatalf("expected two GetTasks calls, got %d", len(sc.getTasksReqs))
+	}
+	if got := sc.getTasksReqs[0].GetPageSize(); got != 6 {
+		t.Fatalf("first page size = %d, want 6", got)
+	}
+	if got := sc.getTasksReqs[1].GetPageSize(); got != 4 {
+		t.Fatalf("second page size = %d, want 4", got)
+	}
+}
+
+func TestNextDoesNotTopUpQueuedTasksBeforeNextPoll(t *testing.T) {
+	enableGetTasks(t)
+	task1 := v1.Task_builder{Id: "aaaaaaaaaaaaaaaaaaaaaaaaaaa", Hello: &v1.Task_HelloTask{}}.Build()
+	task2 := v1.Task_builder{Id: "bbbbbbbbbbbbbbbbbbbbbbbbbbb", Hello: &v1.Task_HelloTask{}}.Build()
+	sc := newFakeBatonServiceClient(nil)
+	sc.getTasksResp = v1.BatonServiceGetTasksResponse_builder{
+		Tasks:    []*v1.Task{task1, task2},
+		NextPoll: durationpb.New(time.Hour),
+	}.Build()
+	mgr := newTestManager(sc)
+
+	if _, _, err := mgr.Next(context.Background()); err != nil {
+		t.Fatalf("Next first fetch: %v", err)
+	}
+	if _, _, err := mgr.Next(context.Background()); err != nil {
+		t.Fatalf("Next queued: %v", err)
+	}
+	if len(sc.getTasksReqs) != 1 {
+		t.Fatalf("expected no top-up before next_poll, got %d GetTasks calls", len(sc.getTasksReqs))
+	}
+}
+
+func TestNextReturnsWaitWhenBatchIsEmpty(t *testing.T) {
+	enableGetTasks(t)
+	sc := newFakeBatonServiceClient(nil)
+	sc.getTasksResp = v1.BatonServiceGetTasksResponse_builder{
+		NextPoll: durationpb.New(time.Hour),
+	}.Build()
+	mgr := newTestManager(sc)
+
+	task, wait, err := mgr.Next(context.Background())
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	if task != nil {
+		t.Fatalf("expected no task, got %+v", task)
+	}
+	if wait <= 0 {
+		t.Fatalf("expected positive wait for empty batch, got %s", wait)
+	}
+}
+
+func TestNextWaitsWhenEnoughKnownTasksAreInFlight(t *testing.T) {
+	enableGetTasks(t)
+	sc := newFakeBatonServiceClient(nil)
+	mgr := newTestManager(sc)
+	for _, id := range []string{
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"bbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		"ccccccccccccccccccccccccccc",
+	} {
+		mgr.taskQueue.inFlight[id] = struct{}{}
+	}
+
+	task, wait, err := mgr.Next(context.Background())
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	if task != nil {
+		t.Fatalf("expected no queued task, got %+v", task)
+	}
+	if wait <= 0 {
+		t.Fatalf("expected positive wait when enough tasks are already in flight, got %s", wait)
+	}
+	if len(sc.getTasksReqs) != 0 {
+		t.Fatalf("expected no GetTasks call while enough tasks are in flight, got %d", len(sc.getTasksReqs))
+	}
+}
+
+func TestNextDoesNotTopUpWhenKnownTasksAtLowWater(t *testing.T) {
+	enableGetTasks(t)
+	task1 := v1.Task_builder{Id: "aaaaaaaaaaaaaaaaaaaaaaaaaaa", Hello: &v1.Task_HelloTask{}}.Build()
+	task2 := v1.Task_builder{Id: "bbbbbbbbbbbbbbbbbbbbbbbbbbb", Hello: &v1.Task_HelloTask{}}.Build()
+	task3 := v1.Task_builder{Id: "ccccccccccccccccccccccccccc", Hello: &v1.Task_HelloTask{}}.Build()
+	sc := newFakeBatonServiceClient(nil)
+	sc.getTasksResp = v1.BatonServiceGetTasksResponse_builder{
+		Tasks: []*v1.Task{task1, task2, task3},
+	}.Build()
+	mgr := newTestManager(sc)
+
+	if _, _, err := mgr.Next(context.Background()); err != nil {
+		t.Fatalf("Next first fetch: %v", err)
+	}
+	if _, _, err := mgr.Next(context.Background()); err != nil {
+		t.Fatalf("Next queued: %v", err)
+	}
+	if len(sc.getTasksReqs) != 1 {
+		t.Fatalf("expected no top-up at low-water, got %d GetTasks calls", len(sc.getTasksReqs))
+	}
+}
+
+func TestNextTopsUpQueuedTasksAfterNextPoll(t *testing.T) {
+	enableGetTasks(t)
+	task1 := v1.Task_builder{Id: "aaaaaaaaaaaaaaaaaaaaaaaaaaa", Hello: &v1.Task_HelloTask{}}.Build()
+	task2 := v1.Task_builder{Id: "bbbbbbbbbbbbbbbbbbbbbbbbbbb", Hello: &v1.Task_HelloTask{}}.Build()
+	task3 := v1.Task_builder{Id: "ccccccccccccccccccccccccccc", Hello: &v1.Task_HelloTask{}}.Build()
+	sc := newFakeBatonServiceClient(nil)
+	sc.getTasksResp = v1.BatonServiceGetTasksResponse_builder{
+		Tasks: []*v1.Task{task1, task2},
+	}.Build()
+	mgr := newTestManager(sc)
+
+	if _, _, err := mgr.Next(context.Background()); err != nil {
+		t.Fatalf("Next first fetch: %v", err)
+	}
+	sc.getTasksResp = v1.BatonServiceGetTasksResponse_builder{
+		Tasks: []*v1.Task{task3},
+	}.Build()
+	if _, _, err := mgr.Next(context.Background()); err != nil {
+		t.Fatalf("Next queued/top-up: %v", err)
+	}
+	if len(sc.getTasksReqs) != 2 {
+		t.Fatalf("expected top-up after elapsed next_poll, got %d GetTasks calls", len(sc.getTasksReqs))
+	}
+}
+
+func TestProcessRemovesKnownTaskID(t *testing.T) {
+	task := v1.Task_builder{Id: "aaaaaaaaaaaaaaaaaaaaaaaaaaa", Hello: &v1.Task_HelloTask{}}.Build()
+	sc := newFakeBatonServiceClient(nil)
+	mgr := newTestManager(sc)
+	mgr.taskQueue.inFlight[task.GetId()] = struct{}{}
+
+	if err := mgr.Process(context.Background(), task, &fakeConnectorClient{}); err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	if got, _ := mgr.taskQueue.fetchParams(); containsString(got, task.GetId()) {
+		t.Fatalf("known task IDs %v still include completed task %q", got, task.GetId())
+	}
+}
+
+func TestNextReturnsGetTasksErrorWhenEnabled(t *testing.T) {
+	enableGetTasks(t)
+	sc := newFakeBatonServiceClient(nil)
+	sc.getTasksErr = status.Error(codes.Unimplemented, "not implemented")
+	mgr := newTestManager(sc)
+
+	_, _, err := mgr.Next(context.Background())
+	if status.Code(err) != codes.Unimplemented {
+		t.Fatalf("expected Unimplemented error, got %v", err)
+	}
+	if sc.getTaskCalls != 0 {
+		t.Fatalf("expected no GetTask fallback calls, got %d", sc.getTaskCalls)
+	}
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
 }
 
 func TestIsRetryableHelloErrorClassification(t *testing.T) {

--- a/pkg/tasks/c1api/service_client.go
+++ b/pkg/tasks/c1api/service_client.go
@@ -30,6 +30,7 @@ type BatonServiceClient interface {
 	batonHelloClient
 
 	GetTask(ctx context.Context, req *v1.BatonServiceGetTaskRequest) (*v1.BatonServiceGetTaskResponse, error)
+	GetTasks(ctx context.Context, req *v1.BatonServiceGetTasksRequest) (*v1.BatonServiceGetTasksResponse, error)
 	Heartbeat(ctx context.Context, req *v1.BatonServiceHeartbeatRequest) (*v1.BatonServiceHeartbeatResponse, error)
 	FinishTask(ctx context.Context, req *v1.BatonServiceFinishTaskRequest) (*v1.BatonServiceFinishTaskResponse, error)
 	Upload(ctx context.Context, task *v1.Task, r io.ReadSeeker) error
@@ -112,6 +113,22 @@ func (c *c1ServiceClient) GetTask(ctx context.Context, in *v1.BatonServiceGetTas
 	in.SetHostId(c.getHostID())
 
 	resp, err := client.GetTask(ctx, in)
+	return resp, err
+}
+
+func (c *c1ServiceClient) GetTasks(ctx context.Context, in *v1.BatonServiceGetTasksRequest) (*v1.BatonServiceGetTasksResponse, error) {
+	ctx, span := tracer.Start(ctx, "c1ServiceClient.GetTasks")
+	var err error
+	defer func() { uotel.EndSpanWithError(span, err) }()
+	client, done, err := c.getClientConn(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer done()
+
+	in.SetHostId(c.getHostID())
+
+	resp, err := client.GetTasks(ctx, in)
 	return resp, err
 }
 

--- a/pkg/tasks/c1api/task_queue.go
+++ b/pkg/tasks/c1api/task_queue.go
@@ -1,0 +1,155 @@
+package c1api
+
+import (
+	"sync"
+	"time"
+
+	v1 "github.com/conductorone/baton-sdk/pb/c1/connectorapi/baton/v1"
+	"github.com/conductorone/baton-sdk/pkg/tasks"
+	taskTypes "github.com/conductorone/baton-sdk/pkg/types/tasks"
+)
+
+type taskQueue struct {
+	mtx        sync.Mutex
+	queued     []*v1.Task
+	inFlight   map[string]struct{}
+	parallel   int
+	nextPollAt time.Time
+}
+
+type pollAction int
+
+const (
+	pollActionNone pollAction = iota
+	pollActionFetch
+	pollActionWait
+)
+
+type pollDecision struct {
+	action pollAction
+	wait   time.Duration
+}
+
+func newTaskQueue(parallelism int) *taskQueue {
+	return &taskQueue{
+		inFlight: make(map[string]struct{}),
+		parallel: parallelism,
+	}
+}
+
+func (q *taskQueue) take() *v1.Task {
+	q.mtx.Lock()
+	defer q.mtx.Unlock()
+
+	if len(q.queued) == 0 {
+		return nil
+	}
+	task := q.queued[0]
+	q.queued = q.queued[1:]
+	if id := task.GetId(); id != "" {
+		q.inFlight[id] = struct{}{}
+	}
+	return task
+}
+
+func (q *taskQueue) enqueue(batch []*v1.Task) {
+	q.mtx.Lock()
+	defer q.mtx.Unlock()
+
+	for _, task := range batch {
+		if task == nil || tasks.Is(task, taskTypes.NoneType) {
+			continue
+		}
+		id := task.GetId()
+		if id != "" {
+			if _, ok := q.inFlight[id]; ok {
+				continue
+			}
+			if q.isQueuedLocked(id) {
+				continue
+			}
+		}
+		q.queued = append(q.queued, task)
+	}
+}
+
+func (q *taskQueue) markDone(task *v1.Task) {
+	q.mtx.Lock()
+	defer q.mtx.Unlock()
+
+	if id := task.GetId(); id != "" {
+		delete(q.inFlight, id)
+	}
+}
+
+// fetchParams returns the params for the next GetTasks request: the IDs the
+// server should skip (queued + in-flight) and how many additional tasks we
+// want. Computed under a single lock so the two values agree on the same
+// snapshot.
+func (q *taskQueue) fetchParams() ([]string, uint32) {
+	q.mtx.Lock()
+	defer q.mtx.Unlock()
+
+	knownIDs := make([]string, 0, len(q.queued)+len(q.inFlight))
+	for _, task := range q.queued {
+		if id := task.GetId(); id != "" {
+			knownIDs = append(knownIDs, id)
+		}
+	}
+	for id := range q.inFlight {
+		knownIDs = append(knownIDs, id)
+	}
+	target := knownTaskHighWater(q.parallel)
+	known := uint32(len(knownIDs)) //nolint:gosec // bounded by local task queue and small target.
+	// Callers only invoke fetchParams when pollDecision returns pollActionFetch,
+	// which guarantees known < lowWater < target, so target-known never underflows.
+	pageSize := target - known
+	return knownIDs, pageSize
+}
+
+func (q *taskQueue) setNextPoll(nextPoll time.Duration) {
+	q.mtx.Lock()
+	defer q.mtx.Unlock()
+
+	q.nextPollAt = time.Now().Add(nextPoll)
+}
+
+func (q *taskQueue) pollDecision() pollDecision {
+	q.mtx.Lock()
+	defer q.mtx.Unlock()
+
+	needsTopUp := len(q.queued)+len(q.inFlight) < int(knownTaskLowWater(q.parallel))
+	if !needsTopUp {
+		return pollDecision{}
+	}
+	if q.nextPollAt.IsZero() {
+		return pollDecision{action: pollActionFetch}
+	}
+	d := time.Until(q.nextPollAt)
+	if d < 0 {
+		return pollDecision{action: pollActionFetch}
+	}
+	return pollDecision{action: pollActionWait, wait: d}
+}
+
+func (q *taskQueue) isQueuedLocked(id string) bool {
+	for _, task := range q.queued {
+		if task.GetId() == id {
+			return true
+		}
+	}
+	return false
+}
+
+func knownTaskLowWater(parallelism int) uint32 {
+	if parallelism <= 0 {
+		parallelism = 1
+	}
+	return uint32(parallelism)
+}
+
+func knownTaskHighWater(parallelism int) uint32 {
+	// Keep one full concurrency window of headroom without allowing the local
+	// queue to grow unbounded.
+	return knownTaskLowWater(parallelism) * 2
+}

--- a/proto/c1/connectorapi/baton/v1/baton.proto
+++ b/proto/c1/connectorapi/baton/v1/baton.proto
@@ -19,6 +19,7 @@ option go_package = "gitlab.com/ductone/c1/pkg/pb/c1/connectorapi/baton/v1";
 service BatonService {
   rpc Hello(BatonServiceHelloRequest) returns (BatonServiceHelloResponse) {}
   rpc GetTask(BatonServiceGetTaskRequest) returns (BatonServiceGetTaskResponse) {}
+  rpc GetTasks(BatonServiceGetTasksRequest) returns (BatonServiceGetTasksResponse) {}
 
   rpc Heartbeat(BatonServiceHeartbeatRequest) returns (BatonServiceHeartbeatResponse) {}
 
@@ -248,6 +249,27 @@ message BatonServiceGetTaskRequest {
   }];
 }
 
+message BatonServiceGetTasksRequest {
+  string host_id = 1 [(validate.rules).string = {
+    min_len: 1
+    max_len: 256
+  }];
+  uint32 page_size = 2 [(validate.rules).uint32 = {gt: 0, lte: 100}];
+  repeated string known_task_ids = 3 [(validate.rules).repeated = {
+    items: {
+      string: {pattern: "^[a-zA-Z0-9]{27}$"}
+    }
+  }];
+  repeated google.protobuf.Any annotations = 4 [(validate.rules).repeated = {max_items: 16}];
+}
+
+message BatonServiceGetTasksResponse {
+  repeated Task tasks = 1 [(validate.rules).repeated = {max_items: 100}];
+  google.protobuf.Duration next_poll = 2;
+  google.protobuf.Duration next_heartbeat = 3;
+  repeated google.protobuf.Any annotations = 4;
+}
+
 message BatonServiceGetTaskResponse {
   Task task = 1;
   google.protobuf.Duration next_poll = 2;
@@ -262,12 +284,21 @@ message BatonServiceHeartbeatRequest {
   }];
   string task_id = 2 [(validate.rules).string = {pattern: "^[a-zA-Z0-9]{27}$"}];
   repeated google.protobuf.Any annotations = 3 [(validate.rules).repeated = {max_items: 16}]; // Useful for returning status updates on the task
+
+  // New batch heartbeat path.
+  repeated string task_ids = 4 [(validate.rules).repeated = {
+    max_items: 100
+    items: {
+      string: {pattern: "^[a-zA-Z0-9]{27}$"}
+    }
+  }];
 }
 
 message BatonServiceHeartbeatResponse {
   google.protobuf.Duration next_heartbeat = 1;
   bool cancelled = 2; // Backend has decided that we should stop working on this
   repeated google.protobuf.Any annotations = 3;
+  repeated string cancelled_task_ids = 4;
 }
 
 message BatonServiceUploadAssetRequest {


### PR DESCRIPTION
## Summary

This PR adds gated support for batched service-mode task claiming via `GetTasks`.

The new path is disabled by default and only enabled with the hidden env var `BATON_GET_TASKS=true`. When enabled, the C1 task manager keeps a small local queue of claimed tasks, tracks queued/in-flight task IDs, and sends `known_task_ids` on each `GetTasks` call so C1 can avoid returning duplicate work.

The batching policy targets a bounded number of known tasks:

- low-water: `taskConcurrency`
- high-water: `2 * taskConcurrency`
- current default: low-water `3`, high-water `6`

## Key Changes

- Adds `GetTasks` request/response support to the Baton connector API.
- Adds SDK-side `GetTasks` client support.
- Adds `BATON_GET_TASKS` hidden env gate.
- Adds a private `taskQueue` for queued tasks, in-flight task IDs, `known_task_ids`, page sizing, and `next_poll` gating.
- Keeps the legacy `GetTask` path isolated when `BATON_GET_TASKS` is unset.
- Keeps startup `Hello` owned by `Bootstrap`, so `Next` no longer self-queues `Hello`.
- Fixes `finishTask` so task handler errors are reported as task failures instead of successes.
- Adds RFC notes for the broader 20x service-mode throughput model.

## Safety Notes

- The default behavior remains the old `GetTask` path.
- The batch path is opt-in only via `BATON_GET_TASKS`.
- The manager respects `next_poll` for remote C1 polling.
- Local queued tasks can be returned immediately; `next_poll` gates only remote fetches.
- Batch size is bounded by local low/high-water logic.
- `GetTask` compatibility is preserved.

## Test Plan

- `go test ./pkg/tasks/c1api ./pkg/connectorrunner`
- `go test -race ./pkg/tasks/c1api ./pkg/connectorrunner`
- `golangci-lint run ./pkg/tasks/c1api ./pkg/connectorrunner`