### PR TITLE
fix: c1z write paths surface Sync/Close errors before reporting success

### DIFF
--- a/pkg/dotc1z/manager/local/local.go
+++ b/pkg/dotc1z/manager/local/local.go
@@ -158,7 +158,12 @@ func (l *localManager) SaveC1Z(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	defer dstFile.Close()
+	dstFileClosed := false
+	defer func() {
+		if !dstFileClosed {
+			_ = dstFile.Close()
+		}
+	}()
 
 	size, err := io.Copy(dstFile, tmpFile)
 	if err != nil {
@@ -170,6 +175,15 @@ func (l *localManager) SaveC1Z(ctx context.Context) error {
 	if err := dstFile.Sync(); err != nil {
 		return fmt.Errorf("failed to sync destination file: %w", err)
 	}
+	// Surface late write-back errors via explicit Close. The deferred
+	// Close above is a safety net for error paths; on the success path
+	// we set dstFileClosed=true to suppress it. Without this the
+	// deferred Close error would be silently discarded after the
+	// function reports success.
+	if err := dstFile.Close(); err != nil {
+		return fmt.Errorf("failed to close destination file: %w", err)
+	}
+	dstFileClosed = true
 
 	log.Debug(
 		"successfully saved c1z locally",

--- a/pkg/synccompactor/compactor.go
+++ b/pkg/synccompactor/compactor.go
@@ -297,12 +297,30 @@ func cpFile(ctx context.Context, sourcePath string, destPath string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create destination file: %w", err)
 	}
-	defer destination.Close()
+	destinationClosed := false
+	defer func() {
+		if !destinationClosed {
+			_ = destination.Close()
+		}
+	}()
 
 	_, err = io.Copy(destination, source)
 	if err != nil {
 		return fmt.Errorf("failed to copy file: %w", err)
 	}
+
+	// Sync + Close + err-check so write-back failures (out-of-disk,
+	// IO error, quota exhaustion) surface here rather than being
+	// silently discarded by the deferred Close after the function
+	// has reported success. Required because the compacted file is
+	// the canonical artifact downstream consumers read.
+	if err := destination.Sync(); err != nil {
+		return fmt.Errorf("failed to sync destination file: %w", err)
+	}
+	if err := destination.Close(); err != nil {
+		return fmt.Errorf("failed to close destination file: %w", err)
+	}
+	destinationClosed = true
 
 	return nil
 }


### PR DESCRIPTION
## What

Two write paths in baton-sdk hand the c1z artifact to a downstream consumer under a 'success' return code without verifying the OS actually flushed the data. The deferred \`Close\` on the destination file silently discards any write-back error.

| Function | File | Issue |
|---|---|---|
| \`localManager.SaveC1Z\` | \`pkg/dotc1z/manager/local/local.go\` | Has explicit \`Sync\` (added for ZFS ARC) but the bare \`defer dstFile.Close()\` discards write-back errors at close time |
| \`cpFile\` | \`pkg/synccompactor/compactor.go\` | No Sync at all; deferred Close is the only close and its error is silently dropped |

## Why

\`io.Copy\` returning success only means writes were accepted into userspace buffers. The kernel can still fail at flush/close time:
- Out-of-disk at flush
- Filesystem IO error during write-back
- Quota exhaustion
- ZFS ARC eviction with subsequent flush failure (the existing comment in SaveC1Z notes this concern)

When such a failure happens, the deferred \`Close\` runs after the success return, its error goes nowhere, and downstream callers consume the torn file. baton-sdk WRITES the c1z files that c1 READS, so torn writes here feed read-side issues already being addressed in [conductorone/c1#17636](https://github.com/conductorone/c1/pull/17636), [#17654](https://github.com/conductorone/c1/pull/17654), and [#17657](https://github.com/conductorone/c1/pull/17657).

## How

Same fix shape as the c1 PRs:

```go
dstFile, err := os.Create(...)
if err != nil { return err }
dstFileClosed := false
defer func() {
    if !dstFileClosed {
        _ = dstFile.Close()  // safety net for error paths
    }
}()

// ... io.Copy ...

if err := dstFile.Sync(); err != nil { return err }
if err := dstFile.Close(); err != nil { return err }
dstFileClosed = true

return nil
```

The \`dstFileClosed\` flag suppresses the deferred Close on the success path so Close is called exactly once. On any error return between the open and the explicit Close, the deferred Close still fires.

## How found

Static analysis [\`error_swallowed_in_deferred_close\`](https://github.com/ductone/occult-go-analysis) detector run against baton-sdk. Same predicate that surfaced the bug class in c1: writable opener (os.Create / os.OpenFile w/write flags) + bare \`defer X.Close()\` + \`io.Copy*\` to the resource.

The detector also flagged 2 other sites in baton-sdk (\`pkg/cli/service_windows.go::interactiveSetup\`, \`pkg/config/generate.go::Generate\`) but those write to user-facing config files where torn-write recovery is straightforward; not included in this PR.

## Test plan

- [ ] \`go build ./pkg/dotc1z/... ./pkg/synccompactor/...\` (passed)
- [ ] Existing tests pass
- [ ] No semantic change on the success path
- [ ] On Sync/Close failure: error surfaces before the function reports success