### PR TITLE
otel: drop redundant 1:1 inner-method spans

### DIFF
--- a/pkg/dotc1z/sql_helpers.go
+++ b/pkg/dotc1z/sql_helpers.go
@@ -653,12 +653,11 @@ func (c *C1File) getResourceObject(ctx context.Context, resourceID *v2.ResourceI
 	return nil
 }
 
+// No span here: every call site (C1File.GetResourceType, GetEntitlement,
+// GetGrant) already owns a span. The duplicate emitted one span per
+// per-resource lookup and was a top contributor to mega-trace span counts.
 func (c *C1File) getConnectorObject(ctx context.Context, tableName string, id string, syncID string, m proto.Message) error {
-	ctx, span := tracer.Start(ctx, "C1File.getConnectorObject")
-	var err error
-	defer func() { uotel.EndSpanWithError(span, err) }()
-
-	err = c.validateDb(ctx)
+	err := c.validateDb(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -827,11 +827,10 @@ func (s *syncer) SyncResources(ctx context.Context, action *Action) error {
 }
 
 // syncResources fetches a given resource from the connector, and returns a slice of new child resources to fetch.
+// No span here: this is the only call site of SyncResources, which already
+// owns a span — the duplicate inflated trace span counts without adding
+// information.
 func (s *syncer) syncResources(ctx context.Context, action *Action) error {
-	ctx, span := tracer.Start(ctx, "syncer.syncResources")
-	var err error
-	defer func() { uotel.EndSpanWithError(span, err) }()
-
 	req := v2.ResourcesServiceListResourcesRequest_builder{
 		ResourceTypeId: action.ResourceTypeID,
 		PageToken:      action.PageToken,
@@ -1091,11 +1090,8 @@ func (s *syncer) SyncEntitlements(ctx context.Context, action *Action) error {
 }
 
 // syncEntitlementsForResource fetches the entitlements for a specific resource from the connector.
+// No span here: only call site is SyncEntitlements, which already owns a span.
 func (s *syncer) syncEntitlementsForResource(ctx context.Context, action *Action) error {
-	ctx, span := tracer.Start(ctx, "syncer.syncEntitlementsForResource")
-	var err error
-	defer func() { uotel.EndSpanWithError(span, err) }()
-
 	resourceID := v2.ResourceId_builder{
 		ResourceType: action.ResourceTypeID,
 		Resource:     action.ResourceID,
@@ -1678,11 +1674,8 @@ func (s *syncer) fetchEtaggedGrantsForResource(
 }
 
 // syncGrantsForResource fetches the grants for a specific resource from the connector.
+// No span here: only call site is SyncGrants, which already owns a span.
 func (s *syncer) syncGrantsForResource(ctx context.Context, action *Action) error {
-	ctx, span := tracer.Start(ctx, "syncer.syncGrantsForResource")
-	var err error
-	defer func() { uotel.EndSpanWithError(span, err) }()
-
 	resourceID := v2.ResourceId_builder{
 		ResourceType: action.ResourceTypeID,
 		Resource:     action.ResourceID,


### PR DESCRIPTION
## Summary
Follow-up to #834. Four inner-method spans each have exactly one call site that already owns a span. The wrapper relationship is 1:1 — both spans always cover the same call — so the inner span doubles the span count without adding information.

Span counts observed in the last 24h:
| inner (drop) | outer (keep) | calls/24h |
|---|---|---|
| `syncer.syncResources` | `syncer.SyncResources` | 9,897 |
| `syncer.syncEntitlementsForResource` | `syncer.SyncEntitlements` | 30,314 |
| `syncer.syncGrantsForResource` | `syncer.SyncGrants` | 86,653 |
| `C1File.getConnectorObject` | `C1File.GetResourceType` / `GetEntitlement` / `GetGrant` | 16,542 |

Same anti-pattern that motivated dropping `C1File.getResourceObject` in #834.

Closes #840.

## Test plan
- [x] `go test ./pkg/sync/... ./pkg/dotc1z/...` passes locally
- [x] `go build ./...` passes
- [ ] After merge, confirm in Datadog that span counts for these four operation names drop to zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)