### PR TITLE
[CXP-559] Classify http2 client connection lost as transient

### DIFF
--- a/pkg/lambda/grpc/util.go
+++ b/pkg/lambda/grpc/util.go
@@ -144,6 +144,7 @@ func isTransientNetworkError(err error) bool {
 	return strings.Contains(msg, "connection reset by peer") ||
 		strings.Contains(msg, "broken pipe") ||
 		strings.Contains(msg, "connection refused") ||
+		strings.Contains(msg, "http2: client connection lost") ||
 		strings.Contains(msg, "i/o timeout") ||
 		strings.Contains(msg, "no such host") ||
 		(strings.Contains(msg, "unexpected EOF") && !strings.Contains(msg, "unexpected EOF on client connection"))

--- a/pkg/lambda/grpc/util_test.go
+++ b/pkg/lambda/grpc/util_test.go
@@ -26,6 +26,7 @@ func TestIsTransientNetworkError(t *testing.T) {
 		{name: "connection reset by peer", err: fmt.Errorf("read tcp 169.254.100.6:53312->10.102.197.53:3128: read: connection reset by peer"), want: true},
 		{name: "broken pipe", err: fmt.Errorf("write: broken pipe"), want: true},
 		{name: "connection refused", err: fmt.Errorf("dial tcp 10.0.0.1:443: connection refused"), want: true},
+		{name: "http2 client connection lost", err: fmt.Errorf("Get \"https://api.github.com/repos/example/repo/collaborators\": http2: client connection lost"), want: true},
 		{name: "i/o timeout", err: fmt.Errorf("dial tcp 10.0.0.1:443: i/o timeout"), want: true},
 		{name: "no such host", err: fmt.Errorf("dial tcp: lookup example.invalid: no such host"), want: true},
 		{name: "unexpected EOF", err: fmt.Errorf("unexpected EOF"), want: true},
@@ -54,6 +55,18 @@ func TestErrorResponse_TransientNetworkError(t *testing.T) {
 	require.Equal(t, codes.Unavailable, st.Code())
 	require.Contains(t, st.Message(), "transient network error")
 	require.Contains(t, st.Message(), "connection reset by peer")
+}
+
+func TestErrorResponse_HTTP2ClientConnectionLost(t *testing.T) {
+	err := fmt.Errorf("github-connector: failed to list collaborators: Get \"https://api.github.com/repos/example/repo/collaborators\": http2: client connection lost")
+	resp := ErrorResponse(err)
+	require.NotNil(t, resp)
+
+	st, stErr := resp.Status()
+	require.NoError(t, stErr)
+	require.Equal(t, codes.Unavailable, st.Code())
+	require.Contains(t, st.Message(), "transient network error")
+	require.Contains(t, st.Message(), "http2: client connection lost")
 }
 
 func TestStatusForApplicationError_ConnectionResetWrapped(t *testing.T) {

--- a/pkg/uhttp/errors.go
+++ b/pkg/uhttp/errors.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"strings"
 	"syscall"
 
 	"google.golang.org/grpc/codes"
@@ -24,6 +25,9 @@ func wrapTransientNetworkError(err error) error {
 	if errors.Is(err, syscall.ECONNRESET) {
 		return WrapErrors(codes.Unavailable, "connection reset", err)
 	}
+	if isHTTP2ClientConnectionLost(err) {
+		return WrapErrors(codes.Unavailable, "http2 client connection lost", err)
+	}
 
 	var urlErr *url.Error
 	if errors.As(err, &urlErr) {
@@ -40,4 +44,8 @@ func wrapTransientNetworkError(err error) error {
 	}
 
 	return err
+}
+
+func isHTTP2ClientConnectionLost(err error) bool {
+	return strings.Contains(err.Error(), "http2: client connection lost")
 }

--- a/pkg/uhttp/transport_test.go
+++ b/pkg/uhttp/transport_test.go
@@ -84,6 +84,34 @@ func TestTransportRoundTrip_ClassifiesTimeout(t *testing.T) {
 	require.Contains(t, st.Message(), "request timeout")
 }
 
+func TestTransportRoundTrip_ClassifiesHTTP2ClientConnectionLost(t *testing.T) {
+	tp := &Transport{
+		roundTripper: errorRoundTripper{
+			err: &url.Error{
+				Op:  "Get",
+				URL: "https://example.com",
+				Err: fmt.Errorf("http2: client connection lost"),
+			},
+		},
+		nextCycle: time.Now().Add(time.Minute),
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.com", nil)
+	require.NoError(t, err)
+
+	resp, err := tp.RoundTrip(req)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	require.Nil(t, resp)
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.Unavailable, st.Code())
+	require.Contains(t, st.Message(), "http2 client connection lost")
+}
+
 type timeoutError struct {
 	err error
 }


### PR DESCRIPTION
## Summary

GitHub API requests that stall past the http2 keepalive window surface as `http2: client connection lost`. This error was **not** classified as a transient network error, so it propagated up untyped — the SDK syncer's retry-on-`codes.Unavailable` safety net (`pkg/sync/parallel_syncer.go` → `pkg/retry`) never engaged, and a sync action would fail on a recoverable connection drop instead of retrying the same page.

This change maps the error to `codes.Unavailable` at both classification boundaries:

- `pkg/uhttp/errors.go` (`wrapTransientNetworkError`) — connector outbound HTTP, e.g. `GET /repos/{org}/{repo}/collaborators`
- `pkg/lambda/grpc/util.go` (`isTransientNetworkError`) — the Lambda invocation boundary, keeping parity with the existing transient classes (connection reset, broken pipe, i/o timeout)

Once classified, the existing action-level retryer resumes the failing paginated request (pagination state is held on the action), and the sync completes.

## Why a substring match

`golang.org/x/net/http2` constructs this error via `errors.New("http2: client connection lost")` with no exported sentinel or type, so a substring match is the only available signal. This mirrors how the lambda classifier already detects `connection reset by peer`, `broken pipe`, etc. The http2 keepalive ping that produces this error is load-bearing (it detects dead tunnels through NLBs/proxies during slow responses in ~30s, and covers mid-body stalls that bare timeouts can't), so removing it to get cleaner error types was rejected as a worse tradeoff.

## Scope

Classification only. This is sufficient to fix sync correctness. A separate, optional transport-level retry (faster recovery + suppressing the per-drop Error log) was considered and deliberately left out of this PR.

## Test plan

- [ ] `pkg/uhttp`: `TestTransportRoundTrip_ClassifiesHTTP2ClientConnectionLost` asserts `codes.Unavailable` through the full `RoundTrip` path
- [ ] `pkg/lambda/grpc`: `TestIsTransientNetworkError` table entry + `TestErrorResponse_HTTP2ClientConnectionLost` end-to-end status assertion
- [ ] `go test ./pkg/uhttp/... ./pkg/lambda/grpc/...` passes
- [ ] `make lint` clean for changed files

See CXP-559 for investigation details.