### PR TITLE
Detach ctx for c1z finalize so caller cancel cannot truncate the artifact

### DIFF
--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -434,20 +433,21 @@ func cleanupDbDir(dbFilePath string, err error) error {
 
 var ErrReadOnly = errors.New("c1z: read only mode")
 
-const defaultCheckpointTimeout = 120
-
-var checkpointTimeout, _ = strconv.ParseInt(os.Getenv("BATON_WAL_CHECKPOINT_TIMEOUT"), 10, 64)
-
-// Close ensures that the sqlite database is flushed to disk, and if any changes were made we update the original database
-// with our changes. The provided context is used for the WAL checkpoint operation. If the context is already expired,
-// a fresh context with a timeout is used to ensure the checkpoint completes.
+// Close ensures that the sqlite database is flushed to disk, and if any
+// changes were made we update the original database with our changes.
+//
+// When there is real finalize work to do (rawDb open, dbUpdated, not
+// read-only), the WAL checkpoint, raw-db close, and saveC1z all run on a
+// detached context bounded by FinalizeTimeout(). Caller cancellation
+// cannot truncate the c1z mid-finalize; the new-root finalize span links
+// back to the caller's trace for navigability without bloating the
+// parent trace.
 //
 //nolint:nonamedreturns // named return required so the deferred span captures all early-return error paths
 func (c *C1File) Close(ctx context.Context) (retErr error) {
 	ctx, span := tracer.Start(ctx, "C1File.Close")
 	defer func() { uotel.EndSpanWithError(span, retErr) }()
 
-	var err error
 	l := ctxzap.Extract(ctx)
 
 	c.closedMu.Lock()
@@ -463,101 +463,132 @@ func (c *C1File) Close(ctx context.Context) (retErr error) {
 		attribute.String("db_path", c.dbFilePath),
 	)
 
+	// Cheap paths (no save-to-disk work) keep the caller's context and
+	// span topology. Read-only opens never write the c1z back, even if
+	// the c1z was opened without being read; the same is true when no
+	// mutations occurred.
+	if !c.dbUpdated || c.readOnly {
+		if c.dbUpdated && c.readOnly {
+			return cleanupDbDir(c.dbFilePath, ErrReadOnly)
+		}
+		if c.rawDb != nil {
+			if err := c.closeRawDB(ctx); err != nil {
+				return cleanupDbDir(c.dbFilePath, err)
+			}
+		}
+		if err := cleanupDbDir(c.dbFilePath, nil); err != nil {
+			return err
+		}
+		c.closed = true
+		return nil
+	}
+
+	if err := c.finalize(ctx); err != nil {
+		return err
+	}
+	c.closed = true
+	return nil
+}
+
+// finalize runs the WAL-checkpoint → close-raw-db → saveC1z sequence on a
+// context that is detached from the caller's cancellation. The detached
+// context is bounded by FinalizeTimeout() so a wedged finalize cannot
+// hold the c1file open indefinitely. The finalize span is a new root
+// linked to the caller's trace so very long syncs don't end up with the
+// upload subtree inflating their span counts.
+func (c *C1File) finalize(ctx context.Context) error {
+	parentCtxErrLabel := uotel.ClassifyCtxErr(ctx.Err())
+
+	timeout := FinalizeTimeout()
+	finalizeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), timeout)
+	defer cancel()
+
+	finalizeCtx, finalizeSpan := uotel.StartWithLink(finalizeCtx, tracer, "C1File.finalize")
+	var finalizeErr error
+	defer func() { uotel.EndSpanWithError(finalizeSpan, finalizeErr) }()
+	finalizeSpan.SetAttributes(
+		attribute.Bool("c1z.finalize.cancel_observed", parentCtxErrLabel != "nil"),
+		attribute.String("c1z.finalize.parent_ctx_err", parentCtxErrLabel),
+		attribute.Int64("c1z.finalize.timeout_seconds", int64(timeout.Seconds())),
+		attribute.String("c1z.finalize.db_path", c.dbFilePath),
+	)
+
+	l := ctxzap.Extract(finalizeCtx)
+
+	// Only WAL-checkpoint and close the raw DB if a handle is open.
+	// Some callers (notably TestC1ZDecoder) manually close c.rawDb to
+	// force a checkpoint before calling Close — that path skips both
+	// operations here and proceeds directly to saveC1z.
 	if c.rawDb != nil {
 		// CRITICAL: Force a full WAL checkpoint before closing the database.
 		// This ensures all WAL data is written back to the main database file
 		// and the writes are synced to disk. Without this, on filesystems with
 		// aggressive caching (like ZFS with large ARC), the subsequent saveC1z()
 		// read could see stale data because the checkpoint writes may still be
-		// in kernel buffers.
-		//
-		// TRUNCATE mode: checkpoint as many frames as possible, then truncate
-		// the WAL file to zero bytes. This guarantees all data is in the main
-		// database file before we read it for compression.
-		if c.dbUpdated && !c.readOnly {
-			// Use a dedicated context for the checkpoint. The caller's context
-			// may already be expired (e.g. Temporal activity deadline), but the
-			// checkpoint is a local SQLite operation that must complete to avoid
-			// saving a stale c1z.
-			checkpointCtx := ctx
-			if ctx.Err() != nil {
-				if checkpointTimeout <= 0 {
-					checkpointTimeout = defaultCheckpointTimeout
-				}
-				var checkpointCancel context.CancelFunc
-				checkpointCtx, checkpointCancel = context.WithTimeout(context.Background(), time.Duration(checkpointTimeout)*time.Second)
-				defer checkpointCancel()
+		// in kernel buffers. TRUNCATE mode checkpoints as many frames as possible
+		// then truncates the WAL file to zero bytes.
+		busy, log, checkpointed, err := c.truncateWAL(finalizeCtx)
+		if err != nil {
+			finalizeErr = fmt.Errorf("c1z: WAL checkpoint failed: %w", err)
+			l.Error("WAL checkpoint failed before close",
+				zap.Error(err),
+				zap.String("db_path", c.dbFilePath))
+			if closeErr := c.closeRawDB(finalizeCtx); closeErr != nil {
+				l.Error("error closing raw db", zap.Error(closeErr))
 			}
-
-			// Use QueryRowContext to read the (busy, log, checkpointed) result.
-			// ExecContext silently discards these values, making partial
-			// checkpoints undetectable — the PRAGMA returns nil error even when
-			// it can't checkpoint all frames due to concurrent readers.
-			busy, log, checkpointed, err := c.truncateWAL(checkpointCtx)
-			if err != nil {
-				l.Error("WAL checkpoint failed before close",
-					zap.Error(err),
-					zap.String("db_path", c.dbFilePath))
-				if closeErr := c.closeRawDB(ctx); closeErr != nil {
-					l.Error("error closing raw db", zap.Error(closeErr))
-				}
-				return cleanupDbDir(c.dbFilePath, fmt.Errorf("c1z: WAL checkpoint failed: %w", err))
+			return cleanupDbDir(c.dbFilePath, finalizeErr)
+		}
+		if busy != 0 || (log >= 0 && checkpointed < log) {
+			finalizeErr = fmt.Errorf("c1z: WAL checkpoint incomplete: busy=%d log=%d checkpointed=%d", busy, log, checkpointed)
+			l.Error("WAL checkpoint incomplete before close",
+				zap.Int("busy", busy),
+				zap.Int("log", log),
+				zap.Int("checkpointed", checkpointed),
+				zap.String("db_path", c.dbFilePath))
+			if closeErr := c.closeRawDB(finalizeCtx); closeErr != nil {
+				l.Error("error closing raw db", zap.Error(closeErr))
 			}
-			if busy != 0 || (log >= 0 && checkpointed < log) {
-				l.Error("WAL checkpoint incomplete before close",
-					zap.Int("busy", busy),
-					zap.Int("log", log),
-					zap.Int("checkpointed", checkpointed),
-					zap.String("db_path", c.dbFilePath))
-				if closeErr := c.closeRawDB(ctx); closeErr != nil {
-					l.Error("error closing raw db", zap.Error(closeErr))
-				}
-				return cleanupDbDir(c.dbFilePath, fmt.Errorf("c1z: WAL checkpoint incomplete: busy=%d log=%d checkpointed=%d", busy, log, checkpointed))
-			}
+			return cleanupDbDir(c.dbFilePath, finalizeErr)
 		}
 
-		err = c.closeRawDB(ctx)
-		if err != nil {
+		if err := c.closeRawDB(finalizeCtx); err != nil {
+			finalizeErr = err
 			return cleanupDbDir(c.dbFilePath, err)
 		}
 	}
 
-	// We only want to save the file if we've made any changes
-	if c.dbUpdated {
-		if c.readOnly {
-			return cleanupDbDir(c.dbFilePath, ErrReadOnly)
-		}
-
-		// Verify WAL was fully checkpointed. If it still has data,
-		// saveC1z would create a c1z missing the WAL contents since
-		// it only reads the main database file.
-		walPath := c.dbFilePath + "-wal"
-		if walInfo, statErr := os.Stat(walPath); statErr == nil && walInfo.Size() > 0 {
-			return cleanupDbDir(c.dbFilePath, fmt.Errorf("c1z: WAL file not empty after close (size=%d) - refusing to save incomplete data", walInfo.Size()))
-		}
-
-		_, saveSpan := tracer.Start(ctx, "C1File.saveC1z")
-		saveSpan.SetAttributes(
-			attribute.String("db_path", c.dbFilePath),
-			attribute.String("output_path", c.outputFilePath),
-			attribute.Int("encoder_concurrency", c.encoderConcurrency),
-		)
-		if dbInfo, statErr := os.Stat(c.dbFilePath); statErr == nil {
-			saveSpan.SetAttributes(attribute.Int64("input_size_bytes", dbInfo.Size()))
-		}
-		err = saveC1z(c.dbFilePath, c.outputFilePath, c.encoderConcurrency)
-		uotel.EndSpanWithError(saveSpan, err)
-		if err != nil {
-			return cleanupDbDir(c.dbFilePath, err)
-		}
+	// Verify WAL was fully checkpointed. If it still has data, saveC1z
+	// would create a c1z missing the WAL contents since it only reads
+	// the main database file.
+	walPath := c.dbFilePath + "-wal"
+	if walInfo, statErr := os.Stat(walPath); statErr == nil && walInfo.Size() > 0 {
+		finalizeErr = fmt.Errorf("c1z: WAL file not empty after close (size=%d) - refusing to save incomplete data", walInfo.Size())
+		return cleanupDbDir(c.dbFilePath, finalizeErr)
 	}
 
-	err = cleanupDbDir(c.dbFilePath, err)
-	if err != nil {
+	_, saveSpan := tracer.Start(finalizeCtx, "C1File.saveC1z")
+	saveSpan.SetAttributes(
+		attribute.String("db_path", c.dbFilePath),
+		attribute.String("output_path", c.outputFilePath),
+		attribute.Int("encoder_concurrency", c.encoderConcurrency),
+	)
+	var saveSize int64
+	if dbInfo, statErr := os.Stat(c.dbFilePath); statErr == nil {
+		saveSize = dbInfo.Size()
+		saveSpan.SetAttributes(attribute.Int64("input_size_bytes", saveSize))
+		finalizeSpan.SetAttributes(attribute.Int64("c1z.finalize.bytes_written", saveSize))
+	}
+	saveErr := saveC1z(c.dbFilePath, c.outputFilePath, c.encoderConcurrency)
+	uotel.EndSpanWithError(saveSpan, saveErr)
+	if saveErr != nil {
+		finalizeErr = saveErr
+		return cleanupDbDir(c.dbFilePath, saveErr)
+	}
+
+	if err := cleanupDbDir(c.dbFilePath, nil); err != nil {
+		finalizeErr = err
 		return err
 	}
-	c.closed = true
-
 	return nil
 }
 

--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -466,15 +466,19 @@ func (c *C1File) Close(ctx context.Context) (retErr error) {
 	// Cheap paths (no save-to-disk work) keep the caller's context and
 	// span topology. Read-only opens never write the c1z back, even if
 	// the c1z was opened without being read; the same is true when no
-	// mutations occurred.
+	// mutations occurred. Every cheap-path branch closes c.rawDb (when
+	// open) before returning so a misuse like opening read-only and
+	// then dirtying via an attached-db mutation still releases the
+	// SQLite handle and any FDs/goroutines it owns.
 	if !c.dbUpdated || c.readOnly {
-		if c.dbUpdated && c.readOnly {
-			return cleanupDbDir(c.dbFilePath, ErrReadOnly)
-		}
 		if c.rawDb != nil {
 			if err := c.closeRawDB(ctx); err != nil {
 				return cleanupDbDir(c.dbFilePath, err)
 			}
+		}
+		if c.dbUpdated && c.readOnly {
+			c.closed = true
+			return cleanupDbDir(c.dbFilePath, ErrReadOnly)
 		}
 		if err := cleanupDbDir(c.dbFilePath, nil); err != nil {
 			return err
@@ -492,12 +496,24 @@ func (c *C1File) Close(ctx context.Context) (retErr error) {
 
 // finalize runs the WAL-checkpoint → close-raw-db → saveC1z sequence on a
 // context that is detached from the caller's cancellation. The detached
-// context is bounded by FinalizeTimeout() so a wedged finalize cannot
-// hold the c1file open indefinitely. The finalize span is a new root
-// linked to the caller's trace so very long syncs don't end up with the
-// upload subtree inflating their span counts.
+// context is bounded by FinalizeTimeout() for the steps that observe
+// ctx (truncateWAL, closeRawDB); saveC1z itself does not take ctx, so
+// its encoder phase is not cancellable today and the upper bound on
+// total finalize wall-clock is effectively FinalizeTimeout +
+// saveC1z-encoder-time. The finalize span is a new root linked to the
+// caller's trace so very long syncs don't end up with the upload
+// subtree inflating their span counts.
+//
+// If the caller propagated a parent ctx error label via
+// uotel.WithParentCtxErrLabel (e.g. syncer.Close did so before
+// detaching), that label wins over re-classifying ctx.Err() — useful
+// because by the time we reach here the caller's ctx may already be
+// the syncer's detached finalizeCtx, which always reports "nil".
 func (c *C1File) finalize(ctx context.Context) error {
 	parentCtxErrLabel := uotel.ClassifyCtxErr(ctx.Err())
+	if propagated, ok := uotel.ParentCtxErrLabel(ctx); ok {
+		parentCtxErrLabel = propagated
+	}
 
 	timeout := FinalizeTimeout()
 	finalizeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), timeout)
@@ -566,23 +582,25 @@ func (c *C1File) finalize(ctx context.Context) error {
 		return cleanupDbDir(c.dbFilePath, finalizeErr)
 	}
 
-	_, saveSpan := tracer.Start(finalizeCtx, "C1File.saveC1z")
+	saveCtx, saveSpan := tracer.Start(finalizeCtx, "C1File.saveC1z")
 	saveSpan.SetAttributes(
 		attribute.String("db_path", c.dbFilePath),
 		attribute.String("output_path", c.outputFilePath),
 		attribute.Int("encoder_concurrency", c.encoderConcurrency),
 	)
-	var saveSize int64
 	if dbInfo, statErr := os.Stat(c.dbFilePath); statErr == nil {
-		saveSize = dbInfo.Size()
-		saveSpan.SetAttributes(attribute.Int64("input_size_bytes", saveSize))
-		finalizeSpan.SetAttributes(attribute.Int64("c1z.finalize.bytes_written", saveSize))
+		saveSpan.SetAttributes(attribute.Int64("input_bytes", dbInfo.Size()))
+		finalizeSpan.SetAttributes(attribute.Int64("c1z.finalize.input_bytes", dbInfo.Size()))
 	}
+	_ = saveCtx // saveC1z doesn't currently take ctx; saveCtx is kept so any future span inside saveC1z attaches to saveSpan, not finalizeSpan.
 	saveErr := saveC1z(c.dbFilePath, c.outputFilePath, c.encoderConcurrency)
 	uotel.EndSpanWithError(saveSpan, saveErr)
 	if saveErr != nil {
 		finalizeErr = saveErr
 		return cleanupDbDir(c.dbFilePath, saveErr)
+	}
+	if outInfo, statErr := os.Stat(c.outputFilePath); statErr == nil {
+		finalizeSpan.SetAttributes(attribute.Int64("c1z.finalize.output_bytes", outInfo.Size()))
 	}
 
 	if err := cleanupDbDir(c.dbFilePath, nil); err != nil {

--- a/pkg/dotc1z/c1file_close_cancel_test.go
+++ b/pkg/dotc1z/c1file_close_cancel_test.go
@@ -72,9 +72,14 @@ func TestC1FileCloseSurvivesCanceledCtx(t *testing.T) {
 			require.Greater(t, info.Size(), int64(0))
 
 			// Reopen and verify the resource type was persisted.
+			// Use context.Background here, not openCtx — t.Context() is
+			// cancelled BEFORE t.Cleanup runs, so a defer/Cleanup-style
+			// close on openCtx would swallow any real cleanup error.
 			f2, err := NewC1ZFile(openCtx, testFilePath)
 			require.NoError(t, err)
-			t.Cleanup(func() { _ = f2.Close(openCtx) })
+			t.Cleanup(func() {
+				require.NoError(t, f2.Close(context.Background()))
+			})
 
 			resp, err := f2.GetResourceType(openCtx, reader_v2.ResourceTypesReaderServiceGetResourceTypeRequest_builder{
 				ResourceTypeId: testResourceType,
@@ -85,10 +90,12 @@ func TestC1FileCloseSurvivesCanceledCtx(t *testing.T) {
 	}
 }
 
-// TestC1FileCloseReadOnlyIgnoresCancel ensures the cheap (no-finalize)
-// branch of Close still respects the caller's context — there is no
-// finalize work to protect, so detaching would only add span noise.
-func TestC1FileCloseReadOnlyIgnoresCancel(t *testing.T) {
+// TestC1FileCloseReadOnlyClosesRawDb checks the cheap-path invariant
+// that even a Close called with a cancelled context fully releases
+// the underlying sql.DB handle. The cheap path's only ctx-bearing op
+// (closeRawDB → c.rawDb.Close) ignores cancellation; this test pins
+// the structural promise that c.rawDb ends up nil regardless.
+func TestC1FileCloseReadOnlyClosesRawDb(t *testing.T) {
 	openCtx := t.Context()
 	testFilePath := filepath.Join(c1zTests.workingDir, "close-readonly.c1z")
 
@@ -102,8 +109,39 @@ func TestC1FileCloseReadOnlyIgnoresCancel(t *testing.T) {
 
 	f2, err := NewC1ZFile(openCtx, testFilePath, WithReadOnly(true))
 	require.NoError(t, err)
+	require.NotNil(t, f2.rawDb, "fixture: rawDb should be open after NewC1ZFile")
 
 	cancelCtx, cancel := context.WithCancel(openCtx)
 	cancel()
 	require.NoError(t, f2.Close(cancelCtx))
+	require.Nil(t, f2.rawDb, "rawDb must be nil-ed out by the cheap-path close even on cancelled ctx")
+	require.True(t, f2.closed, "c.closed must be set after a successful cheap-path close")
+}
+
+// TestC1FileCloseReadOnlyButDirtyClosesRawDb covers the ErrReadOnly
+// short-circuit: a read-only c1z whose dbUpdated flag was somehow
+// set must still have its sql.DB handle closed before Close returns,
+// otherwise the SQLite connection pool leaks against a directory
+// cleanupDbDir just removed.
+func TestC1FileCloseReadOnlyButDirtyClosesRawDb(t *testing.T) {
+	openCtx := t.Context()
+	testFilePath := filepath.Join(c1zTests.workingDir, "close-readonly-dirty.c1z")
+
+	f, err := NewC1ZFile(openCtx, testFilePath)
+	require.NoError(t, err)
+	_, err = f.StartNewSync(openCtx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, f.EndSync(openCtx))
+	require.NoError(t, f.Close(openCtx))
+
+	f2, err := NewC1ZFile(openCtx, testFilePath, WithReadOnly(true))
+	require.NoError(t, err)
+	require.NotNil(t, f2.rawDb)
+	// Force the readonly+dbUpdated cheap-path branch.
+	f2.dbUpdated = true
+
+	err = f2.Close(openCtx)
+	require.ErrorIs(t, err, ErrReadOnly)
+	require.Nil(t, f2.rawDb, "rawDb must be closed before returning ErrReadOnly")
+	require.True(t, f2.closed, "c.closed must be set after returning ErrReadOnly so a retry short-circuits")
 }

--- a/pkg/dotc1z/c1file_close_cancel_test.go
+++ b/pkg/dotc1z/c1file_close_cancel_test.go
@@ -1,0 +1,109 @@
+package dotc1z
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	reader_v2 "github.com/conductorone/baton-sdk/pb/c1/reader/v2"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+)
+
+// TestC1FileCloseSurvivesCanceledCtx exercises the finalize-detach path.
+// A caller cancellation (Temporal activity deadline, pod drain) must NOT
+// stop Close from checkpointing the WAL, writing the c1z, and producing
+// a durable, readable artifact on disk.
+func TestC1FileCloseSurvivesCanceledCtx(t *testing.T) {
+	cases := []struct {
+		name      string
+		slug      string
+		cancelCtx func(t *testing.T) context.Context
+	}{
+		{
+			name: "ctx canceled before close",
+			slug: "canceled",
+			cancelCtx: func(t *testing.T) context.Context {
+				ctx, cancel := context.WithCancel(t.Context())
+				cancel()
+				return ctx
+			},
+		},
+		{
+			name: "ctx deadline already exceeded",
+			slug: "deadline",
+			cancelCtx: func(t *testing.T) context.Context {
+				ctx, cancel := context.WithDeadline(t.Context(), time.Now().Add(-1*time.Second))
+				t.Cleanup(cancel)
+				return ctx
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			testFilePath := filepath.Join(c1zTests.workingDir, "close-cancel-"+tc.slug+".c1z")
+
+			openCtx := t.Context()
+			f, err := NewC1ZFile(openCtx, testFilePath)
+			require.NoError(t, err)
+
+			_, err = f.StartNewSync(openCtx, connectorstore.SyncTypeFull, "")
+			require.NoError(t, err)
+
+			err = f.PutResourceTypes(openCtx, v2.ResourceType_builder{Id: testResourceType}.Build())
+			require.NoError(t, err)
+
+			err = f.EndSync(openCtx)
+			require.NoError(t, err)
+
+			// Now close with a cancelled context. Finalize must still
+			// complete because the detached context inside Close has
+			// its own bound.
+			err = f.Close(tc.cancelCtx(t))
+			require.NoError(t, err)
+
+			// The c1z must exist on disk and be readable.
+			info, err := os.Stat(testFilePath)
+			require.NoError(t, err)
+			require.Greater(t, info.Size(), int64(0))
+
+			// Reopen and verify the resource type was persisted.
+			f2, err := NewC1ZFile(openCtx, testFilePath)
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = f2.Close(openCtx) })
+
+			resp, err := f2.GetResourceType(openCtx, reader_v2.ResourceTypesReaderServiceGetResourceTypeRequest_builder{
+				ResourceTypeId: testResourceType,
+			}.Build())
+			require.NoError(t, err)
+			require.Equal(t, testResourceType, resp.GetResourceType().GetId())
+		})
+	}
+}
+
+// TestC1FileCloseReadOnlyIgnoresCancel ensures the cheap (no-finalize)
+// branch of Close still respects the caller's context — there is no
+// finalize work to protect, so detaching would only add span noise.
+func TestC1FileCloseReadOnlyIgnoresCancel(t *testing.T) {
+	openCtx := t.Context()
+	testFilePath := filepath.Join(c1zTests.workingDir, "close-readonly.c1z")
+
+	// Seed a c1z so we can reopen it read-only.
+	f, err := NewC1ZFile(openCtx, testFilePath)
+	require.NoError(t, err)
+	_, err = f.StartNewSync(openCtx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, f.EndSync(openCtx))
+	require.NoError(t, f.Close(openCtx))
+
+	f2, err := NewC1ZFile(openCtx, testFilePath, WithReadOnly(true))
+	require.NoError(t, err)
+
+	cancelCtx, cancel := context.WithCancel(openCtx)
+	cancel()
+	require.NoError(t, f2.Close(cancelCtx))
+}

--- a/pkg/dotc1z/finalize_timeout.go
+++ b/pkg/dotc1z/finalize_timeout.go
@@ -1,0 +1,36 @@
+package dotc1z
+
+import (
+	"os"
+	"strconv"
+	"time"
+)
+
+// DefaultFinalizeTimeout bounds the detached context used for c1z
+// finalization (WAL checkpoint, save-to-disk, upload). Large tenants take
+// 5-15 min to upload a 4 GB compressed c1z; one hour gives plenty of
+// headroom while still being a hard ceiling so a wedged upload cannot
+// hold a worker indefinitely.
+const DefaultFinalizeTimeout = 1 * time.Hour
+
+// finalizeTimeout holds the resolved value. Set once at package init from
+// BATON_C1Z_FINALIZE_TIMEOUT (seconds); falls back to DefaultFinalizeTimeout
+// when unset or invalid.
+var finalizeTimeout = parseFinalizeTimeout(os.Getenv("BATON_C1Z_FINALIZE_TIMEOUT"))
+
+func parseFinalizeTimeout(v string) time.Duration {
+	if v == "" {
+		return DefaultFinalizeTimeout
+	}
+	secs, err := strconv.ParseInt(v, 10, 64)
+	if err != nil || secs <= 0 {
+		return DefaultFinalizeTimeout
+	}
+	return time.Duration(secs) * time.Second
+}
+
+// FinalizeTimeout returns the bound for the detached context that wraps
+// c1z finalize-and-upload tails.
+func FinalizeTimeout() time.Duration {
+	return finalizeTimeout
+}

--- a/pkg/dotc1z/finalize_timeout_test.go
+++ b/pkg/dotc1z/finalize_timeout_test.go
@@ -1,0 +1,28 @@
+package dotc1z
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseFinalizeTimeout(t *testing.T) {
+	cases := []struct {
+		name string
+		env  string
+		want time.Duration
+	}{
+		{name: "empty falls back to default", env: "", want: DefaultFinalizeTimeout},
+		{name: "garbage falls back to default", env: "not-a-number", want: DefaultFinalizeTimeout},
+		{name: "zero falls back to default", env: "0", want: DefaultFinalizeTimeout},
+		{name: "negative falls back to default", env: "-30", want: DefaultFinalizeTimeout},
+		{name: "valid seconds parses through", env: "1800", want: 30 * time.Minute},
+		{name: "single-second value parses through", env: "1", want: 1 * time.Second},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, parseFinalizeTimeout(tc.env))
+		})
+	}
+}

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -2700,6 +2700,12 @@ func (s *syncer) Close(ctx context.Context) error {
 	timeout := dotc1z.FinalizeTimeout()
 	finalizeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), timeout)
 	defer cancel()
+	// Propagate the original caller's ctx-error label across the detach
+	// so downstream finalize spans (e.g. C1File.finalize) can record
+	// what the caller actually saw — without this, the nested span
+	// would re-classify our already-detached ctx and always report
+	// parent_ctx_err="nil".
+	finalizeCtx = uotel.WithParentCtxErrLabel(finalizeCtx, parentCtxErrLabel)
 	finalizeCtx, finalizeSpan := uotel.StartWithLink(finalizeCtx, tracer, "syncer.finalize")
 	finalizeSpan.SetAttributes(
 		attribute.Bool("c1z.finalize.cancel_observed", parentCtxErrLabel != "nil"),
@@ -2718,8 +2724,13 @@ func (s *syncer) Close(ctx context.Context) error {
 		}
 	}
 
+	// The external resource reader is read-only and has no durable
+	// state to commit — closing it on the caller's ctx (not the
+	// detached finalizeCtx) keeps a hung close from holding the
+	// syncer past the caller's deadline for no commit-correctness
+	// benefit.
 	if s.externalResourceReader != nil {
-		if err := s.externalResourceReader.Close(finalizeCtx); err != nil {
+		if err := s.externalResourceReader.Close(ctx); err != nil {
 			errs = append(errs, fmt.Errorf("error closing external resource reader: %w", err))
 		}
 	}

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -2683,23 +2683,43 @@ func (s *syncer) wireCountsDBSizeProvider() {
 }
 
 // Close closes the datastorage to ensure it is updated on disk.
+//
+// The store close, SaveC1Z (S3 upload), and manager close all run on a
+// context detached from the caller's cancellation. Caller may be a
+// Temporal activity whose deadline has already fired or is about to; we
+// still need to commit the c1z and upload it cleanly. The detached
+// context is bounded by dotc1z.FinalizeTimeout() so a wedged finalize
+// cannot pin a worker indefinitely. A new-root span linked to syncer.Close
+// keeps the upload subtree from inflating very long sync traces.
 func (s *syncer) Close(ctx context.Context) error {
 	ctx, span := tracer.Start(ctx, "syncer.Close")
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
+	parentCtxErrLabel := uotel.ClassifyCtxErr(ctx.Err())
+	timeout := dotc1z.FinalizeTimeout()
+	finalizeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), timeout)
+	defer cancel()
+	finalizeCtx, finalizeSpan := uotel.StartWithLink(finalizeCtx, tracer, "syncer.finalize")
+	finalizeSpan.SetAttributes(
+		attribute.Bool("c1z.finalize.cancel_observed", parentCtxErrLabel != "nil"),
+		attribute.String("c1z.finalize.parent_ctx_err", parentCtxErrLabel),
+		attribute.Int64("c1z.finalize.timeout_seconds", int64(timeout.Seconds())),
+	)
+	defer func() { uotel.EndSpanWithError(finalizeSpan, err) }()
+
 	var errs []error
 
 	var storeCloseErr error
 	if s.store != nil {
-		storeCloseErr = s.store.Close(ctx)
+		storeCloseErr = s.store.Close(finalizeCtx)
 		if storeCloseErr != nil {
 			errs = append(errs, fmt.Errorf("error closing store: %w", storeCloseErr))
 		}
 	}
 
 	if s.externalResourceReader != nil {
-		if err := s.externalResourceReader.Close(ctx); err != nil {
+		if err := s.externalResourceReader.Close(finalizeCtx); err != nil {
 			errs = append(errs, fmt.Errorf("error closing external resource reader: %w", err))
 		}
 	}
@@ -2709,18 +2729,19 @@ func (s *syncer) Close(ctx context.Context) error {
 		// failed to close (e.g. WAL checkpoint failure), saving would
 		// persist a potentially corrupt state.
 		if storeCloseErr == nil {
-			if err := s.c1zManager.SaveC1Z(ctx); err != nil {
+			if err := s.c1zManager.SaveC1Z(finalizeCtx); err != nil {
 				errs = append(errs, err)
 			}
 		}
 		// Always close the manager to clean up temp files, even if save
 		// was skipped or failed.
-		if err := s.c1zManager.Close(ctx); err != nil {
+		if err := s.c1zManager.Close(finalizeCtx); err != nil {
 			errs = append(errs, err)
 		}
 	}
 
-	return errors.Join(errs...)
+	err = errors.Join(errs...)
+	return err
 }
 
 type SyncOpt func(s *syncer)

--- a/pkg/uotel/span_helpers.go
+++ b/pkg/uotel/span_helpers.go
@@ -55,10 +55,45 @@ func ClassifyCtxErr(err error) string {
 	}
 }
 
+// parentCtxErrLabelKey carries the caller's original ctx-error label
+// across a context detach (context.WithoutCancel). Without it,
+// downstream code calling ClassifyCtxErr(ctx.Err()) on the detached
+// context always sees "nil" and the cancel_observed span attribute
+// reads false even when the caller had actually been canceled.
+type parentCtxErrLabelKey struct{}
+
+// WithParentCtxErrLabel returns a new context that carries label as
+// the parent's classified ctx-error. ParentCtxErrLabel reads it back.
+// Use this immediately after context.WithoutCancel so a downstream
+// finalize span can record what the original caller saw.
+func WithParentCtxErrLabel(ctx context.Context, label string) context.Context {
+	return context.WithValue(ctx, parentCtxErrLabelKey{}, label)
+}
+
+// ParentCtxErrLabel returns the label set by WithParentCtxErrLabel,
+// or the empty string and ok=false if no label was propagated.
+func ParentCtxErrLabel(ctx context.Context) (string, bool) {
+	v, ok := ctx.Value(parentCtxErrLabelKey{}).(string)
+	return v, ok
+}
+
 // IsExpectedError returns true for errors that are expected during normal
 // operation and should not be recorded as span errors.
+//
+// For an errors.Join result, true is returned only when EVERY child is
+// itself expected. Otherwise a real error joined with a context cancel
+// would be silently downgraded to Unset span status and dropped from
+// error dashboards.
 func IsExpectedError(err error) bool {
 	if err == nil {
+		return true
+	}
+	if joined, ok := err.(interface{ Unwrap() []error }); ok {
+		for _, e := range joined.Unwrap() {
+			if !IsExpectedError(e) {
+				return false
+			}
+		}
 		return true
 	}
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {

--- a/pkg/uotel/span_helpers.go
+++ b/pkg/uotel/span_helpers.go
@@ -38,6 +38,23 @@ func StartWithLink(
 	return tracer.Start(ctx, name, opts...)
 }
 
+// ClassifyCtxErr maps a context error to a low-cardinality enum label
+// suitable for a span attribute: "nil", "canceled", "deadline_exceeded",
+// or "other" for anything that doesn't unwrap to one of the standard
+// context sentinels.
+func ClassifyCtxErr(err error) string {
+	switch {
+	case err == nil:
+		return "nil"
+	case errors.Is(err, context.Canceled):
+		return "canceled"
+	case errors.Is(err, context.DeadlineExceeded):
+		return "deadline_exceeded"
+	default:
+		return "other"
+	}
+}
+
 // IsExpectedError returns true for errors that are expected during normal
 // operation and should not be recorded as span errors.
 func IsExpectedError(err error) bool {

--- a/pkg/uotel/span_helpers_test.go
+++ b/pkg/uotel/span_helpers_test.go
@@ -28,6 +28,14 @@ func TestIsExpectedError(t *testing.T) {
 		{"generic error", errors.New("something broke"), false},
 		{"grpc not found", status.Error(codes.NotFound, "not found"), false},
 		{"grpc internal", status.Error(codes.Internal, "internal"), false},
+		// Joined errors: every child must be expected for the whole
+		// to be expected. The regression we are guarding against is
+		// errors.Join(context.Canceled, ioerr) being silently
+		// downgraded to Unset span status, hiding the real ioerr.
+		{"join of only expected errors", errors.Join(context.Canceled, context.DeadlineExceeded), true},
+		{"join with a real error is not expected", errors.Join(context.Canceled, errors.New("upload failed")), false},
+		{"join with only a real error is not expected", errors.Join(errors.New("upload failed")), false},
+		{"nested join with a real error is not expected", errors.Join(errors.Join(context.Canceled, errors.New("network down"))), false},
 	}
 
 	for _, tt := range tests {
@@ -37,6 +45,24 @@ func TestIsExpectedError(t *testing.T) {
 				t.Errorf("IsExpectedError(%v) = %v, want %v", tt.err, got, tt.expected)
 			}
 		})
+	}
+}
+
+func TestParentCtxErrLabelRoundtrip(t *testing.T) {
+	base := context.Background()
+	if v, ok := ParentCtxErrLabel(base); ok || v != "" {
+		t.Fatalf("empty ctx should not carry a label, got (%q, %v)", v, ok)
+	}
+	tagged := WithParentCtxErrLabel(base, "canceled")
+	got, ok := ParentCtxErrLabel(tagged)
+	if !ok || got != "canceled" {
+		t.Fatalf("ParentCtxErrLabel = (%q, %v), want (\"canceled\", true)", got, ok)
+	}
+	// Survives context.WithoutCancel — that's the whole point.
+	detached := context.WithoutCancel(tagged)
+	got, ok = ParentCtxErrLabel(detached)
+	if !ok || got != "canceled" {
+		t.Fatalf("label lost across WithoutCancel: got (%q, %v)", got, ok)
 	}
 }
 


### PR DESCRIPTION
## Summary

Caller cancellation (Temporal activity deadline, pod drain, workflow cancel) reaching `C1File.Close` or `syncer.Close` used to propagate into the WAL checkpoint, save-to-disk, and `SaveC1Z` upload. A cancel landing mid-stream produced a c1z that looked plausible to readers but was either short on WAL contents or short on uploaded bytes — the upstream half of the truncated-multipart corruption pattern seen across multiple tenants.

The finalize tail now runs on `context.WithoutCancel(ctx)` bounded by `dotc1z.FinalizeTimeout()` (default 1h, `BATON_C1Z_FINALIZE_TIMEOUT` override). The new span is started via `uotel.StartWithLink` so it forms a short new root trace linked back to the caller's trace — long sync activities don't accumulate the upload subtree.

## Changes

- `pkg/dotc1z/finalize_timeout.go` (new) — `DefaultFinalizeTimeout = 1h` with env-var override.
- `pkg/dotc1z/c1file.go` — `C1File.Close` extracted a `finalize()` method that runs WAL-checkpoint → close-raw-db → `saveC1z` on a detached, bounded ctx. New-root span linked back. Removed the old reactive WAL-only detach and the dead `BATON_WAL_CHECKPOINT_TIMEOUT` env var (its bound is subsumed by the umbrella finalize timeout).
- `pkg/sync/syncer.go` — `syncer.Close` wraps the entire store-close + `SaveC1Z` + manager-close tail in the same detached/new-root pattern. Propagates the caller's original ctx-error label across the detach via `uotel.WithParentCtxErrLabel` so nested finalize spans report the real cancel state.
- `pkg/uotel/span_helpers.go` — adds `ClassifyCtxErr`, `WithParentCtxErrLabel`/`ParentCtxErrLabel`, and tightens `IsExpectedError` to walk `errors.Join` trees correctly (a real error joined with `context.Canceled` no longer hides).
- `pkg/dotc1z/c1file_close_cancel_test.go` (new) and `pkg/dotc1z/finalize_timeout_test.go` (new) — verify cancelled-ctx Close still produces a durable readable c1z; env parse edge cases; rawDb-released invariant on the cheap path.

## Test plan

- [x] `go test ./...` clean
- [x] `make lint` clean on the touched files
- [x] New tests cover: ctx canceled before close, deadline already exceeded, read-only cheap path closes rawDb, ErrReadOnly path does not leak the handle, `IsExpectedError` correctly classifies joined errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)