### PR TITLE
feat(otel): break sync mega-traces with per-action linked roots

### DIFF
--- a/pkg/dotc1z/sql_helpers.go
+++ b/pkg/dotc1z/sql_helpers.go
@@ -593,11 +593,10 @@ func bulkPutConnectorObjectIfNewer[T proto.Message](
 }
 
 func (c *C1File) getResourceObject(ctx context.Context, resourceID *v2.ResourceId, m *v2.Resource, syncID string) error {
-	ctx, span := tracer.Start(ctx, "C1File.getResourceObject")
-	var err error
-	defer func() { uotel.EndSpanWithError(span, err) }()
-
-	err = c.validateDb(ctx)
+	// No span here: this function is always called from C1File.GetResource
+	// which already owns a span. The duplicate emitted one span per
+	// resource-fetch and was a top contributor to mega-trace span counts.
+	err := c.validateDb(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -47,9 +47,10 @@ func NewRetryer(ctx context.Context, config RetryConfig) *Retryer {
 }
 
 func (r *Retryer) ShouldWaitAndRetry(ctx context.Context, err error) bool {
-	ctx, span := tracer.Start(ctx, "retry.ShouldWaitAndRetry")
-	defer span.End()
-
+	// Fast paths that are not actually retrying skip span emission. The
+	// success path is hit once per completed action in the syncer loop,
+	// which historically inflated long-running sync traces by thousands
+	// of no-op spans.
 	if err == nil {
 		r.mu.Lock()
 		r.attempts = 0
@@ -59,6 +60,9 @@ func (r *Retryer) ShouldWaitAndRetry(ctx context.Context, err error) bool {
 	if status.Code(err) != codes.Unavailable && status.Code(err) != codes.DeadlineExceeded {
 		return false
 	}
+
+	ctx, span := tracer.Start(ctx, "retry.ShouldWaitAndRetry")
+	defer span.End()
 
 	r.mu.Lock()
 	r.attempts++

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -573,7 +573,7 @@ func (s *syncer) listAllResourceTypes(ctx context.Context) iter.Seq2[[]*v2.Resou
 
 // SyncResourceTypes calls the ListResourceType() connector endpoint and persists the results in to the datasource.
 func (s *syncer) SyncResourceTypes(ctx context.Context, action *Action) error {
-	ctx, span := tracer.Start(ctx, "syncer.SyncResourceTypes")
+	ctx, span := uotel.StartLinkedRoot(ctx, tracer, "syncer.SyncResourceTypes")
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
@@ -714,7 +714,7 @@ func (s *syncer) getResourceFromConnector(ctx context.Context, resourceID *v2.Re
 }
 
 func (s *syncer) SyncTargetedResource(ctx context.Context, action *Action) error {
-	ctx, span := tracer.Start(ctx, "syncer.SyncTargetedResource")
+	ctx, span := uotel.StartLinkedRoot(ctx, tracer, "syncer.SyncTargetedResource")
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
@@ -793,7 +793,7 @@ func (s *syncer) SyncTargetedResource(ctx context.Context, action *Action) error
 // SyncResources handles fetching all of the resources from the connector given the provided resource types. For each
 // resource, we gather any child resource types it may emit, and traverse the resource tree.
 func (s *syncer) SyncResources(ctx context.Context, action *Action) error {
-	ctx, span := tracer.Start(ctx, "syncer.SyncResources")
+	ctx, span := uotel.StartLinkedRoot(ctx, tracer, "syncer.SyncResources")
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
@@ -1050,7 +1050,7 @@ func (s *syncer) shouldSkipEntitlements(ctx context.Context, r *v2.Resource) (bo
 // SyncEntitlements fetches the entitlements from the connector. It first lists each resource from the datastore,
 // and pushes an action to fetch the entitlements for each resource.
 func (s *syncer) SyncEntitlements(ctx context.Context, action *Action) error {
-	ctx, span := tracer.Start(ctx, "syncer.SyncEntitlements")
+	ctx, span := uotel.StartLinkedRoot(ctx, tracer, "syncer.SyncEntitlements")
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
@@ -1132,7 +1132,7 @@ func (s *syncer) syncEntitlementsForResource(ctx context.Context, action *Action
 }
 
 func (s *syncer) SyncStaticEntitlements(ctx context.Context, action *Action) error {
-	ctx, span := tracer.Start(ctx, "syncer.SyncStaticEntitlements")
+	ctx, span := uotel.StartLinkedRoot(ctx, tracer, "syncer.SyncStaticEntitlements")
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
@@ -1345,7 +1345,7 @@ func (s *syncer) syncAssetsForResource(ctx context.Context, action *Action) erro
 
 // SyncAssets iterates each resource in the data store, and adds an action to fetch all of the assets for that resource.
 func (s *syncer) SyncAssets(ctx context.Context, action *Action) error {
-	ctx, span := tracer.Start(ctx, "syncer.SyncAssets")
+	ctx, span := uotel.StartLinkedRoot(ctx, tracer, "syncer.SyncAssets")
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
@@ -1380,7 +1380,7 @@ func (s *syncer) SyncAssets(ctx context.Context, action *Action) error {
 // SyncGrantExpansion handles the grant expansion phase of sync.
 // It first loads the entitlement graph from grants, fixes any cycles, then runs expansion.
 func (s *syncer) SyncGrantExpansion(ctx context.Context, action *Action) error {
-	ctx, span := tracer.Start(ctx, "syncer.SyncGrantExpansion")
+	ctx, span := uotel.StartLinkedRoot(ctx, tracer, "syncer.SyncGrantExpansion")
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
@@ -1521,7 +1521,7 @@ func (s *syncer) fixEntitlementGraphCycles(ctx context.Context, graph *expand.En
 // SyncGrants fetches the grants for each resource from the connector. It iterates each resource
 // from the datastore, and pushes a new action to sync the grants for each individual resource.
 func (s *syncer) SyncGrants(ctx context.Context, action *Action) error {
-	ctx, span := tracer.Start(ctx, "syncer.SyncGrants")
+	ctx, span := uotel.StartLinkedRoot(ctx, tracer, "syncer.SyncGrants")
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
@@ -1859,7 +1859,7 @@ func (s *syncer) syncGrantsForResource(ctx context.Context, action *Action) erro
 }
 
 func (s *syncer) SyncExternalResources(ctx context.Context, action *Action) error {
-	ctx, span := tracer.Start(ctx, "syncer.SyncExternalResources")
+	ctx, span := uotel.StartLinkedRoot(ctx, tracer, "syncer.SyncExternalResources")
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -573,7 +573,7 @@ func (s *syncer) listAllResourceTypes(ctx context.Context) iter.Seq2[[]*v2.Resou
 
 // SyncResourceTypes calls the ListResourceType() connector endpoint and persists the results in to the datasource.
 func (s *syncer) SyncResourceTypes(ctx context.Context, action *Action) error {
-	ctx, span := uotel.StartLinkedRoot(ctx, tracer, "syncer.SyncResourceTypes")
+	ctx, span := uotel.StartWithLink(ctx, tracer, "syncer.SyncResourceTypes")
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
@@ -714,7 +714,7 @@ func (s *syncer) getResourceFromConnector(ctx context.Context, resourceID *v2.Re
 }
 
 func (s *syncer) SyncTargetedResource(ctx context.Context, action *Action) error {
-	ctx, span := uotel.StartLinkedRoot(ctx, tracer, "syncer.SyncTargetedResource")
+	ctx, span := uotel.StartWithLink(ctx, tracer, "syncer.SyncTargetedResource")
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
@@ -793,7 +793,7 @@ func (s *syncer) SyncTargetedResource(ctx context.Context, action *Action) error
 // SyncResources handles fetching all of the resources from the connector given the provided resource types. For each
 // resource, we gather any child resource types it may emit, and traverse the resource tree.
 func (s *syncer) SyncResources(ctx context.Context, action *Action) error {
-	ctx, span := uotel.StartLinkedRoot(ctx, tracer, "syncer.SyncResources")
+	ctx, span := uotel.StartWithLink(ctx, tracer, "syncer.SyncResources")
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
@@ -1050,7 +1050,7 @@ func (s *syncer) shouldSkipEntitlements(ctx context.Context, r *v2.Resource) (bo
 // SyncEntitlements fetches the entitlements from the connector. It first lists each resource from the datastore,
 // and pushes an action to fetch the entitlements for each resource.
 func (s *syncer) SyncEntitlements(ctx context.Context, action *Action) error {
-	ctx, span := uotel.StartLinkedRoot(ctx, tracer, "syncer.SyncEntitlements")
+	ctx, span := uotel.StartWithLink(ctx, tracer, "syncer.SyncEntitlements")
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
@@ -1132,7 +1132,7 @@ func (s *syncer) syncEntitlementsForResource(ctx context.Context, action *Action
 }
 
 func (s *syncer) SyncStaticEntitlements(ctx context.Context, action *Action) error {
-	ctx, span := uotel.StartLinkedRoot(ctx, tracer, "syncer.SyncStaticEntitlements")
+	ctx, span := uotel.StartWithLink(ctx, tracer, "syncer.SyncStaticEntitlements")
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
@@ -1345,7 +1345,7 @@ func (s *syncer) syncAssetsForResource(ctx context.Context, action *Action) erro
 
 // SyncAssets iterates each resource in the data store, and adds an action to fetch all of the assets for that resource.
 func (s *syncer) SyncAssets(ctx context.Context, action *Action) error {
-	ctx, span := uotel.StartLinkedRoot(ctx, tracer, "syncer.SyncAssets")
+	ctx, span := uotel.StartWithLink(ctx, tracer, "syncer.SyncAssets")
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
@@ -1380,7 +1380,7 @@ func (s *syncer) SyncAssets(ctx context.Context, action *Action) error {
 // SyncGrantExpansion handles the grant expansion phase of sync.
 // It first loads the entitlement graph from grants, fixes any cycles, then runs expansion.
 func (s *syncer) SyncGrantExpansion(ctx context.Context, action *Action) error {
-	ctx, span := uotel.StartLinkedRoot(ctx, tracer, "syncer.SyncGrantExpansion")
+	ctx, span := uotel.StartWithLink(ctx, tracer, "syncer.SyncGrantExpansion")
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
@@ -1521,7 +1521,7 @@ func (s *syncer) fixEntitlementGraphCycles(ctx context.Context, graph *expand.En
 // SyncGrants fetches the grants for each resource from the connector. It iterates each resource
 // from the datastore, and pushes a new action to sync the grants for each individual resource.
 func (s *syncer) SyncGrants(ctx context.Context, action *Action) error {
-	ctx, span := uotel.StartLinkedRoot(ctx, tracer, "syncer.SyncGrants")
+	ctx, span := uotel.StartWithLink(ctx, tracer, "syncer.SyncGrants")
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
@@ -1859,7 +1859,7 @@ func (s *syncer) syncGrantsForResource(ctx context.Context, action *Action) erro
 }
 
 func (s *syncer) SyncExternalResources(ctx context.Context, action *Action) error {
-	ctx, span := uotel.StartLinkedRoot(ctx, tracer, "syncer.SyncExternalResources")
+	ctx, span := uotel.StartWithLink(ctx, tracer, "syncer.SyncExternalResources")
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 

--- a/pkg/uotel/span_helpers.go
+++ b/pkg/uotel/span_helpers.go
@@ -10,6 +10,29 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// StartLinkedRoot starts a new root span linked to the current span in ctx.
+//
+// When ctx already carries a valid span context, the new span is started with
+// trace.WithNewRoot() and a trace.Link back to that span. This breaks the
+// causal chain into a new trace while preserving navigability via the link,
+// and is the recommended way to bound the size of long-running traces (e.g.
+// per-iteration spans inside a loop that processes thousands of items under
+// a single root).
+//
+// If ctx has no span context, this behaves identically to tracer.Start.
+func StartLinkedRoot(
+	ctx context.Context,
+	tracer trace.Tracer,
+	name string,
+	opts ...trace.SpanStartOption,
+) (context.Context, trace.Span) {
+	parentSpanCtx := trace.SpanContextFromContext(ctx)
+	if parentSpanCtx.IsValid() {
+		opts = append(opts, trace.WithNewRoot(), trace.WithLinks(trace.Link{SpanContext: parentSpanCtx}))
+	}
+	return tracer.Start(ctx, name, opts...)
+}
+
 // IsExpectedError returns true for errors that are expected during normal
 // operation and should not be recorded as span errors.
 func IsExpectedError(err error) bool {

--- a/pkg/uotel/span_helpers.go
+++ b/pkg/uotel/span_helpers.go
@@ -10,17 +10,22 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// StartLinkedRoot starts a new root span linked to the current span in ctx.
+// StartWithLink starts a new root span linked to the current span in ctx.
 //
 // When ctx already carries a valid span context, the new span is started with
 // trace.WithNewRoot() and a trace.Link back to that span. This breaks the
-// causal chain into a new trace while preserving navigability via the link,
-// and is the recommended way to bound the size of long-running traces (e.g.
-// per-iteration spans inside a loop that processes thousands of items under
-// a single root).
+// causal chain into a new trace while preserving navigability via the link.
 //
-// If ctx has no span context, this behaves identically to tracer.Start.
-func StartLinkedRoot(
+// Prefer plain tracer.Start for ordinary nested spans. Reach for this only
+// when an outer span would otherwise accumulate hundreds or thousands of
+// children — e.g. a long-running loop that processes each item via a chain
+// of helper spans. Mirrors ctxotel.StartWithLink in the ConductorOne
+// platform repo.
+//
+// Safe to call with the no-op tracer or with a ctx that has no span: the
+// link is omitted and behavior matches tracer.Start. The returned ctx
+// carries the new span, so descendants attach to the new root.
+func StartWithLink(
 	ctx context.Context,
 	tracer trace.Tracer,
 	name string,

--- a/pkg/uotel/span_helpers_test.go
+++ b/pkg/uotel/span_helpers_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"testing"
 
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -36,3 +38,75 @@ func TestIsExpectedError(t *testing.T) {
 		})
 	}
 }
+
+// recordingProcessor is a minimal SpanProcessor that captures ReadOnlySpans
+// so tests can assert on their links/parent without depending on
+// otel/sdk/trace/tracetest (not vendored).
+type recordingProcessor struct {
+	ended []sdktrace.ReadOnlySpan
+}
+
+func (p *recordingProcessor) OnStart(context.Context, sdktrace.ReadWriteSpan) {}
+func (p *recordingProcessor) OnEnd(s sdktrace.ReadOnlySpan)                   { p.ended = append(p.ended, s) }
+func (p *recordingProcessor) Shutdown(context.Context) error                  { return nil }
+func (p *recordingProcessor) ForceFlush(context.Context) error                { return nil }
+
+func TestStartLinkedRoot(t *testing.T) {
+	rec := &recordingProcessor{}
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+	tracer := tp.Tracer("test")
+
+	t.Run("with parent span produces new root with link", func(t *testing.T) {
+		rec.ended = nil
+
+		ctx, parent := tracer.Start(context.Background(), "parent")
+		parentTraceID := parent.SpanContext().TraceID()
+
+		_, child := StartLinkedRoot(ctx, tracer, "child")
+		child.End()
+		parent.End()
+
+		var childSpan sdktrace.ReadOnlySpan
+		for _, s := range rec.ended {
+			if s.Name() == "child" {
+				childSpan = s
+			}
+		}
+		if childSpan == nil {
+			t.Fatal("child span not recorded")
+		}
+		if childSpan.SpanContext().TraceID() == parentTraceID {
+			t.Errorf("expected new trace ID, got same as parent: %s", parentTraceID)
+		}
+		if childSpan.Parent().IsValid() {
+			t.Errorf("expected no parent span ID, got %s", childSpan.Parent().SpanID())
+		}
+		links := childSpan.Links()
+		if len(links) != 1 {
+			t.Fatalf("expected 1 link to parent, got %d", len(links))
+		}
+		if links[0].SpanContext.TraceID() != parentTraceID {
+			t.Errorf("expected link to parent trace %s, got %s", parentTraceID, links[0].SpanContext.TraceID())
+		}
+	})
+
+	t.Run("without parent span behaves like normal Start", func(t *testing.T) {
+		rec.ended = nil
+
+		_, span := StartLinkedRoot(context.Background(), tracer, "orphan")
+		span.End()
+
+		if len(rec.ended) != 1 {
+			t.Fatalf("expected 1 span, got %d", len(rec.ended))
+		}
+		if len(rec.ended[0].Links()) != 0 {
+			t.Errorf("expected no links for orphan span, got %d", len(rec.ended[0].Links()))
+		}
+		if !rec.ended[0].SpanContext().IsValid() {
+			t.Errorf("expected valid span context")
+		}
+	})
+}
+
+// Reference trace package to make the import explicit beyond the embedded use.
+var _ = trace.SpanContextFromContext

--- a/pkg/uotel/span_helpers_test.go
+++ b/pkg/uotel/span_helpers_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"testing"
 
+	"go.opentelemetry.io/otel/attribute"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc/codes"
@@ -51,27 +52,30 @@ func (p *recordingProcessor) OnEnd(s sdktrace.ReadOnlySpan)                   { 
 func (p *recordingProcessor) Shutdown(context.Context) error                  { return nil }
 func (p *recordingProcessor) ForceFlush(context.Context) error                { return nil }
 
-func TestStartLinkedRoot(t *testing.T) {
-	rec := &recordingProcessor{}
-	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
-	tracer := tp.Tracer("test")
+// findSpan returns the first recorded span with the given name.
+func findSpan(rec *recordingProcessor, name string) sdktrace.ReadOnlySpan {
+	for _, s := range rec.ended {
+		if s.Name() == name {
+			return s
+		}
+	}
+	return nil
+}
 
+func TestStartWithLink(t *testing.T) {
 	t.Run("with parent span produces new root with link", func(t *testing.T) {
-		rec.ended = nil
+		rec := &recordingProcessor{}
+		tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+		tracer := tp.Tracer("test")
 
 		ctx, parent := tracer.Start(context.Background(), "parent")
 		parentTraceID := parent.SpanContext().TraceID()
 
-		_, child := StartLinkedRoot(ctx, tracer, "child")
+		_, child := StartWithLink(ctx, tracer, "child")
 		child.End()
 		parent.End()
 
-		var childSpan sdktrace.ReadOnlySpan
-		for _, s := range rec.ended {
-			if s.Name() == "child" {
-				childSpan = s
-			}
-		}
+		childSpan := findSpan(rec, "child")
 		if childSpan == nil {
 			t.Fatal("child span not recorded")
 		}
@@ -91,9 +95,16 @@ func TestStartLinkedRoot(t *testing.T) {
 	})
 
 	t.Run("without parent span behaves like normal Start", func(t *testing.T) {
-		rec.ended = nil
+		rec := &recordingProcessor{}
+		tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+		tracer := tp.Tracer("test")
 
-		_, span := StartLinkedRoot(context.Background(), tracer, "orphan")
+		ctx := context.Background()
+		if trace.SpanContextFromContext(ctx).IsValid() {
+			t.Fatal("background context should not carry a valid span context")
+		}
+
+		_, span := StartWithLink(ctx, tracer, "orphan")
 		span.End()
 
 		if len(rec.ended) != 1 {
@@ -106,7 +117,83 @@ func TestStartLinkedRoot(t *testing.T) {
 			t.Errorf("expected valid span context")
 		}
 	})
-}
 
-// Reference trace package to make the import explicit beyond the embedded use.
-var _ = trace.SpanContextFromContext
+	t.Run("caller-supplied SpanStartOptions are preserved", func(t *testing.T) {
+		rec := &recordingProcessor{}
+		tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+		tracer := tp.Tracer("test")
+
+		ctx, parent := tracer.Start(context.Background(), "parent")
+		_, child := StartWithLink(ctx, tracer, "child",
+			trace.WithAttributes(attribute.String("custom", "val")),
+			trace.WithSpanKind(trace.SpanKindClient),
+		)
+		child.End()
+		parent.End()
+
+		childSpan := findSpan(rec, "child")
+		if childSpan == nil {
+			t.Fatal("child span not recorded")
+		}
+
+		var gotCustom string
+		for _, attr := range childSpan.Attributes() {
+			if attr.Key == "custom" {
+				gotCustom = attr.Value.AsString()
+			}
+		}
+		if gotCustom != "val" {
+			t.Errorf("expected attribute custom=val to pass through, got %q", gotCustom)
+		}
+		if childSpan.SpanKind() != trace.SpanKindClient {
+			t.Errorf("expected SpanKindClient, got %v", childSpan.SpanKind())
+		}
+		if len(childSpan.Links()) != 1 {
+			t.Errorf("expected 1 link (parent), got %d", len(childSpan.Links()))
+		}
+	})
+
+	t.Run("caller-supplied links are additive with the parent link", func(t *testing.T) {
+		rec := &recordingProcessor{}
+		tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+		tracer := tp.Tracer("test")
+
+		// Build a synthetic link target by starting and ending an unrelated span.
+		_, other := tracer.Start(context.Background(), "other")
+		otherSC := other.SpanContext()
+		other.End()
+
+		ctx, parent := tracer.Start(context.Background(), "parent")
+		parentTraceID := parent.SpanContext().TraceID()
+
+		_, child := StartWithLink(ctx, tracer, "child",
+			trace.WithLinks(trace.Link{SpanContext: otherSC}),
+		)
+		child.End()
+		parent.End()
+
+		childSpan := findSpan(rec, "child")
+		if childSpan == nil {
+			t.Fatal("child span not recorded")
+		}
+		links := childSpan.Links()
+		if len(links) != 2 {
+			t.Fatalf("expected 2 links (caller-supplied + parent), got %d", len(links))
+		}
+		var sawOther, sawParent bool
+		for _, l := range links {
+			switch l.SpanContext.TraceID() {
+			case otherSC.TraceID():
+				sawOther = true
+			case parentTraceID:
+				sawParent = true
+			}
+		}
+		if !sawOther {
+			t.Errorf("expected caller-supplied link to be preserved")
+		}
+		if !sawParent {
+			t.Errorf("expected parent link to be added")
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- A single `connector_sync` activity was producing Datadog traces with 100k+ spans (sampled 105,425 and 107,352 in `be-temporal-sync`), all hanging off the `syncer.Sync` root. Recent OTel PRs (#748/#749/#750) instrumented every sync entry point and the per-resource `SyncGrants` (~5k/sync) and `SyncEntitlements` (~3k/sync) actions each fan out ~30 child spans, exploding the trace.
- New `uotel.StartLinkedRoot(ctx, tracer, name, ...)` helper: when ctx already has a valid span, it starts the new span with `trace.WithNewRoot()` and a `trace.Link` back to the parent so each invocation becomes its own trace while remaining navigable from the originating sync.
- Applied at the nine per-action entry points dispatched from `sequentialSync`/`parallelSync`: `SyncResourceTypes`, `SyncResources`, `SyncTargetedResource`, `SyncStaticEntitlements`, `SyncEntitlements`, `SyncGrants`, `SyncGrantExpansion`, `SyncAssets`, `SyncExternalResources`.
- Two cleanups for top span-count contributors that were emitting nothing useful:
  - `retry.ShouldWaitAndRetry` now only emits a span when actually retrying. The success fast path (err==nil) fired once per completed action, adding ~8k no-op spans per sync.
  - `C1File.getResourceObject` no longer emits its own span — it is always wrapped by `C1File.GetResource`, which already owns one. The redundant pair was ~20k spans/sync each.

Sample mega traces:
- [842d844d7785af75315d41445f506b77](https://us3.datadoghq.com/apm/trace/842d844d7785af75315d41445f506b77) — 105,425 spans, 16 min sync
- [8e11dabaa02a9e70352ede094e10f5d2](https://us3.datadoghq.com/apm/trace/8e11dabaa02a9e70352ede094e10f5d2) — 107,352 spans, 14 min sync

Expected effect on the sample trace: ~30k spans eliminated outright; the remainder split into ~8k small per-action traces (each ~30 spans), each linked back to the originating `syncer.Sync` so causality is preserved.

## Test plan
- [x] `go test ./pkg/uotel/... ./pkg/retry/... ./pkg/sync/... ./pkg/dotc1z/...` passes locally
- [x] New unit test `TestStartLinkedRoot` verifies new-trace-id + link-back behavior using a local `SpanProcessor` recorder (`tracetest` isn't vendored)
- [x] `golangci-lint run` on changed files surfaces no new issues (only pre-existing failures in unrelated files)
- [ ] After merge, confirm in Datadog that new `syncer.Sync` traces have only a handful of children and that the per-action sub-traces (e.g. `syncer.SyncGrants`, `syncer.SyncEntitlements`) are independent traces with a `Link` to the originating `syncer.Sync` span

🤖 Generated with [Claude Code](https://claude.com/claude-code)