### PR TITLE
Bind Windows connector listener to loopback address

### DIFF
--- a/internal/connector/connector_server_windows.go
+++ b/internal/connector/connector_server_windows.go
@@ -40,7 +40,7 @@ func (cw *wrapper) getListener(ctx context.Context, serverCfg *connectorwrapperV
 
 	l.Debug("starting listener", zap.Uint32("port", serverCfg.ListenPort))
 
-	listener, err := net.ListenTCP("tcp", &net.TCPAddr{Port: int(serverCfg.ListenPort)})
+	listener, err := net.ListenTCP("tcp", &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: int(serverCfg.ListenPort)})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The getListener function left TCPAddr.IP unset, causing Go to bind on 0.0.0.0 (all interfaces). Explicitly bind to 127.0.0.1 to match the loopback intent of the setupListener port-picking call and restrict the gRPC surface to local-only access.
