### PR TITLE
perf(sync): add WithMinCheckpointInterval syncer option

### DIFF
--- a/pkg/sync/checkpoint_interval_test.go
+++ b/pkg/sync/checkpoint_interval_test.go
@@ -1,0 +1,78 @@
+package sync //nolint:revive,nolintlint // existing package name preserved for backwards compatibility
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithMinCheckpointInterval(t *testing.T) {
+	t.Run("sets positive duration", func(t *testing.T) {
+		s := &syncer{}
+		WithMinCheckpointInterval(5 * time.Second)(s)
+		require.Equal(t, 5*time.Second, s.minCheckpointInterval)
+	})
+
+	t.Run("zero is rejected (field stays at default-zero so Checkpoint falls back)", func(t *testing.T) {
+		s := &syncer{minCheckpointInterval: 7 * time.Second}
+		WithMinCheckpointInterval(0)(s)
+		require.Equal(t, 7*time.Second, s.minCheckpointInterval,
+			"zero must not overwrite a previously-set value")
+	})
+
+	t.Run("negative is rejected", func(t *testing.T) {
+		s := &syncer{minCheckpointInterval: 7 * time.Second}
+		WithMinCheckpointInterval(-1 * time.Second)(s)
+		require.Equal(t, 7*time.Second, s.minCheckpointInterval,
+			"negative must not overwrite a previously-set value")
+	})
+
+	t.Run("starting from zero stays zero for non-positive input", func(t *testing.T) {
+		s := &syncer{}
+		WithMinCheckpointInterval(0)(s)
+		require.Equal(t, time.Duration(0), s.minCheckpointInterval)
+		WithMinCheckpointInterval(-1)(s)
+		require.Equal(t, time.Duration(0), s.minCheckpointInterval)
+	})
+}
+
+// TestSyncerCheckpoint_IntervalGate exercises the interval gate on Checkpoint
+// without touching state.Marshal or store.CheckpointSync. We force-set
+// lastCheckPointTime so the gate is reached, then assert the early-return.
+// A configured interval of 1 hour should short-circuit; the default (10s)
+// should also short-circuit when lastCheckPointTime is "now".
+func TestSyncerCheckpoint_IntervalGate(t *testing.T) {
+	t.Run("configured interval gates non-forced checkpoint", func(t *testing.T) {
+		s := &syncer{
+			minCheckpointInterval: 1 * time.Hour,
+			lastCheckPointTime:    time.Now(),
+		}
+		err := s.Checkpoint(t.Context(), false)
+		require.NoError(t, err, "interval gate must short-circuit before reaching store")
+	})
+
+	t.Run("default interval gates non-forced checkpoint right after a previous one", func(t *testing.T) {
+		s := &syncer{
+			// minCheckpointInterval=0 → Checkpoint falls back to defaultMinCheckpointInterval (10s)
+			lastCheckPointTime: time.Now(),
+		}
+		err := s.Checkpoint(t.Context(), false)
+		require.NoError(t, err)
+	})
+
+	t.Run("zero lastCheckPointTime bypasses the gate", func(t *testing.T) {
+		// lastCheckPointTime.IsZero() → gate does not apply → Checkpoint proceeds
+		// to state.Marshal which will panic on a nil state. We use a deferred
+		// recover to assert we got past the early-return.
+		s := &syncer{
+			minCheckpointInterval: 1 * time.Hour,
+		}
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatal("expected Checkpoint to proceed past the gate (and panic on nil state)")
+			}
+		}()
+		_ = s.Checkpoint(t.Context(), false)
+	})
+}

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -167,6 +167,7 @@ type syncer struct {
 	injectSyncIDAnnotation              bool
 	setSessionStore                     sessions.SetSessionStore
 	syncResourceTypes                   []string
+	minCheckpointInterval               time.Duration
 	workerCount                         int // If 1, sync is sequential (default). If > 1, sync operations are done in parallel.
 	metricsHandler                      metrics.Handler
 	syncIdentity                        uotel.SyncIdentity
@@ -350,11 +351,15 @@ func (a expanderStoreAdapter) GrantsForEntitlementPrincipalSorted() bool {
 	return ok && store.GrantsForEntitlementPrincipalSorted()
 }
 
-const minCheckpointInterval = 10 * time.Second
+const defaultMinCheckpointInterval = 10 * time.Second
 
 // Checkpoint marshals the current state and stores it.
 func (s *syncer) Checkpoint(ctx context.Context, force bool) error {
-	if !force && !s.lastCheckPointTime.IsZero() && time.Since(s.lastCheckPointTime) < minCheckpointInterval {
+	interval := s.minCheckpointInterval
+	if interval == 0 {
+		interval = defaultMinCheckpointInterval
+	}
+	if !force && !s.lastCheckPointTime.IsZero() && time.Since(s.lastCheckPointTime) < interval {
 		return nil
 	}
 	start := time.Now()
@@ -3032,6 +3037,18 @@ func WithRunDuration(d time.Duration) SyncOpt {
 	return func(s *syncer) {
 		if d > 0 {
 			s.runDuration = d
+		}
+	}
+}
+
+// WithMinCheckpointInterval sets the minimum time between non-forced
+// checkpoints. Checkpoints compress and persist the c1z file; for large
+// tenants this dominates CPU. Higher values reduce checkpoint overhead at
+// the cost of more lost work on a hard crash. Default 10s.
+func WithMinCheckpointInterval(d time.Duration) SyncOpt {
+	return func(s *syncer) {
+		if d > 0 {
+			s.minCheckpointInterval = d
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Add `WithMinCheckpointInterval(d time.Duration)` as a `SyncOpt` so callers can tune how often the syncer persists the c1z file during non-forced checkpoints.

## Problem

Profile of be-temporal-sync for a large-tenant connector (72 GB c1z, 180K users, 139K groups) shows **60% of sync CPU** in `CheckpointSync` → `saveC1z` → zstd compression → io.Copy. The current hardcoded `minCheckpointInterval = 10s` means the file is compressed and written to disk every 10 seconds.

For context:
- This tenant's sync activity has had **zero hard crashes** in 15 days of data
- All timeouts are clean activity-window exits (force-checkpoint before return)
- The 10s interval wastes 60% of CPU on checkpoints that protect against a crash that doesn't happen

## Fix

- Rename `minCheckpointInterval` const to `defaultMinCheckpointInterval`
- Add `minCheckpointInterval time.Duration` field on `syncer` struct
- Add `WithMinCheckpointInterval(d)` option
- `Checkpoint(ctx, force=false)` uses the configured interval (falls back to default 10s)
- `Checkpoint(ctx, force=true)` always checkpoints (unchanged — clean exits still save)

## Usage

```go
syncer.New(connector, opts...,
    sync.WithMinCheckpointInterval(2 * time.Minute),
)
```

Setting 2 minutes reduces checkpoint overhead by ~12x (from every 10s to every 120s). The tradeoff: up to 2 minutes of lost work on a hard crash instead of 10 seconds.

## Test plan

- [x] `go vet ./pkg/sync/...` — clean
- [x] `go test ./pkg/sync/...` — all pass
- [x] Default behavior unchanged (0 value falls back to 10s)
- [x] Negative/zero duration ignored (matches WithRunDuration pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)