### PR TITLE
Classify net.Error timeouts as DeadlineExceeded in transport and lambda

### DIFF
--- a/pkg/lambda/grpc/util.go
+++ b/pkg/lambda/grpc/util.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"net"
 	"net/url"
 	"strconv"
 	"strings"
@@ -146,6 +147,9 @@ func isTransientNetworkError(err error) bool {
 		strings.Contains(msg, "connection refused") ||
 		strings.Contains(msg, "http2: client connection lost") ||
 		strings.Contains(msg, "i/o timeout") ||
+		// Timeout strings: mapped to Unavailable as fallback for serialized errors that lost net.Error.
+		strings.Contains(msg, "connection timed out") ||
+		strings.Contains(msg, "TLS handshake timeout") ||
 		strings.Contains(msg, "no such host") ||
 		(strings.Contains(msg, "unexpected EOF") && !strings.Contains(msg, "unexpected EOF on client connection"))
 }
@@ -199,6 +203,13 @@ func statusForApplicationError(err error) *status.Status {
 		if urlErr.Temporary() {
 			return status.Newf(codes.Unavailable, "temporary error: %s", err)
 		}
+	}
+
+	// Catches net.Error timeout types not wrapped in url.Error
+	// (e.g. tls.handshakeTimeoutError at the RoundTrip level).
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return status.Newf(codes.DeadlineExceeded, "network timeout: %s", err)
 	}
 
 	if isTransientNetworkError(err) {

--- a/pkg/lambda/grpc/util_test.go
+++ b/pkg/lambda/grpc/util_test.go
@@ -35,6 +35,8 @@ func TestIsTransientNetworkError(t *testing.T) {
 		{name: "grpc status error", err: status.Errorf(codes.Internal, "internal error"), want: false},
 		{name: "context canceled", err: context.Canceled, want: false},
 		{name: "context deadline exceeded", err: context.DeadlineExceeded, want: false},
+		{name: "TLS handshake timeout", err: fmt.Errorf("net/http: TLS handshake timeout"), want: true},
+		{name: "connection timed out", err: fmt.Errorf("read tcp 10.0.0.1:443: connection timed out"), want: true},
 	}
 
 	for _, tt := range tests {
@@ -102,6 +104,17 @@ func TestStatusForApplicationError_URLTimeout(t *testing.T) {
 	st := statusForApplicationError(err)
 	require.Equal(t, codes.DeadlineExceeded, st.Code())
 	require.Contains(t, st.Message(), "request timeout")
+}
+
+func TestStatusForApplicationError_NetErrorTimeout(t *testing.T) {
+	err := &net.OpError{
+		Op:  "read",
+		Net: "tcp",
+		Err: timeoutError{err: fmt.Errorf("net/http: TLS handshake timeout")},
+	}
+	st := statusForApplicationError(err)
+	require.Equal(t, codes.DeadlineExceeded, st.Code())
+	require.Contains(t, st.Message(), "network timeout")
 }
 
 func TestErrorResponse_UnknownError(t *testing.T) {

--- a/pkg/uhttp/errors.go
+++ b/pkg/uhttp/errors.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/url"
 	"strings"
 	"syscall"
@@ -37,6 +38,13 @@ func wrapTransientNetworkError(err error) error {
 		if urlErr.Temporary() {
 			return WrapErrors(codes.Unavailable, fmt.Sprintf("temporary error: %v", urlErr.URL), urlErr)
 		}
+	}
+
+	// Catches net.Error timeout types not wrapped in url.Error
+	// (e.g. tls.handshakeTimeoutError at the RoundTrip level).
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return WrapErrors(codes.DeadlineExceeded, fmt.Sprintf("network timeout: %v", err), err)
 	}
 
 	if errors.Is(err, context.DeadlineExceeded) {

--- a/pkg/uhttp/transport_test.go
+++ b/pkg/uhttp/transport_test.go
@@ -112,6 +112,34 @@ func TestTransportRoundTrip_ClassifiesHTTP2ClientConnectionLost(t *testing.T) {
 	require.Contains(t, st.Message(), "http2 client connection lost")
 }
 
+func TestTransportRoundTrip_ClassifiesNetErrorTimeout(t *testing.T) {
+	tp := &Transport{
+		roundTripper: errorRoundTripper{
+			err: &net.OpError{
+				Op:  "read",
+				Net: "tcp",
+				Err: timeoutError{err: fmt.Errorf("net/http: TLS handshake timeout")},
+			},
+		},
+		nextCycle: time.Now().Add(time.Minute),
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.com", nil)
+	require.NoError(t, err)
+
+	resp, err := tp.RoundTrip(req)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	require.Nil(t, resp)
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.DeadlineExceeded, st.Code())
+	require.Contains(t, st.Message(), "network timeout")
+}
+
 type timeoutError struct {
 	err error
 }


### PR DESCRIPTION
## Problem

wrapTransientNetworkError and statusForApplicationError handled url.Error
timeouts but missed net.Error timeouts (e.g. tls.handshakeTimeoutError) that
arrive unwrapped at the RoundTrip level.

uhttp.Transport.RoundTrip() is invoked as a transport, before http.Client.Do()
has a chance to wrap errors in url.Error. When a TLS handshake times out, the
net.OpError reaches wrapTransientNetworkError directly — the existing
url.Error.Timeout() check doesn't catch it, and it falls through to codes.Unknown.

## Fix

Add a net.Error timeout check in both wrapTransientNetworkError (uhttp) and
statusForApplicationError (lambda/grpc) after the url.Error block. Structured
errors are now caught before the string-based fallback in isTransientNetworkError.