### PR TITLE
fix: startExplorerAPI returns error so deferred Closes run (bd ikx3)

### DIFF
--- a/cmd/baton/explorer.go
+++ b/cmd/baton/explorer.go
@@ -62,42 +62,47 @@ func startFrontendServer() error {
 	return nil
 }
 
-func startExplorerAPI(cmd *cobra.Command, devMode bool, port int) {
+// startExplorerAPI loads the c1z and runs the explorer HTTP server.
+// Returns error so deferred Closes on m and store fire on the
+// return path; the previous log.Fatal-based shape skipped them via
+// os.Exit and left the sqlite WAL un-checkpointed and the meta
+// store un-flushed.
+func startExplorerAPI(cmd *cobra.Command, devMode bool, port int) error {
 	ctx := cmd.Context()
 
 	filePath, err := cmd.Flags().GetString("file")
 	if err != nil {
-		log.Fatal("error fetching file path", err)
+		return fmt.Errorf("error fetching file path: %w", err)
 	}
 
 	syncID, err := cmd.Flags().GetString("sync-id")
 	if err != nil {
-		log.Fatal("error fetching syncID", err)
+		return fmt.Errorf("error fetching syncID: %w", err)
 	}
 
 	resourceType, err := cmd.Flags().GetString(resourceTypeFlag)
 	if err != nil {
-		log.Fatal("error fetching resourceType", err)
+		return fmt.Errorf("error fetching resourceType: %w", err)
 	}
 
 	m, err := manager.New(ctx, filePath)
 	if err != nil {
-		log.Fatal("error creating c1z manager", err)
+		return fmt.Errorf("error creating c1z manager: %w", err)
 	}
 	defer m.Close(ctx)
 
 	store, err := m.LoadC1Z(ctx)
 	if err != nil {
-		log.Fatal("error loading c1z", err) //nolint:gocritic // reason
+		return fmt.Errorf("error loading c1z: %w", err)
 	}
 	defer store.Close(ctx)
 
 	addr := fmt.Sprintf(":%d", port)
 	ctrl := explorer.NewController(ctx, store, syncID, resourceType, devMode)
-	e := ctrl.Run(addr)
-	if e != nil {
-		log.Fatal("error running explorer", err)
+	if err := ctrl.Run(addr); err != nil {
+		return fmt.Errorf("error running explorer: %w", err)
 	}
+	return nil
 }
 
 func runExplorer(cmd *cobra.Command, args []string) error {
@@ -112,13 +117,17 @@ func runExplorer(cmd *cobra.Command, args []string) error {
 	}
 
 	if isDevMode {
-		go startExplorerAPI(cmd, isDevMode, port)
-		err = startFrontendServer()
-		if err != nil {
-			log.Fatal(err)
+		// API goroutine has no return channel; log + continue.
+		// The frontend server's exit is the loop's terminator.
+		go func() {
+			if apiErr := startExplorerAPI(cmd, isDevMode, port); apiErr != nil {
+				log.Default().Printf("explorer API exited: %v", apiErr)
+			}
+		}()
+		if err := startFrontendServer(); err != nil {
+			return fmt.Errorf("error running frontend server: %w", err)
 		}
+		return nil
 	}
-	startExplorerAPI(cmd, isDevMode, port)
-
-	return nil
+	return startExplorerAPI(cmd, isDevMode, port)
 }

--- a/cmd/baton/explorer_test.go
+++ b/cmd/baton/explorer_test.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// _ pins the post-bd-ikx3 signature of startExplorerAPI: returns
+// error so the deferred m.Close and store.Close run on every exit.
+// The previous shape was log.Fatal-based, which called os.Exit(1)
+// and skipped the defers, leaving the sqlite WAL un-checkpointed
+// and the meta store un-flushed.
+//
+// If a future change reverts to a no-return shape, this assignment
+// stops compiling. runExplorer also propagates the error
+// (`return startExplorerAPI(...)`), so the type system pins the
+// fix from both sides.
+var _ func(*cobra.Command, bool, int) error = startExplorerAPI


### PR DESCRIPTION
## Summary

`cmd/baton/explorer.go::startExplorerAPI` called `log.Fatal` on load and run failures AFTER registering `defer m.Close(ctx)` and `defer store.Close(ctx)`. `log.Fatal` calls `os.Exit(1)`, which bypasses all deferred function calls -- so on startup error, the sqlite WAL was not checkpointed and the meta store was not flushed.

The fix converts `startExplorerAPI` to return error. `runExplorer` propagates the error to cobra, which surfaces the message and sets the right exit code AFTER the defers fire on the normal return path.

## How found

occult-go-analysis c1 profile, 2026-05-19 scan. Originally surfaced as bug #2 in a 5-bug report (wnkx); carried forward as bd ikx3 after the 4-bug PR #842 shipped without it.

## Test plan

- [x] `go build ./cmd/baton/...` passes
- [x] `go vet ./cmd/baton/...` passes
- [x] `explorer_test.go` adds a compile-time signature assertion: `var _ func(*cobra.Command, bool, int) error = startExplorerAPI` -- pins the post-fix shape so a future revert to a void return stops compiling