### PR TITLE
Only optimize DB if we changed a schema or did a data migration.

### DIFF
--- a/pkg/dotc1z/assets.go
+++ b/pkg/dotc1z/assets.go
@@ -50,8 +50,8 @@ func (r *assetsTable) Schema() (string, []interface{}) {
 	}
 }
 
-func (r *assetsTable) Migrations(ctx context.Context, db *goqu.Database) error {
-	return nil
+func (r *assetsTable) Migrations(ctx context.Context, db *goqu.Database) (bool, error) {
+	return false, nil
 }
 
 // PutAsset stores the given asset in the database.

--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -101,12 +101,18 @@ func WithC1FPragma(name string, value string) C1FOption {
 	}
 }
 
+// WithC1FReadOnly opens the c1file in read only mode.
+// Write operations will return an error.
+// Read only mode is faster, as it disables journaling and synchronous writes.
 func WithC1FReadOnly(readOnly bool) C1FOption {
 	return func(o *C1File) {
 		o.readOnly = readOnly
 	}
 }
 
+// WithC1FEncoderConcurrency sets the number of created encoders.
+// Default is 1, which disables async encoding/concurrency.
+// 0 uses GOMAXPROCS.
 func WithC1FEncoderConcurrency(concurrency int) C1FOption {
 	return func(o *C1File) {
 		o.encoderConcurrency = concurrency
@@ -532,7 +538,7 @@ func (c *C1File) init(ctx context.Context) error {
 		return err
 	}
 
-	err = c.InitTables(ctx)
+	shouldOptimize, err := c.InitTables(ctx)
 	if err != nil {
 		l.Error("c1file-init: error initializing tables", zap.Error(err))
 		return err
@@ -549,13 +555,18 @@ func (c *C1File) init(ctx context.Context) error {
 	}
 
 	// Optimize DB. Desired after running migrations to improve performance.
-	_, err = c.db.ExecContext(ctx, "PRAGMA optimize")
-	if err != nil {
-		return err
+	if shouldOptimize {
+		l.Debug("c1file-init: optimizing database", zap.String("db_file_path", c.dbFilePath))
+		startTime := time.Now()
+		_, err = c.db.ExecContext(ctx, "PRAGMA optimize")
+		if err != nil {
+			return err
+		}
+		l.Debug("c1file-init: optimized database",
+			zap.Duration("time_taken", time.Since(startTime)),
+			zap.String("db_file_path", c.dbFilePath),
+		)
 	}
-	l.Debug("c1file-init: optimized database",
-		zap.String("db_file_path", c.dbFilePath),
-	)
 
 	if c.readOnly {
 		// Disable journaling in read only mode, since we're not writing to the database.
@@ -610,32 +621,89 @@ func (c *C1File) init(ctx context.Context) error {
 	return nil
 }
 
-func (c *C1File) InitTables(ctx context.Context) error {
+func getSchemaVersion(ctx context.Context, db *goqu.Database) (int, error) {
+	rows, err := db.QueryContext(ctx, "SELECT schema_version FROM pragma_schema_version;")
+	if err != nil {
+		return 0, fmt.Errorf("c1file-init-tables: error getting schema version: %w", err)
+	}
+	defer rows.Close()
+
+	var schemaVersion int
+	for rows.Next() {
+		err = rows.Scan(&schemaVersion)
+		if err != nil {
+			return 0, fmt.Errorf("c1file-init-tables: error scanning schema version: %w", err)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("c1file-init-tables: error iterating schema version rows: %w", err)
+	}
+
+	return schemaVersion, nil
+}
+
+// InitTables initializes the tables in the database.
+// Returns true if the any migrations were run, false otherwise.
+func (c *C1File) InitTables(ctx context.Context) (bool, error) {
 	ctx, span := tracer.Start(ctx, "C1File.InitTables")
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
+	shouldOptimize := false
 	err = c.validateDb(ctx)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	l := ctxzap.Extract(ctx).With(zap.String("db_file_path", c.dbFilePath))
+
+	// Get schema version before creating tables/indexes/running migrations.
+	schemaVersion, err := getSchemaVersion(ctx, c.db)
+	if err != nil {
+		return false, fmt.Errorf("c1file-init-tables: error getting schema version: %w", err)
+	}
+
 	for _, t := range allTableDescriptors {
 		query, args := t.Schema()
+
+		startTime := time.Now()
 		_, err = c.db.ExecContext(ctx, fmt.Sprintf(query, args...))
 		if err != nil {
 			l.Error("c1file-init-tables: error initializing table schema", zap.Error(err), zap.String("table_name", t.Name()))
-			return fmt.Errorf("c1file-init-tables: error initializing table %s: %w", t.Name(), err)
+			return false, fmt.Errorf("c1file-init-tables: error initializing table %s: %w", t.Name(), err)
 		}
-		err = t.Migrations(ctx, c.db)
+		l.Debug("c1file-init-tables: initialized table",
+			zap.String("table_name", t.Name()),
+			zap.Duration("time_taken", time.Since(startTime)),
+		)
+
+		startTime = time.Now()
+		migrated, err := t.Migrations(ctx, c.db)
 		if err != nil {
-			l.Error("c1file-init-tables: error running migration", zap.Error(err), zap.String("table_name", t.Name()))
-			return fmt.Errorf("c1file-init-tables: error running migration for table %s: %w", t.Name(), err)
+			l.Error("c1file-init-tables: error running migrations", zap.Error(err), zap.String("table_name", t.Name()))
+			return false, fmt.Errorf("c1file-init-tables: error running migrations for table %s: %w", t.Name(), err)
+		}
+		l.Debug("c1file-init-tables: ran migrations",
+			zap.String("table_name", t.Name()),
+			zap.Duration("time_taken", time.Since(startTime)),
+			zap.Bool("migrated", migrated),
+		)
+		if migrated {
+			shouldOptimize = true
 		}
 	}
 
-	return nil
+	if !shouldOptimize {
+		newSchemaVersion, err := getSchemaVersion(ctx, c.db)
+		if err != nil {
+			return false, fmt.Errorf("c1file-init-tables: error getting schema version: %w", err)
+		}
+		if newSchemaVersion > schemaVersion {
+			shouldOptimize = true
+		}
+	}
+
+	return shouldOptimize, nil
 }
 
 // Stats introspects the database and returns the count of objects for the given sync run.

--- a/pkg/dotc1z/clone_sync.go
+++ b/pkg/dotc1z/clone_sync.go
@@ -187,7 +187,10 @@ func (c *C1File) CloneSync(ctx context.Context, outPath string, syncID string) e
 
 	// Open a fresh C1File to compress the populated db into a c1z.
 	// No other connections are open on dbPath at this point.
-	outFile, err := NewC1File(ctx, dbPath)
+	outFile, err := NewC1File(ctx, dbPath,
+		WithC1FEncoderConcurrency(0),
+		WithC1FSkipCleanup(true), // No need to clean up old syncs, as we only copied one sync into the new file.
+	)
 	if err != nil {
 		return err
 	}

--- a/pkg/dotc1z/entitlements.go
+++ b/pkg/dotc1z/entitlements.go
@@ -49,8 +49,8 @@ func (r *entitlementsTable) Schema() (string, []interface{}) {
 	}
 }
 
-func (r *entitlementsTable) Migrations(ctx context.Context, db *goqu.Database) error {
-	return nil
+func (r *entitlementsTable) Migrations(ctx context.Context, db *goqu.Database) (bool, error) {
+	return false, nil
 }
 
 func (c *C1File) ListEntitlements(ctx context.Context, request *v2.EntitlementsServiceListEntitlementsRequest) (*v2.EntitlementsServiceListEntitlementsResponse, error) {

--- a/pkg/dotc1z/grants.go
+++ b/pkg/dotc1z/grants.go
@@ -76,19 +76,19 @@ func isAlreadyExistsError(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "duplicate column name")
 }
 
-func (r *grantsTable) Migrations(ctx context.Context, db *goqu.Database) error {
+func (r *grantsTable) Migrations(ctx context.Context, db *goqu.Database) (bool, error) {
 	// Add expansion column if missing (for older files).
 	if _, err := db.ExecContext(ctx, fmt.Sprintf(
 		"alter table %s add column expansion blob", r.Name(),
 	)); err != nil && !isAlreadyExistsError(err) {
-		return err
+		return false, err
 	}
 
 	// Add needs_expansion column if missing.
 	if _, err := db.ExecContext(ctx, fmt.Sprintf(
 		"alter table %s add column needs_expansion integer not null default 0", r.Name(),
 	)); err != nil && !isAlreadyExistsError(err) {
-		return err
+		return false, err
 	}
 
 	// Create partial index for efficient queries on expandable grants.
@@ -97,7 +97,7 @@ func (r *grantsTable) Migrations(ctx context.Context, db *goqu.Database) error {
 		fmt.Sprintf("idx_grants_sync_expansion_v%s", r.Version()),
 		r.Name(),
 	)); err != nil {
-		return err
+		return false, err
 	}
 
 	// Create partial index for grants needing expansion processing.
@@ -109,12 +109,13 @@ func (r *grantsTable) Migrations(ctx context.Context, db *goqu.Database) error {
 		fmt.Sprintf("idx_grants_sync_needs_expansion_v%s", r.Version()),
 		r.Name(),
 	)); err != nil {
-		return err
+		return false, err
 	}
 
 	// Backfill expansion column from stored grant bytes.
-	if err := backfillGrantExpansionColumn(ctx, db, r.Name()); err != nil {
-		return err
+	backfilled, err := backfillGrantExpansionColumn(ctx, db, r.Name())
+	if err != nil {
+		return false, err
 	}
 
 	// Create index on entitlement_id, sync_id, and grant id.
@@ -123,10 +124,10 @@ func (r *grantsTable) Migrations(ctx context.Context, db *goqu.Database) error {
 		fmt.Sprintf("idx_grants_entitlement_sync_grant_v%s", r.Version()),
 		r.Name(),
 	)); err != nil {
-		return err
+		return false, err
 	}
 
-	return nil
+	return backfilled, nil
 }
 
 func (c *C1File) ListGrants(ctx context.Context, request *v2.GrantsServiceListGrantsRequest) (*v2.GrantsServiceListGrantsResponse, error) {
@@ -651,7 +652,7 @@ func extractAndStripExpansion(grant *v2.Grant) ([]byte, bool) {
 	return data, true
 }
 
-func backfillGrantExpansionColumn(ctx context.Context, db *goqu.Database, tableName string) error {
+func backfillGrantExpansionColumn(ctx context.Context, db *goqu.Database, tableName string) (bool, error) {
 	// Backfill grants only for syncs that have not yet been processed.
 	// The grants_backfilled flag is the single source of truth for whether
 	// this migration work still needs to run for a sync.
@@ -670,25 +671,25 @@ func backfillGrantExpansionColumn(ctx context.Context, db *goqu.Database, tableN
 		`SELECT sync_id FROM %s WHERE grants_backfilled = 0`, syncRuns.Name(),
 	))
 	if err != nil {
-		return err
+		return false, err
 	}
 	var pendingSyncIDs []any
 	for syncRows.Next() {
 		var sid string
 		if err := syncRows.Scan(&sid); err != nil {
 			_ = syncRows.Close()
-			return err
+			return false, err
 		}
 		pendingSyncIDs = append(pendingSyncIDs, sid)
 	}
 	if err := syncRows.Err(); err != nil {
 		_ = syncRows.Close()
-		return err
+		return false, err
 	}
 	_ = syncRows.Close()
 
 	if len(pendingSyncIDs) == 0 {
-		return nil
+		return false, nil
 	}
 
 	placeholders := strings.Repeat("?,", len(pendingSyncIDs))
@@ -710,7 +711,7 @@ func backfillGrantExpansionColumn(ctx context.Context, db *goqu.Database, tableN
 			tableName, placeholders,
 		), args...)
 		if err != nil {
-			return err
+			return false, err
 		}
 
 		type row struct {
@@ -722,13 +723,13 @@ func backfillGrantExpansionColumn(ctx context.Context, db *goqu.Database, tableN
 			var r row
 			if err := rows.Scan(&r.id, &r.data); err != nil {
 				_ = rows.Close()
-				return err
+				return false, err
 			}
 			batch = append(batch, r)
 		}
 		if err := rows.Err(); err != nil {
 			_ = rows.Close()
-			return err
+			return false, err
 		}
 		_ = rows.Close()
 
@@ -752,7 +753,7 @@ func backfillGrantExpansionColumn(ctx context.Context, db *goqu.Database, tableN
 		for _, r := range batch {
 			g := &v2.Grant{}
 			if err := proto.Unmarshal(r.data, g); err != nil {
-				return err
+				return false, err
 			}
 
 			expansionBytes, needsExpansion := extractAndStripExpansion(g)
@@ -764,7 +765,7 @@ func backfillGrantExpansionColumn(ctx context.Context, db *goqu.Database, tableN
 
 			newData, err := proto.Marshal(g)
 			if err != nil {
-				return err
+				return false, err
 			}
 			expandableRows = append(expandableRows, expandableRow{
 				id:             r.id,
@@ -776,7 +777,7 @@ func backfillGrantExpansionColumn(ctx context.Context, db *goqu.Database, tableN
 
 		tx, err := db.BeginTx(ctx, nil)
 		if err != nil {
-			return err
+			return false, err
 		}
 
 		// Batch-mark non-expandable grants with the sentinel in one statement.
@@ -787,7 +788,7 @@ func backfillGrantExpansionColumn(ctx context.Context, db *goqu.Database, tableN
 				`UPDATE %s SET expansion=X'' WHERE id IN (%s)`, tableName, sp,
 			), sentinelIDs...); err != nil {
 				_ = tx.Rollback()
-				return err
+				return false, err
 			}
 		}
 
@@ -798,33 +799,33 @@ func backfillGrantExpansionColumn(ctx context.Context, db *goqu.Database, tableN
 			))
 			if err != nil {
 				_ = tx.Rollback()
-				return err
+				return false, err
 			}
 			for _, er := range expandableRows {
 				if _, err := fullStmt.ExecContext(ctx, er.expansionBytes, er.needsExpansion, er.data, er.id); err != nil {
 					_ = fullStmt.Close()
 					_ = tx.Rollback()
-					return err
+					return false, err
 				}
 			}
 			_ = fullStmt.Close()
 		}
 
 		if err := tx.Commit(); err != nil {
-			return err
+			return false, err
 		}
 	}
 
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
-		return err
+		return false, err
 	}
 	// Convert empty-blob sentinels back to NULL.
 	if _, err := tx.ExecContext(ctx, fmt.Sprintf(
 		`UPDATE %s SET expansion = NULL WHERE expansion = X''`, tableName,
 	)); err != nil {
 		_ = tx.Rollback()
-		return err
+		return false, err
 	}
 	// Mark all not-yet-processed syncs as backfilled so migration work only runs once.
 	if _, err := tx.ExecContext(ctx, fmt.Sprintf(
@@ -832,13 +833,13 @@ func backfillGrantExpansionColumn(ctx context.Context, db *goqu.Database, tableN
 		syncRuns.Name(),
 	)); err != nil {
 		_ = tx.Rollback()
-		return err
+		return false, err
 	}
 	if err := tx.Commit(); err != nil {
-		return err
+		return false, err
 	}
 
-	return nil
+	return true, nil
 }
 
 func executeGrantChunkedUpsert(

--- a/pkg/dotc1z/grants_test.go
+++ b/pkg/dotc1z/grants_test.go
@@ -524,7 +524,8 @@ func TestBackfillMigration_OldSyncGetsExpansionColumn(t *testing.T) {
 	require.NoError(t, err)
 
 	// Step 3: Run the backfill explicitly (as the migration would on re-open).
-	err = backfillGrantExpansionColumn(ctx, c1f.db, grants.Name())
+	backfilled, err := backfillGrantExpansionColumn(ctx, c1f.db, grants.Name())
+	require.True(t, backfilled)
 	require.NoError(t, err)
 
 	// Clear current sync so we can use ViewSync.

--- a/pkg/dotc1z/resouce_types.go
+++ b/pkg/dotc1z/resouce_types.go
@@ -44,8 +44,8 @@ func (r *resourceTypesTable) Schema() (string, []interface{}) {
 	}
 }
 
-func (r *resourceTypesTable) Migrations(ctx context.Context, db *goqu.Database) error {
-	return nil
+func (r *resourceTypesTable) Migrations(ctx context.Context, db *goqu.Database) (bool, error) {
+	return false, nil
 }
 
 func (c *C1File) ListResourceTypes(ctx context.Context, request *v2.ResourceTypesServiceListResourceTypesRequest) (*v2.ResourceTypesServiceListResourceTypesResponse, error) {

--- a/pkg/dotc1z/resources.go
+++ b/pkg/dotc1z/resources.go
@@ -54,8 +54,8 @@ func (r *resourcesTable) Schema() (string, []interface{}) {
 	}
 }
 
-func (r *resourcesTable) Migrations(ctx context.Context, db *goqu.Database) error {
-	return nil
+func (r *resourcesTable) Migrations(ctx context.Context, db *goqu.Database) (bool, error) {
+	return false, nil
 }
 
 func (c *C1File) ListResources(ctx context.Context, request *v2.ResourcesServiceListResourcesRequest) (*v2.ResourcesServiceListResourcesResponse, error) {

--- a/pkg/dotc1z/session_store.go
+++ b/pkg/dotc1z/session_store.go
@@ -55,8 +55,8 @@ func (r *sessionStoreTable) Schema() (string, []interface{}) {
 	}
 }
 
-func (r *sessionStoreTable) Migrations(ctx context.Context, db *goqu.Database) error {
-	return nil
+func (r *sessionStoreTable) Migrations(ctx context.Context, db *goqu.Database) (bool, error) {
+	return false, nil
 }
 
 func applyBag(ctx context.Context, opt ...sessions.SessionStoreOption) (*sessions.SessionStoreBag, error) {

--- a/pkg/dotc1z/sql_helpers.go
+++ b/pkg/dotc1z/sql_helpers.go
@@ -44,7 +44,8 @@ type tableDescriptor interface {
 	Name() string
 	Schema() (string, []any)
 	Version() string
-	Migrations(ctx context.Context, db *goqu.Database) error
+	// Returns true if the any migrations were run, false otherwise.
+	Migrations(ctx context.Context, db *goqu.Database) (bool, error)
 }
 
 type listRequest interface {

--- a/pkg/dotc1z/sync_runs.go
+++ b/pkg/dotc1z/sync_runs.go
@@ -63,56 +63,72 @@ func (r *syncRunsTable) Schema() (string, []interface{}) {
 	}
 }
 
-func (r *syncRunsTable) Migrations(ctx context.Context, db *goqu.Database) error {
+func (r *syncRunsTable) Migrations(ctx context.Context, db *goqu.Database) (bool, error) {
+	migrated := false
+
 	// Check if sync_type column exists
 	var syncTypeExists int
 	err := db.QueryRowContext(ctx, fmt.Sprintf("select count(*) from pragma_table_info('%s') where name='sync_type'", r.Name())).Scan(&syncTypeExists)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if syncTypeExists == 0 {
 		_, err = db.ExecContext(ctx, fmt.Sprintf("alter table %s add column sync_type text not null default 'full'", r.Name()))
 		if err != nil {
-			return err
+			return false, err
 		}
+		migrated = true
 	}
 
 	// Check if parent_sync_id column exists
 	var parentSyncIDExists int
 	err = db.QueryRowContext(ctx, fmt.Sprintf("select count(*) from pragma_table_info('%s') where name='parent_sync_id'", r.Name())).Scan(&parentSyncIDExists)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if parentSyncIDExists == 0 {
 		_, err = db.ExecContext(ctx, fmt.Sprintf("alter table %s add column parent_sync_id text not null default ''", r.Name()))
 		if err != nil {
-			return err
+			return false, err
 		}
+		migrated = true
 	}
 
 	// Check if linked_sync_id column exists
 	var linkedSyncIDExists int
 	err = db.QueryRowContext(ctx, fmt.Sprintf("select count(*) from pragma_table_info('%s') where name='linked_sync_id'", r.Name())).Scan(&linkedSyncIDExists)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if linkedSyncIDExists == 0 {
 		_, err = db.ExecContext(ctx, fmt.Sprintf("alter table %s add column linked_sync_id text not null default ''", r.Name()))
 		if err != nil {
-			return err
+			return false, err
 		}
+		migrated = true
 	}
 
 	// Add supports_diff column if missing (for older files).
-	if _, err = db.ExecContext(ctx, fmt.Sprintf("alter table %s add column supports_diff integer not null default 0", r.Name())); err != nil && !isAlreadyExistsError(err) {
-		return err
-	}
-	// Track whether grant expansion backfill has completed for this sync.
-	if _, err = db.ExecContext(ctx, fmt.Sprintf("alter table %s add column grants_backfilled integer not null default 0", r.Name())); err != nil && !isAlreadyExistsError(err) {
-		return err
+	_, err = db.ExecContext(ctx, fmt.Sprintf("alter table %s add column supports_diff integer not null default 0", r.Name()))
+	if err != nil {
+		if !isAlreadyExistsError(err) {
+			return false, err
+		}
+	} else {
+		migrated = true
 	}
 
-	return nil
+	// Track whether grant expansion backfill has completed for this sync.
+	_, err = db.ExecContext(ctx, fmt.Sprintf("alter table %s add column grants_backfilled integer not null default 0", r.Name()))
+	if err != nil {
+		if !isAlreadyExistsError(err) {
+			return false, err
+		}
+	} else {
+		migrated = true
+	}
+
+	return migrated, nil
 }
 
 type syncRun struct {


### PR DESCRIPTION
For large c1zs, we are wasting time running `PRAGMA optimize` on open, which (if the DB has already been optimized) just scans tables for a while and then does nothing.