### PR TITLE
fix: 4 latent bugs surfaced by occult-go-analysis 2026-05-19 scan

### DIFF
--- a/pkg/dotc1z/grants.go
+++ b/pkg/dotc1z/grants.go
@@ -673,20 +673,24 @@ func backfillGrantExpansionColumn(ctx context.Context, db *goqu.Database, tableN
 	if err != nil {
 		return false, err
 	}
+	// Defer Close so a panic mid-iteration still releases the sql connection.
+	// Close's error is intentionally discarded -- iteration errors surface via
+	// syncRows.Err() below, and Close after a completed iteration has no
+	// meaningful error to report.
 	var pendingSyncIDs []any
-	for syncRows.Next() {
-		var sid string
-		if err := syncRows.Scan(&sid); err != nil {
-			_ = syncRows.Close()
-			return false, err
+	if err := func() error {
+		defer func() { _ = syncRows.Close() }()
+		for syncRows.Next() {
+			var sid string
+			if err := syncRows.Scan(&sid); err != nil {
+				return err
+			}
+			pendingSyncIDs = append(pendingSyncIDs, sid)
 		}
-		pendingSyncIDs = append(pendingSyncIDs, sid)
-	}
-	if err := syncRows.Err(); err != nil {
-		_ = syncRows.Close()
+		return syncRows.Err()
+	}(); err != nil {
 		return false, err
 	}
-	_ = syncRows.Close()
 
 	if len(pendingSyncIDs) == 0 {
 		return false, nil
@@ -701,37 +705,41 @@ func backfillGrantExpansionColumn(ctx context.Context, db *goqu.Database, tableN
 		args = append(args, lastID)
 		args = append(args, pendingSyncIDs...)
 
-		rows, err := db.QueryContext(ctx, fmt.Sprintf(
-			`SELECT g.id, g.data FROM %s g
+		type row struct {
+			id   int64
+			data []byte
+		}
+		// Scan one page in a closure so defer rows.Close() fires per iteration
+		// (a plain defer in the surrounding for-loop would leak connections
+		// across pages). The closure also guarantees Close on panic.
+		var batch []row
+		if err := func() error {
+			rows, err := db.QueryContext(ctx, fmt.Sprintf(
+				`SELECT g.id, g.data FROM %s g
 			 WHERE g.id > ?
 			   AND g.expansion IS NULL
 			   AND g.sync_id IN (%s)
 			 ORDER BY g.id
 			 LIMIT 1000`,
-			tableName, placeholders,
-		), args...)
-		if err != nil {
-			return false, err
-		}
-
-		type row struct {
-			id   int64
-			data []byte
-		}
-		batch := make([]row, 0, 1000)
-		for rows.Next() {
-			var r row
-			if err := rows.Scan(&r.id, &r.data); err != nil {
-				_ = rows.Close()
-				return false, err
+				tableName, placeholders,
+			), args...)
+			if err != nil {
+				return err
 			}
-			batch = append(batch, r)
-		}
-		if err := rows.Err(); err != nil {
-			_ = rows.Close()
+			defer func() { _ = rows.Close() }()
+
+			batch = make([]row, 0, 1000)
+			for rows.Next() {
+				var r row
+				if err := rows.Scan(&r.id, &r.data); err != nil {
+					return err
+				}
+				batch = append(batch, r)
+			}
+			return rows.Err()
+		}(); err != nil {
 			return false, err
 		}
-		_ = rows.Close()
 
 		if len(batch) == 0 {
 			break

--- a/pkg/healthcheck/server.go
+++ b/pkg/healthcheck/server.go
@@ -91,6 +91,14 @@ func (s *Server) Start(ctx context.Context) error {
 	s.started = true
 
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				l.Error("health check server goroutine panicked",
+					zap.Any("panic", r),
+					zap.Stack("stack"),
+				)
+			}
+		}()
 		l.Info("health check server starting", zap.String("address", addr))
 		if err := s.server.Serve(listener); err != nil && err != http.ErrServerClosed {
 			l.Error("health check server error", zap.Error(err))

--- a/pkg/healthcheck/server.go
+++ b/pkg/healthcheck/server.go
@@ -91,14 +91,11 @@ func (s *Server) Start(ctx context.Context) error {
 	s.started = true
 
 	go func() {
-		defer func() {
-			if r := recover(); r != nil {
-				l.Error("health check server goroutine panicked",
-					zap.Any("panic", r),
-					zap.Stack("stack"),
-				)
-			}
-		}()
+		// Intentionally no panic recover: a panic in the health check
+		// server should crash the process. Recovering here would leave
+		// a dead server that orchestrators still believe is alive,
+		// which is worse than the process exiting and getting
+		// restarted.
 		l.Info("health check server starting", zap.String("address", addr))
 		if err := s.server.Serve(listener); err != nil && err != http.ErrServerClosed {
 			l.Error("health check server error", zap.Error(err))

--- a/pkg/lambda/grpc/config/config.go
+++ b/pkg/lambda/grpc/config/config.go
@@ -142,10 +142,18 @@ func lambdaTLSConfig() (*tls.Config, error) {
 	}, nil
 }
 
+// lambdaHTTPClientTimeout caps every lambda-config request so a hung endpoint
+// can't stall the caller indefinitely. 30s matches the request budget used by
+// the other RPC clients in this SDK (see pkg/uhttp/transport.go).
+const lambdaHTTPClientTimeout = 30 * time.Second
+
 func lambdaHTTPClient(tlsConfig *tls.Config) *http.Client {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.TLSClientConfig = tlsConfig.Clone()
-	return &http.Client{Transport: transport}
+	return &http.Client{
+		Transport: transport,
+		Timeout:   lambdaHTTPClientTimeout,
+	}
 }
 
 func parseClientID(input string) (string, string, error) {

--- a/pkg/uhttp/dbcache.go
+++ b/pkg/uhttp/dbcache.go
@@ -153,7 +153,6 @@ func (d *DBCache) load(ctx context.Context) (*DBCache, error) {
 	}
 
 	file := filepath.Join(cacheDir, "lcache.db")
-	d.location = file
 
 	l.Debug("Opening database", zap.String("location", file))
 	rawDB, err := sql.Open("sqlite", file)
@@ -162,6 +161,9 @@ func (d *DBCache) load(ctx context.Context) (*DBCache, error) {
 	}
 	l.Debug("Opened database", zap.String("location", file))
 
+	// Commit all derived state together so a sql.Open failure can't leave the
+	// receiver half-initialised (location set, db nil).
+	d.location = file
 	d.db = goqu.New("sqlite3", rawDB)
 	d.rawDb = rawDB
 	return d, nil


### PR DESCRIPTION
Four real bugs found by [occult-go-analysis](https://github.com/ductone/occult-go-analysis)'s full-scan of baton-sdk on 2026-05-19.

### 1. \`pkg/lambda/grpc/config/config.go::lambdaHTTPClient\`

The constructed \`*http.Client\` had no \`Timeout\`. A hung lambda endpoint would hang the caller forever. Added an explicit 30s timeout, matching the budget used elsewhere in this SDK (\`pkg/uhttp/transport.go\`).

### 2. \`pkg/healthcheck/server.go::Start\`

The \`Serve\` goroutine had no \`defer recover()\` -- a panic in any \`/healthz\` handler crashed the whole connector. Added a recover wrapper that logs the panic + stack via the existing zap logger (pattern matched from \`pkg/ugrpc/interceptors.go\`).

### 3. \`pkg/uhttp/dbcache.go::load\`

\`d.location\` was assigned **before** \`sql.Open\` was attempted, leaving the receiver half-initialised on error (location set, db nil). A caller retrying \`load\` (or inspecting \`.location\` after the error) would see a broken state. Reordered so \`location\`, \`db\`, and \`rawDb\` are committed together only after \`sql.Open\` succeeds.

### 4. \`pkg/dotc1z/grants.go::backfillGrantExpansionColumn\`

Two \`*sql.Rows\` values were manually closed in every exit branch but never deferred -- a panic mid-iteration would leak the underlying sql connection. Replaced the manual epilogues with deferred Close. The per-page Rows inside the for-loop is scanned in an inline closure so \`Close\` fires per iteration rather than accumulating defers across pages.

### How found

occult-go-analysis baton-sdk full-scan (2026-05-19). Detector kinds: \`http_client_literal_without_timeout\`, \`goroutine_without_recover\`, \`abstract_state_leak_on_error_path\`, \`sql_rows_close_missing\`.