### PR TITLE
Clonesync benchmark: Don't fail if we run the benchmark multiple times.

### DIFF
--- a/pkg/dotc1z/clone_sync_bench_test.go
+++ b/pkg/dotc1z/clone_sync_bench_test.go
@@ -56,11 +56,12 @@ func benchmarkCloneSync(b *testing.B, syncID string) {
 		err = c1f.CloneSync(ctx, outPath, syncID)
 		b.StopTimer()
 		require.NoError(b, err)
-		err = c1f.Close(ctx)
-		require.NoError(b, err)
 
 		require.NoError(b, os.Remove(outPath))
 	}
+
+	err = c1f.Close(ctx)
+	require.NoError(b, err)
 }
 
 func BenchmarkCloneSyncSmall(b *testing.B) {


### PR DESCRIPTION
Close the c1 file after running all iterations of the benchmark instead of in the loop.