### PR TITLE
[CXP-527] Enable HTTP/2 PING keepalive in uhttp transport

### DIFF
--- a/pkg/uhttp/transport.go
+++ b/pkg/uhttp/transport.go
@@ -136,10 +136,15 @@ func (t *Transport) make(_ context.Context) (http.RoundTripper, error) {
 		ResponseHeaderTimeout: 60 * time.Second,
 		TLSClientConfig:       t.tlsClientConfig,
 	}
-	err := http2.ConfigureTransport(baseTransport)
+	// PING-frame keepalive: keeps streams alive across intermediaries (e.g.
+	// NLB) that RST idle tunnels. TCP keepalive doesn't cover sockets with
+	// an outstanding write — the state during a slow response.
+	h2, err := http2.ConfigureTransports(baseTransport)
 	if err != nil {
 		return nil, err
 	}
+	h2.ReadIdleTimeout = 15 * time.Second
+	h2.PingTimeout = 15 * time.Second
 	var rv http.RoundTripper = baseTransport
 	rv = &userAgentTripper{next: rv, userAgent: t.userAgent}
 	return rv, nil


### PR DESCRIPTION
## Summary
- Set `ReadIdleTimeout` and `PingTimeout` on the HTTP/2 transport so idle streams emit PING frames before intermediary idle timeouts fire.
- Switches from `http2.ConfigureTransport` to `http2.ConfigureTransports` to access the `*http2.Transport`.

## Why
Connectors running behind an egress proxy fronted by an NLB with a short TCP idle timeout (60s in our environment) hit `http2: timeout awaiting response headers` and `connection reset by peer` on slow paginated upstream responses. TCP keepalive does not cover the failure window because the kernel does not probe a socket with an outstanding write — exactly the state while waiting on response headers. HTTP/2 PING frames flow over the TLS tunnel as application bytes, resetting the NLB idle timer.

## Caveats
- `ForceAttemptHTTP2: true` only *attempts* HTTP/2. If the upstream's ALPN doesn't negotiate `h2`, the connection falls back to HTTP/1.1 and this PING keepalive does **not** apply — `net/http`'s HTTP/1.1 transport has no equivalent application-layer keepalive. Connectors talking to HTTP/1.1-only upstreams through the same NLB will still see `connection reset by peer` on slow paginated responses.
- `PingTimeout = 15s` matches the vendored `x/net/http2` default; it is set explicitly as self-documentation alongside `ReadIdleTimeout`.

## Test plan
- [ ] `go build ./...` and `go test ./pkg/uhttp/...` (passing locally)
- [ ] `make lint` (no new findings; 4 pre-existing gosec findings remain)
- [ ] Vendor into a connector and exercise a long-running paginated sync through the proxy