### PR TITLE
ci(pr-leakage): add caller stub for shared pr-leakage workflow

### DIFF
--- a/.github/workflows/pr-leakage.yaml
+++ b/.github/workflows/pr-leakage.yaml
@@ -1,0 +1,18 @@
+name: pr-leakage
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check:
+    # Pinned to @main until the reusable workflow gets a tagged release; tracked as
+    # follow-up so this caller can pin to a stable ref.
+    uses: ConductorOne/github-workflows/.github/workflows/pr-leakage-check.yaml@main
+    with:
+      pr_number: ${{ github.event.pull_request.number }}
+    secrets: inherit


### PR DESCRIPTION
## Summary

Add a one-file caller stub that wires this repo into the reusable `pr-leakage-check` workflow hosted in `ConductorOne/github-workflows`. The stub scans every PR's title, body, and commit messages for customer-identifying data and internal infra references.

## What changed

- Add `.github/workflows/pr-leakage.yaml` — invokes `ConductorOne/github-workflows/.github/workflows/pr-leakage-check.yaml@main` on `pull_request` events of types `opened`, `edited`, `synchronize`, and `reopened`.

No source code changes.

## Why

config-validation — Public repos must not name a specific customer or expose internal service topology in a permanent, world-readable artifact. The four trigger types cover the failure modes: a clean PR cannot have its body edited later to add a customer name without re-scanning, and new commit messages on a push are also scanned.

## Test plan

- The reusable workflow's own self-test (in `ConductorOne/github-workflows`) covers the scanner against captured leaky and clean fixtures.
- After this stub lands, the next PR opened on this repo triggers the check.
- This PR's own title and body were scanned with the new tool and produced zero findings.

## Risk

low — The workflow runs in the base-repo context with read-only `GITHUB_TOKEN` and pulls the scanner from `@main` of the shared repo, not from the PR head, so a fork PR cannot modify the scanner that runs on it. Failure surfaces as a check failure without blocking merge until a repo admin adds the check to required-checks.

## Follow-ups

- Pin the `uses:` ref to a tagged version once `ConductorOne/github-workflows` cuts one.
- After a bake-in period, add `pr-leakage / check` to this repo's required checks.

Refs: ConductorOne/github-workflows#85