### PR TITLE
Propagate grant cancellation status details

### DIFF
--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -215,7 +215,7 @@ func (cw *wrapper) Run(ctx context.Context, serverCfg *connectorwrapperV1.Server
 
 	server := grpc.NewServer(
 		grpc.Creds(credentials.NewTLS(tlsConfig)),
-		grpc.ChainUnaryInterceptor(ugrpc.UnaryServerInterceptor(ctx)...),
+		grpc.ChainUnaryInterceptor(ugrpc.UnaryServerInterceptor(ctx, grantCancelledStatusUnaryServerInterceptor())...),
 		grpc.ChainStreamInterceptor(ugrpc.StreamServerInterceptors(ctx)...),
 		grpc.StatsHandler(otelgrpc.NewServerHandler(
 			otelgrpc.WithPropagators(

--- a/internal/connector/grant_status.go
+++ b/internal/connector/grant_status.go
@@ -1,0 +1,23 @@
+package connector
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+
+	"github.com/conductorone/baton-sdk/pkg/types/grant"
+)
+
+// grantCancelledStatusUnaryServerInterceptor encodes a grant cancellation marker
+// into the gRPC status returned to the caller.
+func grantCancelledStatusUnaryServerInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		resp, err := handler(ctx, req)
+		if err != nil {
+			if st, ok := grant.StatusForGrantCancelledError(err); ok {
+				return resp, st.Err()
+			}
+		}
+		return resp, err
+	}
+}

--- a/internal/connector/grant_status_test.go
+++ b/internal/connector/grant_status_test.go
@@ -1,0 +1,80 @@
+package connector
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/conductorone/baton-sdk/pkg/types/grant"
+)
+
+// TestGrantCancelledStatusInterceptorPreservesMarkerOverGRPC proves the marker
+// survives the connector-subprocess -> runner gRPC hop once the interceptor is
+// installed. Without it, a wrapped grant.ErrGrantCancelled is flattened to a bare
+// codes.Unknown status and the structured marker is lost before the runner can
+// read it (which is exactly what the c1api finishTask path depends on).
+func TestGrantCancelledStatusInterceptorPreservesMarkerOverGRPC(t *testing.T) {
+	var lc net.ListenConfig
+	lis, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	srv := grpc.NewServer(grpc.ChainUnaryInterceptor(grantCancelledStatusUnaryServerInterceptor()))
+	srv.RegisterService(&grpc.ServiceDesc{
+		ServiceName: "test.GrantService",
+		HandlerType: (*interface{})(nil),
+		Methods: []grpc.MethodDesc{{
+			MethodName: "Grant",
+			Handler: func(_ interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+				in := new(emptypb.Empty)
+				if err := dec(in); err != nil {
+					return nil, err
+				}
+				// Mimics builder.Grant returning a wrapped ErrGrantCancelled.
+				handler := func(ctx context.Context, _ interface{}) (interface{}, error) {
+					return nil, fmt.Errorf("grant failed: %w", grant.NewErrGrantCancelled("reject_if reason"))
+				}
+				info := &grpc.UnaryServerInfo{FullMethod: "/test.GrantService/Grant"}
+				if interceptor == nil {
+					return handler(ctx, in)
+				}
+				return interceptor(ctx, in, info, handler)
+			},
+		}},
+	}, struct{}{})
+	go func() { _ = srv.Serve(lis) }()
+	defer srv.Stop()
+
+	conn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	defer conn.Close()
+
+	recvErr := conn.Invoke(context.Background(), "/test.GrantService/Grant", &emptypb.Empty{}, &emptypb.Empty{})
+	require.Error(t, recvErr)
+
+	// The exact detection the runner's finishTask path relies on must succeed on
+	// the post-gRPC error.
+	reason, ok := grant.GrantCancelledReasonFromError(recvErr)
+	require.True(t, ok, "grant cancellation marker must survive gRPC; got %v", recvErr)
+	require.Equal(t, "reject_if reason", reason)
+}
+
+// TestGrantCancelledStatusInterceptorPassesThroughOtherErrors confirms the
+// interceptor only rewrites grant cancellations and leaves every other error
+// untouched.
+func TestGrantCancelledStatusInterceptorPassesThroughOtherErrors(t *testing.T) {
+	interceptor := grantCancelledStatusUnaryServerInterceptor()
+	sentinel := fmt.Errorf("some other failure")
+
+	_, err := interceptor(context.Background(), nil, &grpc.UnaryServerInfo{},
+		func(context.Context, interface{}) (interface{}, error) { return nil, sentinel })
+
+	require.ErrorIs(t, err, sentinel)
+	_, ok := grant.GrantCancelledReasonFromError(err)
+	require.False(t, ok)
+}

--- a/pkg/lambda/grpc/util.go
+++ b/pkg/lambda/grpc/util.go
@@ -20,6 +20,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	pbtransport "github.com/conductorone/baton-sdk/pb/c1/transport/v1"
+	"github.com/conductorone/baton-sdk/pkg/types/grant"
 )
 
 type timeoutUnit uint8
@@ -184,6 +185,14 @@ func ErrorResponse(err error) *Response {
 // statusForApplicationError mirrors the transient network handling in uhttp for
 // connector SDK clients that bypass the Baton HTTP wrapper.
 func statusForApplicationError(err error) *status.Status {
+	if reason, ok := grant.GrantCancelledReasonFromError(err); ok {
+		st, detailErr := grant.StatusWithGrantCancelledErrorInfo(status.New(codes.Unknown, reason), reason)
+		if detailErr != nil {
+			return status.New(codes.Unknown, reason)
+		}
+		return st
+	}
+
 	switch {
 	case errors.Is(err, context.Canceled):
 		return status.Newf(codes.Canceled, "canceled: %s", err)

--- a/pkg/lambda/grpc/util.go
+++ b/pkg/lambda/grpc/util.go
@@ -185,11 +185,7 @@ func ErrorResponse(err error) *Response {
 // statusForApplicationError mirrors the transient network handling in uhttp for
 // connector SDK clients that bypass the Baton HTTP wrapper.
 func statusForApplicationError(err error) *status.Status {
-	if reason, ok := grant.GrantCancelledReasonFromError(err); ok {
-		st, detailErr := grant.StatusWithGrantCancelledErrorInfo(status.New(codes.Unknown, reason), reason)
-		if detailErr != nil {
-			return status.New(codes.Unknown, reason)
-		}
+	if st, ok := grant.StatusForGrantCancelledError(err); ok {
 		return st
 	}
 

--- a/pkg/lambda/grpc/util_test.go
+++ b/pkg/lambda/grpc/util_test.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/conductorone/baton-sdk/pkg/types/grant"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -125,6 +126,18 @@ func TestErrorResponse_UnknownError(t *testing.T) {
 	st, stErr := resp.Status()
 	require.NoError(t, stErr)
 	require.Equal(t, codes.Unknown, st.Code())
+}
+
+func TestErrorResponse_GrantCancelled(t *testing.T) {
+	resp := ErrorResponse(fmt.Errorf("wrapped: %w", grant.NewErrGrantCancelled("reject_if reason")))
+	require.NotNil(t, resp)
+
+	st, stErr := resp.Status()
+	require.NoError(t, stErr)
+	require.Equal(t, codes.Unknown, st.Code())
+	reason, ok := grant.GrantCancelledReasonFromStatus(st.Proto())
+	require.True(t, ok)
+	require.Equal(t, "reject_if reason", reason)
 }
 
 func TestErrorResponse_ContextCanceled(t *testing.T) {

--- a/pkg/tasks/c1api/manager.go
+++ b/pkg/tasks/c1api/manager.go
@@ -27,6 +27,7 @@ import (
 	v1 "github.com/conductorone/baton-sdk/pb/c1/connectorapi/baton/v1"
 	"github.com/conductorone/baton-sdk/pkg/tasks"
 	"github.com/conductorone/baton-sdk/pkg/types"
+	"github.com/conductorone/baton-sdk/pkg/types/grant"
 	taskTypes "github.com/conductorone/baton-sdk/pkg/types/tasks"
 )
 
@@ -350,13 +351,22 @@ func (c *c1ApiTaskManager) finishTask(ctx context.Context, task *v1.Task, resp p
 			statusErr = status.New(codes.Unknown, taskError.Error())
 		}
 	}
+	statusProto := statusErr.Proto()
+	if reason, ok := grant.GrantCancelledReasonFromError(taskError); ok {
+		statusWithDetails, detailErr := grant.StatusWithGrantCancelledErrorInfo(status.FromProto(statusProto), reason)
+		if detailErr != nil {
+			l.Error("c1_api_task_manager.finishTask(): error adding grant cancellation detail", zap.Error(detailErr))
+			return detailErr
+		}
+		statusProto = statusWithDetails.Proto()
+	}
 
 	_, err = c.serviceClient.FinishTask(finishCtx, v1.BatonServiceFinishTaskRequest_builder{
 		TaskId: task.GetId(),
 		Status: &pbstatus.Status{
-			//nolint:gosec // No risk of overflow because `Code` is a small enum.
-			Code:    int32(statusErr.Code()),
-			Message: statusErr.Message(),
+			Code:    statusProto.GetCode(),
+			Message: statusProto.GetMessage(),
+			Details: statusProto.GetDetails(),
 		},
 		Error: v1.BatonServiceFinishTaskRequest_Error_builder{
 			NonRetryable: errors.Is(taskError, ErrTaskNonRetryable),

--- a/pkg/tasks/c1api/manager.go
+++ b/pkg/tasks/c1api/manager.go
@@ -27,7 +27,6 @@ import (
 	v1 "github.com/conductorone/baton-sdk/pb/c1/connectorapi/baton/v1"
 	"github.com/conductorone/baton-sdk/pkg/tasks"
 	"github.com/conductorone/baton-sdk/pkg/types"
-	"github.com/conductorone/baton-sdk/pkg/types/grant"
 	taskTypes "github.com/conductorone/baton-sdk/pkg/types/tasks"
 )
 
@@ -352,14 +351,6 @@ func (c *c1ApiTaskManager) finishTask(ctx context.Context, task *v1.Task, resp p
 		}
 	}
 	statusProto := statusErr.Proto()
-	if reason, ok := grant.GrantCancelledReasonFromError(taskError); ok {
-		statusWithDetails, detailErr := grant.StatusWithGrantCancelledErrorInfo(status.FromProto(statusProto), reason)
-		if detailErr != nil {
-			l.Error("c1_api_task_manager.finishTask(): error adding grant cancellation detail", zap.Error(detailErr))
-			return detailErr
-		}
-		statusProto = statusWithDetails.Proto()
-	}
 
 	_, err = c.serviceClient.FinishTask(finishCtx, v1.BatonServiceFinishTaskRequest_builder{
 		TaskId: task.GetId(),

--- a/pkg/tasks/c1api/manager_test.go
+++ b/pkg/tasks/c1api/manager_test.go
@@ -17,6 +17,7 @@ import (
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	v1 "github.com/conductorone/baton-sdk/pb/c1/connectorapi/baton/v1"
 	"github.com/conductorone/baton-sdk/pkg/types"
+	"github.com/conductorone/baton-sdk/pkg/types/grant"
 )
 
 // fakeBatonServiceClient is a BatonServiceClient stub that lets tests drive
@@ -30,6 +31,7 @@ type fakeBatonServiceClient struct {
 	getTasksResp   *v1.BatonServiceGetTasksResponse
 	getTasksErr    error
 	getTaskCalls   int
+	finishReqs     []*v1.BatonServiceFinishTaskRequest
 }
 
 func newFakeBatonServiceClient(helloResponses []error) *fakeBatonServiceClient {
@@ -76,7 +78,10 @@ func (f *fakeBatonServiceClient) Heartbeat(context.Context, *v1.BatonServiceHear
 	return &v1.BatonServiceHeartbeatResponse{}, nil
 }
 
-func (f *fakeBatonServiceClient) FinishTask(context.Context, *v1.BatonServiceFinishTaskRequest) (*v1.BatonServiceFinishTaskResponse, error) {
+func (f *fakeBatonServiceClient) FinishTask(_ context.Context, req *v1.BatonServiceFinishTaskRequest) (*v1.BatonServiceFinishTaskResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.finishReqs = append(f.finishReqs, req)
 	return &v1.BatonServiceFinishTaskResponse{}, nil
 }
 
@@ -471,6 +476,30 @@ func TestProcessRemovesKnownTaskID(t *testing.T) {
 	}
 	if got, _ := mgr.taskQueue.fetchParams(); containsString(got, task.GetId()) {
 		t.Fatalf("known task IDs %v still include completed task %q", got, task.GetId())
+	}
+}
+
+func TestFinishTaskGrantCancelledAddsStatusDetail(t *testing.T) {
+	sc := newFakeBatonServiceClient(nil)
+	mgr := newTestManager(sc)
+	task := v1.Task_builder{
+		Id:    "task-1",
+		Grant: v1.Task_GrantTask_builder{}.Build(),
+	}.Build()
+
+	err := mgr.finishTask(context.Background(), task, nil, nil, errors.Join(grant.NewErrGrantCancelled("reject_if reason"), ErrTaskNonRetryable))
+	if err != nil {
+		t.Fatalf("finishTask: %v", err)
+	}
+	if len(sc.finishReqs) != 1 {
+		t.Fatalf("expected one FinishTask request, got %d", len(sc.finishReqs))
+	}
+	reason, ok := grant.GrantCancelledReasonFromStatus(sc.finishReqs[0].GetStatus())
+	if !ok {
+		t.Fatalf("expected grant cancellation status detail, got %#v", sc.finishReqs[0].GetStatus())
+	}
+	if reason != "reject_if reason" {
+		t.Fatalf("expected reason %q, got %q", "reject_if reason", reason)
 	}
 }
 

--- a/pkg/tasks/c1api/manager_test.go
+++ b/pkg/tasks/c1api/manager_test.go
@@ -479,7 +479,7 @@ func TestProcessRemovesKnownTaskID(t *testing.T) {
 	}
 }
 
-func TestFinishTaskGrantCancelledAddsStatusDetail(t *testing.T) {
+func TestFinishTaskForwardsGrantCancelledStatusDetail(t *testing.T) {
 	sc := newFakeBatonServiceClient(nil)
 	mgr := newTestManager(sc)
 	task := v1.Task_builder{
@@ -487,8 +487,17 @@ func TestFinishTaskGrantCancelledAddsStatusDetail(t *testing.T) {
 		Grant: v1.Task_GrantTask_builder{}.Build(),
 	}.Build()
 
-	err := mgr.finishTask(context.Background(), task, nil, nil, errors.Join(grant.NewErrGrantCancelled("reject_if reason"), ErrTaskNonRetryable))
+	// Mirror the real call chain: cc.Grant returns a gRPC status that already
+	// carries the grant-cancellation marker (encoded at the connector's gRPC
+	// boundary), and the grant task handler joins it with ErrTaskNonRetryable
+	// before finishing. finishTask must forward those status details to C1.
+	st, err := grant.StatusWithGrantCancelledErrorInfo(status.New(codes.Unknown, "reject_if reason"), "reject_if reason")
 	if err != nil {
+		t.Fatalf("build status: %v", err)
+	}
+	taskError := errors.Join(st.Err(), ErrTaskNonRetryable)
+
+	if err := mgr.finishTask(context.Background(), task, nil, nil, taskError); err != nil {
 		t.Fatalf("finishTask: %v", err)
 	}
 	if len(sc.finishReqs) != 1 {

--- a/pkg/types/grant/cancelled_test.go
+++ b/pkg/types/grant/cancelled_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestNewErrGrantCancelled(t *testing.T) {
@@ -19,4 +22,43 @@ func TestNewErrGrantCancelled(t *testing.T) {
 
 func TestErrGrantCancelledNil(t *testing.T) {
 	require.Empty(t, (*ErrGrantCancelled)(nil).Error())
+}
+
+func TestGrantCancelledReasonFromError(t *testing.T) {
+	reason, ok := GrantCancelledReasonFromError(errors.Join(errors.New("wrapper"), NewErrGrantCancelled(" rejected by policy ")))
+	require.True(t, ok)
+	require.Equal(t, "rejected by policy", reason)
+}
+
+func TestGrantCancelledReasonFromError_DefaultReason(t *testing.T) {
+	reason, ok := GrantCancelledReasonFromError(NewErrGrantCancelled(""))
+	require.True(t, ok)
+	require.Equal(t, GrantCancelledDefaultReason, reason)
+}
+
+func TestGrantCancelledReasonFromStatus(t *testing.T) {
+	st, err := StatusWithGrantCancelledErrorInfo(nil, "reject_if reason")
+	require.NoError(t, err)
+
+	reason, ok := GrantCancelledReasonFromStatus(st.Proto())
+	require.True(t, ok)
+	require.Equal(t, "reject_if reason", reason)
+}
+
+func TestGrantCancelledReasonFromStatus_MessageFallback(t *testing.T) {
+	st, err := status.New(codes.Unknown, "status message").WithDetails(&errdetails.ErrorInfo{
+		Domain: GrantCancelledErrorInfoDomain,
+		Reason: GrantCancelledErrorInfoReason,
+	})
+	require.NoError(t, err)
+
+	reason, ok := GrantCancelledReasonFromStatus(st.Proto())
+	require.True(t, ok)
+	require.Equal(t, "status message", reason)
+}
+
+func TestGrantCancelledReasonFromStatus_NoMarker(t *testing.T) {
+	reason, ok := GrantCancelledReasonFromStatus(status.New(codes.Unknown, "ordinary error").Proto())
+	require.False(t, ok)
+	require.Empty(t, reason)
 }

--- a/pkg/types/grant/cancelled_test.go
+++ b/pkg/types/grant/cancelled_test.go
@@ -62,3 +62,19 @@ func TestGrantCancelledReasonFromStatus_NoMarker(t *testing.T) {
 	require.False(t, ok)
 	require.Empty(t, reason)
 }
+
+func TestStatusForGrantCancelledError(t *testing.T) {
+	st, ok := StatusForGrantCancelledError(errors.Join(errors.New("wrapper"), NewErrGrantCancelled("reject_if reason")))
+	require.True(t, ok)
+	require.Equal(t, codes.Unknown, st.Code())
+
+	reason, ok := GrantCancelledReasonFromStatus(st.Proto())
+	require.True(t, ok)
+	require.Equal(t, "reject_if reason", reason)
+}
+
+func TestStatusForGrantCancelledError_NotCancelled(t *testing.T) {
+	st, ok := StatusForGrantCancelledError(errors.New("ordinary error"))
+	require.False(t, ok)
+	require.Nil(t, st)
+}

--- a/pkg/types/grant/status.go
+++ b/pkg/types/grant/status.go
@@ -1,0 +1,85 @@
+package grant
+
+import (
+	"errors"
+	"strings"
+
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	rpcstatus "google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	GrantCancelledDefaultReason = "Grant cancelled by connector policy."
+
+	GrantCancelledErrorInfoDomain            = "conductorone.com/baton-sdk"
+	GrantCancelledErrorInfoReason            = "GRANT_CANCELLED"
+	GrantCancelledErrorInfoReasonMetadataKey = "reason"
+)
+
+func GrantCancelledReasonFromError(err error) (string, bool) {
+	if err == nil {
+		return "", false
+	}
+
+	var grantCancelled *ErrGrantCancelled
+	if errors.As(err, &grantCancelled) {
+		return NormalizeGrantCancelledReason(grantCancelled.Error()), true
+	}
+
+	st, ok := status.FromError(err)
+	if !ok {
+		return "", false
+	}
+
+	return GrantCancelledReasonFromStatus(st.Proto())
+}
+
+func GrantCancelledReasonFromStatus(st *rpcstatus.Status) (string, bool) {
+	if st == nil {
+		return "", false
+	}
+
+	for _, detail := range st.GetDetails() {
+		info := &errdetails.ErrorInfo{}
+		if err := detail.UnmarshalTo(info); err != nil {
+			continue
+		}
+		if info.GetDomain() != GrantCancelledErrorInfoDomain || info.GetReason() != GrantCancelledErrorInfoReason {
+			continue
+		}
+		reason := info.GetMetadata()[GrantCancelledErrorInfoReasonMetadataKey]
+		if reason == "" {
+			reason = st.GetMessage()
+		}
+		return NormalizeGrantCancelledReason(reason), true
+	}
+
+	return "", false
+}
+
+func GrantCancelledErrorInfo(reason string) *errdetails.ErrorInfo {
+	return &errdetails.ErrorInfo{
+		Domain: GrantCancelledErrorInfoDomain,
+		Reason: GrantCancelledErrorInfoReason,
+		Metadata: map[string]string{
+			GrantCancelledErrorInfoReasonMetadataKey: NormalizeGrantCancelledReason(reason),
+		},
+	}
+}
+
+func StatusWithGrantCancelledErrorInfo(st *status.Status, reason string) (*status.Status, error) {
+	if st == nil {
+		st = status.New(codes.Unknown, NormalizeGrantCancelledReason(reason))
+	}
+	return st.WithDetails(GrantCancelledErrorInfo(reason))
+}
+
+func NormalizeGrantCancelledReason(reason string) string {
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		return GrantCancelledDefaultReason
+	}
+	return reason
+}

--- a/pkg/types/grant/status.go
+++ b/pkg/types/grant/status.go
@@ -76,6 +76,27 @@ func StatusWithGrantCancelledErrorInfo(st *status.Status, reason string) (*statu
 	return st.WithDetails(GrantCancelledErrorInfo(reason))
 }
 
+// StatusForGrantCancelledError translates a grant-cancellation Go error into the
+// on-the-wire status that carries the marker, reporting whether err (or anything
+// it wraps) was a grant cancellation. It is the single encoder shared by every
+// connector server boundary (the lambda transport and the subprocess connector
+// transport) so the marker is emitted identically regardless of how a connector
+// is deployed.
+func StatusForGrantCancelledError(err error) (*status.Status, bool) {
+	reason, ok := GrantCancelledReasonFromError(err)
+	if !ok {
+		return nil, false
+	}
+	st, detailErr := StatusWithGrantCancelledErrorInfo(nil, reason)
+	if detailErr != nil {
+		// WithDetails only fails for codes.OK and this status is codes.Unknown,
+		// so this is practically unreachable. Degrade to a detail-less status
+		// rather than dropping the failure entirely.
+		return status.New(codes.Unknown, reason), true
+	}
+	return st, true
+}
+
 func NormalizeGrantCancelledReason(reason string) string {
 	reason = strings.TrimSpace(reason)
 	if reason == "" {


### PR DESCRIPTION
_Follow-up to #887._

Add grant status helpers to encode and decode grant cancellation markers in google.rpc.Status, and preserve those details through c1api task finish and lambda gRPC error responses.