### PR TITLE
uhttp: preserve existing RoundTripper when cycle.make fails

### DIFF
--- a/pkg/uhttp/transport.go
+++ b/pkg/uhttp/transport.go
@@ -86,11 +86,17 @@ func (t *Transport) cycle(ctx context.Context) (http.RoundTripper, error) {
 	if t.nextCycle.After(n) && t.roundTripper != nil {
 		return t.roundTripper, nil
 	}
-	var err error
-	t.roundTripper, err = t.make(ctx)
+	// Build into a local; only swap into t.roundTripper after make
+	// succeeds. The previous direct assignment
+	// (`t.roundTripper, err = t.make(ctx)`) clobbered the existing
+	// working RoundTripper with nil on transient make() errors --
+	// subsequent requests served by this Transport would then fail
+	// until the next successful cycle.
+	newRoundTripper, err := t.make(ctx)
 	if err != nil {
 		return nil, err
 	}
+	t.roundTripper = newRoundTripper
 	t.nextCycle = n.Add(time.Minute * 5)
 	return t.roundTripper, nil
 }


### PR DESCRIPTION
## Bug

`Transport.cycle` in `pkg/uhttp/transport.go` directly assigned `t.roundTripper` from `t.make()`'s two return values:

```go
t.roundTripper, err = t.make(ctx)
if err != nil {
    return nil, err
}
```

In Go, a multi-value assignment evaluates the right-hand side and writes both results to the LHS variables. On a `make()` error, `t.roundTripper` becomes `nil` — clobbering whatever RoundTripper was previously working.

`cycle` is called every 5 minutes (or sooner if `nextCycle` has passed) on a long-lived `Transport`. A single transient `make()` failure (network blip, certificate refresh, etc.) leaves the Transport with a `nil` RoundTripper. Subsequent calls through this Transport then either fail outright or re-trigger `cycle` on every request, until one `make()` finally succeeds.

## Detection

Found by occult-go-analysis `abstract_state_leak_on_error_path` per-fn detector: a finite-state-extracted function with an `if err != nil { return ..., err }` early-return between two observable mutations of the receiver.

## Fix

Build the new RoundTripper into a local, then assign to `t.roundTripper` only after `make()` succeeds. On `make()` error, the prior `t.roundTripper` is preserved and subsequent requests keep working.

## Test Plan

- [x] `go build ./pkg/uhttp/...` green
- [x] `go test ./pkg/uhttp/...` green
- [x] `gofmt -l ./pkg/uhttp/` clean
