### PR TITLE
Preserve typed lambda StringMap keys

### DIFF
--- a/pkg/cli/lambda_server__added.go
+++ b/pkg/cli/lambda_server__added.go
@@ -20,6 +20,7 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/ugrpc"
 	"github.com/go-jose/go-jose/v4"
 	"github.com/maypok86/otter/v2"
+	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
@@ -321,13 +322,14 @@ func OptionallyAddLambdaCommand[T field.Configurable](
 				return nil, fmt.Errorf("lambda-run: failed to unmarshal decrypted config: %w", err)
 			}
 
-			effectiveConfig := effectiveLambdaConfig(v, configStruct.AsMap())
+			connectorConfig := configStruct.AsMap()
+			effectiveConfig := effectiveLambdaConfig(v, connectorConfig)
 			logLevelConfig, err := lambdaLogLevelConfigFromViper(effectiveConfig)
 			if err != nil {
 				return nil, err
 			}
 
-			t, err := MakeGenericConfiguration[T](effectiveConfig, decodeOpts)
+			t, err := makeLambdaConnectorConfiguration[T](v, effectiveConfig, connectorConfig, decodeOpts)
 			if err != nil {
 				return nil, fmt.Errorf("lambda-run: failed to make generic configuration: %w", err)
 			}
@@ -481,6 +483,36 @@ func effectiveLambdaConfig(v *viper.Viper, connectorConfig map[string]any) *vipe
 		effectiveConfig.Set(key, value)
 	}
 	return effectiveConfig
+}
+
+// Typed configs must decode the raw lambda payload directly. Decoding them from
+// effectiveConfig would send StringMap values through Viper.Set, which lowercases
+// nested map keys.
+func makeLambdaConnectorConfiguration[T field.Configurable](v *viper.Viper, effectiveConfig *viper.Viper, connectorConfig map[string]any, opts ...field.DecodeHookOption) (T, error) {
+	var config T
+	if _, ok := any(config).(*viper.Viper); ok {
+		if t, ok := any(effectiveConfig).(T); ok {
+			return t, nil
+		}
+		return config, fmt.Errorf("cannot convert *viper.Viper to %T", config)
+	}
+
+	t, err := MakeGenericConfiguration[T](v, opts...)
+	if err != nil {
+		return t, err
+	}
+
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		DecodeHook: field.ComposeDecodeHookFunc(opts...),
+		Result:     any(t),
+	})
+	if err != nil {
+		return t, err
+	}
+	if err := decoder.Decode(connectorConfig); err != nil {
+		return t, err
+	}
+	return t, nil
 }
 
 // createSessionCacheConstructor creates a session cache constructor function that uses the provided gRPC client.

--- a/pkg/cli/lambda_server_test.go
+++ b/pkg/cli/lambda_server_test.go
@@ -49,6 +49,33 @@ func (c *testLambdaConnectorCloseWithContext) Close(context.Context) error {
 	return nil
 }
 
+type testLambdaStringMapConfig struct {
+	UserCustomFields map[string]any `mapstructure:"user-custom-fields"`
+}
+
+func (c *testLambdaStringMapConfig) GetStringSlice(string) []string {
+	return nil
+}
+
+func (c *testLambdaStringMapConfig) GetString(string) string {
+	return ""
+}
+
+func (c *testLambdaStringMapConfig) GetInt(string) int {
+	return 0
+}
+
+func (c *testLambdaStringMapConfig) GetBool(string) bool {
+	return false
+}
+
+func (c *testLambdaStringMapConfig) GetStringMap(fieldName string) map[string]any {
+	if fieldName == "user-custom-fields" {
+		return c.UserCustomFields
+	}
+	return nil
+}
+
 func TestCloseLambdaConnectorGenerationSupportsCloseWithoutContext(t *testing.T) {
 	connector := &testLambdaConnectorCloseWithoutContext{}
 
@@ -86,5 +113,31 @@ func TestEffectiveLambdaConfigSyncResourceTypeIDs(t *testing.T) {
 	want := []string{"user", "group"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("sync-resource-types = %#v, want %#v", got, want)
+	}
+}
+
+func TestMakeLambdaConnectorConfigurationPreservesStringMapKeyCase(t *testing.T) {
+	t.Parallel()
+
+	base := viper.New()
+	connectorConfig := map[string]any{
+		"user-custom-fields": map[string]any{
+			"departmentNav/name": "Department",
+			"customString10":     "Custom String 10",
+		},
+	}
+
+	config, err := makeLambdaConnectorConfiguration[*testLambdaStringMapConfig](base, effectiveLambdaConfig(base, connectorConfig), connectorConfig)
+	if err != nil {
+		t.Fatalf("makeLambdaConnectorConfiguration: %v", err)
+	}
+
+	got := config.GetStringMap("user-custom-fields")
+	want := map[string]any{
+		"departmentNav/name": "Department",
+		"customString10":     "Custom String 10",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("user-custom-fields = %#v, want %#v", got, want)
 	}
 }


### PR DESCRIPTION
## Why
Lambda connector config handling started routing typed connector configs through Viper during the axiomatic runtime work. Viper lowercases nested map keys on Set, so generated connectors with StringMap config fields can receive case-sensitive keys in lowercase and fail sync behavior.

## What this changes
This restores the previous typed-config lambda decode path while keeping the PR #785 runtime config behavior. Lambda runtime settings such as log level, auth method, and sync resource types still use the merged effective Viper config, but typed connector structs decode the raw decrypted connector payload with mapstructure so StringMap entry keys keep their original casing.

This intentionally does not add special handling for legacy *viper.Viper connector configs; available code search did not show pre-axiomatic connectors using *viper.Viper together with StringMapField, and avoiding that workaround keeps the SDK hotfix close to the previous behavior.

Supersedes the broader draft approach in #855.