### PR TITLE
Preserve nested StringMap config in VisitFlags

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -149,6 +149,9 @@ func VisitFlags(cmd *cobra.Command, v *viper.Viper) {
 				_ = cmd.Flags().Set(f.Name, v.GetString(f.Name))
 			}
 		case "stringToString":
+			if hasNestedStringMapValue(v.Get(f.Name)) {
+				return
+			}
 			sm := v.GetStringMapString(f.Name)
 			if len(sm) > 0 {
 				// pflag expects "key=value" CSV format.
@@ -162,6 +165,31 @@ func VisitFlags(cmd *cobra.Command, v *viper.Viper) {
 			_ = cmd.Flags().Set(f.Name, v.GetString(f.Name))
 		}
 	})
+}
+
+func hasNestedStringMapValue(value any) bool {
+	rv := reflect.ValueOf(value)
+	if !rv.IsValid() || rv.Kind() != reflect.Map {
+		return false
+	}
+
+	for _, mapKey := range rv.MapKeys() {
+		mapValue := rv.MapIndex(mapKey)
+		for mapValue.IsValid() && mapValue.Kind() == reflect.Interface {
+			if mapValue.IsNil() {
+				break
+			}
+			mapValue = mapValue.Elem()
+		}
+		if !mapValue.IsValid() {
+			continue
+		}
+		switch mapValue.Kind() {
+		case reflect.Map, reflect.Slice, reflect.Array, reflect.Struct:
+			return true
+		}
+	}
+	return false
 }
 
 func AddCommand(mainCMD *cobra.Command, v *viper.Viper, schema *field.Configuration, subCMD *cobra.Command) (*cobra.Command, error) {

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -184,8 +184,8 @@ func hasNestedStringMapValue(value any) bool {
 		if !mapValue.IsValid() {
 			continue
 		}
-		switch mapValue.Kind() {
-		case reflect.Map, reflect.Slice, reflect.Array, reflect.Struct:
+		kind := mapValue.Kind()
+		if kind == reflect.Map || kind == reflect.Slice || kind == reflect.Array || kind == reflect.Struct {
 			return true
 		}
 	}

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -192,6 +192,36 @@ func TestVisitFlags_StringToString_SingleEntry(t *testing.T) {
 	require.Equal(t, map[string]string{"version": "1"}, got)
 }
 
+func TestVisitFlags_StringToString_NestedYAMLMapNotSet(t *testing.T) {
+	dir := t.TempDir()
+	writeYAML(t, dir, `powershell-actions:
+  create-user:
+    script: New-C1User
+    description: Create user
+`)
+	v := viper.New()
+	v.SetConfigName("config")
+	v.SetConfigType("yaml")
+	v.AddConfigPath(dir)
+	require.NoError(t, v.ReadInConfig())
+
+	schema := field.Configuration{
+		Fields: []field.SchemaField{
+			field.StringMapField("powershell-actions"),
+		},
+	}
+	cmd := setupCommand(t, schema, v)
+
+	require.False(t, cmd.Flags().Lookup("powershell-actions").Changed)
+	require.NoError(t, v.BindPFlags(cmd.Flags()))
+
+	got := v.GetStringMap("powershell-actions")
+	action, ok := got["create-user"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "New-C1User", action["script"])
+	require.Equal(t, "Create user", action["description"])
+}
+
 func TestVisitFlags_String_Unchanged(t *testing.T) {
 	dir := t.TempDir()
 	writeYAML(t, dir, `deployment: dev209168


### PR DESCRIPTION
## Why

CE-739 shows that the v0.8.19 `VisitFlags` `stringToString` handling can silently clobber nested `StringMapField` YAML config. The flat-map conversion from PR #756 is still needed, but nested map values cannot be represented safely as pflag `StringToString` pairs. Setting the pflag marks it changed, so later `BindPFlags` makes the flattened value outrank the original YAML config.

## What this changes

This keeps the existing flat `StringMapField` behavior, but skips pflag setting when the Viper value contains nested map, slice, array, or struct values. In that case the original YAML value remains the source of truth for callers using `GetStringMap`.

Adds a regression test for nested `powershell-actions` YAML and binds pflags after `VisitFlags` to cover the precedence issue.

Validation:

- `go test -mod=vendor ./pkg/cli -run VisitFlags`
- `go test -mod=vendor ./pkg/cli`
- `go test -mod=vendor -tags baton_lambda_support ./pkg/cli`
- `go test -mod=vendor ./...`