### PR TITLE
Expand grants fixes.

### DIFF
--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -889,14 +889,14 @@ func statsToMap(stats *reader_v2.SyncStats, syncType connectorstore.SyncType) ma
 // Stats introspects the database and returns the count of objects for the given sync run.
 // If syncId is empty, it will use the latest sync run of the given type.
 func (c *C1File) Stats(ctx context.Context, syncType connectorstore.SyncType, syncId string) (map[string]int64, error) {
-	sync, stats, err := c.stats(ctx, syncType, syncId)
+	sync, stats, err := c.stats(ctx, syncType, syncId, false)
 	if err != nil {
 		return nil, err
 	}
 	return statsToMap(stats, connectorstore.SyncType(sync.GetSyncType())), nil
 }
 
-func (c *C1File) stats(ctx context.Context, syncType connectorstore.SyncType, syncId string) (*reader_v2.SyncRun, *reader_v2.SyncStats, error) {
+func (c *C1File) stats(ctx context.Context, syncType connectorstore.SyncType, syncId string, forceRefresh bool) (*reader_v2.SyncRun, *reader_v2.SyncStats, error) {
 	ctx, span := tracer.Start(ctx, "C1File.Stats")
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
@@ -921,7 +921,7 @@ func (c *C1File) stats(ctx context.Context, syncType connectorstore.SyncType, sy
 	syncType = connectorstore.SyncType(sync.GetSyncType())
 
 	stats := sync.GetStats()
-	if stats != nil && stats.GetResourceTypes() > 0 {
+	if stats != nil && stats.GetResourceTypes() > 0 && !forceRefresh {
 		return sync, stats, nil
 	}
 
@@ -1028,7 +1028,7 @@ func (c *C1File) grantStats(ctx context.Context, syncType connectorstore.SyncTyp
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
-	_, stats, err := c.stats(ctx, syncType, syncId)
+	_, stats, err := c.stats(ctx, syncType, syncId, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/dotc1z/sync_runs.go
+++ b/pkg/dotc1z/sync_runs.go
@@ -749,7 +749,7 @@ func (c *C1File) endSyncRun(ctx context.Context, syncID string) error {
 	c.dbUpdated = true
 
 	// Run stats to generate and save the cached stats.
-	_, _, statsErr := c.stats(ctx, connectorstore.SyncTypeAny, syncID)
+	_, _, statsErr := c.stats(ctx, connectorstore.SyncTypeAny, syncID, true)
 	if statsErr != nil {
 		// Ignore stats error. We will recalculate them if Stats() is called.
 		ctxzap.Extract(ctx).Warn("c1z: error calculating & saving stats",

--- a/pkg/sync/state.go
+++ b/pkg/sync/state.go
@@ -350,7 +350,13 @@ func (st *state) Unmarshal(input string) error {
 		}
 
 		st.actions = token.ActionsMap
+		if st.actions == nil {
+			st.actions = make(map[string]Action)
+		}
 		st.actionOrder = token.ActionOrder
+		if st.actionOrder == nil {
+			st.actionOrder = []string{}
+		}
 		st.currentActionID = token.CurrentActionID
 		st.needsExpansion = token.NeedsExpansion
 		st.entitlementGraph = token.EntitlementGraph

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -540,6 +540,15 @@ func (s *syncer) Sync(ctx context.Context) error {
 		)
 	}
 
+	if !newSync && s.state.Current() == nil {
+		// Push init action
+		s.state.PushAction(ctx, Action{Op: InitOp})
+		err = s.Checkpoint(ctx, true)
+		if err != nil {
+			return err
+		}
+	}
+
 	warnings, err := s.parallelSync(ctx, runCtx, targetedResources)
 	if err != nil {
 		return err

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -541,7 +541,8 @@ func (s *syncer) Sync(ctx context.Context) error {
 	}
 
 	if !newSync && s.state.Current() == nil {
-		// Push init action
+		l.Debug("current action is nil, pushing init action for sync", zap.String("sync_id", syncID))
+		// Push init action if no current action. This is probably a finished sync that we're running grant expansion on.
 		s.state.PushAction(ctx, Action{Op: InitOp})
 		err = s.Checkpoint(ctx, true)
 		if err != nil {


### PR DESCRIPTION
- If we're resuming a sync and there is no current action, init. This is needed for things like only expanding grants on a finished sync.
- Fix nil pointers unmarshalling state if actions or actionOrder are missing. This can happen on finished syncs.
- Regenerate stats when ending a sync. Otherwise stats will be incorrect after expanding grants on a finished sync.