### PR TITLE
fix: recover panics in background goroutines

### DIFF
--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -272,6 +272,13 @@ func (cw *wrapper) runServer(ctx context.Context, serverCred *tlsV1.Credential) 
 		cw.SessionServer = server
 		go func() {
 			defer sessionListener.Close()
+			defer func() {
+				if r := recover(); r != nil {
+					l.Error("panic in session store server goroutine",
+						zap.Any("panic", r),
+						zap.Stack("stack"))
+				}
+			}()
 			serverErr := session.StartGRPCSessionServerWithOptions(ctx, sessionListener, server,
 				grpc.Creds(credentials.NewTLS(tlsConfig)),
 				grpc.ChainUnaryInterceptor(ugrpc.UnaryServerInterceptor(ctx)...),

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -272,13 +272,6 @@ func (cw *wrapper) runServer(ctx context.Context, serverCred *tlsV1.Credential) 
 		cw.SessionServer = server
 		go func() {
 			defer sessionListener.Close()
-			defer func() {
-				if r := recover(); r != nil {
-					l.Error("panic in session store server goroutine",
-						zap.Any("panic", r),
-						zap.Stack("stack"))
-				}
-			}()
 			serverErr := session.StartGRPCSessionServerWithOptions(ctx, sessionListener, server,
 				grpc.Creds(credentials.NewTLS(tlsConfig)),
 				grpc.ChainUnaryInterceptor(ugrpc.UnaryServerInterceptor(ctx)...),

--- a/pkg/actions/actions.go
+++ b/pkg/actions/actions.go
@@ -444,6 +444,15 @@ func (a *ActionManager) invokeGlobalAction(ctx context.Context, name string, arg
 	// If handler takes longer than an hour, return status failed.
 	go func() { //nolint:gosec // We want to run this in the background.
 		defer close(done)
+		defer func() {
+			if r := recover(); r != nil {
+				ctxzap.Extract(ctx).Error("panic in global action handler",
+					zap.String("action", name),
+					zap.Any("panic", r),
+					zap.Stack("stack"))
+				oa.SetError(ctx, fmt.Errorf("panic in action handler: %v", r))
+			}
+		}()
 		oa.SetStatus(ctx, v2.BatonActionStatus_BATON_ACTION_STATUS_RUNNING)
 		bgCtx := trace.ContextWithSpanContext(context.Background(), trace.SpanContextFromContext(ctx))
 		handlerCtx, cancel := context.WithTimeoutCause(bgCtx, 1*time.Hour, errors.New("action handler timed out"))
@@ -523,6 +532,16 @@ func (a *ActionManager) invokeResourceAction(
 	// Invoke handler in goroutine
 	go func() { //nolint:gosec // We want to run this in the background.
 		defer close(done)
+		defer func() {
+			if r := recover(); r != nil {
+				ctxzap.Extract(ctx).Error("panic in resource action handler",
+					zap.String("resource_type", resourceTypeID),
+					zap.String("action", actionName),
+					zap.Any("panic", r),
+					zap.Stack("stack"))
+				oa.SetError(ctx, fmt.Errorf("panic in action handler: %v", r))
+			}
+		}()
 		oa.SetStatus(ctx, v2.BatonActionStatus_BATON_ACTION_STATUS_RUNNING)
 		bgCtx := trace.ContextWithSpanContext(context.Background(), trace.SpanContextFromContext(ctx))
 		bgCtx = ctxzap.ToContext(bgCtx, ctxzap.Extract(ctx))

--- a/pkg/cli/lambda_server__added.go
+++ b/pkg/cli/lambda_server__added.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -168,7 +169,7 @@ func closeLambdaConnectorGeneration(ctx context.Context, connector types.Connect
 		go func() {
 			defer func() {
 				if r := recover(); r != nil {
-					errCh <- fmt.Errorf("panic in connector Close(ctx): %v", r)
+					errCh <- fmt.Errorf("panic in connector Close(ctx): %v\n%s", r, debug.Stack())
 				}
 			}()
 			errCh <- closer.Close(ctx)
@@ -177,7 +178,7 @@ func closeLambdaConnectorGeneration(ctx context.Context, connector types.Connect
 		go func() {
 			defer func() {
 				if r := recover(); r != nil {
-					errCh <- fmt.Errorf("panic in connector Close(): %v", r)
+					errCh <- fmt.Errorf("panic in connector Close(): %v\n%s", r, debug.Stack())
 				}
 			}()
 			errCh <- closer.Close()

--- a/pkg/cli/lambda_server__added.go
+++ b/pkg/cli/lambda_server__added.go
@@ -166,10 +166,20 @@ func closeLambdaConnectorGeneration(ctx context.Context, connector types.Connect
 	errCh := make(chan error, 1)
 	if closer, ok := connector.(lambdaConnectorCloserWithContext); ok {
 		go func() {
+			defer func() {
+				if r := recover(); r != nil {
+					errCh <- fmt.Errorf("panic in connector Close(ctx): %v", r)
+				}
+			}()
 			errCh <- closer.Close(ctx)
 		}()
 	} else if closer, ok := connector.(lambdaConnectorCloser); ok {
 		go func() {
+			defer func() {
+				if r := recover(); r != nil {
+					errCh <- fmt.Errorf("panic in connector Close(): %v", r)
+				}
+			}()
 			errCh <- closer.Close()
 		}()
 	} else {


### PR DESCRIPTION
## what changed

Four goroutines in the SDK launch background work whose body can panic, but none of them install a `recover`. A panic in a goroutine without a deferred recover takes the entire process down -- the connector daemon dies and any in-flight RPC the client is awaiting hangs forever.

The four sites:

- **`pkg/actions::invokeGlobalAction`** launches the user-supplied global action handler. A panic in a handler now sets the action's error state instead of crashing.
- **`pkg/actions::invokeResourceAction`** launches the user-supplied resource-scoped action handler. Same fix.
- **`pkg/cli::closeLambdaConnectorGeneration`** launches the connector's `Close()` (via reflection on `lambdaConnectorCloserWithContext` / `lambdaConnectorCloser`). A panic in `Close` now flows back to the caller through the same `errCh` the success path uses.
- **`internal/connector::runServer`** launches the gRPC session store server in a goroutine. A panic in the gRPC server (handler, codec, TLS, interceptor) now logs and lets the deferred listener close fire, instead of crashing the connector wrapper.

## why this matters

Action handlers are connector-supplied user code -- the SDK has no way to know what they will do. Same for the connector `Close` lifecycle method. Treating these as trusted-not-to-panic is fragile and has bitten us in similar shapes in connector PRs (see baton-google-workspace `fetchUserTokens` goroutine recover).

## how I found this

Static analysis with [occult-go-analysis](https://github.com/conductorone/occult-go-analysis), c1 profile, `goroutine_without_recover` detector.