### PR TITLE
fix(sync): wire metrics handler into expand ProgressLog

### DIFF
--- a/pkg/sync/progresslog/progresslog.go
+++ b/pkg/sync/progresslog/progresslog.go
@@ -117,7 +117,7 @@ func WithDBSizeProvider(p connectorstore.DBSizeProvider) Option {
 
 // WithMetricsHandler attaches an optional metrics.Handler. When set,
 // LogExpandProgress emits gauges/counters mirroring the structured log fields
-// (actions_remaining, actions_burned, decompressed_bytes, decompressed_bytes_growth)
+// (actions_remaining, actions_burned, decompressed_bytes, decompressed_bytes_delta)
 // so operators can build dashboards instead of scraping log timestamps.
 //
 // The handler should be pre-tagged by the caller (e.g. via Handler.WithTags

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -2962,6 +2962,9 @@ func NormalizeWorkerCount(count int) int {
 // in — baton-sdk has no view of those identifiers.
 func WithMetricsHandler(h metrics.Handler) SyncOpt {
 	return func(s *syncer) {
+		if h == nil {
+			return
+		}
 		s.metricsHandler = h
 	}
 }

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -42,6 +42,7 @@ import (
 	reader_v2 "github.com/conductorone/baton-sdk/pb/c1/reader/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/metrics"
 	"github.com/conductorone/baton-sdk/pkg/sync/progresslog"
 	"github.com/conductorone/baton-sdk/pkg/types"
 )
@@ -141,6 +142,7 @@ type syncer struct {
 	previousSyncMu                      native_sync.Mutex
 	previousSyncIDPtr                   atomic.Pointer[string]
 	workerCount                         int // If 1, sync is sequential (default). If > 1, sync operations are done in parallel.
+	metricsHandler                      metrics.Handler
 }
 
 var _ Syncer = (*syncer)(nil)
@@ -2949,6 +2951,21 @@ func NormalizeWorkerCount(count int) int {
 	return max(count, 1)
 }
 
+// WithMetricsHandler attaches a metrics.Handler that the syncer forwards to
+// progresslog.NewProgressCounts so the grant-expansion OTel instruments
+// (baton.sync.expand.actions_remaining / actions_burned /
+// decompressed_bytes / decompressed_bytes_delta) actually reach the
+// configured exporter instead of the default no-op handler.
+//
+// Callers should pre-tag the handler with the dimensions they want to slice
+// by (e.g. tenant_id, connector_id) via Handler.WithTags before passing it
+// in — baton-sdk has no view of those identifiers.
+func WithMetricsHandler(h metrics.Handler) SyncOpt {
+	return func(s *syncer) {
+		s.metricsHandler = h
+	}
+}
+
 // WithWorkerCount sets the number of workers to use.
 // If <=1, 1 worker is used (default). If > 1, parallel sync is used.
 // If -1, the number of workers is set to the number of CPU cores or 4, whichever is lower.
@@ -2976,6 +2993,9 @@ func NewSyncer(ctx context.Context, c types.ConnectorClient, opts ...SyncOpt) (S
 	}
 
 	progressLogOpts := []progresslog.Option{}
+	if s.metricsHandler != nil {
+		progressLogOpts = append(progressLogOpts, progresslog.WithMetricsHandler(s.metricsHandler))
+	}
 	s.counts = progresslog.NewProgressCounts(ctx, progressLogOpts...)
 	// Wire the DBSizeProvider now if the store is already set (WithConnectorStore
 	// case). For WithC1ZPath, the store is populated later inside loadStore,

--- a/pkg/sync/syncer_metrics_test.go
+++ b/pkg/sync/syncer_metrics_test.go
@@ -1,0 +1,120 @@
+package sync //nolint:revive,nolintlint // we can't change the package name for backwards compatibility
+
+import (
+	"context"
+	"path/filepath"
+	native_sync "sync"
+	"testing"
+
+	"github.com/conductorone/baton-sdk/pkg/metrics"
+	"github.com/conductorone/baton-sdk/pkg/sync/expand"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeMetricsHandler records gauge observations so the test can prove the
+// caller's handler reaches the ProgressLog the syncer constructs.
+type fakeMetricsHandler struct {
+	mu     native_sync.Mutex
+	gauges map[string][]int64
+}
+
+func newFakeMetricsHandler() *fakeMetricsHandler {
+	return &fakeMetricsHandler{gauges: make(map[string][]int64)}
+}
+
+func (h *fakeMetricsHandler) Int64Counter(_, _ string, _ metrics.Unit) metrics.Int64Counter {
+	return noopFakeCounter{}
+}
+
+func (h *fakeMetricsHandler) Int64Gauge(name, _ string, _ metrics.Unit) metrics.Int64Gauge {
+	return &fakeMetricsGauge{handler: h, name: name}
+}
+
+func (h *fakeMetricsHandler) Int64Histogram(_, _ string, _ metrics.Unit) metrics.Int64Histogram {
+	return noopFakeHistogram{}
+}
+
+func (h *fakeMetricsHandler) WithTags(_ map[string]string) metrics.Handler { return h }
+
+func (h *fakeMetricsHandler) observations(name string) []int64 {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := make([]int64, len(h.gauges[name]))
+	copy(out, h.gauges[name])
+	return out
+}
+
+type fakeMetricsGauge struct {
+	handler *fakeMetricsHandler
+	name    string
+}
+
+func (g *fakeMetricsGauge) Observe(_ context.Context, value int64, _ map[string]string) {
+	g.handler.mu.Lock()
+	defer g.handler.mu.Unlock()
+	g.handler.gauges[g.name] = append(g.handler.gauges[g.name], value)
+}
+
+type noopFakeCounter struct{}
+
+func (noopFakeCounter) Add(_ context.Context, _ int64, _ map[string]string) {}
+
+type noopFakeHistogram struct{}
+
+func (noopFakeHistogram) Record(_ context.Context, _ int64, _ map[string]string) {}
+
+// TestNewSyncer_WithMetricsHandler_WiresThroughToProgressLog pins the wiring
+// added to forward a caller's metrics.Handler into progresslog.NewProgressCounts.
+// Without this, a refactor that drops the conditional append inside NewSyncer
+// would silently disable every consumer's baton.sync.expand.* instruments —
+// the structured logs would still fire, so existing tests would stay green.
+func TestNewSyncer_WithMetricsHandler_WiresThroughToProgressLog(t *testing.T) {
+	runWithSyncModes(t, func(t *testing.T, extraOpts []SyncOpt) {
+		ctx := t.Context()
+
+		fake := newFakeMetricsHandler()
+
+		tempDir := t.TempDir()
+		c1zpath := filepath.Join(tempDir, "wiring.c1z")
+		opts := append([]SyncOpt{
+			WithC1ZPath(c1zpath),
+			WithTmpDir(tempDir),
+			WithMetricsHandler(fake),
+		}, extraOpts...)
+
+		syncerIface, err := NewSyncer(ctx, nil, opts...)
+		require.NoError(t, err)
+
+		s, ok := syncerIface.(*syncer)
+		require.True(t, ok, "NewSyncer returns *syncer")
+		require.NotNil(t, s.counts, "ProgressLog should be constructed")
+
+		actions := make([]*expand.EntitlementGraphAction, 7)
+		s.counts.LogExpandProgress(ctx, actions)
+
+		require.Equal(t, []int64{7}, fake.observations("baton.sync.expand.actions_remaining"),
+			"caller's metrics.Handler did not receive the actions_remaining gauge observation — "+
+				"WithMetricsHandler wiring in NewSyncer is broken")
+	})
+}
+
+// TestNewSyncer_NoMetricsHandler_DoesNotPanic pins the default path: callers
+// that omit WithMetricsHandler should get a working ProgressLog backed by the
+// no-op handler. Mirrors progresslog's own NoMetricsHandlerIsSafe coverage
+// at the syncer wiring layer.
+func TestNewSyncer_NoMetricsHandler_DoesNotPanic(t *testing.T) {
+	ctx := t.Context()
+
+	tempDir := t.TempDir()
+	c1zpath := filepath.Join(tempDir, "wiring.c1z")
+	syncerIface, err := NewSyncer(ctx, nil, WithC1ZPath(c1zpath), WithTmpDir(tempDir))
+	require.NoError(t, err)
+
+	s, ok := syncerIface.(*syncer)
+	require.True(t, ok)
+	require.NotNil(t, s.counts)
+
+	require.NotPanics(t, func() {
+		s.counts.LogExpandProgress(ctx, make([]*expand.EntitlementGraphAction, 3))
+	})
+}


### PR DESCRIPTION
## Summary

- `progresslog.NewProgressCounts` is constructed in `pkg/sync/syncer.go:2849` without `WithMetricsHandler`, so the four expand OTel instruments added in #804 (`baton.sync.expand.actions_remaining`, `.actions_burned`, `.decompressed_bytes`, `.decompressed_bytes_delta`) emit to the default no-op handler and never reach an exporter. Structured "Expanding grants" logs still fire; only the metric path is dead.
- Add a `WithMetricsHandler` `SyncOpt` so callers can inject a pre-tagged `metrics.Handler`, and forward it into `progressLogOpts` before `NewProgressCounts`.
- Per the existing doc on `progresslog.WithMetricsHandler` (`pkg/sync/progresslog/progresslog.go:144-158`), the caller owns tagging (`tenant_id` / `connector_id`); baton-sdk does not see those identifiers, so this PR pipes the handler through without decoration.

## Why this matters

During long grant expansions, operators currently have to scrape log timestamps to answer "is this connector burning through actions or wedged?" — the same workflow #804 was meant to obsolete. Once consumers (e.g. the main platform repo) pass their existing sync-scoped handler via `sync.WithMetricsHandler(h)`, the gauges/counters land in Datadog and dashboards/alerts become possible.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/sync/...`
- [x] `golangci-lint run ./pkg/sync/...` — no new findings (the 3 pre-existing issues in `pkg/sync/expand` are untouched by this diff)
- [ ] Consumer side: pass a pre-tagged handler from the main platform repo and confirm `baton.sync.expand.actions_remaining` shows up in Datadog during a grant-expansion step on a connector with grants
