### PR TITLE
synccompactor: pass runCtx into doOneCompaction so c.runDuration actually bounds the loop

### DIFF
--- a/pkg/synccompactor/compactor.go
+++ b/pkg/synccompactor/compactor.go
@@ -216,9 +216,22 @@ func (c *Compactor) Compact(ctx context.Context) (*CompactableSync, error) {
 	l.Debug("new empty partial sync created", zap.String("sync_id", newSyncId))
 
 	// Base sync is c.entries[0], so compact in reverse order. That way we compact the biggest sync last.
+	// Pass runCtx (not the outer ctx) so c.runDuration actually bounds the loop. Without this, the
+	// deadline set on runCtx only gates the pre-flight check above and individual doOneCompaction
+	// calls run under the unbounded parent ctx.
 	for i := len(c.entries) - 1; i >= 0; i-- {
-		err = c.doOneCompaction(ctx, c.entries[i])
+		err = c.doOneCompaction(runCtx, c.entries[i])
 		if err != nil {
+			// When runCtx fires due to c.runDuration, surface the same clean message the pre-flight
+			// check uses instead of bubbling a bare context.DeadlineExceeded out of the inner sqlite
+			// operations. The error is still returned so callers can decide whether to retry.
+			if cause := context.Cause(runCtx); errors.Is(cause, context.DeadlineExceeded) && c.runDuration > 0 && ctx.Err() == nil {
+				l.Info("compaction run duration has expired, exiting compaction early",
+					zap.String("sync_id", c.entries[i].SyncID),
+					zap.Int("syncs_remaining", i),
+				)
+				return nil, fmt.Errorf("compaction run duration has expired: %w", cause)
+			}
 			return nil, fmt.Errorf("failed to compact sync %s: %w", c.entries[i].SyncID, err)
 		}
 	}

--- a/pkg/synccompactor/compactor_test.go
+++ b/pkg/synccompactor/compactor_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	reader_v2 "github.com/conductorone/baton-sdk/pb/c1/reader/v2"
@@ -970,4 +971,85 @@ func TestAttachedCompactorFailsWithNoFullSyncInBase(t *testing.T) {
 	require.Equal(t, connectorstore.SyncTypePartial, syncRuns[0].Type)
 	require.Equal(t, compactedSync.SyncID, syncRuns[0].ID)
 	require.NotNil(t, syncRuns[0].EndedAt)
+}
+
+// TestCompactorRunDurationExpired locks in the user-visible contract that when c.runDuration
+// expires (parent ctx still alive), Compact returns the clean "compaction run duration has expired"
+// error wrapping context.DeadlineExceeded. With a 1ns budget, the pre-flight select check fires
+// first; the in-loop branch added by the runCtx-in-loop fix uses the same message so this also
+// guards regression of that branch's error format.
+func TestCompactorRunDurationExpired(t *testing.T) {
+	ctx := t.Context()
+	inputSyncsDir := t.TempDir()
+	outputDir := t.TempDir()
+	tmpDir := t.TempDir()
+
+	opts := []dotc1z.C1ZOption{
+		dotc1z.WithDecoderOptions(dotc1z.WithDecoderConcurrency(-1)),
+	}
+	syncs := []*CompactableSync{
+		makeEmptySync(t, ctx, inputSyncsDir, opts, connectorstore.SyncTypeFull),
+		makeEmptySync(t, ctx, inputSyncsDir, opts, connectorstore.SyncTypeFull),
+	}
+
+	compactor, cleanup, err := NewCompactor(ctx, outputDir, syncs,
+		WithTmpDir(tmpDir),
+		WithCompactorType(CompactorTypeAttached),
+		WithRunDuration(1*time.Nanosecond),
+	)
+	require.NoError(t, err)
+	defer func() {
+		_ = cleanup()
+	}()
+
+	result, err := compactor.Compact(ctx)
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.ErrorContains(t, err, "compaction run duration has expired")
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+// TestCompactorParentCtxCancelDoesNotMaskAsRunDuration locks in the disambiguation
+// between "runCtx fired due to c.runDuration" and "parent ctx was cancelled".
+// A parent-cancelled runCtx has cause=context.Canceled (not DeadlineExceeded), so the
+// pre-flight branch falls through to default and returns the raw cause — and the in-loop
+// branch's ctx.Err() == nil guard rejects the clean-exit path if parent ctx is also done.
+// The error must NOT be misreported as runDuration expiry.
+func TestCompactorParentCtxCancelDoesNotMaskAsRunDuration(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	inputSyncsDir := t.TempDir()
+	outputDir := t.TempDir()
+	tmpDir := t.TempDir()
+
+	opts := []dotc1z.C1ZOption{
+		dotc1z.WithDecoderOptions(dotc1z.WithDecoderConcurrency(-1)),
+	}
+	syncs := []*CompactableSync{
+		makeEmptySync(t, ctx, inputSyncsDir, opts, connectorstore.SyncTypeFull),
+		makeEmptySync(t, ctx, inputSyncsDir, opts, connectorstore.SyncTypeFull),
+	}
+
+	compactor, cleanup, err := NewCompactor(ctx, outputDir, syncs,
+		WithTmpDir(tmpDir),
+		WithCompactorType(CompactorTypeAttached),
+		// runDuration far longer than the test would take, so it never fires.
+		WithRunDuration(10*time.Minute),
+	)
+	require.NoError(t, err)
+	defer func() {
+		_ = cleanup()
+	}()
+
+	// Cancel parent before Compact starts; pre-flight observes ctx.Done() with
+	// cause=context.Canceled and surfaces it as the raw error rather than the
+	// runDuration message.
+	cancel()
+
+	_, err = compactor.Compact(ctx)
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "compaction run duration has expired",
+		"parent ctx cancel must not be misreported as runDuration expiry")
+	require.ErrorIs(t, err, context.Canceled)
 }


### PR DESCRIPTION
## Summary

`Compact()` builds `runCtx = context.WithTimeout(ctx, c.runDuration)` but the loop calls `doOneCompaction(ctx, ...)`. The deadline only gates the pre-flight select; individual compactions then run under the unbounded parent ctx and can blow past `c.runDuration`.

This is the sibling of the bug fixed in #893 (`WriteEnvelope` walked under an unbounded context). Same shape: a deadline-bearing context exists but inner work uses a different one, so the deadline dangles instead of bounding the work.

## Change

- `pkg/synccompactor/compactor.go`: pass `runCtx` into `doOneCompaction` so `c.runDuration` actually limits the loop.
- When `runCtx` fires *due to its own deadline* (not parent cancellation), surface the same clean **\"compaction run duration has expired\"** message the pre-flight select already uses, instead of letting a bare `context.DeadlineExceeded` bubble out of inner SQLite operations. The error is still returned so callers can decide whether to retry.

## Impact

Caller-visible behavior change for callers that pass `WithRunDuration`:

- **Before:** `c.runDuration` only checked at entry; individual compactions could run as long as the parent ctx allowed. If they did eventually fail (e.g. heartbeat timeout during a long SQLite operation), the error was a raw `context deadline exceeded` from inside `ExecContext`.
- **After:** each `doOneCompaction` is bounded by `c.runDuration`. When the deadline fires, the loop exits with `compaction run duration has expired: context deadline exceeded`, and the structured log identifies which sync was in flight and how many remain.

Callers that don't use `WithRunDuration` are unaffected — `runCtx == ctx` in that branch.

## Test plan

- [x] `go build ./pkg/synccompactor/...`
- [x] `go vet ./pkg/synccompactor/...`
- [x] `go test ./pkg/synccompactor/...` (all existing tests pass)
- [ ] CI

## Context

Surfaced by a code-review bot on a separate compaction stuck-state investigation. Lilly's Entra connector compaction was failing at ~98 min with `context deadline exceeded` from inside `CompactGrants` even though `WithRunDuration(1h)` was passed — because `runCtx` was created but not threaded into the loop, the deadline never fired cleanly; instead the activity hit its Temporal heartbeat timeout while SQLite was blocking.

This PR alone won't unblock Lilly (the compaction still doesn't fit in 1h), but it makes the failure intentional and legible, and matches the contract the option name implies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)