### PR TITLE
dotc1z: nil c.rawDb/c.db even when sqlite Close returns err

### DIFF
--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -395,12 +395,18 @@ func (c *C1File) Close(ctx context.Context) error {
 		}
 
 		err = c.rawDb.Close()
+		// Always drop the handle references, even on Close error: the
+		// handle is dead either way, and the WAL-failure branches
+		// above already nil them before returning. Without this,
+		// after a Close() failure c.rawDb still points at the failed
+		// handle, leaving the C1File in an inconsistent half-closed
+		// state where c.closed is still false but the DB is unusable.
+		c.rawDb = nil
+		c.db = nil
 		if err != nil {
 			return cleanupDbDir(c.dbFilePath, err)
 		}
 	}
-	c.rawDb = nil
-	c.db = nil
 
 	// We only want to save the file if we've made any changes
 	if c.dbUpdated {

--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -395,18 +395,21 @@ func (c *C1File) Close(ctx context.Context) error {
 		}
 
 		err = c.rawDb.Close()
-		// Always drop the handle references, even on Close error: the
-		// handle is dead either way, and the WAL-failure branches
-		// above already nil them before returning. Without this,
-		// after a Close() failure c.rawDb still points at the failed
-		// handle, leaving the C1File in an inconsistent half-closed
-		// state where c.closed is still false but the DB is unusable.
-		c.rawDb = nil
-		c.db = nil
 		if err != nil {
+			// Drop handle references on the Close-failure path
+			// too. The success-path nil assignments below (kept
+			// per the original shape, so validateDb() returns
+			// ErrDbNotOpen) only run if we don't return here, so
+			// without these the failed Close would leave c.rawDb
+			// pointing at a dead handle and validateDb would
+			// report success.
+			c.rawDb = nil
+			c.db = nil
 			return cleanupDbDir(c.dbFilePath, err)
 		}
 	}
+	c.rawDb = nil
+	c.db = nil
 
 	// We only want to save the file if we've made any changes
 	if c.dbUpdated {


### PR DESCRIPTION
## Bug

`C1File.Close` in `pkg/dotc1z/c1file.go` had a half-closed-state bug on sqlite `Close()` failure:

```go
err = c.rawDb.Close()
if err != nil {
    return cleanupDbDir(c.dbFilePath, err)   // <-- c.rawDb still set
}
}
c.rawDb = nil
c.db = nil
```

The two WAL-checkpoint-failure branches earlier in the function already nil out `c.rawDb` and `c.db` before returning — but the regular `Close()` failure path returned without doing so. Result: after a sqlite `Close()` error, the `C1File` is left with:

- `c.closed == false` (set only at the very end of the success path)
- `c.rawDb` pointing at a dead handle
- `c.db` still wrapping that handle

A subsequent `Close()` call would re-enter the body, see `c.rawDb != nil`, and attempt the WAL checkpoint + `Close()` on a dead handle.

## Detection

Found by occult-go-analysis `abstract_state_leak_on_error_path` per-fn detector: a finite-state-extracted function with a mutation before an err-return, then a different mutation after.

## Fix

Hoist `c.rawDb = nil; c.db = nil` to run before the err check on the close path, matching the pattern used by the two WAL-failure branches above. The handle is dead either way after `Close()` returns; the field assignments should reflect that regardless of err.

## Test Plan

- [x] `go build ./pkg/dotc1z/...` green
- [x] `go test ./pkg/dotc1z/...` green
- [x] `gofmt -l ./pkg/dotc1z/` clean
