### PR TITLE
grant: encode ErrGrantCancelled as a typed gRPC status detail

### DIFF
--- a/pkg/tasks/c1api/grant.go
+++ b/pkg/tasks/c1api/grant.go
@@ -13,6 +13,7 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/tasks"
 	"github.com/conductorone/baton-sdk/pkg/types"
+	sdkgrant "github.com/conductorone/baton-sdk/pkg/types/grant"
 	"github.com/conductorone/baton-sdk/pkg/uotel"
 )
 
@@ -50,7 +51,13 @@ func (g *grantTaskHandler) HandleTask(ctx context.Context) error {
 		Principal:   grant.GetPrincipal(),
 	}.Build())
 	if err != nil {
-		l.Error("failed while granting entitlement", zap.Error(err))
+		// A connector can intentionally decline a grant (e.g. a policy rejection) rather than fail to provision it.
+		// The decline rides the gRPC status (a typed ErrorInfo detail) carried by ErrGrantCancelled.
+		if reason, ok := sdkgrant.IsErrGrantCancelled(err); ok {
+			l.Info("connector declined grant; cancelling request", zap.String("reason", reason))
+		} else {
+			l.Error("failed while granting entitlement", zap.Error(err))
+		}
 		return g.helpers.FinishTask(ctx, nil, nil, errors.Join(err, ErrTaskNonRetryable))
 	}
 

--- a/pkg/tasks/c1api/manager.go
+++ b/pkg/tasks/c1api/manager.go
@@ -357,6 +357,9 @@ func (c *c1ApiTaskManager) finishTask(ctx context.Context, task *v1.Task, resp p
 			//nolint:gosec // No risk of overflow because `Code` is a small enum.
 			Code:    int32(statusErr.Code()),
 			Message: statusErr.Message(),
+			// Carry the status details (e.g. a typed ErrorInfo) so structured connector errors survive to C1 instead of being
+			// truncated to code+message.
+			Details: statusErr.Proto().GetDetails(),
 		},
 		Error: v1.BatonServiceFinishTaskRequest_Error_builder{
 			NonRetryable: errors.Is(taskError, ErrTaskNonRetryable),

--- a/pkg/types/grant/cancelled.go
+++ b/pkg/types/grant/cancelled.go
@@ -1,5 +1,20 @@
 package grant
 
+import (
+	"errors"
+
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	GrantCancelledErrorReason = "grant_cancelled"
+	GrantCancelledErrorDomain = "github.com/conductorone/baton-sdk"
+
+	grantCancelledReasonMetadataKey = "reason"
+)
+
 // ErrGrantCancelled indicates a connector intentionally declined to create a grant.
 type ErrGrantCancelled struct {
 	Reason string
@@ -12,6 +27,57 @@ func (e *ErrGrantCancelled) Error() string {
 	return e.Reason
 }
 
+// GRPCStatus encodes the cancellation as a FailedPrecondition status carrying a typed ErrorInfo detail.
+// The status flattening that the connector gRPC boundary applies to handler errors otherwise discards the Go error type;
+// the detail rides the wire so C1 can recognize an intentional decline rather than treating it as a connector failure.
+func (e *ErrGrantCancelled) GRPCStatus() *status.Status {
+	st := status.New(codes.FailedPrecondition, e.Error())
+	withDetails, err := st.WithDetails(&errdetails.ErrorInfo{
+		Reason: GrantCancelledErrorReason,
+		Domain: GrantCancelledErrorDomain,
+		Metadata: map[string]string{
+			grantCancelledReasonMetadataKey: e.Reason,
+		},
+	})
+	if err != nil {
+		return st
+	}
+	return withDetails
+}
+
 func NewErrGrantCancelled(reason string) error {
 	return &ErrGrantCancelled{Reason: reason}
+}
+
+// IsErrGrantCancelled reports whether err is an intentionally declined grant, returning the connector-supplied reason.
+// It matches both the typed error (in-process) and the flattened gRPC status detail (across a transport).
+func IsErrGrantCancelled(err error) (string, bool) {
+	if err == nil {
+		return "", false
+	}
+	var e *ErrGrantCancelled
+	if errors.As(err, &e) {
+		return e.Reason, true
+	}
+	if st, ok := status.FromError(err); ok {
+		return GrantCancelledReasonFromStatus(st)
+	}
+	return "", false
+}
+
+// GrantCancelledReasonFromStatus returns the connector-supplied reason if status carries the grant-cancelled ErrorInfo detail.
+func GrantCancelledReasonFromStatus(st *status.Status) (string, bool) {
+	if st == nil {
+		return "", false
+	}
+	for _, detail := range st.Details() {
+		info, ok := detail.(*errdetails.ErrorInfo)
+		if !ok {
+			continue
+		}
+		if info.GetReason() == GrantCancelledErrorReason && info.GetDomain() == GrantCancelledErrorDomain {
+			return info.GetMetadata()[grantCancelledReasonMetadataKey], true
+		}
+	}
+	return "", false
 }

--- a/pkg/types/grant/cancelled_test.go
+++ b/pkg/types/grant/cancelled_test.go
@@ -2,9 +2,12 @@ package grant
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestNewErrGrantCancelled(t *testing.T) {
@@ -19,4 +22,52 @@ func TestNewErrGrantCancelled(t *testing.T) {
 
 func TestErrGrantCancelledNil(t *testing.T) {
 	require.Empty(t, (*ErrGrantCancelled)(nil).Error())
+}
+
+func TestErrGrantCancelledGRPCStatus(t *testing.T) {
+	st := (&ErrGrantCancelled{Reason: "rejected by policy"}).GRPCStatus()
+	require.Equal(t, codes.FailedPrecondition, st.Code())
+
+	reason, ok := GrantCancelledReasonFromStatus(st)
+	require.True(t, ok)
+	require.Equal(t, "rejected by policy", reason)
+}
+
+func TestIsErrGrantCancelled(t *testing.T) {
+	t.Run("typed error", func(t *testing.T) {
+		reason, ok := IsErrGrantCancelled(NewErrGrantCancelled("rejected by policy"))
+		require.True(t, ok)
+		require.Equal(t, "rejected by policy", reason)
+	})
+
+	t.Run("wrapped typed error", func(t *testing.T) {
+		wrapped := fmt.Errorf("grant failed: %w", NewErrGrantCancelled("rejected by policy"))
+		reason, ok := IsErrGrantCancelled(wrapped)
+		require.True(t, ok)
+		require.Equal(t, "rejected by policy", reason)
+	})
+
+	t.Run("flattened gRPC status", func(t *testing.T) {
+		// Simulate the connector gRPC boundary discarding the Go type but
+		// preserving the status with its detail.
+		flattened := (&ErrGrantCancelled{Reason: "rejected by policy"}).GRPCStatus().Err()
+		reason, ok := IsErrGrantCancelled(flattened)
+		require.True(t, ok)
+		require.Equal(t, "rejected by policy", reason)
+	})
+
+	t.Run("unrelated error", func(t *testing.T) {
+		_, ok := IsErrGrantCancelled(errors.New("boom"))
+		require.False(t, ok)
+	})
+
+	t.Run("unrelated status", func(t *testing.T) {
+		_, ok := IsErrGrantCancelled(status.Error(codes.FailedPrecondition, "some other precondition"))
+		require.False(t, ok)
+	})
+
+	t.Run("nil", func(t *testing.T) {
+		_, ok := IsErrGrantCancelled(nil)
+		require.False(t, ok)
+	})
 }


### PR DESCRIPTION
## Summary

Makes an intentionally-declined grant detectable by C1 — encoding the existing `ErrGrantCancelled` named error as a typed gRPC status detail so it survives the connector gRPC boundary.

_This is a follow-up to #887._ The blocker was that a typed Go error flattens to opaque `code`+`message` over the service-mode gRPC hop. The fix: have `ErrGrantCancelled` carry itself as a structured gRPC status, which rides the **error** channel — so C1 never inserts the grant by default, and an unrecognized variant falls back to the normal error path (fail-safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)