### PR TITLE
Add opaque connector config version

### DIFF
--- a/pb/c1/connectorapi/baton/v1/config.pb.go
+++ b/pb/c1/connectorapi/baton/v1/config.pb.go
@@ -84,6 +84,7 @@ type GetConnectorConfigResponse struct {
 	state         protoimpl.MessageState `protogen:"hybrid.v1"`
 	Config        []byte                 `protobuf:"bytes,1,opt,name=config,proto3" json:"config,omitempty"`
 	LastUpdated   *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=last_updated,json=lastUpdated,proto3" json:"last_updated,omitempty"`
+	Version       string                 `protobuf:"bytes,3,opt,name=version,proto3" json:"version,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -127,6 +128,13 @@ func (x *GetConnectorConfigResponse) GetLastUpdated() *timestamppb.Timestamp {
 	return nil
 }
 
+func (x *GetConnectorConfigResponse) GetVersion() string {
+	if x != nil {
+		return x.Version
+	}
+	return ""
+}
+
 func (x *GetConnectorConfigResponse) SetConfig(v []byte) {
 	if v == nil {
 		v = []byte{}
@@ -136,6 +144,10 @@ func (x *GetConnectorConfigResponse) SetConfig(v []byte) {
 
 func (x *GetConnectorConfigResponse) SetLastUpdated(v *timestamppb.Timestamp) {
 	x.LastUpdated = v
+}
+
+func (x *GetConnectorConfigResponse) SetVersion(v string) {
+	x.Version = v
 }
 
 func (x *GetConnectorConfigResponse) HasLastUpdated() bool {
@@ -154,6 +166,7 @@ type GetConnectorConfigResponse_builder struct {
 
 	Config      []byte
 	LastUpdated *timestamppb.Timestamp
+	Version     string
 }
 
 func (b0 GetConnectorConfigResponse_builder) Build() *GetConnectorConfigResponse {
@@ -162,6 +175,7 @@ func (b0 GetConnectorConfigResponse_builder) Build() *GetConnectorConfigResponse
 	_, _ = b, x
 	x.Config = b.Config
 	x.LastUpdated = b.LastUpdated
+	x.Version = b.Version
 	return m0
 }
 
@@ -447,10 +461,11 @@ const file_c1_connectorapi_baton_v1_config_proto_rawDesc = "" +
 	"\n" +
 	"%c1/connectorapi/baton/v1/config.proto\x12\x18c1.connectorapi.baton.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"H\n" +
 	"\x19GetConnectorConfigRequest\x12+\n" +
-	"\x11requested_version\x18\x01 \x01(\tR\x10requestedVersion\"s\n" +
+	"\x11requested_version\x18\x01 \x01(\tR\x10requestedVersion\"\x8d\x01\n" +
 	"\x1aGetConnectorConfigResponse\x12\x16\n" +
 	"\x06config\x18\x01 \x01(\fR\x06config\x12=\n" +
-	"\flast_updated\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\vlastUpdated\"6\n" +
+	"\flast_updated\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\vlastUpdated\x12\x18\n" +
+	"\aversion\x18\x03 \x01(\tR\aversion\"6\n" +
 	"\fSignedHeader\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x03(\tR\x05value\"\xb2\x01\n" +

--- a/pb/c1/connectorapi/baton/v1/config.pb.validate.go
+++ b/pb/c1/connectorapi/baton/v1/config.pb.validate.go
@@ -192,6 +192,8 @@ func (m *GetConnectorConfigResponse) validate(all bool) error {
 		}
 	}
 
+	// no validation rules for Version
+
 	if len(errors) > 0 {
 		return GetConnectorConfigResponseMultiError(errors)
 	}

--- a/pb/c1/connectorapi/baton/v1/config_protoopaque.pb.go
+++ b/pb/c1/connectorapi/baton/v1/config_protoopaque.pb.go
@@ -84,6 +84,7 @@ type GetConnectorConfigResponse struct {
 	state                  protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_Config      []byte                 `protobuf:"bytes,1,opt,name=config,proto3"`
 	xxx_hidden_LastUpdated *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=last_updated,json=lastUpdated,proto3"`
+	xxx_hidden_Version     string                 `protobuf:"bytes,3,opt,name=version,proto3"`
 	unknownFields          protoimpl.UnknownFields
 	sizeCache              protoimpl.SizeCache
 }
@@ -127,6 +128,13 @@ func (x *GetConnectorConfigResponse) GetLastUpdated() *timestamppb.Timestamp {
 	return nil
 }
 
+func (x *GetConnectorConfigResponse) GetVersion() string {
+	if x != nil {
+		return x.xxx_hidden_Version
+	}
+	return ""
+}
+
 func (x *GetConnectorConfigResponse) SetConfig(v []byte) {
 	if v == nil {
 		v = []byte{}
@@ -136,6 +144,10 @@ func (x *GetConnectorConfigResponse) SetConfig(v []byte) {
 
 func (x *GetConnectorConfigResponse) SetLastUpdated(v *timestamppb.Timestamp) {
 	x.xxx_hidden_LastUpdated = v
+}
+
+func (x *GetConnectorConfigResponse) SetVersion(v string) {
+	x.xxx_hidden_Version = v
 }
 
 func (x *GetConnectorConfigResponse) HasLastUpdated() bool {
@@ -154,6 +166,7 @@ type GetConnectorConfigResponse_builder struct {
 
 	Config      []byte
 	LastUpdated *timestamppb.Timestamp
+	Version     string
 }
 
 func (b0 GetConnectorConfigResponse_builder) Build() *GetConnectorConfigResponse {
@@ -162,6 +175,7 @@ func (b0 GetConnectorConfigResponse_builder) Build() *GetConnectorConfigResponse
 	_, _ = b, x
 	x.xxx_hidden_Config = b.Config
 	x.xxx_hidden_LastUpdated = b.LastUpdated
+	x.xxx_hidden_Version = b.Version
 	return m0
 }
 
@@ -449,10 +463,11 @@ const file_c1_connectorapi_baton_v1_config_proto_rawDesc = "" +
 	"\n" +
 	"%c1/connectorapi/baton/v1/config.proto\x12\x18c1.connectorapi.baton.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"H\n" +
 	"\x19GetConnectorConfigRequest\x12+\n" +
-	"\x11requested_version\x18\x01 \x01(\tR\x10requestedVersion\"s\n" +
+	"\x11requested_version\x18\x01 \x01(\tR\x10requestedVersion\"\x8d\x01\n" +
 	"\x1aGetConnectorConfigResponse\x12\x16\n" +
 	"\x06config\x18\x01 \x01(\fR\x06config\x12=\n" +
-	"\flast_updated\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\vlastUpdated\"6\n" +
+	"\flast_updated\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\vlastUpdated\x12\x18\n" +
+	"\aversion\x18\x03 \x01(\tR\aversion\"6\n" +
 	"\fSignedHeader\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x03(\tR\x05value\"\xb2\x01\n" +

--- a/pkg/cli/lambda_server__added.go
+++ b/pkg/cli/lambda_server__added.go
@@ -443,7 +443,13 @@ func OptionallyAddLambdaCommand[T field.Configurable](
 }
 
 func lambdaConnectorConfigVersion(config *v1.GetConnectorConfigResponse) string {
-	if config == nil || config.GetLastUpdated() == nil {
+	if config == nil {
+		return ""
+	}
+	if config.GetVersion() != "" {
+		return config.GetVersion()
+	}
+	if config.GetLastUpdated() == nil {
 		return ""
 	}
 	return config.GetLastUpdated().AsTime().UTC().Format(time.RFC3339Nano)

--- a/pkg/cli/lambda_server__added_test.go
+++ b/pkg/cli/lambda_server__added_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 	"time"
 
+	v1 "github.com/conductorone/baton-sdk/pb/c1/connectorapi/baton/v1"
 	"github.com/spf13/viper"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestLambdaLogLevelConfigExpiresDebug(t *testing.T) {
@@ -51,5 +53,44 @@ func TestLambdaLogLevelConfigRejectsInvalidLevel(t *testing.T) {
 
 	if _, err := lambdaLogLevelConfigFromViper(v); err == nil {
 		t.Fatal("expected invalid log level to fail")
+	}
+}
+
+func TestLambdaConnectorConfigVersionPrefersOpaqueVersion(t *testing.T) {
+	t.Parallel()
+
+	lastUpdated := time.Date(2026, 5, 19, 15, 0, 0, 123, time.UTC)
+	config := &v1.GetConnectorConfigResponse{
+		LastUpdated: timestamppb.New(lastUpdated),
+		Version:     "runtime=7;deployment=dep-1:sha256:abc;config=2026-05-19T15:00:00Z",
+	}
+
+	if got := lambdaConnectorConfigVersion(config); got != config.Version {
+		t.Fatalf("lambdaConnectorConfigVersion = %q, want %q", got, config.Version)
+	}
+}
+
+func TestLambdaConnectorConfigVersionFallsBackToLastUpdated(t *testing.T) {
+	t.Parallel()
+
+	lastUpdated := time.Date(2026, 5, 19, 15, 0, 0, 123, time.UTC)
+	config := &v1.GetConnectorConfigResponse{
+		LastUpdated: timestamppb.New(lastUpdated),
+	}
+
+	want := "2026-05-19T15:00:00.000000123Z"
+	if got := lambdaConnectorConfigVersion(config); got != want {
+		t.Fatalf("lambdaConnectorConfigVersion = %q, want %q", got, want)
+	}
+}
+
+func TestLambdaConnectorConfigVersionHandlesEmptyConfig(t *testing.T) {
+	t.Parallel()
+
+	if got := lambdaConnectorConfigVersion(nil); got != "" {
+		t.Fatalf("lambdaConnectorConfigVersion(nil) = %q, want empty", got)
+	}
+	if got := lambdaConnectorConfigVersion(&v1.GetConnectorConfigResponse{}); got != "" {
+		t.Fatalf("lambdaConnectorConfigVersion(empty) = %q, want empty", got)
 	}
 }

--- a/proto/c1/connectorapi/baton/v1/config.proto
+++ b/proto/c1/connectorapi/baton/v1/config.proto
@@ -18,6 +18,7 @@ message GetConnectorConfigRequest {
 message GetConnectorConfigResponse {
   bytes config = 1;
   google.protobuf.Timestamp last_updated = 2;
+  string version = 3;
 }
 
 message SignedHeader {


### PR DESCRIPTION
**Why**

C1 needs to stop treating connector config versions as timestamps once runtime-backed Lambdas use logical runtime state. The SDK already compares invoke versions as strings, but cold start still initialized the current generation from `last_updated`, forcing C1 to keep returning timestamp-shaped versions.

**What this changes**

Adds an opaque `version` field to `GetConnectorConfigResponse` and makes Lambda cold start prefer it when present. Older servers remain compatible because the SDK still falls back to `last_updated`.

**Testing**

- `make protogen`
- `buf lint`
- `buf breaking --against 'https://github.com/conductorone/baton-sdk.git#branch=main'`
- `go test -tags=baton_lambda_support -v ./pkg/cli ./pkg/lambda/grpc`
- `git diff --check`

`make lint` currently reports existing gosec findings outside this change.
