### PR TITLE
Adds an optional expiration duration for account provisioning invite flows

### DIFF
--- a/pb/c1/connector/v2/resource.pb.go
+++ b/pb/c1/connector/v2/resource.pb.go
@@ -4078,8 +4078,18 @@ type CreateAccountResponse_SuccessResult struct {
 	state                 protoimpl.MessageState `protogen:"hybrid.v1"`
 	Resource              *Resource              `protobuf:"bytes,1,opt,name=resource,proto3" json:"resource,omitempty"`
 	IsCreateAccountResult bool                   `protobuf:"varint,2,opt,name=is_create_account_result,json=isCreateAccountResult,proto3" json:"is_create_account_result,omitempty"`
-	unknownFields         protoimpl.UnknownFields
-	sizeCache             protoimpl.SizeCache
+	// Optional. When the connector created an invitation-style artifact
+	// (e.g. a GitHub org invite) rather than a fully-provisioned account,
+	// this is the absolute wall-clock time at which that invitation expires
+	// and becomes unusable. c1 surfaces this in the task UI and transitions
+	// the provisioning action to a terminal failure if the user has not
+	// accepted the invitation by this time. Leave unset for connectors whose
+	// CreateAccount truly creates a usable account, or for invitations with
+	// no enforced TTL.
+	// Construct with: timestamppb.New(t).
+	InvitationExpiresAt *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=invitation_expires_at,json=invitationExpiresAt,proto3" json:"invitation_expires_at,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
 }
 
 func (x *CreateAccountResponse_SuccessResult) Reset() {
@@ -4121,12 +4131,23 @@ func (x *CreateAccountResponse_SuccessResult) GetIsCreateAccountResult() bool {
 	return false
 }
 
+func (x *CreateAccountResponse_SuccessResult) GetInvitationExpiresAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.InvitationExpiresAt
+	}
+	return nil
+}
+
 func (x *CreateAccountResponse_SuccessResult) SetResource(v *Resource) {
 	x.Resource = v
 }
 
 func (x *CreateAccountResponse_SuccessResult) SetIsCreateAccountResult(v bool) {
 	x.IsCreateAccountResult = v
+}
+
+func (x *CreateAccountResponse_SuccessResult) SetInvitationExpiresAt(v *timestamppb.Timestamp) {
+	x.InvitationExpiresAt = v
 }
 
 func (x *CreateAccountResponse_SuccessResult) HasResource() bool {
@@ -4136,8 +4157,19 @@ func (x *CreateAccountResponse_SuccessResult) HasResource() bool {
 	return x.Resource != nil
 }
 
+func (x *CreateAccountResponse_SuccessResult) HasInvitationExpiresAt() bool {
+	if x == nil {
+		return false
+	}
+	return x.InvitationExpiresAt != nil
+}
+
 func (x *CreateAccountResponse_SuccessResult) ClearResource() {
 	x.Resource = nil
+}
+
+func (x *CreateAccountResponse_SuccessResult) ClearInvitationExpiresAt() {
+	x.InvitationExpiresAt = nil
 }
 
 type CreateAccountResponse_SuccessResult_builder struct {
@@ -4145,6 +4177,16 @@ type CreateAccountResponse_SuccessResult_builder struct {
 
 	Resource              *Resource
 	IsCreateAccountResult bool
+	// Optional. When the connector created an invitation-style artifact
+	// (e.g. a GitHub org invite) rather than a fully-provisioned account,
+	// this is the absolute wall-clock time at which that invitation expires
+	// and becomes unusable. c1 surfaces this in the task UI and transitions
+	// the provisioning action to a terminal failure if the user has not
+	// accepted the invitation by this time. Leave unset for connectors whose
+	// CreateAccount truly creates a usable account, or for invitations with
+	// no enforced TTL.
+	// Construct with: timestamppb.New(t).
+	InvitationExpiresAt *timestamppb.Timestamp
 }
 
 func (b0 CreateAccountResponse_SuccessResult_builder) Build() *CreateAccountResponse_SuccessResult {
@@ -4153,6 +4195,7 @@ func (b0 CreateAccountResponse_SuccessResult_builder) Build() *CreateAccountResp
 	_, _ = b, x
 	x.Resource = b.Resource
 	x.IsCreateAccountResult = b.IsCreateAccountResult
+	x.InvitationExpiresAt = b.InvitationExpiresAt
 	return m0
 }
 
@@ -4161,15 +4204,8 @@ type CreateAccountResponse_ActionRequiredResult struct {
 	Resource              *Resource              `protobuf:"bytes,1,opt,name=resource,proto3" json:"resource,omitempty"`
 	Message               string                 `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
 	IsCreateAccountResult bool                   `protobuf:"varint,3,opt,name=is_create_account_result,json=isCreateAccountResult,proto3" json:"is_create_account_result,omitempty"`
-	// Optional. Absolute wall-clock time at which the connector-side artifact
-	// (e.g. a GitHub org invite) will expire and become unusable. When set, c1
-	// surfaces this in the task UI and transitions the provisioning action to a
-	// terminal failure if the user has not completed the required action by
-	// expires_at. Leave unset for connectors with no enforced TTL.
-	// Construct with: timestamppb.New(t).
-	ExpiresAt     *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=expires_at,json=expiresAt,proto3" json:"expires_at,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
 }
 
 func (x *CreateAccountResponse_ActionRequiredResult) Reset() {
@@ -4218,13 +4254,6 @@ func (x *CreateAccountResponse_ActionRequiredResult) GetIsCreateAccountResult() 
 	return false
 }
 
-func (x *CreateAccountResponse_ActionRequiredResult) GetExpiresAt() *timestamppb.Timestamp {
-	if x != nil {
-		return x.ExpiresAt
-	}
-	return nil
-}
-
 func (x *CreateAccountResponse_ActionRequiredResult) SetResource(v *Resource) {
 	x.Resource = v
 }
@@ -4237,10 +4266,6 @@ func (x *CreateAccountResponse_ActionRequiredResult) SetIsCreateAccountResult(v 
 	x.IsCreateAccountResult = v
 }
 
-func (x *CreateAccountResponse_ActionRequiredResult) SetExpiresAt(v *timestamppb.Timestamp) {
-	x.ExpiresAt = v
-}
-
 func (x *CreateAccountResponse_ActionRequiredResult) HasResource() bool {
 	if x == nil {
 		return false
@@ -4248,19 +4273,8 @@ func (x *CreateAccountResponse_ActionRequiredResult) HasResource() bool {
 	return x.Resource != nil
 }
 
-func (x *CreateAccountResponse_ActionRequiredResult) HasExpiresAt() bool {
-	if x == nil {
-		return false
-	}
-	return x.ExpiresAt != nil
-}
-
 func (x *CreateAccountResponse_ActionRequiredResult) ClearResource() {
 	x.Resource = nil
-}
-
-func (x *CreateAccountResponse_ActionRequiredResult) ClearExpiresAt() {
-	x.ExpiresAt = nil
 }
 
 type CreateAccountResponse_ActionRequiredResult_builder struct {
@@ -4269,13 +4283,6 @@ type CreateAccountResponse_ActionRequiredResult_builder struct {
 	Resource              *Resource
 	Message               string
 	IsCreateAccountResult bool
-	// Optional. Absolute wall-clock time at which the connector-side artifact
-	// (e.g. a GitHub org invite) will expire and become unusable. When set, c1
-	// surfaces this in the task UI and transitions the provisioning action to a
-	// terminal failure if the user has not completed the required action by
-	// expires_at. Leave unset for connectors with no enforced TTL.
-	// Construct with: timestamppb.New(t).
-	ExpiresAt *timestamppb.Timestamp
 }
 
 func (b0 CreateAccountResponse_ActionRequiredResult_builder) Build() *CreateAccountResponse_ActionRequiredResult {
@@ -4285,7 +4292,6 @@ func (b0 CreateAccountResponse_ActionRequiredResult_builder) Build() *CreateAcco
 	x.Resource = b.Resource
 	x.Message = b.Message
 	x.IsCreateAccountResult = b.IsCreateAccountResult
-	x.ExpiresAt = b.ExpiresAt
 	return m0
 }
 
@@ -4632,7 +4638,7 @@ const file_c1_connector_v2_resource_proto_rawDesc = "" +
 	"\x12credential_options\x18\x02 \x01(\v2\".c1.connector.v2.CredentialOptionsR\x11credentialOptions\x12P\n" +
 	"\x12encryption_configs\x18\x03 \x03(\v2!.c1.connector.v2.EncryptionConfigR\x11encryptionConfigs\x127\n" +
 	"\x10resource_type_id\x18\x04 \x01(\tB\r\xfaB\n" +
-	"r\b \x01(\x80\b\xd0\x01\x01R\x0eresourceTypeId\"\x87\t\n" +
+	"r\b \x01(\x80\b\xd0\x01\x01R\x0eresourceTypeId\"\x9d\t\n" +
 	"\x15CreateAccountResponse\x12P\n" +
 	"\asuccess\x18d \x01(\v24.c1.connector.v2.CreateAccountResponse.SuccessResultH\x00R\asuccess\x12f\n" +
 	"\x0faction_required\x18e \x01(\v2;.c1.connector.v2.CreateAccountResponse.ActionRequiredResultH\x00R\x0eactionRequired\x12c\n" +
@@ -4640,16 +4646,15 @@ const file_c1_connector_v2_resource_proto_rawDesc = "" +
 	"\vin_progress\x18g \x01(\v27.c1.connector.v2.CreateAccountResponse.InProgressResultH\x00R\n" +
 	"inProgress\x12E\n" +
 	"\x0eencrypted_data\x18\x02 \x03(\v2\x1e.c1.connector.v2.EncryptedDataR\rencryptedData\x126\n" +
-	"\vannotations\x18\x03 \x03(\v2\x14.google.protobuf.AnyR\vannotations\x1a\x7f\n" +
+	"\vannotations\x18\x03 \x03(\v2\x14.google.protobuf.AnyR\vannotations\x1a\xcf\x01\n" +
 	"\rSuccessResult\x125\n" +
 	"\bresource\x18\x01 \x01(\v2\x19.c1.connector.v2.ResourceR\bresource\x127\n" +
-	"\x18is_create_account_result\x18\x02 \x01(\bR\x15isCreateAccountResult\x1a\xdb\x01\n" +
+	"\x18is_create_account_result\x18\x02 \x01(\bR\x15isCreateAccountResult\x12N\n" +
+	"\x15invitation_expires_at\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\x13invitationExpiresAt\x1a\xa0\x01\n" +
 	"\x14ActionRequiredResult\x125\n" +
 	"\bresource\x18\x01 \x01(\v2\x19.c1.connector.v2.ResourceR\bresource\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\x127\n" +
-	"\x18is_create_account_result\x18\x03 \x01(\bR\x15isCreateAccountResult\x129\n" +
-	"\n" +
-	"expires_at\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\texpiresAt\x1a\x85\x01\n" +
+	"\x18is_create_account_result\x18\x03 \x01(\bR\x15isCreateAccountResult\x1a\x85\x01\n" +
 	"\x13AlreadyExistsResult\x125\n" +
 	"\bresource\x18\x01 \x01(\v2\x19.c1.connector.v2.ResourceR\bresource\x127\n" +
 	"\x18is_create_account_result\x18\x02 \x01(\bR\x15isCreateAccountResult\x1a\x82\x01\n" +
@@ -4858,8 +4863,8 @@ var file_c1_connector_v2_resource_proto_depIdxs = []int32{
 	19, // 57: c1.connector.v2.CredentialOptions.EncryptedPassword.encrypted_passwords:type_name -> c1.connector.v2.EncryptedData
 	16, // 58: c1.connector.v2.LocalCredentialOptions.RandomPassword.constraints:type_name -> c1.connector.v2.PasswordConstraint
 	23, // 59: c1.connector.v2.CreateAccountResponse.SuccessResult.resource:type_name -> c1.connector.v2.Resource
-	23, // 60: c1.connector.v2.CreateAccountResponse.ActionRequiredResult.resource:type_name -> c1.connector.v2.Resource
-	45, // 61: c1.connector.v2.CreateAccountResponse.ActionRequiredResult.expires_at:type_name -> google.protobuf.Timestamp
+	45, // 60: c1.connector.v2.CreateAccountResponse.SuccessResult.invitation_expires_at:type_name -> google.protobuf.Timestamp
+	23, // 61: c1.connector.v2.CreateAccountResponse.ActionRequiredResult.resource:type_name -> c1.connector.v2.Resource
 	23, // 62: c1.connector.v2.CreateAccountResponse.AlreadyExistsResult.resource:type_name -> c1.connector.v2.Resource
 	23, // 63: c1.connector.v2.CreateAccountResponse.InProgressResult.resource:type_name -> c1.connector.v2.Resource
 	3,  // 64: c1.connector.v2.ResourceTypesService.ListResourceTypes:input_type -> c1.connector.v2.ResourceTypesServiceListResourceTypesRequest

--- a/pb/c1/connector/v2/resource.pb.go
+++ b/pb/c1/connector/v2/resource.pb.go
@@ -14,6 +14,7 @@ import (
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	anypb "google.golang.org/protobuf/types/known/anypb"
 	structpb "google.golang.org/protobuf/types/known/structpb"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	unsafe "unsafe"
 )
@@ -4160,8 +4161,15 @@ type CreateAccountResponse_ActionRequiredResult struct {
 	Resource              *Resource              `protobuf:"bytes,1,opt,name=resource,proto3" json:"resource,omitempty"`
 	Message               string                 `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
 	IsCreateAccountResult bool                   `protobuf:"varint,3,opt,name=is_create_account_result,json=isCreateAccountResult,proto3" json:"is_create_account_result,omitempty"`
-	unknownFields         protoimpl.UnknownFields
-	sizeCache             protoimpl.SizeCache
+	// Optional. Absolute wall-clock time at which the connector-side artifact
+	// (e.g. a GitHub org invite) will expire and become unusable. When set, c1
+	// surfaces this in the task UI and transitions the provisioning action to a
+	// terminal failure if the user has not completed the required action by
+	// expires_at. Leave unset for connectors with no enforced TTL.
+	// Construct with: timestamppb.New(t).
+	ExpiresAt     *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=expires_at,json=expiresAt,proto3" json:"expires_at,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *CreateAccountResponse_ActionRequiredResult) Reset() {
@@ -4210,6 +4218,13 @@ func (x *CreateAccountResponse_ActionRequiredResult) GetIsCreateAccountResult() 
 	return false
 }
 
+func (x *CreateAccountResponse_ActionRequiredResult) GetExpiresAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.ExpiresAt
+	}
+	return nil
+}
+
 func (x *CreateAccountResponse_ActionRequiredResult) SetResource(v *Resource) {
 	x.Resource = v
 }
@@ -4222,6 +4237,10 @@ func (x *CreateAccountResponse_ActionRequiredResult) SetIsCreateAccountResult(v 
 	x.IsCreateAccountResult = v
 }
 
+func (x *CreateAccountResponse_ActionRequiredResult) SetExpiresAt(v *timestamppb.Timestamp) {
+	x.ExpiresAt = v
+}
+
 func (x *CreateAccountResponse_ActionRequiredResult) HasResource() bool {
 	if x == nil {
 		return false
@@ -4229,8 +4248,19 @@ func (x *CreateAccountResponse_ActionRequiredResult) HasResource() bool {
 	return x.Resource != nil
 }
 
+func (x *CreateAccountResponse_ActionRequiredResult) HasExpiresAt() bool {
+	if x == nil {
+		return false
+	}
+	return x.ExpiresAt != nil
+}
+
 func (x *CreateAccountResponse_ActionRequiredResult) ClearResource() {
 	x.Resource = nil
+}
+
+func (x *CreateAccountResponse_ActionRequiredResult) ClearExpiresAt() {
+	x.ExpiresAt = nil
 }
 
 type CreateAccountResponse_ActionRequiredResult_builder struct {
@@ -4239,6 +4269,13 @@ type CreateAccountResponse_ActionRequiredResult_builder struct {
 	Resource              *Resource
 	Message               string
 	IsCreateAccountResult bool
+	// Optional. Absolute wall-clock time at which the connector-side artifact
+	// (e.g. a GitHub org invite) will expire and become unusable. When set, c1
+	// surfaces this in the task UI and transitions the provisioning action to a
+	// terminal failure if the user has not completed the required action by
+	// expires_at. Leave unset for connectors with no enforced TTL.
+	// Construct with: timestamppb.New(t).
+	ExpiresAt *timestamppb.Timestamp
 }
 
 func (b0 CreateAccountResponse_ActionRequiredResult_builder) Build() *CreateAccountResponse_ActionRequiredResult {
@@ -4248,6 +4285,7 @@ func (b0 CreateAccountResponse_ActionRequiredResult_builder) Build() *CreateAcco
 	x.Resource = b.Resource
 	x.Message = b.Message
 	x.IsCreateAccountResult = b.IsCreateAccountResult
+	x.ExpiresAt = b.ExpiresAt
 	return m0
 }
 
@@ -4479,7 +4517,7 @@ var File_c1_connector_v2_resource_proto protoreflect.FileDescriptor
 
 const file_c1_connector_v2_resource_proto_rawDesc = "" +
 	"\n" +
-	"\x1ec1/connector/v2/resource.proto\x12\x0fc1.connector.v2\x1a\x19google/protobuf/any.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x17validate/validate.proto\"\x98\x04\n" +
+	"\x1ec1/connector/v2/resource.proto\x12\x0fc1.connector.v2\x1a\x19google/protobuf/any.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x17validate/validate.proto\"\x98\x04\n" +
 	"\fResourceType\x12\x1a\n" +
 	"\x02id\x18\x01 \x01(\tB\n" +
 	"\xfaB\ar\x05 \x01(\x80\bR\x02id\x120\n" +
@@ -4594,7 +4632,7 @@ const file_c1_connector_v2_resource_proto_rawDesc = "" +
 	"\x12credential_options\x18\x02 \x01(\v2\".c1.connector.v2.CredentialOptionsR\x11credentialOptions\x12P\n" +
 	"\x12encryption_configs\x18\x03 \x03(\v2!.c1.connector.v2.EncryptionConfigR\x11encryptionConfigs\x127\n" +
 	"\x10resource_type_id\x18\x04 \x01(\tB\r\xfaB\n" +
-	"r\b \x01(\x80\b\xd0\x01\x01R\x0eresourceTypeId\"\xcc\b\n" +
+	"r\b \x01(\x80\b\xd0\x01\x01R\x0eresourceTypeId\"\x87\t\n" +
 	"\x15CreateAccountResponse\x12P\n" +
 	"\asuccess\x18d \x01(\v24.c1.connector.v2.CreateAccountResponse.SuccessResultH\x00R\asuccess\x12f\n" +
 	"\x0faction_required\x18e \x01(\v2;.c1.connector.v2.CreateAccountResponse.ActionRequiredResultH\x00R\x0eactionRequired\x12c\n" +
@@ -4605,11 +4643,13 @@ const file_c1_connector_v2_resource_proto_rawDesc = "" +
 	"\vannotations\x18\x03 \x03(\v2\x14.google.protobuf.AnyR\vannotations\x1a\x7f\n" +
 	"\rSuccessResult\x125\n" +
 	"\bresource\x18\x01 \x01(\v2\x19.c1.connector.v2.ResourceR\bresource\x127\n" +
-	"\x18is_create_account_result\x18\x02 \x01(\bR\x15isCreateAccountResult\x1a\xa0\x01\n" +
+	"\x18is_create_account_result\x18\x02 \x01(\bR\x15isCreateAccountResult\x1a\xdb\x01\n" +
 	"\x14ActionRequiredResult\x125\n" +
 	"\bresource\x18\x01 \x01(\v2\x19.c1.connector.v2.ResourceR\bresource\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\x127\n" +
-	"\x18is_create_account_result\x18\x03 \x01(\bR\x15isCreateAccountResult\x1a\x85\x01\n" +
+	"\x18is_create_account_result\x18\x03 \x01(\bR\x15isCreateAccountResult\x129\n" +
+	"\n" +
+	"expires_at\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\texpiresAt\x1a\x85\x01\n" +
 	"\x13AlreadyExistsResult\x125\n" +
 	"\bresource\x18\x01 \x01(\v2\x19.c1.connector.v2.ResourceR\bresource\x127\n" +
 	"\x18is_create_account_result\x18\x02 \x01(\bR\x15isCreateAccountResult\x1a\x82\x01\n" +
@@ -4755,6 +4795,7 @@ var file_c1_connector_v2_resource_proto_goTypes = []any{
 	(*EncryptionConfig_JWKPublicKeyConfig)(nil),           // 42: c1.connector.v2.EncryptionConfig.JWKPublicKeyConfig
 	(*anypb.Any)(nil),                                     // 43: google.protobuf.Any
 	(*structpb.Struct)(nil),                               // 44: google.protobuf.Struct
+	(*timestamppb.Timestamp)(nil),                         // 45: google.protobuf.Timestamp
 }
 var file_c1_connector_v2_resource_proto_depIdxs = []int32{
 	0,  // 0: c1.connector.v2.ResourceType.traits:type_name -> c1.connector.v2.ResourceType.Trait
@@ -4818,29 +4859,30 @@ var file_c1_connector_v2_resource_proto_depIdxs = []int32{
 	16, // 58: c1.connector.v2.LocalCredentialOptions.RandomPassword.constraints:type_name -> c1.connector.v2.PasswordConstraint
 	23, // 59: c1.connector.v2.CreateAccountResponse.SuccessResult.resource:type_name -> c1.connector.v2.Resource
 	23, // 60: c1.connector.v2.CreateAccountResponse.ActionRequiredResult.resource:type_name -> c1.connector.v2.Resource
-	23, // 61: c1.connector.v2.CreateAccountResponse.AlreadyExistsResult.resource:type_name -> c1.connector.v2.Resource
-	23, // 62: c1.connector.v2.CreateAccountResponse.InProgressResult.resource:type_name -> c1.connector.v2.Resource
-	3,  // 63: c1.connector.v2.ResourceTypesService.ListResourceTypes:input_type -> c1.connector.v2.ResourceTypesServiceListResourceTypesRequest
-	24, // 64: c1.connector.v2.ResourcesService.ListResources:input_type -> c1.connector.v2.ResourcesServiceListResourcesRequest
-	26, // 65: c1.connector.v2.ResourceGetterService.GetResource:input_type -> c1.connector.v2.ResourceGetterServiceGetResourceRequest
-	5,  // 66: c1.connector.v2.ResourceManagerService.CreateResource:input_type -> c1.connector.v2.CreateResourceRequest
-	7,  // 67: c1.connector.v2.ResourceManagerService.DeleteResource:input_type -> c1.connector.v2.DeleteResourceRequest
-	9,  // 68: c1.connector.v2.ResourceDeleterService.DeleteResourceV2:input_type -> c1.connector.v2.DeleteResourceV2Request
-	11, // 69: c1.connector.v2.CredentialManagerService.RotateCredential:input_type -> c1.connector.v2.RotateCredentialRequest
-	17, // 70: c1.connector.v2.AccountManagerService.CreateAccount:input_type -> c1.connector.v2.CreateAccountRequest
-	4,  // 71: c1.connector.v2.ResourceTypesService.ListResourceTypes:output_type -> c1.connector.v2.ResourceTypesServiceListResourceTypesResponse
-	25, // 72: c1.connector.v2.ResourcesService.ListResources:output_type -> c1.connector.v2.ResourcesServiceListResourcesResponse
-	27, // 73: c1.connector.v2.ResourceGetterService.GetResource:output_type -> c1.connector.v2.ResourceGetterServiceGetResourceResponse
-	6,  // 74: c1.connector.v2.ResourceManagerService.CreateResource:output_type -> c1.connector.v2.CreateResourceResponse
-	8,  // 75: c1.connector.v2.ResourceManagerService.DeleteResource:output_type -> c1.connector.v2.DeleteResourceResponse
-	10, // 76: c1.connector.v2.ResourceDeleterService.DeleteResourceV2:output_type -> c1.connector.v2.DeleteResourceV2Response
-	12, // 77: c1.connector.v2.CredentialManagerService.RotateCredential:output_type -> c1.connector.v2.RotateCredentialResponse
-	18, // 78: c1.connector.v2.AccountManagerService.CreateAccount:output_type -> c1.connector.v2.CreateAccountResponse
-	71, // [71:79] is the sub-list for method output_type
-	63, // [63:71] is the sub-list for method input_type
-	63, // [63:63] is the sub-list for extension type_name
-	63, // [63:63] is the sub-list for extension extendee
-	0,  // [0:63] is the sub-list for field type_name
+	45, // 61: c1.connector.v2.CreateAccountResponse.ActionRequiredResult.expires_at:type_name -> google.protobuf.Timestamp
+	23, // 62: c1.connector.v2.CreateAccountResponse.AlreadyExistsResult.resource:type_name -> c1.connector.v2.Resource
+	23, // 63: c1.connector.v2.CreateAccountResponse.InProgressResult.resource:type_name -> c1.connector.v2.Resource
+	3,  // 64: c1.connector.v2.ResourceTypesService.ListResourceTypes:input_type -> c1.connector.v2.ResourceTypesServiceListResourceTypesRequest
+	24, // 65: c1.connector.v2.ResourcesService.ListResources:input_type -> c1.connector.v2.ResourcesServiceListResourcesRequest
+	26, // 66: c1.connector.v2.ResourceGetterService.GetResource:input_type -> c1.connector.v2.ResourceGetterServiceGetResourceRequest
+	5,  // 67: c1.connector.v2.ResourceManagerService.CreateResource:input_type -> c1.connector.v2.CreateResourceRequest
+	7,  // 68: c1.connector.v2.ResourceManagerService.DeleteResource:input_type -> c1.connector.v2.DeleteResourceRequest
+	9,  // 69: c1.connector.v2.ResourceDeleterService.DeleteResourceV2:input_type -> c1.connector.v2.DeleteResourceV2Request
+	11, // 70: c1.connector.v2.CredentialManagerService.RotateCredential:input_type -> c1.connector.v2.RotateCredentialRequest
+	17, // 71: c1.connector.v2.AccountManagerService.CreateAccount:input_type -> c1.connector.v2.CreateAccountRequest
+	4,  // 72: c1.connector.v2.ResourceTypesService.ListResourceTypes:output_type -> c1.connector.v2.ResourceTypesServiceListResourceTypesResponse
+	25, // 73: c1.connector.v2.ResourcesService.ListResources:output_type -> c1.connector.v2.ResourcesServiceListResourcesResponse
+	27, // 74: c1.connector.v2.ResourceGetterService.GetResource:output_type -> c1.connector.v2.ResourceGetterServiceGetResourceResponse
+	6,  // 75: c1.connector.v2.ResourceManagerService.CreateResource:output_type -> c1.connector.v2.CreateResourceResponse
+	8,  // 76: c1.connector.v2.ResourceManagerService.DeleteResource:output_type -> c1.connector.v2.DeleteResourceResponse
+	10, // 77: c1.connector.v2.ResourceDeleterService.DeleteResourceV2:output_type -> c1.connector.v2.DeleteResourceV2Response
+	12, // 78: c1.connector.v2.CredentialManagerService.RotateCredential:output_type -> c1.connector.v2.RotateCredentialResponse
+	18, // 79: c1.connector.v2.AccountManagerService.CreateAccount:output_type -> c1.connector.v2.CreateAccountResponse
+	72, // [72:80] is the sub-list for method output_type
+	64, // [64:72] is the sub-list for method input_type
+	64, // [64:64] is the sub-list for extension type_name
+	64, // [64:64] is the sub-list for extension extendee
+	0,  // [0:64] is the sub-list for field type_name
 }
 
 func init() { file_c1_connector_v2_resource_proto_init() }

--- a/pb/c1/connector/v2/resource.pb.validate.go
+++ b/pb/c1/connector/v2/resource.pb.validate.go
@@ -6302,6 +6302,35 @@ func (m *CreateAccountResponse_ActionRequiredResult) validate(all bool) error {
 
 	// no validation rules for IsCreateAccountResult
 
+	if all {
+		switch v := interface{}(m.GetExpiresAt()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, CreateAccountResponse_ActionRequiredResultValidationError{
+					field:  "ExpiresAt",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, CreateAccountResponse_ActionRequiredResultValidationError{
+					field:  "ExpiresAt",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetExpiresAt()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return CreateAccountResponse_ActionRequiredResultValidationError{
+				field:  "ExpiresAt",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if len(errors) > 0 {
 		return CreateAccountResponse_ActionRequiredResultMultiError(errors)
 	}

--- a/pb/c1/connector/v2/resource.pb.validate.go
+++ b/pb/c1/connector/v2/resource.pb.validate.go
@@ -6163,6 +6163,35 @@ func (m *CreateAccountResponse_SuccessResult) validate(all bool) error {
 
 	// no validation rules for IsCreateAccountResult
 
+	if all {
+		switch v := interface{}(m.GetInvitationExpiresAt()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, CreateAccountResponse_SuccessResultValidationError{
+					field:  "InvitationExpiresAt",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, CreateAccountResponse_SuccessResultValidationError{
+					field:  "InvitationExpiresAt",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetInvitationExpiresAt()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return CreateAccountResponse_SuccessResultValidationError{
+				field:  "InvitationExpiresAt",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if len(errors) > 0 {
 		return CreateAccountResponse_SuccessResultMultiError(errors)
 	}
@@ -6301,35 +6330,6 @@ func (m *CreateAccountResponse_ActionRequiredResult) validate(all bool) error {
 	// no validation rules for Message
 
 	// no validation rules for IsCreateAccountResult
-
-	if all {
-		switch v := interface{}(m.GetExpiresAt()).(type) {
-		case interface{ ValidateAll() error }:
-			if err := v.ValidateAll(); err != nil {
-				errors = append(errors, CreateAccountResponse_ActionRequiredResultValidationError{
-					field:  "ExpiresAt",
-					reason: "embedded message failed validation",
-					cause:  err,
-				})
-			}
-		case interface{ Validate() error }:
-			if err := v.Validate(); err != nil {
-				errors = append(errors, CreateAccountResponse_ActionRequiredResultValidationError{
-					field:  "ExpiresAt",
-					reason: "embedded message failed validation",
-					cause:  err,
-				})
-			}
-		}
-	} else if v, ok := interface{}(m.GetExpiresAt()).(interface{ Validate() error }); ok {
-		if err := v.Validate(); err != nil {
-			return CreateAccountResponse_ActionRequiredResultValidationError{
-				field:  "ExpiresAt",
-				reason: "embedded message failed validation",
-				cause:  err,
-			}
-		}
-	}
 
 	if len(errors) > 0 {
 		return CreateAccountResponse_ActionRequiredResultMultiError(errors)

--- a/pb/c1/connector/v2/resource_protoopaque.pb.go
+++ b/pb/c1/connector/v2/resource_protoopaque.pb.go
@@ -14,6 +14,7 @@ import (
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	anypb "google.golang.org/protobuf/types/known/anypb"
 	structpb "google.golang.org/protobuf/types/known/structpb"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	unsafe "unsafe"
 )
@@ -4147,6 +4148,7 @@ type CreateAccountResponse_ActionRequiredResult struct {
 	xxx_hidden_Resource              *Resource              `protobuf:"bytes,1,opt,name=resource,proto3"`
 	xxx_hidden_Message               string                 `protobuf:"bytes,2,opt,name=message,proto3"`
 	xxx_hidden_IsCreateAccountResult bool                   `protobuf:"varint,3,opt,name=is_create_account_result,json=isCreateAccountResult,proto3"`
+	xxx_hidden_ExpiresAt             *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=expires_at,json=expiresAt,proto3"`
 	unknownFields                    protoimpl.UnknownFields
 	sizeCache                        protoimpl.SizeCache
 }
@@ -4197,6 +4199,13 @@ func (x *CreateAccountResponse_ActionRequiredResult) GetIsCreateAccountResult() 
 	return false
 }
 
+func (x *CreateAccountResponse_ActionRequiredResult) GetExpiresAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.xxx_hidden_ExpiresAt
+	}
+	return nil
+}
+
 func (x *CreateAccountResponse_ActionRequiredResult) SetResource(v *Resource) {
 	x.xxx_hidden_Resource = v
 }
@@ -4209,6 +4218,10 @@ func (x *CreateAccountResponse_ActionRequiredResult) SetIsCreateAccountResult(v 
 	x.xxx_hidden_IsCreateAccountResult = v
 }
 
+func (x *CreateAccountResponse_ActionRequiredResult) SetExpiresAt(v *timestamppb.Timestamp) {
+	x.xxx_hidden_ExpiresAt = v
+}
+
 func (x *CreateAccountResponse_ActionRequiredResult) HasResource() bool {
 	if x == nil {
 		return false
@@ -4216,8 +4229,19 @@ func (x *CreateAccountResponse_ActionRequiredResult) HasResource() bool {
 	return x.xxx_hidden_Resource != nil
 }
 
+func (x *CreateAccountResponse_ActionRequiredResult) HasExpiresAt() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_ExpiresAt != nil
+}
+
 func (x *CreateAccountResponse_ActionRequiredResult) ClearResource() {
 	x.xxx_hidden_Resource = nil
+}
+
+func (x *CreateAccountResponse_ActionRequiredResult) ClearExpiresAt() {
+	x.xxx_hidden_ExpiresAt = nil
 }
 
 type CreateAccountResponse_ActionRequiredResult_builder struct {
@@ -4226,6 +4250,13 @@ type CreateAccountResponse_ActionRequiredResult_builder struct {
 	Resource              *Resource
 	Message               string
 	IsCreateAccountResult bool
+	// Optional. Absolute wall-clock time at which the connector-side artifact
+	// (e.g. a GitHub org invite) will expire and become unusable. When set, c1
+	// surfaces this in the task UI and transitions the provisioning action to a
+	// terminal failure if the user has not completed the required action by
+	// expires_at. Leave unset for connectors with no enforced TTL.
+	// Construct with: timestamppb.New(t).
+	ExpiresAt *timestamppb.Timestamp
 }
 
 func (b0 CreateAccountResponse_ActionRequiredResult_builder) Build() *CreateAccountResponse_ActionRequiredResult {
@@ -4235,6 +4266,7 @@ func (b0 CreateAccountResponse_ActionRequiredResult_builder) Build() *CreateAcco
 	x.xxx_hidden_Resource = b.Resource
 	x.xxx_hidden_Message = b.Message
 	x.xxx_hidden_IsCreateAccountResult = b.IsCreateAccountResult
+	x.xxx_hidden_ExpiresAt = b.ExpiresAt
 	return m0
 }
 
@@ -4466,7 +4498,7 @@ var File_c1_connector_v2_resource_proto protoreflect.FileDescriptor
 
 const file_c1_connector_v2_resource_proto_rawDesc = "" +
 	"\n" +
-	"\x1ec1/connector/v2/resource.proto\x12\x0fc1.connector.v2\x1a\x19google/protobuf/any.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x17validate/validate.proto\"\x98\x04\n" +
+	"\x1ec1/connector/v2/resource.proto\x12\x0fc1.connector.v2\x1a\x19google/protobuf/any.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x17validate/validate.proto\"\x98\x04\n" +
 	"\fResourceType\x12\x1a\n" +
 	"\x02id\x18\x01 \x01(\tB\n" +
 	"\xfaB\ar\x05 \x01(\x80\bR\x02id\x120\n" +
@@ -4581,7 +4613,7 @@ const file_c1_connector_v2_resource_proto_rawDesc = "" +
 	"\x12credential_options\x18\x02 \x01(\v2\".c1.connector.v2.CredentialOptionsR\x11credentialOptions\x12P\n" +
 	"\x12encryption_configs\x18\x03 \x03(\v2!.c1.connector.v2.EncryptionConfigR\x11encryptionConfigs\x127\n" +
 	"\x10resource_type_id\x18\x04 \x01(\tB\r\xfaB\n" +
-	"r\b \x01(\x80\b\xd0\x01\x01R\x0eresourceTypeId\"\xcc\b\n" +
+	"r\b \x01(\x80\b\xd0\x01\x01R\x0eresourceTypeId\"\x87\t\n" +
 	"\x15CreateAccountResponse\x12P\n" +
 	"\asuccess\x18d \x01(\v24.c1.connector.v2.CreateAccountResponse.SuccessResultH\x00R\asuccess\x12f\n" +
 	"\x0faction_required\x18e \x01(\v2;.c1.connector.v2.CreateAccountResponse.ActionRequiredResultH\x00R\x0eactionRequired\x12c\n" +
@@ -4592,11 +4624,13 @@ const file_c1_connector_v2_resource_proto_rawDesc = "" +
 	"\vannotations\x18\x03 \x03(\v2\x14.google.protobuf.AnyR\vannotations\x1a\x7f\n" +
 	"\rSuccessResult\x125\n" +
 	"\bresource\x18\x01 \x01(\v2\x19.c1.connector.v2.ResourceR\bresource\x127\n" +
-	"\x18is_create_account_result\x18\x02 \x01(\bR\x15isCreateAccountResult\x1a\xa0\x01\n" +
+	"\x18is_create_account_result\x18\x02 \x01(\bR\x15isCreateAccountResult\x1a\xdb\x01\n" +
 	"\x14ActionRequiredResult\x125\n" +
 	"\bresource\x18\x01 \x01(\v2\x19.c1.connector.v2.ResourceR\bresource\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\x127\n" +
-	"\x18is_create_account_result\x18\x03 \x01(\bR\x15isCreateAccountResult\x1a\x85\x01\n" +
+	"\x18is_create_account_result\x18\x03 \x01(\bR\x15isCreateAccountResult\x129\n" +
+	"\n" +
+	"expires_at\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\texpiresAt\x1a\x85\x01\n" +
 	"\x13AlreadyExistsResult\x125\n" +
 	"\bresource\x18\x01 \x01(\v2\x19.c1.connector.v2.ResourceR\bresource\x127\n" +
 	"\x18is_create_account_result\x18\x02 \x01(\bR\x15isCreateAccountResult\x1a\x82\x01\n" +
@@ -4742,6 +4776,7 @@ var file_c1_connector_v2_resource_proto_goTypes = []any{
 	(*EncryptionConfig_JWKPublicKeyConfig)(nil),           // 42: c1.connector.v2.EncryptionConfig.JWKPublicKeyConfig
 	(*anypb.Any)(nil),                                     // 43: google.protobuf.Any
 	(*structpb.Struct)(nil),                               // 44: google.protobuf.Struct
+	(*timestamppb.Timestamp)(nil),                         // 45: google.protobuf.Timestamp
 }
 var file_c1_connector_v2_resource_proto_depIdxs = []int32{
 	0,  // 0: c1.connector.v2.ResourceType.traits:type_name -> c1.connector.v2.ResourceType.Trait
@@ -4805,29 +4840,30 @@ var file_c1_connector_v2_resource_proto_depIdxs = []int32{
 	16, // 58: c1.connector.v2.LocalCredentialOptions.RandomPassword.constraints:type_name -> c1.connector.v2.PasswordConstraint
 	23, // 59: c1.connector.v2.CreateAccountResponse.SuccessResult.resource:type_name -> c1.connector.v2.Resource
 	23, // 60: c1.connector.v2.CreateAccountResponse.ActionRequiredResult.resource:type_name -> c1.connector.v2.Resource
-	23, // 61: c1.connector.v2.CreateAccountResponse.AlreadyExistsResult.resource:type_name -> c1.connector.v2.Resource
-	23, // 62: c1.connector.v2.CreateAccountResponse.InProgressResult.resource:type_name -> c1.connector.v2.Resource
-	3,  // 63: c1.connector.v2.ResourceTypesService.ListResourceTypes:input_type -> c1.connector.v2.ResourceTypesServiceListResourceTypesRequest
-	24, // 64: c1.connector.v2.ResourcesService.ListResources:input_type -> c1.connector.v2.ResourcesServiceListResourcesRequest
-	26, // 65: c1.connector.v2.ResourceGetterService.GetResource:input_type -> c1.connector.v2.ResourceGetterServiceGetResourceRequest
-	5,  // 66: c1.connector.v2.ResourceManagerService.CreateResource:input_type -> c1.connector.v2.CreateResourceRequest
-	7,  // 67: c1.connector.v2.ResourceManagerService.DeleteResource:input_type -> c1.connector.v2.DeleteResourceRequest
-	9,  // 68: c1.connector.v2.ResourceDeleterService.DeleteResourceV2:input_type -> c1.connector.v2.DeleteResourceV2Request
-	11, // 69: c1.connector.v2.CredentialManagerService.RotateCredential:input_type -> c1.connector.v2.RotateCredentialRequest
-	17, // 70: c1.connector.v2.AccountManagerService.CreateAccount:input_type -> c1.connector.v2.CreateAccountRequest
-	4,  // 71: c1.connector.v2.ResourceTypesService.ListResourceTypes:output_type -> c1.connector.v2.ResourceTypesServiceListResourceTypesResponse
-	25, // 72: c1.connector.v2.ResourcesService.ListResources:output_type -> c1.connector.v2.ResourcesServiceListResourcesResponse
-	27, // 73: c1.connector.v2.ResourceGetterService.GetResource:output_type -> c1.connector.v2.ResourceGetterServiceGetResourceResponse
-	6,  // 74: c1.connector.v2.ResourceManagerService.CreateResource:output_type -> c1.connector.v2.CreateResourceResponse
-	8,  // 75: c1.connector.v2.ResourceManagerService.DeleteResource:output_type -> c1.connector.v2.DeleteResourceResponse
-	10, // 76: c1.connector.v2.ResourceDeleterService.DeleteResourceV2:output_type -> c1.connector.v2.DeleteResourceV2Response
-	12, // 77: c1.connector.v2.CredentialManagerService.RotateCredential:output_type -> c1.connector.v2.RotateCredentialResponse
-	18, // 78: c1.connector.v2.AccountManagerService.CreateAccount:output_type -> c1.connector.v2.CreateAccountResponse
-	71, // [71:79] is the sub-list for method output_type
-	63, // [63:71] is the sub-list for method input_type
-	63, // [63:63] is the sub-list for extension type_name
-	63, // [63:63] is the sub-list for extension extendee
-	0,  // [0:63] is the sub-list for field type_name
+	45, // 61: c1.connector.v2.CreateAccountResponse.ActionRequiredResult.expires_at:type_name -> google.protobuf.Timestamp
+	23, // 62: c1.connector.v2.CreateAccountResponse.AlreadyExistsResult.resource:type_name -> c1.connector.v2.Resource
+	23, // 63: c1.connector.v2.CreateAccountResponse.InProgressResult.resource:type_name -> c1.connector.v2.Resource
+	3,  // 64: c1.connector.v2.ResourceTypesService.ListResourceTypes:input_type -> c1.connector.v2.ResourceTypesServiceListResourceTypesRequest
+	24, // 65: c1.connector.v2.ResourcesService.ListResources:input_type -> c1.connector.v2.ResourcesServiceListResourcesRequest
+	26, // 66: c1.connector.v2.ResourceGetterService.GetResource:input_type -> c1.connector.v2.ResourceGetterServiceGetResourceRequest
+	5,  // 67: c1.connector.v2.ResourceManagerService.CreateResource:input_type -> c1.connector.v2.CreateResourceRequest
+	7,  // 68: c1.connector.v2.ResourceManagerService.DeleteResource:input_type -> c1.connector.v2.DeleteResourceRequest
+	9,  // 69: c1.connector.v2.ResourceDeleterService.DeleteResourceV2:input_type -> c1.connector.v2.DeleteResourceV2Request
+	11, // 70: c1.connector.v2.CredentialManagerService.RotateCredential:input_type -> c1.connector.v2.RotateCredentialRequest
+	17, // 71: c1.connector.v2.AccountManagerService.CreateAccount:input_type -> c1.connector.v2.CreateAccountRequest
+	4,  // 72: c1.connector.v2.ResourceTypesService.ListResourceTypes:output_type -> c1.connector.v2.ResourceTypesServiceListResourceTypesResponse
+	25, // 73: c1.connector.v2.ResourcesService.ListResources:output_type -> c1.connector.v2.ResourcesServiceListResourcesResponse
+	27, // 74: c1.connector.v2.ResourceGetterService.GetResource:output_type -> c1.connector.v2.ResourceGetterServiceGetResourceResponse
+	6,  // 75: c1.connector.v2.ResourceManagerService.CreateResource:output_type -> c1.connector.v2.CreateResourceResponse
+	8,  // 76: c1.connector.v2.ResourceManagerService.DeleteResource:output_type -> c1.connector.v2.DeleteResourceResponse
+	10, // 77: c1.connector.v2.ResourceDeleterService.DeleteResourceV2:output_type -> c1.connector.v2.DeleteResourceV2Response
+	12, // 78: c1.connector.v2.CredentialManagerService.RotateCredential:output_type -> c1.connector.v2.RotateCredentialResponse
+	18, // 79: c1.connector.v2.AccountManagerService.CreateAccount:output_type -> c1.connector.v2.CreateAccountResponse
+	72, // [72:80] is the sub-list for method output_type
+	64, // [64:72] is the sub-list for method input_type
+	64, // [64:64] is the sub-list for extension type_name
+	64, // [64:64] is the sub-list for extension extendee
+	0,  // [0:64] is the sub-list for field type_name
 }
 
 func init() { file_c1_connector_v2_resource_proto_init() }

--- a/pb/c1/connector/v2/resource_protoopaque.pb.go
+++ b/pb/c1/connector/v2/resource_protoopaque.pb.go
@@ -4065,6 +4065,7 @@ type CreateAccountResponse_SuccessResult struct {
 	state                            protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_Resource              *Resource              `protobuf:"bytes,1,opt,name=resource,proto3"`
 	xxx_hidden_IsCreateAccountResult bool                   `protobuf:"varint,2,opt,name=is_create_account_result,json=isCreateAccountResult,proto3"`
+	xxx_hidden_InvitationExpiresAt   *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=invitation_expires_at,json=invitationExpiresAt,proto3"`
 	unknownFields                    protoimpl.UnknownFields
 	sizeCache                        protoimpl.SizeCache
 }
@@ -4108,12 +4109,23 @@ func (x *CreateAccountResponse_SuccessResult) GetIsCreateAccountResult() bool {
 	return false
 }
 
+func (x *CreateAccountResponse_SuccessResult) GetInvitationExpiresAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.xxx_hidden_InvitationExpiresAt
+	}
+	return nil
+}
+
 func (x *CreateAccountResponse_SuccessResult) SetResource(v *Resource) {
 	x.xxx_hidden_Resource = v
 }
 
 func (x *CreateAccountResponse_SuccessResult) SetIsCreateAccountResult(v bool) {
 	x.xxx_hidden_IsCreateAccountResult = v
+}
+
+func (x *CreateAccountResponse_SuccessResult) SetInvitationExpiresAt(v *timestamppb.Timestamp) {
+	x.xxx_hidden_InvitationExpiresAt = v
 }
 
 func (x *CreateAccountResponse_SuccessResult) HasResource() bool {
@@ -4123,8 +4135,19 @@ func (x *CreateAccountResponse_SuccessResult) HasResource() bool {
 	return x.xxx_hidden_Resource != nil
 }
 
+func (x *CreateAccountResponse_SuccessResult) HasInvitationExpiresAt() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_InvitationExpiresAt != nil
+}
+
 func (x *CreateAccountResponse_SuccessResult) ClearResource() {
 	x.xxx_hidden_Resource = nil
+}
+
+func (x *CreateAccountResponse_SuccessResult) ClearInvitationExpiresAt() {
+	x.xxx_hidden_InvitationExpiresAt = nil
 }
 
 type CreateAccountResponse_SuccessResult_builder struct {
@@ -4132,6 +4155,16 @@ type CreateAccountResponse_SuccessResult_builder struct {
 
 	Resource              *Resource
 	IsCreateAccountResult bool
+	// Optional. When the connector created an invitation-style artifact
+	// (e.g. a GitHub org invite) rather than a fully-provisioned account,
+	// this is the absolute wall-clock time at which that invitation expires
+	// and becomes unusable. c1 surfaces this in the task UI and transitions
+	// the provisioning action to a terminal failure if the user has not
+	// accepted the invitation by this time. Leave unset for connectors whose
+	// CreateAccount truly creates a usable account, or for invitations with
+	// no enforced TTL.
+	// Construct with: timestamppb.New(t).
+	InvitationExpiresAt *timestamppb.Timestamp
 }
 
 func (b0 CreateAccountResponse_SuccessResult_builder) Build() *CreateAccountResponse_SuccessResult {
@@ -4140,6 +4173,7 @@ func (b0 CreateAccountResponse_SuccessResult_builder) Build() *CreateAccountResp
 	_, _ = b, x
 	x.xxx_hidden_Resource = b.Resource
 	x.xxx_hidden_IsCreateAccountResult = b.IsCreateAccountResult
+	x.xxx_hidden_InvitationExpiresAt = b.InvitationExpiresAt
 	return m0
 }
 
@@ -4148,7 +4182,6 @@ type CreateAccountResponse_ActionRequiredResult struct {
 	xxx_hidden_Resource              *Resource              `protobuf:"bytes,1,opt,name=resource,proto3"`
 	xxx_hidden_Message               string                 `protobuf:"bytes,2,opt,name=message,proto3"`
 	xxx_hidden_IsCreateAccountResult bool                   `protobuf:"varint,3,opt,name=is_create_account_result,json=isCreateAccountResult,proto3"`
-	xxx_hidden_ExpiresAt             *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=expires_at,json=expiresAt,proto3"`
 	unknownFields                    protoimpl.UnknownFields
 	sizeCache                        protoimpl.SizeCache
 }
@@ -4199,13 +4232,6 @@ func (x *CreateAccountResponse_ActionRequiredResult) GetIsCreateAccountResult() 
 	return false
 }
 
-func (x *CreateAccountResponse_ActionRequiredResult) GetExpiresAt() *timestamppb.Timestamp {
-	if x != nil {
-		return x.xxx_hidden_ExpiresAt
-	}
-	return nil
-}
-
 func (x *CreateAccountResponse_ActionRequiredResult) SetResource(v *Resource) {
 	x.xxx_hidden_Resource = v
 }
@@ -4218,10 +4244,6 @@ func (x *CreateAccountResponse_ActionRequiredResult) SetIsCreateAccountResult(v 
 	x.xxx_hidden_IsCreateAccountResult = v
 }
 
-func (x *CreateAccountResponse_ActionRequiredResult) SetExpiresAt(v *timestamppb.Timestamp) {
-	x.xxx_hidden_ExpiresAt = v
-}
-
 func (x *CreateAccountResponse_ActionRequiredResult) HasResource() bool {
 	if x == nil {
 		return false
@@ -4229,19 +4251,8 @@ func (x *CreateAccountResponse_ActionRequiredResult) HasResource() bool {
 	return x.xxx_hidden_Resource != nil
 }
 
-func (x *CreateAccountResponse_ActionRequiredResult) HasExpiresAt() bool {
-	if x == nil {
-		return false
-	}
-	return x.xxx_hidden_ExpiresAt != nil
-}
-
 func (x *CreateAccountResponse_ActionRequiredResult) ClearResource() {
 	x.xxx_hidden_Resource = nil
-}
-
-func (x *CreateAccountResponse_ActionRequiredResult) ClearExpiresAt() {
-	x.xxx_hidden_ExpiresAt = nil
 }
 
 type CreateAccountResponse_ActionRequiredResult_builder struct {
@@ -4250,13 +4261,6 @@ type CreateAccountResponse_ActionRequiredResult_builder struct {
 	Resource              *Resource
 	Message               string
 	IsCreateAccountResult bool
-	// Optional. Absolute wall-clock time at which the connector-side artifact
-	// (e.g. a GitHub org invite) will expire and become unusable. When set, c1
-	// surfaces this in the task UI and transitions the provisioning action to a
-	// terminal failure if the user has not completed the required action by
-	// expires_at. Leave unset for connectors with no enforced TTL.
-	// Construct with: timestamppb.New(t).
-	ExpiresAt *timestamppb.Timestamp
 }
 
 func (b0 CreateAccountResponse_ActionRequiredResult_builder) Build() *CreateAccountResponse_ActionRequiredResult {
@@ -4266,7 +4270,6 @@ func (b0 CreateAccountResponse_ActionRequiredResult_builder) Build() *CreateAcco
 	x.xxx_hidden_Resource = b.Resource
 	x.xxx_hidden_Message = b.Message
 	x.xxx_hidden_IsCreateAccountResult = b.IsCreateAccountResult
-	x.xxx_hidden_ExpiresAt = b.ExpiresAt
 	return m0
 }
 
@@ -4613,7 +4616,7 @@ const file_c1_connector_v2_resource_proto_rawDesc = "" +
 	"\x12credential_options\x18\x02 \x01(\v2\".c1.connector.v2.CredentialOptionsR\x11credentialOptions\x12P\n" +
 	"\x12encryption_configs\x18\x03 \x03(\v2!.c1.connector.v2.EncryptionConfigR\x11encryptionConfigs\x127\n" +
 	"\x10resource_type_id\x18\x04 \x01(\tB\r\xfaB\n" +
-	"r\b \x01(\x80\b\xd0\x01\x01R\x0eresourceTypeId\"\x87\t\n" +
+	"r\b \x01(\x80\b\xd0\x01\x01R\x0eresourceTypeId\"\x9d\t\n" +
 	"\x15CreateAccountResponse\x12P\n" +
 	"\asuccess\x18d \x01(\v24.c1.connector.v2.CreateAccountResponse.SuccessResultH\x00R\asuccess\x12f\n" +
 	"\x0faction_required\x18e \x01(\v2;.c1.connector.v2.CreateAccountResponse.ActionRequiredResultH\x00R\x0eactionRequired\x12c\n" +
@@ -4621,16 +4624,15 @@ const file_c1_connector_v2_resource_proto_rawDesc = "" +
 	"\vin_progress\x18g \x01(\v27.c1.connector.v2.CreateAccountResponse.InProgressResultH\x00R\n" +
 	"inProgress\x12E\n" +
 	"\x0eencrypted_data\x18\x02 \x03(\v2\x1e.c1.connector.v2.EncryptedDataR\rencryptedData\x126\n" +
-	"\vannotations\x18\x03 \x03(\v2\x14.google.protobuf.AnyR\vannotations\x1a\x7f\n" +
+	"\vannotations\x18\x03 \x03(\v2\x14.google.protobuf.AnyR\vannotations\x1a\xcf\x01\n" +
 	"\rSuccessResult\x125\n" +
 	"\bresource\x18\x01 \x01(\v2\x19.c1.connector.v2.ResourceR\bresource\x127\n" +
-	"\x18is_create_account_result\x18\x02 \x01(\bR\x15isCreateAccountResult\x1a\xdb\x01\n" +
+	"\x18is_create_account_result\x18\x02 \x01(\bR\x15isCreateAccountResult\x12N\n" +
+	"\x15invitation_expires_at\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\x13invitationExpiresAt\x1a\xa0\x01\n" +
 	"\x14ActionRequiredResult\x125\n" +
 	"\bresource\x18\x01 \x01(\v2\x19.c1.connector.v2.ResourceR\bresource\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\x127\n" +
-	"\x18is_create_account_result\x18\x03 \x01(\bR\x15isCreateAccountResult\x129\n" +
-	"\n" +
-	"expires_at\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\texpiresAt\x1a\x85\x01\n" +
+	"\x18is_create_account_result\x18\x03 \x01(\bR\x15isCreateAccountResult\x1a\x85\x01\n" +
 	"\x13AlreadyExistsResult\x125\n" +
 	"\bresource\x18\x01 \x01(\v2\x19.c1.connector.v2.ResourceR\bresource\x127\n" +
 	"\x18is_create_account_result\x18\x02 \x01(\bR\x15isCreateAccountResult\x1a\x82\x01\n" +
@@ -4839,8 +4841,8 @@ var file_c1_connector_v2_resource_proto_depIdxs = []int32{
 	19, // 57: c1.connector.v2.CredentialOptions.EncryptedPassword.encrypted_passwords:type_name -> c1.connector.v2.EncryptedData
 	16, // 58: c1.connector.v2.LocalCredentialOptions.RandomPassword.constraints:type_name -> c1.connector.v2.PasswordConstraint
 	23, // 59: c1.connector.v2.CreateAccountResponse.SuccessResult.resource:type_name -> c1.connector.v2.Resource
-	23, // 60: c1.connector.v2.CreateAccountResponse.ActionRequiredResult.resource:type_name -> c1.connector.v2.Resource
-	45, // 61: c1.connector.v2.CreateAccountResponse.ActionRequiredResult.expires_at:type_name -> google.protobuf.Timestamp
+	45, // 60: c1.connector.v2.CreateAccountResponse.SuccessResult.invitation_expires_at:type_name -> google.protobuf.Timestamp
+	23, // 61: c1.connector.v2.CreateAccountResponse.ActionRequiredResult.resource:type_name -> c1.connector.v2.Resource
 	23, // 62: c1.connector.v2.CreateAccountResponse.AlreadyExistsResult.resource:type_name -> c1.connector.v2.Resource
 	23, // 63: c1.connector.v2.CreateAccountResponse.InProgressResult.resource:type_name -> c1.connector.v2.Resource
 	3,  // 64: c1.connector.v2.ResourceTypesService.ListResourceTypes:input_type -> c1.connector.v2.ResourceTypesServiceListResourceTypesRequest

--- a/pkg/connectorbuilder/connectorbuilder_test.go
+++ b/pkg/connectorbuilder/connectorbuilder_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/pagination"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -431,6 +432,47 @@ func (t *testAccountManager) CreateAccount(
 }
 
 func (t *testAccountManager) CreateAccountCapabilityDetails(ctx context.Context) (*v2.CredentialDetailsAccountProvisioning, annotations.Annotations, error) {
+	return nil, annotations.Annotations{}, nil
+}
+
+// testActionRequiredAccountManager returns an ActionRequiredResult with a fixed
+// ExpiresAt and Message so tests can assert the field passes through the
+// connectorbuilder switch arm and survives wire-format round-trips.
+type testActionRequiredAccountManager struct {
+	ResourceSyncer
+	expiresAt time.Time
+	message   string
+}
+
+func newTestActionRequiredAccountManager(resourceType string, expiresAt time.Time, message string) AccountManager {
+	return &testActionRequiredAccountManager{
+		ResourceSyncer: newTestResourceSyncer(resourceType),
+		expiresAt:      expiresAt,
+		message:        message,
+	}
+}
+
+func (t *testActionRequiredAccountManager) CreateAccount(
+	ctx context.Context,
+	accountInfo *v2.AccountInfo,
+	credentialOptions *v2.LocalCredentialOptions,
+) (CreateAccountResponse, []*v2.PlaintextData, annotations.Annotations, error) {
+	r := v2.CreateAccountResponse_ActionRequiredResult_builder{
+		IsCreateAccountResult: true,
+		Resource: v2.Resource_builder{
+			Id: v2.ResourceId_builder{
+				ResourceType: t.ResourceType(ctx).GetId(),
+				Resource:     "pending-account",
+			}.Build(),
+			DisplayName: "Pending User",
+		}.Build(),
+		Message:   t.message,
+		ExpiresAt: timestamppb.New(t.expiresAt),
+	}.Build()
+	return r, []*v2.PlaintextData{}, annotations.Annotations{}, nil
+}
+
+func (t *testActionRequiredAccountManager) CreateAccountCapabilityDetails(ctx context.Context) (*v2.CredentialDetailsAccountProvisioning, annotations.Annotations, error) {
 	return nil, annotations.Annotations{}, nil
 }
 
@@ -1082,6 +1124,57 @@ func TestAccountManager(t *testing.T) {
 	require.NotNil(t, createAccountResp)
 	require.Equal(t, "created-account", createAccountResp.GetSuccess().GetResource().GetId().GetResource())
 	require.Equal(t, "Test User", createAccountResp.GetSuccess().GetResource().GetDisplayName())
+}
+
+// TestAccountManagerActionRequiredExpiresAt asserts that a connector returning
+// an ActionRequiredResult with ExpiresAt set has the field preserved through
+// the connectorbuilder CreateAccount switch arm and survives a proto
+// Marshal/Unmarshal round-trip on the wire format.
+func TestAccountManagerActionRequiredExpiresAt(t *testing.T) {
+	ctx := context.Background()
+
+	// Use a fixed, sub-second-precision UTC time so we can verify nanosecond
+	// fidelity through the round-trip.
+	expiresAt := time.Date(2026, 5, 14, 15, 4, 5, 123456789, time.UTC)
+	const wantMessage = "GitHub org invite sent. Waiting for user to accept."
+
+	accountManager := newTestActionRequiredAccountManager("user", expiresAt, wantMessage)
+	connector, err := NewConnector(ctx, newTestConnector([]ResourceSyncer{accountManager}))
+	require.NoError(t, err)
+
+	resp, err := connector.CreateAccount(ctx, v2.CreateAccountRequest_builder{
+		AccountInfo: v2.AccountInfo_builder{
+			Profile: &structpb.Struct{Fields: map[string]*structpb.Value{}},
+		}.Build(),
+		CredentialOptions: v2.CredentialOptions_builder{
+			NoPassword: &v2.CredentialOptions_NoPassword{},
+		}.Build(),
+	}.Build())
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	ar := resp.GetActionRequired()
+	require.NotNil(t, ar, "expected ActionRequired result on response")
+	require.Equal(t, wantMessage, ar.GetMessage())
+	require.Equal(t, "pending-account", ar.GetResource().GetId().GetResource())
+	require.NotNil(t, ar.GetExpiresAt(), "ExpiresAt should be set on response")
+	require.True(t, ar.GetExpiresAt().AsTime().Equal(expiresAt),
+		"ExpiresAt: got %s, want %s", ar.GetExpiresAt().AsTime(), expiresAt)
+
+	// Wire-format round-trip: ExpiresAt must survive Marshal/Unmarshal to the
+	// nanosecond, since older c1 readers must reliably observe new fields.
+	wire, err := proto.Marshal(resp)
+	require.NoError(t, err)
+
+	var got v2.CreateAccountResponse
+	require.NoError(t, proto.Unmarshal(wire, &got))
+
+	gotAR := got.GetActionRequired()
+	require.NotNil(t, gotAR)
+	require.Equal(t, wantMessage, gotAR.GetMessage())
+	require.NotNil(t, gotAR.GetExpiresAt())
+	require.True(t, gotAR.GetExpiresAt().AsTime().Equal(expiresAt),
+		"round-tripped ExpiresAt: got %s, want %s", gotAR.GetExpiresAt().AsTime(), expiresAt)
 }
 
 func TestCredentialManager(t *testing.T) {

--- a/pkg/connectorbuilder/connectorbuilder_test.go
+++ b/pkg/connectorbuilder/connectorbuilder_test.go
@@ -435,44 +435,43 @@ func (t *testAccountManager) CreateAccountCapabilityDetails(ctx context.Context)
 	return nil, annotations.Annotations{}, nil
 }
 
-// testActionRequiredAccountManager returns an ActionRequiredResult with a fixed
-// ExpiresAt and Message so tests can assert the field passes through the
-// connectorbuilder switch arm and survives wire-format round-trips.
-type testActionRequiredAccountManager struct {
+// testInvitationAccountManager returns a SuccessResult with a fixed
+// InvitationExpiresAt so tests can assert the field passes through the
+// connectorbuilder switch arm and survives wire-format round-trips. Models
+// connectors (e.g. GitHub) whose CreateAccount produces a pending invitation
+// rather than a fully-provisioned account.
+type testInvitationAccountManager struct {
 	ResourceSyncer
-	expiresAt time.Time
-	message   string
+	invitationExpiresAt time.Time
 }
 
-func newTestActionRequiredAccountManager(resourceType string, expiresAt time.Time, message string) AccountManager {
-	return &testActionRequiredAccountManager{
-		ResourceSyncer: newTestResourceSyncer(resourceType),
-		expiresAt:      expiresAt,
-		message:        message,
+func newTestInvitationAccountManager(resourceType string, invitationExpiresAt time.Time) AccountManager {
+	return &testInvitationAccountManager{
+		ResourceSyncer:      newTestResourceSyncer(resourceType),
+		invitationExpiresAt: invitationExpiresAt,
 	}
 }
 
-func (t *testActionRequiredAccountManager) CreateAccount(
+func (t *testInvitationAccountManager) CreateAccount(
 	ctx context.Context,
 	accountInfo *v2.AccountInfo,
 	credentialOptions *v2.LocalCredentialOptions,
 ) (CreateAccountResponse, []*v2.PlaintextData, annotations.Annotations, error) {
-	r := v2.CreateAccountResponse_ActionRequiredResult_builder{
+	r := v2.CreateAccountResponse_SuccessResult_builder{
 		IsCreateAccountResult: true,
 		Resource: v2.Resource_builder{
 			Id: v2.ResourceId_builder{
 				ResourceType: t.ResourceType(ctx).GetId(),
-				Resource:     "pending-account",
+				Resource:     "invited-account",
 			}.Build(),
-			DisplayName: "Pending User",
+			DisplayName: "Invited User",
 		}.Build(),
-		Message:   t.message,
-		ExpiresAt: timestamppb.New(t.expiresAt),
+		InvitationExpiresAt: timestamppb.New(t.invitationExpiresAt),
 	}.Build()
 	return r, []*v2.PlaintextData{}, annotations.Annotations{}, nil
 }
 
-func (t *testActionRequiredAccountManager) CreateAccountCapabilityDetails(ctx context.Context) (*v2.CredentialDetailsAccountProvisioning, annotations.Annotations, error) {
+func (t *testInvitationAccountManager) CreateAccountCapabilityDetails(ctx context.Context) (*v2.CredentialDetailsAccountProvisioning, annotations.Annotations, error) {
 	return nil, annotations.Annotations{}, nil
 }
 
@@ -1126,19 +1125,20 @@ func TestAccountManager(t *testing.T) {
 	require.Equal(t, "Test User", createAccountResp.GetSuccess().GetResource().GetDisplayName())
 }
 
-// TestAccountManagerActionRequiredExpiresAt asserts that a connector returning
-// an ActionRequiredResult with ExpiresAt set has the field preserved through
-// the connectorbuilder CreateAccount switch arm and survives a proto
-// Marshal/Unmarshal round-trip on the wire format.
-func TestAccountManagerActionRequiredExpiresAt(t *testing.T) {
+// TestAccountManagerSuccessInvitationExpiresAt asserts that a connector
+// returning a SuccessResult with InvitationExpiresAt set has the field
+// preserved through the connectorbuilder CreateAccount switch arm and
+// survives a proto Marshal/Unmarshal round-trip on the wire format. Models
+// the GitHub-org-invite flow where CreateAccount returns a successful but
+// pending invitation with a 7-day TTL.
+func TestAccountManagerSuccessInvitationExpiresAt(t *testing.T) {
 	ctx := context.Background()
 
-	// Use a fixed, sub-second-precision UTC time so we can verify nanosecond
-	// fidelity through the round-trip.
-	expiresAt := time.Date(2026, 5, 14, 15, 4, 5, 123456789, time.UTC)
-	const wantMessage = "GitHub org invite sent. Waiting for user to accept."
+	// Fixed, sub-second-precision UTC time to verify nanosecond fidelity
+	// through Marshal/Unmarshal.
+	invitationExpiresAt := time.Date(2026, 5, 14, 15, 4, 5, 123456789, time.UTC)
 
-	accountManager := newTestActionRequiredAccountManager("user", expiresAt, wantMessage)
+	accountManager := newTestInvitationAccountManager("user", invitationExpiresAt)
 	connector, err := NewConnector(ctx, newTestConnector([]ResourceSyncer{accountManager}))
 	require.NoError(t, err)
 
@@ -1153,28 +1153,26 @@ func TestAccountManagerActionRequiredExpiresAt(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 
-	ar := resp.GetActionRequired()
-	require.NotNil(t, ar, "expected ActionRequired result on response")
-	require.Equal(t, wantMessage, ar.GetMessage())
-	require.Equal(t, "pending-account", ar.GetResource().GetId().GetResource())
-	require.NotNil(t, ar.GetExpiresAt(), "ExpiresAt should be set on response")
-	require.True(t, ar.GetExpiresAt().AsTime().Equal(expiresAt),
-		"ExpiresAt: got %s, want %s", ar.GetExpiresAt().AsTime(), expiresAt)
+	success := resp.GetSuccess()
+	require.NotNil(t, success, "expected Success result on response")
+	require.Equal(t, "invited-account", success.GetResource().GetId().GetResource())
+	require.NotNil(t, success.GetInvitationExpiresAt(), "InvitationExpiresAt should be set on response")
+	require.True(t, success.GetInvitationExpiresAt().AsTime().Equal(invitationExpiresAt),
+		"InvitationExpiresAt: got %s, want %s", success.GetInvitationExpiresAt().AsTime(), invitationExpiresAt)
 
-	// Wire-format round-trip: ExpiresAt must survive Marshal/Unmarshal to the
-	// nanosecond, since older c1 readers must reliably observe new fields.
+	// Wire-format round-trip: InvitationExpiresAt must survive Marshal/Unmarshal
+	// to the nanosecond, since older c1 readers must reliably observe new fields.
 	wire, err := proto.Marshal(resp)
 	require.NoError(t, err)
 
 	var got v2.CreateAccountResponse
 	require.NoError(t, proto.Unmarshal(wire, &got))
 
-	gotAR := got.GetActionRequired()
-	require.NotNil(t, gotAR)
-	require.Equal(t, wantMessage, gotAR.GetMessage())
-	require.NotNil(t, gotAR.GetExpiresAt())
-	require.True(t, gotAR.GetExpiresAt().AsTime().Equal(expiresAt),
-		"round-tripped ExpiresAt: got %s, want %s", gotAR.GetExpiresAt().AsTime(), expiresAt)
+	gotSuccess := got.GetSuccess()
+	require.NotNil(t, gotSuccess)
+	require.NotNil(t, gotSuccess.GetInvitationExpiresAt())
+	require.True(t, gotSuccess.GetInvitationExpiresAt().AsTime().Equal(invitationExpiresAt),
+		"round-tripped InvitationExpiresAt: got %s, want %s", gotSuccess.GetInvitationExpiresAt().AsTime(), invitationExpiresAt)
 }
 
 func TestCredentialManager(t *testing.T) {

--- a/proto/c1/connector/v2/resource.proto
+++ b/proto/c1/connector/v2/resource.proto
@@ -4,6 +4,7 @@ package c1.connector.v2;
 
 import "google/protobuf/any.proto";
 import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
 import "validate/validate.proto";
 
 option go_package = "github.com/conductorone/baton-sdk/pb/c1/connector/v2";
@@ -232,6 +233,13 @@ message CreateAccountResponse {
     Resource resource = 1;
     string message = 2;
     bool is_create_account_result = 3;
+    // Optional. Absolute wall-clock time at which the connector-side artifact
+    // (e.g. a GitHub org invite) will expire and become unusable. When set, c1
+    // surfaces this in the task UI and transitions the provisioning action to a
+    // terminal failure if the user has not completed the required action by
+    // expires_at. Leave unset for connectors with no enforced TTL.
+    // Construct with: timestamppb.New(t).
+    google.protobuf.Timestamp expires_at = 4;
   }
   message AlreadyExistsResult {
     Resource resource = 1;

--- a/proto/c1/connector/v2/resource.proto
+++ b/proto/c1/connector/v2/resource.proto
@@ -228,18 +228,21 @@ message CreateAccountResponse {
   message SuccessResult {
     Resource resource = 1;
     bool is_create_account_result = 2;
+    // Optional. When the connector created an invitation-style artifact
+    // (e.g. a GitHub org invite) rather than a fully-provisioned account,
+    // this is the absolute wall-clock time at which that invitation expires
+    // and becomes unusable. c1 surfaces this in the task UI and transitions
+    // the provisioning action to a terminal failure if the user has not
+    // accepted the invitation by this time. Leave unset for connectors whose
+    // CreateAccount truly creates a usable account, or for invitations with
+    // no enforced TTL.
+    // Construct with: timestamppb.New(t).
+    google.protobuf.Timestamp invitation_expires_at = 3;
   }
   message ActionRequiredResult {
     Resource resource = 1;
     string message = 2;
     bool is_create_account_result = 3;
-    // Optional. Absolute wall-clock time at which the connector-side artifact
-    // (e.g. a GitHub org invite) will expire and become unusable. When set, c1
-    // surfaces this in the task UI and transitions the provisioning action to a
-    // terminal failure if the user has not completed the required action by
-    // expires_at. Leave unset for connectors with no enforced TTL.
-    // Construct with: timestamppb.New(t).
-    google.protobuf.Timestamp expires_at = 4;
   }
   message AlreadyExistsResult {
     Resource resource = 1;

--- a/proto/c1/connectorapi/baton/v1/baton.proto
+++ b/proto/c1/connectorapi/baton/v1/baton.proto
@@ -254,7 +254,10 @@ message BatonServiceGetTasksRequest {
     min_len: 1
     max_len: 256
   }];
-  uint32 page_size = 2 [(validate.rules).uint32 = {gt: 0, lte: 100}];
+  uint32 page_size = 2 [(validate.rules).uint32 = {
+    gt: 0
+    lte: 100
+  }];
   repeated string known_task_ids = 3 [(validate.rules).repeated = {
     items: {
       string: {pattern: "^[a-zA-Z0-9]{27}$"}


### PR DESCRIPTION
We need the ability for a connector state when an invite will expire so we can surface stale accounts in the c1 UI. This PR does that by adding a field for the connector to set. 