### PR TITLE
Add options to CloneSync().

### DIFF
--- a/pkg/dotc1z/c1file_store.go
+++ b/pkg/dotc1z/c1file_store.go
@@ -300,8 +300,8 @@ func (s c1FileSyncMeta) Stats(ctx context.Context, syncType connectorstore.SyncT
 type c1FileFileOps struct{ c *C1File }
 
 // CloneSync implements FileOps. Direct passthrough.
-func (f c1FileFileOps) CloneSync(ctx context.Context, outPath string, syncID string) error {
-	return f.c.CloneSync(ctx, outPath, syncID)
+func (f c1FileFileOps) CloneSync(ctx context.Context, outPath string, syncID string, opts ...C1FOption) error {
+	return f.c.CloneSync(ctx, outPath, syncID, opts...)
 }
 
 // GenerateSyncDiff implements FileOps. Direct passthrough.

--- a/pkg/dotc1z/clone_sync.go
+++ b/pkg/dotc1z/clone_sync.go
@@ -87,10 +87,16 @@ func cloneTableQuery(tableName string, columns []string) string {
 // 3. Execute an ATTACH query to bring our empty sqlite db into the context of our db connection
 // 4. Select directly from the cloned db and insert directly into the new database.
 // 5. Close and save the new database as a c1z at the configured path.
-func (c *C1File) CloneSync(ctx context.Context, outPath string, syncID string) error {
+func (c *C1File) CloneSync(ctx context.Context, outPath string, syncID string, opts ...C1FOption) error {
 	ctx, span := tracer.Start(ctx, "C1File.CloneSync")
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
+
+	defaultOpts := []C1FOption{
+		WithC1FEncoderConcurrency(0),
+		WithC1FSkipCleanup(true), // No need to clean up old syncs, as we only copied one sync into the new file.
+	}
+	opts = append(defaultOpts, opts...)
 
 	// Be sure that the output path is empty else return an error
 	_, err = os.Stat(outPath)
@@ -187,10 +193,7 @@ func (c *C1File) CloneSync(ctx context.Context, outPath string, syncID string) e
 
 	// Open a fresh C1File to compress the populated db into a c1z.
 	// No other connections are open on dbPath at this point.
-	outFile, err := NewC1File(ctx, dbPath,
-		WithC1FEncoderConcurrency(0),
-		WithC1FSkipCleanup(true), // No need to clean up old syncs, as we only copied one sync into the new file.
-	)
+	outFile, err := NewC1File(ctx, dbPath, opts...)
 	if err != nil {
 		return err
 	}

--- a/pkg/dotc1z/engine/pebble/adapter_clone_sync.go
+++ b/pkg/dotc1z/engine/pebble/adapter_clone_sync.go
@@ -36,7 +36,9 @@ func cloneSync(
 	a *Adapter,
 	encoding dotc1z.PayloadEncoding,
 	outPath, syncID string,
+	_ ...dotc1z.C1FOption,
 ) error {
+	//TODO: Support options in pebble.
 	if _, err := os.Stat(outPath); err == nil || !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("clone-sync: output path (%s) must not exist for cloning to proceed", outPath)
 	}

--- a/pkg/dotc1z/engine/pebble/adapter_file_ops.go
+++ b/pkg/dotc1z/engine/pebble/adapter_file_ops.go
@@ -34,8 +34,8 @@ type pebbleFileOps struct {
 // Pebble-backed c1z at outPath. See cloneSync for the strategy:
 // range-copy every sync-scoped keyspace into a fresh engine,
 // checkpoint, and emit a v3 envelope.
-func (f pebbleFileOps) CloneSync(ctx context.Context, outPath string, syncID string) error {
-	return cloneSync(ctx, f.a, f.encoding, outPath, syncID)
+func (f pebbleFileOps) CloneSync(ctx context.Context, outPath string, syncID string, opts ...dotc1z.C1FOption) error {
+	return cloneSync(ctx, f.a, f.encoding, outPath, syncID, opts...)
 }
 
 // GenerateSyncDiff computes the additions-only set difference

--- a/pkg/dotc1z/file_ops.go
+++ b/pkg/dotc1z/file_ops.go
@@ -10,7 +10,7 @@ type FileOps interface {
 	// CloneSync materializes the given sync run's data into a freshly
 	// created standalone c1z file at outPath. Used by c1's storeCompletedSyncC1Z
 	// activity to archive a completed sync.
-	CloneSync(ctx context.Context, outPath string, syncID string) error
+	CloneSync(ctx context.Context, outPath string, syncID string, opts ...C1FOption) error
 
 	// GenerateSyncDiff computes the diff between two existing sync runs
 	// in this same file and writes the delta as a new SyncTypePartial

--- a/pkg/sync/state.go
+++ b/pkg/sync/state.go
@@ -62,6 +62,15 @@ type State interface {
 	ClearExclusionGroupTracking(ctx context.Context)
 }
 
+func NeedsExpansion(stateStr string) (bool, error) {
+	state := newState()
+	err := state.Unmarshal(stateStr)
+	if err != nil {
+		return false, err
+	}
+	return state.NeedsExpansion(), nil
+}
+
 // ActionOp represents a sync operation.
 type ActionOp uint8
 


### PR DESCRIPTION
Also add NeedsExpansion() helper to check if a c1z needs expansion.

These are useful for speeding up syncs for service mode connectors in c1.