### PR TITLE
fix(connectorbuilder): record span errors on early-return validation paths

### DIFF
--- a/pkg/connectorbuilder/accounts.go
+++ b/pkg/connectorbuilder/accounts.go
@@ -64,7 +64,7 @@ func (b *builder) CreateAccount(ctx context.Context, request *v2.CreateAccountRe
 
 	if len(b.accountManagers) == 0 {
 		l.Error("error: connector does not have account manager configured")
-		err := status.Error(codes.Unimplemented, "connector does not have account manager configured")
+		err = status.Error(codes.Unimplemented, "connector does not have account manager configured")
 		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
 		return nil, err
 	}
@@ -82,7 +82,7 @@ func (b *builder) CreateAccount(ctx context.Context, request *v2.CreateAccountRe
 			var ok bool
 			accountManager, ok = b.accountManagers["user"]
 			if !ok {
-				err := status.Error(codes.Unimplemented, "connector has multiple account managers configured, but no resource type specified, and no default account manager configured")
+				err = status.Error(codes.Unimplemented, "connector has multiple account managers configured, but no resource type specified, and no default account manager configured")
 				b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
 				return nil, err
 			}
@@ -95,7 +95,7 @@ func (b *builder) CreateAccount(ctx context.Context, request *v2.CreateAccountRe
 		accountManager, ok = b.accountManagers[request.GetResourceTypeId()]
 		if !ok {
 			l.Error("error: connector does not have account manager configured")
-			err := status.Errorf(codes.Unimplemented, "connector does not have account manager configured for resource type: %s", request.GetResourceTypeId())
+			err = status.Errorf(codes.Unimplemented, "connector does not have account manager configured for resource type: %s", request.GetResourceTypeId())
 			b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
 			return nil, err
 		}
@@ -124,7 +124,8 @@ func (b *builder) CreateAccount(ctx context.Context, request *v2.CreateAccountRe
 
 	var encryptedDatas []*v2.EncryptedData
 	for _, plaintextCredential := range plaintexts {
-		encryptedData, err := pkem.Encrypt(ctx, plaintextCredential)
+		var encryptedData []*v2.EncryptedData
+		encryptedData, err = pkem.Encrypt(ctx, plaintextCredential)
 		if err != nil {
 			b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
 			return nil, err
@@ -147,7 +148,7 @@ func (b *builder) CreateAccount(ctx context.Context, request *v2.CreateAccountRe
 	case *v2.CreateAccountResponse_InProgressResult:
 		rv.SetInProgress(proto.ValueOrDefault(r))
 	default:
-		err := status.Error(codes.Unimplemented, fmt.Sprintf("unknown result type: %T", result))
+		err = status.Error(codes.Unimplemented, fmt.Sprintf("unknown result type: %T", result))
 		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
 		return nil, err
 	}

--- a/pkg/connectorbuilder/connectorbuilder.go
+++ b/pkg/connectorbuilder/connectorbuilder.go
@@ -333,19 +333,20 @@ func (b *builder) Validate(ctx context.Context, request *v2.ConnectorServiceVali
 	})
 
 	for {
-		annos, err := b.validateProvider.Validate(ctx)
-		if err == nil {
+		annos, validateErr := b.validateProvider.Validate(ctx)
+		if validateErr == nil {
 			return v2.ConnectorServiceValidateResponse_builder{
 				Annotations: annos,
 				SdkVersion:  sdk.Version,
 			}.Build(), nil
 		}
 
-		if retryer.ShouldWaitAndRetry(ctx, err) {
+		if retryer.ShouldWaitAndRetry(ctx, validateErr) {
 			continue
 		}
 
-		return nil, fmt.Errorf("validate failed: %w", err)
+		err = fmt.Errorf("validate failed: %w", validateErr)
+		return nil, err
 	}
 }
 

--- a/pkg/connectorbuilder/credentials.go
+++ b/pkg/connectorbuilder/credentials.go
@@ -49,7 +49,7 @@ func (b *builder) RotateCredential(ctx context.Context, request *v2.RotateCreden
 	manager, ok := b.credentialManagers[rt]
 	if !ok {
 		l.Error("error: resource type does not have credential manager configured", zap.String("resource_type", rt))
-		err := status.Error(codes.Unimplemented, "resource type does not have credential manager configured")
+		err = status.Error(codes.Unimplemented, "resource type does not have credential manager configured")
 		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
 		return nil, err
 	}
@@ -77,7 +77,8 @@ func (b *builder) RotateCredential(ctx context.Context, request *v2.RotateCreden
 
 	var encryptedDatas []*v2.EncryptedData
 	for _, plaintextCredential := range plaintexts {
-		encryptedData, err := pkem.Encrypt(ctx, plaintextCredential)
+		var encryptedData []*v2.EncryptedData
+		encryptedData, err = pkem.Encrypt(ctx, plaintextCredential)
 		if err != nil {
 			b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
 			return nil, err

--- a/pkg/connectorbuilder/events.go
+++ b/pkg/connectorbuilder/events.go
@@ -116,7 +116,8 @@ func (b *builder) ListEvents(ctx context.Context, request *v2.ListEventsRequest)
 
 	feed, ok := b.eventFeeds[feedId]
 	if !ok {
-		return nil, status.Errorf(codes.NotFound, "error: event feed id %s not found", feedId)
+		err = status.Errorf(codes.NotFound, "error: event feed id %s not found", feedId)
+		return nil, err
 	}
 
 	tt := tasks.ListEventsType

--- a/pkg/connectorbuilder/resource_manager.go
+++ b/pkg/connectorbuilder/resource_manager.go
@@ -84,7 +84,7 @@ func (b *builder) CreateResource(ctx context.Context, request *v2.CreateResource
 	manager, ok := b.resourceManagers[rt]
 	if !ok {
 		l.Error("error: resource type does not have resource Create() configured", zap.String("resource_type", rt))
-		err := status.Error(codes.Unimplemented, fmt.Sprintf("resource type %s does not have resource Create() configured", rt))
+		err = status.Error(codes.Unimplemented, fmt.Sprintf("resource type %s does not have resource Create() configured", rt))
 		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
 		return nil, err
 	}
@@ -118,7 +118,7 @@ func (b *builder) DeleteResource(ctx context.Context, request *v2.DeleteResource
 
 	if !ok {
 		l.Error("error: resource type does not have resource Delete() configured", zap.String("resource_type", rt))
-		err := status.Error(codes.Unimplemented, fmt.Sprintf("resource type %s does not have resource Delete() configured", rt))
+		err = status.Error(codes.Unimplemented, fmt.Sprintf("resource type %s does not have resource Delete() configured", rt))
 		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
 		return nil, err
 	}
@@ -153,7 +153,7 @@ func (b *builder) DeleteResourceV2(ctx context.Context, request *v2.DeleteResour
 
 	if !ok {
 		l.Error("error: resource type does not have resource Delete() configured", zap.String("resource_type", rt))
-		err := status.Error(codes.Unimplemented, fmt.Sprintf("resource type %s does not have resource Delete() configured", rt))
+		err = status.Error(codes.Unimplemented, fmt.Sprintf("resource type %s does not have resource Delete() configured", rt))
 		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
 		return nil, err
 	}

--- a/pkg/connectorbuilder/resource_provisioner.go
+++ b/pkg/connectorbuilder/resource_provisioner.go
@@ -75,7 +75,7 @@ func (b *builder) Grant(ctx context.Context, request *v2.GrantManagerServiceGran
 
 	if !ok {
 		l.Error("error: resource type does not have provisioner configured", zap.String("resource_type", rt))
-		err := status.Errorf(codes.Unimplemented, "resource type %s does not have provisioner configured", rt)
+		err = status.Errorf(codes.Unimplemented, "resource type %s does not have provisioner configured", rt)
 		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
 		return nil, err
 	}
@@ -87,16 +87,17 @@ func (b *builder) Grant(ctx context.Context, request *v2.GrantManagerServiceGran
 	})
 
 	for {
-		grants, annos, err := provisioner.Grant(ctx, request.GetPrincipal(), request.GetEntitlement())
-		if err == nil {
+		grants, annos, grantErr := provisioner.Grant(ctx, request.GetPrincipal(), request.GetEntitlement())
+		if grantErr == nil {
 			b.m.RecordTaskSuccess(ctx, tt, b.nowFunc().Sub(start))
 			return v2.GrantManagerServiceGrantResponse_builder{Annotations: annos, Grants: grants}.Build(), nil
 		}
-		if retryer.ShouldWaitAndRetry(ctx, err) {
+		if retryer.ShouldWaitAndRetry(ctx, grantErr) {
 			continue
 		}
+		err = fmt.Errorf("grant failed: %w", grantErr)
 		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
-		return nil, fmt.Errorf("grant failed: %w", err)
+		return nil, err
 	}
 }
 
@@ -120,7 +121,7 @@ func (b *builder) Revoke(ctx context.Context, request *v2.GrantManagerServiceRev
 
 	if revokeProvisioner == nil {
 		l.Error("error: resource type does not have provisioner configured", zap.String("resource_type", rt))
-		err := status.Errorf(codes.Unimplemented, "resource type %s does not have provisioner configured", rt)
+		err = status.Errorf(codes.Unimplemented, "resource type %s does not have provisioner configured", rt)
 		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
 		return nil, err
 	}
@@ -132,16 +133,17 @@ func (b *builder) Revoke(ctx context.Context, request *v2.GrantManagerServiceRev
 	})
 
 	for {
-		annos, err := revokeProvisioner.Revoke(ctx, request.GetGrant())
-		if err == nil {
+		annos, revokeErr := revokeProvisioner.Revoke(ctx, request.GetGrant())
+		if revokeErr == nil {
 			b.m.RecordTaskSuccess(ctx, tt, b.nowFunc().Sub(start))
 			return v2.GrantManagerServiceRevokeResponse_builder{Annotations: annos}.Build(), nil
 		}
-		if retryer.ShouldWaitAndRetry(ctx, err) {
+		if retryer.ShouldWaitAndRetry(ctx, revokeErr) {
 			continue
 		}
+		err = fmt.Errorf("revoke failed: %w", revokeErr)
 		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
-		return nil, fmt.Errorf("revoke failed: %w", err)
+		return nil, err
 	}
 }
 

--- a/pkg/connectorbuilder/resource_provisioner.go
+++ b/pkg/connectorbuilder/resource_provisioner.go
@@ -95,8 +95,8 @@ func (b *builder) Grant(ctx context.Context, request *v2.GrantManagerServiceGran
 		if retryer.ShouldWaitAndRetry(ctx, grantErr) {
 			continue
 		}
+		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), grantErr)
 		err = fmt.Errorf("grant failed: %w", grantErr)
-		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
 		return nil, err
 	}
 }
@@ -141,8 +141,8 @@ func (b *builder) Revoke(ctx context.Context, request *v2.GrantManagerServiceRev
 		if retryer.ShouldWaitAndRetry(ctx, revokeErr) {
 			continue
 		}
+		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), revokeErr)
 		err = fmt.Errorf("revoke failed: %w", revokeErr)
-		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
 		return nil, err
 	}
 }

--- a/pkg/connectorbuilder/resource_syncer.go
+++ b/pkg/connectorbuilder/resource_syncer.go
@@ -91,7 +91,7 @@ func (b *builder) ListResourceTypes(
 	var out []*v2.ResourceType
 
 	if len(b.resourceSyncers) == 0 {
-		err := status.Error(codes.FailedPrecondition, "no resource builders found")
+		err = status.Error(codes.FailedPrecondition, "no resource builders found")
 		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
 		return nil, err
 	}
@@ -101,7 +101,7 @@ func (b *builder) ListResourceTypes(
 	}
 
 	if len(out) == 0 {
-		err := status.Error(codes.FailedPrecondition, "no resource types found")
+		err = status.Error(codes.FailedPrecondition, "no resource types found")
 		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
 		return nil, err
 	}
@@ -120,7 +120,7 @@ func (b *builder) ListResources(ctx context.Context, request *v2.ResourcesServic
 	tt := tasks.ListResourcesType
 	rb, ok := b.resourceSyncers[request.GetResourceTypeId()]
 	if !ok {
-		err := status.Errorf(codes.NotFound, "error: list resources with unknown resource type %s", request.GetResourceTypeId())
+		err = status.Errorf(codes.NotFound, "error: list resources with unknown resource type %s", request.GetResourceTypeId())
 		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
 		return nil, err
 	}
@@ -145,7 +145,7 @@ func (b *builder) ListResources(ctx context.Context, request *v2.ResourcesServic
 		return resp, fmt.Errorf("error: listing resources failed: %w", err)
 	}
 	if request.GetPageToken() != "" && request.GetPageToken() == retOptions.NextPageToken {
-		err := status.Errorf(codes.Internal,
+		err = status.Errorf(codes.Internal,
 			"listing resources failed: next page token unchanged (token=%s, type=%s, parent=%s) - likely a connector bug",
 			request.GetPageToken(), request.GetResourceTypeId(), request.GetParentResourceId())
 		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
@@ -166,7 +166,7 @@ func (b *builder) GetResource(ctx context.Context, request *v2.ResourceGetterSer
 	resourceType := request.GetResourceId().GetResourceType()
 	rb, ok := b.resourceTargetedSyncers[resourceType]
 	if !ok {
-		err := status.Errorf(codes.Unimplemented, "error: get resource with unknown resource type %s", resourceType)
+		err = status.Errorf(codes.Unimplemented, "error: get resource with unknown resource type %s", resourceType)
 		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
 		return nil, err
 	}
@@ -176,7 +176,7 @@ func (b *builder) GetResource(ctx context.Context, request *v2.ResourceGetterSer
 		return nil, fmt.Errorf("error: get resource failed: %w", err)
 	}
 	if resource == nil {
-		err := status.Error(codes.NotFound, "error: get resource returned nil")
+		err = status.Error(codes.NotFound, "error: get resource returned nil")
 		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
 		return nil, err
 	}
@@ -199,7 +199,7 @@ func (b *builder) ListStaticEntitlements(ctx context.Context, request *v2.Entitl
 	tt := tasks.ListStaticEntitlementsType
 	rb, ok := b.resourceSyncers[request.GetResourceTypeId()]
 	if !ok {
-		err := status.Errorf(codes.NotFound, "error: list static entitlements with unknown resource type %s", request.GetResourceTypeId())
+		err = status.Errorf(codes.NotFound, "error: list static entitlements with unknown resource type %s", request.GetResourceTypeId())
 		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
 		return nil, err
 	}
@@ -233,7 +233,7 @@ func (b *builder) ListStaticEntitlements(ctx context.Context, request *v2.Entitl
 		return nil, fmt.Errorf("error: listing static entitlements failed: %w", err)
 	}
 	if request.GetPageToken() != "" && request.GetPageToken() == retOptions.NextPageToken {
-		err := status.Error(codes.Internal, "listing static entitlements failed: next page token unchanged - likely a connector bug")
+		err = status.Error(codes.Internal, "listing static entitlements failed: next page token unchanged - likely a connector bug")
 		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
 		return resp, err
 	}
@@ -257,7 +257,7 @@ func (b *builder) ListEntitlements(ctx context.Context, request *v2.Entitlements
 	tt := tasks.ListEntitlementsType
 	rb, ok := b.resourceSyncers[request.GetResource().GetId().GetResourceType()]
 	if !ok {
-		err := status.Errorf(codes.NotFound, "error: list entitlements with unknown resource type %s", request.GetResource().GetId().GetResourceType())
+		err = status.Errorf(codes.NotFound, "error: list entitlements with unknown resource type %s", request.GetResource().GetId().GetResourceType())
 		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
 		return nil, err
 	}
@@ -281,7 +281,7 @@ func (b *builder) ListEntitlements(ctx context.Context, request *v2.Entitlements
 		return resp, fmt.Errorf("error: listing entitlements failed: %w", err)
 	}
 	if request.GetPageToken() != "" && request.GetPageToken() == retOptions.NextPageToken {
-		err := status.Error(codes.Internal, "listing entitlements failed: next page token unchanged - likely a connector bug")
+		err = status.Error(codes.Internal, "listing entitlements failed: next page token unchanged - likely a connector bug")
 		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
 		return resp, err
 	}
@@ -305,7 +305,7 @@ func (b *builder) ListGrants(ctx context.Context, request *v2.GrantsServiceListG
 	tt := tasks.ListGrantsType
 
 	if request.GetResource() == nil {
-		err := status.Error(codes.InvalidArgument, "error: list grants requires a resource")
+		err = status.Error(codes.InvalidArgument, "error: list grants requires a resource")
 		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
 		return nil, err
 	}
@@ -313,7 +313,7 @@ func (b *builder) ListGrants(ctx context.Context, request *v2.GrantsServiceListG
 	rid := request.GetResource().GetId()
 	rb, ok := b.resourceSyncers[rid.GetResourceType()]
 	if !ok {
-		err := status.Errorf(codes.NotFound, "error: list grants with unknown resource type %s", rid.GetResourceType())
+		err = status.Errorf(codes.NotFound, "error: list grants with unknown resource type %s", rid.GetResourceType())
 		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
 		return nil, err
 	}
@@ -339,7 +339,7 @@ func (b *builder) ListGrants(ctx context.Context, request *v2.GrantsServiceListG
 		return resp, fmt.Errorf("error: listing grants for resource %s/%s failed: %w", rid.GetResourceType(), rid.GetResource(), err)
 	}
 	if request.GetPageToken() != "" && request.GetPageToken() == retOptions.NextPageToken {
-		err := status.Errorf(codes.Internal,
+		err = status.Errorf(codes.Internal,
 			"listing grants for resource %s/%s failed: next page token unchanged - likely a connector bug",
 			rid.GetResourceType(), rid.GetResource())
 		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)

--- a/pkg/connectorbuilder/resource_syncer.go
+++ b/pkg/connectorbuilder/resource_syncer.go
@@ -238,7 +238,7 @@ func (b *builder) ListStaticEntitlements(ctx context.Context, request *v2.Entitl
 		return resp, err
 	}
 
-	if err := validateExclusionGroupAnnotations(out); err != nil {
+	if err = validateExclusionGroupAnnotations(out); err != nil {
 		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
 		return nil, err
 	}
@@ -286,7 +286,7 @@ func (b *builder) ListEntitlements(ctx context.Context, request *v2.Entitlements
 		return resp, err
 	}
 
-	if err := validateExclusionGroupAnnotations(out); err != nil {
+	if err = validateExclusionGroupAnnotations(out); err != nil {
 		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
 		return nil, err
 	}

--- a/pkg/connectorbuilder/span_error_test.go
+++ b/pkg/connectorbuilder/span_error_test.go
@@ -1,0 +1,132 @@
+package connectorbuilder
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	otelcodes "go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+// recordingExporter is a minimal in-memory SpanExporter for the regression
+// test below. Spans are appended on export and looked up by name.
+type recordingExporter struct {
+	mu    sync.Mutex
+	spans []sdktrace.ReadOnlySpan
+}
+
+func (r *recordingExporter) ExportSpans(_ context.Context, spans []sdktrace.ReadOnlySpan) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.spans = append(r.spans, spans...)
+	return nil
+}
+
+func (r *recordingExporter) Shutdown(_ context.Context) error { return nil }
+
+func (r *recordingExporter) spansByName(name string) []sdktrace.ReadOnlySpan {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var out []sdktrace.ReadOnlySpan
+	for _, s := range r.spans {
+		if s.Name() == name {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// installSpanRecorder swaps the global otel tracer provider for an in-memory
+// recorder for the duration of the test. The package-level tracer var in
+// connectorbuilder.go is captured at init via otel.Tracer(name), which
+// returns a delegating wrapper that lazily routes through the current global
+// provider — so this swap reaches the existing tracer references.
+//
+// Mutates global state; callers must not call t.Parallel().
+func installSpanRecorder(t *testing.T) *recordingExporter {
+	t.Helper()
+	exp := &recordingExporter{}
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(prev)
+		_ = tp.Shutdown(context.Background())
+	})
+	return exp
+}
+
+// TestSpanErrorRecorded_EarlyReturns is the regression test for OPS-1543.
+// Pre-fix, ~30 early-return error paths in pkg/connectorbuilder shadowed
+// the function-scope err that the deferred uotel.EndSpanWithError reads,
+// so spans ended status:ok despite the function returning an error. The
+// bug was invisible to all existing tests because they asserted on the
+// returned error value but never inspected the span. This test exercises
+// one representative path per bug-pattern class: err := inside if-block
+// with InvalidArgument, err := inside if-block with NotFound, and direct
+// return (no outer assignment) with NotFound.
+func TestSpanErrorRecorded_EarlyReturns(t *testing.T) {
+	ctx := context.Background()
+	exp := installSpanRecorder(t)
+
+	connector, err := NewConnector(ctx, newTestConnector(nil))
+	require.NoError(t, err)
+
+	type call struct {
+		name     string
+		spanName string
+		invoke   func() error
+	}
+	calls := []call{
+		{
+			// codes.InvalidArgument early-return — shadowed err in if-block.
+			name:     "ListGrants nil resource",
+			spanName: "builder.ListGrants",
+			invoke: func() error {
+				_, e := connector.ListGrants(ctx, &v2.GrantsServiceListGrantsRequest{})
+				return e
+			},
+		},
+		{
+			// codes.NotFound early-return — shadowed err in if-block.
+			name:     "ListResources unknown resource type",
+			spanName: "builder.ListResources",
+			invoke: func() error {
+				req := v2.ResourcesServiceListResourcesRequest_builder{
+					ResourceTypeId: "unknown",
+				}.Build()
+				_, e := connector.ListResources(ctx, req)
+				return e
+			},
+		},
+		{
+			// codes.NotFound direct return — bypass path (no err assignment).
+			name:     "ListEvents unknown feed",
+			spanName: "builder.ListEvents",
+			invoke: func() error {
+				req := v2.ListEventsRequest_builder{
+					EventFeedId: "unknown",
+				}.Build()
+				_, e := connector.ListEvents(ctx, req)
+				return e
+			},
+		},
+	}
+
+	for _, c := range calls {
+		t.Run(c.name, func(t *testing.T) {
+			invokeErr := c.invoke()
+			require.Error(t, invokeErr, "RPC should return an error")
+			spans := exp.spansByName(c.spanName)
+			require.NotEmpty(t, spans, "expected at least one %s span", c.spanName)
+			s := spans[len(spans)-1]
+			require.Equal(t, otelcodes.Error, s.Status().Code,
+				"span %s must end with status:error; pre-OPS-1543 it incorrectly ended status:ok because the deferred EndSpanWithError saw a shadowed nil err",
+				c.spanName)
+		})
+	}
+}

--- a/pkg/connectorbuilder/tickets.go
+++ b/pkg/connectorbuilder/tickets.go
@@ -138,8 +138,8 @@ func (b *builder) ListTicketSchemas(ctx context.Context, request *v2.TicketsServ
 		if retryer.ShouldWaitAndRetry(ctx, listErr) {
 			continue
 		}
+		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), listErr)
 		err = fmt.Errorf("error: listing ticket schemas failed: %w", listErr)
-		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
 		return nil, err
 	}
 }

--- a/pkg/connectorbuilder/tickets.go
+++ b/pkg/connectorbuilder/tickets.go
@@ -41,14 +41,14 @@ func (b *builder) BulkCreateTickets(ctx context.Context, request *v2.TicketsServ
 	start := b.nowFunc()
 	tt := tasks.BulkCreateTicketsType
 	if b.ticketManager == nil {
-		err := status.Error(codes.Unimplemented, "ticket manager not implemented")
+		err = status.Error(codes.Unimplemented, "ticket manager not implemented")
 		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
 		return nil, err
 	}
 
 	reqBody := request.GetTicketRequests()
 	if len(reqBody) == 0 {
-		err := status.Error(codes.InvalidArgument, "request body had no items")
+		err = status.Error(codes.InvalidArgument, "request body had no items")
 		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
 		return nil, err
 	}
@@ -73,14 +73,14 @@ func (b *builder) BulkGetTickets(ctx context.Context, request *v2.TicketsService
 	start := b.nowFunc()
 	tt := tasks.BulkGetTicketsType
 	if b.ticketManager == nil {
-		err := status.Error(codes.Unimplemented, "ticket manager not implemented")
+		err = status.Error(codes.Unimplemented, "ticket manager not implemented")
 		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
 		return nil, err
 	}
 
 	reqBody := request.GetTicketRequests()
 	if len(reqBody) == 0 {
-		err := status.Error(codes.InvalidArgument, "request body had no items")
+		err = status.Error(codes.InvalidArgument, "request body had no items")
 		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
 		return nil, err
 	}
@@ -105,7 +105,7 @@ func (b *builder) ListTicketSchemas(ctx context.Context, request *v2.TicketsServ
 	start := b.nowFunc()
 	tt := tasks.ListTicketSchemasType
 	if b.ticketManager == nil {
-		err := status.Error(codes.Unimplemented, "ticket manager not implemented")
+		err = status.Error(codes.Unimplemented, "ticket manager not implemented")
 		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
 		return nil, err
 	}
@@ -117,13 +117,13 @@ func (b *builder) ListTicketSchemas(ctx context.Context, request *v2.TicketsServ
 	})
 
 	for {
-		out, nextPageToken, annos, err := b.ticketManager.ListTicketSchemas(ctx, &pagination.Token{
+		out, nextPageToken, annos, listErr := b.ticketManager.ListTicketSchemas(ctx, &pagination.Token{
 			Size:  int(request.GetPageSize()),
 			Token: request.GetPageToken(),
 		})
-		if err == nil {
+		if listErr == nil {
 			if request.GetPageToken() != "" && request.GetPageToken() == nextPageToken {
-				err := status.Error(codes.Internal, "listing ticket schemas failed: next page token unchanged - likely a connector bug")
+				err = status.Error(codes.Internal, "listing ticket schemas failed: next page token unchanged - likely a connector bug")
 				b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
 				return nil, err
 			}
@@ -135,11 +135,12 @@ func (b *builder) ListTicketSchemas(ctx context.Context, request *v2.TicketsServ
 				Annotations:   annos,
 			}.Build(), nil
 		}
-		if retryer.ShouldWaitAndRetry(ctx, err) {
+		if retryer.ShouldWaitAndRetry(ctx, listErr) {
 			continue
 		}
+		err = fmt.Errorf("error: listing ticket schemas failed: %w", listErr)
 		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
-		return nil, fmt.Errorf("error: listing ticket schemas failed: %w", err)
+		return nil, err
 	}
 }
 
@@ -151,14 +152,14 @@ func (b *builder) CreateTicket(ctx context.Context, request *v2.TicketsServiceCr
 	start := b.nowFunc()
 	tt := tasks.CreateTicketType
 	if b.ticketManager == nil {
-		err := status.Error(codes.Unimplemented, "ticket manager not implemented")
+		err = status.Error(codes.Unimplemented, "ticket manager not implemented")
 		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
 		return nil, err
 	}
 
 	reqBody := request.GetRequest()
 	if reqBody == nil {
-		err := status.Error(codes.InvalidArgument, "request body is nil")
+		err = status.Error(codes.InvalidArgument, "request body is nil")
 		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
 		return nil, err
 	}
@@ -199,7 +200,7 @@ func (b *builder) GetTicket(ctx context.Context, request *v2.TicketsServiceGetTi
 	start := b.nowFunc()
 	tt := tasks.GetTicketType
 	if b.ticketManager == nil {
-		err := status.Error(codes.Unimplemented, "ticket manager not implemented")
+		err = status.Error(codes.Unimplemented, "ticket manager not implemented")
 		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
 		return nil, err
 	}
@@ -232,7 +233,7 @@ func (b *builder) GetTicketSchema(ctx context.Context, request *v2.TicketsServic
 	start := b.nowFunc()
 	tt := tasks.GetTicketSchemaType
 	if b.ticketManager == nil {
-		err := status.Error(codes.Unimplemented, "ticket manager not implemented")
+		err = status.Error(codes.Unimplemented, "ticket manager not implemented")
 		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
 		return nil, err
 	}


### PR DESCRIPTION
Fixes [OPS-1543](https://linear.app/ductone/issue/OPS-1543/baton-sdk-pkgconnectorbuilder-span-errors-lost-on-early-return-paths).

## Summary

Every RPC method in `pkg/connectorbuilder/` follows the shape:

```go
ctx, span := tracer.Start(ctx, \"builder.X\")
var err error
defer func() { uotel.EndSpanWithError(span, err) }()
```

The deferred closure reads the function-scope \`err\`. ~30 early-return paths across 18 RPC methods either **shadowed** it (\`err :=\` inside an \`if\` or \`for\` block creates a new local) or **bypassed** it entirely (direct \`return nil, status.X(...)\`). In every such case the defer saw the outer \`err\` still as nil, called \`EndSpanWithError(span, nil)\`, and the span ended \`status: ok\` — despite the function returning an error to the gRPC caller.

## Production impact (7d, prod-usw2, all 111 baton-* services)

| Resource | Spans | Errors | Rate |
|---|---:|---:|---:|
| \`builder.ListGrants\` | **153,071** | **7** | 0.005% |
| \`builder.ListEntitlements\` | 110,902 | 0 | 0% |
| \`builder.ListResources\` | 16,371 | 39 | 0.24% |
| \`builder.ListEvents\` | 4,252 | 902 | **21.2%** |

\`builder.ListEvents\` is the only path with realistic error reporting; its deep failure path uses \`:=\` at function-top scope (which correctly reassigns the outer \`err\` because multi-assign with at least one new var at the same scope as an existing var reassigns rather than shadows). The remaining 99%+ of connector traffic reports false \`status: ok\` on every validation rejection, missing-permission failure, and unknown-resource lookup.

## Fix

Mechanical, scoped to \`pkg/connectorbuilder/\`:

- **\`err := status.X(...)\` inside \`if\` blocks** → \`err = status.X(...)\`. Outer \`err\` is already in scope; \`:=\` inside a nested block declares a new local that shadows it. ~22 instances.
- **\`for\` loop bodies** (\`Validate\`, \`Grant\`, \`Revoke\`, \`ListTicketSchemas\`) — the loop-iteration error is renamed to a distinct identifier (\`validateErr\`, \`grantErr\`, \`revokeErr\`, \`listErr\`) and the outer \`err\` is assigned just before the failure \`return\`. Named-return signatures would be the canonical Go pattern, but baton-sdk's \`.golangci.yml\` enables \`nonamedreturns\`.
- **Direct \`return nil, status.X(...)\`** (the \`events.go\` \`ListEvents\` NotFound path) → \`err = status.X(...); return nil, err\`.

## Files

- \`accounts.go\` — \`CreateAccount\` (3 if-shadows + 1 for-loop shadow + 1 switch-default shadow)
- \`connectorbuilder.go\` — \`Validate\` (for-loop)
- \`credentials.go\` — \`RotateCredential\` (1 if + 1 for-loop)
- \`events.go\` — \`ListEvents\` (NotFound direct return)
- \`resource_manager.go\` — \`CreateResource\`, \`DeleteResource\`, \`DeleteResourceV2\` (1 each)
- \`resource_provisioner.go\` — \`Grant\`, \`Revoke\` (1 if + 1 for-loop each)
- \`resource_syncer.go\` — all six RPCs
- \`tickets.go\` — all six RPCs (\`ListTicketSchemas\` has both for-loop and nested-if shadows)

\`actions.go\` was already correct (all error returns come from top-scope multi-assign, which reassigns rather than shadows). \`assets.go\` is a no-op stub with no error paths.

## Test plan

- [x] \`go test -count=1 -short ./pkg/connectorbuilder/...\` passes locally
- [x] \`golangci-lint run --timeout=6m ./pkg/connectorbuilder/...\` clean
- [ ] **Post-merge:** verify in Datadog that \`builder.ListGrants\` / \`builder.ListEntitlements\` / etc. start producing \`status:error\` spans at meaningful rates — query [service:baton-* @ddenv:prod-usw2 status:error](https://us3.datadoghq.com/apm/traces?query=service%3Abaton-*+%40ddenv%3Aprod-usw2+status%3Aerror) and confirm the resource_name distribution broadens beyond \`builder.ListEvents\`.

## Out of scope / follow-ups

- **Lint rule to prevent regression.** A \`ruleguard\` or \`forbidigo\` rule that detects \`err :=\` inside the body of a function with a \`defer ... EndSpanWithError(span, err) ...\` would catch any reintroduction. Worth filing separately — the rule design needs care to avoid false positives on legitimate top-scope reassignment.
- **Regression test.** An in-memory \`SpanExporter\` test that exercises each early-return path would be valuable but requires global otel-provider mocking; pushing on it would expand this PR significantly. Filed as a follow-up.
- **Wrapping vs span fidelity.** Several handlers do \`return resp, fmt.Errorf(\"... failed: %w\", err)\` while the span sees the unwrapped inner error. Mild observability inconsistency; not regressed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)