### PR TITLE
dotc1z: add OTel spans on C1File.Close, saveC1z, rawDb.Close

### DIFF
--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/doug-martin/goqu/v9"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.opentelemetry.io/otel/attribute"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -358,7 +359,10 @@ var checkpointTimeout, _ = strconv.ParseInt(os.Getenv("BATON_WAL_CHECKPOINT_TIME
 // with our changes. The provided context is used for the WAL checkpoint operation. If the context is already expired,
 // a fresh context with a timeout is used to ensure the checkpoint completes.
 func (c *C1File) Close(ctx context.Context) error {
+	ctx, span := tracer.Start(ctx, "C1File.Close")
 	var err error
+	defer func() { uotel.EndSpanWithError(span, err) }()
+
 	l := ctxzap.Extract(ctx)
 
 	c.closedMu.Lock()
@@ -367,6 +371,12 @@ func (c *C1File) Close(ctx context.Context) error {
 		l.Warn("close called on already-closed c1file", zap.String("db_path", c.dbFilePath))
 		return nil
 	}
+
+	span.SetAttributes(
+		attribute.Bool("read_only", c.readOnly),
+		attribute.Bool("db_updated", c.dbUpdated),
+		attribute.String("db_path", c.dbFilePath),
+	)
 
 	if c.rawDb != nil {
 		// CRITICAL: Force a full WAL checkpoint before closing the database.
@@ -427,7 +437,7 @@ func (c *C1File) Close(ctx context.Context) error {
 			}
 		}
 
-		err = c.rawDb.Close()
+		err = c.closeRawDB(ctx)
 		if err != nil {
 			// Drop handle references on the Close-failure path
 			// too. The success-path nil assignments below (kept
@@ -458,7 +468,7 @@ func (c *C1File) Close(ctx context.Context) error {
 			return cleanupDbDir(c.dbFilePath, fmt.Errorf("c1z: WAL file not empty after close (size=%d) - refusing to save incomplete data", walInfo.Size()))
 		}
 
-		err = saveC1z(c.dbFilePath, c.outputFilePath, c.encoderConcurrency)
+		err = c.runSaveC1z(ctx)
 		if err != nil {
 			return cleanupDbDir(c.dbFilePath, err)
 		}
@@ -471,6 +481,34 @@ func (c *C1File) Close(ctx context.Context) error {
 	c.closed = true
 
 	return nil
+}
+
+// closeRawDB wraps c.rawDb.Close with a span so the pure-Go SQLite
+// handle-close cost is visible alongside truncateWAL and saveC1z.
+func (c *C1File) closeRawDB(ctx context.Context) error {
+	_, span := tracer.Start(ctx, "C1File.closeRawDB")
+	var err error
+	defer func() { uotel.EndSpanWithError(span, err) }()
+	err = c.rawDb.Close()
+	return err
+}
+
+// runSaveC1z wraps saveC1z with a span so the zstd recompression to the
+// output c1z file (the heavy work for large databases) is visible.
+func (c *C1File) runSaveC1z(ctx context.Context) error {
+	_, span := tracer.Start(ctx, "C1File.saveC1z")
+	var err error
+	defer func() { uotel.EndSpanWithError(span, err) }()
+	span.SetAttributes(
+		attribute.String("db_path", c.dbFilePath),
+		attribute.String("output_path", c.outputFilePath),
+		attribute.Int("encoder_concurrency", c.encoderConcurrency),
+	)
+	if dbInfo, statErr := os.Stat(c.dbFilePath); statErr == nil {
+		span.SetAttributes(attribute.Int64("input_size_bytes", dbInfo.Size()))
+	}
+	err = saveC1z(c.dbFilePath, c.outputFilePath, c.encoderConcurrency)
+	return err
 }
 
 // truncateWAL truncates the WAL file.

--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -358,11 +358,12 @@ var checkpointTimeout, _ = strconv.ParseInt(os.Getenv("BATON_WAL_CHECKPOINT_TIME
 // Close ensures that the sqlite database is flushed to disk, and if any changes were made we update the original database
 // with our changes. The provided context is used for the WAL checkpoint operation. If the context is already expired,
 // a fresh context with a timeout is used to ensure the checkpoint completes.
-func (c *C1File) Close(ctx context.Context) error {
+//nolint:nonamedreturns // named return required so the deferred span captures all early-return error paths
+func (c *C1File) Close(ctx context.Context) (retErr error) {
 	ctx, span := tracer.Start(ctx, "C1File.Close")
-	var err error
-	defer func() { uotel.EndSpanWithError(span, err) }()
+	defer func() { uotel.EndSpanWithError(span, retErr) }()
 
+	var err error
 	l := ctxzap.Extract(ctx)
 
 	c.closedMu.Lock()

--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -415,12 +415,9 @@ func (c *C1File) Close(ctx context.Context) (retErr error) {
 				l.Error("WAL checkpoint failed before close",
 					zap.Error(err),
 					zap.String("db_path", c.dbFilePath))
-				closeErr := c.rawDb.Close()
-				if closeErr != nil {
+				if closeErr := c.closeRawDB(ctx); closeErr != nil {
 					l.Error("error closing raw db", zap.Error(closeErr))
 				}
-				c.rawDb = nil
-				c.db = nil
 				return cleanupDbDir(c.dbFilePath, fmt.Errorf("c1z: WAL checkpoint failed: %w", err))
 			}
 			if busy != 0 || (log >= 0 && checkpointed < log) {
@@ -429,32 +426,18 @@ func (c *C1File) Close(ctx context.Context) (retErr error) {
 					zap.Int("log", log),
 					zap.Int("checkpointed", checkpointed),
 					zap.String("db_path", c.dbFilePath))
-				closeErr := c.rawDb.Close()
-				if closeErr != nil {
+				if closeErr := c.closeRawDB(ctx); closeErr != nil {
 					l.Error("error closing raw db", zap.Error(closeErr))
 				}
-				c.rawDb = nil
-				c.db = nil
 				return cleanupDbDir(c.dbFilePath, fmt.Errorf("c1z: WAL checkpoint incomplete: busy=%d log=%d checkpointed=%d", busy, log, checkpointed))
 			}
 		}
 
 		err = c.closeRawDB(ctx)
 		if err != nil {
-			// Drop handle references on the Close-failure path
-			// too. The success-path nil assignments below (kept
-			// per the original shape, so validateDb() returns
-			// ErrDbNotOpen) only run if we don't return here, so
-			// without these the failed Close would leave c.rawDb
-			// pointing at a dead handle and validateDb would
-			// report success.
-			c.rawDb = nil
-			c.db = nil
 			return cleanupDbDir(c.dbFilePath, err)
 		}
 	}
-	c.rawDb = nil
-	c.db = nil
 
 	// We only want to save the file if we've made any changes
 	if c.dbUpdated {
@@ -470,7 +453,17 @@ func (c *C1File) Close(ctx context.Context) (retErr error) {
 			return cleanupDbDir(c.dbFilePath, fmt.Errorf("c1z: WAL file not empty after close (size=%d) - refusing to save incomplete data", walInfo.Size()))
 		}
 
-		err = c.runSaveC1z(ctx)
+		_, saveSpan := tracer.Start(ctx, "C1File.saveC1z")
+		saveSpan.SetAttributes(
+			attribute.String("db_path", c.dbFilePath),
+			attribute.String("output_path", c.outputFilePath),
+			attribute.Int("encoder_concurrency", c.encoderConcurrency),
+		)
+		if dbInfo, statErr := os.Stat(c.dbFilePath); statErr == nil {
+			saveSpan.SetAttributes(attribute.Int64("input_size_bytes", dbInfo.Size()))
+		}
+		err = saveC1z(c.dbFilePath, c.outputFilePath, c.encoderConcurrency)
+		uotel.EndSpanWithError(saveSpan, err)
 		if err != nil {
 			return cleanupDbDir(c.dbFilePath, err)
 		}
@@ -485,31 +478,17 @@ func (c *C1File) Close(ctx context.Context) (retErr error) {
 	return nil
 }
 
-// closeRawDB wraps c.rawDb.Close with a span so the pure-Go SQLite
-// handle-close cost is visible alongside truncateWAL and saveC1z.
+// closeRawDB wraps c.rawDb.Close with a span and drops the handle
+// references on the C1File so callers do not have to repeat the
+// nil-out. Returns the error from rawDb.Close so error paths can
+// still propagate or log it.
 func (c *C1File) closeRawDB(ctx context.Context) error {
 	_, span := tracer.Start(ctx, "C1File.closeRawDB")
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 	err = c.rawDb.Close()
-	return err
-}
-
-// runSaveC1z wraps saveC1z with a span so the zstd recompression to the
-// output c1z file (the heavy work for large databases) is visible.
-func (c *C1File) runSaveC1z(ctx context.Context) error {
-	_, span := tracer.Start(ctx, "C1File.saveC1z")
-	var err error
-	defer func() { uotel.EndSpanWithError(span, err) }()
-	span.SetAttributes(
-		attribute.String("db_path", c.dbFilePath),
-		attribute.String("output_path", c.outputFilePath),
-		attribute.Int("encoder_concurrency", c.encoderConcurrency),
-	)
-	if dbInfo, statErr := os.Stat(c.dbFilePath); statErr == nil {
-		span.SetAttributes(attribute.Int64("input_size_bytes", dbInfo.Size()))
-	}
-	err = saveC1z(c.dbFilePath, c.outputFilePath, c.encoderConcurrency)
+	c.rawDb = nil
+	c.db = nil
 	return err
 }
 

--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -358,6 +358,7 @@ var checkpointTimeout, _ = strconv.ParseInt(os.Getenv("BATON_WAL_CHECKPOINT_TIME
 // Close ensures that the sqlite database is flushed to disk, and if any changes were made we update the original database
 // with our changes. The provided context is used for the WAL checkpoint operation. If the context is already expired,
 // a fresh context with a timeout is used to ensure the checkpoint completes.
+//
 //nolint:nonamedreturns // named return required so the deferred span captures all early-return error paths
 func (c *C1File) Close(ctx context.Context) (retErr error) {
 	ctx, span := tracer.Start(ctx, "C1File.Close")


### PR DESCRIPTION
## Summary

Today only the inner WAL truncate is spanned (`C1File.truncateWAL`). The outer `C1File.Close`, the pure-Go SQLite handle close, and `saveC1z` (zstd recompression of the database back into a `.c1z` file) are all unspanned. We cannot answer "is closing the c1z reader slow?" with a single Datadog query — the hypothesis raised by Geoff Greer during a recent prod investigation.

Wrap with `tracer.Start` + `uotel.EndSpanWithError`:

- `C1File.Close` (outer) — top-level operation
- `C1File.closeRawDB` — pure-Go SQLite handle close (the normal-path one at line 430; error-path closes at 406/420 stay direct since they're already inside the parent Close span and only fire on WAL checkpoint failure)
- `C1File.saveC1z` — zstd recompression on writer path

Attributes on `Close`: `read_only`, `db_updated`, `db_path`. Attributes on `saveC1z`: `db_path`, `output_path`, `encoder_concurrency`, `input_size_bytes` (from `os.Stat` of the SQLite file before compression).

No behavior changes; `saveC1z` keeps its current signature.

## Test plan

- [ ] CI green
- [ ] After vendor-bump into c1 and deploy to prod-usw2, verify spans appear in be-temporal-sync:
  - `@operation_name:C1File.Close env:prod-usw2 service:be-temporal-sync`
  - `@operation_name:C1File.saveC1z env:prod-usw2`
- [ ] Compare p99 duration of `C1File.Close` for `@db_updated:true` (writer/sync) vs `@db_updated:false` (read-only/uplift). Geoff's hypothesis is that the writer-side close (saveC1z driven) is the slow one.

## Note on pre-existing test failures

`TestPutResources` and `TestGrantStatsGroupByParity` fail on plain `main` too with `unable to open database file (14)` — pre-existing flake in this repo's test environment, unrelated to this change.

## Companion PR (c1)

A companion platform-repo PR adds spans around the c1-side wrappers (`connectorReaderCache.{Get, Close, evictApp, evictConnector}`, `runStore.{getOrFetchArtifact, fetchArtifact, Close}`). The two together give us end-to-end visibility on the uplift reader-close path.

Refs OPS-1564.
