### PR TITLE
WIP/spike (parked): perf(dotc1z): transparent-paging Stream variants [OPS-1483]

### DIFF
--- a/pkg/dotc1z/grants_bench_test.go
+++ b/pkg/dotc1z/grants_bench_test.go
@@ -139,3 +139,45 @@ func BenchmarkListGrantsForEntitlement(b *testing.B) {
 		})
 	}
 }
+
+// BenchmarkListGrantsForEntitlementStream is the streaming counterpart to
+// BenchmarkListGrantsForEntitlement (OPS-1483). Compare alloc/op and ns/op
+// across the two paths. Total bytes allocated should be similar — both decode
+// the same N protos overall — but the streaming variant keeps only ~100 decoded
+// grants resident at a time, regardless of N. The peak-inuse difference is not
+// captured by standard benchmark metrics; see the issue for measurement notes.
+func BenchmarkListGrantsForEntitlementStream(b *testing.B) {
+	for _, numGrants := range grantCounts {
+		b.Run(fmt.Sprintf("grants=%d", numGrants), func(b *testing.B) {
+			f, entitlementID, cleanup := setupBenchmarkDB(b, numGrants)
+			defer cleanup()
+
+			ctx := b.Context()
+
+			entResp, err := f.GetEntitlement(ctx, reader_v2.EntitlementsReaderServiceGetEntitlementRequest_builder{
+				EntitlementId: entitlementID,
+			}.Build())
+			require.NoError(b, err)
+
+			req := reader_v2.GrantsReaderServiceListGrantsForEntitlementRequest_builder{
+				Entitlement: entResp.GetEntitlement(),
+			}.Build()
+
+			b.ReportAllocs()
+
+			for b.Loop() {
+				totalGrants := 0
+				err := f.ListGrantsForEntitlementStream(ctx, req, func(g *v2.Grant) error {
+					totalGrants++
+					return nil
+				})
+				if err != nil {
+					b.Fatal(err)
+				}
+				if totalGrants != numGrants {
+					b.Fatalf("expected %d grants, got %d", numGrants, totalGrants)
+				}
+			}
+		})
+	}
+}

--- a/pkg/dotc1z/grants_stream.go
+++ b/pkg/dotc1z/grants_stream.go
@@ -1,0 +1,159 @@
+package dotc1z
+
+import (
+	"context"
+	"fmt"
+
+	"google.golang.org/protobuf/proto"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	reader_v2 "github.com/conductorone/baton-sdk/pb/c1/reader/v2"
+	"github.com/conductorone/baton-sdk/pkg/uotel"
+)
+
+// grantStreamPageSize is the internal page size used by the streaming grant readers.
+// Bounds peak heap to ~pageSize × sizeof(*v2.Grant) per call; the constant trades
+// heap-bounding strength against query overhead. modernc.org/sqlite (pure-Go) has
+// a meaningful per-query cost, so very small pages (<500) make the streaming
+// variant dramatically slower than the slice variant on large entitlements. 1000
+// gives a 10× peak-heap reduction vs the 10000 maxPageSize default with manageable
+// latency cost; see BenchmarkListGrantsForEntitlementStream in grants_bench_test.go.
+const grantStreamPageSize = 1000
+
+// ListGrantsForEntitlementStream invokes scan for each grant matching the request,
+// transparently paging through the underlying grants table in fixed-size batches.
+// Peak heap is bounded to ~grantStreamPageSize decoded grants per call regardless
+// of total grant count on the entitlement.
+//
+// Unlike ListGrantsForEntitlement, this method does NOT hold a SQL cursor while
+// scan runs — each batch's rows are closed before scan is invoked. scan MAY
+// safely call back into other *C1File methods (e.g. GetResourceType) without
+// deadlocking against the pinned writer connection.
+//
+// If scan returns a non-nil error, iteration stops and that error is returned.
+// Context cancellation is checked between batches.
+//
+// The caller-provided PageSize and PageToken on request are ignored; internal
+// paging is fixed and starts from the beginning. All other request fields
+// (Entitlement, Annotations, …) are honored.
+func (c *C1File) ListGrantsForEntitlementStream(
+	ctx context.Context,
+	request *reader_v2.GrantsReaderServiceListGrantsForEntitlementRequest,
+	scan func(*v2.Grant) error,
+) (retErr error) {
+	ctx, span := tracer.Start(ctx, "C1File.ListGrantsForEntitlementStream")
+	defer func() { uotel.EndSpanWithError(span, retErr) }()
+
+	if scan == nil {
+		return fmt.Errorf("ListGrantsForEntitlementStream: scan callback is nil")
+	}
+
+	inner := proto.Clone(request).(*reader_v2.GrantsReaderServiceListGrantsForEntitlementRequest)
+	inner.PageSize = grantStreamPageSize
+	inner.PageToken = ""
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		batch, nextPageToken, err := listConnectorObjects(ctx, c, grants.Name(), inner, func() *v2.Grant { return &v2.Grant{} })
+		if err != nil {
+			return fmt.Errorf("error streaming grants for entitlement '%s': %w", request.GetEntitlement().GetId(), err)
+		}
+
+		for _, g := range batch {
+			if err := scan(g); err != nil {
+				return err
+			}
+		}
+
+		if nextPageToken == "" {
+			return nil
+		}
+		inner.PageToken = nextPageToken
+	}
+}
+
+// ListGrantsForPrincipalStream is the streaming counterpart to ListGrantsForPrincipal.
+// Semantics mirror ListGrantsForEntitlementStream: peak-heap-bounded paging, no SQL
+// cursor held across scan, callback may safely re-enter *C1File.
+func (c *C1File) ListGrantsForPrincipalStream(
+	ctx context.Context,
+	request *reader_v2.GrantsReaderServiceListGrantsForEntitlementRequest,
+	scan func(*v2.Grant) error,
+) (retErr error) {
+	ctx, span := tracer.Start(ctx, "C1File.ListGrantsForPrincipalStream")
+	defer func() { uotel.EndSpanWithError(span, retErr) }()
+
+	if scan == nil {
+		return fmt.Errorf("ListGrantsForPrincipalStream: scan callback is nil")
+	}
+
+	inner := proto.Clone(request).(*reader_v2.GrantsReaderServiceListGrantsForEntitlementRequest)
+	inner.PageSize = grantStreamPageSize
+	inner.PageToken = ""
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		batch, nextPageToken, err := listConnectorObjects(ctx, c, grants.Name(), inner, func() *v2.Grant { return &v2.Grant{} })
+		if err != nil {
+			return fmt.Errorf("error streaming grants for principal '%s': %w", request.GetPrincipalId(), err)
+		}
+
+		for _, g := range batch {
+			if err := scan(g); err != nil {
+				return err
+			}
+		}
+
+		if nextPageToken == "" {
+			return nil
+		}
+		inner.PageToken = nextPageToken
+	}
+}
+
+// ListGrantsForResourceTypeStream is the streaming counterpart to ListGrantsForResourceType.
+// Semantics mirror ListGrantsForEntitlementStream.
+func (c *C1File) ListGrantsForResourceTypeStream(
+	ctx context.Context,
+	request *reader_v2.GrantsReaderServiceListGrantsForResourceTypeRequest,
+	scan func(*v2.Grant) error,
+) (retErr error) {
+	ctx, span := tracer.Start(ctx, "C1File.ListGrantsForResourceTypeStream")
+	defer func() { uotel.EndSpanWithError(span, retErr) }()
+
+	if scan == nil {
+		return fmt.Errorf("ListGrantsForResourceTypeStream: scan callback is nil")
+	}
+
+	inner := proto.Clone(request).(*reader_v2.GrantsReaderServiceListGrantsForResourceTypeRequest)
+	inner.PageSize = grantStreamPageSize
+	inner.PageToken = ""
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		batch, nextPageToken, err := listConnectorObjects(ctx, c, grants.Name(), inner, func() *v2.Grant { return &v2.Grant{} })
+		if err != nil {
+			return fmt.Errorf("error streaming grants for resource type '%s': %w", request.GetResourceTypeId(), err)
+		}
+
+		for _, g := range batch {
+			if err := scan(g); err != nil {
+				return err
+			}
+		}
+
+		if nextPageToken == "" {
+			return nil
+		}
+		inner.PageToken = nextPageToken
+	}
+}

--- a/pkg/dotc1z/grants_stream_test.go
+++ b/pkg/dotc1z/grants_stream_test.go
@@ -1,0 +1,202 @@
+package dotc1z
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	reader_v2 "github.com/conductorone/baton-sdk/pb/c1/reader/v2"
+)
+
+// streamTestFixture mirrors setupBenchmarkDB but is testing.T-friendly.
+type streamTestFixture struct {
+	f             *C1File
+	entitlementID string
+	resourceType  *v2.ResourceType
+}
+
+func newStreamFixture(t *testing.T, numGrants int) *streamTestFixture {
+	t.Helper()
+	ctx := t.Context()
+	tempDir := t.TempDir()
+
+	f, err := NewC1ZFile(ctx, tempDir+"/test.c1z",
+		WithTmpDir(tempDir),
+		WithEncoderConcurrency(0),
+		WithDecoderOptions(WithDecoderConcurrency(0)),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = f.Close(ctx) })
+
+	_, _, err = f.StartOrResumeSync(ctx, "full", "")
+	require.NoError(t, err)
+
+	rt := &v2.ResourceType{Id: "test-type", DisplayName: "Test Type"}
+	require.NoError(t, f.PutResourceTypes(ctx, rt))
+
+	res := &v2.Resource{
+		Id:          &v2.ResourceId{ResourceType: "test-type", Resource: "test-resource"},
+		DisplayName: "Test Resource",
+	}
+	require.NoError(t, f.PutResources(ctx, res))
+
+	ent := &v2.Entitlement{Id: "test-entitlement", Resource: res}
+	require.NoError(t, f.PutEntitlements(ctx, ent))
+
+	grants := make([]*v2.Grant, numGrants)
+	for i := range numGrants {
+		grants[i] = &v2.Grant{
+			Id:          fmt.Sprintf("grant-%d", i),
+			Entitlement: ent,
+			Principal: &v2.Resource{
+				Id: &v2.ResourceId{
+					ResourceType: "test-type",
+					Resource:     fmt.Sprintf("principal-%d", i),
+				},
+			},
+		}
+	}
+	batchSize := 1000
+	for i := 0; i < len(grants); i += batchSize {
+		end := min(i+batchSize, len(grants))
+		require.NoError(t, f.PutGrants(ctx, grants[i:end]...))
+	}
+
+	return &streamTestFixture{f: f, entitlementID: ent.Id, resourceType: rt}
+}
+
+func (fx *streamTestFixture) entitlement(t *testing.T) *v2.Entitlement {
+	t.Helper()
+	ctx := t.Context()
+	resp, err := fx.f.GetEntitlement(ctx, reader_v2.EntitlementsReaderServiceGetEntitlementRequest_builder{
+		EntitlementId: fx.entitlementID,
+	}.Build())
+	require.NoError(t, err)
+	return resp.GetEntitlement()
+}
+
+// collectSlice returns every grant for the entitlement via the non-streaming RPC,
+// paging until exhausted. This is the reference implementation the streaming
+// variant must match.
+func (fx *streamTestFixture) collectSlice(t *testing.T) []*v2.Grant {
+	t.Helper()
+	ctx := t.Context()
+	var out []*v2.Grant
+	pageToken := ""
+	for {
+		resp, err := fx.f.ListGrantsForEntitlement(ctx, &reader_v2.GrantsReaderServiceListGrantsForEntitlementRequest{
+			Entitlement: fx.entitlement(t),
+			PageSize:    1000,
+			PageToken:   pageToken,
+		})
+		require.NoError(t, err)
+		out = append(out, resp.GetList()...)
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			return out
+		}
+	}
+}
+
+// TestListGrantsForEntitlementStream_ParityWithSlice is the equivalence gate for
+// OPS-1483: streaming must visit the exact same grants in the same order as the
+// paginated slice path, exactly once each.
+func TestListGrantsForEntitlementStream_ParityWithSlice(t *testing.T) {
+	// 2500 grants > 2× grantStreamPageSize forces multi-page paging in stream.
+	fx := newStreamFixture(t, 2500)
+
+	wantGrants := fx.collectSlice(t)
+	wantIDs := make([]string, len(wantGrants))
+	for i, g := range wantGrants {
+		wantIDs[i] = g.GetId()
+	}
+
+	var gotIDs []string
+	err := fx.f.ListGrantsForEntitlementStream(
+		t.Context(),
+		&reader_v2.GrantsReaderServiceListGrantsForEntitlementRequest{
+			Entitlement: fx.entitlement(t),
+		},
+		func(g *v2.Grant) error {
+			gotIDs = append(gotIDs, g.GetId())
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, wantIDs, gotIDs,
+		"stream visited a different set/order of grants than the slice path")
+}
+
+// TestListGrantsForEntitlementStream_ScanErrorPropagates asserts a scan error
+// stops iteration immediately and the error bubbles up.
+func TestListGrantsForEntitlementStream_ScanErrorPropagates(t *testing.T) {
+	fx := newStreamFixture(t, 2500)
+	sentinel := errors.New("stop")
+
+	count := 0
+	err := fx.f.ListGrantsForEntitlementStream(
+		t.Context(),
+		&reader_v2.GrantsReaderServiceListGrantsForEntitlementRequest{
+			Entitlement: fx.entitlement(t),
+		},
+		func(g *v2.Grant) error {
+			count++
+			if count == 5 {
+				return sentinel
+			}
+			return nil
+		},
+	)
+	require.ErrorIs(t, err, sentinel)
+	require.Equal(t, 5, count,
+		"stream did not halt immediately on scan error; visited %d grants instead of 5", count)
+}
+
+// TestListGrantsForEntitlementStream_NilScanRejected guards the documented
+// contract that scan must be non-nil.
+func TestListGrantsForEntitlementStream_NilScanRejected(t *testing.T) {
+	fx := newStreamFixture(t, 10)
+	err := fx.f.ListGrantsForEntitlementStream(
+		t.Context(),
+		&reader_v2.GrantsReaderServiceListGrantsForEntitlementRequest{
+			Entitlement: fx.entitlement(t),
+		},
+		nil,
+	)
+	require.Error(t, err)
+}
+
+// TestListGrantsForEntitlementStream_NoDeadlockOnReentrantCall is the regression
+// test for baton-sdk PR #619's failure mode. The stream MUST release its SQL
+// cursor between batches so user code in scan can safely re-enter *C1File
+// methods (e.g. GetResourceType) without deadlocking against the pinned conn.
+func TestListGrantsForEntitlementStream_NoDeadlockOnReentrantCall(t *testing.T) {
+	const n = 2500
+	fx := newStreamFixture(t, n)
+
+	count := 0
+	err := fx.f.ListGrantsForEntitlementStream(
+		t.Context(),
+		&reader_v2.GrantsReaderServiceListGrantsForEntitlementRequest{
+			Entitlement: fx.entitlement(t),
+		},
+		func(g *v2.Grant) error {
+			count++
+			// Re-enter C1File from inside the iterator. With the single-conn
+			// pin this would deadlock if the stream were holding a rows cursor.
+			resp, err := fx.f.GetResourceType(t.Context(), reader_v2.ResourceTypesReaderServiceGetResourceTypeRequest_builder{
+				ResourceTypeId: g.GetPrincipal().GetId().GetResourceType(),
+			}.Build())
+			if err != nil {
+				return fmt.Errorf("re-entrant GetResourceType failed: %w", err)
+			}
+			require.Equal(t, "test-type", resp.GetResourceType().GetId())
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, n, count)
+}


### PR DESCRIPTION
> **🚧 WIP / EXPERIMENT — DRAFT, NOT FOR REVIEW.** First-cut spike for OPS-1483. Numbers and design are real and tests pass, but this is an experiment to validate the transparent-paging approach before committing to the c1-side migration. Do not merge. Feedback welcome; design may change.

## Summary

Adds three streaming methods on `*C1File`:

- `ListGrantsForEntitlementStream(ctx, req, scan func(*v2.Grant) error) error`
- `ListGrantsForPrincipalStream(ctx, req, scan func(*v2.Grant) error) error`
- `ListGrantsForResourceTypeStream(ctx, req, scan func(*v2.Grant) error) error`

Each iterates the matching grants via the `scan` callback, transparently paging through the underlying `grants` table in **1000-row batches**.

**Peak heap during iteration is bounded to ~1000 decoded grants** (independent of total grant count), vs up to `V2MaxPageSize = 10000` in the existing slice-returning RPCs. The new methods close the SQL cursor between batches, so `scan` may safely call back into other `*C1File` methods (e.g. `GetResourceType`) without deadlocking against the pinned writer connection — the failure mode that closed [PR #619](https://github.com/ConductorOne/baton-sdk/pull/619).

This is an additive change. Existing `ListGrants*` slice RPCs are untouched; callers migrate at their own pace.

## Why now

Sibling to (see internal platform-repo PR) — the "Address memory and GC issues in Temporal Worker" project. OPS-1193's streaming PRs bound the *caller-side* slice accumulators on the uplift hot path; this PR bounds the in-baton-sdk per-page proto buffer that those callers can't control.

Per the platform repo stored memory: `proto.Unmarshal(*v2.Grant)` via `fetchGrantsForEntitlementV2 → ListGrantsForEntitlement → listConnectorObjects` is 0.96 % inuse / 8.68 GB cum on `be-temporal-worker`. Page size of 1000 gives a 10× peak-heap reduction for the per-call buffer with manageable latency cost on realistic-size entitlements.

## Benchmark

`go test -bench '^BenchmarkListGrantsForEntitlement(Stream)?$' -benchtime=3x` on AMD Ryzen 7 5700X3D:

| N grants  | Slice ns/op | Stream ns/op | Slice B/op  | Stream B/op | Δ ns/op    |
|-----------|------------:|-------------:|------------:|------------:|------------|
| 100       |     510 µs  |     454 µs   |    110 KB   |    120 KB   | **-11 %**  |
| 1,000     |   3.45 ms   |   3.46 ms    |   1.05 MB   |   1.05 MB   |   ≈ 0 %    |
| 10,000    |  34.9 ms    |  86.5 ms     |  10.64 MB   |  10.58 MB   | 2.5× slower |
| 100,000   |   893 ms    |    6.2 s     |   106 MB    |   106 MB    | 7× slower |

- **Total allocations are within 1 %** across all N — both paths decode the same total number of protos.
- **Latency penalty at extreme N is the expected price** for bounding peak heap. The design goal is OOM-prevention on outsized entitlements, not raw throughput. Real-world median entitlements are well under 10K grants, where the cost is ≤ 2.5×.
- The per-query overhead in pure-Go `modernc.org/sqlite` is what amortizes badly at small page sizes; a single round trip costs the same whether you fetch 100 or 10,000 rows.

## Open questions before this leaves draft

- [ ] Is **page size 1000** the right default, or should it be exposed as a parameter / option? Different call sites may want different tradeoffs.
- [ ] Should we add the **dedicated read-only `*sql.DB` pool** in the same PR, or punt to a follow-up? Punted in this draft because `wal_checkpoint(TRUNCATE)` coordination needs design care.
- [ ] Do we want to **eliminate the slice variants** once consumers migrate, or keep them indefinitely as the back-compat path?
- [ ] **Server-streaming proto RPC** — out of scope here, but worth a design call: does the platform repo's `fetchGrantsForEntitlementV2` consume this as a Go API on `*C1File`, or do we expose it through `c1/reader/v2`?

## Test plan

- [x] `TestListGrantsForEntitlementStream_ParityWithSlice` — at 2500 grants (multi-page), streaming visits the exact same grants in the same order as the paginated slice path.
- [x] `TestListGrantsForEntitlementStream_ScanErrorPropagates` — scan error halts iteration immediately, error bubbles up.
- [x] `TestListGrantsForEntitlementStream_NilScanRejected` — nil scan is rejected with an error.
- [x] `TestListGrantsForEntitlementStream_NoDeadlockOnReentrantCall` — **regression test for PR #619's failure mode.** scan calls `GetResourceType` from inside the iterator across all 2500 grants; no deadlock against the single-conn pin.
- [ ] CI green
- [ ] Owner / design review

## Rollout (proposed — subject to design feedback)

- Additive only — no existing callers are affected.
- Tag a baton-sdk release once merged, then `go.mod` bump in `the platform repo`.
- Then `fetchGrantsForEntitlementV2` in `pkg/temporal/activity/app/fetch_v2.go` migrates to the streaming RPC under a feature flag (separate the platform repo PR).

## Out of scope (deferred — see Linear)

- Dedicated read-only `*sql.DB` pool. Real design problem (`wal_checkpoint(TRUNCATE)` coordination) that doesn't need to block this fix.
- Server-streaming proto RPC for `ListGrantsForEntitlement`. The new Stream methods are regular Go APIs on `*C1File`; that's enough for the in-process consumer in `the platform repo`.
- FST + roaring sidecar projection. Re-evaluate only if 2a + the platform repo migration still leaves meaningful alloc-rate pressure.

Linear: https://linear.app/ductone/issue/OPS-1483

🤖 Generated with [Claude Code](https://claude.com/claude-code)
