### PR TITLE
dotc1z: demote already-closed Close to Debug — defensive, idempotent path

### DIFF
--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -493,7 +493,7 @@ func (c *C1File) Close(ctx context.Context) (retErr error) {
 	c.closedMu.Lock()
 	defer c.closedMu.Unlock()
 	if c.closed {
-		l.Warn("close called on already-closed c1file", zap.String("db_path", c.dbFilePath))
+		l.Debug("close called on already-closed c1file", zap.String("db_path", c.dbFilePath))
 		return nil
 	}
 


### PR DESCRIPTION
## Summary
`C1File.Close()` is intentionally idempotent: a second close acquires the lock, sees `c.closed` set, and returns nil. Today it also logs at Warn, which makes the entry look like an operator should investigate when in fact the lifecycle is working as designed.

`pkg/synccompactor/compactor.go:271-274` explicitly documents reliance on this contract — the synccompactor pattern is `defer cleanup; on-success cleanup=nil` plus an inner explicit close on the same store. The defer + explicit-close pattern is also the canonical caller shape in `syncer.Close` and provisioner teardown.

Audit on one C1 tenant: **~60 Warn entries / 2h**; fleet-wide ~289k Warns / 7d, all benign idempotent-second-close paths.

Demote to Debug. The graceful early-return is self-documenting; an operator who wants to see the path can flip the log level.

## Test plan
- [x] `go test ./pkg/dotc1z/...` green
- [x] Verified no test, monitor, or log-filter rule keys on the message string (rg across baton-sdk + vendored c1 + Datadog monitor search)
- [ ] After upstream merge + c1 baton-sdk bump, confirm the Warn rate drops on c1's tenant logs

## Code-review summary
Risk: **Low**. No behavior change (return value unchanged, log key unchanged, only level shifts Warn→Debug). Zero loss-of-signal — verified no consumers grep this string anywhere. Single-line revert if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)