### PR TITLE
Preserve lambda StringMap key case

### DIFF
--- a/pkg/cli/lambda_server__added.go
+++ b/pkg/cli/lambda_server__added.go
@@ -20,6 +20,7 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/ugrpc"
 	"github.com/go-jose/go-jose/v4"
 	"github.com/maypok86/otter/v2"
+	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
@@ -321,13 +322,17 @@ func OptionallyAddLambdaCommand[T field.Configurable](
 				return nil, fmt.Errorf("lambda-run: failed to unmarshal decrypted config: %w", err)
 			}
 
-			effectiveConfig := effectiveLambdaConfig(v, configStruct.AsMap())
+			connectorConfig := configStruct.AsMap()
+			effectiveConfig, err := effectiveLambdaConfig(v, connectorConfig, connectorSchema)
+			if err != nil {
+				return nil, err
+			}
 			logLevelConfig, err := lambdaLogLevelConfigFromViper(effectiveConfig)
 			if err != nil {
 				return nil, err
 			}
 
-			t, err := MakeGenericConfiguration[T](effectiveConfig, decodeOpts)
+			t, err := makeLambdaConnectorConfiguration[T](v, effectiveConfig, connectorConfig, decodeOpts)
 			if err != nil {
 				return nil, fmt.Errorf("lambda-run: failed to make generic configuration: %w", err)
 			}
@@ -475,12 +480,90 @@ func cloneViperSettings(v *viper.Viper) *viper.Viper {
 	return cloned
 }
 
-func effectiveLambdaConfig(v *viper.Viper, connectorConfig map[string]any) *viper.Viper {
+func effectiveLambdaConfig(v *viper.Viper, connectorConfig map[string]any, connectorSchema field.Configuration) (*viper.Viper, error) {
 	effectiveConfig := cloneViperSettings(v)
+	stringMapFields := lambdaStringMapFields(connectorSchema)
 	for key, value := range connectorConfig {
+		var err error
+		value, err = lambdaViperConfigValue(key, value, stringMapFields)
+		if err != nil {
+			return nil, fmt.Errorf("lambda-run: failed to preserve StringMap config %q: %w", key, err)
+		}
 		effectiveConfig.Set(key, value)
 	}
-	return effectiveConfig
+	return effectiveConfig, nil
+}
+
+func lambdaStringMapFields(connectorSchema field.Configuration) map[string]struct{} {
+	fields := make(map[string]struct{})
+	add := func(schemaFields []field.SchemaField) {
+		for _, schemaField := range schemaFields {
+			if schemaField.Variant == field.StringMapVariant {
+				fields[schemaField.FieldName] = struct{}{}
+			}
+		}
+	}
+	add(connectorSchema.Fields)
+	for _, fieldGroup := range connectorSchema.FieldGroups {
+		add(fieldGroup.Fields)
+	}
+	return fields
+}
+
+func lambdaViperConfigValue(key string, value any, stringMapFields map[string]struct{}) (any, error) {
+	if _, ok := stringMapFields[key]; !ok {
+		return value, nil
+	}
+	switch value.(type) {
+	case map[string]any:
+	default:
+		return value, nil
+	}
+	// Viper.GetStringMap parses JSON strings without lowercasing their keys.
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	return string(encoded), nil
+}
+
+// Viper.Set lowercases map keys recursively, so typed connector configs decode
+// merged settings with the raw lambda payload to preserve StringMap key case.
+func makeLambdaConnectorConfiguration[T field.Configurable](v *viper.Viper, effectiveConfig *viper.Viper, connectorConfig map[string]any, opts ...field.DecodeHookOption) (T, error) {
+	var config T
+	if _, ok := any(config).(*viper.Viper); ok {
+		if t, ok := any(effectiveConfig).(T); ok {
+			return t, nil
+		}
+		return config, fmt.Errorf("cannot convert *viper.Viper to %T", config)
+	}
+
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		DecodeHook:       field.ComposeDecodeHookFunc(opts...),
+		Result:           &config,
+		WeaklyTypedInput: true,
+		ZeroFields:       true,
+	})
+	if err != nil {
+		return config, err
+	}
+	if err := decoder.Decode(lambdaConnectorSettings(v, connectorConfig)); err != nil {
+		return config, err
+	}
+	return config, nil
+}
+
+func lambdaConnectorSettings(v *viper.Viper, connectorConfig map[string]any) map[string]any {
+	settings := map[string]any{}
+	if v != nil {
+		for key, value := range v.AllSettings() {
+			settings[key] = value
+		}
+	}
+	for key, value := range connectorConfig {
+		settings[key] = value
+	}
+	return settings
 }
 
 // createSessionCacheConstructor creates a session cache constructor function that uses the provided gRPC client.

--- a/pkg/cli/lambda_server_test.go
+++ b/pkg/cli/lambda_server_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/field"
 	"github.com/spf13/viper"
 )
 
@@ -49,6 +50,64 @@ func (c *testLambdaConnectorCloseWithContext) Close(context.Context) error {
 	return nil
 }
 
+type testLambdaStringMapConfig struct {
+	StringMapField map[string]any `mapstructure:"string-map-field"`
+	IntField       int            `mapstructure:"int-field"`
+}
+
+func (c *testLambdaStringMapConfig) GetStringSlice(string) []string {
+	return nil
+}
+
+func (c *testLambdaStringMapConfig) GetString(string) string {
+	return ""
+}
+
+func (c *testLambdaStringMapConfig) GetInt(fieldName string) int {
+	if c != nil && fieldName == "int-field" {
+		return c.IntField
+	}
+	return 0
+}
+
+func (c *testLambdaStringMapConfig) GetBool(string) bool {
+	return false
+}
+
+func (c *testLambdaStringMapConfig) GetStringMap(fieldName string) map[string]any {
+	if fieldName == "string-map-field" {
+		return c.StringMapField
+	}
+	return nil
+}
+
+type testLambdaValueConfig struct {
+	StringField string `mapstructure:"string-field"`
+}
+
+func (c testLambdaValueConfig) GetStringSlice(string) []string {
+	return nil
+}
+
+func (c testLambdaValueConfig) GetString(fieldName string) string {
+	if fieldName == "string-field" {
+		return c.StringField
+	}
+	return ""
+}
+
+func (c testLambdaValueConfig) GetInt(string) int {
+	return 0
+}
+
+func (c testLambdaValueConfig) GetBool(string) bool {
+	return false
+}
+
+func (c testLambdaValueConfig) GetStringMap(string) map[string]any {
+	return nil
+}
+
 func TestCloseLambdaConnectorGenerationSupportsCloseWithoutContext(t *testing.T) {
 	connector := &testLambdaConnectorCloseWithoutContext{}
 
@@ -79,12 +138,200 @@ func TestEffectiveLambdaConfigSyncResourceTypeIDs(t *testing.T) {
 	connectorConfig := map[string]any{
 		"sync-resource-types": []any{"user", "group"},
 	}
+	schema := field.NewConfiguration(nil)
 
-	effectiveConfig := effectiveLambdaConfig(base, connectorConfig)
+	effectiveConfig, err := effectiveLambdaConfig(base, connectorConfig, schema)
+	if err != nil {
+		t.Fatalf("effectiveLambdaConfig: %v", err)
+	}
 
 	got := effectiveConfig.GetStringSlice("sync-resource-types")
 	want := []string{"user", "group"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("sync-resource-types = %#v, want %#v", got, want)
+	}
+}
+
+func TestMakeLambdaConnectorConfigurationPreservesStringMapKeyCase(t *testing.T) {
+	t.Parallel()
+
+	base := viper.New()
+	connectorConfig := map[string]any{
+		"string-map-field": map[string]any{
+			"CompanyID": "123",
+			"userName":  "alice",
+			"URLToken":  "secret",
+		},
+	}
+	schema := field.NewConfiguration([]field.SchemaField{
+		field.StringMapField("string-map-field"),
+	})
+	effectiveConfig, err := effectiveLambdaConfig(base, connectorConfig, schema)
+	if err != nil {
+		t.Fatalf("effectiveLambdaConfig: %v", err)
+	}
+
+	config, err := makeLambdaConnectorConfiguration[*testLambdaStringMapConfig](base, effectiveConfig, connectorConfig)
+	if err != nil {
+		t.Fatalf("makeLambdaConnectorConfiguration: %v", err)
+	}
+
+	got := config.GetStringMap("string-map-field")
+	want := map[string]any{
+		"CompanyID": "123",
+		"userName":  "alice",
+		"URLToken":  "secret",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("string-map-field = %#v, want %#v", got, want)
+	}
+}
+
+func TestMakeLambdaConnectorConfigurationReplacesBaseStringMap(t *testing.T) {
+	t.Parallel()
+
+	base := viper.New()
+	base.Set("string-map-field", map[string]any{
+		"fallback":  "unused",
+		"CompanyID": "old",
+	})
+	connectorConfig := map[string]any{
+		"string-map-field": map[string]any{
+			"CompanyID": "123",
+		},
+	}
+	schema := field.NewConfiguration([]field.SchemaField{
+		field.StringMapField("string-map-field"),
+	})
+	effectiveConfig, err := effectiveLambdaConfig(base, connectorConfig, schema)
+	if err != nil {
+		t.Fatalf("effectiveLambdaConfig: %v", err)
+	}
+
+	config, err := makeLambdaConnectorConfiguration[*testLambdaStringMapConfig](base, effectiveConfig, connectorConfig)
+	if err != nil {
+		t.Fatalf("makeLambdaConnectorConfiguration: %v", err)
+	}
+
+	got := config.GetStringMap("string-map-field")
+	want := map[string]any{"CompanyID": "123"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("string-map-field = %#v, want %#v", got, want)
+	}
+}
+
+func TestMakeLambdaConnectorConfigurationClearsBaseStringMap(t *testing.T) {
+	t.Parallel()
+
+	base := viper.New()
+	base.Set("string-map-field", map[string]any{
+		"fallback": "unused",
+	})
+	connectorConfig := map[string]any{
+		"string-map-field": map[string]any{},
+	}
+	schema := field.NewConfiguration([]field.SchemaField{
+		field.StringMapField("string-map-field"),
+	})
+	effectiveConfig, err := effectiveLambdaConfig(base, connectorConfig, schema)
+	if err != nil {
+		t.Fatalf("effectiveLambdaConfig: %v", err)
+	}
+
+	config, err := makeLambdaConnectorConfiguration[*testLambdaStringMapConfig](base, effectiveConfig, connectorConfig)
+	if err != nil {
+		t.Fatalf("makeLambdaConnectorConfiguration: %v", err)
+	}
+
+	got := config.GetStringMap("string-map-field")
+	want := map[string]any{}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("string-map-field = %#v, want %#v", got, want)
+	}
+}
+
+func TestMakeLambdaConnectorConfigurationRemoteValueOverridesInvalidBase(t *testing.T) {
+	t.Parallel()
+
+	base := viper.New()
+	base.Set("int-field", "not-an-int")
+	connectorConfig := map[string]any{
+		"int-field": 42,
+	}
+	schema := field.NewConfiguration([]field.SchemaField{
+		field.IntField("int-field"),
+	})
+	effectiveConfig, err := effectiveLambdaConfig(base, connectorConfig, schema)
+	if err != nil {
+		t.Fatalf("effectiveLambdaConfig: %v", err)
+	}
+
+	config, err := makeLambdaConnectorConfiguration[*testLambdaStringMapConfig](base, effectiveConfig, connectorConfig)
+	if err != nil {
+		t.Fatalf("makeLambdaConnectorConfiguration: %v", err)
+	}
+
+	if got, want := config.GetInt("int-field"), 42; got != want {
+		t.Fatalf("int-field = %d, want %d", got, want)
+	}
+}
+
+func TestMakeLambdaConnectorConfigurationSupportsValueConfig(t *testing.T) {
+	t.Parallel()
+
+	base := viper.New()
+	connectorConfig := map[string]any{
+		"string-field": "configured",
+	}
+	schema := field.NewConfiguration([]field.SchemaField{
+		field.StringField("string-field"),
+	})
+	effectiveConfig, err := effectiveLambdaConfig(base, connectorConfig, schema)
+	if err != nil {
+		t.Fatalf("effectiveLambdaConfig: %v", err)
+	}
+
+	config, err := makeLambdaConnectorConfiguration[testLambdaValueConfig](base, effectiveConfig, connectorConfig)
+	if err != nil {
+		t.Fatalf("makeLambdaConnectorConfiguration: %v", err)
+	}
+
+	if got, want := config.GetString("string-field"), "configured"; got != want {
+		t.Fatalf("string-field = %q, want %q", got, want)
+	}
+}
+
+func TestMakeLambdaConnectorConfigurationPreservesStringMapKeyCaseForViperConfig(t *testing.T) {
+	t.Parallel()
+
+	base := viper.New()
+	connectorConfig := map[string]any{
+		"string-map-field": map[string]any{
+			"CompanyID": "123",
+			"userName":  "alice",
+			"URLToken":  "secret",
+		},
+	}
+	schema := field.NewConfiguration([]field.SchemaField{
+		field.StringMapField("string-map-field"),
+	})
+	effectiveConfig, err := effectiveLambdaConfig(base, connectorConfig, schema)
+	if err != nil {
+		t.Fatalf("effectiveLambdaConfig: %v", err)
+	}
+
+	config, err := makeLambdaConnectorConfiguration[*viper.Viper](base, effectiveConfig, connectorConfig)
+	if err != nil {
+		t.Fatalf("makeLambdaConnectorConfiguration: %v", err)
+	}
+
+	got := config.GetStringMap("string-map-field")
+	want := map[string]any{
+		"CompanyID": "123",
+		"userName":  "alice",
+		"URLToken":  "secret",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("string-map-field = %#v, want %#v", got, want)
 	}
 }


### PR DESCRIPTION
## Why
Lambda connector config handling started routing typed connector configs through Viper during the runtime work. Viper lowercases map keys recursively on Set, so StringMap entries with case-sensitive keys can arrive at connectors in lowercase and break sync behavior.

## What this changes
This keeps the merged Viper config path for lambda runtime settings such as log level, auth method, and sync resource types, but decodes typed connector config structs from the decrypted connector payload with mapstructure. That restores the previous StringMap key behavior while preserving the hot-reload runtime settings added in PR #785.

A regression test covers mixed-case StringMap keys round-tripping unchanged.