### PR TITLE
fix(dotc1z): drop malformed grants (nil principal/entitlement) at write time

### DIFF
--- a/pkg/dotc1z/dotc1z.go
+++ b/pkg/dotc1z/dotc1z.go
@@ -34,6 +34,14 @@ var (
 		metric.WithDescription("Grants kept full-blob by the unsafeForSlim escape hatch on slim-enabled writers."),
 	)
 
+	// Increments when a malformed grant (nil principal or entitlement) is
+	// dropped at write time instead of being persisted. A non-zero value
+	// means an upstream connector is emitting out-of-contract grants.
+	grantMalformedCounter, _ = meter.Int64Counter(
+		"c1z_grant_malformed_dropped_total",
+		metric.WithDescription("Grants dropped at write time for missing a principal or entitlement."),
+	)
+
 	// Pre-built so we don't allocate a fresh attribute.Set on every
 	// grant write. WithAttributes sorts and dedups on each call;
 	// WithAttributeSet on a shared Set is allocation-free.

--- a/pkg/dotc1z/grants.go
+++ b/pkg/dotc1z/grants.go
@@ -560,17 +560,37 @@ func slimGrantForWrite(grant *v2.Grant) {
 	grant.SetPrincipal(nil)
 }
 
+// maxMalformedLogsPerBatch caps how many individual malformed grants are
+// logged per batch before collapsing to a single aggregate line, so a broken
+// connector emitting a run of bad grants can't flood the logs. The exact count
+// is always available via grantMalformedCounter.
+const maxMalformedLogsPerBatch = 10
+
+// grantHasValidIdentity reports whether a grant carries the identity a stored
+// row needs to be queryable. baseGrantRecord extracts these columns straight
+// off the proto with nil-safe getters, so a missing OR empty value would be
+// written as unqueryable junk (and an empty grant id additionally collides on
+// the (external_id, sync_id) unique index). The proto contract
+// (grant.proto) makes all of these required.
+func grantHasValidIdentity(g *v2.Grant) bool {
+	pid := g.GetPrincipal().GetId()
+	return g.GetId() != "" &&
+		pid.GetResourceType() != "" && pid.GetResource() != "" &&
+		g.GetEntitlement().GetId() != ""
+}
+
 // dropMalformedGrants returns the grants that are safe to persist, dropping
-// any with a nil principal or entitlement. Dropped grants are logged (with the
-// grant id) and counted via grantMalformedCounter. We drop-and-continue rather
-// than failing the batch so one buggy connector grant can't abort an entire
-// sync's grant write; the metric and log make the bad data visible.
+// any missing required identity (principal, entitlement, or grant id — nil or
+// empty). Dropped grants are logged (capped per batch) and counted via
+// grantMalformedCounter. We drop-and-continue rather than failing the batch so
+// one buggy connector grant can't abort an entire sync's grant write; the
+// metric and log make the bad data visible.
 func dropMalformedGrants(ctx context.Context, msgs []*v2.Grant) []*v2.Grant {
 	// Fast path: scan for the first malformed grant. The overwhelmingly common
 	// case is that every grant is well-formed, so avoid reallocating then.
 	firstBad := -1
 	for i, g := range msgs {
-		if g.GetPrincipal() == nil || g.GetEntitlement() == nil {
+		if !grantHasValidIdentity(g) {
 			firstBad = i
 			break
 		}
@@ -582,17 +602,29 @@ func dropMalformedGrants(ctx context.Context, msgs []*v2.Grant) []*v2.Grant {
 	l := ctxzap.Extract(ctx)
 	valid := make([]*v2.Grant, 0, len(msgs))
 	valid = append(valid, msgs[:firstBad]...)
+	dropped := 0
 	for _, g := range msgs[firstBad:] {
-		if g.GetPrincipal() == nil || g.GetEntitlement() == nil {
+		if !grantHasValidIdentity(g) {
 			grantMalformedCounter.Add(ctx, 1)
-			l.Error("dropping malformed grant: missing principal or entitlement",
-				zap.String("grant_id", g.GetId()),
-				zap.Bool("has_principal", g.GetPrincipal() != nil),
-				zap.Bool("has_entitlement", g.GetEntitlement() != nil),
-			)
+			if dropped < maxMalformedLogsPerBatch {
+				pid := g.GetPrincipal().GetId()
+				l.Error("dropping malformed grant: missing required identity",
+					zap.String("grant_id", g.GetId()),
+					zap.String("principal_resource_type", pid.GetResourceType()),
+					zap.String("principal_resource_id", pid.GetResource()),
+					zap.String("entitlement_id", g.GetEntitlement().GetId()),
+				)
+			}
+			dropped++
 			continue
 		}
 		valid = append(valid, g)
+	}
+	if dropped > maxMalformedLogsPerBatch {
+		l.Error("dropped malformed grants in batch (per-grant logging capped)",
+			zap.Int("total_dropped", dropped),
+			zap.Int("logged", maxMalformedLogsPerBatch),
+		)
 	}
 	return valid
 }
@@ -607,14 +639,14 @@ func upsertGrantsInternal(
 		return nil
 	}
 
-	// A grant's principal and entitlement are required by the proto contract
-	// (grant.proto: both are (validate.rules).message{required:true}). The
-	// column extractor (baseGrantRecord) reads identity columns straight off
-	// the live proto via nil-safe opaque getters, so a malformed grant would
-	// be silently persisted with empty principal/entitlement columns —
-	// unqueryable junk rather than a loud failure. Drop such grants here so
-	// bad connector data can't enter the store, and surface it (log + metric)
-	// rather than failing the whole batch.
+	// A grant's principal, entitlement, and id are required by the proto
+	// contract (grant.proto). The column extractor (baseGrantRecord) reads
+	// identity columns straight off the live proto via nil-safe opaque getters,
+	// so a grant missing any of them would be silently persisted with empty
+	// identity columns — unqueryable junk rather than a loud failure (and an
+	// empty id collides on the (external_id, sync_id) unique index). Drop such
+	// grants here so bad connector data can't enter the store, and surface it
+	// (log + metric) rather than failing the whole batch.
 	msgs = dropMalformedGrants(ctx, msgs)
 	if len(msgs) == 0 {
 		return nil

--- a/pkg/dotc1z/grants.go
+++ b/pkg/dotc1z/grants.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/doug-martin/goqu/v9"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
@@ -558,6 +560,43 @@ func slimGrantForWrite(grant *v2.Grant) {
 	grant.SetPrincipal(nil)
 }
 
+// dropMalformedGrants returns the grants that are safe to persist, dropping
+// any with a nil principal or entitlement. Dropped grants are logged (with the
+// grant id) and counted via grantMalformedCounter. We drop-and-continue rather
+// than failing the batch so one buggy connector grant can't abort an entire
+// sync's grant write; the metric and log make the bad data visible.
+func dropMalformedGrants(ctx context.Context, msgs []*v2.Grant) []*v2.Grant {
+	// Fast path: scan for the first malformed grant. The overwhelmingly common
+	// case is that every grant is well-formed, so avoid reallocating then.
+	firstBad := -1
+	for i, g := range msgs {
+		if g.GetPrincipal() == nil || g.GetEntitlement() == nil {
+			firstBad = i
+			break
+		}
+	}
+	if firstBad == -1 {
+		return msgs
+	}
+
+	l := ctxzap.Extract(ctx)
+	valid := make([]*v2.Grant, 0, len(msgs))
+	valid = append(valid, msgs[:firstBad]...)
+	for _, g := range msgs[firstBad:] {
+		if g.GetPrincipal() == nil || g.GetEntitlement() == nil {
+			grantMalformedCounter.Add(ctx, 1)
+			l.Error("dropping malformed grant: missing principal or entitlement",
+				zap.String("grant_id", g.GetId()),
+				zap.Bool("has_principal", g.GetPrincipal() != nil),
+				zap.Bool("has_entitlement", g.GetEntitlement() != nil),
+			)
+			continue
+		}
+		valid = append(valid, g)
+	}
+	return valid
+}
+
 func upsertGrantsInternal(
 	ctx context.Context,
 	c *C1File,
@@ -567,6 +606,20 @@ func upsertGrantsInternal(
 	if len(msgs) == 0 {
 		return nil
 	}
+
+	// A grant's principal and entitlement are required by the proto contract
+	// (grant.proto: both are (validate.rules).message{required:true}). The
+	// column extractor (baseGrantRecord) reads identity columns straight off
+	// the live proto via nil-safe opaque getters, so a malformed grant would
+	// be silently persisted with empty principal/entitlement columns —
+	// unqueryable junk rather than a loud failure. Drop such grants here so
+	// bad connector data can't enter the store, and surface it (log + metric)
+	// rather than failing the whole batch.
+	msgs = dropMalformedGrants(ctx, msgs)
+	if len(msgs) == 0 {
+		return nil
+	}
+
 	ctx, span := tracer.Start(ctx, "C1File.bulkUpsertGrants")
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()

--- a/pkg/dotc1z/grants_malformed_test.go
+++ b/pkg/dotc1z/grants_malformed_test.go
@@ -1,0 +1,74 @@
+package dotc1z
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+)
+
+// TestPutGrants_DropsMalformedGrants verifies that grants missing a principal
+// or entitlement are dropped at write time rather than persisted as rows with
+// empty identity columns. The well-formed grant in the same batch must still
+// be written.
+func TestPutGrants_DropsMalformedGrants(t *testing.T) {
+	ctx := context.Background()
+	c1f, _, cleanup := newTestC1z(ctx, t)
+	defer cleanup()
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build()}.Build()
+	ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1}.Build()
+
+	good := v2.Grant_builder{Id: "grant-good", Entitlement: ent1, Principal: u1}.Build()
+	nilPrincipal := v2.Grant_builder{Id: "grant-nil-principal", Entitlement: ent1, Principal: nil}.Build()
+	nilEntitlement := v2.Grant_builder{Id: "grant-nil-entitlement", Entitlement: nil, Principal: u1}.Build()
+
+	// Malformed grants are interleaved with the good one to exercise the
+	// copy-from-firstBad path.
+	require.NoError(t, c1f.PutGrants(ctx, nilPrincipal, good, nilEntitlement))
+
+	resp, err := c1f.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{}.Build())
+	require.NoError(t, err)
+	require.Len(t, resp.GetList(), 1, "only the well-formed grant should be persisted")
+	require.Equal(t, "grant-good", resp.GetList()[0].GetId())
+}
+
+// TestPutGrants_AllMalformedIsNoop verifies a batch consisting entirely of
+// malformed grants writes nothing and does not error.
+func TestPutGrants_AllMalformedIsNoop(t *testing.T) {
+	ctx := context.Background()
+	c1f, _, cleanup := newTestC1z(ctx, t)
+	defer cleanup()
+
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build()}.Build()
+
+	require.NoError(t, c1f.PutGrants(ctx,
+		v2.Grant_builder{Id: "x", Entitlement: nil, Principal: u1}.Build(),
+		v2.Grant_builder{Id: "y", Entitlement: nil, Principal: nil}.Build(),
+	))
+
+	resp, err := c1f.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{}.Build())
+	require.NoError(t, err)
+	require.Empty(t, resp.GetList())
+}
+
+// TestDropMalformedGrants_AllValidReturnsSameSlice ensures the fast path
+// returns the input untouched (no reallocation) when every grant is valid.
+func TestDropMalformedGrants_AllValidReturnsSameSlice(t *testing.T) {
+	ctx := context.Background()
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build()}.Build()
+	ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1}.Build()
+
+	msgs := []*v2.Grant{
+		v2.Grant_builder{Id: "a", Entitlement: ent1, Principal: u1}.Build(),
+		v2.Grant_builder{Id: "b", Entitlement: ent1, Principal: u1}.Build(),
+	}
+	got := dropMalformedGrants(ctx, msgs)
+	require.Len(t, got, 2)
+	require.Equal(t, "a", got[0].GetId())
+	require.Equal(t, "b", got[1].GetId())
+}

--- a/pkg/dotc1z/grants_malformed_test.go
+++ b/pkg/dotc1z/grants_malformed_test.go
@@ -9,30 +9,87 @@ import (
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 )
 
-// TestPutGrants_DropsMalformedGrants verifies that grants missing a principal
-// or entitlement are dropped at write time rather than persisted as rows with
-// empty identity columns. The well-formed grant in the same batch must still
-// be written.
-func TestPutGrants_DropsMalformedGrants(t *testing.T) {
-	ctx := context.Background()
-	c1f, _, cleanup := newTestC1z(ctx, t)
-	defer cleanup()
+type grantFixtures struct {
+	good           *v2.Grant
+	nilPrincipal   *v2.Grant
+	nilEntitlement *v2.Grant
+	emptyPrincipal *v2.Grant // non-nil principal, empty ResourceId
+	emptyGrantID   *v2.Grant
+}
 
+func grantTestFixtures() grantFixtures {
 	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
 	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build()}.Build()
 	ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1}.Build()
 
-	good := v2.Grant_builder{Id: "grant-good", Entitlement: ent1, Principal: u1}.Build()
-	nilPrincipal := v2.Grant_builder{Id: "grant-nil-principal", Entitlement: ent1, Principal: nil}.Build()
-	nilEntitlement := v2.Grant_builder{Id: "grant-nil-entitlement", Entitlement: nil, Principal: u1}.Build()
+	return grantFixtures{
+		good:           v2.Grant_builder{Id: "grant-good", Entitlement: ent1, Principal: u1}.Build(),
+		nilPrincipal:   v2.Grant_builder{Id: "grant-nil-principal", Entitlement: ent1, Principal: nil}.Build(),
+		nilEntitlement: v2.Grant_builder{Id: "grant-nil-entitlement", Entitlement: nil, Principal: u1}.Build(),
+		// Non-nil principal whose ResourceId is empty — passes a nil check but
+		// would still be written with empty principal identity columns.
+		emptyPrincipal: v2.Grant_builder{
+			Id:          "grant-empty-principal-id",
+			Entitlement: ent1,
+			Principal:   v2.Resource_builder{Id: v2.ResourceId_builder{}.Build()}.Build(),
+		}.Build(),
+		// Empty grant id collides on the (external_id, sync_id) unique index.
+		emptyGrantID: v2.Grant_builder{Id: "", Entitlement: ent1, Principal: u1}.Build(),
+	}
+}
 
-	// Malformed grants are interleaved with the good one to exercise the
-	// copy-from-firstBad path.
-	require.NoError(t, c1f.PutGrants(ctx, nilPrincipal, good, nilEntitlement))
+// TestPutGrants_DropsMalformedGrants verifies that grants missing required
+// identity (nil OR empty principal/entitlement/id) are dropped at write time
+// rather than persisted as rows with empty identity columns. The well-formed
+// grant in the same batch must still be written. Exercised on both the
+// full-blob and slim writers, since both share upsertGrantsInternal.
+func TestPutGrants_DropsMalformedGrants(t *testing.T) {
+	for _, slim := range []bool{false, true} {
+		slim := slim
+		name := "fullblob"
+		if slim {
+			name = "slim"
+		}
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			var opts []C1ZOption
+			if slim {
+				opts = append(opts, WithV2GrantsWriter(true))
+			}
+			c1f, _, cleanup := newTestC1z(ctx, t, opts...)
+			defer cleanup()
+
+			f := grantTestFixtures()
+
+			// Malformed grants are interleaved with the good one to exercise the
+			// copy-from-firstBad path.
+			require.NoError(t, c1f.PutGrants(ctx, f.nilPrincipal, f.good, f.nilEntitlement, f.emptyPrincipal, f.emptyGrantID))
+
+			resp, err := c1f.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{}.Build())
+			require.NoError(t, err)
+			require.Len(t, resp.GetList(), 1, "only the well-formed grant should be persisted")
+			require.Equal(t, "grant-good", resp.GetList()[0].GetId())
+		})
+	}
+}
+
+// TestStoreExpandedGrants_DropsMalformedGrants verifies the drop also protects
+// the expansion write path (PreserveExpansion mode), not just PutGrants. A
+// good grant is seeded first; a later StoreExpandedGrants batch containing a
+// malformed grant must not add it.
+func TestStoreExpandedGrants_DropsMalformedGrants(t *testing.T) {
+	ctx := context.Background()
+	c1f, _, cleanup := newTestC1z(ctx, t)
+	defer cleanup()
+
+	f := grantTestFixtures()
+	require.NoError(t, c1f.PutGrants(ctx, f.good))
+
+	require.NoError(t, c1f.StoreExpandedGrants(ctx, f.nilPrincipal))
 
 	resp, err := c1f.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{}.Build())
 	require.NoError(t, err)
-	require.Len(t, resp.GetList(), 1, "only the well-formed grant should be persisted")
+	require.Len(t, resp.GetList(), 1, "malformed expanded grant must not be persisted")
 	require.Equal(t, "grant-good", resp.GetList()[0].GetId())
 }
 
@@ -43,12 +100,9 @@ func TestPutGrants_AllMalformedIsNoop(t *testing.T) {
 	c1f, _, cleanup := newTestC1z(ctx, t)
 	defer cleanup()
 
-	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build()}.Build()
+	f := grantTestFixtures()
 
-	require.NoError(t, c1f.PutGrants(ctx,
-		v2.Grant_builder{Id: "x", Entitlement: nil, Principal: u1}.Build(),
-		v2.Grant_builder{Id: "y", Entitlement: nil, Principal: nil}.Build(),
-	))
+	require.NoError(t, c1f.PutGrants(ctx, f.nilPrincipal, f.nilEntitlement, f.emptyPrincipal))
 
 	resp, err := c1f.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{}.Build())
 	require.NoError(t, err)
@@ -56,19 +110,26 @@ func TestPutGrants_AllMalformedIsNoop(t *testing.T) {
 }
 
 // TestDropMalformedGrants_AllValidReturnsSameSlice ensures the fast path
-// returns the input untouched (no reallocation) when every grant is valid.
+// returns the input slice itself (no reallocation) when every grant is valid.
 func TestDropMalformedGrants_AllValidReturnsSameSlice(t *testing.T) {
 	ctx := context.Background()
-	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
-	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build()}.Build()
-	ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1}.Build()
+	f := grantTestFixtures()
 
-	msgs := []*v2.Grant{
-		v2.Grant_builder{Id: "a", Entitlement: ent1, Principal: u1}.Build(),
-		v2.Grant_builder{Id: "b", Entitlement: ent1, Principal: u1}.Build(),
-	}
+	msgs := []*v2.Grant{f.good, f.good}
 	got := dropMalformedGrants(ctx, msgs)
 	require.Len(t, got, 2)
-	require.Equal(t, "a", got[0].GetId())
-	require.Equal(t, "b", got[1].GetId())
+	// Identity, not just equality: the fast path must not reallocate.
+	require.Same(t, &msgs[0], &got[0], "all-valid fast path must return the input slice unmodified")
+}
+
+// TestGrantHasValidIdentity covers the predicate's boundaries directly.
+func TestGrantHasValidIdentity(t *testing.T) {
+	f := grantTestFixtures()
+
+	require.True(t, grantHasValidIdentity(f.good))
+	require.False(t, grantHasValidIdentity(f.nilPrincipal), "nil principal")
+	require.False(t, grantHasValidIdentity(f.nilEntitlement), "nil entitlement")
+	require.False(t, grantHasValidIdentity(f.emptyPrincipal), "empty principal resource id")
+	require.False(t, grantHasValidIdentity(f.emptyGrantID), "empty grant id")
+	require.False(t, grantHasValidIdentity(nil), "nil grant")
 }


### PR DESCRIPTION
## Summary

Drop malformed grants (nil principal or nil entitlement) at the c1z write path instead of silently persisting them with empty identity columns.

Fixes #916.

## Problem

`baseGrantRecord` extracts a grant's principal/entitlement identity columns straight off the live proto using nil-safe opaque getters. A grant with a nil principal or entitlement therefore does **not** panic and is **not** rejected — it's written with `principal_resource_id = ""` / `entitlement_id = ""` (empty satisfies the `not null` constraint). The result is an unqueryable junk row that nothing surfaces.

Every other layer already treats these fields as required:
- `grant.proto` marks `principal` and `entitlement` `(validate.rules).message = {required: true}`
- `NewGrant()` panics on a nil principal
- the grant task handler (`pkg/tasks/c1api/grant.go:35`) rejects nil principal/entitlement as a non-retryable "malformed grant task"

The local write path was the only place that let them through. Surfaced during review of #863.

## Fix

`upsertGrantsInternal` (which backs both `PutGrants` and `StoreExpandedGrants`) now runs `dropMalformedGrants` first:
- drops any grant with a nil principal or entitlement
- logs the dropped grant id at error level
- increments a new `c1z_grant_malformed_dropped_total` metric
- fast-paths (no reallocation) when every grant is well-formed

**Policy choice — drop-and-continue vs. hard-fail.** This PR drops-and-continues so one buggy connector grant can't abort an entire sync's grant write, matching the graceful-degradation already used in grant expansion. The strict alternative (fail the batch, matching the task handler) is a one-line change. @ggreer — flagging for your call; happy to flip it.

## Test plan

- [x] `TestPutGrants_DropsMalformedGrants` — interleaved `nilPrincipal, good, nilEntitlement` batch → only the well-formed grant persists
- [x] `TestPutGrants_AllMalformedIsNoop` — all-malformed batch writes nothing, no error
- [x] `TestDropMalformedGrants_AllValidReturnsSameSlice` — fast path returns input untouched
- [x] Pre-fix verification: with the drop disabled, all three grants persist (two with empty identity columns)
- [x] `go test -short ./pkg/dotc1z/...` — pass
- [x] `golangci-lint run pkg/dotc1z/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)