### PR TITLE
Add shared PR review workflow

### DIFF
--- a/.github/workflows/pr-review.yaml
+++ b/.github/workflows/pr-review.yaml
@@ -1,0 +1,31 @@
+name: PR Review
+
+on:
+  pull_request_target:
+
+concurrency:
+  group: pr-review-${{ github.workflow_ref }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  pr-review:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout PR base
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+      - name: Run PR Review
+        uses: ConductorOne/github-workflows/.github/actions/pr-review@main
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          pr_number: ${{ github.event.pull_request.number }}
+          review_prompt: general
+    timeout-minutes: 10


### PR DESCRIPTION
**Why**

baton-sdk is not a connector implementation, so the connector-specific PR review profile is not the right fit. Until the organization ruleset covers this repo with the general profile, adding a repo-local workflow gives baton-sdk the same PR review coverage without waiting on ruleset changes.

**What this changes**

- Adds a `pull_request_target` PR review workflow for baton-sdk.
- Checks out only the PR base SHA with persisted credentials disabled.
- Calls the shared `ConductorOne/github-workflows` PR review action with the `general` prompt profile.
- Passes only the Anthropic API key and the scoped GitHub token instead of using `secrets: inherit`.
- Sets explicit job permissions and workflow-ref concurrency.

**Validation**

- Parsed `.github/workflows/pr-review.yaml` with `yq`.
- Ran `git diff --check`.
- Verified the workflow uses base checkout, `persist-credentials: false`, and `review_prompt: general`.