### PR TITLE
dotc1z: add WithSkipVacuum option to skip VACUUM step inside Cleanup

### DIFF
--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -138,10 +138,18 @@ func WithC1FSkipCleanup(skip bool) C1FOption {
 }
 
 // WithC1FSkipVacuum skips the VACUUM step at the end of Cleanup() when set to
-// true. The old-sync delete and WAL truncate inside Cleanup still run. Use
-// when the cost of VACUUM (a full page-by-page rewrite of the DB) exceeds the
-// space-reclamation benefit for the caller's workload — typically iterative
-// compaction where the file is consumed immediately and not re-read at rest.
+// true. The old-sync delete and WAL truncate inside Cleanup still run.
+//
+// Low-level option for callers operating on a [C1File] directly. Most callers
+// should use [WithSkipVacuum] on [NewC1ZFile] instead, which propagates this
+// setting through the C1Z constructor.
+//
+// Trade-off: skipping VACUUM leaves freed pages on the SQLite freelist instead
+// of reclaiming them, so the c1z file on disk grows across syncs with no upper
+// bound until a real VACUUM runs. Use when the file is consumed immediately
+// and re-encoded (e.g. iterative compaction); avoid when the c1z is intended
+// to sit at rest or be read repeatedly. See also [WithC1FSkipCleanup] to skip
+// the whole Cleanup step instead.
 func WithC1FSkipVacuum(skip bool) C1FOption {
 	return func(o *C1File) {
 		o.skipVacuum = skip
@@ -322,10 +330,15 @@ func WithSkipCleanup(skip bool) C1ZOption {
 }
 
 // WithSkipVacuum skips the VACUUM step at the end of Cleanup() when set to
-// true. The old-sync delete and WAL truncate inside Cleanup still run. Use
-// when the cost of VACUUM (a full page-by-page rewrite of the DB) exceeds the
-// space-reclamation benefit for the caller's workload — typically iterative
-// compaction where the file is consumed immediately and not re-read at rest.
+// true. The old-sync delete and WAL truncate inside Cleanup still run.
+//
+// Trade-off: skipping VACUUM leaves freed pages on the SQLite freelist instead
+// of reclaiming them, so the c1z file on disk grows across syncs with no upper
+// bound until a real VACUUM runs. Use when the file is consumed immediately
+// and re-encoded (e.g. iterative compaction where the output is supplanted on
+// the next iteration); avoid when the c1z is intended to sit at rest or be
+// read repeatedly. No effect when [WithSkipCleanup] is also set, since
+// Cleanup returns early in that case.
 func WithSkipVacuum(skip bool) C1ZOption {
 	return func(o *c1zOptions) {
 		o.skipVacuum = skip

--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -70,6 +70,7 @@ type C1File struct {
 	// Sync cleanup settings
 	syncLimit   int
 	skipCleanup bool
+	skipVacuum  bool
 
 	// See WithC1FV2GrantsWriter.
 	v2GrantsWriter bool
@@ -133,6 +134,17 @@ func WithC1FEncoderConcurrency(concurrency int) C1FOption {
 func WithC1FSkipCleanup(skip bool) C1FOption {
 	return func(o *C1File) {
 		o.skipCleanup = skip
+	}
+}
+
+// WithC1FSkipVacuum skips the VACUUM step at the end of Cleanup() when set to
+// true. The old-sync delete and WAL truncate inside Cleanup still run. Use
+// when the cost of VACUUM (a full page-by-page rewrite of the DB) exceeds the
+// space-reclamation benefit for the caller's workload — typically iterative
+// compaction where the file is consumed immediately and not re-read at rest.
+func WithC1FSkipVacuum(skip bool) C1FOption {
+	return func(o *C1File) {
+		o.skipVacuum = skip
 	}
 }
 
@@ -249,6 +261,7 @@ type c1zOptions struct {
 	encoderConcurrency int
 	syncLimit          int
 	skipCleanup        bool
+	skipVacuum         bool
 	v2GrantsWriter     bool
 
 	// engine is the storage engine to use for newly created files.
@@ -305,6 +318,17 @@ func WithEncoderConcurrency(concurrency int) C1ZOption {
 func WithSkipCleanup(skip bool) C1ZOption {
 	return func(o *c1zOptions) {
 		o.skipCleanup = skip
+	}
+}
+
+// WithSkipVacuum skips the VACUUM step at the end of Cleanup() when set to
+// true. The old-sync delete and WAL truncate inside Cleanup still run. Use
+// when the cost of VACUUM (a full page-by-page rewrite of the DB) exceeds the
+// space-reclamation benefit for the caller's workload — typically iterative
+// compaction where the file is consumed immediately and not re-read at rest.
+func WithSkipVacuum(skip bool) C1ZOption {
+	return func(o *c1zOptions) {
+		o.skipVacuum = skip
 	}
 }
 
@@ -388,6 +412,9 @@ func NewC1ZFile(ctx context.Context, outputFilePath string, opts ...C1ZOption) (
 	}
 	if options.skipCleanup {
 		c1fopts = append(c1fopts, WithC1FSkipCleanup(true))
+	}
+	if options.skipVacuum {
+		c1fopts = append(c1fopts, WithC1FSkipVacuum(true))
 	}
 	if options.v2GrantsWriter {
 		c1fopts = append(c1fopts, WithC1FV2GrantsWriter(true))

--- a/pkg/dotc1z/sync_runs.go
+++ b/pkg/dotc1z/sync_runs.go
@@ -852,12 +852,16 @@ func (c *C1File) Cleanup(ctx context.Context) error {
 		l.Info("Removed old sync data.", zap.String("sync_id", id))
 	}
 
-	l.Debug("vacuuming database")
-	err = c.Vacuum(ctx)
-	if err != nil {
-		return wrapSqliteInterruptError(err)
+	if c.skipVacuum {
+		l.Info("skip_vacuum option is set, skipping VACUUM in Cleanup")
+	} else {
+		l.Debug("vacuuming database")
+		err = c.Vacuum(ctx)
+		if err != nil {
+			return wrapSqliteInterruptError(err)
+		}
+		l.Debug("vacuum complete")
 	}
-	l.Debug("vacuum complete")
 
 	c.dbUpdated = true
 

--- a/pkg/dotc1z/sync_runs.go
+++ b/pkg/dotc1z/sync_runs.go
@@ -853,7 +853,9 @@ func (c *C1File) Cleanup(ctx context.Context) error {
 	}
 
 	if c.skipVacuum {
-		l.Info("skip_vacuum option is set, skipping VACUUM in Cleanup")
+		l.Info("skip_vacuum option is set, skipping VACUUM in Cleanup",
+			zap.String("db_file_path", c.dbFilePath),
+		)
 	} else {
 		l.Debug("vacuuming database")
 		err = c.Vacuum(ctx)

--- a/pkg/dotc1z/sync_runs_test.go
+++ b/pkg/dotc1z/sync_runs_test.go
@@ -104,6 +104,58 @@ func TestCleanupVacuumWAL(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestCleanupSkipVacuum verifies that WithSkipVacuum prevents the VACUUM step
+// from running inside Cleanup() while keeping the old-sync delete + WAL truncate
+// behavior intact. With vacuum skipped, freed pages stay on the freelist instead
+// of being reclaimed — the page_count stays the same and freelist_count remains
+// non-zero. Counter-test to TestCleanupVacuum which asserts both go down.
+func TestCleanupSkipVacuum(t *testing.T) {
+	ctx := t.Context()
+	tmpDir := t.TempDir()
+
+	testFilePath := filepath.Join(tmpDir, "test.c1z")
+
+	f, err := dotc1z.NewC1ZFile(ctx, testFilePath, dotc1z.WithSkipVacuum(true))
+	require.NoError(t, err)
+
+	_, err = c1ztest.CreateTestSync(ctx, t, f, c1ztest.C1ZCounts{
+		ResourceTypeCount: 3,
+		ResourceCount:     10,
+		UserCount:         10,
+		EntitlementCount:  10,
+		GrantCount:        25,
+	})
+	require.NoError(t, err)
+
+	var pageCount int
+	row := f.RawDB().QueryRowContext(ctx, "PRAGMA page_count")
+	require.NoError(t, row.Scan(&pageCount))
+	require.Greater(t, pageCount, 0)
+
+	var freelistCount int
+	row = f.RawDB().QueryRowContext(ctx, "PRAGMA freelist_count")
+	require.NoError(t, row.Scan(&freelistCount))
+	require.Greater(t, freelistCount, 0)
+
+	err = f.Cleanup(ctx)
+	require.NoError(t, err)
+
+	// Vacuum was skipped, so page_count should NOT have decreased and freelist_count
+	// should still be non-zero (pages freed by DeleteSyncRun stay on the freelist).
+	var afterPageCount int
+	row = f.RawDB().QueryRowContext(ctx, "PRAGMA page_count")
+	require.NoError(t, row.Scan(&afterPageCount))
+	require.Equal(t, pageCount, afterPageCount, "page_count should be unchanged when vacuum is skipped")
+
+	var afterFreelistCount int
+	row = f.RawDB().QueryRowContext(ctx, "PRAGMA freelist_count")
+	require.NoError(t, row.Scan(&afterFreelistCount))
+	require.Greater(t, afterFreelistCount, 0, "freelist_count should remain non-zero when vacuum is skipped")
+
+	err = f.Close(ctx)
+	require.NoError(t, err)
+}
+
 func TestCleanupSyncLimit(t *testing.T) {
 	ctx := t.Context()
 	tmpDir := t.TempDir()

--- a/pkg/dotc1z/sync_runs_test.go
+++ b/pkg/dotc1z/sync_runs_test.go
@@ -105,10 +105,15 @@ func TestCleanupVacuumWAL(t *testing.T) {
 }
 
 // TestCleanupSkipVacuum verifies that WithSkipVacuum prevents the VACUUM step
-// from running inside Cleanup() while keeping the old-sync delete + WAL truncate
-// behavior intact. With vacuum skipped, freed pages stay on the freelist instead
-// of being reclaimed — the page_count stays the same and freelist_count remains
-// non-zero. Counter-test to TestCleanupVacuum which asserts both go down.
+// from running inside Cleanup() while keeping the old-sync delete behavior
+// intact. With vacuum skipped, freed pages stay on the freelist — page_count
+// stays the same and freelist_count remains non-zero. Counter-test to
+// TestCleanupVacuum which asserts both go down.
+//
+// The test creates 3 finished syncs so DeleteSyncRun actually runs (default
+// syncLimit=2 keeps the latest 2 and deletes the oldest 1). After Cleanup,
+// the file is closed, re-opened, and ListSyncRuns is asserted to return 2
+// entries — proving that the delete happened correctly even with vacuum off.
 func TestCleanupSkipVacuum(t *testing.T) {
 	ctx := t.Context()
 	tmpDir := t.TempDir()
@@ -118,30 +123,37 @@ func TestCleanupSkipVacuum(t *testing.T) {
 	f, err := dotc1z.NewC1ZFile(ctx, testFilePath, dotc1z.WithSkipVacuum(true))
 	require.NoError(t, err)
 
-	_, err = c1ztest.CreateTestSync(ctx, t, f, c1ztest.C1ZCounts{
+	counts := c1ztest.C1ZCounts{
 		ResourceTypeCount: 3,
 		ResourceCount:     10,
 		UserCount:         10,
 		EntitlementCount:  10,
 		GrantCount:        25,
-	})
-	require.NoError(t, err)
+	}
+	// Three syncs > default syncLimit (2) → DeleteSyncRun will actually run during
+	// Cleanup. This is what we need to verify the "delete still happens with vacuum
+	// skipped" invariant; a single sync would short-circuit the delete loop.
+	for range 3 {
+		_, err = c1ztest.CreateTestSync(ctx, t, f, counts)
+		require.NoError(t, err)
+	}
 
+	// Note: we don't assert freelist_count > 0 here pre-Cleanup. Across multiple
+	// sequential syncs, SQLite reuses freelist pages from earlier syncs to satisfy
+	// new INSERTs, so by the third sync the freelist may have been consumed back
+	// to zero. The signal we care about is post-Cleanup: DeleteSyncRun should free
+	// pages that, with vacuum skipped, stay on the freelist instead of being
+	// reclaimed.
 	var pageCount int
 	row := f.RawDB().QueryRowContext(ctx, "PRAGMA page_count")
 	require.NoError(t, row.Scan(&pageCount))
 	require.Greater(t, pageCount, 0)
 
-	var freelistCount int
-	row = f.RawDB().QueryRowContext(ctx, "PRAGMA freelist_count")
-	require.NoError(t, row.Scan(&freelistCount))
-	require.Greater(t, freelistCount, 0)
-
 	err = f.Cleanup(ctx)
 	require.NoError(t, err)
 
 	// Vacuum was skipped, so page_count should NOT have decreased and freelist_count
-	// should still be non-zero (pages freed by DeleteSyncRun stay on the freelist).
+	// should be non-zero (pages freed by DeleteSyncRun stay on the freelist).
 	var afterPageCount int
 	row = f.RawDB().QueryRowContext(ctx, "PRAGMA page_count")
 	require.NoError(t, row.Scan(&afterPageCount))
@@ -150,10 +162,22 @@ func TestCleanupSkipVacuum(t *testing.T) {
 	var afterFreelistCount int
 	row = f.RawDB().QueryRowContext(ctx, "PRAGMA freelist_count")
 	require.NoError(t, row.Scan(&afterFreelistCount))
-	require.Greater(t, afterFreelistCount, 0, "freelist_count should remain non-zero when vacuum is skipped")
+	require.Greater(t, afterFreelistCount, 0, "freelist_count should be non-zero post-Cleanup when vacuum is skipped (proves DeleteSyncRun freed pages and they stayed)")
 
 	err = f.Close(ctx)
 	require.NoError(t, err)
+
+	// Re-open and verify the c1z is still readable post-Cleanup (file got re-saved
+	// on Close even though vacuum was skipped) and that exactly syncLimit (2) syncs
+	// remain — proving DeleteSyncRun ran.
+	reopened, err := dotc1z.NewC1ZFile(ctx, testFilePath)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = reopened.Close(ctx)
+	})
+	syncRuns, _, err := reopened.ListSyncRuns(ctx, "", 100)
+	require.NoError(t, err)
+	require.Len(t, syncRuns, 2, "Cleanup should have deleted the oldest sync, leaving syncLimit (2) remaining")
 }
 
 func TestCleanupSyncLimit(t *testing.T) {


### PR DESCRIPTION
## Summary

\`Cleanup()\` unconditionally runs a full \`VACUUM\` after deleting old syncs. For most callers this is fine — periodic c1z files at rest benefit from the page reclamation. For **iterative compaction** (where the output c1z is consumed immediately and supplanted on the next iteration), the cost of rewriting every page exceeds the space-reclamation benefit.

This PR adds \`WithSkipVacuum\` / \`WithC1FSkipVacuum\` opt-outs for just the VACUUM step. DeleteSyncRun and the WAL-truncate behavior inside \`Cleanup()\` still run. Default unchanged: VACUUM runs unless explicitly skipped.

## Why

Production observation: on a 60-second profile of an iterative compaction, \`sqlite._sqlite3RunVacuum\` was the single biggest contributor at **29% of CPU** plus the dominant share of disk I/O (\`_unixWrite\` 18%, \`_unixRead\` 19%). The compaction's output c1z gets read once into the next iteration's base and then superseded, so the page reclamation is wasted work — but ~30% of every compaction's wall time goes to it.

Letting the caller (synccompactor / c1's incremental-sync activity) skip vacuum reclaims that wall time. Concretely, for a tenant whose single compaction was running 98+ minutes and timing out, dropping ~30% should bring it inside the activity's existing 1h soft deadline + 2h hard ceiling.

## Caveats

- The c1z file remains valid sqlite. Subsequent opens succeed; queries work.
- The file is bigger on disk than after a real vacuum (freelist pages aren't reclaimed). For an iterative compaction whose output is consumed immediately, this is fine. For a c1z that will sit at rest for a long time, prefer the default.
- This is an option, not the default. Callers opt in.

## Tests

- New \`TestCleanupSkipVacuum\` mirrors the existing \`TestCleanupVacuum\` and asserts the inverse: with the option set, \`page_count\` is unchanged after Cleanup and \`freelist_count\` remains non-zero. Confirms VACUUM was actually skipped and the freed pages stay on the freelist.
- All existing tests pass.

## Files

- \`pkg/dotc1z/c1file.go\`: add \`skipVacuum\` field + \`WithSkipVacuum\` (C1Z) / \`WithC1FSkipVacuum\` (C1F) options; propagate from c1zOptions → C1File
- \`pkg/dotc1z/sync_runs.go\`: \`Cleanup\` gates the VACUUM call on \`c.skipVacuum\`; structured log emitted when skipped
- \`pkg/dotc1z/sync_runs_test.go\`: \`TestCleanupSkipVacuum\`

## Companion / context

A companion c1 PR will add a per-tenant FF that, when set, plumbs \`dotc1z.WithSkipVacuum(true)\` into the synccompactor's c1zOptions. That PR is gated on this one landing + a vendor bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)