### PR TITLE
feat(sync): stamp connector identity on sync/dotc1z spans + c1z size metric

### DIFF
--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -568,6 +568,7 @@ func (c *C1File) finalize(ctx context.Context) error {
 		attribute.Int64("c1z.finalize.timeout_seconds", int64(timeout.Seconds())),
 		attribute.String("c1z.finalize.db_path", c.dbFilePath),
 	)
+	uotel.SetSyncIdentityAttrs(finalizeCtx, finalizeSpan)
 
 	l := ctxzap.Extract(finalizeCtx)
 
@@ -641,6 +642,7 @@ func (c *C1File) finalize(ctx context.Context) error {
 	}
 	if outInfo, statErr := os.Stat(c.outputFilePath); statErr == nil {
 		finalizeSpan.SetAttributes(attribute.Int64("c1z.finalize.output_bytes", outInfo.Size()))
+		recordC1ZSize(finalizeCtx, "finalize", outInfo.Size())
 	}
 
 	if err := cleanupDbDir(c.dbFilePath, nil); err != nil {

--- a/pkg/dotc1z/dotc1z.go
+++ b/pkg/dotc1z/dotc1z.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/uotel"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 )
 
@@ -39,7 +40,30 @@ var (
 	// WithAttributeSet on a shared Set is allocation-free.
 	slimWriteAttrTrue  = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("slim", true)))
 	slimWriteAttrFalse = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("slim", false)))
+
+	// On-disk c1z size, recorded after vacuum and finalize. Tagged by
+	// catalog_name only — connector_id is too high-cardinality for a metric
+	// and is available per-connector on the spans instead. The phase attribute
+	// separates the post-VACUUM uncompressed db ("vacuum") from the compressed
+	// output file ("finalize").
+	c1zSizeGauge, _ = meter.Int64Gauge(
+		"c1z_size_bytes",
+		metric.WithDescription("On-disk c1z size in bytes. Attributes: phase (vacuum|finalize), catalog_name."),
+		metric.WithUnit("By"),
+	)
 )
+
+// recordC1ZSize emits the c1z size gauge for phase, tagged by catalog_name when known.
+func recordC1ZSize(ctx context.Context, phase string, sizeBytes int64) {
+	if sizeBytes <= 0 {
+		return
+	}
+	attrs := []attribute.KeyValue{attribute.String("phase", phase)}
+	if id, ok := uotel.SyncIdentityFromContext(ctx); ok && id.CatalogName != "" {
+		attrs = append(attrs, attribute.String("catalog_name", id.CatalogName))
+	}
+	c1zSizeGauge.Record(ctx, sizeBytes, metric.WithAttributes(attrs...))
+}
 
 // NewC1FileReader returns a connectorstore.Reader implementation for the given sqlite db file path.
 func NewC1FileReader(ctx context.Context, dbFilePath string, opts ...C1FOption) (connectorstore.Reader, error) {

--- a/pkg/dotc1z/sync_runs.go
+++ b/pkg/dotc1z/sync_runs.go
@@ -14,6 +14,7 @@ import (
 	"github.com/doug-martin/goqu/v9"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"github.com/segmentio/ksuid"
+	"go.opentelemetry.io/otel/attribute"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -848,6 +849,7 @@ func wrapSqliteInterruptError(err error) error {
 
 func (c *C1File) Cleanup(ctx context.Context) error {
 	ctx, span := tracer.Start(ctx, "C1File.Cleanup")
+	uotel.SetSyncIdentityAttrs(ctx, span)
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
@@ -1016,6 +1018,7 @@ func (c *C1File) DeleteSyncRun(ctx context.Context, syncID string) error {
 // Vacuum runs a VACUUM on the database to reclaim space.
 func (c *C1File) Vacuum(ctx context.Context) error {
 	ctx, span := tracer.Start(ctx, "C1File.Vacuum")
+	uotel.SetSyncIdentityAttrs(ctx, span)
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
@@ -1024,9 +1027,21 @@ func (c *C1File) Vacuum(ctx context.Context) error {
 		return err
 	}
 
+	sizeBefore, _ := c.CurrentDBSizeBytes()
+
 	_, err = c.rawDb.ExecContext(ctx, "VACUUM")
 	if err != nil {
 		return err
+	}
+
+	sizeAfter, sizeErr := c.CurrentDBSizeBytes()
+	if sizeErr == nil {
+		span.SetAttributes(
+			attribute.Int64("c1z.vacuum.size_before_bytes", sizeBefore),
+			attribute.Int64("c1z.vacuum.size_after_bytes", sizeAfter),
+			attribute.Int64("c1z.vacuum.reclaimed_bytes", sizeBefore-sizeAfter),
+		)
+		recordC1ZSize(ctx, "vacuum", sizeAfter)
 	}
 
 	c.dbUpdated = true

--- a/pkg/dotc1z/sync_runs.go
+++ b/pkg/dotc1z/sync_runs.go
@@ -1027,7 +1027,7 @@ func (c *C1File) Vacuum(ctx context.Context) error {
 		return err
 	}
 
-	sizeBefore, _ := c.CurrentDBSizeBytes()
+	sizeBefore, sizeBeforeErr := c.CurrentDBSizeBytes()
 
 	_, err = c.rawDb.ExecContext(ctx, "VACUUM")
 	if err != nil {
@@ -1036,12 +1036,16 @@ func (c *C1File) Vacuum(ctx context.Context) error {
 
 	sizeAfter, sizeErr := c.CurrentDBSizeBytes()
 	if sizeErr == nil {
-		span.SetAttributes(
-			attribute.Int64("c1z.vacuum.size_before_bytes", sizeBefore),
-			attribute.Int64("c1z.vacuum.size_after_bytes", sizeAfter),
-			attribute.Int64("c1z.vacuum.reclaimed_bytes", sizeBefore-sizeAfter),
-		)
+		span.SetAttributes(attribute.Int64("c1z.vacuum.size_after_bytes", sizeAfter))
 		recordC1ZSize(ctx, "vacuum", sizeAfter)
+		// reclaimed_bytes is only meaningful with a valid pre-VACUUM size;
+		// a failed sizeBefore returns 0 and would emit negative reclaimed.
+		if sizeBeforeErr == nil {
+			span.SetAttributes(
+				attribute.Int64("c1z.vacuum.size_before_bytes", sizeBefore),
+				attribute.Int64("c1z.vacuum.reclaimed_bytes", sizeBefore-sizeAfter),
+			)
+		}
 	}
 
 	c.dbUpdated = true

--- a/pkg/sync/parallel_syncer.go
+++ b/pkg/sync/parallel_syncer.go
@@ -9,7 +9,9 @@ import (
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/retry"
+	"github.com/conductorone/baton-sdk/pkg/uotel"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.opentelemetry.io/otel/attribute"
 	"go.uber.org/zap"
 )
 
@@ -269,6 +271,22 @@ type workerResult struct {
 func (s *syncer) syncParallel(ctx context.Context, retryer *retry.Retryer, actions []*Action, f func(ctx context.Context, action *Action) error) ([]error, error) {
 	l := ctxzap.Extract(ctx)
 	l.Info("syncing in parallel", zap.Int("actions", len(actions)), zap.Int("workers", s.workerCount))
+
+	// One bounded summary span per fan-out batch. The per-action work (f) starts
+	// its own linked-root span, so this stays a handful of spans per sync rather
+	// than one per resource/grant.
+	op := ""
+	if len(actions) > 0 {
+		op = actions[0].Op.String()
+	}
+	ctx, span := tracer.Start(ctx, "syncer.syncParallel")
+	span.SetAttributes(
+		attribute.String("sync.op", op),
+		attribute.Int("sync.action_count", len(actions)),
+		attribute.Int("sync.worker_count", s.workerCount),
+	)
+	uotel.SetSyncIdentityAttrs(ctx, span)
+	defer span.End()
 
 	ctx, cancel := context.WithCancelCause(ctx)
 	defer cancel(nil)

--- a/pkg/sync/parallel_syncer.go
+++ b/pkg/sync/parallel_syncer.go
@@ -286,7 +286,8 @@ func (s *syncer) syncParallel(ctx context.Context, retryer *retry.Retryer, actio
 		attribute.Int("sync.worker_count", s.workerCount),
 	)
 	uotel.SetSyncIdentityAttrs(ctx, span)
-	defer span.End()
+	var batchErr error
+	defer func() { uotel.EndSpanWithError(span, batchErr) }()
 
 	ctx, cancel := context.WithCancelCause(ctx)
 	defer cancel(nil)
@@ -328,7 +329,8 @@ func (s *syncer) syncParallel(ctx context.Context, retryer *retry.Retryer, actio
 		}
 	}
 
-	return warnings, errors.Join(errs...)
+	batchErr = errors.Join(errs...)
+	return warnings, batchErr
 }
 
 // syncOneAction processes a single action to completion,

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -3000,15 +3000,12 @@ func WithWorkerCount(count int) SyncOpt {
 
 // WithSyncIdentity stamps connector identity onto sync and dotc1z spans (and
 // the c1z size metric) so a single connector's work is filterable in APM.
-// Keys match the pprof.Do labels set by the platform sync activity.
-func WithSyncIdentity(tenantID, connectorID, catalogID, catalogName string) SyncOpt {
+// Attribute keys match the pprof.Do labels set by the platform sync activity,
+// so spans and CPU profiles line up. Sync injects this into the run context
+// via uotel.WithSyncIdentity, which is how it reaches dotc1z spans too.
+func WithSyncIdentity(id uotel.SyncIdentity) SyncOpt {
 	return func(s *syncer) {
-		s.syncIdentity = uotel.SyncIdentity{
-			TenantID:    tenantID,
-			ConnectorID: connectorID,
-			CatalogID:   catalogID,
-			CatalogName: catalogName,
-		}
+		s.syncIdentity = id
 	}
 }
 

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -143,6 +143,7 @@ type syncer struct {
 	previousSyncIDPtr                   atomic.Pointer[string]
 	workerCount                         int // If 1, sync is sequential (default). If > 1, sync operations are done in parallel.
 	metricsHandler                      metrics.Handler
+	syncIdentity                        uotel.SyncIdentity
 }
 
 var _ Syncer = (*syncer)(nil)
@@ -415,6 +416,13 @@ func (s *syncer) getActiveSyncID() string {
 // into the datasource. This allows for graceful resumes if a sync is interrupted.
 func (s *syncer) Sync(ctx context.Context) error {
 	ctx, span := tracer.Start(ctx, "syncer.Sync")
+	// Propagate connector identity to every descendant span (sync + dotc1z).
+	// An explicit WithSyncIdentity option wins; otherwise inherit whatever the
+	// caller already set on ctx.
+	if !s.syncIdentity.IsZero() {
+		ctx = uotel.WithSyncIdentity(ctx, s.syncIdentity)
+	}
+	uotel.SetSyncIdentityAttrs(ctx, span)
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
@@ -598,6 +606,7 @@ func (s *syncer) Sync(ctx context.Context) error {
 
 func (s *syncer) SkipSync(ctx context.Context) error {
 	ctx, span := tracer.Start(ctx, "syncer.SkipSync")
+	uotel.SetSyncIdentityAttrs(ctx, span)
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
@@ -667,6 +676,7 @@ func (s *syncer) listAllResourceTypes(ctx context.Context) iter.Seq2[[]*v2.Resou
 // SyncResourceTypes calls the ListResourceType() connector endpoint and persists the results in to the datasource.
 func (s *syncer) SyncResourceTypes(ctx context.Context, action *Action) error {
 	ctx, span := uotel.StartWithLink(ctx, tracer, "syncer.SyncResourceTypes")
+	uotel.SetSyncIdentityAttrs(ctx, span)
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
@@ -807,6 +817,7 @@ func (s *syncer) getResourceFromConnector(ctx context.Context, resourceID *v2.Re
 
 func (s *syncer) SyncTargetedResource(ctx context.Context, action *Action) error {
 	ctx, span := uotel.StartWithLink(ctx, tracer, "syncer.SyncTargetedResource")
+	uotel.SetSyncIdentityAttrs(ctx, span)
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
@@ -886,6 +897,7 @@ func (s *syncer) SyncTargetedResource(ctx context.Context, action *Action) error
 // resource, we gather any child resource types it may emit, and traverse the resource tree.
 func (s *syncer) SyncResources(ctx context.Context, action *Action) error {
 	ctx, span := uotel.StartWithLink(ctx, tracer, "syncer.SyncResources")
+	uotel.SetSyncIdentityAttrs(ctx, span)
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
@@ -1139,6 +1151,7 @@ func (s *syncer) shouldSkipEntitlements(ctx context.Context, r *v2.Resource) (bo
 // and pushes an action to fetch the entitlements for each resource.
 func (s *syncer) SyncEntitlements(ctx context.Context, action *Action) error {
 	ctx, span := uotel.StartWithLink(ctx, tracer, "syncer.SyncEntitlements")
+	uotel.SetSyncIdentityAttrs(ctx, span)
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
@@ -1221,6 +1234,7 @@ func (s *syncer) syncEntitlementsForResource(ctx context.Context, action *Action
 
 func (s *syncer) SyncStaticEntitlements(ctx context.Context, action *Action) error {
 	ctx, span := uotel.StartWithLink(ctx, tracer, "syncer.SyncStaticEntitlements")
+	uotel.SetSyncIdentityAttrs(ctx, span)
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
@@ -1455,6 +1469,7 @@ func (s *syncer) syncAssetsForResource(ctx context.Context, action *Action) erro
 // SyncAssets iterates each resource in the data store, and adds an action to fetch all of the assets for that resource.
 func (s *syncer) SyncAssets(ctx context.Context, action *Action) error {
 	ctx, span := uotel.StartWithLink(ctx, tracer, "syncer.SyncAssets")
+	uotel.SetSyncIdentityAttrs(ctx, span)
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
@@ -1490,6 +1505,7 @@ func (s *syncer) SyncAssets(ctx context.Context, action *Action) error {
 // It first loads the entitlement graph from grants, fixes any cycles, then runs expansion.
 func (s *syncer) SyncGrantExpansion(ctx context.Context, action *Action) error {
 	ctx, span := uotel.StartWithLink(ctx, tracer, "syncer.SyncGrantExpansion")
+	uotel.SetSyncIdentityAttrs(ctx, span)
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
@@ -1631,6 +1647,7 @@ func (s *syncer) fixEntitlementGraphCycles(ctx context.Context, graph *expand.En
 // from the datastore, and pushes a new action to sync the grants for each individual resource.
 func (s *syncer) SyncGrants(ctx context.Context, action *Action) error {
 	ctx, span := uotel.StartWithLink(ctx, tracer, "syncer.SyncGrants")
+	uotel.SetSyncIdentityAttrs(ctx, span)
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
@@ -1992,6 +2009,7 @@ func (s *syncer) syncGrantsForResource(ctx context.Context, action *Action) erro
 
 func (s *syncer) SyncExternalResources(ctx context.Context, action *Action) error {
 	ctx, span := uotel.StartWithLink(ctx, tracer, "syncer.SyncExternalResources")
+	uotel.SetSyncIdentityAttrs(ctx, span)
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
@@ -2765,6 +2783,7 @@ func (s *syncer) Close(ctx context.Context) error {
 	// parent_ctx_err="nil".
 	finalizeCtx = uotel.WithParentCtxErrLabel(finalizeCtx, parentCtxErrLabel)
 	finalizeCtx, finalizeSpan := uotel.StartWithLink(finalizeCtx, tracer, "syncer.finalize")
+	uotel.SetSyncIdentityAttrs(finalizeCtx, finalizeSpan)
 	finalizeSpan.SetAttributes(
 		attribute.Bool("c1z.finalize.cancel_observed", parentCtxErrLabel != "nil"),
 		attribute.String("c1z.finalize.parent_ctx_err", parentCtxErrLabel),
@@ -2976,6 +2995,20 @@ func WithMetricsHandler(h metrics.Handler) SyncOpt {
 func WithWorkerCount(count int) SyncOpt {
 	return func(s *syncer) {
 		s.workerCount = NormalizeWorkerCount(count)
+	}
+}
+
+// WithSyncIdentity stamps connector identity onto sync and dotc1z spans (and
+// the c1z size metric) so a single connector's work is filterable in APM.
+// Keys match the pprof.Do labels set by the platform sync activity.
+func WithSyncIdentity(tenantID, connectorID, catalogID, catalogName string) SyncOpt {
+	return func(s *syncer) {
+		s.syncIdentity = uotel.SyncIdentity{
+			TenantID:    tenantID,
+			ConnectorID: connectorID,
+			CatalogID:   catalogID,
+			CatalogName: catalogName,
+		}
 	}
 }
 

--- a/pkg/uotel/identity.go
+++ b/pkg/uotel/identity.go
@@ -19,6 +19,7 @@ type SyncIdentity struct {
 	CatalogName string
 }
 
+// IsZero reports whether id has no fields set.
 func (id SyncIdentity) IsZero() bool {
 	return id == SyncIdentity{}
 }
@@ -43,7 +44,9 @@ func (id SyncIdentity) Attrs() []attribute.KeyValue {
 
 type syncIdentityKey struct{}
 
-// WithSyncIdentity returns a context carrying id for downstream span stamping.
+// WithSyncIdentity returns a child of ctx carrying id. It only stores the
+// identity; spans are stamped where SetSyncIdentityAttrs(ctx, span) is called,
+// not here.
 func WithSyncIdentity(ctx context.Context, id SyncIdentity) context.Context {
 	return context.WithValue(ctx, syncIdentityKey{}, id)
 }

--- a/pkg/uotel/identity.go
+++ b/pkg/uotel/identity.go
@@ -14,6 +14,7 @@ import (
 // CPU profiles line up on the same dimensions.
 type SyncIdentity struct {
 	TenantID    string
+	AppID       string
 	ConnectorID string
 	CatalogID   string
 	CatalogName string
@@ -26,9 +27,12 @@ func (id SyncIdentity) IsZero() bool {
 
 // Attrs returns the non-empty identity fields as span attributes.
 func (id SyncIdentity) Attrs() []attribute.KeyValue {
-	attrs := make([]attribute.KeyValue, 0, 4)
+	attrs := make([]attribute.KeyValue, 0, 5)
 	if id.TenantID != "" {
 		attrs = append(attrs, attribute.String("tenant_id", id.TenantID))
+	}
+	if id.AppID != "" {
+		attrs = append(attrs, attribute.String("app_id", id.AppID))
 	}
 	if id.ConnectorID != "" {
 		attrs = append(attrs, attribute.String("connector_id", id.ConnectorID))

--- a/pkg/uotel/identity.go
+++ b/pkg/uotel/identity.go
@@ -1,0 +1,63 @@
+package uotel
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// SyncIdentity carries the platform identifiers for a connector sync. It is
+// propagated through the context so spans deep in the sync and dotc1z call
+// trees can be filtered to a single connector in APM. The attribute keys
+// match the pprof.Do labels set by the platform sync activity, so spans and
+// CPU profiles line up on the same dimensions.
+type SyncIdentity struct {
+	TenantID    string
+	ConnectorID string
+	CatalogID   string
+	CatalogName string
+}
+
+func (id SyncIdentity) IsZero() bool {
+	return id == SyncIdentity{}
+}
+
+// Attrs returns the non-empty identity fields as span attributes.
+func (id SyncIdentity) Attrs() []attribute.KeyValue {
+	attrs := make([]attribute.KeyValue, 0, 4)
+	if id.TenantID != "" {
+		attrs = append(attrs, attribute.String("tenant_id", id.TenantID))
+	}
+	if id.ConnectorID != "" {
+		attrs = append(attrs, attribute.String("connector_id", id.ConnectorID))
+	}
+	if id.CatalogID != "" {
+		attrs = append(attrs, attribute.String("catalog_id", id.CatalogID))
+	}
+	if id.CatalogName != "" {
+		attrs = append(attrs, attribute.String("catalog_name", id.CatalogName))
+	}
+	return attrs
+}
+
+type syncIdentityKey struct{}
+
+// WithSyncIdentity returns a context carrying id for downstream span stamping.
+func WithSyncIdentity(ctx context.Context, id SyncIdentity) context.Context {
+	return context.WithValue(ctx, syncIdentityKey{}, id)
+}
+
+// SyncIdentityFromContext returns the identity set by WithSyncIdentity.
+func SyncIdentityFromContext(ctx context.Context) (SyncIdentity, bool) {
+	id, ok := ctx.Value(syncIdentityKey{}).(SyncIdentity)
+	return id, ok
+}
+
+// SetSyncIdentityAttrs stamps the connector identity carried in ctx onto span.
+// No-op when ctx carries no identity, so it is safe to call on every span.
+func SetSyncIdentityAttrs(ctx context.Context, span trace.Span) {
+	if id, ok := SyncIdentityFromContext(ctx); ok {
+		span.SetAttributes(id.Attrs()...)
+	}
+}

--- a/pkg/uotel/identity_test.go
+++ b/pkg/uotel/identity_test.go
@@ -1,0 +1,66 @@
+package uotel
+
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel/attribute"
+)
+
+func TestSyncIdentityAttrs(t *testing.T) {
+	t.Run("all fields", func(t *testing.T) {
+		id := SyncIdentity{TenantID: "t1", ConnectorID: "c1", CatalogID: "cat1", CatalogName: "okta"}
+		got := id.Attrs()
+		want := map[attribute.Key]string{
+			"tenant_id":    "t1",
+			"connector_id": "c1",
+			"catalog_id":   "cat1",
+			"catalog_name": "okta",
+		}
+		if len(got) != len(want) {
+			t.Fatalf("got %d attrs, want %d", len(got), len(want))
+		}
+		for _, kv := range got {
+			if want[kv.Key] != kv.Value.AsString() {
+				t.Errorf("attr %s = %q, want %q", kv.Key, kv.Value.AsString(), want[kv.Key])
+			}
+		}
+	})
+
+	t.Run("empty fields omitted", func(t *testing.T) {
+		id := SyncIdentity{ConnectorID: "c1"}
+		got := id.Attrs()
+		if len(got) != 1 || got[0].Key != "connector_id" {
+			t.Fatalf("expected only connector_id, got %v", got)
+		}
+	})
+
+	t.Run("zero", func(t *testing.T) {
+		if !(SyncIdentity{}).IsZero() {
+			t.Error("empty SyncIdentity should be zero")
+		}
+		if (SyncIdentity{TenantID: "t"}).IsZero() {
+			t.Error("populated SyncIdentity should not be zero")
+		}
+		if len((SyncIdentity{}).Attrs()) != 0 {
+			t.Error("zero identity should produce no attrs")
+		}
+	})
+}
+
+func TestSyncIdentityContextRoundTrip(t *testing.T) {
+	id := SyncIdentity{TenantID: "t1", ConnectorID: "c1"}
+	ctx := WithSyncIdentity(context.Background(), id)
+
+	got, ok := SyncIdentityFromContext(ctx)
+	if !ok {
+		t.Fatal("expected identity in context")
+	}
+	if got != id {
+		t.Errorf("round-trip mismatch: got %+v, want %+v", got, id)
+	}
+
+	if _, ok := SyncIdentityFromContext(context.Background()); ok {
+		t.Error("bare context should not carry identity")
+	}
+}

--- a/pkg/uotel/identity_test.go
+++ b/pkg/uotel/identity_test.go
@@ -10,10 +10,11 @@ import (
 
 func TestSyncIdentityAttrs(t *testing.T) {
 	t.Run("all fields", func(t *testing.T) {
-		id := SyncIdentity{TenantID: "t1", ConnectorID: "c1", CatalogID: "cat1", CatalogName: "okta"}
+		id := SyncIdentity{TenantID: "t1", AppID: "a1", ConnectorID: "c1", CatalogID: "cat1", CatalogName: "okta"}
 		got := id.Attrs()
 		want := map[attribute.Key]string{
 			"tenant_id":    "t1",
+			"app_id":       "a1",
 			"connector_id": "c1",
 			"catalog_id":   "cat1",
 			"catalog_name": "okta",
@@ -77,7 +78,7 @@ func TestSetSyncIdentityAttrs(t *testing.T) {
 		rec := &recordingProcessor{}
 		tr := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec)).Tracer("test")
 
-		id := SyncIdentity{TenantID: "t1", ConnectorID: "c1", CatalogID: "cat1", CatalogName: "okta"}
+		id := SyncIdentity{TenantID: "t1", AppID: "a1", ConnectorID: "c1", CatalogID: "cat1", CatalogName: "okta"}
 		ctx, span := tr.Start(WithSyncIdentity(context.Background(), id), "test.span")
 		SetSyncIdentityAttrs(ctx, span)
 		span.End()
@@ -111,7 +112,7 @@ func TestSetSyncIdentityAttrs(t *testing.T) {
 		}
 		for _, a := range got.Attributes() {
 			switch a.Key {
-			case "tenant_id", "connector_id", "catalog_id", "catalog_name":
+			case "tenant_id", "app_id", "connector_id", "catalog_id", "catalog_name":
 				t.Errorf("unexpected identity attr %s on span with no identity in ctx", a.Key)
 			}
 		}

--- a/pkg/uotel/identity_test.go
+++ b/pkg/uotel/identity_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
 func TestSyncIdentityAttrs(t *testing.T) {
@@ -30,8 +31,11 @@ func TestSyncIdentityAttrs(t *testing.T) {
 	t.Run("empty fields omitted", func(t *testing.T) {
 		id := SyncIdentity{ConnectorID: "c1"}
 		got := id.Attrs()
-		if len(got) != 1 || got[0].Key != "connector_id" {
-			t.Fatalf("expected only connector_id, got %v", got)
+		if len(got) != 1 {
+			t.Fatalf("expected 1 attr, got %d: %v", len(got), got)
+		}
+		if got[0].Key != "connector_id" || got[0].Value.AsString() != "c1" {
+			t.Errorf("expected connector_id=c1, got %s=%q", got[0].Key, got[0].Value.AsString())
 		}
 	})
 
@@ -63,4 +67,53 @@ func TestSyncIdentityContextRoundTrip(t *testing.T) {
 	if _, ok := SyncIdentityFromContext(context.Background()); ok {
 		t.Error("bare context should not carry identity")
 	}
+}
+
+// TestSetSyncIdentityAttrs is the regression guard for the span-stamping path
+// that every sync/dotc1z span relies on: break the ctx-propagation chain and
+// spans silently lose all identity attributes with no other test failing.
+func TestSetSyncIdentityAttrs(t *testing.T) {
+	t.Run("stamps span when ctx carries identity", func(t *testing.T) {
+		rec := &recordingProcessor{}
+		tr := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec)).Tracer("test")
+
+		id := SyncIdentity{TenantID: "t1", ConnectorID: "c1", CatalogID: "cat1", CatalogName: "okta"}
+		ctx, span := tr.Start(WithSyncIdentity(context.Background(), id), "test.span")
+		SetSyncIdentityAttrs(ctx, span)
+		span.End()
+
+		got := findSpan(rec, "test.span")
+		if got == nil {
+			t.Fatal("span not recorded")
+		}
+		attrs := map[attribute.Key]string{}
+		for _, a := range got.Attributes() {
+			attrs[a.Key] = a.Value.AsString()
+		}
+		for _, want := range id.Attrs() {
+			if attrs[want.Key] != want.Value.AsString() {
+				t.Errorf("attr %s = %q, want %q", want.Key, attrs[want.Key], want.Value.AsString())
+			}
+		}
+	})
+
+	t.Run("no-op when ctx carries no identity", func(t *testing.T) {
+		rec := &recordingProcessor{}
+		tr := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec)).Tracer("test")
+
+		_, span := tr.Start(context.Background(), "test.noop")
+		SetSyncIdentityAttrs(context.Background(), span)
+		span.End()
+
+		got := findSpan(rec, "test.noop")
+		if got == nil {
+			t.Fatal("span not recorded")
+		}
+		for _, a := range got.Attributes() {
+			switch a.Key {
+			case "tenant_id", "connector_id", "catalog_id", "catalog_name":
+				t.Errorf("unexpected identity attr %s on span with no identity in ctx", a.Key)
+			}
+		}
+	})
 }


### PR DESCRIPTION
## Why

Sync and dotc1z spans already exist (`syncer.Sync`, `syncer.SyncResources/Grants/Entitlements`, `C1File.Vacuum/Cleanup/finalize`, …) but carry **no connector identity**, so a single connector's sync/c1z work can't be filtered per-connector in APM. In a recent incident a connector's sync silently looped + VACUUMed for days and was only findable via CPU **profile labels** — the spans were useless for it. This closes that gap and adds the c1z-size signal that loop would have surfaced immediately.

## What

- **`uotel.SyncIdentity`** — context-propagated `{tenant_id, connector_id, catalog_id, catalog_name}`. Attribute keys match the platform's `pprof.Do` labels, so spans and CPU profiles line up on the same dimensions.
- **`sync.WithSyncIdentity(...)` option** — `Sync()` injects identity into the run context, so every descendant span (sync **and** dotc1z, via the threaded ctx) gets stamped. Explicit option wins; otherwise inherits whatever the caller already set on ctx.
- **Identity stamped** on every linked-root sync operation span + `C1File.Vacuum/Cleanup/finalize/saveC1z`.
- **Bounded summary span** on the parallel fan-out (`syncParallel`): one span per batch with `sync.op` / `sync.action_count` / `sync.worker_count`. The per-action work already starts its own `StartWithLink` root, so this stays a handful of spans per sync — **traces do not grow with resource/grant count**.
- **`C1File.Vacuum`** records `c1z.vacuum.{size_before,size_after,reclaimed}_bytes`.
- **`c1z_size_bytes` gauge** (`phase=vacuum|finalize`), tagged **`catalog_name` only** — `connector_id` is too high-cardinality for a metric and is already on the spans for per-connector drill-down.

## Trace-length safety

No new per-item spans. Identity stamping is attributes on existing spans; the only new span is one bounded summary per fan-out batch. The existing `StartWithLink` (new-root-linked-to-parent) pattern is preserved throughout.

## Wiring

Identity flows by context value, so this lights up once the platform caller sets it (the `ductone/c1` sync activity already computes `tenant_id`/`connector_id`/`catalog_id`/`catalog_name` for its `pprof.Do` labels — a follow-up passes the same values via `WithSyncIdentity` after this SDK release). Until then the changes are inert no-ops.

## Test

- New `pkg/uotel/identity_test.go` (Attrs/IsZero/context round-trip).
- `go build` + `go vet` clean (incl. `-tags=baton_lambda_support`); `pkg/uotel`, `pkg/dotc1z`, `pkg/sync` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)