### PR TITLE
connector: demote "session store is nil" warn to debug

### DIFF
--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -70,8 +70,18 @@ func (c *connectorClient) SetSessionStoreSetter(sessionStoreSetter sessions.SetS
 
 func (c *connectorClient) SetSessionStore(ctx context.Context, store sessions.SessionStore) {
 	if c.sessionStoreSetter == nil {
+		// Demoted from Warn to Debug: this path is the normal case for
+		// any connector that didn't opt into session storage (i.e.,
+		// wrapper.run never set cw.SessionServer to non-nil, so
+		// SetSessionStoreSetter received nil at startup). The syncer
+		// still calls SetSessionStore unconditionally on every sync, so
+		// at Warn level this fires once per sync per non-session-store
+		// connector — pure noise that masked real warnings downstream.
+		// Debug keeps the "you forgot to wire this" signal available for
+		// developers running at debug level without polluting prod logs.
+		// See https://github.com/ConductorOne/baton-sdk/issues/907.
 		l := ctxzap.Extract(ctx)
-		l.Warn("connectorClient's session store is nil")
+		l.Debug("connectorClient's session store is nil — connector did not opt into session storage")
 		return
 	}
 	c.sessionStoreSetter.SetSessionStore(ctx, store)


### PR DESCRIPTION
## Summary

Closes #907.

\`connectorClient.SetSessionStore()\` warned \`"connectorClient's session store is nil"\` on every sync for any connector that intentionally didn't opt into session storage. The flow:

- \`wrapper.run()\` unconditionally calls \`client.SetSessionStoreSetter(cw.SessionServer)\`
- \`cw.SessionServer\` is only non-nil when the session-listener block ran (gated by \`WithSessionStoreEnabled\`)
- For opt-out connectors, \`SetSessionStoreSetter(nil)\` leaves the field nil
- Then \`syncer.go:2569\` calls \`SetSessionStore\` every sync → warn fires

Demoting to Debug preserves the "you forgot to wire this" hint for developers at debug level; silent in production.

Surfaced upstream from c1ockwork's self-health-check hub. Without this we had to ad-hoc demote the finding on our side; this closes the loop at the root.

## Test plan
- [x] \`go build ./...\` clean.
- [ ] Post-merge: opt-out connectors stop logging the warning on every sync.