### PR TITLE
ugrpc: attach trace_id/span_id zap fields for log<->trace correlation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,3 +55,4 @@ Output message types defined in `proto/baton/v1/outputs.proto`. Generated with B
 - **Nix flake** for dev environment (`.envrc` + `flake.nix`)
 - **golangci-lint v2** with 26+ linters; line length limit of 200 chars
 - **Buf** for protobuf generation and linting
+

--- a/pkg/tasks/c1api/manager.go
+++ b/pkg/tasks/c1api/manager.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/uotel"
+	"github.com/conductorone/baton-sdk/pkg/uotel/uotelzap"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
@@ -112,6 +113,7 @@ type BootstrappingTaskManager interface {
 
 func (c *c1ApiTaskManager) Bootstrap(ctx context.Context, cc types.ConnectorClient) error {
 	ctx, span := tracer.Start(ctx, "c1ApiTaskManager.Bootstrap")
+	ctx = uotelzap.WithSpanLogFields(ctx)
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
@@ -200,6 +202,7 @@ func isRetryableHelloError(err error) bool {
 // the side that runs concurrently and it shares no mutable state with Next.
 func (c *c1ApiTaskManager) Next(ctx context.Context) (*v1.Task, time.Duration, error) {
 	ctx, span := tracer.Start(ctx, "c1ApiTaskManager.Next", trace.WithNewRoot())
+	ctx = uotelzap.WithSpanLogFields(ctx)
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 	l := ctxzap.Extract(ctx)
@@ -378,6 +381,7 @@ func (c *c1ApiTaskManager) ShouldDebug() bool {
 
 func (c *c1ApiTaskManager) Process(ctx context.Context, task *v1.Task, cc types.ConnectorClient) error {
 	ctx, span := tracer.Start(ctx, "c1ApiTaskManager.Process", trace.WithNewRoot())
+	ctx = uotelzap.WithSpanLogFields(ctx)
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 	l := ctxzap.Extract(ctx)

--- a/pkg/tasks/local/accounter.go
+++ b/pkg/tasks/local/accounter.go
@@ -13,6 +13,7 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/tasks"
 	"github.com/conductorone/baton-sdk/pkg/types"
 	"github.com/conductorone/baton-sdk/pkg/uotel"
+	"github.com/conductorone/baton-sdk/pkg/uotel/uotelzap"
 )
 
 type localAccountManager struct {
@@ -47,6 +48,7 @@ func (m *localAccountManager) Next(ctx context.Context) (*v1.Task, time.Duration
 
 func (m *localAccountManager) Process(ctx context.Context, task *v1.Task, cc types.ConnectorClient) error {
 	ctx, span := tracer.Start(ctx, "localAccountManager.Process", trace.WithNewRoot())
+	ctx = uotelzap.WithSpanLogFields(ctx)
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 

--- a/pkg/tasks/local/action_invoker.go
+++ b/pkg/tasks/local/action_invoker.go
@@ -15,6 +15,7 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/tasks"
 	"github.com/conductorone/baton-sdk/pkg/types"
 	"github.com/conductorone/baton-sdk/pkg/uotel"
+	"github.com/conductorone/baton-sdk/pkg/uotel/uotelzap"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 )
 
@@ -50,8 +51,9 @@ func (m *localActionInvoker) Next(ctx context.Context) (*v1.Task, time.Duration,
 }
 
 func (m *localActionInvoker) Process(ctx context.Context, task *v1.Task, cc types.ConnectorClient) error {
-	l := ctxzap.Extract(ctx)
 	ctx, span := tracer.Start(ctx, "localActionInvoker.Process", trace.WithNewRoot())
+	ctx = uotelzap.WithSpanLogFields(ctx)
+	l := ctxzap.Extract(ctx)
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 

--- a/pkg/tasks/local/compactor.go
+++ b/pkg/tasks/local/compactor.go
@@ -10,6 +10,7 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/tasks"
 	"github.com/conductorone/baton-sdk/pkg/types"
 	"github.com/conductorone/baton-sdk/pkg/uotel"
+	"github.com/conductorone/baton-sdk/pkg/uotel/uotelzap"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
@@ -43,6 +44,7 @@ func (m *localCompactor) Next(ctx context.Context) (*v1.Task, time.Duration, err
 
 func (m *localCompactor) Process(ctx context.Context, task *v1.Task, cc types.ConnectorClient) error {
 	ctx, span := tracer.Start(ctx, "localCompactor.Process", trace.WithNewRoot())
+	ctx = uotelzap.WithSpanLogFields(ctx)
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 	log := ctxzap.Extract(ctx)

--- a/pkg/tasks/local/deleter.go
+++ b/pkg/tasks/local/deleter.go
@@ -12,6 +12,7 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/tasks"
 	"github.com/conductorone/baton-sdk/pkg/types"
 	"github.com/conductorone/baton-sdk/pkg/uotel"
+	"github.com/conductorone/baton-sdk/pkg/uotel/uotelzap"
 )
 
 type localResourceDeleter struct {
@@ -42,6 +43,7 @@ func (m *localResourceDeleter) Next(ctx context.Context) (*v1.Task, time.Duratio
 
 func (m *localResourceDeleter) Process(ctx context.Context, task *v1.Task, cc types.ConnectorClient) error {
 	ctx, span := tracer.Start(ctx, "localResourceDeleter.Process", trace.WithNewRoot())
+	ctx = uotelzap.WithSpanLogFields(ctx)
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 

--- a/pkg/tasks/local/differ.go
+++ b/pkg/tasks/local/differ.go
@@ -11,6 +11,7 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/tasks"
 	"github.com/conductorone/baton-sdk/pkg/types"
 	"github.com/conductorone/baton-sdk/pkg/uotel"
+	"github.com/conductorone/baton-sdk/pkg/uotel/uotelzap"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
@@ -44,6 +45,7 @@ func (m *localDiffer) Next(ctx context.Context) (*v1.Task, time.Duration, error)
 
 func (m *localDiffer) Process(ctx context.Context, task *v1.Task, cc types.ConnectorClient) error {
 	ctx, span := tracer.Start(ctx, "localDiffer.Process", trace.WithNewRoot())
+	ctx = uotelzap.WithSpanLogFields(ctx)
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 	log := ctxzap.Extract(ctx)

--- a/pkg/tasks/local/event_feed.go
+++ b/pkg/tasks/local/event_feed.go
@@ -11,6 +11,7 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/tasks"
 	"github.com/conductorone/baton-sdk/pkg/types"
 	"github.com/conductorone/baton-sdk/pkg/uotel"
+	"github.com/conductorone/baton-sdk/pkg/uotel/uotelzap"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -47,6 +48,7 @@ func (m *localEventFeed) Next(ctx context.Context) (*v1.Task, time.Duration, err
 
 func (m *localEventFeed) Process(ctx context.Context, task *v1.Task, cc types.ConnectorClient) error {
 	ctx, span := tracer.Start(ctx, "localEventFeed.Process", trace.WithNewRoot())
+	ctx = uotelzap.WithSpanLogFields(ctx)
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 

--- a/pkg/tasks/local/granter.go
+++ b/pkg/tasks/local/granter.go
@@ -12,6 +12,7 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/tasks"
 	"github.com/conductorone/baton-sdk/pkg/types"
 	"github.com/conductorone/baton-sdk/pkg/uotel"
+	"github.com/conductorone/baton-sdk/pkg/uotel/uotelzap"
 )
 
 type localGranter struct {
@@ -43,6 +44,7 @@ func (m *localGranter) Next(ctx context.Context) (*v1.Task, time.Duration, error
 
 func (m *localGranter) Process(ctx context.Context, task *v1.Task, cc types.ConnectorClient) error {
 	ctx, span := tracer.Start(ctx, "localGranter.Process", trace.WithNewRoot())
+	ctx = uotelzap.WithSpanLogFields(ctx)
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 

--- a/pkg/tasks/local/revoker.go
+++ b/pkg/tasks/local/revoker.go
@@ -12,6 +12,7 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/tasks"
 	"github.com/conductorone/baton-sdk/pkg/types"
 	"github.com/conductorone/baton-sdk/pkg/uotel"
+	"github.com/conductorone/baton-sdk/pkg/uotel/uotelzap"
 )
 
 type localRevoker struct {
@@ -41,6 +42,7 @@ func (m *localRevoker) Next(ctx context.Context) (*v1.Task, time.Duration, error
 
 func (m *localRevoker) Process(ctx context.Context, task *v1.Task, cc types.ConnectorClient) error {
 	ctx, span := tracer.Start(ctx, "localRevoker.Process", trace.WithNewRoot())
+	ctx = uotelzap.WithSpanLogFields(ctx)
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 

--- a/pkg/tasks/local/rotator.go
+++ b/pkg/tasks/local/rotator.go
@@ -12,6 +12,7 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/tasks"
 	"github.com/conductorone/baton-sdk/pkg/types"
 	"github.com/conductorone/baton-sdk/pkg/uotel"
+	"github.com/conductorone/baton-sdk/pkg/uotel/uotelzap"
 )
 
 type localCredentialRotator struct {
@@ -42,6 +43,7 @@ func (m *localCredentialRotator) Next(ctx context.Context) (*v1.Task, time.Durat
 
 func (m *localCredentialRotator) Process(ctx context.Context, task *v1.Task, cc types.ConnectorClient) error {
 	ctx, span := tracer.Start(ctx, "localCredentialRotator.Process", trace.WithNewRoot())
+	ctx = uotelzap.WithSpanLogFields(ctx)
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 

--- a/pkg/tasks/local/syncer.go
+++ b/pkg/tasks/local/syncer.go
@@ -15,6 +15,7 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/tasks"
 	"github.com/conductorone/baton-sdk/pkg/types"
 	"github.com/conductorone/baton-sdk/pkg/uotel"
+	"github.com/conductorone/baton-sdk/pkg/uotel/uotelzap"
 )
 
 type localSyncer struct {
@@ -100,6 +101,7 @@ func (m *localSyncer) Next(ctx context.Context) (*v1.Task, time.Duration, error)
 
 func (m *localSyncer) Process(ctx context.Context, task *v1.Task, cc types.ConnectorClient) error {
 	ctx, span := tracer.Start(ctx, "localSyncer.Process", trace.WithNewRoot())
+	ctx = uotelzap.WithSpanLogFields(ctx)
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 

--- a/pkg/tasks/local/ticket.go
+++ b/pkg/tasks/local/ticket.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/conductorone/baton-sdk/pkg/uotel"
+	"github.com/conductorone/baton-sdk/pkg/uotel/uotelzap"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	v1 "github.com/conductorone/baton-sdk/pb/c1/connectorapi/baton/v1"
@@ -66,6 +67,7 @@ func (m *localBulkCreateTicket) Next(ctx context.Context) (*v1.Task, time.Durati
 
 func (m *localBulkCreateTicket) Process(ctx context.Context, task *v1.Task, cc types.ConnectorClient) error {
 	ctx, span := tracer.Start(ctx, "localBulkCreateTicket.Process", trace.WithNewRoot())
+	ctx = uotelzap.WithSpanLogFields(ctx)
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 

--- a/pkg/ugrpc/logging.go
+++ b/pkg/ugrpc/logging.go
@@ -9,10 +9,13 @@ import (
 	grpc_logging "github.com/grpc-ecosystem/go-grpc-middleware/logging"
 	grpc_zap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+
+	"github.com/conductorone/baton-sdk/pkg/uotel/uotelzap"
 )
 
 // UnaryServerInterceptor returns a new unary server interceptors that adds zap.Logger to the context.
@@ -72,7 +75,12 @@ func newLoggerForCall(ctx context.Context, logger *zap.Logger, fullMethodString 
 	if d, ok := ctx.Deadline(); ok {
 		f = append(f, zap.String("grpc.request.deadline", d.Format(time.RFC3339)))
 	}
-	callLog := logger.With(append(f, serverCallFields(fullMethodString)...)...)
+	f = append(f, serverCallFields(fullMethodString)...)
+	// Attach trace_id/span_id from the active OTel span so log lines can be
+	// correlated with the surrounding trace. The otelgrpc stats handler runs
+	// before unary/stream interceptors so the span is already on ctx.
+	f = append(f, uotelzap.SpanToLogFields(trace.SpanContextFromContext(ctx))...)
+	callLog := logger.With(f...)
 	return ctxzap.ToContext(ctx, callLog)
 }
 

--- a/pkg/ugrpc/logging_test.go
+++ b/pkg/ugrpc/logging_test.go
@@ -1,0 +1,84 @@
+package ugrpc
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// newCaptureLogger returns a logger that writes JSON-encoded entries to buf so
+// tests can assert that specific fields land on log lines.
+func newCaptureLogger(buf *bytes.Buffer) *zap.Logger {
+	encCfg := zap.NewProductionEncoderConfig()
+	encCfg.TimeKey = "" // keep test output deterministic
+	core := zapcore.NewCore(
+		zapcore.NewJSONEncoder(encCfg),
+		zapcore.AddSync(buf),
+		zap.DebugLevel,
+	)
+	return zap.New(core)
+}
+
+func TestNewLoggerForCall_AttachesTraceFieldsWhenSpanPresent(t *testing.T) {
+	traceID, err := trace.TraceIDFromHex("0123456789abcdef0123456789abcdef")
+	if err != nil {
+		t.Fatalf("TraceIDFromHex: %v", err)
+	}
+	spanID, err := trace.SpanIDFromHex("fedcba9876543210")
+	if err != nil {
+		t.Fatalf("SpanIDFromHex: %v", err)
+	}
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: trace.FlagsSampled,
+	})
+	ctx := trace.ContextWithSpanContext(context.Background(), sc)
+
+	var buf bytes.Buffer
+	base := newCaptureLogger(&buf)
+	newCtx := newLoggerForCall(ctx, base, "/svc.v1.Svc/Method", time.Unix(0, 0))
+	ctxzap.Extract(newCtx).Info("hello")
+
+	var entry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("unmarshal log entry: %v\nentry: %s", err, buf.String())
+	}
+	if got, want := entry["dd.trace_id"], "81985529216486895"; got != want {
+		t.Errorf("dd.trace_id = %v, want %v", got, want)
+	}
+	if got, want := entry["dd.span_id"], "18364758544493064720"; got != want {
+		t.Errorf("dd.span_id = %v, want %v", got, want)
+	}
+	if got, want := entry["grpc.service"], "svc.v1.Svc"; got != want {
+		t.Errorf("grpc.service = %v, want %v", got, want)
+	}
+	if got, want := entry["grpc.method"], "Method"; got != want {
+		t.Errorf("grpc.method = %v, want %v", got, want)
+	}
+}
+
+func TestNewLoggerForCall_NoTraceFieldsWhenSpanAbsent(t *testing.T) {
+	var buf bytes.Buffer
+	base := newCaptureLogger(&buf)
+	newCtx := newLoggerForCall(context.Background(), base, "/svc.v1.Svc/Method", time.Unix(0, 0))
+	ctxzap.Extract(newCtx).Info("hello")
+
+	var entry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("unmarshal log entry: %v\nentry: %s", err, buf.String())
+	}
+	if _, ok := entry["dd.trace_id"]; ok {
+		t.Errorf("dd.trace_id should not be set when no span on ctx; entry=%v", entry)
+	}
+	if _, ok := entry["dd.span_id"]; ok {
+		t.Errorf("dd.span_id should not be set when no span on ctx; entry=%v", entry)
+	}
+}

--- a/pkg/uotel/uotelzap/uotelzap.go
+++ b/pkg/uotel/uotelzap/uotelzap.go
@@ -14,12 +14,12 @@ import (
 )
 
 const (
-	// TraceIdLogKey is the zap field name Datadog uses to correlate logs with
+	// TraceIDLogKey is the zap field name Datadog uses to correlate logs with
 	// traces when the SDK is running under the OTel-to-Datadog pipeline.
-	TraceIdLogKey = "dd.trace_id"
-	// SpanIdLogKey is the zap field name Datadog uses to correlate logs with
+	TraceIDLogKey = "dd.trace_id"
+	// SpanIDLogKey is the zap field name Datadog uses to correlate logs with
 	// spans when the SDK is running under the OTel-to-Datadog pipeline.
-	SpanIdLogKey = "dd.span_id"
+	SpanIDLogKey = "dd.span_id"
 )
 
 // ConvertTraceID converts an OTel hex trace/span id to the decimal form
@@ -47,8 +47,8 @@ func SpanToLogFields(spanContext trace.SpanContext) []zap.Field {
 		return nil
 	}
 	return []zap.Field{
-		zap.String(TraceIdLogKey, ConvertTraceID(spanContext.TraceID().String())),
-		zap.String(SpanIdLogKey, ConvertTraceID(spanContext.SpanID().String())),
+		zap.String(TraceIDLogKey, ConvertTraceID(spanContext.TraceID().String())),
+		zap.String(SpanIDLogKey, ConvertTraceID(spanContext.SpanID().String())),
 	}
 }
 

--- a/pkg/uotel/uotelzap/uotelzap.go
+++ b/pkg/uotel/uotelzap/uotelzap.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"strconv"
 
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 )
@@ -22,9 +23,15 @@ const (
 	SpanIDLogKey = "dd.span_id"
 )
 
-// ConvertTraceID converts an OTel hex trace/span id to the decimal form
+// ConvertTraceID converts an OTel hex trace or span id to the decimal form
 // Datadog expects for log<->trace correlation.
 // https://docs.datadoghq.com/tracing/connect_logs_and_traces/opentelemetry/
+//
+// For 128-bit OTel trace IDs the low 64 bits are returned, matching Datadog's
+// OTel ingestion behavior; span IDs are already 64 bits and are passed through.
+// Returns "" for inputs shorter than 16 hex chars or that fail to parse — most
+// callers should prefer SpanToLogFields, which gates on SpanContext validity
+// before getting here.
 func ConvertTraceID(id string) string {
 	if len(id) < 16 {
 		return ""
@@ -55,4 +62,17 @@ func SpanToLogFields(spanContext trace.SpanContext) []zap.Field {
 // LogFieldsFromContext is a convenience for SpanToLogFields(trace.SpanContextFromContext(ctx)).
 func LogFieldsFromContext(ctx context.Context) []zap.Field {
 	return SpanToLogFields(trace.SpanContextFromContext(ctx))
+}
+
+// WithSpanLogFields enriches the ctx-scoped zap logger with the trace_id and
+// span_id of the active OTel span so subsequent log lines correlate with the
+// surrounding trace. It is a no-op when there is no valid span on ctx (in that
+// case the ctx is returned unchanged). Call it immediately after starting a
+// new root span so descendant log lines inherit the fields.
+func WithSpanLogFields(ctx context.Context) context.Context {
+	fields := LogFieldsFromContext(ctx)
+	if fields == nil {
+		return ctx
+	}
+	return ctxzap.ToContext(ctx, ctxzap.Extract(ctx).With(fields...))
 }

--- a/pkg/uotel/uotelzap/uotelzap.go
+++ b/pkg/uotel/uotelzap/uotelzap.go
@@ -1,0 +1,58 @@
+// Package uotelzap converts OpenTelemetry span context into zap log fields so
+// log lines can be correlated with traces in the OTel-to-Datadog pipeline. It
+// is intentionally kept dependency-light (otel/trace + zap only) so callers
+// can import it without pulling in the full OTel SDK exporters held by
+// pkg/uotel.
+package uotelzap
+
+import (
+	"context"
+	"strconv"
+
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
+)
+
+const (
+	// TraceIdLogKey is the zap field name Datadog uses to correlate logs with
+	// traces when the SDK is running under the OTel-to-Datadog pipeline.
+	TraceIdLogKey = "dd.trace_id"
+	// SpanIdLogKey is the zap field name Datadog uses to correlate logs with
+	// spans when the SDK is running under the OTel-to-Datadog pipeline.
+	SpanIdLogKey = "dd.span_id"
+)
+
+// ConvertTraceID converts an OTel hex trace/span id to the decimal form
+// Datadog expects for log<->trace correlation.
+// https://docs.datadoghq.com/tracing/connect_logs_and_traces/opentelemetry/
+func ConvertTraceID(id string) string {
+	if len(id) < 16 {
+		return ""
+	}
+	if len(id) > 16 {
+		id = id[16:]
+	}
+	intValue, err := strconv.ParseUint(id, 16, 64)
+	if err != nil {
+		return ""
+	}
+	return strconv.FormatUint(intValue, 10)
+}
+
+// SpanToLogFields returns zap fields that associate a log line with the given
+// span. Returns nil when the span context is not valid so callers can safely
+// append the result unconditionally.
+func SpanToLogFields(spanContext trace.SpanContext) []zap.Field {
+	if !spanContext.IsValid() {
+		return nil
+	}
+	return []zap.Field{
+		zap.String(TraceIdLogKey, ConvertTraceID(spanContext.TraceID().String())),
+		zap.String(SpanIdLogKey, ConvertTraceID(spanContext.SpanID().String())),
+	}
+}
+
+// LogFieldsFromContext is a convenience for SpanToLogFields(trace.SpanContextFromContext(ctx)).
+func LogFieldsFromContext(ctx context.Context) []zap.Field {
+	return SpanToLogFields(trace.SpanContextFromContext(ctx))
+}

--- a/pkg/uotel/uotelzap/uotelzap_test.go
+++ b/pkg/uotel/uotelzap/uotelzap_test.go
@@ -1,0 +1,74 @@
+package uotelzap
+
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestConvertTraceID(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"short", "abc", ""},
+		{"invalid_hex", "zzzzzzzzzzzzzzzz", ""},
+		{"16_lower_hex_max", "ffffffffffffffff", "18446744073709551615"},
+		{"32_hex_uses_lower_64", "0123456789abcdef0123456789abcdef", "81985529216486895"},
+		{"32_hex_zero_upper", "00000000000000000000000000000001", "1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ConvertTraceID(tc.in)
+			if got != tc.want {
+				t.Fatalf("ConvertTraceID(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSpanToLogFields_InvalidSpanReturnsNil(t *testing.T) {
+	if got := SpanToLogFields(trace.SpanContext{}); got != nil {
+		t.Fatalf("expected nil for zero SpanContext, got %v", got)
+	}
+	if got := LogFieldsFromContext(context.Background()); got != nil {
+		t.Fatalf("expected nil for context without span, got %v", got)
+	}
+}
+
+func TestSpanToLogFields_ValidSpanProducesDDFields(t *testing.T) {
+	traceID, err := trace.TraceIDFromHex("0123456789abcdef0123456789abcdef")
+	if err != nil {
+		t.Fatalf("TraceIDFromHex: %v", err)
+	}
+	spanID, err := trace.SpanIDFromHex("0123456789abcdef")
+	if err != nil {
+		t.Fatalf("SpanIDFromHex: %v", err)
+	}
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: trace.FlagsSampled,
+	})
+
+	fields := SpanToLogFields(sc)
+	if len(fields) != 2 {
+		t.Fatalf("expected 2 fields, got %d", len(fields))
+	}
+	wantTrace := "81985529216486895"
+	wantSpan := "81985529216486895"
+	if fields[0].Key != TraceIdLogKey || fields[0].String != wantTrace {
+		t.Fatalf("trace field = %q=%q, want %q=%q", fields[0].Key, fields[0].String, TraceIdLogKey, wantTrace)
+	}
+	if fields[1].Key != SpanIdLogKey || fields[1].String != wantSpan {
+		t.Fatalf("span field = %q=%q, want %q=%q", fields[1].Key, fields[1].String, SpanIdLogKey, wantSpan)
+	}
+
+	ctx := trace.ContextWithSpanContext(context.Background(), sc)
+	if got := LogFieldsFromContext(ctx); len(got) != 2 {
+		t.Fatalf("LogFieldsFromContext returned %d fields, want 2", len(got))
+	}
+}

--- a/pkg/uotel/uotelzap/uotelzap_test.go
+++ b/pkg/uotel/uotelzap/uotelzap_test.go
@@ -60,11 +60,11 @@ func TestSpanToLogFields_ValidSpanProducesDDFields(t *testing.T) {
 	}
 	wantTrace := "81985529216486895"
 	wantSpan := "81985529216486895"
-	if fields[0].Key != TraceIdLogKey || fields[0].String != wantTrace {
-		t.Fatalf("trace field = %q=%q, want %q=%q", fields[0].Key, fields[0].String, TraceIdLogKey, wantTrace)
+	if fields[0].Key != TraceIDLogKey || fields[0].String != wantTrace {
+		t.Fatalf("trace field = %q=%q, want %q=%q", fields[0].Key, fields[0].String, TraceIDLogKey, wantTrace)
 	}
-	if fields[1].Key != SpanIdLogKey || fields[1].String != wantSpan {
-		t.Fatalf("span field = %q=%q, want %q=%q", fields[1].Key, fields[1].String, SpanIdLogKey, wantSpan)
+	if fields[1].Key != SpanIDLogKey || fields[1].String != wantSpan {
+		t.Fatalf("span field = %q=%q, want %q=%q", fields[1].Key, fields[1].String, SpanIDLogKey, wantSpan)
 	}
 
 	ctx := trace.ContextWithSpanContext(context.Background(), sc)

--- a/pkg/uotel/uotelzap/uotelzap_test.go
+++ b/pkg/uotel/uotelzap/uotelzap_test.go
@@ -1,10 +1,15 @@
 package uotelzap
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"testing"
 
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 func TestConvertTraceID(t *testing.T) {
@@ -44,7 +49,9 @@ func TestSpanToLogFields_ValidSpanProducesDDFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("TraceIDFromHex: %v", err)
 	}
-	spanID, err := trace.SpanIDFromHex("0123456789abcdef")
+	// Pick a span ID with a distinct decimal form so a future regression that
+	// swaps the trace/span fields can't pass silently.
+	spanID, err := trace.SpanIDFromHex("fedcba9876543210")
 	if err != nil {
 		t.Fatalf("SpanIDFromHex: %v", err)
 	}
@@ -59,7 +66,7 @@ func TestSpanToLogFields_ValidSpanProducesDDFields(t *testing.T) {
 		t.Fatalf("expected 2 fields, got %d", len(fields))
 	}
 	wantTrace := "81985529216486895"
-	wantSpan := "81985529216486895"
+	wantSpan := "18364758544493064720"
 	if fields[0].Key != TraceIDLogKey || fields[0].String != wantTrace {
 		t.Fatalf("trace field = %q=%q, want %q=%q", fields[0].Key, fields[0].String, TraceIDLogKey, wantTrace)
 	}
@@ -71,4 +78,49 @@ func TestSpanToLogFields_ValidSpanProducesDDFields(t *testing.T) {
 	if got := LogFieldsFromContext(ctx); len(got) != 2 {
 		t.Fatalf("LogFieldsFromContext returned %d fields, want 2", len(got))
 	}
+}
+
+func TestWithSpanLogFields(t *testing.T) {
+	traceID, err := trace.TraceIDFromHex("0123456789abcdef0123456789abcdef")
+	if err != nil {
+		t.Fatalf("TraceIDFromHex: %v", err)
+	}
+	spanID, err := trace.SpanIDFromHex("fedcba9876543210")
+	if err != nil {
+		t.Fatalf("SpanIDFromHex: %v", err)
+	}
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: trace.FlagsSampled,
+	})
+
+	t.Run("attaches_fields_when_span_present", func(t *testing.T) {
+		var buf bytes.Buffer
+		enc := zap.NewProductionEncoderConfig()
+		enc.TimeKey = ""
+		logger := zap.New(zapcore.NewCore(zapcore.NewJSONEncoder(enc), zapcore.AddSync(&buf), zap.DebugLevel))
+
+		ctx := ctxzap.ToContext(trace.ContextWithSpanContext(context.Background(), sc), logger)
+		ctx = WithSpanLogFields(ctx)
+		ctxzap.Extract(ctx).Info("hello")
+
+		var entry map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+			t.Fatalf("unmarshal: %v\n%s", err, buf.String())
+		}
+		if entry[TraceIDLogKey] != "81985529216486895" {
+			t.Errorf("trace = %v, want 81985529216486895", entry[TraceIDLogKey])
+		}
+		if entry[SpanIDLogKey] != "18364758544493064720" {
+			t.Errorf("span = %v, want 18364758544493064720", entry[SpanIDLogKey])
+		}
+	})
+
+	t.Run("no_op_without_span", func(t *testing.T) {
+		ctx := context.Background()
+		if WithSpanLogFields(ctx) != ctx {
+			t.Errorf("expected ctx to be returned unchanged when no span")
+		}
+	})
 }


### PR DESCRIPTION
## Summary

- gRPC log lines were missing `dd.trace_id` / `dd.span_id`, so Datadog couldn't correlate connector logs with their surrounding spans.
- `pkg/ugrpc/logging.go:newLoggerForCall` now pulls the span from `trace.SpanContextFromContext(ctx)` (set by the `otelgrpc` stats handler in `internal/connector/connector.go`) and attaches DD-shaped trace/span fields to the ctx logger.
- Port of the c1 helper (`pkg/udatadog/otel_convert.go`) → `pkg/uotel/uotelzap` (its own subpackage so importers don't pull in `pkg/uotel`'s OTel SDK exporters).

## Linear

[OPS-1530](https://linear.app/ductone/issue/OPS-1530/baton-sdk-grpc-logs-missing-trace-id-breaking-logtrace-correlation-in)

## Test plan

- [x] Unit tests for `ConvertTraceID` (16-hex, 32-hex lower-64 slice, invalid hex, short input) and `SpanToLogFields` (invalid SpanContext returns nil; valid SpanContext returns dd.trace_id/dd.span_id in decimal).
- [x] `go build ./...` and `go test ./pkg/uotel/uotelzap/...` clean.
- [ ] Smoke-test on a real connector: verify `dd.trace_id` shows up on log records in Datadog and that clicking "View related logs" from a span surfaces matching lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)