### PR TITLE
perf(dotc1z): add prepared statement cache for repeated SQL queries

### DIFF
--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -67,6 +67,11 @@ type C1File struct {
 	slowQueryThreshold    time.Duration
 	slowQueryLogFrequency time.Duration
 
+	// Prepared statement cache: keyed by SQL text, lazily populated.
+	// With MaxOpenConns(1) all stmts are bound to the single connection.
+	stmtCache   map[string]*sql.Stmt
+	stmtCacheMu sync.Mutex
+
 	// Sync cleanup settings
 	syncLimit   int
 	skipCleanup bool
@@ -216,6 +221,7 @@ func NewC1File(ctx context.Context, dbFilePath string, opts ...C1FOption) (*C1Fi
 		slowQueryThreshold:    5 * time.Second,
 		slowQueryLogFrequency: 1 * time.Minute,
 		encoderConcurrency:    1,
+		stmtCache:             make(map[string]*sql.Stmt),
 	}
 
 	for _, opt := range opts {
@@ -568,10 +574,42 @@ func (c *C1File) closeRawDB(ctx context.Context) error {
 	_, span := tracer.Start(ctx, "C1File.closeRawDB")
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
+
+	c.stmtCacheMu.Lock()
+	for _, stmt := range c.stmtCache {
+		stmt.Close()
+	}
+	c.stmtCache = nil
+	c.stmtCacheMu.Unlock()
+
 	err = c.rawDb.Close()
 	c.rawDb = nil
 	c.db = nil
 	return err
+}
+
+func (c *C1File) getOrPrepare(ctx context.Context, query string) (*sql.Stmt, error) {
+	c.stmtCacheMu.Lock()
+	if stmt, ok := c.stmtCache[query]; ok {
+		c.stmtCacheMu.Unlock()
+		return stmt, nil
+	}
+	c.stmtCacheMu.Unlock()
+
+	stmt, err := c.rawDb.PrepareContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+
+	c.stmtCacheMu.Lock()
+	if existing, ok := c.stmtCache[query]; ok {
+		c.stmtCacheMu.Unlock()
+		stmt.Close()
+		return existing, nil
+	}
+	c.stmtCache[query] = stmt
+	c.stmtCacheMu.Unlock()
+	return stmt, nil
 }
 
 // truncateWAL truncates the WAL file.

--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -590,6 +590,10 @@ func (c *C1File) closeRawDB(ctx context.Context) error {
 
 func (c *C1File) getOrPrepare(ctx context.Context, query string) (*sql.Stmt, error) {
 	c.stmtCacheMu.Lock()
+	if c.stmtCache == nil {
+		c.stmtCacheMu.Unlock()
+		return nil, ErrDbNotOpen
+	}
 	if stmt, ok := c.stmtCache[query]; ok {
 		c.stmtCacheMu.Unlock()
 		return stmt, nil
@@ -598,7 +602,7 @@ func (c *C1File) getOrPrepare(ctx context.Context, query string) (*sql.Stmt, err
 
 	stmt, err := c.rawDb.PrepareContext(ctx, query)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getOrPrepare: %w", err)
 	}
 
 	c.stmtCacheMu.Lock()

--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -606,6 +606,11 @@ func (c *C1File) getOrPrepare(ctx context.Context, query string) (*sql.Stmt, err
 	}
 
 	c.stmtCacheMu.Lock()
+	if c.stmtCache == nil {
+		c.stmtCacheMu.Unlock()
+		stmt.Close()
+		return nil, ErrDbNotOpen
+	}
 	if existing, ok := c.stmtCache[query]; ok {
 		c.stmtCacheMu.Unlock()
 		stmt.Close()

--- a/pkg/dotc1z/grants.go
+++ b/pkg/dotc1z/grants.go
@@ -229,7 +229,11 @@ func listGrantsGeneric(ctx context.Context, c *C1File, req listRequest) ([]*v2.G
 	}
 
 	queryStart := time.Now()
-	rows, err := c.db.QueryContext(ctx, query, args...)
+	stmt, err := c.getOrPrepare(ctx, query)
+	if err != nil {
+		return nil, "", err
+	}
+	rows, err := stmt.QueryContext(ctx, args...)
 	if err != nil {
 		return nil, "", err
 	}

--- a/pkg/dotc1z/grants_expandable_query.go
+++ b/pkg/dotc1z/grants_expandable_query.go
@@ -73,7 +73,11 @@ func (c *C1File) listExpandableGrantsInternal(
 		return nil, "", err
 	}
 
-	rows, err := c.db.QueryContext(ctx, query, args...)
+	stmt, err := c.getOrPrepare(ctx, query)
+	if err != nil {
+		return nil, "", err
+	}
+	rows, err := stmt.QueryContext(ctx, args...)
 	if err != nil {
 		return nil, "", err
 	}
@@ -196,7 +200,11 @@ func (c *C1File) listGrantsWithExpansionInternal(ctx context.Context, opts grant
 		return nil, err
 	}
 
-	rows, err := c.db.QueryContext(ctx, query, args...)
+	stmt, err := c.getOrPrepare(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := stmt.QueryContext(ctx, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/dotc1z/grants_hydrate.go
+++ b/pkg/dotc1z/grants_hydrate.go
@@ -64,10 +64,14 @@ func hydrateSingleGrant(ctx context.Context, c *C1File, syncID string, g *v2.Gra
 		return nil
 	}
 
-	row := c.db.QueryRowContext(ctx, fmt.Sprintf(
+	q := fmt.Sprintf(
 		`SELECT entitlement_id, resource_type_id, resource_id, principal_resource_type_id, principal_resource_id
-		 FROM %s WHERE external_id = ? AND sync_id = ?`, grants.Name(),
-	), g.GetId(), syncID)
+		 FROM %s WHERE external_id = ? AND sync_id = ?`, grants.Name())
+	stmt, err := c.getOrPrepare(ctx, q)
+	if err != nil {
+		return err
+	}
+	row := stmt.QueryRowContext(ctx, g.GetId(), syncID)
 	var k grantJoinKeys
 	if err := row.Scan(
 		&k.EntitlementID,

--- a/pkg/dotc1z/sql_helpers.go
+++ b/pkg/dotc1z/sql_helpers.go
@@ -245,8 +245,12 @@ func listConnectorObjects[T proto.Message](ctx context.Context, c *C1File, table
 	// Start timing the query execution
 	queryStartTime := time.Now()
 
-	// Execute the query
-	rows, err := c.db.QueryContext(ctx, query, args...)
+	// Execute the query via prepared statement cache
+	stmt, err := c.getOrPrepare(ctx, query)
+	if err != nil {
+		return nil, "", err
+	}
+	rows, err := stmt.QueryContext(ctx, args...)
 	if err != nil {
 		return nil, "", err
 	}
@@ -599,7 +603,11 @@ func (c *C1File) getResourceObject(ctx context.Context, resourceID *v2.ResourceI
 	}
 
 	data := make([]byte, 0)
-	row := c.db.QueryRowContext(ctx, query, args...)
+	stmt, err := c.getOrPrepare(ctx, query)
+	if err != nil {
+		return err
+	}
+	row := stmt.QueryRowContext(ctx, args...)
 	err = row.Scan(&data)
 	if err != nil {
 		return err
@@ -659,7 +667,11 @@ func (c *C1File) getConnectorObject(ctx context.Context, tableName string, id st
 	}
 
 	var data []byte
-	row := c.db.QueryRowContext(ctx, query, args...)
+	stmt, err := c.getOrPrepare(ctx, query)
+	if err != nil {
+		return err
+	}
+	row := stmt.QueryRowContext(ctx, args...)
 	err = row.Scan(&data)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

- Add a `map[string]*sql.Stmt` cache on `*C1File` that eliminates repeated SQLite statement compilation for read queries
- Profile evidence: `modernc.org/sqlite.(*conn).bind` consumes **163s/hr (5.6% CPU)** recompiling the same ~10 SQL shapes thousands of times per sync
- With `MaxOpenConns(1)`, all statements are bound to a single connection for the lifetime of the sync activity — ideal for caching

## How it works

goqu already uses `.Prepared(true)` on all read paths, generating stable `?`-placeholder SQL. The SQL text is deterministic for each query shape (determined by which WHERE clauses are active). `getOrPrepare(ctx, query)` checks the cache; on miss, prepares the statement and stores it. On hit, returns the cached `*sql.Stmt` immediately.

## Call sites converted (7)

| File | Function | Hot path |
|---|---|---|
| `sql_helpers.go` | `listConnectorObjects` | Main sync list loop |
| `sql_helpers.go` | `getConnectorObject` | GetEntitlement, GetResource |
| `sql_helpers.go` | `getResourceObject` | GetResource variant |
| `grants.go` | `listGrantsGeneric` | ListGrantsForEntitlement |
| `grants_expandable_query.go` | `listExpandableGrantsInternal` | Expansion work queue |
| `grants_expandable_query.go` | `listGrantsWithExpansionInternal` | Expansion data read |
| `grants_hydrate.go` | `hydrateSingleGrant` | Slim-grant hydration |

## What's NOT changed

- Write paths (`executeChunkedInsert`) — already use transactions, INSERT shapes vary with batch size
- The goqu query builder still runs (SQL text still built each call to use as cache key) — eliminating goqu is a future follow-up

## Benchmark

```
                              main (baseline)      stmt-cache           delta
BenchmarkExpandSmall            89.0s                73.3s              -17.7%
BenchmarkExpandSmallMedium     113.9s                94.4s              -17.1%
```

17-18% wall-clock improvement. Allocations flat (goqu still builds the SQL string — savings are pure CPU from eliminating bytecode recompilation).

## Test plan

- [x] `go test -short ./pkg/dotc1z/...` — all pass
- [x] `go test ./pkg/sync/...` — all pass
- [x] `go vet ./pkg/dotc1z/...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)