### PR TITLE
Retry transient token-service failures during startup Hello

### DIFF
--- a/pkg/tasks/c1api/manager.go
+++ b/pkg/tasks/c1api/manager.go
@@ -166,18 +166,19 @@ func (c *c1ApiTaskManager) Bootstrap(ctx context.Context, cc types.ConnectorClie
 // errors are treated as retryable by default; known-permanent gRPC codes
 // (auth, malformed, unimplemented, missing tenant/connector, server-side
 // precondition) short-circuit the retry loop.
+//
+// We deliberately do NOT treat context.Canceled / context.DeadlineExceeded as
+// non-retryable here. Cancellation or expiry of the *caller's* ctx is handled
+// by Bootstrap, which checks ctx.Err() after every attempt and bails before it
+// ever consults this classifier. A context-deadline error that reaches this
+// function while the caller's ctx is still live therefore originates from an
+// *internal* timeout — most importantly the 30s dial timeout the C1 service
+// client applies via grpc.WithBlock when C1 is briefly unreachable at startup.
+// That is a transient condition we must retry: classifying it as permanent
+// makes the startup Hello give up after a single attempt and the connector
+// exits without ever sending the Hello once C1 becomes reachable again.
 func isRetryableHelloError(err error) bool {
 	if err == nil {
-		return false
-	}
-	// If the caller's ctx already expired/cancelled, retrying would just burn
-	// time we no longer have. We check this via errors.Is on the sentinels so
-	// a gRPC-wrapped DeadlineExceeded that originated from our ctx still
-	// counts as non-retryable. A bare codes.DeadlineExceeded from the server
-	// (without a ctx sentinel in the chain) falls through to the default
-	// branch below and is treated as transient — that's the server-side
-	// timeout case, which can succeed on a retry.
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return false
 	}
 	st, ok := status.FromError(err)

--- a/pkg/tasks/c1api/manager_test.go
+++ b/pkg/tasks/c1api/manager_test.go
@@ -3,6 +3,7 @@ package c1api
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"sync"
 	"sync/atomic"
@@ -210,6 +211,58 @@ func TestBootstrapHonorsContextCancellationDuringBackoff(t *testing.T) {
 	err := mgr.Bootstrap(ctx, cc)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestBootstrapRetriesOnInternalDialTimeout(t *testing.T) {
+	withFastBackoff(t)
+
+	// The C1 service client dials each RPC with grpc.WithBlock under a 30s
+	// timeout. When C1 is briefly unreachable at startup the dial blocks and
+	// surfaces an error wrapping context.DeadlineExceeded from that *internal*
+	// dial ctx — not the caller's. This must be retried, not treated as a
+	// permanent failure that gives up before the Hello is ever delivered.
+	dialTimeout := fmt.Errorf("rpc error: dialing c1 backend: %w", context.DeadlineExceeded)
+	sc := newFakeBatonServiceClient([]error{dialTimeout, dialTimeout, nil})
+	cc := &fakeConnectorClient{}
+	mgr := newTestManager(sc)
+
+	if err := mgr.Bootstrap(context.Background(), cc); err != nil {
+		t.Fatalf("Bootstrap should retry transient dial timeouts and succeed, got: %v", err)
+	}
+	if sc.helloCalls != 3 {
+		t.Fatalf("expected 3 Hello calls (2 dial timeouts + success), got %d", sc.helloCalls)
+	}
+}
+
+func TestBootstrapStopsWhenCallerContextCancelled(t *testing.T) {
+	withFastBackoff(t)
+
+	// When the *caller's* ctx is cancelled, Bootstrap must bail via its own
+	// ctx.Err() check rather than spinning in the retry loop — even now that
+	// context errors are no longer short-circuited as non-retryable by
+	// isRetryableHelloError. Feed an endless supply of retryable errors so a
+	// regression that ignored ctx.Err() would loop instead of returning.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	transient := status.Error(codes.Unavailable, "server busy")
+	responses := make([]error, 100)
+	for i := range responses {
+		responses[i] = transient
+	}
+	sc := newFakeBatonServiceClient(responses)
+	cc := &fakeConnectorClient{}
+	mgr := newTestManager(sc)
+
+	err := mgr.Bootstrap(ctx, cc)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled from cancelled caller ctx, got %v", err)
+	}
+	// At most one attempt should run before the ctx.Err() guard returns; the
+	// retry loop must never be entered.
+	if sc.helloCalls > 1 {
+		t.Fatalf("expected Bootstrap to bail without retrying on caller cancellation, got %d Hello calls", sc.helloCalls)
 	}
 }
 
@@ -505,8 +558,14 @@ func TestIsRetryableHelloErrorClassification(t *testing.T) {
 		want bool
 	}{
 		{"nil", nil, false},
-		{"ctx-canceled", context.Canceled, false},
-		{"ctx-deadline", context.DeadlineExceeded, false},
+		// A context error that reaches the classifier is an *internal* timeout
+		// (e.g. the C1 client's 30s WithBlock dial timeout), not the caller's
+		// ctx — Bootstrap bails on caller cancellation via its own ctx.Err()
+		// check before consulting this function. Internal timeouts are transient
+		// and must be retried.
+		{"ctx-canceled", context.Canceled, true},
+		{"ctx-deadline", context.DeadlineExceeded, true},
+		{"wrapped-ctx-deadline-dial-timeout", fmt.Errorf("dialing c1: %w", context.DeadlineExceeded), true},
 		{"unauthenticated", status.Error(codes.Unauthenticated, "bad token"), false},
 		{"permission-denied", status.Error(codes.PermissionDenied, "forbidden"), false},
 		{"invalid-argument", status.Error(codes.InvalidArgument, "malformed"), false},

--- a/pkg/ugrpc/c1_credential_provider.go
+++ b/pkg/ugrpc/c1_credential_provider.go
@@ -61,6 +61,27 @@ func parseClientID(input string) (string, string, error) {
 	return clientName, items[0], nil
 }
 
+// tokenStatusError maps a non-200 response from the C1 token endpoint to a
+// gRPC status error. Transient server-side and throttling responses (5xx, 429,
+// 408) are reported as codes.Unavailable so that callers — most importantly the
+// startup Hello Bootstrap and the service-mode task poll loop — retry instead
+// of treating a momentary token-service outage as a permanent auth failure.
+// (A 503 from the token endpoint was previously surfaced as Unauthenticated,
+// which the Hello retry classifier treats as fatal, so a brief token-service
+// blip at startup could permanently skip the Hello / kill the connector.)
+// Genuine credential problems (401/403, malformed requests, etc.) stay
+// Unauthenticated so misconfigured connectors still fail fast.
+func tokenStatusError(statusCode int, statusText string) error {
+	code := codes.Unauthenticated
+	switch {
+	case statusCode == http.StatusRequestTimeout, // 408
+		statusCode == http.StatusTooManyRequests,     // 429
+		statusCode >= http.StatusInternalServerError: // 5xx
+		code = codes.Unavailable
+	}
+	return status.Errorf(code, "failed to get token: %s", statusText)
+}
+
 func (c *c1TokenSource) Token() (*oauth2.Token, error) {
 	jsigner, err := jose.NewSigner(
 		jose.SigningKey{
@@ -134,7 +155,7 @@ func (c *c1TokenSource) Token() (*oauth2.Token, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, status.Errorf(codes.Unauthenticated, "failed to get token: %s", resp.Status)
+		return nil, tokenStatusError(resp.StatusCode, resp.Status)
 	}
 
 	c1t := &c1Token{}

--- a/pkg/ugrpc/c1_credential_provider_test.go
+++ b/pkg/ugrpc/c1_credential_provider_test.go
@@ -1,0 +1,44 @@
+package ugrpc
+
+import (
+	"net/http"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestTokenStatusErrorClassification pins the mapping from token-endpoint HTTP
+// statuses to gRPC codes. Transient server/throttling responses must be
+// retryable (Unavailable) so a momentary token-service outage at startup does
+// not permanently skip the Hello, while genuine credential problems stay
+// non-retryable (Unauthenticated) so misconfigured connectors fail fast.
+func TestTokenStatusErrorClassification(t *testing.T) {
+	cases := []struct {
+		name       string
+		statusCode int
+		want       codes.Code
+	}{
+		// The production failure that motivated this: a transient 503 from the
+		// token endpoint must be retryable, not a fatal auth error.
+		{"503-service-unavailable", http.StatusServiceUnavailable, codes.Unavailable},
+		{"500-internal", http.StatusInternalServerError, codes.Unavailable},
+		{"502-bad-gateway", http.StatusBadGateway, codes.Unavailable},
+		{"504-gateway-timeout", http.StatusGatewayTimeout, codes.Unavailable},
+		{"429-too-many-requests", http.StatusTooManyRequests, codes.Unavailable},
+		{"408-request-timeout", http.StatusRequestTimeout, codes.Unavailable},
+		// Genuine credential / request problems remain fatal.
+		{"401-unauthorized", http.StatusUnauthorized, codes.Unauthenticated},
+		{"403-forbidden", http.StatusForbidden, codes.Unauthenticated},
+		{"400-bad-request", http.StatusBadRequest, codes.Unauthenticated},
+		{"404-not-found", http.StatusNotFound, codes.Unauthenticated},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tokenStatusError(tc.statusCode, http.StatusText(tc.statusCode))
+			if got := status.Code(err); got != tc.want {
+				t.Fatalf("tokenStatusError(%d) code = %s, want %s", tc.statusCode, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

In service mode, a transient `503` from the C1 token endpoint at startup could cause the connector to **never send its Hello** — and then either run unregistered (older fire-once Hello task) or, post-#799, give up in `Bootstrap` and exit.

Root cause: `c1TokenSource.Token()` mapped **every** non-200 token response to `codes.Unauthenticated`, so a momentary token-service blip was indistinguishable from bad credentials and got treated as a permanent auth failure by the Hello retry classifier.

Observed in the field as repeated:
```
rpc error: code = Unauthenticated desc = failed to get token: 503 Service Unavailable
```
The Hello failed and was never retried while the run loop kept polling, so the connector synced without ever registering via Hello.

## Fix

- **ugrpc**: classify transient token-endpoint statuses (`5xx`/`429`/`408`) as `codes.Unavailable` (retryable). Genuine credential problems (`401`/`403`/`400`) stay `Unauthenticated` so misconfigured connectors still fail fast.
- **c1api**: drop the `context.Canceled`/`context.DeadlineExceeded` short-circuit in `isRetryableHelloError`. `Bootstrap` already bails on genuine caller cancellation via its own `ctx.Err()` check; the sentinel branch additionally misclassified the internal 30s `grpc.WithBlock` dial timeout as permanent.

Both changes make the blocking startup Hello introduced in #799 actually resilient to transient connect/auth failures.

## Tests

- `TestTokenStatusErrorClassification` — 5xx/429/408 → `Unavailable`; 401/403/400/404 → `Unauthenticated`.
- `TestBootstrapRetriesOnInternalDialTimeout` — a wrapped `DeadlineExceeded` (dial timeout) with a live caller ctx now retries (fails under the old classifier).
- `TestBootstrapStopsWhenCallerContextCancelled` — genuine caller cancellation still bails without entering the retry loop.

`go test` green; `golangci-lint --new-from-rev=HEAD` reports 0 new issues.