### PR TITLE
otel: drop spans on trivial in-memory syncer helpers

### DIFF
--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -651,11 +651,10 @@ func (s *syncer) hasChildResources(resource *v2.Resource) bool {
 }
 
 // getSubResources fetches the sub resource types from a resources' annotations.
+// No span here: this is per-resource in-memory annotation iteration with no I/O.
+// At sync scale (100k+ resources per trace) the span overhead and trace bloat
+// outweighed any debugging value.
 func (s *syncer) getSubResources(ctx context.Context, parent *v2.Resource) error {
-	ctx, span := tracer.Start(ctx, "syncer.getSubResources")
-	var err error
-	defer func() { uotel.EndSpanWithError(span, err) }()
-
 	syncResourceTypeMap := make(map[string]bool)
 	for _, rt := range s.syncResourceTypes {
 		syncResourceTypeMap[rt] = true
@@ -910,11 +909,11 @@ func (s *syncer) syncResources(ctx context.Context, action *Action) error {
 	return s.nextPageOrFinishAction(ctx, action, resp.GetNextPageToken())
 }
 
+// No span here: this is called per-resource, but only does I/O on the
+// first time a resource type is seen (cached afterward). The wrapped
+// C1File.GetResourceType call is itself spanned, so we still see the
+// uncached path.
 func (s *syncer) validateResourceTraits(ctx context.Context, r *v2.Resource) error {
-	ctx, span := tracer.Start(ctx, "syncer.validateResourceTraits")
-	var err error
-	defer func() { uotel.EndSpanWithError(span, err) }()
-
 	resourceTypeTraits, ok := s.resourceTypeTraits.Load(r.GetId().GetResourceType())
 	if !ok {
 		resourceTypeResponse, err := s.store.GetResourceType(ctx, reader_v2.ResourceTypesReaderServiceGetResourceTypeRequest_builder{
@@ -962,11 +961,9 @@ func (s *syncer) validateResourceTraits(ctx context.Context, r *v2.Resource) err
 
 // shouldSkipEntitlementsAndGrants determines if we should sync entitlements for a given resource. We cache the
 // result of this function for each resource type to avoid constant lookups in the database.
+// No span here: the function is called per-resource and is almost always a cached map
+// lookup; the uncached path hits C1File.GetResourceType, which is itself spanned.
 func (s *syncer) shouldSkipEntitlementsAndGrants(ctx context.Context, r *v2.Resource) (bool, error) {
-	ctx, span := tracer.Start(ctx, "syncer.shouldSkipEntitlementsAndGrants")
-	var err error
-	defer func() { uotel.EndSpanWithError(span, err) }()
-
 	if s.state.ShouldSkipEntitlementsAndGrants() {
 		return true, nil
 	}
@@ -1009,11 +1006,10 @@ func (s *syncer) shouldSkipGrants(ctx context.Context, r *v2.Resource) (bool, er
 	return s.shouldSkipEntitlementsAndGrants(ctx, r)
 }
 
+// No span here: shouldSkipEntitlements is called per-resource and almost
+// always a cached map lookup; uncached path hits C1File.GetResourceType,
+// which is itself spanned.
 func (s *syncer) shouldSkipEntitlements(ctx context.Context, r *v2.Resource) (bool, error) {
-	ctx, span := tracer.Start(ctx, "syncer.shouldSkipEntitlements")
-	var err error
-	defer func() { uotel.EndSpanWithError(span, err) }()
-
 	ok, err := s.shouldSkipEntitlementsAndGrants(ctx, r)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
## Summary
Drop the `tracer.Start` (+ matching `defer uotel.EndSpanWithError`) from four syncer helpers that emit a span per call but do pure in-memory work. At sync scale these balloon trace span counts without surfacing useful timing.

Span counts observed in the last 24h across baton-sdk traces:
| count | function | nature |
|------:|---|---|
| 127,761 | `syncer.validateResourceTraits` | trait list iteration |
| 111,047 | `syncer.getSubResources` | annotation iteration |
| 91,296 | `syncer.shouldSkipEntitlementsAndGrants` | cached map lookup |
| 39,985 | `syncer.shouldSkipEntitlements` | cached map lookup |

A single 109,299-span trace ([`0f866754…`](https://us3.datadoghq.com/apm/trace/0f866754f06f4696b74ea7c9b585a579)) had 21,851 + 11,478 + 5,739 + 5,684 of these spans alone (~40% of the trace).

Cache miss in `validateResourceTraits` / `shouldSkipEntitlementsAndGrants` / `shouldSkipEntitlements` calls `C1File.GetResourceType`, which is itself spanned — the uncached I/O path remains visible.

Closes #836. Follow-up to #834.

## Test plan
- [x] `go test ./pkg/sync/...` passes locally
- [x] `go build ./...` passes
- [ ] After merge, confirm in Datadog that span counts for these four operation names drop to zero and that representative `syncer.Sync*` traces are noticeably smaller

🤖 Generated with [Claude Code](https://claude.com/claude-code)