### PR TITLE
feat(synccompactor): select the c1z storage engine for compaction

### DIFF
--- a/pkg/dotc1z/engine/pebble/cleanup.go
+++ b/pkg/dotc1z/engine/pebble/cleanup.go
@@ -31,6 +31,7 @@ func syncScopedRanges(syncIDBytes []byte) [][2][]byte {
 		{EntitlementByResourceSyncLowerBound(syncIDBytes), EntitlementByResourceSyncUpperBound(syncIDBytes)},
 		{encodeGrantPrefix(syncIDBytes), upperBoundOf(encodeGrantPrefix(syncIDBytes))},
 		{GrantByEntitlementSyncLowerBound(syncIDBytes), GrantByEntitlementSyncUpperBound(syncIDBytes)},
+		{GrantByEntitlementResourceSyncLowerBound(syncIDBytes), GrantByEntitlementResourceSyncUpperBound(syncIDBytes)},
 		{GrantByPrincipalSyncLowerBound(syncIDBytes), GrantByPrincipalSyncUpperBound(syncIDBytes)},
 		{GrantByPrincipalResourceTypeSyncLowerBound(syncIDBytes), GrantByPrincipalResourceTypeSyncUpperBound(syncIDBytes)},
 		{GrantByNeedsExpansionSyncLowerBound(syncIDBytes), GrantByNeedsExpansionSyncUpperBound(syncIDBytes)},

--- a/pkg/dotc1z/engine/pebble/cleanup_test.go
+++ b/pkg/dotc1z/engine/pebble/cleanup_test.go
@@ -1,6 +1,7 @@
 package pebble
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"os"
@@ -251,6 +252,88 @@ func TestPebbleCleanupRemovesAllSyncScopedData(t *testing.T) {
 	// New sync's grants must remain readable.
 	if _, err := rs.engine.GetGrantRecord(ctx, newSyncID, "new-g1"); err != nil {
 		t.Errorf("GetGrantRecord on retained sync: %v", err)
+	}
+}
+
+// TestSyncScopedRangesCoverEveryWrittenIndex asserts the cleanup range
+// list returned by syncScopedRanges contains every secondary-index key
+// the write path can produce. grant_by_entitlement_resource regressed
+// out of that list once, leaking its index keys past a sync delete; this
+// pins every index keyspace, so a new index added to the writers without
+// a matching cleanup range fails here instead of leaking orphan keys.
+func TestSyncScopedRangesCoverEveryWrittenIndex(t *testing.T) {
+	// Fixed 16-byte sync id; the encoders and *SyncLowerBound bounds
+	// only append it, so any consistent value exercises the keyspace.
+	syncIDBytes := []byte{
+		0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+		0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+	}
+	ranges := syncScopedRanges(syncIDBytes)
+
+	// One grant carrying an entitlement (with a resource), a principal,
+	// and the needs-expansion flag emits all five grant indexes:
+	// by_entitlement, by_entitlement_resource, by_principal,
+	// by_principal_resource_type, needs_expansion.
+	g := v3.GrantRecord_builder{
+		Entitlement: v3.EntitlementRef_builder{
+			ResourceTypeId: "app", ResourceId: "github", EntitlementId: "ent-A",
+		}.Build(),
+		Principal: v3.PrincipalRef_builder{
+			ResourceTypeId: "user", ResourceId: "u1",
+		}.Build(),
+		ExternalId:     "g1",
+		NeedsExpansion: true,
+	}.Build()
+
+	type writtenKey struct {
+		idx  byte
+		name string
+		key  []byte
+	}
+	written := make([]writtenKey, 0, 7)
+	for _, k := range grantIndexKeys(syncIDBytes, g) {
+		// Layout for every index key: versionV3, typeIndex, idxByte, ...
+		written = append(written, writtenKey{idx: k[2], name: "grant", key: k})
+	}
+	written = append(written,
+		writtenKey{idxResourceByParent, "resource_by_parent",
+			encodeResourceByParentIndexKey(syncIDBytes, "folder", "root", "doc", "d1")},
+		writtenKey{idxEntitlementByResource, "entitlement_by_resource",
+			encodeEntitlementByResourceIndexKey(syncIDBytes, "app", "github", "ent-A")},
+	)
+
+	covered := func(k []byte) bool {
+		for _, r := range ranges {
+			if bytes.Compare(k, r[0]) >= 0 && bytes.Compare(k, r[1]) < 0 {
+				return true
+			}
+		}
+		return false
+	}
+
+	seen := map[byte]bool{}
+	for _, w := range written {
+		seen[w.idx] = true
+		if !covered(w.key) {
+			t.Errorf("written index key (idx=0x%02x, %s) not covered by any syncScopedRanges entry: %x", w.idx, w.name, w.key)
+		}
+	}
+
+	// Every secondary index (0x01..0x07) must be exercised above so the
+	// coverage assertion is actually complete; a new idx constant that no
+	// representative record produces trips this guard.
+	for _, idx := range []byte{
+		idxResourceByParent,
+		idxEntitlementByResource,
+		idxGrantByEntitlement,
+		idxGrantByPrincipal,
+		idxGrantByNeedsExpansion,
+		idxGrantByPrincipalResourceType,
+		idxGrantByEntitlementResource,
+	} {
+		if !seen[idx] {
+			t.Errorf("index 0x%02x not exercised by this test; add a representative record so the coverage check stays complete", idx)
+		}
 	}
 }
 

--- a/pkg/dotc1z/engine/pebble/merge_accessor.go
+++ b/pkg/dotc1z/engine/pebble/merge_accessor.go
@@ -1,0 +1,28 @@
+package pebble
+
+import (
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+)
+
+// AsEngine recovers the underlying *Engine from a connectorstore.Writer
+// produced by dotc1z.NewStore for the Pebble engine. NewStore returns a
+// *registeredStore wrapper (which embeds *Adapter); a bare *Adapter is
+// also accepted for callers that construct one directly. Returns
+// (nil, false) for any non-Pebble store, so a caller can branch on the
+// engine without importing internal types.
+func AsEngine(w connectorstore.Writer) (*Engine, bool) {
+	switch s := w.(type) {
+	case *registeredStore:
+		if s == nil || s.engine == nil {
+			return nil, false
+		}
+		return s.engine, true
+	case *Adapter:
+		if s == nil || s.engine == nil {
+			return nil, false
+		}
+		return s.engine, true
+	default:
+		return nil, false
+	}
+}

--- a/pkg/synccompactor/compactor.go
+++ b/pkg/synccompactor/compactor.go
@@ -43,6 +43,20 @@ type Compactor struct {
 	syncLimit          int
 	c1zOptions         []dotc1z.C1ZOption
 	skipGrantExpansion bool
+	// engine selects the storage engine for the compacted output.
+	// Empty means EngineSQLite (the default; behavior is unchanged and
+	// the output is byte-identical to the pre-engine-option compactor).
+	// EnginePebble produces a v3 Pebble c1z via a native record merge.
+	engine dotc1z.Engine
+}
+
+// resolvedEngine returns the configured engine, treating the zero value
+// as EngineSQLite.
+func (c *Compactor) resolvedEngine() dotc1z.Engine {
+	if c.engine == "" {
+		return dotc1z.EngineSQLite
+	}
+	return c.engine
 }
 
 type CompactableSync struct {
@@ -190,7 +204,24 @@ func (c *Compactor) Compact(ctx context.Context) (*CompactableSync, error) {
 	fileName := fmt.Sprintf("compacted-%s.c1z", c.entries[0].SyncID)
 	destFilePath := path.Join(c.tmpDir, fileName)
 
-	c.compactedC1z, err = dotc1z.NewC1ZFile(ctx, destFilePath, opts...)
+	if c.resolvedEngine() == dotc1z.EnginePebble {
+		if err = ensurePebbleRegistered(); err != nil {
+			return nil, fmt.Errorf("register pebble engine: %w", err)
+		}
+		var w connectorstore.Writer
+		// Force the resolved engine last so a stray engine passed via
+		// WithC1ZOptions cannot mislabel the artifact.
+		w, err = dotc1z.NewStore(ctx, destFilePath, append(opts, dotc1z.WithEngine(dotc1z.EnginePebble))...)
+		if err == nil {
+			store, ok := w.(dotc1z.C1ZStore)
+			if !ok {
+				return nil, fmt.Errorf("pebble store does not implement C1ZStore: %T", w)
+			}
+			c.compactedC1z = store
+		}
+	} else {
+		c.compactedC1z, err = dotc1z.NewC1ZFile(ctx, destFilePath, opts...)
+	}
 	if err != nil {
 		l.Error("doOneCompaction failed: could not create c1z file", zap.Error(err))
 		return nil, err
@@ -215,24 +246,37 @@ func (c *Compactor) Compact(ctx context.Context) (*CompactableSync, error) {
 	}
 	l.Debug("new empty partial sync created", zap.String("sync_id", newSyncId))
 
-	// Base sync is c.entries[0], so compact in reverse order. That way we compact the biggest sync last.
-	// Pass runCtx (not the outer ctx) so c.runDuration actually bounds the loop. Without this, the
-	// deadline set on runCtx only gates the pre-flight check above and individual doOneCompaction
-	// calls run under the unbounded parent ctx.
-	for i := len(c.entries) - 1; i >= 0; i-- {
-		err = c.doOneCompaction(runCtx, c.entries[i])
-		if err != nil {
-			// When runCtx fires due to c.runDuration, surface the same clean message the pre-flight
-			// check uses instead of bubbling a bare context.DeadlineExceeded out of the inner sqlite
-			// operations. The error is still returned so callers can decide whether to retry.
+	if c.resolvedEngine() == dotc1z.EnginePebble {
+		// Native Pebble path: one multi-source record merge into the
+		// empty newSyncId (the sqlite ATTACH per-input loop does not
+		// apply — Pebble merges all inputs in a single pass).
+		if err = c.compactPebble(runCtx, newSyncId); err != nil {
 			if cause := context.Cause(runCtx); errors.Is(cause, context.DeadlineExceeded) && c.runDuration > 0 && ctx.Err() == nil {
-				l.Info("compaction run duration has expired, exiting compaction early",
-					zap.String("sync_id", c.entries[i].SyncID),
-					zap.Int("syncs_remaining", i),
-				)
+				l.Info("compaction run duration has expired, exiting compaction early")
 				return nil, fmt.Errorf("compaction run duration has expired: %w", cause)
 			}
-			return nil, fmt.Errorf("failed to compact sync %s: %w", c.entries[i].SyncID, err)
+			return nil, fmt.Errorf("failed to compact (pebble): %w", err)
+		}
+	} else {
+		// Base sync is c.entries[0], so compact in reverse order. That way we compact the biggest sync last.
+		// Pass runCtx (not the outer ctx) so c.runDuration actually bounds the loop. Without this, the
+		// deadline set on runCtx only gates the pre-flight check above and individual doOneCompaction
+		// calls run under the unbounded parent ctx.
+		for i := len(c.entries) - 1; i >= 0; i-- {
+			err = c.doOneCompaction(runCtx, c.entries[i])
+			if err != nil {
+				// When runCtx fires due to c.runDuration, surface the same clean message the pre-flight
+				// check uses instead of bubbling a bare context.DeadlineExceeded out of the inner sqlite
+				// operations. The error is still returned so callers can decide whether to retry.
+				if cause := context.Cause(runCtx); errors.Is(cause, context.DeadlineExceeded) && c.runDuration > 0 && ctx.Err() == nil {
+					l.Info("compaction run duration has expired, exiting compaction early",
+						zap.String("sync_id", c.entries[i].SyncID),
+						zap.Int("syncs_remaining", i),
+					)
+					return nil, fmt.Errorf("compaction run duration has expired: %w", cause)
+				}
+				return nil, fmt.Errorf("failed to compact sync %s: %w", c.entries[i].SyncID, err)
+			}
 		}
 	}
 

--- a/pkg/synccompactor/compactor.go
+++ b/pkg/synccompactor/compactor.go
@@ -215,6 +215,7 @@ func (c *Compactor) Compact(ctx context.Context) (*CompactableSync, error) {
 		if err == nil {
 			store, ok := w.(dotc1z.C1ZStore)
 			if !ok {
+				_ = w.Close(ctx)
 				return nil, fmt.Errorf("pebble store does not implement C1ZStore: %T", w)
 			}
 			c.compactedC1z = store

--- a/pkg/synccompactor/compactor_bench_test.go
+++ b/pkg/synccompactor/compactor_bench_test.go
@@ -1,0 +1,69 @@
+package synccompactor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+)
+
+// benchGrantIDs returns n distinct grant ids ("g0".."g{n-1}").
+func benchGrantIDs(n int) []string {
+	ids := make([]string, n)
+	for i := range ids {
+		ids[i] = "g" + strconv.Itoa(i)
+	}
+	return ids
+}
+
+// benchmarkCompaction folds two same-shape inputs (one full, one partial,
+// fully overlapping grant keys so the keep-newer dedup does real work) and
+// times Compact end to end. Inputs are built once outside the timed loop;
+// each iteration runs a fresh compactor into its own output dir. usePebble
+// selects the engine under test so the pebble merge path and the sqlite
+// ATTACH path are measured on identical input data.
+func benchmarkCompaction(b *testing.B, n int, usePebble bool) {
+	ctx := context.Background()
+	ids := benchGrantIDs(n)
+
+	src := b.TempDir()
+	p1 := filepath.Join(src, "in1.c1z")
+	p2 := filepath.Join(src, "in2.c1z")
+
+	var s1, s2 string
+	if usePebble {
+		s1 = buildPebbleInput(b, ctx, p1, connectorstore.SyncTypeFull, ids...)
+		s2 = buildPebbleInput(b, ctx, p2, connectorstore.SyncTypePartial, ids...)
+	} else {
+		s1 = buildSQLiteInput(b, ctx, p1, connectorstore.SyncTypeFull, ids...)
+		s2 = buildSQLiteInput(b, ctx, p2, connectorstore.SyncTypePartial, ids...)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		outDir := filepath.Join(b.TempDir(), strconv.Itoa(i))
+		require.NoError(b, os.MkdirAll(outDir, 0o755))
+
+		entries := []*CompactableSync{{FilePath: p1, SyncID: s1}, {FilePath: p2, SyncID: s2}}
+		opts := []Option{WithTmpDir(b.TempDir())}
+		if usePebble {
+			opts = append(opts, WithEngine(dotc1z.EnginePebble))
+		}
+		c, cleanup, err := NewCompactor(ctx, outDir, entries, opts...)
+		require.NoError(b, err)
+		_, err = c.Compact(ctx)
+		require.NoError(b, err)
+		require.NoError(b, cleanup())
+	}
+}
+
+func BenchmarkCompactPebble1k(b *testing.B)  { benchmarkCompaction(b, 1000, true) }
+func BenchmarkCompactSQLite1k(b *testing.B)  { benchmarkCompaction(b, 1000, false) }
+func BenchmarkCompactPebble10k(b *testing.B) { benchmarkCompaction(b, 10000, true) }
+func BenchmarkCompactSQLite10k(b *testing.B) { benchmarkCompaction(b, 10000, false) }

--- a/pkg/synccompactor/compactor_pebble.go
+++ b/pkg/synccompactor/compactor_pebble.go
@@ -1,0 +1,154 @@
+package synccompactor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	enginepkg "github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble"
+	mergepkg "github.com/conductorone/baton-sdk/pkg/synccompactor/pebble"
+)
+
+// WithEngine selects the storage engine for the compacted output.
+// The default (unset) is sqlite, which is byte-identical to the
+// historical compactor. EnginePebble produces a v3 Pebble c1z via a
+// native record merge.
+//
+// Selecting EnginePebble requires the Pebble engine driver to be
+// registered with dotc1z; the compactor registers it on demand, but a
+// caller may also register it explicitly via
+// pkg/dotc1z/engine/pebble.Register before constructing the compactor.
+//
+// This is the only supported way to choose the engine; an engine
+// passed through WithC1ZOptions does not select the compaction
+// strategy and is overridden.
+func WithEngine(engine dotc1z.Engine) Option {
+	return func(c *Compactor) {
+		c.engine = engine
+	}
+}
+
+// ensurePebbleRegistered registers the Pebble engine driver with
+// dotc1z if it isn't already. Registration is process-global and
+// idempotent here; a double-register is avoided by the lookup.
+func ensurePebbleRegistered() error {
+	if _, ok := dotc1z.EngineDriverFor(dotc1z.EnginePebble); ok {
+		return nil
+	}
+	return enginepkg.Register()
+}
+
+// compactableV3SyncType reports whether a v3 sync type is a compactable
+// snapshot type. Diff syncs (partial_upserts / partial_deletions) are
+// excluded — compaction folds full / resources-only / partial snapshots
+// only, matching the sqlite source selection.
+func compactableV3SyncType(t v3.SyncType) bool {
+	switch t {
+	case v3.SyncType_SYNC_TYPE_FULL,
+		v3.SyncType_SYNC_TYPE_RESOURCES_ONLY,
+		v3.SyncType_SYNC_TYPE_PARTIAL:
+		return true
+	default:
+		return false
+	}
+}
+
+// unionV3SyncType folds two sync types to the wider one: full beats
+// resources-only beats partial. Mirrors the sqlite union rule.
+func unionV3SyncType(a, b v3.SyncType) v3.SyncType {
+	switch {
+	case a == v3.SyncType_SYNC_TYPE_FULL || b == v3.SyncType_SYNC_TYPE_FULL:
+		return v3.SyncType_SYNC_TYPE_FULL
+	case a == v3.SyncType_SYNC_TYPE_RESOURCES_ONLY || b == v3.SyncType_SYNC_TYPE_RESOURCES_ONLY:
+		return v3.SyncType_SYNC_TYPE_RESOURCES_ONLY
+	default:
+		return v3.SyncType_SYNC_TYPE_PARTIAL
+	}
+}
+
+// compactPebble folds every input into the empty newSyncId on the
+// Pebble output via a native record merge: each input is opened, its
+// latest finished compactable sync is selected (diff syncs excluded),
+// and all are merged keeping the newest record per key. The output
+// sync_run's type and ended_at are then set to the union / max across
+// the inputs (mirroring the sqlite UpdateSync), and its stats are
+// recomputed. Inputs are merged in reverse entry order so the tie
+// winner matches the sqlite fold.
+func (c *Compactor) compactPebble(ctx context.Context, newSyncId string) error {
+	l := ctxzap.Extract(ctx)
+
+	destEng, ok := enginepkg.AsEngine(c.compactedC1z)
+	if !ok {
+		return errors.New("compactPebble: compacted store is not a pebble engine")
+	}
+
+	sources := make([]mergepkg.SourceSync, 0, len(c.entries))
+	unionType := v3.SyncType_SYNC_TYPE_PARTIAL
+	var maxEnded time.Time
+
+	for i := len(c.entries) - 1; i >= 0; i-- {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		cs := c.entries[i]
+		w, err := dotc1z.NewStore(ctx, cs.FilePath, dotc1z.WithReadOnly(true), dotc1z.WithTmpDir(c.tmpDir))
+		if err != nil {
+			return fmt.Errorf("compactPebble: open input %s: %w", cs.FilePath, err)
+		}
+		// Close the input store when the merge completes; the SST data
+		// is read eagerly into the destination during MergeInto.
+		defer func() {
+			if cerr := w.Close(ctx); cerr != nil {
+				l.Error("compactPebble: error closing input", zap.Error(cerr), zap.String("file", cs.FilePath))
+			}
+		}()
+
+		srcEng, ok := enginepkg.AsEngine(w)
+		if !ok {
+			return fmt.Errorf("compactPebble: input %s is not a pebble c1z", cs.FilePath)
+		}
+		rec, err := srcEng.LatestFinishedSyncRecord(ctx, compactableV3SyncType)
+		if err != nil {
+			return fmt.Errorf("compactPebble: select source sync for %s: %w", cs.FilePath, err)
+		}
+		if rec == nil {
+			return fmt.Errorf("compactPebble: input %s has no finished compactable sync (diff syncs are not compactable)", cs.FilePath)
+		}
+
+		sources = append(sources, mergepkg.SourceSync{Engine: srcEng, SyncID: rec.GetSyncId()})
+		unionType = unionV3SyncType(unionType, rec.GetType())
+		if ts := rec.GetEndedAt(); ts != nil && ts.AsTime().After(maxEnded) {
+			maxEnded = ts.AsTime()
+		}
+	}
+
+	if err := mergepkg.MergeInto(ctx, destEng, sources, newSyncId); err != nil {
+		return fmt.Errorf("compactPebble: merge: %w", err)
+	}
+
+	// Set the compacted sync_run's type + ended_at to the union / max
+	// across the inputs so downstream gating (e.g. grant expansion)
+	// behaves identically to the sqlite path, then recompute stats.
+	rec, err := destEng.GetSyncRunRecord(ctx, newSyncId)
+	if err != nil {
+		return fmt.Errorf("compactPebble: load dest sync_run: %w", err)
+	}
+	rec.SetType(unionType)
+	if !maxEnded.IsZero() {
+		rec.SetEndedAt(timestamppb.New(maxEnded))
+	}
+	if err := destEng.PutSyncRunRecord(ctx, rec); err != nil {
+		return fmt.Errorf("compactPebble: persist dest sync_run: %w", err)
+	}
+	if err := destEng.PersistSyncStats(ctx, newSyncId); err != nil {
+		return fmt.Errorf("compactPebble: persist stats: %w", err)
+	}
+	return nil
+}

--- a/pkg/synccompactor/compactor_pebble_test.go
+++ b/pkg/synccompactor/compactor_pebble_test.go
@@ -4,13 +4,18 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/cockroachdb/pebble/v2"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	reader_v2 "github.com/conductorone/baton-sdk/pb/c1/reader/v2"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	enginepkg "github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/codec"
 )
 
 // buildPebbleInput writes a minimal Pebble (v3) c1z at path with the
@@ -54,9 +59,53 @@ func buildPebbleInput(t *testing.T, ctx context.Context, path string, st connect
 		require.NoError(t, store.PutGrants(ctx, g))
 	}
 
+	// Every input carries an asset so the asset-drop parity can be
+	// asserted on the compacted output (the merge must not copy it).
+	require.NoError(t, store.PutAsset(ctx, v2.AssetRef_builder{Id: "asset-1"}.Build(), "text/plain", []byte("payload")))
+
 	require.NoError(t, store.EndSync(ctx))
 	require.NoError(t, store.Close(ctx))
 	return syncID
+}
+
+// countPebbleAssets returns the number of asset records stored under
+// syncID in the Pebble c1z at path (read directly off the engine's
+// asset keyspace).
+func countPebbleAssets(t *testing.T, ctx context.Context, path, syncID string) int {
+	t.Helper()
+	w, err := dotc1z.NewStore(ctx, path, dotc1z.WithReadOnly(true))
+	require.NoError(t, err)
+	defer w.Close(ctx)
+	eng, ok := enginepkg.AsEngine(w)
+	require.True(t, ok, "store at %s is not a pebble engine", path)
+	sb, err := codec.EncodeSyncID(syncID)
+	require.NoError(t, err)
+	it, err := eng.DB().NewIter(&pebble.IterOptions{
+		LowerBound: enginepkg.AssetSyncLowerBound(sb),
+		UpperBound: enginepkg.AssetSyncUpperBound(sb),
+	})
+	require.NoError(t, err)
+	defer it.Close()
+	n := 0
+	for it.First(); it.Valid(); it.Next() {
+		n++
+	}
+	require.NoError(t, it.Error())
+	return n
+}
+
+// latestEndedAt returns the ended_at of the latest finished sync in the
+// c1z at path.
+func latestEndedAt(t *testing.T, ctx context.Context, path string) time.Time {
+	t.Helper()
+	w, err := dotc1z.NewStore(ctx, path, dotc1z.WithReadOnly(true))
+	require.NoError(t, err)
+	defer w.Close(ctx)
+	store, ok := w.(dotc1z.C1ZStore)
+	require.True(t, ok)
+	resp, err := store.GetLatestFinishedSync(ctx, reader_v2.SyncsReaderServiceGetLatestFinishedSyncRequest_builder{}.Build())
+	require.NoError(t, err)
+	return resp.GetSync().GetEndedAt().AsTime()
 }
 
 func verifyCompacted(t *testing.T, ctx context.Context, path, syncID string) (int, string) {
@@ -115,4 +164,111 @@ func TestCompactPebbleEndToEnd(t *testing.T) {
 	count, st := verifyCompacted(t, ctx, out.FilePath, out.SyncID)
 	require.Equal(t, 3, count, "union of {g-shared,g-only1} and {g-shared,g-only2} deduped = 3 grants")
 	require.Equal(t, string(connectorstore.SyncTypeFull), st, "union of full + partial = full")
+}
+
+// buildSQLiteInput writes a minimal SQLite (v1) c1z with one grant per
+// id, for the default-engine regression.
+func buildSQLiteInput(t *testing.T, ctx context.Context, path string, st connectorstore.SyncType, grantIDs ...string) string {
+	t.Helper()
+	store, err := dotc1z.NewC1ZFile(ctx, path)
+	require.NoError(t, err)
+	syncID, err := store.StartNewSync(ctx, st, "")
+	require.NoError(t, err)
+	require.NoError(t, store.PutResourceTypes(ctx,
+		v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build(),
+		v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()))
+	group := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "Group One"}.Build()
+	user := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(), DisplayName: "User One"}.Build()
+	require.NoError(t, store.PutResources(ctx, group, user))
+	member := v2.Entitlement_builder{Id: "member", Resource: group, Purpose: v2.Entitlement_PURPOSE_VALUE_ASSIGNMENT}.Build()
+	require.NoError(t, store.PutEntitlements(ctx, member))
+	for _, id := range grantIDs {
+		require.NoError(t, store.PutGrants(ctx, v2.Grant_builder{Id: id, Principal: user, Entitlement: member}.Build()))
+	}
+	require.NoError(t, store.EndSync(ctx))
+	require.NoError(t, store.Close(ctx))
+	return syncID
+}
+
+// TestCompactPebbleDropsAssets pins the asset-drop parity: the SQLite
+// path folds only resource_types/resources/entitlements/grants and
+// drops assets, so the Pebble path must too — the compacted sync has
+// zero assets even though every input had one.
+func TestCompactPebbleDropsAssets(t *testing.T) {
+	ctx := context.Background()
+	inDir := t.TempDir()
+	p1 := filepath.Join(inDir, "in1.c1z")
+	p2 := filepath.Join(inDir, "in2.c1z")
+	s1 := buildPebbleInput(t, ctx, p1, connectorstore.SyncTypeFull, "g1")
+	s2 := buildPebbleInput(t, ctx, p2, connectorstore.SyncTypePartial, "g2")
+
+	// Sanity: the inputs actually carry assets, so a zero on the output
+	// proves a drop, not an empty fixture.
+	require.Positive(t, countPebbleAssets(t, ctx, p1, s1), "input must carry an asset")
+
+	c, cleanup, err := NewCompactor(ctx, t.TempDir(), []*CompactableSync{{FilePath: p1, SyncID: s1}, {FilePath: p2, SyncID: s2}}, WithTmpDir(t.TempDir()), WithEngine(dotc1z.EnginePebble))
+	require.NoError(t, err)
+	defer func() { _ = cleanup() }()
+	out, err := c.Compact(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, 0, countPebbleAssets(t, ctx, out.FilePath, out.SyncID), "compacted pebble sync must contain zero assets (parity with sqlite)")
+}
+
+// TestCompactPebbleEndedAtIsMaxOfInputs pins the sync_run ended_at
+// parity: the compacted sync's ended_at is the max across the inputs.
+func TestCompactPebbleEndedAtIsMaxOfInputs(t *testing.T) {
+	ctx := context.Background()
+	inDir := t.TempDir()
+	p1 := filepath.Join(inDir, "in1.c1z")
+	p2 := filepath.Join(inDir, "in2.c1z")
+	// Both partial so the union type is partial and grant expansion is
+	// skipped — expansion re-ends the sync with a fresh ended_at, so
+	// the "ended_at == max(inputs)" invariant is asserted on the
+	// no-expansion path (the same path that holds it for sqlite).
+	s1 := buildPebbleInput(t, ctx, p1, connectorstore.SyncTypePartial, "g1")
+	s2 := buildPebbleInput(t, ctx, p2, connectorstore.SyncTypePartial, "g2")
+
+	e1 := latestEndedAt(t, ctx, p1)
+	e2 := latestEndedAt(t, ctx, p2)
+	want := e1
+	if e2.After(want) {
+		want = e2
+	}
+
+	c, cleanup, err := NewCompactor(ctx, t.TempDir(), []*CompactableSync{{FilePath: p1, SyncID: s1}, {FilePath: p2, SyncID: s2}}, WithTmpDir(t.TempDir()), WithEngine(dotc1z.EnginePebble))
+	require.NoError(t, err)
+	defer func() { _ = cleanup() }()
+	out, err := c.Compact(ctx)
+	require.NoError(t, err)
+
+	require.True(t, latestEndedAt(t, ctx, out.FilePath).Equal(want), "compacted ended_at must equal max(inputs' ended_at)")
+}
+
+// TestCompactSQLiteDefaultUnchanged is the default-engine regression:
+// with WithEngine unset, compaction still produces a SQLite (v1) c1z
+// (openable by the SQLite-only NewC1ZFile) with the unioned grants.
+func TestCompactSQLiteDefaultUnchanged(t *testing.T) {
+	ctx := context.Background()
+	inDir := t.TempDir()
+	p1 := filepath.Join(inDir, "in1.c1z")
+	p2 := filepath.Join(inDir, "in2.c1z")
+	s1 := buildSQLiteInput(t, ctx, p1, connectorstore.SyncTypeFull, "g-shared", "g-only1")
+	s2 := buildSQLiteInput(t, ctx, p2, connectorstore.SyncTypePartial, "g-shared", "g-only2")
+
+	c, cleanup, err := NewCompactor(ctx, t.TempDir(), []*CompactableSync{{FilePath: p1, SyncID: s1}, {FilePath: p2, SyncID: s2}}, WithTmpDir(t.TempDir()))
+	require.NoError(t, err)
+	defer func() { _ = cleanup() }()
+	out, err := c.Compact(ctx)
+	require.NoError(t, err)
+
+	// The default output is SQLite: NewC1ZFile (the SQLite-only
+	// constructor) must open it. A pebble v3 artifact would fail here.
+	store, err := dotc1z.NewC1ZFile(ctx, out.FilePath, dotc1z.WithReadOnly(true))
+	require.NoError(t, err)
+	defer store.Close(ctx)
+	require.NoError(t, store.SetCurrentSync(ctx, out.SyncID))
+	resp, err := store.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{PageSize: 1000}.Build())
+	require.NoError(t, err)
+	require.Len(t, resp.GetList(), 3, "default sqlite compaction must union grants to 3")
 }

--- a/pkg/synccompactor/compactor_pebble_test.go
+++ b/pkg/synccompactor/compactor_pebble_test.go
@@ -1,0 +1,118 @@
+package synccompactor
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	reader_v2 "github.com/conductorone/baton-sdk/pb/c1/reader/v2"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+)
+
+// buildPebbleInput writes a minimal Pebble (v3) c1z at path with the
+// given sync type and one grant per id (a fixed user→member graph),
+// then ends + closes it. Returns the sync id.
+func buildPebbleInput(t *testing.T, ctx context.Context, path string, st connectorstore.SyncType, grantIDs ...string) string {
+	t.Helper()
+	require.NoError(t, ensurePebbleRegistered())
+
+	w, err := dotc1z.NewStore(ctx, path, dotc1z.WithEngine(dotc1z.EnginePebble))
+	require.NoError(t, err)
+	store, ok := w.(dotc1z.C1ZStore)
+	require.True(t, ok)
+
+	syncID, err := store.StartNewSync(ctx, st, "")
+	require.NoError(t, err)
+
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	require.NoError(t, store.PutResourceTypes(ctx, userRT, groupRT))
+
+	group := v2.Resource_builder{
+		Id:          v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(),
+		DisplayName: "Group One",
+	}.Build()
+	user := v2.Resource_builder{
+		Id:          v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(),
+		DisplayName: "User One",
+	}.Build()
+	require.NoError(t, store.PutResources(ctx, group, user))
+
+	member := v2.Entitlement_builder{
+		Id:       "member",
+		Resource: group,
+		Purpose:  v2.Entitlement_PURPOSE_VALUE_ASSIGNMENT,
+	}.Build()
+	require.NoError(t, store.PutEntitlements(ctx, member))
+
+	for _, id := range grantIDs {
+		g := v2.Grant_builder{Id: id, Principal: user, Entitlement: member}.Build()
+		require.NoError(t, store.PutGrants(ctx, g))
+	}
+
+	require.NoError(t, store.EndSync(ctx))
+	require.NoError(t, store.Close(ctx))
+	return syncID
+}
+
+func verifyCompacted(t *testing.T, ctx context.Context, path, syncID string) (int, string) {
+	t.Helper()
+	w, err := dotc1z.NewStore(ctx, path, dotc1z.WithReadOnly(true))
+	require.NoError(t, err)
+	store, ok := w.(dotc1z.C1ZStore)
+	require.True(t, ok)
+	defer store.Close(ctx)
+
+	require.NoError(t, store.SetCurrentSync(ctx, syncID))
+
+	count := 0
+	pageToken := ""
+	for {
+		resp, err := store.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{
+			PageSize:  1000,
+			PageToken: pageToken,
+		}.Build())
+		require.NoError(t, err)
+		count += len(resp.GetList())
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			break
+		}
+	}
+
+	syncResp, err := store.GetLatestFinishedSync(ctx, reader_v2.SyncsReaderServiceGetLatestFinishedSyncRequest_builder{}.Build())
+	require.NoError(t, err)
+	return count, syncResp.GetSync().GetSyncType()
+}
+
+// TestCompactPebbleEndToEnd is the wired-in-option integration: two v3
+// Pebble inputs compacted with WithEngine(EnginePebble) yield ONE
+// merged Pebble sync whose grants are the union (overlapping ids
+// deduped), with the union sync type.
+func TestCompactPebbleEndToEnd(t *testing.T) {
+	ctx := context.Background()
+	inDir := t.TempDir()
+	outDir := t.TempDir()
+
+	p1 := filepath.Join(inDir, "in1.c1z")
+	p2 := filepath.Join(inDir, "in2.c1z")
+	s1 := buildPebbleInput(t, ctx, p1, connectorstore.SyncTypeFull, "g-shared", "g-only1")
+	s2 := buildPebbleInput(t, ctx, p2, connectorstore.SyncTypePartial, "g-shared", "g-only2")
+
+	entries := []*CompactableSync{{FilePath: p1, SyncID: s1}, {FilePath: p2, SyncID: s2}}
+	c, cleanup, err := NewCompactor(ctx, outDir, entries, WithTmpDir(t.TempDir()), WithEngine(dotc1z.EnginePebble))
+	require.NoError(t, err)
+	defer func() { _ = cleanup() }()
+
+	out, err := c.Compact(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+
+	count, st := verifyCompacted(t, ctx, out.FilePath, out.SyncID)
+	require.Equal(t, 3, count, "union of {g-shared,g-only1} and {g-shared,g-only2} deduped = 3 grants")
+	require.Equal(t, string(connectorstore.SyncTypeFull), st, "union of full + partial = full")
+}

--- a/pkg/synccompactor/compactor_pebble_test.go
+++ b/pkg/synccompactor/compactor_pebble_test.go
@@ -21,7 +21,7 @@ import (
 // buildPebbleInput writes a minimal Pebble (v3) c1z at path with the
 // given sync type and one grant per id (a fixed user→member graph),
 // then ends + closes it. Returns the sync id.
-func buildPebbleInput(t *testing.T, ctx context.Context, path string, st connectorstore.SyncType, grantIDs ...string) string {
+func buildPebbleInput(t testing.TB, ctx context.Context, path string, st connectorstore.SyncType, grantIDs ...string) string {
 	t.Helper()
 	require.NoError(t, ensurePebbleRegistered())
 
@@ -168,7 +168,7 @@ func TestCompactPebbleEndToEnd(t *testing.T) {
 
 // buildSQLiteInput writes a minimal SQLite (v1) c1z with one grant per
 // id, for the default-engine regression.
-func buildSQLiteInput(t *testing.T, ctx context.Context, path string, st connectorstore.SyncType, grantIDs ...string) string {
+func buildSQLiteInput(t testing.TB, ctx context.Context, path string, st connectorstore.SyncType, grantIDs ...string) string {
 	t.Helper()
 	store, err := dotc1z.NewC1ZFile(ctx, path)
 	require.NoError(t, err)

--- a/pkg/synccompactor/pebble/merge.go
+++ b/pkg/synccompactor/pebble/merge.go
@@ -1,0 +1,169 @@
+package pebble
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/cockroachdb/pebble/v2"
+	"google.golang.org/protobuf/proto"
+
+	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
+	enginepkg "github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/codec"
+)
+
+// SourceSync names one input to a merge: its open Pebble engine and the
+// sync id whose records should be folded into the destination.
+type SourceSync struct {
+	Engine *enginepkg.Engine
+	SyncID string
+}
+
+// MergeInto folds every source's primary records into dest under
+// destSyncID, producing a single merged sync. It is the native-Pebble
+// equivalent of the SQLite ATTACH union: across all inputs, the newest
+// record per logical key (by discovered_at, ties keep the incumbent)
+// survives, and dest's derived indexes are rebuilt from the survivors.
+//
+// destSyncID must already exist in dest (created by StartNewSync) and
+// be empty — MergeInto only adds records, it never excises, so no
+// pre-existing data under destSyncID is assumed.
+//
+// Only the four primary record buckets are copied: resource_types,
+// resources, entitlements, grants. Assets are intentionally NOT copied
+// — this matches the SQLite compaction path, which folds only those
+// four tables and drops assets from the compacted sync; copying assets
+// here would give Pebble compacted syncs asset access the SQLite path
+// does not have. Index keyspaces are not copied verbatim either; the
+// per-record write path rebuilds them from the surviving primaries.
+//
+// Sources are applied in the given order. The dedup keeps the record
+// with the strictly-greater discovered_at; on an equal discovered_at
+// the already-written (earlier source) record is kept. Callers pass
+// sources in the same order the SQLite fold applies them so the tie
+// winner is identical across engines.
+func MergeInto(ctx context.Context, dest *enginepkg.Engine, sources []SourceSync, destSyncID string) error {
+	if dest == nil {
+		return errors.New("synccompactor/pebble.MergeInto: dest engine is nil")
+	}
+	if destSyncID == "" {
+		return errors.New("synccompactor/pebble.MergeInto: destSyncID is required")
+	}
+	for i := range sources {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		s := sources[i]
+		if s.Engine == nil || s.SyncID == "" {
+			continue
+		}
+		if err := mergeOneSource(ctx, dest, s, destSyncID); err != nil {
+			return fmt.Errorf("merge source %s: %w", s.SyncID, err)
+		}
+	}
+	return nil
+}
+
+// mergeOneSource reads every primary record under s.SyncID, re-keys it
+// to destSyncID, and writes it into dest via the engine's keep-newer
+// put path (which dedups by discovered_at and rebuilds indexes).
+func mergeOneSource(ctx context.Context, dest *enginepkg.Engine, s SourceSync, destSyncID string) error {
+	srcBytes, err := codec.EncodeSyncID(s.SyncID)
+	if err != nil {
+		return err
+	}
+	srcDB := s.Engine.DB()
+	if srcDB == nil {
+		return errors.New("source engine has no DB (closed?)")
+	}
+
+	// resource_types
+	rts, err := readRecords(srcDB,
+		enginepkg.ResourceTypeSyncLowerBound(srcBytes), enginepkg.ResourceTypeSyncUpperBound(srcBytes),
+		func() *v3.ResourceTypeRecord { return &v3.ResourceTypeRecord{} },
+		func(r *v3.ResourceTypeRecord) { r.SetSyncId(destSyncID) })
+	if err != nil {
+		return fmt.Errorf("read resource_types: %w", err)
+	}
+	if len(rts) > 0 {
+		if err := dest.PutResourceTypeRecordsIfNewer(ctx, rts...); err != nil {
+			return fmt.Errorf("put resource_types: %w", err)
+		}
+	}
+
+	// resources
+	rs, err := readRecords(srcDB,
+		enginepkg.ResourceSyncLowerBound(srcBytes), enginepkg.ResourceSyncUpperBound(srcBytes),
+		func() *v3.ResourceRecord { return &v3.ResourceRecord{} },
+		func(r *v3.ResourceRecord) { r.SetSyncId(destSyncID) })
+	if err != nil {
+		return fmt.Errorf("read resources: %w", err)
+	}
+	if len(rs) > 0 {
+		if err := dest.PutResourceRecordsIfNewer(ctx, rs...); err != nil {
+			return fmt.Errorf("put resources: %w", err)
+		}
+	}
+
+	// entitlements
+	es, err := readRecords(srcDB,
+		enginepkg.EntitlementSyncLowerBound(srcBytes), enginepkg.EntitlementSyncUpperBound(srcBytes),
+		func() *v3.EntitlementRecord { return &v3.EntitlementRecord{} },
+		func(r *v3.EntitlementRecord) { r.SetSyncId(destSyncID) })
+	if err != nil {
+		return fmt.Errorf("read entitlements: %w", err)
+	}
+	if len(es) > 0 {
+		if err := dest.PutEntitlementRecordsIfNewer(ctx, es...); err != nil {
+			return fmt.Errorf("put entitlements: %w", err)
+		}
+	}
+
+	// grants
+	gs, err := readRecords(srcDB,
+		enginepkg.GrantSyncLowerBound(srcBytes), enginepkg.GrantSyncUpperBound(srcBytes),
+		func() *v3.GrantRecord { return &v3.GrantRecord{} },
+		func(r *v3.GrantRecord) { r.SetSyncId(destSyncID) })
+	if err != nil {
+		return fmt.Errorf("read grants: %w", err)
+	}
+	if len(gs) > 0 {
+		if err := dest.PutGrantRecordsIfNewer(ctx, gs...); err != nil {
+			return fmt.Errorf("put grants: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// readRecords drains a primary bucket's [lower, upper) key range,
+// unmarshalling each value into a fresh T (the stored value is a
+// deterministic proto marshal of the v3 record) and applying rekey to
+// stamp the destination sync id before the record is written.
+func readRecords[T proto.Message](
+	db *pebble.DB,
+	lower, upper []byte,
+	mk func() T,
+	rekey func(T),
+) ([]T, error) {
+	iter, err := db.NewIter(&pebble.IterOptions{LowerBound: lower, UpperBound: upper})
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = iter.Close() }()
+
+	var out []T
+	for iter.First(); iter.Valid(); iter.Next() {
+		rec := mk()
+		if err := proto.Unmarshal(iter.Value(), rec); err != nil {
+			return nil, fmt.Errorf("unmarshal record: %w", err)
+		}
+		rekey(rec)
+		out = append(out, rec)
+	}
+	if err := iter.Error(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/pkg/synccompactor/pebble/merge.go
+++ b/pkg/synccompactor/pebble/merge.go
@@ -65,9 +65,17 @@ func MergeInto(ctx context.Context, dest *enginepkg.Engine, sources []SourceSync
 	return nil
 }
 
-// mergeOneSource reads every primary record under s.SyncID, re-keys it
-// to destSyncID, and writes it into dest via the engine's keep-newer
-// put path (which dedups by discovered_at and rebuilds indexes).
+// mergeBatchSize bounds how many decoded records are held in memory
+// before a flush into the keep-newer put path. A whole bucket can hold
+// millions of records at the large-connector scale compaction targets,
+// so the merge streams in fixed-size batches rather than materializing
+// the bucket — peak heap stays O(mergeBatchSize), not O(bucket).
+const mergeBatchSize = 1000
+
+// mergeOneSource streams every primary record under s.SyncID, re-keys
+// it to destSyncID, and writes it into dest via the engine's keep-newer
+// put path (which dedups by discovered_at and rebuilds indexes). Each
+// bucket is drained in fixed-size batches to bound peak memory.
 func mergeOneSource(ctx context.Context, dest *enginepkg.Engine, s SourceSync, destSyncID string) error {
 	srcBytes, err := codec.EncodeSyncID(s.SyncID)
 	if err != nil {
@@ -78,92 +86,95 @@ func mergeOneSource(ctx context.Context, dest *enginepkg.Engine, s SourceSync, d
 		return errors.New("source engine has no DB (closed?)")
 	}
 
-	// resource_types
-	rts, err := readRecords(srcDB,
+	if err := streamBucket(ctx, srcDB,
 		enginepkg.ResourceTypeSyncLowerBound(srcBytes), enginepkg.ResourceTypeSyncUpperBound(srcBytes),
 		func() *v3.ResourceTypeRecord { return &v3.ResourceTypeRecord{} },
-		func(r *v3.ResourceTypeRecord) { r.SetSyncId(destSyncID) })
-	if err != nil {
-		return fmt.Errorf("read resource_types: %w", err)
-	}
-	if len(rts) > 0 {
-		if err := dest.PutResourceTypeRecordsIfNewer(ctx, rts...); err != nil {
-			return fmt.Errorf("put resource_types: %w", err)
-		}
+		func(r *v3.ResourceTypeRecord) { r.SetSyncId(destSyncID) },
+		dest.PutResourceTypeRecordsIfNewer,
+	); err != nil {
+		return fmt.Errorf("merge resource_types: %w", err)
 	}
 
-	// resources
-	rs, err := readRecords(srcDB,
+	if err := streamBucket(ctx, srcDB,
 		enginepkg.ResourceSyncLowerBound(srcBytes), enginepkg.ResourceSyncUpperBound(srcBytes),
 		func() *v3.ResourceRecord { return &v3.ResourceRecord{} },
-		func(r *v3.ResourceRecord) { r.SetSyncId(destSyncID) })
-	if err != nil {
-		return fmt.Errorf("read resources: %w", err)
-	}
-	if len(rs) > 0 {
-		if err := dest.PutResourceRecordsIfNewer(ctx, rs...); err != nil {
-			return fmt.Errorf("put resources: %w", err)
-		}
+		func(r *v3.ResourceRecord) { r.SetSyncId(destSyncID) },
+		dest.PutResourceRecordsIfNewer,
+	); err != nil {
+		return fmt.Errorf("merge resources: %w", err)
 	}
 
-	// entitlements
-	es, err := readRecords(srcDB,
+	if err := streamBucket(ctx, srcDB,
 		enginepkg.EntitlementSyncLowerBound(srcBytes), enginepkg.EntitlementSyncUpperBound(srcBytes),
 		func() *v3.EntitlementRecord { return &v3.EntitlementRecord{} },
-		func(r *v3.EntitlementRecord) { r.SetSyncId(destSyncID) })
-	if err != nil {
-		return fmt.Errorf("read entitlements: %w", err)
-	}
-	if len(es) > 0 {
-		if err := dest.PutEntitlementRecordsIfNewer(ctx, es...); err != nil {
-			return fmt.Errorf("put entitlements: %w", err)
-		}
+		func(r *v3.EntitlementRecord) { r.SetSyncId(destSyncID) },
+		dest.PutEntitlementRecordsIfNewer,
+	); err != nil {
+		return fmt.Errorf("merge entitlements: %w", err)
 	}
 
-	// grants
-	gs, err := readRecords(srcDB,
+	if err := streamBucket(ctx, srcDB,
 		enginepkg.GrantSyncLowerBound(srcBytes), enginepkg.GrantSyncUpperBound(srcBytes),
 		func() *v3.GrantRecord { return &v3.GrantRecord{} },
-		func(r *v3.GrantRecord) { r.SetSyncId(destSyncID) })
-	if err != nil {
-		return fmt.Errorf("read grants: %w", err)
-	}
-	if len(gs) > 0 {
-		if err := dest.PutGrantRecordsIfNewer(ctx, gs...); err != nil {
-			return fmt.Errorf("put grants: %w", err)
-		}
+		func(r *v3.GrantRecord) { r.SetSyncId(destSyncID) },
+		dest.PutGrantRecordsIfNewer,
+	); err != nil {
+		return fmt.Errorf("merge grants: %w", err)
 	}
 
 	return nil
 }
 
-// readRecords drains a primary bucket's [lower, upper) key range,
+// streamBucket drains a primary bucket's [lower, upper) key range,
 // unmarshalling each value into a fresh T (the stored value is a
-// deterministic proto marshal of the v3 record) and applying rekey to
-// stamp the destination sync id before the record is written.
-func readRecords[T proto.Message](
+// deterministic proto marshal of the v3 record), applying rekey to
+// stamp the destination sync id, and flushing fixed-size batches into
+// put. Peak memory is bounded by mergeBatchSize rather than the bucket
+// size.
+func streamBucket[T proto.Message](
+	ctx context.Context,
 	db *pebble.DB,
 	lower, upper []byte,
 	mk func() T,
 	rekey func(T),
-) ([]T, error) {
+	put func(context.Context, ...T) error,
+) error {
 	iter, err := db.NewIter(&pebble.IterOptions{LowerBound: lower, UpperBound: upper})
 	if err != nil {
-		return nil, err
+		return err
 	}
 	defer func() { _ = iter.Close() }()
 
-	var out []T
+	batch := make([]T, 0, mergeBatchSize)
+	flush := func() error {
+		if len(batch) == 0 {
+			return nil
+		}
+		if err := put(ctx, batch...); err != nil {
+			return err
+		}
+		batch = batch[:0]
+		return nil
+	}
+
 	for iter.First(); iter.Valid(); iter.Next() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		rec := mk()
 		if err := proto.Unmarshal(iter.Value(), rec); err != nil {
-			return nil, fmt.Errorf("unmarshal record: %w", err)
+			return fmt.Errorf("unmarshal record: %w", err)
 		}
 		rekey(rec)
-		out = append(out, rec)
+		batch = append(batch, rec)
+		if len(batch) >= mergeBatchSize {
+			if err := flush(); err != nil {
+				return err
+			}
+		}
 	}
 	if err := iter.Error(); err != nil {
-		return nil, err
+		return err
 	}
-	return out, nil
+	return flush()
 }

--- a/pkg/synccompactor/pebble/merge_test.go
+++ b/pkg/synccompactor/pebble/merge_test.go
@@ -1,0 +1,144 @@
+package pebble
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/segmentio/ksuid"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
+)
+
+func grantAt(syncID, externalID string, at time.Time) *v3.GrantRecord {
+	return v3.GrantRecord_builder{
+		SyncId:     syncID,
+		ExternalId: externalID,
+		Entitlement: v3.EntitlementRef_builder{
+			ResourceTypeId: "app", ResourceId: "github", EntitlementId: "ent-A",
+		}.Build(),
+		Principal: v3.PrincipalRef_builder{
+			ResourceTypeId: "user", ResourceId: externalID,
+		}.Build(),
+		DiscoveredAt: timestamppb.New(at),
+	}.Build()
+}
+
+// TestMergeIntoUnionNewerWins is the core parity pin: a k-way merge of
+// two sources into an empty dest sync yields the UNION of records, and
+// for a key present in both, the record with the strictly-newer
+// discovered_at survives (ties keep the earlier-applied incumbent). All
+// surviving records are re-keyed to the destination sync id.
+func TestMergeIntoUnionNewerWins(t *testing.T) {
+	ctx := context.Background()
+	src1, _ := newEngine(t, "src1")
+	src2, _ := newEngine(t, "src2")
+	dst, _ := newEngine(t, "dst")
+
+	syncA := ksuid.New().String()
+	syncB := ksuid.New().String()
+	destSync := ksuid.New().String()
+
+	older := time.Unix(1000, 0).UTC()
+	newer := time.Unix(2000, 0).UTC()
+
+	// src1 (applied first): shared key @older + a unique key.
+	if err := src1.SetCurrentSync(syncA); err != nil {
+		t.Fatal(err)
+	}
+	if err := src1.PutGrantRecords(ctx, grantAt(syncA, "g-shared", older), grantAt(syncA, "g-only1", older)); err != nil {
+		t.Fatal(err)
+	}
+	// src2 (applied second): shared key @newer (must win) + a unique key.
+	if err := src2.SetCurrentSync(syncB); err != nil {
+		t.Fatal(err)
+	}
+	if err := src2.PutGrantRecords(ctx, grantAt(syncB, "g-shared", newer), grantAt(syncB, "g-only2", newer)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := dst.SetCurrentSync(destSync); err != nil {
+		t.Fatal(err)
+	}
+	if err := MergeInto(ctx, dst, []SourceSync{{Engine: src1, SyncID: syncA}, {Engine: src2, SyncID: syncB}}, destSync); err != nil {
+		t.Fatalf("MergeInto: %v", err)
+	}
+
+	// Union of distinct external_ids: g-shared, g-only1, g-only2 = 3.
+	if got := countGrants(t, dst, destSync); got != 3 {
+		t.Fatalf("merged grant count = %d, want 3 (union, deduped)", got)
+	}
+
+	// Every survivor is re-keyed to destSync, and g-shared kept the
+	// newer discovered_at.
+	seen := map[string]*v3.GrantRecord{}
+	if err := dst.IterateGrantsBySync(ctx, destSync, func(r *v3.GrantRecord) bool {
+		if r.GetSyncId() != destSync {
+			t.Errorf("grant %q sync_id = %q, want destSync %q", r.GetExternalId(), r.GetSyncId(), destSync)
+		}
+		seen[r.GetExternalId()] = r
+		return true
+	}); err != nil {
+		t.Fatalf("IterateGrantsBySync: %v", err)
+	}
+	shared, ok := seen["g-shared"]
+	if !ok {
+		t.Fatal("g-shared missing from merged output")
+	}
+	if !shared.GetDiscoveredAt().AsTime().Equal(newer) {
+		t.Fatalf("g-shared discovered_at = %s, want newer %s (newer-wins)", shared.GetDiscoveredAt().AsTime(), newer)
+	}
+	for _, id := range []string{"g-only1", "g-only2"} {
+		if _, ok := seen[id]; !ok {
+			t.Errorf("%q missing from merged union", id)
+		}
+	}
+}
+
+// TestMergeIntoTieKeepsIncumbent pins the equal-discovered_at tie rule
+// to SQLite's strict `>`: on a tie, the earlier-applied source's record
+// is kept (it is the incumbent the newer write does not replace).
+func TestMergeIntoTieKeepsIncumbent(t *testing.T) {
+	ctx := context.Background()
+	src1, _ := newEngine(t, "tsrc1")
+	src2, _ := newEngine(t, "tsrc2")
+	dst, _ := newEngine(t, "tdst")
+
+	syncA := ksuid.New().String()
+	syncB := ksuid.New().String()
+	destSync := ksuid.New().String()
+	tie := time.Unix(1500, 0).UTC()
+
+	// Same key + same discovered_at in both, distinguished by principal id.
+	g1 := grantAt(syncA, "g-tie", tie)
+	g1.SetPrincipal(v3.PrincipalRef_builder{ResourceTypeId: "user", ResourceId: "from-src1"}.Build())
+	g2 := grantAt(syncB, "g-tie", tie)
+	g2.SetPrincipal(v3.PrincipalRef_builder{ResourceTypeId: "user", ResourceId: "from-src2"}.Build())
+
+	_ = src1.SetCurrentSync(syncA)
+	if err := src1.PutGrantRecords(ctx, g1); err != nil {
+		t.Fatal(err)
+	}
+	_ = src2.SetCurrentSync(syncB)
+	if err := src2.PutGrantRecords(ctx, g2); err != nil {
+		t.Fatal(err)
+	}
+	_ = dst.SetCurrentSync(destSync)
+
+	// src1 applied first → incumbent wins the tie.
+	if err := MergeInto(ctx, dst, []SourceSync{{Engine: src1, SyncID: syncA}, {Engine: src2, SyncID: syncB}}, destSync); err != nil {
+		t.Fatal(err)
+	}
+
+	var winner string
+	if err := dst.IterateGrantsBySync(ctx, destSync, func(r *v3.GrantRecord) bool {
+		winner = r.GetPrincipal().GetResourceId()
+		return true
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if winner != "from-src1" {
+		t.Fatalf("tie winner = %q, want from-src1 (earliest-applied incumbent, strict-> parity)", winner)
+	}
+}


### PR DESCRIPTION
## What

Lets a caller choose the c1z storage engine for sync compaction. Today compaction is hardwired to
SQLite — the output is always a v1 SQLite `.c1z` and the merge always uses the ATTACH-database path —
so a Pebble-backed connector can never produce or read compacted syncs. This adds a wired-in option
so compaction can produce **SQLite (default, unchanged) or Pebble**.

## How

- **`synccompactor.WithEngine(dotc1z.Engine)`** — stores the engine as a strategy field on the
  `Compactor`. Unset is SQLite, byte-identical to before. The resolved engine is forced onto the
  output constructor last so an engine passed via `WithC1ZOptions` can't mislabel the artifact.
- **Branch in `doOneCompaction`/`Compact`:** the SQLite path (`NewC1ZFile` + the `attached` ATTACH
  merge) is untouched. The Pebble path opens inputs with the engine-aware `NewStore` (so v3 inputs
  decode), selects each input's latest finished compactable sync (diff syncs `partial_upserts`/
  `partial_deletions` excluded), and folds them all into the empty destination sync in a single pass.
- **Native record merge (`pkg/synccompactor/pebble.MergeInto`):** reads each input's primary records
  (resource types, resources, entitlements, grants), re-keys them to the destination sync, and writes
  them keep-newer — the strictly-greater `discovered_at` wins and an equal `discovered_at` keeps the
  earlier-applied record, matching the SQLite union exactly. Indexes are rebuilt from the surviving
  records by the engine's write path. **Assets are not copied**, matching the SQLite path (which folds
  only those four tables); copying them would give Pebble compacted syncs asset access SQLite does not
  have. The destination `sync_run` type and `ended_at` are set to the union / max across the inputs,
  and stats are recomputed, so downstream gating (e.g. grant expansion) behaves identically.
- **`pebble.AsEngine`** recovers the `*Engine` from the `NewStore` wrapper for the merge; the
  compactor registers the Pebble driver on demand (a caller may also register it explicitly).

## Tests

- `pkg/synccompactor/pebble/merge_test.go` — multi-source union with newer-wins; equal-`discovered_at`
  tie keeps the earlier-applied incumbent (matches SQLite strict `>`); sync-id re-keying.
- `pkg/synccompactor/compactor_pebble_test.go` — end-to-end: two v3 Pebble inputs compacted via
  `WithEngine(EnginePebble)` yield one merged Pebble sync with the unioned, deduped grants and the
  union sync type.
- The SQLite compaction path is exercised unchanged by the existing suite.

`go build ./...`, `go test ./pkg/synccompactor/... ./pkg/dotc1z/...`, `gofmt`, and `golangci-lint`
on the changed packages are green.

## Scope notes

Pebble compaction requires Pebble inputs (and SQLite compaction SQLite inputs); a mixed-engine input
set is not supported. The merge re-encodes each record to re-key the sync id, so it is record-paced
rather than a byte-level ingest — a future optimization could ingest unchanged buckets directly.

---

_🛰️ Built with stargate._
