### PR TITLE
much much faster compaction for pebble only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ dist/
 .claude/settings.local.json
 
 *.map
+
+# Local profiling output and benchmark fixtures (pprof files, prebuilt
+# compaction fixture trees referenced via BATON_COMPACTION_COMPARE_FIXTURES_DIR).
+.profiles/

--- a/pb/c1/c1z/v3/manifest.pb.go
+++ b/pb/c1/c1z/v3/manifest.pb.go
@@ -392,11 +392,18 @@ func (b0 RecordTypeInfo_builder) Build() *RecordTypeInfo {
 }
 
 type SyncRunSummary struct {
-	state         protoimpl.MessageState `protogen:"hybrid.v1"`
-	SyncId        string                 `protobuf:"bytes,1,opt,name=sync_id,json=syncId,proto3" json:"sync_id,omitempty"`
-	Type          v3.SyncType            `protobuf:"varint,2,opt,name=type,proto3,enum=c1.storage.v3.SyncType" json:"type,omitempty"`
-	StartedAt     *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=started_at,json=startedAt,proto3" json:"started_at,omitempty"`
-	EndedAt       *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=ended_at,json=endedAt,proto3" json:"ended_at,omitempty"`
+	state        protoimpl.MessageState `protogen:"hybrid.v1"`
+	SyncId       string                 `protobuf:"bytes,1,opt,name=sync_id,json=syncId,proto3" json:"sync_id,omitempty"`
+	Type         v3.SyncType            `protobuf:"varint,2,opt,name=type,proto3,enum=c1.storage.v3.SyncType" json:"type,omitempty"`
+	StartedAt    *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=started_at,json=startedAt,proto3" json:"started_at,omitempty"`
+	EndedAt      *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=ended_at,json=endedAt,proto3" json:"ended_at,omitempty"`
+	ParentSyncId string                 `protobuf:"bytes,5,opt,name=parent_sync_id,json=parentSyncId,proto3" json:"parent_sync_id,omitempty"`
+	// Projection of the engine's stats sidecar for this sync, when one
+	// exists. Lets readers (compaction source selection, overlay bucket
+	// planning, tooling) get row counts from the envelope header without
+	// unpacking the payload. Absent for syncs whose sidecar was never
+	// written (e.g. interrupted syncs).
+	Stats         *v3.SyncStatsRecord `protobuf:"bytes,6,opt,name=stats,proto3" json:"stats,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -454,6 +461,20 @@ func (x *SyncRunSummary) GetEndedAt() *timestamppb.Timestamp {
 	return nil
 }
 
+func (x *SyncRunSummary) GetParentSyncId() string {
+	if x != nil {
+		return x.ParentSyncId
+	}
+	return ""
+}
+
+func (x *SyncRunSummary) GetStats() *v3.SyncStatsRecord {
+	if x != nil {
+		return x.Stats
+	}
+	return nil
+}
+
 func (x *SyncRunSummary) SetSyncId(v string) {
 	x.SyncId = v
 }
@@ -470,6 +491,14 @@ func (x *SyncRunSummary) SetEndedAt(v *timestamppb.Timestamp) {
 	x.EndedAt = v
 }
 
+func (x *SyncRunSummary) SetParentSyncId(v string) {
+	x.ParentSyncId = v
+}
+
+func (x *SyncRunSummary) SetStats(v *v3.SyncStatsRecord) {
+	x.Stats = v
+}
+
 func (x *SyncRunSummary) HasStartedAt() bool {
 	if x == nil {
 		return false
@@ -484,6 +513,13 @@ func (x *SyncRunSummary) HasEndedAt() bool {
 	return x.EndedAt != nil
 }
 
+func (x *SyncRunSummary) HasStats() bool {
+	if x == nil {
+		return false
+	}
+	return x.Stats != nil
+}
+
 func (x *SyncRunSummary) ClearStartedAt() {
 	x.StartedAt = nil
 }
@@ -492,13 +528,24 @@ func (x *SyncRunSummary) ClearEndedAt() {
 	x.EndedAt = nil
 }
 
+func (x *SyncRunSummary) ClearStats() {
+	x.Stats = nil
+}
+
 type SyncRunSummary_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	SyncId    string
-	Type      v3.SyncType
-	StartedAt *timestamppb.Timestamp
-	EndedAt   *timestamppb.Timestamp
+	SyncId       string
+	Type         v3.SyncType
+	StartedAt    *timestamppb.Timestamp
+	EndedAt      *timestamppb.Timestamp
+	ParentSyncId string
+	// Projection of the engine's stats sidecar for this sync, when one
+	// exists. Lets readers (compaction source selection, overlay bucket
+	// planning, tooling) get row counts from the envelope header without
+	// unpacking the payload. Absent for syncs whose sidecar was never
+	// written (e.g. interrupted syncs).
+	Stats *v3.SyncStatsRecord
 }
 
 func (b0 SyncRunSummary_builder) Build() *SyncRunSummary {
@@ -509,6 +556,8 @@ func (b0 SyncRunSummary_builder) Build() *SyncRunSummary {
 	x.Type = b.Type
 	x.StartedAt = b.StartedAt
 	x.EndedAt = b.EndedAt
+	x.ParentSyncId = b.ParentSyncId
+	x.Stats = b.Stats
 	return m0
 }
 
@@ -608,13 +657,15 @@ const file_c1_c1z_v3_manifest_proto_rawDesc = "" +
 	"\x0eRecordTypeInfo\x12*\n" +
 	"\x11message_full_name\x18\x01 \x01(\tR\x0fmessageFullName\x12%\n" +
 	"\x0eschema_version\x18\x02 \x01(\rR\rschemaVersion\x12'\n" +
-	"\x0festimated_count\x18\x03 \x01(\x03R\x0eestimatedCount\"\xc8\x01\n" +
+	"\x0festimated_count\x18\x03 \x01(\x03R\x0eestimatedCount\"\xa4\x02\n" +
 	"\x0eSyncRunSummary\x12\x17\n" +
 	"\async_id\x18\x01 \x01(\tR\x06syncId\x12+\n" +
 	"\x04type\x18\x02 \x01(\x0e2\x17.c1.storage.v3.SyncTypeR\x04type\x129\n" +
 	"\n" +
 	"started_at\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\tstartedAt\x125\n" +
-	"\bended_at\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\aendedAt\"p\n" +
+	"\bended_at\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\aendedAt\x12$\n" +
+	"\x0eparent_sync_id\x18\x05 \x01(\tR\fparentSyncId\x124\n" +
+	"\x05stats\x18\x06 \x01(\v2\x1e.c1.storage.v3.SyncStatsRecordR\x05stats\"p\n" +
 	"\x12PebbleEngineConfig\x120\n" +
 	"\x14format_major_version\x18\x01 \x01(\rR\x12formatMajorVersion\x12(\n" +
 	"\x10cache_size_bytes\x18\x02 \x01(\x04R\x0ecacheSizeBytes*l\n" +
@@ -635,6 +686,7 @@ var file_c1_c1z_v3_manifest_proto_goTypes = []any{
 	(*descriptorpb.FileDescriptorSet)(nil), // 6: google.protobuf.FileDescriptorSet
 	(v3.SyncType)(0),                       // 7: c1.storage.v3.SyncType
 	(*timestamppb.Timestamp)(nil),          // 8: google.protobuf.Timestamp
+	(*v3.SyncStatsRecord)(nil),             // 9: c1.storage.v3.SyncStatsRecord
 }
 var file_c1_c1z_v3_manifest_proto_depIdxs = []int32{
 	5, // 0: c1.c1z.v3.C1ZManifestV3.engine_config:type_name -> google.protobuf.Any
@@ -645,11 +697,12 @@ var file_c1_c1z_v3_manifest_proto_depIdxs = []int32{
 	7, // 5: c1.c1z.v3.SyncRunSummary.type:type_name -> c1.storage.v3.SyncType
 	8, // 6: c1.c1z.v3.SyncRunSummary.started_at:type_name -> google.protobuf.Timestamp
 	8, // 7: c1.c1z.v3.SyncRunSummary.ended_at:type_name -> google.protobuf.Timestamp
-	8, // [8:8] is the sub-list for method output_type
-	8, // [8:8] is the sub-list for method input_type
-	8, // [8:8] is the sub-list for extension type_name
-	8, // [8:8] is the sub-list for extension extendee
-	0, // [0:8] is the sub-list for field type_name
+	9, // 8: c1.c1z.v3.SyncRunSummary.stats:type_name -> c1.storage.v3.SyncStatsRecord
+	9, // [9:9] is the sub-list for method output_type
+	9, // [9:9] is the sub-list for method input_type
+	9, // [9:9] is the sub-list for extension type_name
+	9, // [9:9] is the sub-list for extension extendee
+	0, // [0:9] is the sub-list for field type_name
 }
 
 func init() { file_c1_c1z_v3_manifest_proto_init() }

--- a/pb/c1/c1z/v3/manifest.pb.validate.go
+++ b/pb/c1/c1z/v3/manifest.pb.validate.go
@@ -461,6 +461,37 @@ func (m *SyncRunSummary) validate(all bool) error {
 		}
 	}
 
+	// no validation rules for ParentSyncId
+
+	if all {
+		switch v := interface{}(m.GetStats()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, SyncRunSummaryValidationError{
+					field:  "Stats",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, SyncRunSummaryValidationError{
+					field:  "Stats",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetStats()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return SyncRunSummaryValidationError{
+				field:  "Stats",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if len(errors) > 0 {
 		return SyncRunSummaryMultiError(errors)
 	}

--- a/pb/c1/c1z/v3/manifest_protoopaque.pb.go
+++ b/pb/c1/c1z/v3/manifest_protoopaque.pb.go
@@ -368,13 +368,15 @@ func (b0 RecordTypeInfo_builder) Build() *RecordTypeInfo {
 }
 
 type SyncRunSummary struct {
-	state                protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_SyncId    string                 `protobuf:"bytes,1,opt,name=sync_id,json=syncId,proto3"`
-	xxx_hidden_Type      v3.SyncType            `protobuf:"varint,2,opt,name=type,proto3,enum=c1.storage.v3.SyncType"`
-	xxx_hidden_StartedAt *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=started_at,json=startedAt,proto3"`
-	xxx_hidden_EndedAt   *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=ended_at,json=endedAt,proto3"`
-	unknownFields        protoimpl.UnknownFields
-	sizeCache            protoimpl.SizeCache
+	state                   protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_SyncId       string                 `protobuf:"bytes,1,opt,name=sync_id,json=syncId,proto3"`
+	xxx_hidden_Type         v3.SyncType            `protobuf:"varint,2,opt,name=type,proto3,enum=c1.storage.v3.SyncType"`
+	xxx_hidden_StartedAt    *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=started_at,json=startedAt,proto3"`
+	xxx_hidden_EndedAt      *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=ended_at,json=endedAt,proto3"`
+	xxx_hidden_ParentSyncId string                 `protobuf:"bytes,5,opt,name=parent_sync_id,json=parentSyncId,proto3"`
+	xxx_hidden_Stats        *v3.SyncStatsRecord    `protobuf:"bytes,6,opt,name=stats,proto3"`
+	unknownFields           protoimpl.UnknownFields
+	sizeCache               protoimpl.SizeCache
 }
 
 func (x *SyncRunSummary) Reset() {
@@ -430,6 +432,20 @@ func (x *SyncRunSummary) GetEndedAt() *timestamppb.Timestamp {
 	return nil
 }
 
+func (x *SyncRunSummary) GetParentSyncId() string {
+	if x != nil {
+		return x.xxx_hidden_ParentSyncId
+	}
+	return ""
+}
+
+func (x *SyncRunSummary) GetStats() *v3.SyncStatsRecord {
+	if x != nil {
+		return x.xxx_hidden_Stats
+	}
+	return nil
+}
+
 func (x *SyncRunSummary) SetSyncId(v string) {
 	x.xxx_hidden_SyncId = v
 }
@@ -446,6 +462,14 @@ func (x *SyncRunSummary) SetEndedAt(v *timestamppb.Timestamp) {
 	x.xxx_hidden_EndedAt = v
 }
 
+func (x *SyncRunSummary) SetParentSyncId(v string) {
+	x.xxx_hidden_ParentSyncId = v
+}
+
+func (x *SyncRunSummary) SetStats(v *v3.SyncStatsRecord) {
+	x.xxx_hidden_Stats = v
+}
+
 func (x *SyncRunSummary) HasStartedAt() bool {
 	if x == nil {
 		return false
@@ -460,6 +484,13 @@ func (x *SyncRunSummary) HasEndedAt() bool {
 	return x.xxx_hidden_EndedAt != nil
 }
 
+func (x *SyncRunSummary) HasStats() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_Stats != nil
+}
+
 func (x *SyncRunSummary) ClearStartedAt() {
 	x.xxx_hidden_StartedAt = nil
 }
@@ -468,13 +499,24 @@ func (x *SyncRunSummary) ClearEndedAt() {
 	x.xxx_hidden_EndedAt = nil
 }
 
+func (x *SyncRunSummary) ClearStats() {
+	x.xxx_hidden_Stats = nil
+}
+
 type SyncRunSummary_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	SyncId    string
-	Type      v3.SyncType
-	StartedAt *timestamppb.Timestamp
-	EndedAt   *timestamppb.Timestamp
+	SyncId       string
+	Type         v3.SyncType
+	StartedAt    *timestamppb.Timestamp
+	EndedAt      *timestamppb.Timestamp
+	ParentSyncId string
+	// Projection of the engine's stats sidecar for this sync, when one
+	// exists. Lets readers (compaction source selection, overlay bucket
+	// planning, tooling) get row counts from the envelope header without
+	// unpacking the payload. Absent for syncs whose sidecar was never
+	// written (e.g. interrupted syncs).
+	Stats *v3.SyncStatsRecord
 }
 
 func (b0 SyncRunSummary_builder) Build() *SyncRunSummary {
@@ -485,6 +527,8 @@ func (b0 SyncRunSummary_builder) Build() *SyncRunSummary {
 	x.xxx_hidden_Type = b.Type
 	x.xxx_hidden_StartedAt = b.StartedAt
 	x.xxx_hidden_EndedAt = b.EndedAt
+	x.xxx_hidden_ParentSyncId = b.ParentSyncId
+	x.xxx_hidden_Stats = b.Stats
 	return m0
 }
 
@@ -581,13 +625,15 @@ const file_c1_c1z_v3_manifest_proto_rawDesc = "" +
 	"\x0eRecordTypeInfo\x12*\n" +
 	"\x11message_full_name\x18\x01 \x01(\tR\x0fmessageFullName\x12%\n" +
 	"\x0eschema_version\x18\x02 \x01(\rR\rschemaVersion\x12'\n" +
-	"\x0festimated_count\x18\x03 \x01(\x03R\x0eestimatedCount\"\xc8\x01\n" +
+	"\x0festimated_count\x18\x03 \x01(\x03R\x0eestimatedCount\"\xa4\x02\n" +
 	"\x0eSyncRunSummary\x12\x17\n" +
 	"\async_id\x18\x01 \x01(\tR\x06syncId\x12+\n" +
 	"\x04type\x18\x02 \x01(\x0e2\x17.c1.storage.v3.SyncTypeR\x04type\x129\n" +
 	"\n" +
 	"started_at\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\tstartedAt\x125\n" +
-	"\bended_at\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\aendedAt\"p\n" +
+	"\bended_at\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\aendedAt\x12$\n" +
+	"\x0eparent_sync_id\x18\x05 \x01(\tR\fparentSyncId\x124\n" +
+	"\x05stats\x18\x06 \x01(\v2\x1e.c1.storage.v3.SyncStatsRecordR\x05stats\"p\n" +
 	"\x12PebbleEngineConfig\x120\n" +
 	"\x14format_major_version\x18\x01 \x01(\rR\x12formatMajorVersion\x12(\n" +
 	"\x10cache_size_bytes\x18\x02 \x01(\x04R\x0ecacheSizeBytes*l\n" +
@@ -608,6 +654,7 @@ var file_c1_c1z_v3_manifest_proto_goTypes = []any{
 	(*descriptorpb.FileDescriptorSet)(nil), // 6: google.protobuf.FileDescriptorSet
 	(v3.SyncType)(0),                       // 7: c1.storage.v3.SyncType
 	(*timestamppb.Timestamp)(nil),          // 8: google.protobuf.Timestamp
+	(*v3.SyncStatsRecord)(nil),             // 9: c1.storage.v3.SyncStatsRecord
 }
 var file_c1_c1z_v3_manifest_proto_depIdxs = []int32{
 	5, // 0: c1.c1z.v3.C1ZManifestV3.engine_config:type_name -> google.protobuf.Any
@@ -618,11 +665,12 @@ var file_c1_c1z_v3_manifest_proto_depIdxs = []int32{
 	7, // 5: c1.c1z.v3.SyncRunSummary.type:type_name -> c1.storage.v3.SyncType
 	8, // 6: c1.c1z.v3.SyncRunSummary.started_at:type_name -> google.protobuf.Timestamp
 	8, // 7: c1.c1z.v3.SyncRunSummary.ended_at:type_name -> google.protobuf.Timestamp
-	8, // [8:8] is the sub-list for method output_type
-	8, // [8:8] is the sub-list for method input_type
-	8, // [8:8] is the sub-list for extension type_name
-	8, // [8:8] is the sub-list for extension extendee
-	0, // [0:8] is the sub-list for field type_name
+	9, // 8: c1.c1z.v3.SyncRunSummary.stats:type_name -> c1.storage.v3.SyncStatsRecord
+	9, // [9:9] is the sub-list for method output_type
+	9, // [9:9] is the sub-list for method input_type
+	9, // [9:9] is the sub-list for extension type_name
+	9, // [9:9] is the sub-list for extension extendee
+	0, // [0:9] is the sub-list for field type_name
 }
 
 func init() { file_c1_c1z_v3_manifest_proto_init() }

--- a/pb/c1/storage/v3/records.pb.go
+++ b/pb/c1/storage/v3/records.pb.go
@@ -286,7 +286,6 @@ func (b0 GrantSourceRecord_builder) Build() *GrantSourceRecord {
 
 type ResourceTypeRecord struct {
 	state        protoimpl.MessageState `protogen:"hybrid.v1"`
-	SyncId       string                 `protobuf:"bytes,1,opt,name=sync_id,json=syncId,proto3" json:"sync_id,omitempty"`
 	ExternalId   string                 `protobuf:"bytes,2,opt,name=external_id,json=externalId,proto3" json:"external_id,omitempty"`
 	DisplayName  string                 `protobuf:"bytes,3,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
 	Traits       []string               `protobuf:"bytes,4,rep,name=traits,proto3" json:"traits,omitempty"`
@@ -326,13 +325,6 @@ func (x *ResourceTypeRecord) ProtoReflect() protoreflect.Message {
 		return ms
 	}
 	return mi.MessageOf(x)
-}
-
-func (x *ResourceTypeRecord) GetSyncId() string {
-	if x != nil {
-		return x.SyncId
-	}
-	return ""
 }
 
 func (x *ResourceTypeRecord) GetExternalId() string {
@@ -384,10 +376,6 @@ func (x *ResourceTypeRecord) GetSourcedExternally() bool {
 	return false
 }
 
-func (x *ResourceTypeRecord) SetSyncId(v string) {
-	x.SyncId = v
-}
-
 func (x *ResourceTypeRecord) SetExternalId(v string) {
 	x.ExternalId = v
 }
@@ -430,7 +418,6 @@ func (x *ResourceTypeRecord) ClearDiscoveredAt() {
 type ResourceTypeRecord_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	SyncId       string
 	ExternalId   string
 	DisplayName  string
 	Traits       []string
@@ -449,7 +436,6 @@ func (b0 ResourceTypeRecord_builder) Build() *ResourceTypeRecord {
 	m0 := &ResourceTypeRecord{}
 	b, x := &b0, m0
 	_, _ = b, x
-	x.SyncId = b.SyncId
 	x.ExternalId = b.ExternalId
 	x.DisplayName = b.DisplayName
 	x.Traits = b.Traits
@@ -462,7 +448,6 @@ func (b0 ResourceTypeRecord_builder) Build() *ResourceTypeRecord {
 
 type ResourceRecord struct {
 	state          protoimpl.MessageState `protogen:"hybrid.v1"`
-	SyncId         string                 `protobuf:"bytes,1,opt,name=sync_id,json=syncId,proto3" json:"sync_id,omitempty"`
 	ResourceTypeId string                 `protobuf:"bytes,2,opt,name=resource_type_id,json=resourceTypeId,proto3" json:"resource_type_id,omitempty"`
 	ResourceId     string                 `protobuf:"bytes,3,opt,name=resource_id,json=resourceId,proto3" json:"resource_id,omitempty"`
 	DisplayName    string                 `protobuf:"bytes,4,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
@@ -497,13 +482,6 @@ func (x *ResourceRecord) ProtoReflect() protoreflect.Message {
 		return ms
 	}
 	return mi.MessageOf(x)
-}
-
-func (x *ResourceRecord) GetSyncId() string {
-	if x != nil {
-		return x.SyncId
-	}
-	return ""
 }
 
 func (x *ResourceRecord) GetResourceTypeId() string {
@@ -553,10 +531,6 @@ func (x *ResourceRecord) GetDiscoveredAt() *timestamppb.Timestamp {
 		return x.DiscoveredAt
 	}
 	return nil
-}
-
-func (x *ResourceRecord) SetSyncId(v string) {
-	x.SyncId = v
 }
 
 func (x *ResourceRecord) SetResourceTypeId(v string) {
@@ -612,7 +586,6 @@ func (x *ResourceRecord) ClearDiscoveredAt() {
 type ResourceRecord_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	SyncId         string
 	ResourceTypeId string
 	ResourceId     string
 	DisplayName    string
@@ -626,7 +599,6 @@ func (b0 ResourceRecord_builder) Build() *ResourceRecord {
 	m0 := &ResourceRecord{}
 	b, x := &b0, m0
 	_, _ = b, x
-	x.SyncId = b.SyncId
 	x.ResourceTypeId = b.ResourceTypeId
 	x.ResourceId = b.ResourceId
 	x.DisplayName = b.DisplayName
@@ -639,7 +611,6 @@ func (b0 ResourceRecord_builder) Build() *ResourceRecord {
 
 type EntitlementRecord struct {
 	state        protoimpl.MessageState `protogen:"hybrid.v1"`
-	SyncId       string                 `protobuf:"bytes,1,opt,name=sync_id,json=syncId,proto3" json:"sync_id,omitempty"`
 	ExternalId   string                 `protobuf:"bytes,2,opt,name=external_id,json=externalId,proto3" json:"external_id,omitempty"`
 	Resource     *ResourceRef           `protobuf:"bytes,3,opt,name=resource,proto3" json:"resource,omitempty"`
 	DisplayName  string                 `protobuf:"bytes,4,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
@@ -688,13 +659,6 @@ func (x *EntitlementRecord) ProtoReflect() protoreflect.Message {
 		return ms
 	}
 	return mi.MessageOf(x)
-}
-
-func (x *EntitlementRecord) GetSyncId() string {
-	if x != nil {
-		return x.SyncId
-	}
-	return ""
 }
 
 func (x *EntitlementRecord) GetExternalId() string {
@@ -760,10 +724,6 @@ func (x *EntitlementRecord) GetGrantableToResourceTypeIds() []string {
 	return nil
 }
 
-func (x *EntitlementRecord) SetSyncId(v string) {
-	x.SyncId = v
-}
-
 func (x *EntitlementRecord) SetExternalId(v string) {
 	x.ExternalId = v
 }
@@ -825,7 +785,6 @@ func (x *EntitlementRecord) ClearDiscoveredAt() {
 type EntitlementRecord_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	SyncId       string
 	ExternalId   string
 	Resource     *ResourceRef
 	DisplayName  string
@@ -853,7 +812,6 @@ func (b0 EntitlementRecord_builder) Build() *EntitlementRecord {
 	m0 := &EntitlementRecord{}
 	b, x := &b0, m0
 	_, _ = b, x
-	x.SyncId = b.SyncId
 	x.ExternalId = b.ExternalId
 	x.Resource = b.Resource
 	x.DisplayName = b.DisplayName
@@ -868,7 +826,6 @@ func (b0 EntitlementRecord_builder) Build() *EntitlementRecord {
 
 type GrantRecord struct {
 	state      protoimpl.MessageState `protogen:"hybrid.v1"`
-	SyncId     string                 `protobuf:"bytes,1,opt,name=sync_id,json=syncId,proto3" json:"sync_id,omitempty"`
 	ExternalId string                 `protobuf:"bytes,2,opt,name=external_id,json=externalId,proto3" json:"external_id,omitempty"`
 	// entitlement carries TWO indexes:
 	//
@@ -917,13 +874,6 @@ func (x *GrantRecord) ProtoReflect() protoreflect.Message {
 		return ms
 	}
 	return mi.MessageOf(x)
-}
-
-func (x *GrantRecord) GetSyncId() string {
-	if x != nil {
-		return x.SyncId
-	}
-	return ""
 }
 
 func (x *GrantRecord) GetExternalId() string {
@@ -980,10 +930,6 @@ func (x *GrantRecord) GetSources() map[string]*GrantSourceRecord {
 		return x.Sources
 	}
 	return nil
-}
-
-func (x *GrantRecord) SetSyncId(v string) {
-	x.SyncId = v
 }
 
 func (x *GrantRecord) SetExternalId(v string) {
@@ -1065,7 +1011,6 @@ func (x *GrantRecord) ClearExpansion() {
 type GrantRecord_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	SyncId     string
 	ExternalId string
 	// entitlement carries TWO indexes:
 	//
@@ -1093,7 +1038,6 @@ func (b0 GrantRecord_builder) Build() *GrantRecord {
 	m0 := &GrantRecord{}
 	b, x := &b0, m0
 	_, _ = b, x
-	x.SyncId = b.SyncId
 	x.ExternalId = b.ExternalId
 	x.Entitlement = b.Entitlement
 	x.Principal = b.Principal
@@ -1619,9 +1563,8 @@ const file_c1_storage_v3_records_proto_rawDesc = "" +
 	"\vresource_id\x18\x02 \x01(\tR\n" +
 	"resourceId\x12%\n" +
 	"\x0eentitlement_id\x18\x03 \x01(\tR\rentitlementId\x12\x1b\n" +
-	"\tis_direct\x18\x04 \x01(\bR\bisDirect\"\xff\x02\n" +
-	"\x12ResourceTypeRecord\x12\x17\n" +
-	"\async_id\x18\x01 \x01(\tR\x06syncId\x12\x1f\n" +
+	"\tis_direct\x18\x04 \x01(\bR\bisDirect\"\xec\x02\n" +
+	"\x12ResourceTypeRecord\x12\x1f\n" +
 	"\vexternal_id\x18\x02 \x01(\tR\n" +
 	"externalId\x12!\n" +
 	"\fdisplay_name\x18\x03 \x01(\tR\vdisplayName\x12\x16\n" +
@@ -1629,10 +1572,9 @@ const file_c1_storage_v3_records_proto_rawDesc = "" +
 	"\vannotations\x18\x05 \x03(\v2\x14.google.protobuf.AnyR\vannotations\x12?\n" +
 	"\rdiscovered_at\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\fdiscoveredAt\x12 \n" +
 	"\vdescription\x18\a \x01(\tR\vdescription\x12-\n" +
-	"\x12sourced_externally\x18\b \x01(\bR\x11sourcedExternally:*\x82\xf9+&\n" +
-	"\x0eresource_types\x12\async_id\x12\vexternal_id\"\xcf\x03\n" +
-	"\x0eResourceRecord\x12\x17\n" +
-	"\async_id\x18\x01 \x01(\tR\x06syncId\x12(\n" +
+	"\x12sourced_externally\x18\b \x01(\bR\x11sourcedExternally:!\x82\xf9+\x1d\n" +
+	"\x0eresource_types\x12\vexternal_idJ\x04\b\x01\x10\x02R\async_id\"\xbc\x03\n" +
+	"\x0eResourceRecord\x12(\n" +
 	"\x10resource_type_id\x18\x02 \x01(\tR\x0eresourceTypeId\x12\x1f\n" +
 	"\vresource_id\x18\x03 \x01(\tR\n" +
 	"resourceId\x12!\n" +
@@ -1641,10 +1583,9 @@ const file_c1_storage_v3_records_proto_rawDesc = "" +
 	"\x06parent\x18\x06 \x01(\v2\x1a.c1.storage.v3.ResourceRefB.\x8a\xf9+*\n" +
 	"\tby_parent\x1a\x10resource_type_id\x1a\vresource_idR\x06parent\x126\n" +
 	"\vannotations\x18\a \x03(\v2\x14.google.protobuf.AnyR\vannotations\x12?\n" +
-	"\rdiscovered_at\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\fdiscoveredAt:7\x82\xf9+3\n" +
-	"\tresources\x12\async_id\x12\x10resource_type_id\x12\vresource_id\"\x91\x04\n" +
-	"\x11EntitlementRecord\x12\x17\n" +
-	"\async_id\x18\x01 \x01(\tR\x06syncId\x12\x1f\n" +
+	"\rdiscovered_at\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\fdiscoveredAt:.\x82\xf9+*\n" +
+	"\tresources\x12\x10resource_type_id\x12\vresource_idJ\x04\b\x01\x10\x02R\async_id\"\xfe\x03\n" +
+	"\x11EntitlementRecord\x12\x1f\n" +
 	"\vexternal_id\x18\x02 \x01(\tR\n" +
 	"externalId\x12h\n" +
 	"\bresource\x18\x03 \x01(\v2\x1a.c1.storage.v3.ResourceRefB0\x8a\xf9+,\n" +
@@ -1656,10 +1597,9 @@ const file_c1_storage_v3_records_proto_rawDesc = "" +
 	"\rdiscovered_at\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\fdiscoveredAt\x12\x12\n" +
 	"\x04slug\x18\t \x01(\tR\x04slug\x12B\n" +
 	"\x1egrantable_to_resource_type_ids\x18\n" +
-	" \x03(\tR\x1agrantableToResourceTypeIds:(\x82\xf9+$\n" +
-	"\fentitlements\x12\async_id\x12\vexternal_id\"\xad\x06\n" +
-	"\vGrantRecord\x12\x17\n" +
-	"\async_id\x18\x01 \x01(\tR\x06syncId\x12\x1f\n" +
+	" \x03(\tR\x1agrantableToResourceTypeIds:\x1f\x82\xf9+\x1b\n" +
+	"\fentitlements\x12\vexternal_idJ\x04\b\x01\x10\x02R\async_id\"\x9a\x06\n" +
+	"\vGrantRecord\x12\x1f\n" +
 	"\vexternal_id\x18\x02 \x01(\tR\n" +
 	"externalId\x12\x98\x01\n" +
 	"\ventitlement\x18\x03 \x01(\v2\x1d.c1.storage.v3.EntitlementRefBW\x8a\xf9+S\n" +
@@ -1674,8 +1614,8 @@ const file_c1_storage_v3_records_proto_rawDesc = "" +
 	"\asources\x18\t \x03(\v2'.c1.storage.v3.GrantRecord.SourcesEntryR\asources\x1a\\\n" +
 	"\fSourcesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x126\n" +
-	"\x05value\x18\x02 \x01(\v2 .c1.storage.v3.GrantSourceRecordR\x05value:\x028\x01:\"\x82\xf9+\x1e\n" +
-	"\x06grants\x12\async_id\x12\vexternal_id\"\xe3\x01\n" +
+	"\x05value\x18\x02 \x01(\v2 .c1.storage.v3.GrantSourceRecordR\x05value:\x028\x01:\x19\x82\xf9+\x15\n" +
+	"\x06grants\x12\vexternal_idJ\x04\b\x01\x10\x02R\async_id\"\xe3\x01\n" +
 	"\vAssetRecord\x12\x17\n" +
 	"\async_id\x18\x01 \x01(\tR\x06syncId\x12\x1f\n" +
 	"\vexternal_id\x18\x02 \x01(\tR\n" +

--- a/pb/c1/storage/v3/records.pb.validate.go
+++ b/pb/c1/storage/v3/records.pb.validate.go
@@ -271,8 +271,6 @@ func (m *ResourceTypeRecord) validate(all bool) error {
 
 	var errors []error
 
-	// no validation rules for SyncId
-
 	// no validation rules for ExternalId
 
 	// no validation rules for DisplayName
@@ -445,8 +443,6 @@ func (m *ResourceRecord) validate(all bool) error {
 	}
 
 	var errors []error
-
-	// no validation rules for SyncId
 
 	// no validation rules for ResourceTypeId
 
@@ -647,8 +643,6 @@ func (m *EntitlementRecord) validate(all bool) error {
 	}
 
 	var errors []error
-
-	// no validation rules for SyncId
 
 	// no validation rules for ExternalId
 
@@ -853,8 +847,6 @@ func (m *GrantRecord) validate(all bool) error {
 	}
 
 	var errors []error
-
-	// no validation rules for SyncId
 
 	// no validation rules for ExternalId
 

--- a/pb/c1/storage/v3/records_protoopaque.pb.go
+++ b/pb/c1/storage/v3/records_protoopaque.pb.go
@@ -283,7 +283,6 @@ func (b0 GrantSourceRecord_builder) Build() *GrantSourceRecord {
 
 type ResourceTypeRecord struct {
 	state                        protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_SyncId            string                 `protobuf:"bytes,1,opt,name=sync_id,json=syncId,proto3"`
 	xxx_hidden_ExternalId        string                 `protobuf:"bytes,2,opt,name=external_id,json=externalId,proto3"`
 	xxx_hidden_DisplayName       string                 `protobuf:"bytes,3,opt,name=display_name,json=displayName,proto3"`
 	xxx_hidden_Traits            []string               `protobuf:"bytes,4,rep,name=traits,proto3"`
@@ -318,13 +317,6 @@ func (x *ResourceTypeRecord) ProtoReflect() protoreflect.Message {
 		return ms
 	}
 	return mi.MessageOf(x)
-}
-
-func (x *ResourceTypeRecord) GetSyncId() string {
-	if x != nil {
-		return x.xxx_hidden_SyncId
-	}
-	return ""
 }
 
 func (x *ResourceTypeRecord) GetExternalId() string {
@@ -378,10 +370,6 @@ func (x *ResourceTypeRecord) GetSourcedExternally() bool {
 	return false
 }
 
-func (x *ResourceTypeRecord) SetSyncId(v string) {
-	x.xxx_hidden_SyncId = v
-}
-
 func (x *ResourceTypeRecord) SetExternalId(v string) {
 	x.xxx_hidden_ExternalId = v
 }
@@ -424,7 +412,6 @@ func (x *ResourceTypeRecord) ClearDiscoveredAt() {
 type ResourceTypeRecord_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	SyncId       string
 	ExternalId   string
 	DisplayName  string
 	Traits       []string
@@ -443,7 +430,6 @@ func (b0 ResourceTypeRecord_builder) Build() *ResourceTypeRecord {
 	m0 := &ResourceTypeRecord{}
 	b, x := &b0, m0
 	_, _ = b, x
-	x.xxx_hidden_SyncId = b.SyncId
 	x.xxx_hidden_ExternalId = b.ExternalId
 	x.xxx_hidden_DisplayName = b.DisplayName
 	x.xxx_hidden_Traits = b.Traits
@@ -456,7 +442,6 @@ func (b0 ResourceTypeRecord_builder) Build() *ResourceTypeRecord {
 
 type ResourceRecord struct {
 	state                     protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_SyncId         string                 `protobuf:"bytes,1,opt,name=sync_id,json=syncId,proto3"`
 	xxx_hidden_ResourceTypeId string                 `protobuf:"bytes,2,opt,name=resource_type_id,json=resourceTypeId,proto3"`
 	xxx_hidden_ResourceId     string                 `protobuf:"bytes,3,opt,name=resource_id,json=resourceId,proto3"`
 	xxx_hidden_DisplayName    string                 `protobuf:"bytes,4,opt,name=display_name,json=displayName,proto3"`
@@ -491,13 +476,6 @@ func (x *ResourceRecord) ProtoReflect() protoreflect.Message {
 		return ms
 	}
 	return mi.MessageOf(x)
-}
-
-func (x *ResourceRecord) GetSyncId() string {
-	if x != nil {
-		return x.xxx_hidden_SyncId
-	}
-	return ""
 }
 
 func (x *ResourceRecord) GetResourceTypeId() string {
@@ -549,10 +527,6 @@ func (x *ResourceRecord) GetDiscoveredAt() *timestamppb.Timestamp {
 		return x.xxx_hidden_DiscoveredAt
 	}
 	return nil
-}
-
-func (x *ResourceRecord) SetSyncId(v string) {
-	x.xxx_hidden_SyncId = v
 }
 
 func (x *ResourceRecord) SetResourceTypeId(v string) {
@@ -608,7 +582,6 @@ func (x *ResourceRecord) ClearDiscoveredAt() {
 type ResourceRecord_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	SyncId         string
 	ResourceTypeId string
 	ResourceId     string
 	DisplayName    string
@@ -622,7 +595,6 @@ func (b0 ResourceRecord_builder) Build() *ResourceRecord {
 	m0 := &ResourceRecord{}
 	b, x := &b0, m0
 	_, _ = b, x
-	x.xxx_hidden_SyncId = b.SyncId
 	x.xxx_hidden_ResourceTypeId = b.ResourceTypeId
 	x.xxx_hidden_ResourceId = b.ResourceId
 	x.xxx_hidden_DisplayName = b.DisplayName
@@ -635,7 +607,6 @@ func (b0 ResourceRecord_builder) Build() *ResourceRecord {
 
 type EntitlementRecord struct {
 	state                                 protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_SyncId                     string                 `protobuf:"bytes,1,opt,name=sync_id,json=syncId,proto3"`
 	xxx_hidden_ExternalId                 string                 `protobuf:"bytes,2,opt,name=external_id,json=externalId,proto3"`
 	xxx_hidden_Resource                   *ResourceRef           `protobuf:"bytes,3,opt,name=resource,proto3"`
 	xxx_hidden_DisplayName                string                 `protobuf:"bytes,4,opt,name=display_name,json=displayName,proto3"`
@@ -672,13 +643,6 @@ func (x *EntitlementRecord) ProtoReflect() protoreflect.Message {
 		return ms
 	}
 	return mi.MessageOf(x)
-}
-
-func (x *EntitlementRecord) GetSyncId() string {
-	if x != nil {
-		return x.xxx_hidden_SyncId
-	}
-	return ""
 }
 
 func (x *EntitlementRecord) GetExternalId() string {
@@ -746,10 +710,6 @@ func (x *EntitlementRecord) GetGrantableToResourceTypeIds() []string {
 	return nil
 }
 
-func (x *EntitlementRecord) SetSyncId(v string) {
-	x.xxx_hidden_SyncId = v
-}
-
 func (x *EntitlementRecord) SetExternalId(v string) {
 	x.xxx_hidden_ExternalId = v
 }
@@ -811,7 +771,6 @@ func (x *EntitlementRecord) ClearDiscoveredAt() {
 type EntitlementRecord_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	SyncId       string
 	ExternalId   string
 	Resource     *ResourceRef
 	DisplayName  string
@@ -839,7 +798,6 @@ func (b0 EntitlementRecord_builder) Build() *EntitlementRecord {
 	m0 := &EntitlementRecord{}
 	b, x := &b0, m0
 	_, _ = b, x
-	x.xxx_hidden_SyncId = b.SyncId
 	x.xxx_hidden_ExternalId = b.ExternalId
 	x.xxx_hidden_Resource = b.Resource
 	x.xxx_hidden_DisplayName = b.DisplayName
@@ -854,7 +812,6 @@ func (b0 EntitlementRecord_builder) Build() *EntitlementRecord {
 
 type GrantRecord struct {
 	state                     protoimpl.MessageState        `protogen:"opaque.v1"`
-	xxx_hidden_SyncId         string                        `protobuf:"bytes,1,opt,name=sync_id,json=syncId,proto3"`
 	xxx_hidden_ExternalId     string                        `protobuf:"bytes,2,opt,name=external_id,json=externalId,proto3"`
 	xxx_hidden_Entitlement    *EntitlementRef               `protobuf:"bytes,3,opt,name=entitlement,proto3"`
 	xxx_hidden_Principal      *PrincipalRef                 `protobuf:"bytes,4,opt,name=principal,proto3"`
@@ -890,13 +847,6 @@ func (x *GrantRecord) ProtoReflect() protoreflect.Message {
 		return ms
 	}
 	return mi.MessageOf(x)
-}
-
-func (x *GrantRecord) GetSyncId() string {
-	if x != nil {
-		return x.xxx_hidden_SyncId
-	}
-	return ""
 }
 
 func (x *GrantRecord) GetExternalId() string {
@@ -955,10 +905,6 @@ func (x *GrantRecord) GetSources() map[string]*GrantSourceRecord {
 		return x.xxx_hidden_Sources
 	}
 	return nil
-}
-
-func (x *GrantRecord) SetSyncId(v string) {
-	x.xxx_hidden_SyncId = v
 }
 
 func (x *GrantRecord) SetExternalId(v string) {
@@ -1040,7 +986,6 @@ func (x *GrantRecord) ClearExpansion() {
 type GrantRecord_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	SyncId     string
 	ExternalId string
 	// entitlement carries TWO indexes:
 	//
@@ -1068,7 +1013,6 @@ func (b0 GrantRecord_builder) Build() *GrantRecord {
 	m0 := &GrantRecord{}
 	b, x := &b0, m0
 	_, _ = b, x
-	x.xxx_hidden_SyncId = b.SyncId
 	x.xxx_hidden_ExternalId = b.ExternalId
 	x.xxx_hidden_Entitlement = b.Entitlement
 	x.xxx_hidden_Principal = b.Principal
@@ -1589,9 +1533,8 @@ const file_c1_storage_v3_records_proto_rawDesc = "" +
 	"\vresource_id\x18\x02 \x01(\tR\n" +
 	"resourceId\x12%\n" +
 	"\x0eentitlement_id\x18\x03 \x01(\tR\rentitlementId\x12\x1b\n" +
-	"\tis_direct\x18\x04 \x01(\bR\bisDirect\"\xff\x02\n" +
-	"\x12ResourceTypeRecord\x12\x17\n" +
-	"\async_id\x18\x01 \x01(\tR\x06syncId\x12\x1f\n" +
+	"\tis_direct\x18\x04 \x01(\bR\bisDirect\"\xec\x02\n" +
+	"\x12ResourceTypeRecord\x12\x1f\n" +
 	"\vexternal_id\x18\x02 \x01(\tR\n" +
 	"externalId\x12!\n" +
 	"\fdisplay_name\x18\x03 \x01(\tR\vdisplayName\x12\x16\n" +
@@ -1599,10 +1542,9 @@ const file_c1_storage_v3_records_proto_rawDesc = "" +
 	"\vannotations\x18\x05 \x03(\v2\x14.google.protobuf.AnyR\vannotations\x12?\n" +
 	"\rdiscovered_at\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\fdiscoveredAt\x12 \n" +
 	"\vdescription\x18\a \x01(\tR\vdescription\x12-\n" +
-	"\x12sourced_externally\x18\b \x01(\bR\x11sourcedExternally:*\x82\xf9+&\n" +
-	"\x0eresource_types\x12\async_id\x12\vexternal_id\"\xcf\x03\n" +
-	"\x0eResourceRecord\x12\x17\n" +
-	"\async_id\x18\x01 \x01(\tR\x06syncId\x12(\n" +
+	"\x12sourced_externally\x18\b \x01(\bR\x11sourcedExternally:!\x82\xf9+\x1d\n" +
+	"\x0eresource_types\x12\vexternal_idJ\x04\b\x01\x10\x02R\async_id\"\xbc\x03\n" +
+	"\x0eResourceRecord\x12(\n" +
 	"\x10resource_type_id\x18\x02 \x01(\tR\x0eresourceTypeId\x12\x1f\n" +
 	"\vresource_id\x18\x03 \x01(\tR\n" +
 	"resourceId\x12!\n" +
@@ -1611,10 +1553,9 @@ const file_c1_storage_v3_records_proto_rawDesc = "" +
 	"\x06parent\x18\x06 \x01(\v2\x1a.c1.storage.v3.ResourceRefB.\x8a\xf9+*\n" +
 	"\tby_parent\x1a\x10resource_type_id\x1a\vresource_idR\x06parent\x126\n" +
 	"\vannotations\x18\a \x03(\v2\x14.google.protobuf.AnyR\vannotations\x12?\n" +
-	"\rdiscovered_at\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\fdiscoveredAt:7\x82\xf9+3\n" +
-	"\tresources\x12\async_id\x12\x10resource_type_id\x12\vresource_id\"\x91\x04\n" +
-	"\x11EntitlementRecord\x12\x17\n" +
-	"\async_id\x18\x01 \x01(\tR\x06syncId\x12\x1f\n" +
+	"\rdiscovered_at\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\fdiscoveredAt:.\x82\xf9+*\n" +
+	"\tresources\x12\x10resource_type_id\x12\vresource_idJ\x04\b\x01\x10\x02R\async_id\"\xfe\x03\n" +
+	"\x11EntitlementRecord\x12\x1f\n" +
 	"\vexternal_id\x18\x02 \x01(\tR\n" +
 	"externalId\x12h\n" +
 	"\bresource\x18\x03 \x01(\v2\x1a.c1.storage.v3.ResourceRefB0\x8a\xf9+,\n" +
@@ -1626,10 +1567,9 @@ const file_c1_storage_v3_records_proto_rawDesc = "" +
 	"\rdiscovered_at\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\fdiscoveredAt\x12\x12\n" +
 	"\x04slug\x18\t \x01(\tR\x04slug\x12B\n" +
 	"\x1egrantable_to_resource_type_ids\x18\n" +
-	" \x03(\tR\x1agrantableToResourceTypeIds:(\x82\xf9+$\n" +
-	"\fentitlements\x12\async_id\x12\vexternal_id\"\xad\x06\n" +
-	"\vGrantRecord\x12\x17\n" +
-	"\async_id\x18\x01 \x01(\tR\x06syncId\x12\x1f\n" +
+	" \x03(\tR\x1agrantableToResourceTypeIds:\x1f\x82\xf9+\x1b\n" +
+	"\fentitlements\x12\vexternal_idJ\x04\b\x01\x10\x02R\async_id\"\x9a\x06\n" +
+	"\vGrantRecord\x12\x1f\n" +
 	"\vexternal_id\x18\x02 \x01(\tR\n" +
 	"externalId\x12\x98\x01\n" +
 	"\ventitlement\x18\x03 \x01(\v2\x1d.c1.storage.v3.EntitlementRefBW\x8a\xf9+S\n" +
@@ -1644,8 +1584,8 @@ const file_c1_storage_v3_records_proto_rawDesc = "" +
 	"\asources\x18\t \x03(\v2'.c1.storage.v3.GrantRecord.SourcesEntryR\asources\x1a\\\n" +
 	"\fSourcesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x126\n" +
-	"\x05value\x18\x02 \x01(\v2 .c1.storage.v3.GrantSourceRecordR\x05value:\x028\x01:\"\x82\xf9+\x1e\n" +
-	"\x06grants\x12\async_id\x12\vexternal_id\"\xe3\x01\n" +
+	"\x05value\x18\x02 \x01(\v2 .c1.storage.v3.GrantSourceRecordR\x05value:\x028\x01:\x19\x82\xf9+\x15\n" +
+	"\x06grants\x12\vexternal_idJ\x04\b\x01\x10\x02R\async_id\"\xe3\x01\n" +
 	"\vAssetRecord\x12\x17\n" +
 	"\async_id\x18\x01 \x01(\tR\x06syncId\x12\x1f\n" +
 	"\vexternal_id\x18\x02 \x01(\tR\n" +

--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -348,6 +348,10 @@ type c1zOptions struct {
 	// values: PayloadEncodingTarZstd (default), PayloadEncodingTar.
 	// Zero value means PayloadEncodingTarZstd.
 	payloadEncoding PayloadEncoding
+
+	// decoderPool optionally scopes v3 payload-decoder reuse to the
+	// caller's operation. See WithDecoderPool.
+	decoderPool *EnvelopeDecoderPool
 }
 
 type C1ZOption func(*c1zOptions)

--- a/pkg/dotc1z/engine/equivalence/equivalence_test.go
+++ b/pkg/dotc1z/engine/equivalence/equivalence_test.go
@@ -24,7 +24,6 @@ func openPebble(t *testing.T) *enginepkg.Engine {
 
 func mkGrant(syncID, externalID, entID, principalRT, principalID string) *v3.GrantRecord {
 	return v3.GrantRecord_builder{
-		SyncId:     syncID,
 		ExternalId: externalID,
 		Entitlement: v3.EntitlementRef_builder{
 			ResourceTypeId: "app",

--- a/pkg/dotc1z/engine/equivalence/memory.go
+++ b/pkg/dotc1z/engine/equivalence/memory.go
@@ -47,7 +47,9 @@ func (m *MemoryRef) PutGrantRecord(_ context.Context, r *v3.GrantRecord) error {
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	sid := m.resolveSync(r.GetSyncId())
+	// GrantRecord values do not carry a sync_id in v3; writer paths bind
+	// grants to the current sync's keyspace.
+	sid := m.resolveSync("")
 	if sid == "" {
 		return fmt.Errorf("memoryref: no sync_id")
 	}

--- a/pkg/dotc1z/engine/pebble/adapter.go
+++ b/pkg/dotc1z/engine/pebble/adapter.go
@@ -105,6 +105,8 @@ func (a *Adapter) StartNewSync(ctx context.Context, syncType connectorstore.Sync
 		StartedAt:    timestamppb.New(a.current.startedAt),
 	}.Build()
 	if err := a.engine.PutSyncRunRecord(ctx, rec); err != nil {
+		a.current = syncRunState{}
+		a.engine.clearCurrentSync()
 		return "", err
 	}
 	return syncID, nil

--- a/pkg/dotc1z/engine/pebble/adapter_clone_sync.go
+++ b/pkg/dotc1z/engine/pebble/adapter_clone_sync.go
@@ -141,7 +141,7 @@ func cloneSync(
 		}
 	}()
 
-	manifest, err := BuildManifest(encoding)
+	manifest, err := BuildManifestWithSyncRuns(ctx, dest, encoding)
 	if err != nil {
 		return err
 	}

--- a/pkg/dotc1z/engine/pebble/adapter_clone_sync_test.go
+++ b/pkg/dotc1z/engine/pebble/adapter_clone_sync_test.go
@@ -9,6 +9,7 @@ import (
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	formatv3 "github.com/conductorone/baton-sdk/pkg/dotc1z/format/v3"
 )
 
 // TestCloneSyncRoundtrip writes a small sync to a Pebble-backed
@@ -43,6 +44,24 @@ func TestCloneSyncRoundtrip(t *testing.T) {
 	}
 	if _, err := os.Stat(clonePath); err != nil {
 		t.Fatalf("clone file missing: %v", err)
+	}
+	f, err := os.Open(clonePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := formatv3.ReadManifestHeader(f)
+	if cerr := f.Close(); cerr != nil {
+		t.Fatal(cerr)
+	}
+	if err != nil {
+		t.Fatalf("ReadManifestHeader clone: %v", err)
+	}
+	runs := manifest.GetSyncRuns()
+	if len(runs) != 1 {
+		t.Fatalf("clone manifest sync_runs = %d, want 1", len(runs))
+	}
+	if runs[0].GetStats() == nil {
+		t.Fatal("clone manifest sync_run stats is nil")
 	}
 
 	if err := src.Close(ctx); err != nil {

--- a/pkg/dotc1z/engine/pebble/adapter_diff.go
+++ b/pkg/dotc1z/engine/pebble/adapter_diff.go
@@ -81,7 +81,13 @@ func generateSyncDiff(ctx context.Context, a *Adapter, baseSyncID, appliedSyncID
 	if err := a.engine.PutSyncRunRecord(ctx, diffRun); err != nil {
 		return "", fmt.Errorf("generate-diff: put diff sync run: %w", err)
 	}
-	if err := a.engine.SetCurrentSync(diffSyncID); err != nil {
+	// Bind through the ADAPTER so its tracked sync stays in lockstep
+	// with the engine — the diff records below are written via the
+	// engine's current-sync key context (v3 values carry no sync_id).
+	// The binding is left on the diff sync when we return: the diff is
+	// now the latest finished sync, so this matches where SQLite's
+	// latest-finished read resolution would land anyway.
+	if err := a.SetCurrentSync(ctx, diffSyncID); err != nil {
 		return "", fmt.Errorf("generate-diff: set current diff sync: %w", err)
 	}
 

--- a/pkg/dotc1z/engine/pebble/adapter_diff.go
+++ b/pkg/dotc1z/engine/pebble/adapter_diff.go
@@ -81,6 +81,9 @@ func generateSyncDiff(ctx context.Context, a *Adapter, baseSyncID, appliedSyncID
 	if err := a.engine.PutSyncRunRecord(ctx, diffRun); err != nil {
 		return "", fmt.Errorf("generate-diff: put diff sync run: %w", err)
 	}
+	if err := a.engine.SetCurrentSync(diffSyncID); err != nil {
+		return "", fmt.Errorf("generate-diff: set current diff sync: %w", err)
+	}
 
 	// Per-record-type set difference. Each helper iterates the
 	// applied sync's primary keyspace, checks base for the same
@@ -126,8 +129,8 @@ func existsAt(db *pebble.DB, key []byte) (bool, error) {
 }
 
 // diffResourceTypes copies resource_types that exist under
-// appliedBytes but not under baseBytes, rewriting their stored
-// SyncId to the diff sync.
+// appliedBytes but not under baseBytes. The destination sync is
+// supplied by the engine's current-sync key context.
 func diffResourceTypes(ctx context.Context, a *Adapter, baseBytes, appliedBytes []byte, diffSyncID string) error {
 	srcPrefix := encodeResourceTypePrefix(appliedBytes)
 	return iterDiff(ctx, a.engine.DB(), srcPrefix, upperBoundOf(srcPrefix), func(_ []byte, val []byte) error {
@@ -141,7 +144,6 @@ func diffResourceTypes(ctx context.Context, a *Adapter, baseBytes, appliedBytes 
 		} else if exists {
 			return nil
 		}
-		rec.SetSyncId(diffSyncID)
 		return a.engine.PutResourceTypeRecord(ctx, &rec)
 	})
 }
@@ -159,7 +161,6 @@ func diffResources(ctx context.Context, a *Adapter, baseBytes, appliedBytes []by
 		} else if exists {
 			return nil
 		}
-		rec.SetSyncId(diffSyncID)
 		return a.engine.PutResourceRecord(ctx, &rec)
 	})
 }
@@ -177,7 +178,6 @@ func diffEntitlements(ctx context.Context, a *Adapter, baseBytes, appliedBytes [
 		} else if exists {
 			return nil
 		}
-		rec.SetSyncId(diffSyncID)
 		return a.engine.PutEntitlementRecord(ctx, &rec)
 	})
 }
@@ -195,7 +195,6 @@ func diffGrants(ctx context.Context, a *Adapter, baseBytes, appliedBytes []byte,
 		} else if exists {
 			return nil
 		}
-		rec.SetSyncId(diffSyncID)
 		return a.engine.PutGrantRecord(ctx, &rec)
 	})
 }

--- a/pkg/dotc1z/engine/pebble/adapter_diff_test.go
+++ b/pkg/dotc1z/engine/pebble/adapter_diff_test.go
@@ -62,9 +62,9 @@ func TestGenerateSyncDiffAdditionsOnly(t *testing.T) {
 		t.Fatal("GenerateSyncDiff returned empty diffID")
 	}
 
-	if err := store.SetCurrentSync(ctx, diffID); err != nil {
-		t.Fatalf("SetCurrentSync diff: %v", err)
-	}
+	// GenerateSyncDiff leaves the store bound to the diff sync (adapter
+	// and engine in lockstep) — reads must resolve to it with no
+	// explicit SetCurrentSync.
 	resp, err := store.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{}.Build())
 	if err != nil {
 		t.Fatalf("ListGrants diff: %v", err)
@@ -74,6 +74,82 @@ func TestGenerateSyncDiffAdditionsOnly(t *testing.T) {
 	}
 	if got := resp.GetList()[0].GetId(); got != "g3" {
 		t.Fatalf("diff grant id = %q, want g3", got)
+	}
+}
+
+// TestGenerateSyncDiffPersistsAcrossReopen pins the dirty-bit contract:
+// when GenerateSyncDiff is the ONLY mutation on an opened store, Close
+// must still save the envelope, and the diff sync must survive a
+// reopen. Without the pebbleStore FileOps dirty-marking wrapper, the
+// diff would exist only in the discarded temp directory.
+func TestGenerateSyncDiffPersistsAcrossReopen(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "diff-reopen.c1z")
+
+	// Pass 1: write two finished syncs and save.
+	store, err := dotc1z.NewStore(ctx, path, dotc1z.WithEngine(dotc1z.EnginePebble))
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	baseSync, err := store.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.PutGrants(ctx, mkV2Grant("g1", "ent", "user", "alice")); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.EndSync(ctx); err != nil {
+		t.Fatal(err)
+	}
+	appliedSync, err := store.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.PutGrants(ctx,
+		mkV2Grant("g1", "ent", "user", "alice"),
+		mkV2Grant("g2", "ent", "user", "bob"),
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.EndSync(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(ctx); err != nil {
+		t.Fatalf("close pass 1: %v", err)
+	}
+
+	// Pass 2: reopen; the diff is the only mutation before Close.
+	store, err = dotc1z.NewStore(ctx, path, dotc1z.WithEngine(dotc1z.EnginePebble))
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	diffID, err := store.FileOps().GenerateSyncDiff(ctx, baseSync, appliedSync)
+	if err != nil {
+		t.Fatalf("GenerateSyncDiff: %v", err)
+	}
+	if err := store.Close(ctx); err != nil {
+		t.Fatalf("close pass 2: %v", err)
+	}
+
+	// Pass 3: the diff sync must have been saved into the envelope.
+	reopened, err := dotc1z.NewStore(ctx, path, dotc1z.WithReadOnly(true))
+	if err != nil {
+		t.Fatalf("reopen read-only: %v", err)
+	}
+	defer reopened.Close(ctx)
+	if err := reopened.SetCurrentSync(ctx, diffID); err != nil {
+		t.Fatalf("SetCurrentSync diff after reopen: %v", err)
+	}
+	resp, err := reopened.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{}.Build())
+	if err != nil {
+		t.Fatalf("ListGrants diff after reopen: %v", err)
+	}
+	if got := len(resp.GetList()); got != 1 {
+		t.Fatalf("diff ListGrants after reopen = %d, want 1", got)
+	}
+	if got := resp.GetList()[0].GetId(); got != "g2" {
+		t.Fatalf("diff grant id after reopen = %q, want g2", got)
 	}
 }
 

--- a/pkg/dotc1z/engine/pebble/adapter_test.go
+++ b/pkg/dotc1z/engine/pebble/adapter_test.go
@@ -2,6 +2,7 @@ package pebble
 
 import (
 	"context"
+	"errors"
 	"io"
 	"strings"
 	"testing"
@@ -11,6 +12,7 @@ import (
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	reader_v2 "github.com/conductorone/baton-sdk/pb/c1/reader/v2"
+	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
 )
 
@@ -131,6 +133,43 @@ func TestAdapterStartSyncAndPutGrants(t *testing.T) {
 	// EndSync stamps ended_at.
 	if err := a.EndSync(ctx); err != nil {
 		t.Fatalf("EndSync: %v", err)
+	}
+}
+
+func TestAdapterEndSyncClearsEngineCurrentSync(t *testing.T) {
+	ctx := context.Background()
+	a := newAdapter(t)
+
+	syncID, err := a.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	if err != nil {
+		t.Fatalf("StartNewSync: %v", err)
+	}
+	if err := a.PutGrants(ctx, mkV2Grant("g1", "ent-A", "user", "alice")); err != nil {
+		t.Fatalf("PutGrants: %v", err)
+	}
+	if err := a.EndSync(ctx); err != nil {
+		t.Fatalf("EndSync: %v", err)
+	}
+
+	if err := a.engine.PutGrantRecord(ctx, makeGrant(syncID, "g2", "ent-B", "bob")); !errors.Is(err, ErrNoCurrentSync) {
+		t.Fatalf("direct engine write after EndSync: got %v, want ErrNoCurrentSync", err)
+	}
+	if err := a.engine.IterateGrantsByEntitlement(ctx, "", "ent-A", func(*v3.GrantRecord) bool {
+		t.Fatal("iterator should not resolve an ended sync via empty sync id")
+		return false
+	}); !errors.Is(err, ErrNoCurrentSync) {
+		t.Fatalf("direct engine index read after EndSync: got %v, want ErrNoCurrentSync", err)
+	}
+
+	count := 0
+	if err := a.engine.IterateGrantsByEntitlement(ctx, syncID, "ent-A", func(*v3.GrantRecord) bool {
+		count++
+		return true
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("ended sync grant index count = %d, want 1", count)
 	}
 }
 

--- a/pkg/dotc1z/engine/pebble/checkpoint_wal_envelope_test.go
+++ b/pkg/dotc1z/engine/pebble/checkpoint_wal_envelope_test.go
@@ -1,0 +1,66 @@
+package pebble_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble"
+)
+
+// TestSavedC1ZReopensAfterWALTruncation covers the end-to-end close
+// contract through the envelope: sync → Close (save) → reopen the
+// .c1z writable (the connector-resume path) → data intact → run a
+// second sync → close → reopen again. Exercises both the read and
+// write reopen paths against a WAL-free checkpoint payload.
+//
+// Lives in the external test package because it drives the store
+// through dotc1z, which imports this engine package.
+func TestSavedC1ZReopensAfterWALTruncation(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "wal-free.c1z")
+
+	runSync := func(rtID string) string {
+		t.Helper()
+		w, err := dotc1z.NewStore(ctx, path, dotc1z.WithEngine(dotc1z.EnginePebble), dotc1z.WithTmpDir(t.TempDir()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		syncID, err := w.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := w.PutResourceTypes(ctx, v2.ResourceType_builder{Id: rtID}.Build()); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.EndSync(ctx); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.Close(ctx); err != nil {
+			t.Fatal(err)
+		}
+		return syncID
+	}
+
+	first := runSync("user")
+	second := runSync("group")
+
+	// Reopen read-only and verify both syncs survived their round trips.
+	w, err := dotc1z.NewStore(ctx, path, dotc1z.WithReadOnly(true), dotc1z.WithTmpDir(t.TempDir()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = w.Close(ctx) }()
+	eng, ok := pebble.AsEngine(w)
+	if !ok {
+		t.Fatalf("not a pebble store: %T", w)
+	}
+	for _, syncID := range []string{first, second} {
+		if _, err := eng.GetSyncRunRecord(ctx, syncID); err != nil {
+			t.Fatalf("sync %s lost across save/reopen: %v", syncID, err)
+		}
+	}
+}

--- a/pkg/dotc1z/engine/pebble/checkpoint_wal_test.go
+++ b/pkg/dotc1z/engine/pebble/checkpoint_wal_test.go
@@ -1,0 +1,106 @@
+package pebble
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/segmentio/ksuid"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
+)
+
+// TestCheckpointWALsAreEmpty locks in the close/save contract: a
+// checkpoint cut by CheckpointTo carries no WAL bytes. Pebble copies
+// physical WAL files into checkpoints, and WAL recycling fills those
+// files with stale garbage whose replay (CRC mismatch → per-bit
+// bit-flip diagnostic) measured ~23% of total CPU in a 500-source
+// compaction. CheckpointTo flushes first, so truncating the copied
+// WALs to zero loses nothing — and the checkpoint must reopen cleanly
+// with all data intact.
+func TestCheckpointWALsAreEmpty(t *testing.T) {
+	ctx := context.Background()
+	eng, _ := newTestEngine(t)
+	syncID := ksuid.New().String()
+	if err := eng.MarkFreshSync(syncID); err != nil {
+		t.Fatal(err)
+	}
+	if err := eng.PutSyncRunRecord(ctx, v3.SyncRunRecord_builder{
+		SyncId:    syncID,
+		Type:      v3.SyncType_SYNC_TYPE_FULL,
+		StartedAt: timestamppb.Now(),
+		EndedAt:   timestamppb.Now(),
+	}.Build()); err != nil {
+		t.Fatal(err)
+	}
+	grants := make([]*v3.GrantRecord, 0, 100)
+	for i := 0; i < 100; i++ {
+		grants = append(grants, v3.GrantRecord_builder{
+			ExternalId: "grant-" + strconv.Itoa(i),
+			Entitlement: v3.EntitlementRef_builder{
+				ResourceTypeId: "group", ResourceId: "g1", EntitlementId: "member",
+			}.Build(),
+			Principal: v3.PrincipalRef_builder{
+				ResourceTypeId: "user", ResourceId: "u" + strconv.Itoa(i),
+			}.Build(),
+			DiscoveredAt: timestamppb.Now(),
+		}.Build())
+	}
+	if err := eng.PutGrantRecords(ctx, grants...); err != nil {
+		t.Fatal(err)
+	}
+	if err := eng.EndFreshSync(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	ckDir := filepath.Join(t.TempDir(), "checkpoint")
+	if err := eng.CheckpointTo(ctx, ckDir); err != nil {
+		t.Fatalf("CheckpointTo: %v", err)
+	}
+
+	// Every WAL segment in the checkpoint must be zero bytes.
+	entries, err := os.ReadDir(ckDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, ent := range entries {
+		if ent.IsDir() || filepath.Ext(ent.Name()) != ".log" {
+			continue
+		}
+		info, err := ent.Info()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Size() != 0 {
+			t.Fatalf("checkpoint WAL %s has %d bytes, want 0 (stale recycled content leaks into every open)", ent.Name(), info.Size())
+		}
+	}
+
+	// The checkpoint must reopen cleanly (read-only — the compaction
+	// source path) with every record intact.
+	reopened, err := Open(ctx, ckDir, WithReadOnly(true))
+	if err != nil {
+		t.Fatalf("Open checkpoint: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	rec, err := reopened.GetSyncRunRecord(ctx, syncID)
+	if err != nil {
+		t.Fatalf("GetSyncRunRecord: %v", err)
+	}
+	if rec.GetEndedAt() == nil {
+		t.Fatal("reopened sync run lost ended_at")
+	}
+	count := 0
+	if err := reopened.IterateGrantsBySync(ctx, syncID, func(*v3.GrantRecord) bool {
+		count++
+		return true
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if count != 100 {
+		t.Fatalf("reopened grant count = %d, want 100", count)
+	}
+}

--- a/pkg/dotc1z/engine/pebble/engine.go
+++ b/pkg/dotc1z/engine/pebble/engine.go
@@ -210,6 +210,20 @@ func (e *Engine) MarkFreshSync(syncID string) error {
 	return nil
 }
 
+// clearCurrentSync detaches the engine from its current sync and disables
+// fresh-sync write shortcuts. After this, operations that resolve an empty
+// sync_id fail with ErrNoCurrentSync until StartNewSync, ResumeSync, or
+// SetCurrentSync binds a sync again.
+func (e *Engine) clearCurrentSync() {
+	e.currentSyncMu.Lock()
+	e.currentSync = nil
+	e.freshSync = false
+	e.freshGrantsEmpty = false
+	e.freshResourcesEmpty = false
+	e.freshEntitlementsEmpty = false
+	e.currentSyncMu.Unlock()
+}
+
 // IsFreshSync reports whether the engine is in the fresh-sync write
 // path (set by MarkFreshSync).
 func (e *Engine) IsFreshSync() bool {
@@ -260,14 +274,14 @@ func (e *Engine) takeFreshEntitlementsEmpty() bool {
 // + fsyncs the WAL so the data written during the sync is on disk
 // before the caller returns. Called by Adapter.EndSync.
 func (e *Engine) EndFreshSync(ctx context.Context) error {
-	e.currentSyncMu.Lock()
+	e.writeMu.Lock()
+	defer e.writeMu.Unlock()
+
+	e.currentSyncMu.RLock()
 	wasFresh := e.freshSync
-	e.freshSync = false
-	e.freshGrantsEmpty = false
-	e.freshResourcesEmpty = false
-	e.freshEntitlementsEmpty = false
-	e.currentSyncMu.Unlock()
+	e.currentSyncMu.RUnlock()
 	if !wasFresh {
+		e.clearCurrentSync()
 		return nil
 	}
 	// Flush the memtable (turns NoSync-buffered writes into on-disk
@@ -278,6 +292,7 @@ func (e *Engine) EndFreshSync(ctx context.Context) error {
 	if err := e.db.LogData(nil, pebble.Sync); err != nil {
 		return fmt.Errorf("EndFreshSync: fsync WAL: %w", err)
 	}
+	e.clearCurrentSync()
 	return nil
 }
 
@@ -340,6 +355,27 @@ func (e *Engine) withWrite(fn func() error) error {
 	return fn()
 }
 
+// withWriteBarrier serializes a short critical section against all
+// engine writes without permanently quiescing the engine. It is used by
+// snapshotting code that must observe "all writes before the barrier,
+// no writes during the barrier, writes may resume after".
+func (e *Engine) withWriteBarrier(fn func() error) error {
+	if err := e.checkWritable(); err != nil {
+		return err
+	}
+	e.writeWG.Add(1)
+	defer e.writeWG.Done()
+	if e.closing.Load() {
+		return ErrEngineQuiesced
+	}
+	e.writeMu.Lock()
+	defer e.writeMu.Unlock()
+	if err := e.checkWritable(); err != nil {
+		return err
+	}
+	return fn()
+}
+
 func (e *Engine) Save(ctx context.Context, dest string) error {
 	return errors.New("pebble engine: Save requires the dotc1z.Save shim (envelope write); use CheckpointTo for direct directory access")
 }
@@ -393,9 +429,9 @@ func (e *Engine) DB() *pebble.DB { return e.db }
 // destDir. destDir must not exist yet. Pebble creates it and
 // hard-links SSTs where possible.
 //
-// The source engine stays writable after CheckpointTo returns; this
-// is the building block dotc1z's higher-level Save wraps with the v3
-// envelope format.
+// The source engine stays writable after CheckpointTo returns; writes
+// are only blocked while the checkpoint is cut. This is the building
+// block dotc1z's higher-level Save wraps with the v3 envelope format.
 //
 // The explicit Flush is what makes the snapshot WAL-independent:
 // every committed write lands in SSTs before the checkpoint is cut.
@@ -403,22 +439,23 @@ func (e *Engine) DB() *pebble.DB { return e.db }
 // redundant after the flush, and it appends a WAL record, guaranteeing
 // the checkpoint carries a WAL file.
 //
-// Callers must not write to the engine concurrently with CheckpointTo;
-// a write committed between the Flush and the Checkpoint would exist
-// only in the WAL, which truncateCheckpointWALs discards below.
-// dotc1z's save path runs at Close with the store already quiesced, so
-// this holds for all current callers.
+// CheckpointTo takes the engine write barrier for the whole
+// Flush→Checkpoint→truncate window. That prevents a write from
+// committing between the Flush and Checkpoint — such a write would
+// otherwise exist only in the WAL, which truncateCheckpointWALs discards.
 func (e *Engine) CheckpointTo(ctx context.Context, destDir string) error {
-	if err := e.db.Flush(); err != nil {
-		return fmt.Errorf("checkpoint flush: %w", err)
-	}
-	if err := e.db.Checkpoint(destDir); err != nil {
-		return fmt.Errorf("checkpoint: %w", err)
-	}
-	if err := truncateCheckpointWALs(destDir); err != nil {
-		return fmt.Errorf("checkpoint truncate WALs: %w", err)
-	}
-	return nil
+	return e.withWriteBarrier(func() error {
+		if err := e.db.Flush(); err != nil {
+			return fmt.Errorf("checkpoint flush: %w", err)
+		}
+		if err := e.db.Checkpoint(destDir); err != nil {
+			return fmt.Errorf("checkpoint: %w", err)
+		}
+		if err := truncateCheckpointWALs(destDir); err != nil {
+			return fmt.Errorf("checkpoint truncate WALs: %w", err)
+		}
+		return nil
+	})
 }
 
 // truncateCheckpointWALs truncates every WAL segment in a freshly cut

--- a/pkg/dotc1z/engine/pebble/engine.go
+++ b/pkg/dotc1z/engine/pebble/engine.go
@@ -396,12 +396,61 @@ func (e *Engine) DB() *pebble.DB { return e.db }
 // The source engine stays writable after CheckpointTo returns; this
 // is the building block dotc1z's higher-level Save wraps with the v3
 // envelope format.
+//
+// The explicit Flush is what makes the snapshot WAL-independent:
+// every committed write lands in SSTs before the checkpoint is cut.
+// We deliberately do NOT pass pebble.WithFlushedWAL() — it would be
+// redundant after the flush, and it appends a WAL record, guaranteeing
+// the checkpoint carries a WAL file.
+//
+// Callers must not write to the engine concurrently with CheckpointTo;
+// a write committed between the Flush and the Checkpoint would exist
+// only in the WAL, which truncateCheckpointWALs discards below.
+// dotc1z's save path runs at Close with the store already quiesced, so
+// this holds for all current callers.
 func (e *Engine) CheckpointTo(ctx context.Context, destDir string) error {
 	if err := e.db.Flush(); err != nil {
 		return fmt.Errorf("checkpoint flush: %w", err)
 	}
-	if err := e.db.Checkpoint(destDir, pebble.WithFlushedWAL()); err != nil {
+	if err := e.db.Checkpoint(destDir); err != nil {
 		return fmt.Errorf("checkpoint: %w", err)
+	}
+	if err := truncateCheckpointWALs(destDir); err != nil {
+		return fmt.Errorf("checkpoint truncate WALs: %w", err)
+	}
+	return nil
+}
+
+// truncateCheckpointWALs truncates every WAL segment in a freshly cut
+// checkpoint directory to zero bytes.
+//
+// Why: pebble copies WAL files into checkpoints wholesale
+// (checkpoint.go: recycling makes hard-links unsafe), and WAL
+// recycling means the copied file's physical content is mostly stale
+// records from the file's previous life. Replaying that on every
+// subsequent open is expensive — stale chunks fail their CRC and
+// trigger pebble's per-bit bit-flip corruption diagnostic
+// (record.Reader.nextChunk → bitflip.CheckSliceForBitFlip). Profiling
+// a 500-source compaction showed WAL replay at ~23% of total CPU.
+//
+// After CheckpointTo's flush there is no unflushed data, so the WAL
+// carries nothing the checkpoint needs. We truncate rather than delete:
+// a zero-length WAL is indistinguishable from a freshly created one
+// (replay reads a clean EOF), whereas deleting the file would change
+// the file set pebble's open sequence discovers and validates against
+// the manifest's minUnflushedLogNum.
+func truncateCheckpointWALs(destDir string) error {
+	entries, err := os.ReadDir(destDir)
+	if err != nil {
+		return err
+	}
+	for _, ent := range entries {
+		if ent.IsDir() || filepath.Ext(ent.Name()) != ".log" {
+			continue
+		}
+		if err := os.Truncate(filepath.Join(destDir, ent.Name()), 0); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/dotc1z/engine/pebble/engine_test.go
+++ b/pkg/dotc1z/engine/pebble/engine_test.go
@@ -57,7 +57,6 @@ func regularFileSizeUnder(t *testing.T, dir string) int64 {
 // makeGrant returns a fully-populated GrantRecord under the given sync.
 func makeGrant(syncID, externalID, entID, principalID string) *v3.GrantRecord {
 	return v3.GrantRecord_builder{
-		SyncId:     syncID,
 		ExternalId: externalID,
 		Entitlement: v3.EntitlementRef_builder{
 			ResourceTypeId: "app",

--- a/pkg/dotc1z/engine/pebble/entitlements.go
+++ b/pkg/dotc1z/engine/pebble/entitlements.go
@@ -39,9 +39,13 @@ func (e *Engine) PutEntitlementRecords(ctx context.Context, records ...*v3.Entit
 
 		fresh := e.IsFreshSync()
 		skipGet := e.takeFreshEntitlementsEmpty()
+		idBytes, err := e.resolveSyncBytes("")
+		if err != nil {
+			return err
+		}
 
 		type dedupKey struct {
-			syncID, extID string
+			extID string
 		}
 		var dedup map[dedupKey]int
 		if len(records) > 1 {
@@ -50,38 +54,18 @@ func (e *Engine) PutEntitlementRecords(ctx context.Context, records ...*v3.Entit
 				if r == nil {
 					continue
 				}
-				dedup[dedupKey{r.GetSyncId(), r.GetExternalId()}] = i
+				dedup[dedupKey{r.GetExternalId()}] = i
 			}
 		}
 
-		var (
-			lastSyncIDStr string
-			lastIDBytes   []byte
-			haveLast      bool
-		)
 		for i, r := range records {
 			if r == nil {
 				continue
 			}
 			if dedup != nil {
-				if dedup[dedupKey{r.GetSyncId(), r.GetExternalId()}] != i {
+				if dedup[dedupKey{r.GetExternalId()}] != i {
 					continue
 				}
-			}
-			var (
-				idBytes []byte
-				err     error
-			)
-			if sid := r.GetSyncId(); haveLast && sid == lastSyncIDStr {
-				idBytes = lastIDBytes
-			} else {
-				idBytes, err = e.resolveSyncBytes(sid)
-				if err != nil {
-					return err
-				}
-				lastSyncIDStr = sid
-				lastIDBytes = idBytes
-				haveLast = true
 			}
 			key := encodeEntitlementKey(idBytes, r.GetExternalId())
 			val, err := marshalRecord(r)
@@ -92,12 +76,7 @@ func (e *Engine) PutEntitlementRecords(ctx context.Context, records ...*v3.Entit
 				oldVal, closer, getErr := e.db.Get(key)
 				switch {
 				case getErr == nil:
-					old := &v3.EntitlementRecord{}
-					if err := unmarshalRecord(oldVal, old); err != nil {
-						closer.Close()
-						return fmt.Errorf("PutEntitlementRecords: unmarshal old %q: %w", r.GetExternalId(), err)
-					}
-					if err := e.deleteEntitlementIndexes(idxBatch, idBytes, old); err != nil {
+					if err := e.deleteEntitlementIndexesRaw(idxBatch, idBytes, r.GetExternalId(), oldVal); err != nil {
 						closer.Close()
 						return err
 					}
@@ -159,12 +138,7 @@ func (e *Engine) DeleteEntitlementRecord(ctx context.Context, syncID, externalID
 			}
 			return err
 		}
-		old := &v3.EntitlementRecord{}
-		if err := unmarshalRecord(oldVal, old); err != nil {
-			closer.Close()
-			return fmt.Errorf("DeleteEntitlementRecord: unmarshal old %q: %w", externalID, err)
-		}
-		if err := e.deleteEntitlementIndexes(batch, idBytes, old); err != nil {
+		if err := e.deleteEntitlementIndexesRaw(batch, idBytes, externalID, oldVal); err != nil {
 			closer.Close()
 			return err
 		}
@@ -187,19 +161,6 @@ func (e *Engine) writeEntitlementIndexes(batch *pebble.Batch, syncIDBytes []byte
 		r.GetExternalId(),
 	)
 	return batch.Set(k, nil, nil)
-}
-
-func (e *Engine) deleteEntitlementIndexes(batch *pebble.Batch, syncIDBytes []byte, r *v3.EntitlementRecord) error {
-	res := r.GetResource()
-	if res == nil || res.GetResourceId() == "" {
-		return nil
-	}
-	k := encodeEntitlementByResourceIndexKey(
-		syncIDBytes,
-		res.GetResourceTypeId(), res.GetResourceId(),
-		r.GetExternalId(),
-	)
-	return batch.Delete(k, nil)
 }
 
 func (e *Engine) IterateEntitlementsBySync(ctx context.Context, syncID string, yield func(*v3.EntitlementRecord) bool) error {

--- a/pkg/dotc1z/engine/pebble/grant_read_arena_test.go
+++ b/pkg/dotc1z/engine/pebble/grant_read_arena_test.go
@@ -26,7 +26,6 @@ func TestGrantReadArenaReconcileAbsent(t *testing.T) {
 	// fields). This is the on-wire shape the reconcile pass exists
 	// to recover.
 	r := v3.GrantRecord_builder{
-		SyncId:     syncID,
 		ExternalId: "bare",
 	}.Build()
 	if err := e.PutGrantRecord(ctx, r); err != nil {

--- a/pkg/dotc1z/engine/pebble/grant_write_scale_bench_test.go
+++ b/pkg/dotc1z/engine/pebble/grant_write_scale_bench_test.go
@@ -62,7 +62,6 @@ func makeGrantRecordBatch(syncID string, offset, count int) []*v3.GrantRecord {
 		pr.SetResourceId("u" + strconv.Itoa(id))
 
 		r := &v3.GrantRecord{}
-		r.SetSyncId(syncID)
 		r.SetExternalId("grant-" + strconv.Itoa(id))
 		r.SetEntitlement(ent)
 		r.SetPrincipal(pr)

--- a/pkg/dotc1z/engine/pebble/grants.go
+++ b/pkg/dotc1z/engine/pebble/grants.go
@@ -80,14 +80,19 @@ func (e *Engine) PutGrantRecords(ctx context.Context, records ...*v3.GrantRecord
 		// in-sync calls already committed (e.g. paginated sources
 		// emitting an external_id on two pages).
 		skipGet := e.takeFreshGrantsEmpty()
+		// GrantRecord values do not carry sync_id in v3; records are
+		// written under the engine's currently bound sync.
+		idBytes, err := e.resolveSyncBytes("")
+		if err != nil {
+			return err
+		}
 
 		// Dedup pre-pass: keep only the LAST occurrence of each
-		// (sync_id, external_id). The map value is the records[]
+		// external_id. The map value is the records[]
 		// index — when we re-iterate, we process record i only if
-		// dedup[(sync,ext)] == i.
+		// dedup[ext] == i.
 		type dedupKey struct {
-			syncID string
-			extID  string
+			extID string
 		}
 		var dedup map[dedupKey]int
 		if len(records) > 1 {
@@ -96,42 +101,18 @@ func (e *Engine) PutGrantRecords(ctx context.Context, records ...*v3.GrantRecord
 				if r == nil {
 					continue
 				}
-				dedup[dedupKey{r.GetSyncId(), r.GetExternalId()}] = i
+				dedup[dedupKey{r.GetExternalId()}] = i
 			}
 		}
 
-		// Cache the resolved sync_id across records sharing the same
-		// string. The adapter's V2→V3 translator stamps every record
-		// with the engine's current sync, so the common case is one
-		// distinct sync_id per call.
-		var (
-			lastSyncIDStr string
-			lastIDBytes   []byte
-			haveLast      bool
-		)
 		for i, r := range records {
 			if r == nil {
 				continue
 			}
 			if dedup != nil {
-				if dedup[dedupKey{r.GetSyncId(), r.GetExternalId()}] != i {
+				if dedup[dedupKey{r.GetExternalId()}] != i {
 					continue
 				}
-			}
-			var (
-				idBytes []byte
-				err     error
-			)
-			if sid := r.GetSyncId(); haveLast && sid == lastSyncIDStr {
-				idBytes = lastIDBytes
-			} else {
-				idBytes, err = e.resolveSyncBytes(sid)
-				if err != nil {
-					return err
-				}
-				lastSyncIDStr = sid
-				lastIDBytes = idBytes
-				haveLast = true
 			}
 			key := encodeGrantKey(idBytes, r.GetExternalId())
 			val, err := marshalRecord(r)
@@ -142,12 +123,7 @@ func (e *Engine) PutGrantRecords(ctx context.Context, records ...*v3.GrantRecord
 				oldVal, closer, getErr := e.db.Get(key)
 				switch {
 				case getErr == nil:
-					old := &v3.GrantRecord{}
-					if err := unmarshalRecord(oldVal, old); err != nil {
-						closer.Close()
-						return fmt.Errorf("PutGrantRecords: unmarshal old %q: %w", r.GetExternalId(), err)
-					}
-					if err := e.deleteGrantIndexes(idxBatch, idBytes, old); err != nil {
+					if err := e.deleteGrantIndexesRaw(idxBatch, idBytes, r.GetExternalId(), oldVal); err != nil {
 						closer.Close()
 						return err
 					}
@@ -198,22 +174,9 @@ func (e *Engine) UnsafePutUniqueGrantRecords(ctx context.Context, records ...*v3
 		if !e.IsFreshSync() {
 			return errors.New("UnsafePutUniqueGrantRecords: sync is not fresh")
 		}
-		// Resolve sync_id bytes once per distinct sync_id (usually one) on the
-		// calling goroutine so the parallel encoders only read the map.
-		syncBytes := make(map[string][]byte)
-		for _, r := range records {
-			if r == nil {
-				continue
-			}
-			sid := r.GetSyncId()
-			if _, ok := syncBytes[sid]; ok {
-				continue
-			}
-			idBytes, err := e.resolveSyncBytes(sid)
-			if err != nil {
-				return err
-			}
-			syncBytes[sid] = idBytes
+		idBytes, err := e.resolveSyncBytes("")
+		if err != nil {
+			return err
 		}
 
 		type encoded struct {
@@ -254,7 +217,6 @@ func (e *Engine) UnsafePutUniqueGrantRecords(ctx context.Context, records ...*v3
 					if r == nil {
 						continue
 					}
-					idBytes := syncBytes[r.GetSyncId()]
 					val, err := marshalRecord(r)
 					if err != nil {
 						errMu.Lock()
@@ -346,12 +308,7 @@ func (e *Engine) DeleteGrantRecord(ctx context.Context, syncID, externalID strin
 			}
 			return err
 		}
-		old := &v3.GrantRecord{}
-		if err := unmarshalRecord(oldVal, old); err != nil {
-			closer.Close()
-			return fmt.Errorf("DeleteGrantRecord: unmarshal old %q: %w", externalID, err)
-		}
-		if err := e.deleteGrantIndexes(batch, idBytes, old); err != nil {
+		if err := e.deleteGrantIndexesRaw(batch, idBytes, externalID, oldVal); err != nil {
 			closer.Close()
 			return err
 		}
@@ -403,66 +360,6 @@ func (e *Engine) writeGrantIndexes(batch *pebble.Batch, syncIDBytes []byte, r *v
 		if err := batch.Set(k, nil, nil); err != nil {
 			return err
 		}
-	}
-	return nil
-}
-
-// deleteGrantIndexes mirrors writeGrantIndexes but with batch.Delete.
-func (e *Engine) deleteGrantIndexes(batch *pebble.Batch, syncIDBytes []byte, r *v3.GrantRecord) error {
-	ent := r.GetEntitlement()
-	princ := r.GetPrincipal()
-	ext := r.GetExternalId()
-
-	if ent != nil && princ != nil {
-		k := encodeGrantByEntitlementIndexKey(
-			syncIDBytes,
-			ent.GetEntitlementId(),
-			princ.GetResourceTypeId(),
-			princ.GetResourceId(),
-			ext,
-		)
-		if err := batch.Delete(k, nil); err != nil {
-			return err
-		}
-	}
-	if ent != nil && ent.GetResourceId() != "" {
-		k := encodeGrantByEntitlementResourceIndexKey(
-			syncIDBytes,
-			ent.GetResourceTypeId(),
-			ent.GetResourceId(),
-			ext,
-		)
-		if err := batch.Delete(k, nil); err != nil {
-			return err
-		}
-	}
-	if princ != nil {
-		k := encodeGrantByPrincipalIndexKey(
-			syncIDBytes,
-			princ.GetResourceTypeId(),
-			princ.GetResourceId(),
-			ext,
-		)
-		if err := batch.Delete(k, nil); err != nil {
-			return err
-		}
-		kRT := encodeGrantByPrincipalResourceTypeIndexKey(
-			syncIDBytes,
-			princ.GetResourceTypeId(),
-			ext,
-		)
-		if err := batch.Delete(kRT, nil); err != nil {
-			return err
-		}
-	}
-	// Always Delete the needs_expansion key, even when the old
-	// record didn't carry the flag. Delete on a non-existent key
-	// is a Pebble no-op, so this is cheaper than checking the
-	// flag first and gives correct behavior when a connector
-	// flips needs_expansion=false on a subsequent write of the
-	// same external_id.
-	if err := batch.Delete(encodeGrantByNeedsExpansionIndexKey(syncIDBytes, ext), nil); err != nil {
-		return err
 	}
 	return nil
 }

--- a/pkg/dotc1z/engine/pebble/if_newer.go
+++ b/pkg/dotc1z/engine/pebble/if_newer.go
@@ -37,31 +37,33 @@ func (e *Engine) PutGrantRecordsIfNewer(ctx context.Context, records ...*v3.Gran
 	return e.withWrite(func() error {
 		batch := e.db.NewBatch()
 		defer batch.Close()
+		idBytes, err := e.resolveSyncBytes("")
+		if err != nil {
+			return err
+		}
 		written := 0
 		for _, r := range records {
 			if r == nil {
 				continue
 			}
-			idBytes, err := e.resolveSyncBytes(r.GetSyncId())
-			if err != nil {
-				return err
-			}
 			key := encodeGrantKey(idBytes, r.GetExternalId())
 			oldVal, closer, getErr := e.db.Get(key)
 			switch {
 			case getErr == nil:
-				old := &v3.GrantRecord{}
-				if err := unmarshalRecord(oldVal, old); err != nil {
+				write, err := discoveredAtIsNewerThanRaw(r.GetDiscoveredAt(), oldVal, grantDiscoveredAtField)
+				if err != nil {
 					closer.Close()
-					return fmt.Errorf("PutGrantRecordsIfNewer: unmarshal old: %w", err)
+					return fmt.Errorf("PutGrantRecordsIfNewer: scan old discovered_at: %w", err)
 				}
-				closer.Close()
-				if !discoveredAtIsNewer(r.GetDiscoveredAt(), old.GetDiscoveredAt()) {
+				if !write {
+					closer.Close()
 					continue
 				}
-				if err := e.deleteGrantIndexes(batch, idBytes, old); err != nil {
+				if err := e.deleteGrantIndexesRaw(batch, idBytes, r.GetExternalId(), oldVal); err != nil {
+					closer.Close()
 					return err
 				}
+				closer.Close()
 			case errors.Is(getErr, pebble.ErrNotFound):
 				// no existing record — write unconditionally
 			default:
@@ -95,31 +97,33 @@ func (e *Engine) PutResourceRecordsIfNewer(ctx context.Context, records ...*v3.R
 	return e.withWrite(func() error {
 		batch := e.db.NewBatch()
 		defer batch.Close()
+		idBytes, err := e.resolveSyncBytes("")
+		if err != nil {
+			return err
+		}
 		written := 0
 		for _, r := range records {
 			if r == nil {
 				continue
 			}
-			idBytes, err := e.resolveSyncBytes(r.GetSyncId())
-			if err != nil {
-				return err
-			}
 			key := encodeResourceKey(idBytes, r.GetResourceTypeId(), r.GetResourceId())
 			oldVal, closer, getErr := e.db.Get(key)
 			switch {
 			case getErr == nil:
-				old := &v3.ResourceRecord{}
-				if err := unmarshalRecord(oldVal, old); err != nil {
+				write, err := discoveredAtIsNewerThanRaw(r.GetDiscoveredAt(), oldVal, resourceDiscoveredAtField)
+				if err != nil {
 					closer.Close()
-					return fmt.Errorf("PutResourceRecordsIfNewer: unmarshal old: %w", err)
+					return fmt.Errorf("PutResourceRecordsIfNewer: scan old discovered_at: %w", err)
 				}
-				closer.Close()
-				if !discoveredAtIsNewer(r.GetDiscoveredAt(), old.GetDiscoveredAt()) {
+				if !write {
+					closer.Close()
 					continue
 				}
-				if err := e.deleteResourceIndexes(batch, idBytes, old); err != nil {
+				if err := e.deleteResourceIndexesRaw(batch, idBytes, r.GetResourceTypeId(), r.GetResourceId(), oldVal); err != nil {
+					closer.Close()
 					return err
 				}
+				closer.Close()
 			case errors.Is(getErr, pebble.ErrNotFound):
 			default:
 				return fmt.Errorf("PutResourceRecordsIfNewer: get: %w", getErr)
@@ -151,31 +155,33 @@ func (e *Engine) PutEntitlementRecordsIfNewer(ctx context.Context, records ...*v
 	return e.withWrite(func() error {
 		batch := e.db.NewBatch()
 		defer batch.Close()
+		idBytes, err := e.resolveSyncBytes("")
+		if err != nil {
+			return err
+		}
 		written := 0
 		for _, r := range records {
 			if r == nil {
 				continue
 			}
-			idBytes, err := e.resolveSyncBytes(r.GetSyncId())
-			if err != nil {
-				return err
-			}
 			key := encodeEntitlementKey(idBytes, r.GetExternalId())
 			oldVal, closer, getErr := e.db.Get(key)
 			switch {
 			case getErr == nil:
-				old := &v3.EntitlementRecord{}
-				if err := unmarshalRecord(oldVal, old); err != nil {
+				write, err := discoveredAtIsNewerThanRaw(r.GetDiscoveredAt(), oldVal, entitlementDiscoveredAtField)
+				if err != nil {
 					closer.Close()
-					return fmt.Errorf("PutEntitlementRecordsIfNewer: unmarshal old: %w", err)
+					return fmt.Errorf("PutEntitlementRecordsIfNewer: scan old discovered_at: %w", err)
 				}
-				closer.Close()
-				if !discoveredAtIsNewer(r.GetDiscoveredAt(), old.GetDiscoveredAt()) {
+				if !write {
+					closer.Close()
 					continue
 				}
-				if err := e.deleteEntitlementIndexes(batch, idBytes, old); err != nil {
+				if err := e.deleteEntitlementIndexesRaw(batch, idBytes, r.GetExternalId(), oldVal); err != nil {
+					closer.Close()
 					return err
 				}
+				closer.Close()
 			case errors.Is(getErr, pebble.ErrNotFound):
 			default:
 				return fmt.Errorf("PutEntitlementRecordsIfNewer: get: %w", getErr)
@@ -207,26 +213,26 @@ func (e *Engine) PutResourceTypeRecordsIfNewer(ctx context.Context, records ...*
 	return e.withWrite(func() error {
 		batch := e.db.NewBatch()
 		defer batch.Close()
+		idBytes, err := e.resolveSyncBytes("")
+		if err != nil {
+			return err
+		}
 		written := 0
 		for _, r := range records {
 			if r == nil {
 				continue
 			}
-			idBytes, err := e.resolveSyncBytes(r.GetSyncId())
-			if err != nil {
-				return err
-			}
 			key := encodeResourceTypeKey(idBytes, r.GetExternalId())
 			oldVal, closer, getErr := e.db.Get(key)
 			switch {
 			case getErr == nil:
-				old := &v3.ResourceTypeRecord{}
-				if err := unmarshalRecord(oldVal, old); err != nil {
+				write, err := discoveredAtIsNewerThanRaw(r.GetDiscoveredAt(), oldVal, resourceTypeDiscoveredAtField)
+				if err != nil {
 					closer.Close()
-					return fmt.Errorf("PutResourceTypeRecordsIfNewer: unmarshal old: %w", err)
+					return fmt.Errorf("PutResourceTypeRecordsIfNewer: scan old discovered_at: %w", err)
 				}
 				closer.Close()
-				if !discoveredAtIsNewer(r.GetDiscoveredAt(), old.GetDiscoveredAt()) {
+				if !write {
 					continue
 				}
 			case errors.Is(getErr, pebble.ErrNotFound):

--- a/pkg/dotc1z/engine/pebble/index_migrations_test.go
+++ b/pkg/dotc1z/engine/pebble/index_migrations_test.go
@@ -52,7 +52,6 @@ func TestApplyIndexMigrationsBackfillsNeedsExpansion(t *testing.T) {
 	// written by an older engine that didn't know about
 	// idxGrantByNeedsExpansion.
 	rec := v3.GrantRecord_builder{
-		SyncId:     syncID,
 		ExternalId: "g-pending",
 		Entitlement: v3.EntitlementRef_builder{
 			ResourceTypeId: "app", ResourceId: "github", EntitlementId: "ent-A",

--- a/pkg/dotc1z/engine/pebble/manifest.go
+++ b/pkg/dotc1z/engine/pebble/manifest.go
@@ -1,7 +1,14 @@
 package pebble
 
 import (
+	"context"
+	"fmt"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
+
 	c1zv3 "github.com/conductorone/baton-sdk/pb/c1/c1z/v3"
+	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
 	formatv3 "github.com/conductorone/baton-sdk/pkg/dotc1z/format/v3"
 )
@@ -20,6 +27,59 @@ func BuildManifest(encoding c1zstore.PayloadEncoding) (*c1zv3.C1ZManifestV3, err
 		PayloadEncoding:     payloadEncodingToProto(encoding),
 		Descriptors:         descriptors,
 	}.Build(), nil
+}
+
+// BuildManifestWithSyncRuns assembles the manifest including the
+// sync-run projection from e. Used by pkg/dotc1z's Pebble store when
+// saving the envelope at Close, so readers can enumerate syncs and
+// read row counts from the envelope header without unpacking the
+// Pebble payload (consumed by compaction source selection via
+// formatv3.ReadManifestHeader).
+func BuildManifestWithSyncRuns(ctx context.Context, e *Engine, encoding c1zstore.PayloadEncoding) (*c1zv3.C1ZManifestV3, error) {
+	m, err := BuildManifest(encoding)
+	if err != nil {
+		return nil, err
+	}
+	syncRuns, err := syncRunSummaries(ctx, e)
+	if err != nil {
+		return nil, err
+	}
+	m.SetSyncRuns(syncRuns)
+	return m, nil
+}
+
+// syncRunSummaries projects every sync_run record (plus its stats
+// sidecar, when present) into manifest summaries.
+//
+// A stats sidecar read failure downgrades to a summary without stats
+// (the consumer falls back to opening the payload) rather than failing
+// the save — stats are advisory; the payload remains authoritative.
+func syncRunSummaries(ctx context.Context, e *Engine) ([]*c1zv3.SyncRunSummary, error) {
+	var out []*c1zv3.SyncRunSummary
+	l := ctxzap.Extract(ctx)
+	err := e.IterateAllSyncRuns(ctx, func(r *v3.SyncRunRecord) bool {
+		stats, serr := e.readSyncStats(ctx, r.GetSyncId())
+		if serr != nil {
+			l.Warn("pebble: manifest sync-run projection: stats sidecar read failed; writing summary without stats",
+				zap.String("sync_id", r.GetSyncId()),
+				zap.Error(serr),
+			)
+			stats = nil
+		}
+		out = append(out, c1zv3.SyncRunSummary_builder{
+			SyncId:       r.GetSyncId(),
+			Type:         r.GetType(),
+			StartedAt:    r.GetStartedAt(),
+			EndedAt:      r.GetEndedAt(),
+			ParentSyncId: r.GetParentSyncId(),
+			Stats:        stats,
+		}.Build())
+		return true
+	})
+	if err != nil {
+		return nil, fmt.Errorf("pebble: manifest sync-run projection: %w", err)
+	}
+	return out, nil
 }
 
 // payloadEncodingToProto maps the public c1zstore.PayloadEncoding to

--- a/pkg/dotc1z/engine/pebble/manifest_projection_test.go
+++ b/pkg/dotc1z/engine/pebble/manifest_projection_test.go
@@ -1,0 +1,105 @@
+package pebble_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	formatv3 "github.com/conductorone/baton-sdk/pkg/dotc1z/format/v3"
+)
+
+// TestManifestSyncRunProjection locks in the envelope's sync-run
+// projection: after a sync is written and the store saved, the v3
+// manifest header alone (no payload unpack) must carry the sync run
+// and its stats sidecar. This is what lets compaction source selection
+// and overlay bucket planning skip unpacking sources entirely.
+func TestManifestSyncRunProjection(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "projection.c1z")
+	w, err := dotc1z.NewStore(ctx, path, dotc1z.WithEngine(dotc1z.EnginePebble), dotc1z.WithTmpDir(t.TempDir()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	syncID, err := w.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	if err := w.PutResourceTypes(ctx, userRT, groupRT); err != nil {
+		t.Fatal(err)
+	}
+	user := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build()}.Build()
+	group := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	if err := w.PutResources(ctx, user, group); err != nil {
+		t.Fatal(err)
+	}
+	ent := v2.Entitlement_builder{Id: "ent-1", Resource: group}.Build()
+	if err := w.PutEntitlements(ctx, ent); err != nil {
+		t.Fatal(err)
+	}
+	grant := v2.Grant_builder{Id: "grant-1", Entitlement: ent, Principal: user}.Build()
+	if err := w.PutGrants(ctx, grant); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.EndSync(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	m, err := formatv3.ReadManifestHeader(f)
+	if err != nil {
+		t.Fatalf("ReadManifestHeader: %v", err)
+	}
+	runs := m.GetSyncRuns()
+	if len(runs) != 1 {
+		t.Fatalf("manifest sync_runs = %d, want 1", len(runs))
+	}
+	run := runs[0]
+	if run.GetSyncId() != syncID {
+		t.Fatalf("summary sync_id = %q, want %q", run.GetSyncId(), syncID)
+	}
+	if run.GetEndedAt() == nil {
+		t.Fatal("summary ended_at is nil for a finished sync")
+	}
+	stats := run.GetStats()
+	if stats == nil {
+		t.Fatal("summary stats is nil; expected stats sidecar projection")
+	}
+	if got, want := stats.GetResourceTypes(), int64(2); got != want {
+		t.Fatalf("stats resource_types = %d, want %d", got, want)
+	}
+	if got, want := stats.GetResources(), int64(2); got != want {
+		t.Fatalf("stats resources = %d, want %d", got, want)
+	}
+	if got, want := stats.GetEntitlements(), int64(1); got != want {
+		t.Fatalf("stats entitlements = %d, want %d", got, want)
+	}
+	if got, want := stats.GetGrants(), int64(1); got != want {
+		t.Fatalf("stats grants = %d, want %d", got, want)
+	}
+
+	// The engine-dispatch header path must surface the same projection.
+	if _, err := f.Seek(0, 0); err != nil {
+		t.Fatal(err)
+	}
+	env, err := formatv3.ReadEnvelopeHeader(f)
+	if err != nil {
+		t.Fatalf("ReadEnvelopeHeader: %v", err)
+	}
+	defer env.Close()
+	if got := len(env.Manifest.GetSyncRuns()); got != 1 {
+		t.Fatalf("ReadEnvelopeHeader sync_runs = %d, want 1", got)
+	}
+}

--- a/pkg/dotc1z/engine/pebble/merge_accessor.go
+++ b/pkg/dotc1z/engine/pebble/merge_accessor.go
@@ -1,7 +1,13 @@
 package pebble
 
 import (
+	"context"
+	"errors"
+
+	reader_v2 "github.com/conductorone/baton-sdk/pb/c1/reader/v2"
+	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/codec"
 )
 
 // engineAccessor is implemented by *Adapter and by pkg/dotc1z's Pebble
@@ -33,4 +39,300 @@ func AsEngine(w connectorstore.Writer) (*Engine, bool) {
 		}
 	}
 	return nil, false
+}
+
+// ReadSyncStatsRecord returns the raw stats sidecar record for a sync,
+// or (nil, nil) when no sidecar exists. Exposed for synccompactor
+// tests that compare merge-accumulated stats against a recompute.
+func ReadSyncStatsRecord(ctx context.Context, e *Engine, syncID string) (*v3.SyncStatsRecord, error) {
+	if e == nil {
+		return nil, nil
+	}
+	return e.readSyncStats(ctx, syncID)
+}
+
+// SyncStatsFromRecord converts the engine-internal stats sidecar shape
+// into the public reader stats type used by C1ZStore APIs and compactor
+// planning. The public type intentionally has no assets field, so assets
+// remain available only on the sidecar record.
+func SyncStatsFromRecord(stats *v3.SyncStatsRecord) *reader_v2.SyncStats {
+	if stats == nil {
+		return nil
+	}
+	return reader_v2.SyncStats_builder{
+		ResourceTypes:           stats.GetResourceTypes(),
+		Resources:               stats.GetResources(),
+		Entitlements:            stats.GetEntitlements(),
+		Grants:                  stats.GetGrants(),
+		ResourcesByResourceType: stats.GetResourcesByResourceType(),
+		GrantsByResourceType:    stats.GetGrantsByEntitlementResourceType(),
+	}.Build()
+}
+
+func CachedSyncStats(ctx context.Context, e *Engine, syncID string) (*reader_v2.SyncStats, bool, error) {
+	if e == nil {
+		return nil, false, nil
+	}
+	stats, err := e.readSyncStats(ctx, syncID)
+	if err != nil {
+		return nil, false, err
+	}
+	if stats == nil {
+		return nil, false, nil
+	}
+	return SyncStatsFromRecord(stats), true, nil
+}
+
+// engineOnlyCloser and fixtureNormalizer are implemented by
+// pkg/dotc1z's Pebble store wrapper (pebbleStore). The wrapper lives in
+// dotc1z, which imports this package, so the engine side dispatches on
+// interfaces instead of the concrete type.
+type engineOnlyCloser interface {
+	CloseEngineOnly() error
+}
+
+type fixtureNormalizer interface {
+	NormalizeForFixtureSave(ctx context.Context, syncID string) error
+}
+
+// CloseEngineOnly closes the Pebble engine inside a store wrapper without
+// removing that store's unpacked temp directory. This is useful when a caller
+// owns a parent temp directory and wants one bulk cleanup after closing many
+// read-only source stores.
+func CloseEngineOnly(w connectorstore.Writer) error {
+	switch s := w.(type) {
+	case engineOnlyCloser:
+		return s.CloseEngineOnly()
+	case *Adapter:
+		if s == nil || s.engine == nil {
+			return nil
+		}
+		return s.engine.Close()
+	default:
+		return nil
+	}
+}
+
+// NormalizeForFixtureSave flushes and compacts one sync in a Pebble
+// store, then marks the wrapper dirty so Close writes a fresh c1z envelope.
+// This is intentionally narrow: benchmark fixtures should not measure WAL
+// replay or un-compacted LSM shape left over from fixture generation.
+func NormalizeForFixtureSave(ctx context.Context, w connectorstore.Writer, syncID string) error {
+	s, ok := w.(fixtureNormalizer)
+	if !ok {
+		return errors.New("pebble NormalizeForFixtureSave: writer is not a pebble store wrapper")
+	}
+	return s.NormalizeForFixtureSave(ctx, syncID)
+}
+
+func ResourceTypeRecordKey(syncIDBytes []byte, externalID string) []byte {
+	return encodeResourceTypeKey(syncIDBytes, externalID)
+}
+
+func ResourceRecordKey(syncIDBytes []byte, resourceTypeID string, resourceID string) []byte {
+	return encodeResourceKey(syncIDBytes, resourceTypeID, resourceID)
+}
+
+func EntitlementRecordKey(syncIDBytes []byte, externalID string) []byte {
+	return encodeEntitlementKey(syncIDBytes, externalID)
+}
+
+func GrantRecordKey(syncIDBytes []byte, externalID string) []byte {
+	return encodeGrantKey(syncIDBytes, externalID)
+}
+
+func ResourceIndexKeys(syncIDBytes []byte, r *v3.ResourceRecord) [][]byte {
+	parent := r.GetParent()
+	if parent == nil || parent.GetResourceId() == "" {
+		return nil
+	}
+	return [][]byte{encodeResourceByParentIndexKey(syncIDBytes, parent.GetResourceTypeId(), parent.GetResourceId(), r.GetResourceTypeId(), r.GetResourceId())}
+}
+
+func ForEachResourceIndexKey(syncIDBytes []byte, r *v3.ResourceRecord, yield func([]byte) error) error {
+	parent := r.GetParent()
+	if parent == nil || parent.GetResourceId() == "" {
+		return nil
+	}
+	return yield(encodeResourceByParentIndexKey(syncIDBytes, parent.GetResourceTypeId(), parent.GetResourceId(), r.GetResourceTypeId(), r.GetResourceId()))
+}
+
+func ForEachResourceIndexKeyRaw(syncIDBytes []byte, parentRT string, parentID string, resourceTypeID string, resourceID string, yield func([]byte) error) error {
+	if parentID == "" {
+		return nil
+	}
+	return yield(encodeResourceByParentIndexKey(syncIDBytes, parentRT, parentID, resourceTypeID, resourceID))
+}
+
+// Byte-slice appenders let merge/overlay code build index keys from borrowed
+// protobuf string bytes. Avoiding intermediate string conversion was the last
+// large allocation drop in the same-size syncs=50 overlay profile (~2.4M to
+// ~0.8M allocs/op, combined with scratch reuse).
+func AppendResourceIndexKeyRawBytes(dst []byte, syncIDBytes []byte, parentRT []byte, parentID []byte, resourceTypeID []byte, resourceID []byte) []byte {
+	dst = append(dst, versionV3, typeIndex, idxResourceByParent)
+	dst = append(dst, syncIDBytes...)
+	dst = codec.AppendTupleSeparator(dst)
+	dst = codec.AppendTupleBytes(dst, parentRT)
+	dst = codec.AppendTupleSeparator(dst)
+	dst = codec.AppendTupleBytes(dst, parentID)
+	dst = codec.AppendTupleSeparator(dst)
+	dst = codec.AppendTupleBytes(dst, resourceTypeID)
+	dst = codec.AppendTupleSeparator(dst)
+	return codec.AppendTupleBytes(dst, resourceID)
+}
+
+func EntitlementIndexKeys(syncIDBytes []byte, r *v3.EntitlementRecord) [][]byte {
+	res := r.GetResource()
+	if res == nil || res.GetResourceId() == "" {
+		return nil
+	}
+	return [][]byte{encodeEntitlementByResourceIndexKey(syncIDBytes, res.GetResourceTypeId(), res.GetResourceId(), r.GetExternalId())}
+}
+
+func ForEachEntitlementIndexKey(syncIDBytes []byte, r *v3.EntitlementRecord, yield func([]byte) error) error {
+	res := r.GetResource()
+	if res == nil || res.GetResourceId() == "" {
+		return nil
+	}
+	return yield(encodeEntitlementByResourceIndexKey(syncIDBytes, res.GetResourceTypeId(), res.GetResourceId(), r.GetExternalId()))
+}
+
+func ForEachEntitlementIndexKeyRaw(syncIDBytes []byte, resourceRT string, resourceID string, externalID string, yield func([]byte) error) error {
+	if resourceID == "" {
+		return nil
+	}
+	return yield(encodeEntitlementByResourceIndexKey(syncIDBytes, resourceRT, resourceID, externalID))
+}
+
+func AppendEntitlementIndexKeyRawBytes(dst []byte, syncIDBytes []byte, resourceRT []byte, resourceID []byte, externalID []byte) []byte {
+	dst = append(dst, versionV3, typeIndex, idxEntitlementByResource)
+	dst = append(dst, syncIDBytes...)
+	dst = codec.AppendTupleSeparator(dst)
+	dst = codec.AppendTupleBytes(dst, resourceRT)
+	dst = codec.AppendTupleSeparator(dst)
+	dst = codec.AppendTupleBytes(dst, resourceID)
+	dst = codec.AppendTupleSeparator(dst)
+	return codec.AppendTupleBytes(dst, externalID)
+}
+
+func GrantIndexKeys(syncIDBytes []byte, r *v3.GrantRecord) [][]byte {
+	return grantIndexKeys(syncIDBytes, r)
+}
+
+func ForEachGrantIndexKey(syncIDBytes []byte, r *v3.GrantRecord, yield func([]byte) error) error {
+	ent := r.GetEntitlement()
+	princ := r.GetPrincipal()
+	ext := r.GetExternalId()
+	if ent != nil && princ != nil {
+		if err := yield(encodeGrantByEntitlementIndexKey(syncIDBytes, ent.GetEntitlementId(), princ.GetResourceTypeId(), princ.GetResourceId(), ext)); err != nil {
+			return err
+		}
+	}
+	if ent != nil && ent.GetResourceId() != "" {
+		if err := yield(encodeGrantByEntitlementResourceIndexKey(syncIDBytes, ent.GetResourceTypeId(), ent.GetResourceId(), ext)); err != nil {
+			return err
+		}
+	}
+	if princ != nil {
+		if err := yield(encodeGrantByPrincipalIndexKey(syncIDBytes, princ.GetResourceTypeId(), princ.GetResourceId(), ext)); err != nil {
+			return err
+		}
+		if err := yield(encodeGrantByPrincipalResourceTypeIndexKey(syncIDBytes, princ.GetResourceTypeId(), ext)); err != nil {
+			return err
+		}
+	}
+	if r.GetNeedsExpansion() {
+		if err := yield(encodeGrantByNeedsExpansionIndexKey(syncIDBytes, ext)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func ForEachGrantIndexKeyRaw(
+	syncIDBytes []byte,
+	entitlementRT string,
+	entitlementResourceID string,
+	entitlementID string,
+	principalRT string,
+	principalID string,
+	externalID string,
+	needsExpansion bool,
+	yield func([]byte) error,
+) error {
+	if entitlementID != "" && principalRT != "" && principalID != "" {
+		if err := yield(encodeGrantByEntitlementIndexKey(syncIDBytes, entitlementID, principalRT, principalID, externalID)); err != nil {
+			return err
+		}
+	}
+	if entitlementResourceID != "" {
+		if err := yield(encodeGrantByEntitlementResourceIndexKey(syncIDBytes, entitlementRT, entitlementResourceID, externalID)); err != nil {
+			return err
+		}
+	}
+	if principalRT != "" && principalID != "" {
+		if err := yield(encodeGrantByPrincipalIndexKey(syncIDBytes, principalRT, principalID, externalID)); err != nil {
+			return err
+		}
+		if err := yield(encodeGrantByPrincipalResourceTypeIndexKey(syncIDBytes, principalRT, externalID)); err != nil {
+			return err
+		}
+	}
+	if needsExpansion {
+		if err := yield(encodeGrantByNeedsExpansionIndexKey(syncIDBytes, externalID)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func AppendGrantByEntitlementIndexKeyRawBytes(dst []byte, syncIDBytes []byte, entitlementID []byte, principalRT []byte, principalID []byte, externalID []byte) []byte {
+	dst = append(dst, versionV3, typeIndex, idxGrantByEntitlement)
+	dst = append(dst, syncIDBytes...)
+	dst = codec.AppendTupleSeparator(dst)
+	dst = codec.AppendTupleBytes(dst, entitlementID)
+	dst = codec.AppendTupleSeparator(dst)
+	dst = codec.AppendTupleBytes(dst, principalRT)
+	dst = codec.AppendTupleSeparator(dst)
+	dst = codec.AppendTupleBytes(dst, principalID)
+	dst = codec.AppendTupleSeparator(dst)
+	return codec.AppendTupleBytes(dst, externalID)
+}
+
+func AppendGrantByEntitlementResourceIndexKeyRawBytes(dst []byte, syncIDBytes []byte, entitlementRT []byte, entitlementResourceID []byte, externalID []byte) []byte {
+	dst = append(dst, versionV3, typeIndex, idxGrantByEntitlementResource)
+	dst = append(dst, syncIDBytes...)
+	dst = codec.AppendTupleSeparator(dst)
+	dst = codec.AppendTupleBytes(dst, entitlementRT)
+	dst = codec.AppendTupleSeparator(dst)
+	dst = codec.AppendTupleBytes(dst, entitlementResourceID)
+	dst = codec.AppendTupleSeparator(dst)
+	return codec.AppendTupleBytes(dst, externalID)
+}
+
+func AppendGrantByPrincipalIndexKeyRawBytes(dst []byte, syncIDBytes []byte, principalRT []byte, principalID []byte, externalID []byte) []byte {
+	dst = append(dst, versionV3, typeIndex, idxGrantByPrincipal)
+	dst = append(dst, syncIDBytes...)
+	dst = codec.AppendTupleSeparator(dst)
+	dst = codec.AppendTupleBytes(dst, principalRT)
+	dst = codec.AppendTupleSeparator(dst)
+	dst = codec.AppendTupleBytes(dst, principalID)
+	dst = codec.AppendTupleSeparator(dst)
+	return codec.AppendTupleBytes(dst, externalID)
+}
+
+func AppendGrantByPrincipalResourceTypeIndexKeyRawBytes(dst []byte, syncIDBytes []byte, principalRT []byte, externalID []byte) []byte {
+	dst = append(dst, versionV3, typeIndex, idxGrantByPrincipalResourceType)
+	dst = append(dst, syncIDBytes...)
+	dst = codec.AppendTupleSeparator(dst)
+	dst = codec.AppendTupleBytes(dst, principalRT)
+	dst = codec.AppendTupleSeparator(dst)
+	return codec.AppendTupleBytes(dst, externalID)
+}
+
+func AppendGrantByNeedsExpansionIndexKeyRawBytes(dst []byte, syncIDBytes []byte, externalID []byte) []byte {
+	dst = append(dst, versionV3, typeIndex, idxGrantByNeedsExpansion)
+	dst = append(dst, syncIDBytes...)
+	dst = codec.AppendTupleSeparator(dst)
+	return codec.AppendTupleBytes(dst, externalID)
 }

--- a/pkg/dotc1z/engine/pebble/mutation_test.go
+++ b/pkg/dotc1z/engine/pebble/mutation_test.go
@@ -100,7 +100,6 @@ func TestPutResourceRecordOverwriteCleansIndexes(t *testing.T) {
 
 	mkRes := func(parentRT, parentID string) *v3.ResourceRecord {
 		return v3.ResourceRecord_builder{
-			SyncId:         syncID,
 			ResourceTypeId: "user",
 			ResourceId:     "alice",
 			Parent: v3.ResourceRef_builder{
@@ -146,7 +145,6 @@ func TestPutEntitlementRecordOverwriteCleansIndexes(t *testing.T) {
 	}
 	mkEnt := func(resID string) *v3.EntitlementRecord {
 		return v3.EntitlementRecord_builder{
-			SyncId:     syncID,
 			ExternalId: "read",
 			Resource: v3.ResourceRef_builder{
 				ResourceTypeId: "app",
@@ -254,7 +252,6 @@ func TestFreshSyncWithinCallDuplicateResourceDedup(t *testing.T) {
 	}
 	mkRes := func(parentID string) *v3.ResourceRecord {
 		return v3.ResourceRecord_builder{
-			SyncId:         syncID,
 			ResourceTypeId: "user",
 			ResourceId:     "alice",
 			Parent: v3.ResourceRef_builder{
@@ -294,7 +291,6 @@ func TestFreshSyncWithinCallDuplicateEntitlementDedup(t *testing.T) {
 	}
 	mkEnt := func(resID string) *v3.EntitlementRecord {
 		return v3.EntitlementRecord_builder{
-			SyncId:     syncID,
 			ExternalId: "read",
 			Resource: v3.ResourceRef_builder{
 				ResourceTypeId: "app",

--- a/pkg/dotc1z/engine/pebble/pending_expansion_test.go
+++ b/pkg/dotc1z/engine/pebble/pending_expansion_test.go
@@ -24,7 +24,6 @@ func TestPendingExpansionIndexRoundtrip(t *testing.T) {
 	}
 
 	gPending := v3.GrantRecord_builder{
-		SyncId:     syncID,
 		ExternalId: "g-pending",
 		Entitlement: v3.EntitlementRef_builder{
 			ResourceTypeId: "app", ResourceId: "github", EntitlementId: "ent-A",
@@ -38,7 +37,6 @@ func TestPendingExpansionIndexRoundtrip(t *testing.T) {
 		NeedsExpansion: true,
 	}.Build()
 	gProcessed := v3.GrantRecord_builder{
-		SyncId:     syncID,
 		ExternalId: "g-processed",
 		Entitlement: v3.EntitlementRef_builder{
 			ResourceTypeId: "app", ResourceId: "github", EntitlementId: "ent-B",
@@ -52,7 +50,6 @@ func TestPendingExpansionIndexRoundtrip(t *testing.T) {
 		NeedsExpansion: false,
 	}.Build()
 	gPlain := v3.GrantRecord_builder{
-		SyncId:     syncID,
 		ExternalId: "g-plain",
 		Entitlement: v3.EntitlementRef_builder{
 			ResourceTypeId: "app", ResourceId: "github", EntitlementId: "ent-C",
@@ -80,7 +77,6 @@ func TestPendingExpansionIndexRoundtrip(t *testing.T) {
 	// Flip g-pending to NeedsExpansion=false. The index entry must
 	// disappear (mirrors the syncer's post-expansion write).
 	gPendingDone := v3.GrantRecord_builder{
-		SyncId:     syncID,
 		ExternalId: "g-pending",
 		Entitlement: v3.EntitlementRef_builder{
 			ResourceTypeId: "app", ResourceId: "github", EntitlementId: "ent-A",
@@ -115,12 +111,11 @@ func TestPendingExpansionIndexRoundtrip(t *testing.T) {
 func TestPebbleGrantStorePendingExpansionPage(t *testing.T) {
 	ctx := context.Background()
 	a := newAdapter(t)
-	syncID, err := a.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	_, err := a.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
 	if err != nil {
 		t.Fatalf("StartNewSync: %v", err)
 	}
 	rec := v3.GrantRecord_builder{
-		SyncId:     syncID,
 		ExternalId: "g1",
 		Entitlement: v3.EntitlementRef_builder{
 			ResourceTypeId: "app", ResourceId: "github", EntitlementId: "ent-A",

--- a/pkg/dotc1z/engine/pebble/raw_records.go
+++ b/pkg/dotc1z/engine/pebble/raw_records.go
@@ -1,0 +1,400 @@
+package pebble
+
+import (
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/cockroachdb/pebble/v2"
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const (
+	resourceTypeDiscoveredAtField protowire.Number = 6
+	resourceDiscoveredAtField     protowire.Number = 8
+	entitlementDiscoveredAtField  protowire.Number = 8
+	grantDiscoveredAtField        protowire.Number = 5
+)
+
+func discoveredAtIsNewerThanRaw(incoming *timestamppb.Timestamp, existingValue []byte, field protowire.Number) (bool, error) {
+	if incoming == nil {
+		return false, nil
+	}
+	existing, ok, err := rawDiscoveredAtNanos(existingValue, field)
+	if err != nil {
+		return false, err
+	}
+	if !ok {
+		return true, nil
+	}
+	return incoming.AsTime().UnixNano() > existing, nil
+}
+
+func rawDiscoveredAtNanos(value []byte, field protowire.Number) (int64, bool, error) {
+	for len(value) > 0 {
+		num, typ, n := protowire.ConsumeTag(value)
+		if n < 0 {
+			return 0, false, protowire.ParseError(n)
+		}
+		value = value[n:]
+		if num != field {
+			n = protowire.ConsumeFieldValue(num, typ, value)
+			if n < 0 {
+				return 0, false, protowire.ParseError(n)
+			}
+			value = value[n:]
+			continue
+		}
+		if typ != protowire.BytesType {
+			return 0, false, fmt.Errorf("raw record: discovered_at has wire type %v", typ)
+		}
+		ts, n := protowire.ConsumeBytes(value)
+		if n < 0 {
+			return 0, false, protowire.ParseError(n)
+		}
+		nanos, err := rawTimestampNanos(ts)
+		return nanos, true, err
+	}
+	return 0, false, nil
+}
+
+func rawTimestampNanos(value []byte) (int64, error) {
+	var seconds int64
+	var nanos int32
+	for len(value) > 0 {
+		num, typ, n := protowire.ConsumeTag(value)
+		if n < 0 {
+			return 0, protowire.ParseError(n)
+		}
+		value = value[n:]
+		switch num {
+		case 1:
+			if typ != protowire.VarintType {
+				return 0, fmt.Errorf("raw record: timestamp seconds has wire type %v", typ)
+			}
+			v, n := protowire.ConsumeVarint(value)
+			if n < 0 {
+				return 0, protowire.ParseError(n)
+			}
+			if v > math.MaxInt64 {
+				return 0, fmt.Errorf("raw record: timestamp seconds exceeds int64: %d", v)
+			}
+			seconds = int64(v)
+			value = value[n:]
+		case 2:
+			if typ != protowire.VarintType {
+				return 0, fmt.Errorf("raw record: timestamp nanos has wire type %v", typ)
+			}
+			v, n := protowire.ConsumeVarint(value)
+			if n < 0 {
+				return 0, protowire.ParseError(n)
+			}
+			if v > math.MaxInt32 {
+				return 0, fmt.Errorf("raw record: timestamp nanos exceeds int32: %d", v)
+			}
+			nanos = int32(v)
+			value = value[n:]
+		default:
+			n = protowire.ConsumeFieldValue(num, typ, value)
+			if n < 0 {
+				return 0, protowire.ParseError(n)
+			}
+			value = value[n:]
+		}
+	}
+	if seconds > math.MaxInt64/int64(time.Second) {
+		return 0, fmt.Errorf("raw record: timestamp seconds overflow: %d", seconds)
+	}
+	return seconds*int64(time.Second) + int64(nanos), nil
+}
+
+func (e *Engine) deleteResourceIndexesRaw(batch *pebble.Batch, syncIDBytes []byte, resourceTypeID string, resourceID string, value []byte) error {
+	parentRT, parentID, err := scanResourceParentRaw(value)
+	if err != nil {
+		return err
+	}
+	if parentID == "" {
+		return nil
+	}
+	return batch.Delete(encodeResourceByParentIndexKey(syncIDBytes, parentRT, parentID, resourceTypeID, resourceID), nil)
+}
+
+func (e *Engine) deleteEntitlementIndexesRaw(batch *pebble.Batch, syncIDBytes []byte, externalID string, value []byte) error {
+	resourceRT, resourceID, err := scanEntitlementResourceRaw(value)
+	if err != nil {
+		return err
+	}
+	if resourceID == "" {
+		return nil
+	}
+	return batch.Delete(encodeEntitlementByResourceIndexKey(syncIDBytes, resourceRT, resourceID, externalID), nil)
+}
+
+func (e *Engine) deleteGrantIndexesRaw(batch *pebble.Batch, syncIDBytes []byte, externalID string, value []byte) error {
+	entRT, entRID, entID, principalRT, principalID, _, err := scanGrantIndexFieldsRaw(value)
+	if err != nil {
+		return err
+	}
+	if entID != "" && principalRT != "" && principalID != "" {
+		if err := batch.Delete(encodeGrantByEntitlementIndexKey(syncIDBytes, entID, principalRT, principalID, externalID), nil); err != nil {
+			return err
+		}
+	}
+	if entRID != "" {
+		if err := batch.Delete(encodeGrantByEntitlementResourceIndexKey(syncIDBytes, entRT, entRID, externalID), nil); err != nil {
+			return err
+		}
+	}
+	if principalRT != "" && principalID != "" {
+		if err := batch.Delete(encodeGrantByPrincipalIndexKey(syncIDBytes, principalRT, principalID, externalID), nil); err != nil {
+			return err
+		}
+		if err := batch.Delete(encodeGrantByPrincipalResourceTypeIndexKey(syncIDBytes, principalRT, externalID), nil); err != nil {
+			return err
+		}
+	}
+	return batch.Delete(encodeGrantByNeedsExpansionIndexKey(syncIDBytes, externalID), nil)
+}
+
+// scanGrantEntitlementResourceTypeRaw extracts only the entitlement's
+// resource_type_id from a marshaled GrantRecord, borrowing the bytes
+// from value. The stats grouping path needs just this one field;
+// scanGrantIndexFieldsRaw materializes five strings per grant. Like
+// the full scanner, the last occurrence of the entitlement field wins.
+func scanGrantEntitlementResourceTypeRaw(value []byte) ([]byte, error) {
+	var entRT []byte
+	for len(value) > 0 {
+		num, typ, n := protowire.ConsumeTag(value)
+		if n < 0 {
+			return nil, protowire.ParseError(n)
+		}
+		value = value[n:]
+		if num != 3 {
+			n = protowire.ConsumeFieldValue(num, typ, value)
+			if n < 0 {
+				return nil, protowire.ParseError(n)
+			}
+			value = value[n:]
+			continue
+		}
+		if typ != protowire.BytesType {
+			return nil, fmt.Errorf("raw record: grant entitlement has wire type %v", typ)
+		}
+		msg, n := protowire.ConsumeBytes(value)
+		if n < 0 {
+			return nil, protowire.ParseError(n)
+		}
+		if err := scanResourceRefRawBytes(msg, func(fnum protowire.Number, val []byte) {
+			if fnum == 1 {
+				entRT = val
+			}
+		}); err != nil {
+			return nil, err
+		}
+		value = value[n:]
+	}
+	return entRT, nil
+}
+
+// scanResourceParentRaw and scanEntitlementResourceRaw keep the LAST
+// occurrence of the target field, matching scanGrantIndexFieldsRaw and
+// approximating proto merge semantics. Values written by this SDK carry
+// at most one occurrence, so this only matters for foreign writers.
+func scanResourceParentRaw(value []byte) (string, string, error) {
+	var rt, id string
+	for len(value) > 0 {
+		num, typ, n := protowire.ConsumeTag(value)
+		if n < 0 {
+			return "", "", protowire.ParseError(n)
+		}
+		value = value[n:]
+		if num != 6 {
+			n = protowire.ConsumeFieldValue(num, typ, value)
+			if n < 0 {
+				return "", "", protowire.ParseError(n)
+			}
+			value = value[n:]
+			continue
+		}
+		if typ != protowire.BytesType {
+			return "", "", fmt.Errorf("raw record: resource parent has wire type %v", typ)
+		}
+		msg, n := protowire.ConsumeBytes(value)
+		if n < 0 {
+			return "", "", protowire.ParseError(n)
+		}
+		var err error
+		rt, id, err = scanResourceRefRaw(msg)
+		if err != nil {
+			return "", "", err
+		}
+		value = value[n:]
+	}
+	return rt, id, nil
+}
+
+func scanEntitlementResourceRaw(value []byte) (string, string, error) {
+	var rt, id string
+	for len(value) > 0 {
+		num, typ, n := protowire.ConsumeTag(value)
+		if n < 0 {
+			return "", "", protowire.ParseError(n)
+		}
+		value = value[n:]
+		if num != 3 {
+			n = protowire.ConsumeFieldValue(num, typ, value)
+			if n < 0 {
+				return "", "", protowire.ParseError(n)
+			}
+			value = value[n:]
+			continue
+		}
+		if typ != protowire.BytesType {
+			return "", "", fmt.Errorf("raw record: entitlement resource has wire type %v", typ)
+		}
+		msg, n := protowire.ConsumeBytes(value)
+		if n < 0 {
+			return "", "", protowire.ParseError(n)
+		}
+		var err error
+		rt, id, err = scanResourceRefRaw(msg)
+		if err != nil {
+			return "", "", err
+		}
+		value = value[n:]
+	}
+	return rt, id, nil
+}
+
+func scanGrantIndexFieldsRaw(value []byte) (string, string, string, string, string, bool, error) {
+	var entRT, entRID, entID, principalRT, principalID string
+	var needsExpansion bool
+	for len(value) > 0 {
+		num, typ, n := protowire.ConsumeTag(value)
+		if n < 0 {
+			return "", "", "", "", "", false, protowire.ParseError(n)
+		}
+		value = value[n:]
+		switch num {
+		case 3:
+			if typ != protowire.BytesType {
+				return "", "", "", "", "", false, fmt.Errorf("raw record: grant entitlement has wire type %v", typ)
+			}
+			msg, n := protowire.ConsumeBytes(value)
+			if n < 0 {
+				return "", "", "", "", "", false, protowire.ParseError(n)
+			}
+			var err error
+			entRT, entRID, entID, err = scanEntitlementRefRaw(msg)
+			if err != nil {
+				return "", "", "", "", "", false, err
+			}
+			value = value[n:]
+		case 4:
+			if typ != protowire.BytesType {
+				return "", "", "", "", "", false, fmt.Errorf("raw record: grant principal has wire type %v", typ)
+			}
+			msg, n := protowire.ConsumeBytes(value)
+			if n < 0 {
+				return "", "", "", "", "", false, protowire.ParseError(n)
+			}
+			var err error
+			principalRT, principalID, err = scanPrincipalRefRaw(msg)
+			if err != nil {
+				return "", "", "", "", "", false, err
+			}
+			value = value[n:]
+		case 7:
+			if typ != protowire.VarintType {
+				return "", "", "", "", "", false, fmt.Errorf("raw record: grant needs_expansion has wire type %v", typ)
+			}
+			v, n := protowire.ConsumeVarint(value)
+			if n < 0 {
+				return "", "", "", "", "", false, protowire.ParseError(n)
+			}
+			needsExpansion = v != 0
+			value = value[n:]
+		default:
+			n = protowire.ConsumeFieldValue(num, typ, value)
+			if n < 0 {
+				return "", "", "", "", "", false, protowire.ParseError(n)
+			}
+			value = value[n:]
+		}
+	}
+	return entRT, entRID, entID, principalRT, principalID, needsExpansion, nil
+}
+
+func scanResourceRefRaw(value []byte) (string, string, error) {
+	var rt, id []byte
+	err := scanResourceRefRawBytes(value, func(num protowire.Number, val []byte) {
+		switch num {
+		case 1:
+			rt = val
+		case 2:
+			id = val
+		default:
+		}
+	})
+	return string(rt), string(id), err
+}
+
+func scanEntitlementRefRaw(value []byte) (string, string, string, error) {
+	var rt, rid, eid []byte
+	err := scanResourceRefRawBytes(value, func(num protowire.Number, val []byte) {
+		switch num {
+		case 1:
+			rt = val
+		case 2:
+			rid = val
+		case 3:
+			eid = val
+		default:
+		}
+	})
+	return string(rt), string(rid), string(eid), err
+}
+
+func scanPrincipalRefRaw(value []byte) (string, string, error) {
+	var rt, id []byte
+	err := scanResourceRefRawBytes(value, func(num protowire.Number, val []byte) {
+		switch num {
+		case 1:
+			rt = val
+		case 2:
+			id = val
+		default:
+		}
+	})
+	return string(rt), string(id), err
+}
+
+func scanResourceRefRawBytes(value []byte, set func(protowire.Number, []byte)) error {
+	for len(value) > 0 {
+		num, typ, n := protowire.ConsumeTag(value)
+		if n < 0 {
+			return protowire.ParseError(n)
+		}
+		value = value[n:]
+		if typ != protowire.BytesType {
+			n = protowire.ConsumeFieldValue(num, typ, value)
+			if n < 0 {
+				return protowire.ParseError(n)
+			}
+			value = value[n:]
+			continue
+		}
+		b, n := protowire.ConsumeBytes(value)
+		if n < 0 {
+			return protowire.ParseError(n)
+		}
+		switch num {
+		case 1, 2, 3:
+			set(num, b)
+		default:
+		}
+		value = value[n:]
+	}
+	return nil
+}

--- a/pkg/dotc1z/engine/pebble/records_test.go
+++ b/pkg/dotc1z/engine/pebble/records_test.go
@@ -21,7 +21,6 @@ func TestPutGetResourceType(t *testing.T) {
 	}
 
 	r := v3.ResourceTypeRecord_builder{
-		SyncId:       syncID,
 		ExternalId:   "user",
 		DisplayName:  "User",
 		Traits:       []string{"trait-user"},
@@ -48,7 +47,6 @@ func TestIterateResourceTypesBySync(t *testing.T) {
 	}
 	for i := 0; i < 20; i++ {
 		r := v3.ResourceTypeRecord_builder{
-			SyncId:      syncID,
 			ExternalId:  ksuid.New().String(),
 			DisplayName: "RT",
 		}.Build()
@@ -77,7 +75,6 @@ func TestResourceWithParentIndex(t *testing.T) {
 	}
 
 	parent := v3.ResourceRecord_builder{
-		SyncId:         syncID,
 		ResourceTypeId: "group",
 		ResourceId:     "admins",
 		DisplayName:    "Admins",
@@ -89,7 +86,6 @@ func TestResourceWithParentIndex(t *testing.T) {
 	// 5 user resources with `parent` pointing at the admins group.
 	for i := 0; i < 5; i++ {
 		child := v3.ResourceRecord_builder{
-			SyncId:         syncID,
 			ResourceTypeId: "user",
 			ResourceId:     ksuid.New().String(),
 			DisplayName:    "User",
@@ -105,7 +101,6 @@ func TestResourceWithParentIndex(t *testing.T) {
 	// 3 resources NOT under the admins group.
 	for i := 0; i < 3; i++ {
 		other := v3.ResourceRecord_builder{
-			SyncId:         syncID,
 			ResourceTypeId: "user",
 			ResourceId:     ksuid.New().String(),
 		}.Build()
@@ -149,7 +144,6 @@ func TestEntitlementByResourceIndex(t *testing.T) {
 	// 4 entitlements on group/admins, 2 on group/devs.
 	for i := 0; i < 4; i++ {
 		r := v3.EntitlementRecord_builder{
-			SyncId:     syncID,
 			ExternalId: ksuid.New().String(),
 			Resource: v3.ResourceRef_builder{
 				ResourceTypeId: "group",
@@ -163,7 +157,6 @@ func TestEntitlementByResourceIndex(t *testing.T) {
 	}
 	for i := 0; i < 2; i++ {
 		r := v3.EntitlementRecord_builder{
-			SyncId:     syncID,
 			ExternalId: ksuid.New().String(),
 			Resource: v3.ResourceRef_builder{
 				ResourceTypeId: "group",

--- a/pkg/dotc1z/engine/pebble/resource_types.go
+++ b/pkg/dotc1z/engine/pebble/resource_types.go
@@ -33,7 +33,7 @@ func (e *Engine) PutResourceTypeRecords(ctx context.Context, records ...*v3.Reso
 			if r == nil {
 				continue
 			}
-			idBytes, err := e.resolveSyncBytes(r.GetSyncId())
+			idBytes, err := e.resolveSyncBytes("")
 			if err != nil {
 				return err
 			}

--- a/pkg/dotc1z/engine/pebble/resources.go
+++ b/pkg/dotc1z/engine/pebble/resources.go
@@ -41,9 +41,13 @@ func (e *Engine) PutResourceRecords(ctx context.Context, records ...*v3.Resource
 
 		fresh := e.IsFreshSync()
 		skipGet := e.takeFreshResourcesEmpty()
+		idBytes, err := e.resolveSyncBytes("")
+		if err != nil {
+			return err
+		}
 
 		type dedupKey struct {
-			syncID, rtID, resID string
+			rtID, resID string
 		}
 		var dedup map[dedupKey]int
 		if len(records) > 1 {
@@ -52,38 +56,18 @@ func (e *Engine) PutResourceRecords(ctx context.Context, records ...*v3.Resource
 				if r == nil {
 					continue
 				}
-				dedup[dedupKey{r.GetSyncId(), r.GetResourceTypeId(), r.GetResourceId()}] = i
+				dedup[dedupKey{r.GetResourceTypeId(), r.GetResourceId()}] = i
 			}
 		}
 
-		var (
-			lastSyncIDStr string
-			lastIDBytes   []byte
-			haveLast      bool
-		)
 		for i, r := range records {
 			if r == nil {
 				continue
 			}
 			if dedup != nil {
-				if dedup[dedupKey{r.GetSyncId(), r.GetResourceTypeId(), r.GetResourceId()}] != i {
+				if dedup[dedupKey{r.GetResourceTypeId(), r.GetResourceId()}] != i {
 					continue
 				}
-			}
-			var (
-				idBytes []byte
-				err     error
-			)
-			if sid := r.GetSyncId(); haveLast && sid == lastSyncIDStr {
-				idBytes = lastIDBytes
-			} else {
-				idBytes, err = e.resolveSyncBytes(sid)
-				if err != nil {
-					return err
-				}
-				lastSyncIDStr = sid
-				lastIDBytes = idBytes
-				haveLast = true
 			}
 			key := encodeResourceKey(idBytes, r.GetResourceTypeId(), r.GetResourceId())
 			val, err := marshalRecord(r)
@@ -94,13 +78,7 @@ func (e *Engine) PutResourceRecords(ctx context.Context, records ...*v3.Resource
 				oldVal, closer, getErr := e.db.Get(key)
 				switch {
 				case getErr == nil:
-					old := &v3.ResourceRecord{}
-					if err := unmarshalRecord(oldVal, old); err != nil {
-						closer.Close()
-						return fmt.Errorf("PutResourceRecords: unmarshal old %s/%s: %w",
-							r.GetResourceTypeId(), r.GetResourceId(), err)
-					}
-					if err := e.deleteResourceIndexes(idxBatch, idBytes, old); err != nil {
+					if err := e.deleteResourceIndexesRaw(idxBatch, idBytes, r.GetResourceTypeId(), r.GetResourceId(), oldVal); err != nil {
 						closer.Close()
 						return err
 					}
@@ -165,12 +143,7 @@ func (e *Engine) DeleteResourceRecord(ctx context.Context, syncID, resourceTypeI
 			}
 			return err
 		}
-		old := &v3.ResourceRecord{}
-		if err := unmarshalRecord(oldVal, old); err != nil {
-			closer.Close()
-			return fmt.Errorf("DeleteResourceRecord: unmarshal old %s/%s: %w", resourceTypeID, resourceID, err)
-		}
-		if err := e.deleteResourceIndexes(batch, idBytes, old); err != nil {
+		if err := e.deleteResourceIndexesRaw(batch, idBytes, resourceTypeID, resourceID, oldVal); err != nil {
 			closer.Close()
 			return err
 		}
@@ -193,19 +166,6 @@ func (e *Engine) writeResourceIndexes(batch *pebble.Batch, syncIDBytes []byte, r
 		r.GetResourceTypeId(), r.GetResourceId(),
 	)
 	return batch.Set(k, nil, nil)
-}
-
-func (e *Engine) deleteResourceIndexes(batch *pebble.Batch, syncIDBytes []byte, r *v3.ResourceRecord) error {
-	parent := r.GetParent()
-	if parent == nil || parent.GetResourceId() == "" {
-		return nil
-	}
-	k := encodeResourceByParentIndexKey(
-		syncIDBytes,
-		parent.GetResourceTypeId(), parent.GetResourceId(),
-		r.GetResourceTypeId(), r.GetResourceId(),
-	)
-	return batch.Delete(k, nil)
 }
 
 func (e *Engine) IterateResourcesBySync(ctx context.Context, syncID string, yield func(*v3.ResourceRecord) bool) error {

--- a/pkg/dotc1z/engine/pebble/store_expanded_grants_discovered_at_test.go
+++ b/pkg/dotc1z/engine/pebble/store_expanded_grants_discovered_at_test.go
@@ -40,7 +40,6 @@ func TestStoreExpandedGrantsPreservesDiscoveredAt(t *testing.T) {
 	// bypassing the adapter's now() stamp.
 	seeded := timestamppb.New(time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC))
 	seed := v3.GrantRecord_builder{
-		SyncId:     syncID,
 		ExternalId: "g-1",
 		Entitlement: v3.EntitlementRef_builder{
 			ResourceTypeId: "app", ResourceId: "github", EntitlementId: "ent-A",

--- a/pkg/dotc1z/engine/pebble/sync_stats_sidecar.go
+++ b/pkg/dotc1z/engine/pebble/sync_stats_sidecar.go
@@ -1,6 +1,7 @@
 package pebble
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -112,47 +113,100 @@ func (e *Engine) writeSyncStats(ctx context.Context, syncID string, rec *v3.Sync
 // O(N) work the sidecar is designed to avoid on read — only the
 // EndFreshSync write path and the on-Open migration backfill
 // invoke it.
+//
+// This intentionally scans raw Pebble key/value ranges instead of using
+// Iterate*BySync. Counting keys and shallow-scanning only the grant grouping
+// field removed the final stats-sidecar full unmarshal from compaction; in the
+// same-size syncs=50 overlay case allocs dropped from ~3.05M to ~2.41M/op.
 func (e *Engine) computeSyncStats(ctx context.Context, syncID string) (*v3.SyncStatsRecord, error) {
 	rec := &v3.SyncStatsRecord{}
 	rec.SetSyncId(syncID)
-	resourcesByRT := map[string]int64{}
-	grantsByEntitlementRT := map[string]int64{}
+	idBytes, err := codec.EncodeSyncID(syncID)
+	if err != nil {
+		return nil, err
+	}
 
-	if err := e.IterateResourceTypesBySync(ctx, syncID, func(*v3.ResourceTypeRecord) bool {
-		rec.SetResourceTypes(rec.GetResourceTypes() + 1)
-		return true
-	}); err != nil {
+	resourceTypes, err := countKeyRange(ctx, e.db, ResourceTypeSyncLowerBound(idBytes), ResourceTypeSyncUpperBound(idBytes), nil)
+	if err != nil {
 		return nil, fmt.Errorf("computeSyncStats: resource_types: %w", err)
 	}
-	if err := e.IterateResourcesBySync(ctx, syncID, func(r *v3.ResourceRecord) bool {
-		rec.SetResources(rec.GetResources() + 1)
-		resourcesByRT[r.GetResourceTypeId()]++
-		return true
-	}); err != nil {
+	rec.SetResourceTypes(resourceTypes)
+
+	// Resource primary keys sort by resource_type_id, so per-RT groups
+	// are contiguous: track the current run and materialize one map key
+	// per group instead of one string per row. (A plain
+	// counts[string(rt)]++ would allocate per row — the compiler only
+	// elides the []byte->string conversion for map reads, not writes.)
+	resourcesByRT := map[string]int64{}
+	resLower := ResourceSyncLowerBound(idBytes)
+	var rtScratch, curRT []byte
+	var curCount int64
+	resources, err := countKeyRange(ctx, e.db, resLower, ResourceSyncUpperBound(idBytes), func(key []byte, _ []byte) error {
+		if len(key) <= len(resLower) {
+			return fmt.Errorf("resource key shorter than expected lower bound")
+		}
+		var derr error
+		rtScratch, _, derr = codec.DecodeTupleStringTo(rtScratch[:0], key[len(resLower)+1:], 0)
+		if derr != nil {
+			return derr
+		}
+		if curCount > 0 && bytes.Equal(rtScratch, curRT) {
+			curCount++
+			return nil
+		}
+		if curCount > 0 {
+			resourcesByRT[string(curRT)] += curCount
+		}
+		curRT = append(curRT[:0], rtScratch...)
+		curCount = 1
+		return nil
+	})
+	if err != nil {
 		return nil, fmt.Errorf("computeSyncStats: resources: %w", err)
 	}
-	if err := e.IterateEntitlementsBySync(ctx, syncID, func(*v3.EntitlementRecord) bool {
-		rec.SetEntitlements(rec.GetEntitlements() + 1)
-		return true
-	}); err != nil {
+	if curCount > 0 {
+		resourcesByRT[string(curRT)] += curCount
+	}
+	rec.SetResources(resources)
+
+	entitlements, err := countKeyRange(ctx, e.db, EntitlementSyncLowerBound(idBytes), EntitlementSyncUpperBound(idBytes), nil)
+	if err != nil {
 		return nil, fmt.Errorf("computeSyncStats: entitlements: %w", err)
 	}
-	if err := e.IterateGrantsBySync(ctx, syncID, func(g *v3.GrantRecord) bool {
-		rec.SetGrants(rec.GetGrants() + 1)
-		// Entitlement's resource_type — matches the SQLite grants
-		// table's resource_type_id column semantic, which is what
-		// the existing GrantStats() caller expects.
-		grantsByEntitlementRT[g.GetEntitlement().GetResourceTypeId()]++
-		return true
-	}); err != nil {
+	rec.SetEntitlements(entitlements)
+
+	// Grant primary keys sort by external id, so entitlement-RT groups
+	// are NOT contiguous. map[string]*int64 keeps the per-row map read
+	// allocation-free and only materializes a key string the first time
+	// each resource type appears.
+	grantsByEntRTPtr := map[string]*int64{}
+	grants, err := countKeyRange(ctx, e.db, GrantSyncLowerBound(idBytes), GrantSyncUpperBound(idBytes), func(_ []byte, value []byte) error {
+		entRT, err := scanGrantEntitlementResourceTypeRaw(value)
+		if err != nil {
+			return err
+		}
+		if p, ok := grantsByEntRTPtr[string(entRT)]; ok {
+			*p++
+			return nil
+		}
+		n := int64(1)
+		grantsByEntRTPtr[string(entRT)] = &n
+		return nil
+	})
+	if err != nil {
 		return nil, fmt.Errorf("computeSyncStats: grants: %w", err)
 	}
-	if err := e.IterateAssetsBySync(ctx, syncID, func(*v3.AssetRecord) bool {
-		rec.SetAssets(rec.GetAssets() + 1)
-		return true
-	}); err != nil {
+	grantsByEntitlementRT := make(map[string]int64, len(grantsByEntRTPtr))
+	for rt, p := range grantsByEntRTPtr {
+		grantsByEntitlementRT[rt] = *p
+	}
+	rec.SetGrants(grants)
+
+	assets, err := countKeyRange(ctx, e.db, AssetSyncLowerBound(idBytes), AssetSyncUpperBound(idBytes), nil)
+	if err != nil {
 		return nil, fmt.Errorf("computeSyncStats: assets: %w", err)
 	}
+	rec.SetAssets(assets)
 	rec.SetResourcesByResourceType(resourcesByRT)
 	rec.SetGrantsByEntitlementResourceType(grantsByEntitlementRT)
 	rec.SetWrittenAt(timestamppb.Now())
@@ -168,4 +222,39 @@ func (e *Engine) PersistSyncStats(ctx context.Context, syncID string) error {
 		return err
 	}
 	return e.writeSyncStats(ctx, syncID, rec)
+}
+
+// PersistComputedSyncStats writes a caller-computed stats record —
+// e.g. one accumulated while the synccompactor wrote merge winners —
+// without re-scanning the keyspaces. SyncId and WrittenAt are set
+// here so callers only fill counts. Durability matches
+// PersistSyncStats (pebble.Sync via writeSyncStats).
+func (e *Engine) PersistComputedSyncStats(ctx context.Context, syncID string, rec *v3.SyncStatsRecord) error {
+	if rec == nil {
+		return fmt.Errorf("PersistComputedSyncStats: nil record")
+	}
+	rec.SetSyncId(syncID)
+	rec.SetWrittenAt(timestamppb.Now())
+	return e.writeSyncStats(ctx, syncID, rec)
+}
+
+func countKeyRange(ctx context.Context, db *pebble.DB, lower []byte, upper []byte, visit func(key []byte, value []byte) error) (int64, error) {
+	iter, err := db.NewIter(&pebble.IterOptions{LowerBound: lower, UpperBound: upper})
+	if err != nil {
+		return 0, err
+	}
+	defer iter.Close()
+	var count int64
+	for iter.First(); iter.Valid(); iter.Next() {
+		if err := ctx.Err(); err != nil {
+			return 0, err
+		}
+		count++
+		if visit != nil {
+			if err := visit(iter.Key(), iter.Value()); err != nil {
+				return 0, err
+			}
+		}
+	}
+	return count, iter.Error()
 }

--- a/pkg/dotc1z/engine/pebble/translate_v2.go
+++ b/pkg/dotc1z/engine/pebble/translate_v2.go
@@ -21,9 +21,10 @@ import (
 
 // --- Grant ---
 
-// V2GrantToV3 produces a v3.GrantRecord from a v2.Grant. The caller
-// supplies sync_id since v2.Grant has no sync_id field (the connector
-// writes are scoped to the engine's current sync).
+// V2GrantToV3 produces a v3.GrantRecord from a v2.Grant. The syncID
+// parameter is retained for call-site symmetry with other translators;
+// v3 data records no longer store sync_id in the value because sync scope is
+// encoded in Pebble keys by the engine write path.
 //
 // The GrantExpandable annotation (if any) is extracted into the
 // dedicated Expansion field and stripped from Annotations, and
@@ -38,7 +39,6 @@ func V2GrantToV3(syncID string, g *v2.Grant) *v3.GrantRecord {
 	}
 	expansion, annotations := extractV2Expansion(g.GetAnnotations())
 	return v3.GrantRecord_builder{
-		SyncId:         syncID,
 		ExternalId:     g.GetId(),
 		Entitlement:    entitlementToRef(g.GetEntitlement()),
 		Principal:      resourceToPrincipalRef(g.GetPrincipal()),
@@ -241,7 +241,6 @@ func (a *grantTranslateArena) translateV2Grant(syncID string, g *v2.Grant) *v3.G
 	}
 	a.grantRecords = append(a.grantRecords, v3.GrantRecord{})
 	rec := &a.grantRecords[len(a.grantRecords)-1]
-	rec.SetSyncId(syncID)
 	rec.SetExternalId(g.GetId())
 	if entRef != nil {
 		rec.SetEntitlement(entRef)
@@ -326,7 +325,8 @@ func v3GrantSourcesToV2(m map[string]*v3.GrantSourceRecord) *v2.GrantSources {
 
 // --- Resource ---
 
-// V2ResourceToV3 maps v2.Resource → v3.ResourceRecord. Caller supplies sync_id.
+// V2ResourceToV3 maps v2.Resource → v3.ResourceRecord. syncID is not stored in
+// the value; Pebble keys carry sync scope.
 func V2ResourceToV3(syncID string, r *v2.Resource) *v3.ResourceRecord {
 	if r == nil {
 		return nil
@@ -339,7 +339,6 @@ func V2ResourceToV3(syncID string, r *v2.Resource) *v3.ResourceRecord {
 		}.Build()
 	}
 	return v3.ResourceRecord_builder{
-		SyncId:         syncID,
 		ResourceTypeId: r.GetId().GetResourceType(),
 		ResourceId:     r.GetId().GetResource(),
 		DisplayName:    r.GetDisplayName(),
@@ -387,7 +386,6 @@ func V2ResourceTypeToV3(syncID string, rt *v2.ResourceType) *v3.ResourceTypeReco
 		traits = append(traits, traitToString(t))
 	}
 	return v3.ResourceTypeRecord_builder{
-		SyncId:            syncID,
 		ExternalId:        rt.GetId(),
 		DisplayName:       rt.GetDisplayName(),
 		Traits:            traits,
@@ -465,7 +463,6 @@ func V2EntitlementToV3(syncID string, e *v2.Entitlement) *v3.EntitlementRecord {
 		}
 	}
 	return v3.EntitlementRecord_builder{
-		SyncId:                     syncID,
 		ExternalId:                 e.GetId(),
 		Resource:                   res,
 		DisplayName:                e.GetDisplayName(),

--- a/pkg/dotc1z/engine/pebble/translate_v2_test.go
+++ b/pkg/dotc1z/engine/pebble/translate_v2_test.go
@@ -27,9 +27,6 @@ func TestV2GrantRoundtrip(t *testing.T) {
 	}.Build()
 
 	v3rec := V2GrantToV3("sync-id-1", original)
-	if v3rec.GetSyncId() != "sync-id-1" {
-		t.Errorf("sync_id: got %q", v3rec.GetSyncId())
-	}
 	if v3rec.GetExternalId() != "grant-1" {
 		t.Errorf("external_id: got %q", v3rec.GetExternalId())
 	}

--- a/pkg/dotc1z/engine_registry.go
+++ b/pkg/dotc1z/engine_registry.go
@@ -37,6 +37,37 @@ type StoreOptions struct {
 	// engines that produce a v3 envelope (currently Pebble). Zero
 	// value means "engine default" (PayloadEncodingTarZstd for Pebble).
 	PayloadEncoding PayloadEncoding
+
+	// DecoderPool optionally scopes v3 payload-decoder reuse to the
+	// caller's operation (see WithDecoderPool). Nil means a one-shot
+	// decoder per open.
+	DecoderPool *EnvelopeDecoderPool
+}
+
+// EnvelopeDecoderPool re-exports the v3 envelope payload decoder pool
+// so callers (e.g. the sync compactor) can scope decoder reuse to one
+// operation without importing the format package. See
+// formatv3.DecoderPool for semantics.
+type EnvelopeDecoderPool = formatv3.DecoderPool
+
+// NewEnvelopeDecoderPool returns an empty pool; the caller owns its
+// lifetime and must Close it when the operation completes.
+func NewEnvelopeDecoderPool() *EnvelopeDecoderPool {
+	return formatv3.NewDecoderPool()
+}
+
+// WithDecoderPool threads a caller-owned envelope decoder pool through
+// a store open. Useful only for callers that open MANY v3 c1z files in
+// one operation (the compactor opens one envelope per source per
+// merge); each open draws its zstd payload decoder from the pool
+// instead of constructing a fresh one. The caller must Close the pool
+// when the operation finishes — that deterministic release is the
+// point of scoping the pool instead of sharing one process-wide.
+// Ignored by the SQLite (v1) engine and harmless when nil.
+func WithDecoderPool(p *EnvelopeDecoderPool) C1ZOption {
+	return func(o *c1zOptions) {
+		o.decoderPool = p
+	}
 }
 
 // EngineDriver opens a .c1z file for a specific storage engine. The SQLite
@@ -142,6 +173,7 @@ func storeOptionsFromC1ZOptions(options *c1zOptions) StoreOptions {
 		V2GrantsWriter:     options.v2GrantsWriter,
 		Engine:             options.engine,
 		PayloadEncoding:    options.payloadEncoding,
+		DecoderPool:        options.decoderPool,
 	}
 	if out.Engine == "" {
 		out.Engine = EngineSQLite
@@ -228,12 +260,17 @@ func selectStoreDriver(ctx context.Context, outputFilePath string, options *c1zO
 		if _, err := f.Seek(0, 0); err != nil {
 			return nil, err
 		}
-		env, err := formatv3.ReadEnvelope(f)
+		// Engine dispatch only needs the small manifest header. Avoiding the
+		// descriptor closure unmarshal cut the clean skewed-500 overlay profile
+		// from ~3.64M to ~1.74M allocs/op; ReadManifestHeader (vs
+		// ReadEnvelopeHeader) additionally skips constructing a zstd payload
+		// decoder that dispatch never reads from — one wasted
+		// window-allocation + worker spin-up per open.
+		m, err := formatv3.ReadManifestHeader(f)
 		if err != nil {
 			return nil, err
 		}
-		defer env.Close()
-		fileEngine = Engine(env.Manifest.GetEngine())
+		fileEngine = Engine(m.GetEngine())
 	default:
 		return nil, ErrInvalidFile
 	}

--- a/pkg/dotc1z/format/v3/decoder_pool_test.go
+++ b/pkg/dotc1z/format/v3/decoder_pool_test.go
@@ -1,0 +1,102 @@
+package v3
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	c1zv3 "github.com/conductorone/baton-sdk/pb/c1/c1z/v3"
+)
+
+// buildPoolTestEnvelope writes a tiny TAR_ZSTD envelope and returns its
+// bytes.
+func buildPoolTestEnvelope(t *testing.T) []byte {
+	t.Helper()
+	srcDir := filepath.Join(t.TempDir(), "src")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "CURRENT"), []byte("MANIFEST-000001\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	m := &c1zv3.C1ZManifestV3{
+		Engine:          "pebble",
+		PayloadEncoding: c1zv3.PayloadEncoding_PAYLOAD_ENCODING_TAR_ZSTD,
+	}
+	var buf bytes.Buffer
+	if err := WriteEnvelope(&buf, m, srcDir); err != nil {
+		t.Fatalf("WriteEnvelope: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// TestDecoderPoolScopedReuse locks in the pool's lifecycle contract:
+// an envelope returns its decoder to the pool at Close, the next read
+// drains the idle decoder instead of constructing one, and Close
+// releases everything — decoders returned after Close are destroyed,
+// never re-pooled.
+func TestDecoderPoolScopedReuse(t *testing.T) {
+	data := buildPoolTestEnvelope(t)
+	pool := NewDecoderPool()
+
+	env1, err := ReadEnvelopeHeaderWithPool(bytes.NewReader(data), pool)
+	if err != nil {
+		t.Fatalf("ReadEnvelopeHeaderWithPool: %v", err)
+	}
+	if err := ExtractZstdTar(env1.PayloadReader, t.TempDir()); err != nil {
+		t.Fatalf("ExtractZstdTar: %v", err)
+	}
+	if err := env1.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(pool.idle); got != 1 {
+		t.Fatalf("idle decoders after first close = %d, want 1", got)
+	}
+
+	env2, err := ReadEnvelopeHeaderWithPool(bytes.NewReader(data), pool)
+	if err != nil {
+		t.Fatalf("ReadEnvelopeHeaderWithPool (reuse): %v", err)
+	}
+	if got := len(pool.idle); got != 0 {
+		t.Fatalf("idle decoders during second read = %d, want 0 (reuse expected)", got)
+	}
+	if err := ExtractZstdTar(env2.PayloadReader, t.TempDir()); err != nil {
+		t.Fatalf("ExtractZstdTar (reuse): %v", err)
+	}
+	if err := env2.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(pool.idle); got != 1 {
+		t.Fatalf("idle decoders after second close = %d, want 1", got)
+	}
+
+	pool.Close()
+	if got := len(pool.idle); got != 0 {
+		t.Fatalf("idle decoders after pool close = %d, want 0", got)
+	}
+
+	// An envelope closed after the pool destroys its decoder instead
+	// of re-pooling it.
+	env3, err := ReadEnvelopeHeaderWithPool(bytes.NewReader(data), pool)
+	if err != nil {
+		t.Fatalf("ReadEnvelopeHeaderWithPool (after pool close): %v", err)
+	}
+	if err := env3.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(pool.idle); got != 0 {
+		t.Fatalf("idle decoders after late close = %d, want 0 (pool is closed)", got)
+	}
+
+	// Nil pool is valid everywhere.
+	var nilPool *DecoderPool
+	env4, err := ReadEnvelopeHeaderWithPool(bytes.NewReader(data), nilPool)
+	if err != nil {
+		t.Fatalf("ReadEnvelopeHeaderWithPool (nil pool): %v", err)
+	}
+	if err := env4.Close(); err != nil {
+		t.Fatal(err)
+	}
+	nilPool.Close()
+}

--- a/pkg/dotc1z/format/v3/envelope.go
+++ b/pkg/dotc1z/format/v3/envelope.go
@@ -14,6 +14,8 @@ import (
 
 	c1zv3 "github.com/conductorone/baton-sdk/pb/c1/c1z/v3"
 	"github.com/klauspost/compress/zstd"
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/proto"
 )
 
 // C1Z3Magic is the 5-byte header that identifies a v3 c1z file. Same
@@ -211,15 +213,109 @@ type Envelope struct {
 	PayloadReader io.Reader
 
 	zstdReader *zstd.Decoder
+	pool       *DecoderPool
 }
 
-// Close releases any pooled decoder resources held by PayloadReader.
+// Close returns the payload decoder to the envelope's DecoderPool (when
+// one was supplied) or destroys it.
 func (e *Envelope) Close() error {
 	if e.zstdReader != nil {
-		e.zstdReader.Close()
+		if e.pool != nil {
+			e.pool.put(e.zstdReader)
+		} else {
+			e.zstdReader.Close()
+		}
 		e.zstdReader = nil
+		e.pool = nil
 	}
 	return nil
+}
+
+// DecoderPool reuses zstd payload decoders across envelope reads. A
+// decoder retains its window/history buffers across Reset, so reuse
+// avoids both the construction cost (worker goroutine spin-up, buffer
+// allocation) and the per-open garbage when many envelopes are read in
+// a loop — the compactor opens one envelope per source per merge.
+//
+// The pool is deliberately NOT process-global: a pooled decoder keeps
+// whatever buffers its largest stream grew, so the owner scopes the
+// pool to the operation that benefits (one pool per compaction) and
+// calls Close when done, releasing everything deterministically
+// instead of waiting out sync.Pool's GC-paced eviction in a long-lived
+// worker process. Callers that open a single envelope pass a nil pool
+// and get a one-shot decoder destroyed at Envelope.Close.
+type DecoderPool struct {
+	mu     sync.Mutex
+	idle   []*zstd.Decoder
+	closed bool
+}
+
+// NewDecoderPool returns an empty pool. The caller owns its lifetime
+// and must call Close to release idle decoders.
+func NewDecoderPool() *DecoderPool {
+	return &DecoderPool{}
+}
+
+// get returns an idle decoder reset onto r, or constructs one (with the
+// standard decoder memory cap). Nil-receiver safe: a nil pool always
+// constructs, and the Envelope destroys the decoder at Close.
+func (p *DecoderPool) get(r io.Reader) (*zstd.Decoder, error) {
+	if p != nil {
+		p.mu.Lock()
+		if n := len(p.idle); n > 0 {
+			dec := p.idle[n-1]
+			p.idle = p.idle[:n-1]
+			p.mu.Unlock()
+			if err := dec.Reset(r); err != nil {
+				dec.Close()
+				return nil, err
+			}
+			return dec, nil
+		}
+		p.mu.Unlock()
+	}
+	return zstd.NewReader(r, zstd.WithDecoderMaxMemory(decoderMaxMemoryBytes()))
+}
+
+// put detaches dec from its reader and parks it for reuse. Decoders
+// returned after Close (an envelope outliving the pool) are destroyed
+// rather than leaked into a closed pool.
+func (p *DecoderPool) put(dec *zstd.Decoder) {
+	if dec == nil {
+		return
+	}
+	if p == nil {
+		dec.Close()
+		return
+	}
+	if err := dec.Reset(nil); err != nil {
+		dec.Close()
+		return
+	}
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		dec.Close()
+		return
+	}
+	p.idle = append(p.idle, dec)
+	p.mu.Unlock()
+}
+
+// Close releases every idle decoder and marks the pool closed; later
+// puts destroy their decoders. Safe to call on a nil pool.
+func (p *DecoderPool) Close() {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	idle := p.idle
+	p.idle = nil
+	p.closed = true
+	p.mu.Unlock()
+	for _, dec := range idle {
+		dec.Close()
+	}
 }
 
 // ReadEnvelope reads a v3 envelope from r. r must be positioned at the
@@ -236,7 +332,43 @@ func (e *Envelope) Close() error {
 // exceeds the configured budget (BATON_DECODER_MAX_DECODED_SIZE_MB,
 // default 10 GiB) — the same knobs the v1 decoder honors.
 func ReadEnvelope(r io.Reader) (*Envelope, error) {
-	// 1. Magic.
+	return readEnvelope(r, false, nil)
+}
+
+// ReadEnvelopeHeader is the low-allocation open path for engine dispatch.
+// It parses only the cheap manifest fields (engine, engine_schema_version,
+// payload_encoding, sync_runs) and skips the descriptor closure. Call
+// ReadEnvelope when callers need the full self-describing descriptor set.
+func ReadEnvelopeHeader(r io.Reader) (*Envelope, error) {
+	return readEnvelope(r, true, nil)
+}
+
+// ReadEnvelopeHeaderWithPool is ReadEnvelopeHeader with a caller-scoped
+// payload decoder pool: the envelope draws its zstd decoder from pool
+// and returns it on Close instead of destroying it. Used by callers
+// that open many envelopes in a loop (compaction source opens). A nil
+// pool behaves exactly like ReadEnvelopeHeader.
+func ReadEnvelopeHeaderWithPool(r io.Reader, pool *DecoderPool) (*Envelope, error) {
+	return readEnvelope(r, true, pool)
+}
+
+// ReadManifestHeader parses only the cheap manifest fields and stops
+// before the payload: no zstd decoder is constructed and not a single
+// payload byte is read. This is the "shallow unpack" path for callers
+// that want envelope metadata — sync run summaries with their cached
+// stats — without rematerializing the Pebble directory (compaction
+// source selection, overlay bucket planning, tooling).
+func ReadManifestHeader(r io.Reader) (*c1zv3.C1ZManifestV3, error) {
+	mb, err := readManifestBytes(r)
+	if err != nil {
+		return nil, err
+	}
+	return unmarshalManifestHeader(mb)
+}
+
+// readManifestBytes consumes the magic, the manifest length prefix, and
+// the manifest bytes, leaving r positioned at the first payload byte.
+func readManifestBytes(r io.Reader) ([]byte, error) {
 	magic := make([]byte, len(C1Z3Magic))
 	if _, err := io.ReadFull(r, magic); err != nil {
 		return nil, fmt.Errorf("%w: reading magic: %w", ErrEnvelopeTruncated, err)
@@ -244,7 +376,6 @@ func ReadEnvelope(r io.Reader) (*Envelope, error) {
 	if !bytes.Equal(magic, C1Z3Magic) {
 		return nil, ErrInvalidV3Magic
 	}
-	// 2. Manifest length.
 	var lenBuf [4]byte
 	if _, err := io.ReadFull(r, lenBuf[:]); err != nil {
 		return nil, fmt.Errorf("%w: reading manifest length: %w", ErrEnvelopeTruncated, err)
@@ -253,12 +384,24 @@ func ReadEnvelope(r io.Reader) (*Envelope, error) {
 	if mlen > maxManifestBytes {
 		return nil, fmt.Errorf("c1z v3: manifest claims %d bytes, exceeds cap %d", mlen, maxManifestBytes)
 	}
-	// 3. Manifest bytes.
 	mb := make([]byte, mlen)
 	if _, err := io.ReadFull(r, mb); err != nil {
 		return nil, fmt.Errorf("%w: reading manifest: %w", ErrEnvelopeTruncated, err)
 	}
-	m, err := UnmarshalManifest(mb)
+	return mb, nil
+}
+
+func readEnvelope(r io.Reader, headerOnly bool, pool *DecoderPool) (*Envelope, error) {
+	mb, err := readManifestBytes(r)
+	if err != nil {
+		return nil, err
+	}
+	var m *c1zv3.C1ZManifestV3
+	if headerOnly {
+		m, err = unmarshalManifestHeader(mb)
+	} else {
+		m, err = UnmarshalManifest(mb)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -266,11 +409,12 @@ func ReadEnvelope(r io.Reader) (*Envelope, error) {
 	env := &Envelope{Manifest: m}
 	switch m.GetPayloadEncoding() {
 	case c1zv3.PayloadEncoding_PAYLOAD_ENCODING_TAR_ZSTD:
-		zr, err := zstd.NewReader(r, zstd.WithDecoderMaxMemory(decoderMaxMemoryBytes()))
+		zr, err := pool.get(r)
 		if err != nil {
 			return nil, fmt.Errorf("c1z v3: zstd reader: %w", err)
 		}
 		env.zstdReader = zr
+		env.pool = pool
 		env.PayloadReader = &limitedPayloadReader{r: zr, limit: maxDecodedPayloadBytes()}
 	case c1zv3.PayloadEncoding_PAYLOAD_ENCODING_TAR:
 		env.PayloadReader = &limitedPayloadReader{r: r, limit: maxDecodedPayloadBytes()}
@@ -278,6 +422,83 @@ func ReadEnvelope(r io.Reader) (*Envelope, error) {
 		return nil, fmt.Errorf("c1z v3: unsupported payload encoding %v", m.GetPayloadEncoding())
 	}
 	return env, nil
+}
+
+// unmarshalManifestHeader decodes the cheap manifest fields by hand:
+// engine (1), engine_schema_version (2), payload_encoding (4), and the
+// sync_runs projection (40). The descriptor closure (field 10) — by far
+// the largest field — is skipped, which is what makes header reads
+// cheap enough for engine dispatch on every open. Sync run summaries
+// are small and few (bounded by the sync retention limit), so decoding
+// them here costs a handful of allocations.
+func unmarshalManifestHeader(b []byte) (*c1zv3.C1ZManifestV3, error) {
+	out := &c1zv3.C1ZManifestV3{}
+	for len(b) > 0 {
+		num, typ, n := protowire.ConsumeTag(b)
+		if n < 0 {
+			return nil, protowire.ParseError(n)
+		}
+		b = b[n:]
+		switch num {
+		case 1:
+			if typ != protowire.BytesType {
+				return nil, fmt.Errorf("c1z v3: manifest engine has wire type %v", typ)
+			}
+			v, n := protowire.ConsumeString(b)
+			if n < 0 {
+				return nil, protowire.ParseError(n)
+			}
+			out.SetEngine(v)
+			b = b[n:]
+		case 2:
+			if typ != protowire.VarintType {
+				return nil, fmt.Errorf("c1z v3: manifest engine_schema_version has wire type %v", typ)
+			}
+			v, n := protowire.ConsumeVarint(b)
+			if n < 0 {
+				return nil, protowire.ParseError(n)
+			}
+			if v > uint64(^uint32(0)) {
+				return nil, fmt.Errorf("c1z v3: manifest engine_schema_version overflow: %d", v)
+			}
+			out.SetEngineSchemaVersion(uint32(v))
+			b = b[n:]
+		case 4:
+			if typ != protowire.VarintType {
+				return nil, fmt.Errorf("c1z v3: manifest payload_encoding has wire type %v", typ)
+			}
+			v, n := protowire.ConsumeVarint(b)
+			if n < 0 {
+				return nil, protowire.ParseError(n)
+			}
+			if v > uint64(1<<31-1) {
+				return nil, fmt.Errorf("c1z v3: manifest payload_encoding overflow: %d", v)
+			}
+			out.SetPayloadEncoding(c1zv3.PayloadEncoding(v))
+			b = b[n:]
+		case 40:
+			if typ != protowire.BytesType {
+				return nil, fmt.Errorf("c1z v3: manifest sync_runs has wire type %v", typ)
+			}
+			v, n := protowire.ConsumeBytes(b)
+			if n < 0 {
+				return nil, protowire.ParseError(n)
+			}
+			summary := &c1zv3.SyncRunSummary{}
+			if err := proto.Unmarshal(v, summary); err != nil {
+				return nil, fmt.Errorf("%w: sync_runs entry: %w", ErrManifestInvalid, err)
+			}
+			out.SetSyncRuns(append(out.GetSyncRuns(), summary))
+			b = b[n:]
+		default:
+			n := protowire.ConsumeFieldValue(num, typ, b)
+			if n < 0 {
+				return nil, protowire.ParseError(n)
+			}
+			b = b[n:]
+		}
+	}
+	return out, nil
 }
 
 // writeZstdTar walks dir in sorted order, writing each entry into a

--- a/pkg/dotc1z/pebble_store.go
+++ b/pkg/dotc1z/pebble_store.go
@@ -40,7 +40,7 @@ func (pebbleDriver) OpenStore(ctx context.Context, outputFilePath string, opts S
 	}
 
 	dbDir := filepath.Join(tmpDir, "db")
-	if err := unpackExistingPebbleC1Z(outputFilePath, dbDir); err != nil {
+	if err := unpackExistingPebbleC1Z(outputFilePath, dbDir, opts.DecoderPool); err != nil {
 		return nil, cleanupOnError(err)
 	}
 
@@ -60,7 +60,7 @@ func (pebbleDriver) OpenStore(ctx context.Context, outputFilePath string, opts S
 	}, nil
 }
 
-func unpackExistingPebbleC1Z(outputFilePath string, dbDir string) error {
+func unpackExistingPebbleC1Z(outputFilePath string, dbDir string, pool *EnvelopeDecoderPool) error {
 	stat, err := os.Stat(outputFilePath)
 	switch {
 	case errors.Is(err, os.ErrNotExist):
@@ -77,7 +77,7 @@ func unpackExistingPebbleC1Z(outputFilePath string, dbDir string) error {
 	}
 	defer f.Close()
 
-	env, err := formatv3.ReadEnvelope(f)
+	env, err := formatv3.ReadEnvelopeHeaderWithPool(f, pool)
 	if err != nil {
 		return err
 	}
@@ -157,6 +157,55 @@ func (s *pebbleStore) PebbleEngine() *pebble.Engine {
 		return nil
 	}
 	return s.engine
+}
+
+// CloseEngineOnly closes the Pebble engine without removing the
+// store's unpacked temp directory, refusing to discard a dirty
+// writable store. Consumed by the compactor's chunk lifecycle via
+// pebble.CloseEngineOnly, where a caller owns a parent temp directory
+// and does one bulk cleanup after closing many read-only sources.
+func (s *pebbleStore) CloseEngineOnly() error {
+	if s == nil || s.engine == nil {
+		return nil
+	}
+	s.closeMu.Lock()
+	if s.closed {
+		s.closeMu.Unlock()
+		return nil
+	}
+	if !s.readOnly && s.dirty {
+		s.closeMu.Unlock()
+		return errors.New("pebble CloseEngineOnly: refusing to discard dirty writable store")
+	}
+	s.closed = true
+	s.closeMu.Unlock()
+	return s.engine.Close()
+}
+
+// NormalizeForFixtureSave flushes and compacts one sync, then marks the
+// store dirty so Close writes a fresh c1z envelope. Intentionally
+// narrow (consumed by benchmark fixture generation via
+// pebble.NormalizeForFixtureSave): fixtures should not measure WAL
+// replay or un-compacted LSM shape left over from generation.
+func (s *pebbleStore) NormalizeForFixtureSave(ctx context.Context, syncID string) error {
+	if s == nil || s.engine == nil {
+		return nil
+	}
+	if s.readOnly {
+		return errors.New("pebble NormalizeForFixtureSave: store is read-only")
+	}
+	if err := s.engine.Flush(ctx); err != nil {
+		return err
+	}
+	if err := s.engine.CompactSyncRanges(ctx, syncID); err != nil {
+		return err
+	}
+	s.closeMu.Lock()
+	if !s.closed {
+		s.dirty = true
+	}
+	s.closeMu.Unlock()
+	return nil
 }
 
 func (s *pebbleStore) markDirty(err error) error {
@@ -457,7 +506,7 @@ func (s *pebbleStore) save(ctx context.Context) error {
 		}
 	}()
 
-	manifest, err := pebble.BuildManifest(s.payloadEncoding)
+	manifest, err := pebble.BuildManifestWithSyncRuns(ctx, s.engine, s.payloadEncoding)
 	if err != nil {
 		return err
 	}

--- a/pkg/dotc1z/pebble_store.go
+++ b/pkg/dotc1z/pebble_store.go
@@ -122,13 +122,38 @@ type pebbleStore struct {
 // route SQLite *C1File handles today.
 var _ C1ZStore = (*pebbleStore)(nil)
 
-// FileOps overrides the Adapter-level FileOps so CloneSync threads
-// the pebbleStore's configured payload encoding into the destination
-// c1z. Without this, clone output would always use the default
-// TAR_ZSTD even when the source store was opened with
-// WithPayloadEncoding(PayloadEncodingTar).
+// FileOps overrides the Adapter-level FileOps for two reasons:
+//
+//   - CloneSync threads the pebbleStore's configured payload encoding
+//     into the destination c1z (otherwise clone output would always
+//     use the default TAR_ZSTD); and
+//   - GenerateSyncDiff writes a NEW sync into THIS store, so it must
+//     flip the dirty bit — without it, Close would skip the envelope
+//     save and the diff sync would exist only in the discarded temp
+//     directory.
 func (s *pebbleStore) FileOps() FileOps {
-	return s.FileOpsWithEncoding(s.payloadEncoding)
+	return pebbleStoreFileOps{inner: s.FileOpsWithEncoding(s.payloadEncoding), store: s}
+}
+
+// pebbleStoreFileOps wraps the Adapter-level FileOps to route the one
+// mutating-in-place method (GenerateSyncDiff) through the store's
+// dirty-marking path. CloneSync writes a separate file and passes
+// through unchanged.
+type pebbleStoreFileOps struct {
+	inner FileOps
+	store *pebbleStore
+}
+
+func (f pebbleStoreFileOps) CloneSync(ctx context.Context, outPath string, syncID string, opts ...CloneSyncOption) error {
+	return f.inner.CloneSync(ctx, outPath, syncID, opts...)
+}
+
+func (f pebbleStoreFileOps) GenerateSyncDiff(ctx context.Context, baseSyncID, appliedSyncID string) (string, error) {
+	diffSyncID, err := f.inner.GenerateSyncDiff(ctx, baseSyncID, appliedSyncID)
+	if err != nil {
+		return "", err
+	}
+	return diffSyncID, f.store.markDirty(nil)
 }
 
 // Metadata extends the embedded Adapter's Metadata with this store's

--- a/pkg/synccompactor/compactor.go
+++ b/pkg/synccompactor/compactor.go
@@ -48,6 +48,20 @@ type Compactor struct {
 	// the output is byte-identical to the pre-engine-option compactor).
 	// EnginePebble produces a v3 Pebble c1z via a native record merge.
 	engine dotc1z.Engine
+	// pebbleMode optionally forces the Pebble merge strategy; the zero
+	// value (Auto) lets the compactor choose. See WithPebbleCompactorMode.
+	pebbleMode PebbleCompactorMode
+	// overlaySeenKeyLimit / overlayRecordChunkSize optionally override
+	// the overlay merge tunables; zero means the merge defaults. See
+	// WithOverlaySeenKeyLimit / WithOverlayRecordChunkSize.
+	overlaySeenKeyLimit    int64
+	overlayRecordChunkSize int
+	// decoderPool scopes v3 payload-decoder reuse to one Compact run:
+	// every source envelope open draws from it instead of constructing
+	// a fresh zstd decoder, and Compact closes it on the way out so no
+	// decoder buffers outlive the compaction (deliberately NOT a
+	// process-global pool — see dotc1z.WithDecoderPool).
+	decoderPool *dotc1z.EnvelopeDecoderPool
 }
 
 // resolvedEngine returns the configured engine, treating the zero value
@@ -203,6 +217,17 @@ func (c *Compactor) Compact(ctx context.Context) (*CompactableSync, error) {
 
 	fileName := fmt.Sprintf("compacted-%s.c1z", c.entries[0].SyncID)
 	destFilePath := path.Join(c.tmpDir, fileName)
+
+	if c.resolvedEngine() == dotc1z.EnginePebble {
+		// One payload-decoder pool for the whole compaction: the merge
+		// opens every source's envelope (selection + per-chunk unpack),
+		// and reusing one decoder across those opens avoids a fresh
+		// window allocation + worker spin-up per source. Closed when
+		// Compact returns so nothing is retained by the process after.
+		c.decoderPool = dotc1z.NewEnvelopeDecoderPool()
+		defer c.decoderPool.Close()
+		opts = append(opts, dotc1z.WithDecoderPool(c.decoderPool))
+	}
 
 	if c.resolvedEngine() == dotc1z.EnginePebble {
 		// Force the resolved engine last so a stray engine passed via

--- a/pkg/synccompactor/compactor_compare_bench_test.go
+++ b/pkg/synccompactor/compactor_compare_bench_test.go
@@ -1,0 +1,335 @@
+package synccompactor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	pebbleengine "github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble"
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkCompactorSQLiteVsPebbleKWay(b *testing.B) {
+	ctx := context.Background()
+
+	for _, sourceCount := range []int{10, 50, 500} {
+		sourceCount := sourceCount
+		b.Run(fmt.Sprintf("syncs=%d", sourceCount), func(b *testing.B) {
+			benchmarkCompactorSQLiteVsPebbleKWayCase(b, ctx, sourceCount, compactorCompareSize{
+				resources:    250,
+				entitlements: 500,
+				grants:       2500,
+			})
+		})
+	}
+}
+
+func BenchmarkCompactorSQLiteVsPebbleSkewed(b *testing.B) {
+	ctx := context.Background()
+
+	for _, sourceCount := range []int{10, 50, 500} {
+		sourceCount := sourceCount
+		b.Run(fmt.Sprintf("syncs=%d", sourceCount), func(b *testing.B) {
+			benchmarkCompactorSQLiteVsPebbleSkewedCase(b, ctx, sourceCount)
+		})
+	}
+}
+
+type compactorCompareSize struct {
+	resources    int
+	entitlements int
+	grants       int
+}
+
+type compactorCompareFixtureManifest struct {
+	SQLite []*CompactableSync `json:"sqlite"`
+	Pebble []*CompactableSync `json:"pebble"`
+}
+
+func benchmarkCompactorSQLiteVsPebbleKWayCase(b *testing.B, ctx context.Context, sourceCount int, size compactorCompareSize) {
+	if inputs, ok := loadCompareFixtureManifest(b, sourceCount, "same"); ok {
+		benchmarkCompactorInputs(b, ctx, sourceCount, size, inputs.SQLite, inputs.Pebble)
+		return
+	}
+	fixtureDir := compareFixtureBuildDir(b, sourceCount, "same")
+	sqliteInputs := buildCompareSQLiteInputs(b, ctx, filepath.Join(fixtureDir, "sqlite"), sourceCount, size)
+	pebbleInputs := convertCompareInputsToPebble(b, ctx, filepath.Join(fixtureDir, "pebble"), sqliteInputs)
+	writeCompareFixtureManifestIfRequested(b, sourceCount, "same", sqliteInputs, pebbleInputs)
+	benchmarkCompactorInputs(b, ctx, sourceCount, size, sqliteInputs, pebbleInputs)
+}
+
+func benchmarkCompactorSQLiteVsPebbleSkewedCase(b *testing.B, ctx context.Context, sourceCount int) {
+	if inputs, ok := loadCompareFixtureManifest(b, sourceCount, "skewed"); ok {
+		benchmarkCompactorInputs(b, ctx, sourceCount, compactorCompareSize{
+			resources:    250,
+			entitlements: 500,
+			grants:       2500,
+		}, inputs.SQLite, inputs.Pebble)
+		return
+	}
+	fixtureDir := compareFixtureBuildDir(b, sourceCount, "skewed")
+	sqliteInputs := buildCompareSkewedSQLiteInputs(b, ctx, filepath.Join(fixtureDir, "sqlite"), sourceCount)
+	pebbleInputs := convertCompareInputsToPebble(b, ctx, filepath.Join(fixtureDir, "pebble"), sqliteInputs)
+	writeCompareFixtureManifestIfRequested(b, sourceCount, "skewed", sqliteInputs, pebbleInputs)
+	benchmarkCompactorInputs(b, ctx, sourceCount, compactorCompareSize{
+		resources:    250,
+		entitlements: 500,
+		grants:       2500,
+	}, sqliteInputs, pebbleInputs)
+}
+
+func compareFixtureManifestPath(root string, sourceCount int, shape string) string {
+	return filepath.Join(root, shape, fmt.Sprintf("syncs-%d", sourceCount), "manifest.json")
+}
+
+func compareFixtureBuildDir(b *testing.B, sourceCount int, shape string) string {
+	b.Helper()
+	root := os.Getenv("BATON_WRITE_COMPACTION_COMPARE_FIXTURES_DIR")
+	if root == "" {
+		return b.TempDir()
+	}
+	dir := filepath.Join(root, shape, fmt.Sprintf("syncs-%d", sourceCount))
+	// #nosec G703 - benchmark fixture root is an explicit developer-provided env var.
+	require.NoError(b, os.RemoveAll(dir))
+	// #nosec G703 - benchmark fixture root is an explicit developer-provided env var.
+	require.NoError(b, os.MkdirAll(dir, 0o755))
+	return dir
+}
+
+func loadCompareFixtureManifest(b *testing.B, sourceCount int, shape string) (compactorCompareFixtureManifest, bool) {
+	b.Helper()
+	root := os.Getenv("BATON_COMPACTION_COMPARE_FIXTURES_DIR")
+	if root == "" {
+		return compactorCompareFixtureManifest{}, false
+	}
+	path := compareFixtureManifestPath(root, sourceCount, shape)
+	data, err := os.ReadFile(path)
+	require.NoError(b, err)
+	var manifest compactorCompareFixtureManifest
+	require.NoError(b, json.Unmarshal(data, &manifest))
+	return manifest, true
+}
+
+func writeCompareFixtureManifestIfRequested(b *testing.B, sourceCount int, shape string, sqliteInputs []*CompactableSync, pebbleInputs []*CompactableSync) {
+	b.Helper()
+	root := os.Getenv("BATON_WRITE_COMPACTION_COMPARE_FIXTURES_DIR")
+	if root == "" {
+		return
+	}
+	path := compareFixtureManifestPath(root, sourceCount, shape)
+	require.NoError(b, os.MkdirAll(filepath.Dir(path), 0o755))
+	data, err := json.MarshalIndent(compactorCompareFixtureManifest{SQLite: sqliteInputs, Pebble: pebbleInputs}, "", "  ")
+	require.NoError(b, err)
+	require.NoError(b, os.WriteFile(path, data, 0o600))
+	b.Skipf("wrote compactor compare fixtures to %s", path)
+}
+
+func benchmarkCompactorInputs(
+	b *testing.B,
+	ctx context.Context,
+	sourceCount int,
+	size compactorCompareSize,
+	sqliteInputs []*CompactableSync,
+	pebbleInputs []*CompactableSync,
+) {
+	for _, tc := range []struct {
+		name       string
+		inputs     []*CompactableSync
+		engine     dotc1z.Engine
+		pebbleMode PebbleCompactorMode
+	}{
+		{name: "sqlite", inputs: sqliteInputs},
+		{name: "pebble_kway", inputs: pebbleInputs, engine: dotc1z.EnginePebble, pebbleMode: PebbleCompactorModeKWay},
+		{name: "pebble_overlay", inputs: pebbleInputs, engine: dotc1z.EnginePebble, pebbleMode: PebbleCompactorModeOverlay},
+	} {
+		tc := tc
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ReportMetric(float64(sourceCount), "sources/op")
+			b.ReportMetric(float64(size.resources), "resources_per_source")
+			b.ReportMetric(float64(size.entitlements), "entitlements_per_source")
+			b.ReportMetric(float64(size.grants), "grants_per_source")
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				outputDir := b.TempDir()
+				tmpDir := b.TempDir()
+				opts := []Option{WithTmpDir(tmpDir), WithSkipGrantExpansion()}
+				if tc.engine != "" {
+					opts = append(opts, WithEngine(tc.engine), WithPebbleCompactorMode(tc.pebbleMode))
+				}
+				c, cleanup, err := NewCompactor(ctx, outputDir, tc.inputs, opts...)
+				require.NoError(b, err)
+				out, err := c.Compact(ctx)
+				require.NoError(b, err)
+				require.NotNil(b, out)
+				b.StopTimer()
+				require.NoError(b, cleanup())
+				b.StartTimer()
+			}
+		})
+	}
+}
+
+func buildCompareSkewedSQLiteInputs(b *testing.B, ctx context.Context, dir string, sourceCount int) []*CompactableSync {
+	b.Helper()
+	require.NoError(b, os.MkdirAll(dir, 0o755))
+	out := make([]*CompactableSync, 0, sourceCount)
+	for sourceIdx := 0; sourceIdx < sourceCount; sourceIdx++ {
+		syncType := connectorstore.SyncTypePartial
+		size := compactorCompareSize{
+			resources:    1,
+			entitlements: 2,
+			grants:       5,
+		}
+		if sourceIdx == 0 {
+			syncType = connectorstore.SyncTypeFull
+			size = compactorCompareSize{
+				resources:    250,
+				entitlements: 500,
+				grants:       2500,
+			}
+		}
+		path := filepath.Join(dir, fmt.Sprintf("source-%03d.c1z", sourceIdx))
+		syncID := writeCompareSQLiteSource(b, ctx, path, sourceIdx, syncType, size)
+		out = append(out, &CompactableSync{FilePath: path, SyncID: syncID})
+	}
+	return out
+}
+
+func buildCompareSQLiteInputs(b *testing.B, ctx context.Context, dir string, sourceCount int, size compactorCompareSize) []*CompactableSync {
+	b.Helper()
+	require.NoError(b, os.MkdirAll(dir, 0o755))
+	out := make([]*CompactableSync, 0, sourceCount)
+	for sourceIdx := 0; sourceIdx < sourceCount; sourceIdx++ {
+		syncType := connectorstore.SyncTypePartial
+		if sourceIdx == 0 {
+			syncType = connectorstore.SyncTypeFull
+		}
+		path := filepath.Join(dir, fmt.Sprintf("source-%03d.c1z", sourceIdx))
+		syncID := writeCompareSQLiteSource(b, ctx, path, sourceIdx, syncType, size)
+		out = append(out, &CompactableSync{FilePath: path, SyncID: syncID})
+	}
+	return out
+}
+
+func writeCompareSQLiteSource(
+	b *testing.B,
+	ctx context.Context,
+	path string,
+	sourceIdx int,
+	syncType connectorstore.SyncType,
+	size compactorCompareSize,
+) string {
+	b.Helper()
+	store, err := dotc1z.NewC1ZFile(ctx, path,
+		dotc1z.WithPragma("journal_mode", "OFF"),
+		dotc1z.WithPragma("synchronous", "OFF"),
+		dotc1z.WithEncoderConcurrency(0),
+		dotc1z.WithDecoderOptions(dotc1z.WithDecoderConcurrency(-1)),
+	)
+	require.NoError(b, err)
+	syncID, err := store.StartNewSync(ctx, syncType, "")
+	require.NoError(b, err)
+
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	require.NoError(b, store.PutResourceTypes(ctx, userRT, groupRT))
+
+	userCount := max(1, size.resources/2)
+	groupCount := max(1, size.resources-userCount)
+	users := make([]*v2.Resource, 0, userCount)
+	groups := make([]*v2.Resource, 0, groupCount)
+	resources := make([]*v2.Resource, 0, size.resources)
+	for i := 0; i < userCount; i++ {
+		user := v2.Resource_builder{
+			Id:          v2.ResourceId_builder{ResourceType: "user", Resource: compareObjectID(sourceIdx, i, size.resources)}.Build(),
+			DisplayName: fmt.Sprintf("User %d", i),
+		}.Build()
+		users = append(users, user)
+		resources = append(resources, user)
+	}
+	for i := 0; i < groupCount; i++ {
+		group := v2.Resource_builder{
+			Id:          v2.ResourceId_builder{ResourceType: "group", Resource: compareObjectID(sourceIdx, i, size.resources)}.Build(),
+			DisplayName: fmt.Sprintf("Group %d", i),
+		}.Build()
+		groups = append(groups, group)
+		resources = append(resources, group)
+	}
+	require.NoError(b, store.PutResources(ctx, resources...))
+
+	entitlements := make([]*v2.Entitlement, 0, size.entitlements)
+	for i := 0; i < size.entitlements; i++ {
+		entitlement := v2.Entitlement_builder{
+			Id:       compareObjectID(sourceIdx, i, size.entitlements),
+			Resource: groups[i%len(groups)],
+			Purpose:  v2.Entitlement_PURPOSE_VALUE_ASSIGNMENT,
+		}.Build()
+		entitlements = append(entitlements, entitlement)
+	}
+	require.NoError(b, store.PutEntitlements(ctx, entitlements...))
+
+	grants := make([]*v2.Grant, 0, 10000)
+	flush := func() {
+		require.NoError(b, store.PutGrants(ctx, grants...))
+		grants = grants[:0]
+	}
+	for grantIdx := 0; grantIdx < size.grants; grantIdx++ {
+		grants = append(grants, v2.Grant_builder{
+			Id:          compareObjectID(sourceIdx, grantIdx, size.grants),
+			Principal:   users[grantIdx%len(users)],
+			Entitlement: entitlements[grantIdx%len(entitlements)],
+		}.Build())
+		if len(grants) >= cap(grants) {
+			flush()
+		}
+	}
+	if len(grants) > 0 {
+		flush()
+	}
+	require.NoError(b, store.EndSync(ctx))
+	require.NoError(b, store.Close(ctx))
+	return syncID
+}
+
+func compareObjectID(sourceIdx int, i int, total int) string {
+	if i < max(1, total/5) {
+		return fmt.Sprintf("shared-%d", i)
+	}
+	return fmt.Sprintf("source-%03d-%d", sourceIdx, i)
+}
+
+func convertCompareInputsToPebble(b *testing.B, ctx context.Context, dir string, sqliteInputs []*CompactableSync) []*CompactableSync {
+	b.Helper()
+	require.NoError(b, os.MkdirAll(dir, 0o755))
+	out := make([]*CompactableSync, 0, len(sqliteInputs))
+	for i, input := range sqliteInputs {
+		src, err := dotc1z.NewC1ZFile(ctx, input.FilePath,
+			dotc1z.WithReadOnly(true),
+			dotc1z.WithDecoderOptions(dotc1z.WithDecoderConcurrency(-1)),
+			dotc1z.WithTmpDir(dir),
+		)
+		require.NoError(b, err)
+		outPath := filepath.Join(dir, fmt.Sprintf("source-%03d.pebble.c1z", i))
+		stats, err := src.ToPebble(ctx, outPath, input.SyncID, dotc1z.WithConvertTmpDir(dir))
+		require.NoError(b, err)
+		require.NoError(b, src.Close(ctx))
+		normalizePebbleCompareFixture(b, ctx, dir, outPath, stats.DestSyncID)
+		out = append(out, &CompactableSync{FilePath: outPath, SyncID: stats.DestSyncID})
+	}
+	return out
+}
+
+func normalizePebbleCompareFixture(b *testing.B, ctx context.Context, tmpDir string, path string, syncID string) {
+	b.Helper()
+	w, err := dotc1z.NewStore(ctx, path, dotc1z.WithTmpDir(tmpDir))
+	require.NoError(b, err)
+	require.NoError(b, pebbleengine.NormalizeForFixtureSave(ctx, w, syncID))
+	require.NoError(b, w.Close(ctx))
+}

--- a/pkg/synccompactor/compactor_pebble.go
+++ b/pkg/synccompactor/compactor_pebble.go
@@ -4,15 +4,19 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	c1zv3 "github.com/conductorone/baton-sdk/pb/c1/c1z/v3"
+	reader_v2 "github.com/conductorone/baton-sdk/pb/c1/reader/v2"
 	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z"
 	enginepkg "github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble"
+	formatv3 "github.com/conductorone/baton-sdk/pkg/dotc1z/format/v3"
 	mergepkg "github.com/conductorone/baton-sdk/pkg/synccompactor/pebble"
 )
 
@@ -27,6 +31,70 @@ import (
 func WithEngine(engine dotc1z.Engine) Option {
 	return func(c *Compactor) {
 		c.engine = engine
+	}
+}
+
+// PebbleCompactorMode selects the record-merge strategy for Pebble
+// (v3) compaction.
+type PebbleCompactorMode string
+
+const (
+	// PebbleCompactorModeAuto (the zero value) picks the best strategy.
+	// Currently that is overlay: it won or tied every measured shape
+	// (same-size and skewed inputs at 10/50/500 sources) and degrades
+	// gracefully — buckets whose estimated keys exceed its in-memory
+	// seen-set bound are routed to the kway path inside the merge.
+	PebbleCompactorModeAuto PebbleCompactorMode = ""
+
+	// PebbleCompactorModeKWay forces the bounded-fan-in external merge
+	// sort. Never the fastest on its own, but it is the machinery
+	// overlay falls back to for oversized buckets; forcing it is for
+	// debugging and benchmarks.
+	PebbleCompactorModeKWay PebbleCompactorMode = "kway"
+
+	// PebbleCompactorModeOverlay forces the seen-set overlay merge.
+	PebbleCompactorModeOverlay PebbleCompactorMode = "overlay"
+)
+
+// WithPebbleCompactorMode overrides the Pebble merge strategy. The
+// default (PebbleCompactorModeAuto) chooses for you; passing an
+// explicit mode is intended for benchmarks and debugging, not normal
+// operation. No-op for the SQLite engine.
+func WithPebbleCompactorMode(mode PebbleCompactorMode) Option {
+	return func(c *Compactor) {
+		c.pebbleMode = mode
+	}
+}
+
+// WithOverlaySeenKeyLimit overrides the overlay merge's per-bucket
+// seen-set cap: buckets whose estimated key count exceeds it route to
+// the K-way run-file fallback. Zero (the default) uses the merge's
+// built-in production value. Intended for tests and benchmarks; the
+// cap bounds merge memory (~40B per seen key).
+func WithOverlaySeenKeyLimit(n int64) Option {
+	return func(c *Compactor) {
+		c.overlaySeenKeyLimit = n
+	}
+}
+
+// WithOverlayRecordChunkSize overrides how many winner records the
+// overlay merge buffers per raw write batch. Zero (the default) uses
+// the merge's built-in production value.
+func WithOverlayRecordChunkSize(n int) Option {
+	return func(c *Compactor) {
+		c.overlayRecordChunkSize = n
+	}
+}
+
+// resolvedPebbleMode returns the effective merge strategy: an explicit
+// WithPebbleCompactorMode wins, and Auto resolves to overlay (see
+// PebbleCompactorModeAuto for why).
+func (c *Compactor) resolvedPebbleMode() PebbleCompactorMode {
+	switch c.pebbleMode {
+	case PebbleCompactorModeKWay, PebbleCompactorModeOverlay:
+		return c.pebbleMode
+	default:
+		return PebbleCompactorModeOverlay
 	}
 }
 
@@ -58,6 +126,66 @@ func unionV3SyncType(a, b v3.SyncType) v3.SyncType {
 	}
 }
 
+// manifestSourceSelection is the result of picking a compaction source
+// sync from the envelope manifest's sync-run projection.
+type manifestSourceSelection struct {
+	syncID   string
+	syncType v3.SyncType
+	endedAt  time.Time
+	stats    *reader_v2.SyncStats
+}
+
+// selectSourceSyncFromManifest reads the v3 envelope header (manifest
+// only — no payload unpack, no zstd decode) and picks the latest
+// finished compactable sync from the manifest's sync_runs projection.
+// The selection rule mirrors Engine.LatestFinishedSyncRecord: newest
+// ended_at, ties broken by the greater sync_id (KSUIDs sort by time).
+//
+// Returns ok=false when the file predates the projection (no sync_runs
+// recorded), isn't a readable v3 envelope, or has no finished
+// compactable sync — callers fall back to the unpack path, which
+// produces the canonical errors.
+func selectSourceSyncFromManifest(path string) (manifestSourceSelection, bool) {
+	f, err := os.Open(path)
+	if err != nil {
+		return manifestSourceSelection{}, false
+	}
+	defer f.Close()
+	m, err := formatv3.ReadManifestHeader(f)
+	if err != nil {
+		return manifestSourceSelection{}, false
+	}
+	var best *c1zv3.SyncRunSummary
+	for _, r := range m.GetSyncRuns() {
+		if r == nil || r.GetEndedAt() == nil || !compactableV3SyncType(r.GetType()) {
+			continue
+		}
+		if best == nil {
+			best = r
+			continue
+		}
+		curEnd, bestEnd := r.GetEndedAt().AsTime(), best.GetEndedAt().AsTime()
+		switch {
+		case curEnd.After(bestEnd):
+			best = r
+		case curEnd.Equal(bestEnd) && r.GetSyncId() > best.GetSyncId():
+			best = r
+		}
+	}
+	if best == nil {
+		return manifestSourceSelection{}, false
+	}
+	sel := manifestSourceSelection{
+		syncID:   best.GetSyncId(),
+		syncType: best.GetType(),
+		endedAt:  best.GetEndedAt().AsTime(),
+	}
+	if s := best.GetStats(); s != nil {
+		sel.stats = enginepkg.SyncStatsFromRecord(s)
+	}
+	return sel, true
+}
+
 // compactPebble folds every input into the empty newSyncId on the
 // Pebble output via a native record merge: each input is opened, its
 // latest finished compactable sync is selected (diff syncs excluded),
@@ -74,7 +202,9 @@ func (c *Compactor) compactPebble(ctx context.Context, newSyncId string) error {
 		return errors.New("compactPebble: compacted store is not a pebble engine")
 	}
 
-	sources := make([]mergepkg.SourceSync, 0, len(c.entries))
+	pebbleCompactorMode := c.resolvedPebbleMode()
+	useOverlay := pebbleCompactorMode == PebbleCompactorModeOverlay
+	sources := make([]mergepkg.SourceFile, 0, len(c.entries))
 	unionType := v3.SyncType_SYNC_TYPE_PARTIAL
 	var maxEnded time.Time
 
@@ -83,38 +213,96 @@ func (c *Compactor) compactPebble(ctx context.Context, newSyncId string) error {
 			return err
 		}
 		cs := c.entries[i]
-		w, err := dotc1z.NewStore(ctx, cs.FilePath, dotc1z.WithReadOnly(true), dotc1z.WithTmpDir(c.tmpDir))
-		if err != nil {
-			return fmt.Errorf("compactPebble: open input %s: %w", cs.FilePath, err)
-		}
-		// Close the input store when the merge completes; the SST data
-		// is read eagerly into the destination during MergeInto.
-		defer func() {
-			if cerr := w.Close(ctx); cerr != nil {
-				l.Error("compactPebble: error closing input", zap.Error(cerr), zap.String("file", cs.FilePath))
+
+		// Fast path: read the latest finished compactable sync (and its
+		// cached stats) from the envelope manifest's sync-run projection
+		// — a header read, no payload unpack. Files written before the
+		// projection existed fall back to the unpack path below.
+		if sel, ok := selectSourceSyncFromManifest(cs.FilePath); ok {
+			sources = append(sources, mergepkg.SourceFile{Path: cs.FilePath, SyncID: sel.syncID, Stats: sel.stats, DecoderPool: c.decoderPool})
+			unionType = unionV3SyncType(unionType, sel.syncType)
+			if sel.endedAt.After(maxEnded) {
+				maxEnded = sel.endedAt
 			}
+			continue
+		}
+
+		source, syncType, endedAt, err := func() (mergepkg.SourceFile, v3.SyncType, time.Time, error) {
+			var zeroSource mergepkg.SourceFile
+			w, err := dotc1z.NewStore(ctx, cs.FilePath, dotc1z.WithReadOnly(true), dotc1z.WithTmpDir(c.tmpDir), dotc1z.WithDecoderPool(c.decoderPool))
+			if err != nil {
+				return zeroSource, v3.SyncType_SYNC_TYPE_UNSPECIFIED, time.Time{}, fmt.Errorf("compactPebble: open input %s: %w", cs.FilePath, err)
+			}
+			defer func() {
+				if cerr := w.Close(ctx); cerr != nil {
+					l.Error("compactPebble: error closing source store", zap.Error(cerr), zap.String("file", cs.FilePath))
+				}
+			}()
+
+			srcEng, ok := enginepkg.AsEngine(w)
+			if !ok {
+				return zeroSource, v3.SyncType_SYNC_TYPE_UNSPECIFIED, time.Time{}, fmt.Errorf("compactPebble: input %s is not a pebble c1z", cs.FilePath)
+			}
+			rec, err := srcEng.LatestFinishedSyncRecord(ctx, compactableV3SyncType)
+			if err != nil {
+				return zeroSource, v3.SyncType_SYNC_TYPE_UNSPECIFIED, time.Time{}, fmt.Errorf("compactPebble: select source sync for %s: %w", cs.FilePath, err)
+			}
+			if rec == nil {
+				return zeroSource, v3.SyncType_SYNC_TYPE_UNSPECIFIED, time.Time{}, fmt.Errorf("compactPebble: input %s has no finished compactable sync (diff syncs are not compactable)", cs.FilePath)
+			}
+
+			// Record only (Path, SyncID, Stats) and fully close the store,
+			// removing its unpacked directory. The merge re-unpacks each
+			// source when its chunk is processed and removes it when the
+			// chunk closes, so peak disk is O(fan-in) source directories,
+			// not O(len(entries)). The fallback unpacks one source at a
+			// time and pays one extra unpack per source (selection + merge).
+			source := mergepkg.SourceFile{Path: cs.FilePath, SyncID: rec.GetSyncId(), DecoderPool: c.decoderPool}
+			if useOverlay {
+				stats, ok, err := enginepkg.CachedSyncStats(ctx, srcEng, rec.GetSyncId())
+				if err != nil {
+					return zeroSource, v3.SyncType_SYNC_TYPE_UNSPECIFIED, time.Time{}, fmt.Errorf("compactPebble: cached stats for %s: %w", cs.FilePath, err)
+				}
+				if ok {
+					source.Stats = stats
+				}
+			}
+			var endedAt time.Time
+			if ts := rec.GetEndedAt(); ts != nil {
+				endedAt = ts.AsTime()
+			}
+			return source, rec.GetType(), endedAt, nil
 		}()
-
-		srcEng, ok := enginepkg.AsEngine(w)
-		if !ok {
-			return fmt.Errorf("compactPebble: input %s is not a pebble c1z", cs.FilePath)
-		}
-		rec, err := srcEng.LatestFinishedSyncRecord(ctx, compactableV3SyncType)
 		if err != nil {
-			return fmt.Errorf("compactPebble: select source sync for %s: %w", cs.FilePath, err)
-		}
-		if rec == nil {
-			return fmt.Errorf("compactPebble: input %s has no finished compactable sync (diff syncs are not compactable)", cs.FilePath)
+			return err
 		}
 
-		sources = append(sources, mergepkg.SourceSync{Engine: srcEng, SyncID: rec.GetSyncId()})
-		unionType = unionV3SyncType(unionType, rec.GetType())
-		if ts := rec.GetEndedAt(); ts != nil && ts.AsTime().After(maxEnded) {
-			maxEnded = ts.AsTime()
+		sources = append(sources, source)
+		unionType = unionV3SyncType(unionType, syncType)
+		if endedAt.After(maxEnded) {
+			maxEnded = endedAt
 		}
 	}
 
-	if err := mergepkg.MergeInto(ctx, destEng, sources, newSyncId); err != nil {
+	var statsRec *v3.SyncStatsRecord
+	var err error
+	switch pebbleCompactorMode {
+	case PebbleCompactorModeOverlay:
+		// Oversized buckets are routed to the K-way run-file path inside
+		// the overlay merge itself (overlayPlanBuckets), so there is no
+		// whole-merge fallback here.
+		var overlayOpts []mergepkg.OverlayOption
+		if c.overlaySeenKeyLimit > 0 {
+			overlayOpts = append(overlayOpts, mergepkg.WithOverlaySeenKeyLimit(c.overlaySeenKeyLimit))
+		}
+		if c.overlayRecordChunkSize > 0 {
+			overlayOpts = append(overlayOpts, mergepkg.WithOverlayRecordChunkSize(c.overlayRecordChunkSize))
+		}
+		statsRec, err = mergepkg.MergeFilesIntoOverlay(ctx, destEng, sources, newSyncId, c.tmpDir, overlayOpts...)
+	default:
+		statsRec, err = mergepkg.MergeFilesInto(ctx, destEng, sources, newSyncId, c.tmpDir)
+	}
+	if err != nil {
 		return fmt.Errorf("compactPebble: merge: %w", err)
 	}
 
@@ -131,6 +319,14 @@ func (c *Compactor) compactPebble(ctx context.Context, newSyncId string) error {
 	}
 	if err := destEng.PutSyncRunRecord(ctx, rec); err != nil {
 		return fmt.Errorf("compactPebble: persist dest sync_run: %w", err)
+	}
+	// The merge accumulated the dest stats while writing winners, so
+	// persist those instead of re-scanning the freshly written output.
+	if statsRec != nil {
+		if err := destEng.PersistComputedSyncStats(ctx, newSyncId, statsRec); err != nil {
+			return fmt.Errorf("compactPebble: persist stats: %w", err)
+		}
+		return nil
 	}
 	if err := destEng.PersistSyncStats(ctx, newSyncId); err != nil {
 		return fmt.Errorf("compactPebble: persist stats: %w", err)

--- a/pkg/synccompactor/compactor_pebble_test.go
+++ b/pkg/synccompactor/compactor_pebble_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cockroachdb/pebble/v2"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	reader_v2 "github.com/conductorone/baton-sdk/pb/c1/reader/v2"
@@ -157,6 +159,21 @@ func TestCompactPebbleEndToEnd(t *testing.T) {
 	count, st := verifyCompacted(t, ctx, out.FilePath, out.SyncID)
 	require.Equal(t, 3, count, "union of {g-shared,g-only1} and {g-shared,g-only2} deduped = 3 grants")
 	require.Equal(t, string(connectorstore.SyncTypeFull), st, "union of full + partial = full")
+
+	store, err := dotc1z.NewStore(ctx, out.FilePath, dotc1z.WithReadOnly(true))
+	require.NoError(t, err)
+	defer store.Close(ctx)
+	require.NoError(t, store.SetCurrentSync(ctx, out.SyncID))
+
+	group := v2.Resource_builder{
+		Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(),
+	}.Build()
+	byResource, err := store.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{
+		Resource: group,
+		PageSize: 1000,
+	}.Build())
+	require.NoError(t, err)
+	require.Len(t, byResource.GetList(), 3, "compacted pebble output must materialize grant_by_entitlement_resource index")
 }
 
 // buildSQLiteInput writes a minimal SQLite (v1) c1z with one grant per
@@ -264,4 +281,416 @@ func TestCompactSQLiteDefaultUnchanged(t *testing.T) {
 	resp, err := store.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{PageSize: 1000}.Build())
 	require.NoError(t, err)
 	require.Len(t, resp.GetList(), 3, "default sqlite compaction must union grants to 3")
+}
+
+type overlayInputSpec struct {
+	syncType connectorstore.SyncType
+	suffix   string
+	grants   []overlayGrantSpec
+}
+
+type overlayGrantSpec struct {
+	id              string
+	principalID     string
+	entitlementID   string
+	needsExpansion  bool
+	skipEntitlement bool
+}
+
+func buildOverlayInput(t testing.TB, ctx context.Context, path string, spec overlayInputSpec) string {
+	t.Helper()
+	store, err := dotc1z.NewStore(ctx, path, dotc1z.WithEngine(dotc1z.EnginePebble), dotc1z.WithTmpDir(t.TempDir()))
+	require.NoError(t, err)
+	syncID, err := store.StartNewSync(ctx, spec.syncType, "")
+	require.NoError(t, err)
+
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+	require.NoError(t, store.PutResourceTypes(ctx, groupRT, userRT))
+
+	group := v2.Resource_builder{
+		Id:          v2.ResourceId_builder{ResourceType: "group", Resource: "engineering"}.Build(),
+		DisplayName: "Engineering",
+	}.Build()
+	alice := v2.Resource_builder{
+		Id:               v2.ResourceId_builder{ResourceType: "user", Resource: "alice"}.Build(),
+		DisplayName:      "Alice " + spec.suffix,
+		ParentResourceId: group.GetId(),
+	}.Build()
+	bob := v2.Resource_builder{
+		Id:               v2.ResourceId_builder{ResourceType: "user", Resource: "bob"}.Build(),
+		DisplayName:      "Bob " + spec.suffix,
+		ParentResourceId: group.GetId(),
+	}.Build()
+	require.NoError(t, store.PutResources(ctx, group, alice, bob))
+
+	entitlementsByID := map[string]*v2.Entitlement{}
+	for _, g := range spec.grants {
+		if g.skipEntitlement {
+			continue
+		}
+		if _, ok := entitlementsByID[g.entitlementID]; ok {
+			continue
+		}
+		entitlementsByID[g.entitlementID] = v2.Entitlement_builder{
+			Id:       g.entitlementID,
+			Resource: group,
+			Purpose:  v2.Entitlement_PURPOSE_VALUE_ASSIGNMENT,
+		}.Build()
+	}
+	for _, ent := range entitlementsByID {
+		require.NoError(t, store.PutEntitlements(ctx, ent))
+	}
+
+	for _, g := range spec.grants {
+		principalID := alice
+		if g.principalID == "bob" {
+			principalID = bob
+		}
+		grant := v2.Grant_builder{
+			Id:          g.id,
+			Principal:   principalID,
+			Entitlement: v2.Entitlement_builder{Id: g.entitlementID, Resource: group, Purpose: v2.Entitlement_PURPOSE_VALUE_ASSIGNMENT}.Build(),
+		}.Build()
+		if g.needsExpansion {
+			grant.SetAnnotations([]*anypb.Any{mustAny(t, v2.GrantExpandable_builder{
+				EntitlementIds: []string{"member"},
+				Shallow:        true,
+			}.Build())})
+		}
+		require.NoError(t, store.PutGrants(ctx, grant))
+	}
+	require.NoError(t, store.EndSync(ctx))
+	require.NoError(t, store.Close(ctx))
+	return syncID
+}
+
+func mustAny(t testing.TB, msg proto.Message) *anypb.Any {
+	t.Helper()
+	out, err := anypb.New(msg)
+	require.NoError(t, err)
+	return out
+}
+
+func compactPebbleOverlay(t testing.TB, ctx context.Context, entries []*CompactableSync, extra ...Option) *CompactableSync {
+	t.Helper()
+	opts := append([]Option{
+		WithTmpDir(t.TempDir()), WithEngine(dotc1z.EnginePebble), WithSkipGrantExpansion(),
+		WithPebbleCompactorMode(PebbleCompactorModeOverlay),
+	}, extra...)
+	c, cleanup, err := NewCompactor(ctx, t.TempDir(), entries, opts...)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, cleanup()) }()
+	out, err := c.Compact(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	return out
+}
+
+func openCompactedPebble(t testing.TB, ctx context.Context, out *CompactableSync) dotc1z.C1ZStore {
+	t.Helper()
+	store, err := dotc1z.NewStore(ctx, out.FilePath, dotc1z.WithReadOnly(true), dotc1z.WithTmpDir(t.TempDir()))
+	require.NoError(t, err)
+	require.NoError(t, store.SetCurrentSync(ctx, out.SyncID))
+	return store
+}
+
+func TestCompactPebbleOverlayMaterializesAllQueryIndexes(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "base.c1z")
+	incPath := filepath.Join(dir, "inc.c1z")
+	baseSync := buildOverlayInput(t, ctx, basePath, overlayInputSpec{
+		syncType: connectorstore.SyncTypeFull,
+		suffix:   "base",
+		grants: []overlayGrantSpec{
+			{id: "g-alice-member", principalID: "alice", entitlementID: "member"},
+			{id: "g-bob-admin", principalID: "bob", entitlementID: "admin", needsExpansion: true},
+		},
+	})
+	incSync := buildOverlayInput(t, ctx, incPath, overlayInputSpec{
+		syncType: connectorstore.SyncTypePartial,
+		suffix:   "incremental",
+		grants: []overlayGrantSpec{
+			{id: "g-inc-bob-member", principalID: "bob", entitlementID: "member"},
+		},
+	})
+	out := compactPebbleOverlay(t, ctx, []*CompactableSync{{FilePath: basePath, SyncID: baseSync}, {FilePath: incPath, SyncID: incSync}})
+	store := openCompactedPebble(t, ctx, out)
+	defer store.Close(ctx)
+
+	group := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "engineering"}.Build()}.Build()
+	alice := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "alice"}.Build(), ParentResourceId: group.GetId()}.Build()
+
+	byResource, err := store.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{Resource: group, PageSize: 100}.Build())
+	require.NoError(t, err)
+	requireGrantIDs(t, byResource.GetList(), "g-alice-member", "g-bob-admin", "g-inc-bob-member")
+
+	member := v2.Entitlement_builder{Id: "member", Resource: group}.Build()
+	byEntitlement, err := store.ListGrantsForEntitlement(ctx, reader_v2.GrantsReaderServiceListGrantsForEntitlementRequest_builder{
+		Entitlement: member,
+		PageSize:    100,
+	}.Build())
+	require.NoError(t, err)
+	requireGrantIDs(t, byEntitlement.GetList(), "g-alice-member", "g-inc-bob-member")
+
+	byPrincipalAndEntitlement, err := store.ListGrantsForEntitlement(ctx, reader_v2.GrantsReaderServiceListGrantsForEntitlementRequest_builder{
+		Entitlement: member,
+		PrincipalId: alice.GetId(),
+		PageSize:    100,
+	}.Build())
+	require.NoError(t, err)
+	requireGrantIDs(t, byPrincipalAndEntitlement.GetList(), "g-alice-member")
+
+	users, err := store.ListResources(ctx, v2.ResourcesServiceListResourcesRequest_builder{ParentResourceId: group.GetId(), PageSize: 100}.Build())
+	require.NoError(t, err)
+	requireResourceIDs(t, users.GetList(), "alice", "bob")
+
+	ents, err := store.ListEntitlements(ctx, v2.EntitlementsServiceListEntitlementsRequest_builder{Resource: group, PageSize: 100}.Build())
+	require.NoError(t, err)
+	requireEntitlementIDs(t, ents.GetList(), "admin", "member")
+
+	pending, next, err := store.Grants().PendingExpansionPage(ctx, "")
+	require.NoError(t, err)
+	require.Empty(t, next)
+	require.Len(t, pending, 1)
+	require.Equal(t, "g-bob-admin", pending[0].GrantExternalID)
+}
+
+func TestCompactPebbleOverlayFirstSeenWinsForOverlappingGrant(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "base.c1z")
+	incPath := filepath.Join(dir, "inc.c1z")
+	baseSync := buildOverlayInput(t, ctx, basePath, overlayInputSpec{
+		syncType: connectorstore.SyncTypeFull,
+		suffix:   "base",
+		grants:   []overlayGrantSpec{{id: "shared", principalID: "alice", entitlementID: "member"}},
+	})
+	incSync := buildOverlayInput(t, ctx, incPath, overlayInputSpec{
+		syncType: connectorstore.SyncTypePartial,
+		suffix:   "incremental",
+		grants:   []overlayGrantSpec{{id: "shared", principalID: "bob", entitlementID: "member"}},
+	})
+	out := compactPebbleOverlay(t, ctx, []*CompactableSync{{FilePath: basePath, SyncID: baseSync}, {FilePath: incPath, SyncID: incSync}})
+	store := openCompactedPebble(t, ctx, out)
+	defer store.Close(ctx)
+	grant, err := store.GetGrant(ctx, reader_v2.GrantsReaderServiceGetGrantRequest_builder{GrantId: "shared"}.Build())
+	require.NoError(t, err)
+	require.Equal(t, "bob", grant.GetGrant().GetPrincipal().GetId().GetResource(), "newest/applied source must win overlay duplicate")
+}
+
+func TestCompactPebbleOverlayFallsBackToKWayAboveSeenLimit(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "base.c1z")
+	incPath := filepath.Join(dir, "inc.c1z")
+	baseSync := buildOverlayInput(t, ctx, basePath, overlayInputSpec{
+		syncType: connectorstore.SyncTypeFull,
+		suffix:   "base",
+		grants:   []overlayGrantSpec{{id: "shared", principalID: "alice", entitlementID: "member"}},
+	})
+	incSync := buildOverlayInput(t, ctx, incPath, overlayInputSpec{
+		syncType: connectorstore.SyncTypePartial,
+		suffix:   "incremental",
+		grants:   []overlayGrantSpec{{id: "shared", principalID: "bob", entitlementID: "member"}},
+	})
+	out := compactPebbleOverlay(t, ctx, []*CompactableSync{{FilePath: basePath, SyncID: baseSync}, {FilePath: incPath, SyncID: incSync}}, WithOverlaySeenKeyLimit(1))
+	store := openCompactedPebble(t, ctx, out)
+	defer store.Close(ctx)
+	grant, err := store.GetGrant(ctx, reader_v2.GrantsReaderServiceGetGrantRequest_builder{GrantId: "shared"}.Build())
+	require.NoError(t, err)
+	require.Equal(t, "bob", grant.GetGrant().GetPrincipal().GetId().GetResource(), "fallback must preserve compaction semantics")
+}
+
+func TestCompactPebbleOverlayFallsBackToKWayWhenMissingStatsPreflightExceedsLimit(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "base.c1z")
+	incPath := filepath.Join(dir, "inc.c1z")
+	baseSync := buildOverlayInput(t, ctx, basePath, overlayInputSpec{
+		syncType: connectorstore.SyncTypeFull,
+		suffix:   "base",
+		grants:   []overlayGrantSpec{{id: "shared", principalID: "alice", entitlementID: "member"}},
+	})
+	incSync := buildOverlayInput(t, ctx, incPath, overlayInputSpec{
+		syncType: connectorstore.SyncTypePartial,
+		suffix:   "incremental",
+		grants:   []overlayGrantSpec{{id: "shared", principalID: "bob", entitlementID: "member"}},
+	})
+	deletePebbleStatsSidecar(t, ctx, basePath)
+	deletePebbleStatsSidecar(t, ctx, incPath)
+
+	out := compactPebbleOverlay(t, ctx, []*CompactableSync{{FilePath: basePath, SyncID: baseSync}, {FilePath: incPath, SyncID: incSync}}, WithOverlaySeenKeyLimit(1))
+	store := openCompactedPebble(t, ctx, out)
+	defer store.Close(ctx)
+	grant, err := store.GetGrant(ctx, reader_v2.GrantsReaderServiceGetGrantRequest_builder{GrantId: "shared"}.Build())
+	require.NoError(t, err)
+	require.Equal(t, "bob", grant.GetGrant().GetPrincipal().GetId().GetResource(), "missing cached stats preflight fallback must preserve compaction semantics")
+}
+
+func TestCompactPebbleOverlayMissingStatsPreflightAllowsSmallInputs(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "base.c1z")
+	incPath := filepath.Join(dir, "inc.c1z")
+	baseSync := buildOverlayInput(t, ctx, basePath, overlayInputSpec{
+		syncType: connectorstore.SyncTypeFull,
+		suffix:   "base",
+		grants:   []overlayGrantSpec{{id: "base-only", principalID: "alice", entitlementID: "member"}},
+	})
+	incSync := buildOverlayInput(t, ctx, incPath, overlayInputSpec{
+		syncType: connectorstore.SyncTypePartial,
+		suffix:   "incremental",
+		grants:   nil,
+	})
+	deletePebbleStatsSidecar(t, ctx, basePath)
+	deletePebbleStatsSidecar(t, ctx, incPath)
+
+	out := compactPebbleOverlay(t, ctx, []*CompactableSync{{FilePath: basePath, SyncID: baseSync}, {FilePath: incPath, SyncID: incSync}}, WithOverlaySeenKeyLimit(100))
+	store := openCompactedPebble(t, ctx, out)
+	defer store.Close(ctx)
+	resp, err := store.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{PageSize: 100}.Build())
+	require.NoError(t, err)
+	requireGrantIDs(t, resp.GetList(), "base-only")
+}
+
+func TestCompactPebbleOverlayWholeBaseBucketFastPathIndexesBaseGrants(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "base.c1z")
+	incPath := filepath.Join(dir, "inc.c1z")
+	baseSync := buildOverlayInput(t, ctx, basePath, overlayInputSpec{
+		syncType: connectorstore.SyncTypeFull,
+		suffix:   "base",
+		grants: []overlayGrantSpec{
+			{id: "base-alice", principalID: "alice", entitlementID: "member"},
+			{id: "base-bob", principalID: "bob", entitlementID: "admin", needsExpansion: true},
+		},
+	})
+	incSync := buildOverlayInput(t, ctx, incPath, overlayInputSpec{
+		syncType: connectorstore.SyncTypePartial,
+		suffix:   "incremental-no-grants",
+		grants:   nil,
+	})
+	out := compactPebbleOverlay(t, ctx, []*CompactableSync{{FilePath: basePath, SyncID: baseSync}, {FilePath: incPath, SyncID: incSync}})
+	store := openCompactedPebble(t, ctx, out)
+	defer store.Close(ctx)
+	group := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "engineering"}.Build()}.Build()
+	byResource, err := store.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{Resource: group, PageSize: 100}.Build())
+	require.NoError(t, err)
+	requireGrantIDs(t, byResource.GetList(), "base-alice", "base-bob")
+	pending, _, err := store.Grants().PendingExpansionPage(ctx, "")
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	require.Equal(t, "base-bob", pending[0].GrantExternalID)
+}
+
+// TestCompactPebbleStatsSidecarMatchesRecompute pins that compaction
+// persists merge-accumulated stats that exactly match a full recompute
+// of the compacted output, for both the K-way path and the overlay
+// path (each forced explicitly via WithPebbleCompactorMode).
+func TestCompactPebbleStatsSidecarMatchesRecompute(t *testing.T) {
+	for _, mode := range []PebbleCompactorMode{PebbleCompactorModeKWay, PebbleCompactorModeOverlay} {
+		t.Run(string(mode), func(t *testing.T) {
+			ctx := context.Background()
+			inDir := t.TempDir()
+			p1 := filepath.Join(inDir, "in1.c1z")
+			p2 := filepath.Join(inDir, "in2.c1z")
+			s1 := buildPebbleInput(t, ctx, p1, connectorstore.SyncTypePartial, "g-shared", "g-only1")
+			s2 := buildPebbleInput(t, ctx, p2, connectorstore.SyncTypePartial, "g-shared", "g-only2")
+
+			c, cleanup, err := NewCompactor(ctx, t.TempDir(),
+				[]*CompactableSync{{FilePath: p1, SyncID: s1}, {FilePath: p2, SyncID: s2}},
+				WithTmpDir(t.TempDir()), WithEngine(dotc1z.EnginePebble), WithSkipGrantExpansion(),
+				WithPebbleCompactorMode(mode))
+			require.NoError(t, err)
+			defer func() { _ = cleanup() }()
+			out, err := c.Compact(ctx)
+			require.NoError(t, err)
+			require.NotNil(t, out)
+
+			w, err := dotc1z.NewStore(ctx, out.FilePath, dotc1z.WithTmpDir(t.TempDir()))
+			require.NoError(t, err)
+			defer w.Close(ctx)
+			eng, ok := enginepkg.AsEngine(w)
+			require.True(t, ok)
+
+			stored, err := enginepkg.ReadSyncStatsRecord(ctx, eng, out.SyncID)
+			require.NoError(t, err)
+			require.NotNil(t, stored, "compaction must persist a stats sidecar")
+
+			// Sanity-pin the expected fixture counts so a dual-sided
+			// systematic error can't slip through the parity check.
+			require.Equal(t, int64(2), stored.GetResourceTypes())
+			require.Equal(t, int64(2), stored.GetResources())
+			require.Equal(t, int64(1), stored.GetEntitlements())
+			require.Equal(t, int64(3), stored.GetGrants(), "union of {g-shared,g-only1} and {g-shared,g-only2}")
+			require.Equal(t, int64(0), stored.GetAssets(), "compaction drops assets")
+			require.Equal(t, map[string]int64{"group": 1, "user": 1}, stored.GetResourcesByResourceType())
+			require.Equal(t, map[string]int64{"group": 3}, stored.GetGrantsByEntitlementResourceType())
+
+			require.NoError(t, eng.PersistSyncStats(ctx, out.SyncID))
+			recomputed, err := enginepkg.ReadSyncStatsRecord(ctx, eng, out.SyncID)
+			require.NoError(t, err)
+			require.NotNil(t, recomputed)
+			require.Equal(t, recomputed.GetResourceTypes(), stored.GetResourceTypes())
+			require.Equal(t, recomputed.GetResources(), stored.GetResources())
+			require.Equal(t, recomputed.GetEntitlements(), stored.GetEntitlements())
+			require.Equal(t, recomputed.GetGrants(), stored.GetGrants())
+			require.Equal(t, recomputed.GetAssets(), stored.GetAssets())
+			require.Equal(t, recomputed.GetResourcesByResourceType(), stored.GetResourcesByResourceType())
+			require.Equal(t, recomputed.GetGrantsByEntitlementResourceType(), stored.GetGrantsByEntitlementResourceType())
+		})
+	}
+}
+
+func requireGrantIDs(t testing.TB, grants []*v2.Grant, want ...string) {
+	t.Helper()
+	got := make([]string, 0, len(grants))
+	for _, grant := range grants {
+		got = append(got, grant.GetId())
+	}
+	require.ElementsMatch(t, want, got)
+}
+
+func requireResourceIDs(t testing.TB, resources []*v2.Resource, want ...string) {
+	t.Helper()
+	got := make([]string, 0, len(resources))
+	for _, resource := range resources {
+		got = append(got, resource.GetId().GetResource())
+	}
+	require.ElementsMatch(t, want, got)
+}
+
+func requireEntitlementIDs(t testing.TB, entitlements []*v2.Entitlement, want ...string) {
+	t.Helper()
+	got := make([]string, 0, len(entitlements))
+	for _, entitlement := range entitlements {
+		got = append(got, entitlement.GetId())
+	}
+	require.ElementsMatch(t, want, got)
+}
+
+func deletePebbleStatsSidecar(t testing.TB, ctx context.Context, path string) {
+	t.Helper()
+	w, err := dotc1z.NewStore(ctx, path, dotc1z.WithTmpDir(t.TempDir()))
+	require.NoError(t, err)
+	eng, ok := enginepkg.AsEngine(w)
+	require.True(t, ok)
+	iter, err := eng.DB().NewIter(&pebble.IterOptions{
+		LowerBound: enginepkg.SyncStatsSidecarLowerBound(),
+		UpperBound: enginepkg.SyncStatsSidecarUpperBound(),
+	})
+	require.NoError(t, err)
+	var keys [][]byte
+	for iter.First(); iter.Valid(); iter.Next() {
+		keys = append(keys, append([]byte(nil), iter.Key()...))
+	}
+	require.NoError(t, iter.Error())
+	require.NoError(t, iter.Close())
+	for _, key := range keys {
+		require.NoError(t, eng.DB().Delete(key, nil))
+	}
+	require.NoError(t, w.Close(ctx))
 }

--- a/pkg/synccompactor/pebble/compactor_bench_test.go
+++ b/pkg/synccompactor/pebble/compactor_bench_test.go
@@ -88,7 +88,6 @@ func benchNewEngine(b *testing.B, name string) (*enginepkg.Engine, string) {
 
 func benchGrant(syncID string, i int) *v3.GrantRecord {
 	return v3.GrantRecord_builder{
-		SyncId:     syncID,
 		ExternalId: "grant-" + strconv.Itoa(i),
 		Entitlement: v3.EntitlementRef_builder{
 			ResourceTypeId: "app",

--- a/pkg/synccompactor/pebble/compactor_test.go
+++ b/pkg/synccompactor/pebble/compactor_test.go
@@ -26,7 +26,6 @@ func newEngine(t *testing.T, name string) (*enginepkg.Engine, string) {
 
 func grant(syncID, externalID, entID, principalID string) *v3.GrantRecord {
 	return v3.GrantRecord_builder{
-		SyncId:     syncID,
 		ExternalId: externalID,
 		Entitlement: v3.EntitlementRef_builder{
 			ResourceTypeId: "app",
@@ -173,19 +172,19 @@ func TestCompactReplacesAllImplementedBuckets(t *testing.T) {
 	}
 
 	if err := dst.PutResourceTypeRecord(ctx, v3.ResourceTypeRecord_builder{
-		SyncId: syncID, ExternalId: "rt-stale", DisplayName: "stale",
+		ExternalId: "rt-stale", DisplayName: "stale",
 	}.Build()); err != nil {
 		t.Fatal(err)
 	}
 	if err := dst.PutResourceRecord(ctx, v3.ResourceRecord_builder{
-		SyncId: syncID, ResourceTypeId: "user", ResourceId: "stale-child",
+		ResourceTypeId: "user", ResourceId: "stale-child",
 		Parent: v3.ResourceRef_builder{ResourceTypeId: "group", ResourceId: "admins"}.Build(),
 	}.Build()); err != nil {
 		t.Fatal(err)
 	}
 	if err := dst.PutEntitlementRecord(ctx, v3.EntitlementRecord_builder{
-		SyncId: syncID, ExternalId: "ent-stale",
-		Resource: v3.ResourceRef_builder{ResourceTypeId: "group", ResourceId: "admins"}.Build(),
+		ExternalId: "ent-stale",
+		Resource:   v3.ResourceRef_builder{ResourceTypeId: "group", ResourceId: "admins"}.Build(),
 	}.Build()); err != nil {
 		t.Fatal(err)
 	}
@@ -201,24 +200,24 @@ func TestCompactReplacesAllImplementedBuckets(t *testing.T) {
 	}
 
 	if err := src.PutResourceTypeRecord(ctx, v3.ResourceTypeRecord_builder{
-		SyncId: syncID, ExternalId: "rt-fresh", DisplayName: "fresh",
+		ExternalId: "rt-fresh", DisplayName: "fresh",
 	}.Build()); err != nil {
 		t.Fatal(err)
 	}
 	if err := src.PutResourceRecord(ctx, v3.ResourceRecord_builder{
-		SyncId: syncID, ResourceTypeId: "group", ResourceId: "admins",
+		ResourceTypeId: "group", ResourceId: "admins",
 	}.Build()); err != nil {
 		t.Fatal(err)
 	}
 	if err := src.PutResourceRecord(ctx, v3.ResourceRecord_builder{
-		SyncId: syncID, ResourceTypeId: "user", ResourceId: "fresh-child",
+		ResourceTypeId: "user", ResourceId: "fresh-child",
 		Parent: v3.ResourceRef_builder{ResourceTypeId: "group", ResourceId: "admins"}.Build(),
 	}.Build()); err != nil {
 		t.Fatal(err)
 	}
 	if err := src.PutEntitlementRecord(ctx, v3.EntitlementRecord_builder{
-		SyncId: syncID, ExternalId: "ent-fresh",
-		Resource: v3.ResourceRef_builder{ResourceTypeId: "group", ResourceId: "admins"}.Build(),
+		ExternalId: "ent-fresh",
+		Resource:   v3.ResourceRef_builder{ResourceTypeId: "group", ResourceId: "admins"}.Build(),
 	}.Build()); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/synccompactor/pebble/kway.go
+++ b/pkg/synccompactor/pebble/kway.go
@@ -1,0 +1,1660 @@
+package pebble
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"time"
+
+	cpebble "github.com/cockroachdb/pebble/v2"
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	reader_v2 "github.com/conductorone/baton-sdk/pb/c1/reader/v2"
+	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	enginepkg "github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/codec"
+)
+
+const (
+	defaultKWayFanIn       = 50
+	runFileBufferSize      = 1 << 20
+	indexSortChunkKeys     = 100000
+	runHeaderSize          = 20
+	runBucketResourceTypes = 0
+	runBucketResources     = 1
+	runBucketEntitlements  = 2
+	runBucketGrants        = 3
+	runBucketCount         = 4
+)
+
+// SourceFile identifies a compactable Pebble c1z input and the sync within it.
+type SourceFile struct {
+	Path   string
+	SyncID string
+	Stats  *reader_v2.SyncStats
+	Engine *enginepkg.Engine
+	DBDir  string
+	// DecoderPool, when set, supplies the v3 payload decoder for every
+	// open of this source (the compactor scopes one pool to the whole
+	// merge). Nil is fine: each open constructs a one-shot decoder.
+	DecoderPool *dotc1z.EnvelopeDecoderPool
+}
+
+// MergeFilesInto folds source syncs into destSyncID using a bounded K-way
+// semantic merge and final SST ingestion. It materializes resource_types,
+// resources, entitlements, and grants plus all derived indexes. Assets are not
+// copied, matching SQLite compaction behavior.
+//
+// On success it returns the dest sync's stats record, accumulated at the
+// final winner-dedupe sites (never at run-file build time — run files keep
+// duplicate keys across chunks until the last merge round), so the caller
+// can persist the stats sidecar without re-scanning the output.
+func MergeFilesInto(ctx context.Context, dest *enginepkg.Engine, sources []SourceFile, destSyncID string, tmpDir string, opts ...KWayOption) (*v3.SyncStatsRecord, error) {
+	return mergeBucketsInto(ctx, dest, sources, destSyncID, tmpDir, allBuckets(), opts...)
+}
+
+func mergeBucketsInto(ctx context.Context, dest *enginepkg.Engine, sources []SourceFile, destSyncID string, tmpDir string, buckets []bucketSpec, opts ...KWayOption) (*v3.SyncStatsRecord, error) {
+	if dest == nil {
+		return nil, fmt.Errorf("kway merge: dest engine is nil")
+	}
+	if destSyncID == "" {
+		return nil, fmt.Errorf("kway merge: destSyncID is required")
+	}
+	cfg := kWayConfig{fanIn: defaultKWayFanIn}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	if cfg.fanIn < 2 {
+		cfg.fanIn = defaultKWayFanIn
+	}
+	destSyncBytes, err := codec.EncodeSyncID(destSyncID)
+	if err != nil {
+		return nil, err
+	}
+	stats := newMergeStatsAccumulator()
+	rm := &asyncRemover{}
+	defer rm.wait()
+	if len(sources) <= cfg.fanIn {
+		if err := mergeSourceChunkToPebble(ctx, dest, tmpDir, sources, 0, destSyncID, destSyncBytes, buckets, stats, rm); err != nil {
+			return nil, err
+		}
+		return stats.record(), nil
+	}
+	roundFiles := make([]runFile, 0, (len(sources)+cfg.fanIn-1)/cfg.fanIn)
+	for start := 0; start < len(sources); start += cfg.fanIn {
+		end := min(start+cfg.fanIn, len(sources))
+		run, err := buildChunkRunFileFromSources(ctx, tmpDir, sources[start:end], start, fmt.Sprintf("initial-%04d", len(roundFiles)), destSyncID, destSyncBytes, buckets, rm)
+		if err != nil {
+			removeRunFiles(roundFiles)
+			return nil, err
+		}
+		roundFiles = append(roundFiles, run)
+	}
+	defer func() {
+		removeRunFiles(roundFiles)
+	}()
+
+	round := 1
+	for len(roundFiles) > cfg.fanIn {
+		next := make([]runFile, 0, (len(roundFiles)+cfg.fanIn-1)/cfg.fanIn)
+		for start := 0; start < len(roundFiles); start += cfg.fanIn {
+			end := min(start+cfg.fanIn, len(roundFiles))
+			merged, err := mergeRunFileGroup(ctx, tmpDir, roundFiles[start:end], fmt.Sprintf("%02d-%04d", round, len(next)), buckets)
+			if err != nil {
+				removeRunFiles(next)
+				return nil, err
+			}
+			next = append(next, merged)
+			// A group's inputs are fully consumed by its merge; delete
+			// them now so run-file disk overhead is bounded by one
+			// group, not one whole round. The deferred removeRunFiles
+			// backstop tolerates the already-deleted paths.
+			removeRunFiles(roundFiles[start:end])
+		}
+		roundFiles = next
+		round++
+	}
+	if err := materializeRunFilesToPebble(ctx, dest, tmpDir, roundFiles, destSyncBytes, buckets, stats); err != nil {
+		return nil, err
+	}
+	return stats.record(), nil
+}
+
+type kWayConfig struct {
+	fanIn int
+}
+
+type KWayOption func(*kWayConfig)
+
+func WithFanIn(fanIn int) KWayOption {
+	return func(c *kWayConfig) {
+		c.fanIn = fanIn
+	}
+}
+
+type runSection struct {
+	offset int64
+	length int64
+}
+
+type runFile struct {
+	path     string
+	sections [runBucketCount]runSection
+}
+
+func removeRunFiles(files []runFile) {
+	for _, file := range files {
+		_ = os.Remove(file.path)
+	}
+}
+
+type sourceHandle struct {
+	rank   int
+	syncID string
+	engine *enginepkg.Engine
+	close  func() error
+}
+
+// sourceChunk owns one fan-in window of open sources. Path-based
+// sources are unpacked under a single chunk-scoped parent directory;
+// close() closes every engine and removes that directory in one
+// recursive delete. Both merge algorithms are chunk-major over sources
+// (a source is never revisited after its chunk closes), so this bounds
+// peak disk at O(fan-in) unpacked sources instead of O(total). The
+// compactor's final tmp-root cleanup remains the backstop for anything
+// a failed chunk leaves behind.
+type sourceChunk struct {
+	handles []sourceHandle
+	dir     string // chunk-scoped unpack dir; empty when no Path sources
+}
+
+func (c *sourceChunk) close() {
+	closeSourceHandles(c.handles)
+	if c.dir != "" {
+		_ = os.RemoveAll(c.dir)
+	}
+}
+
+// closeAsync closes the chunk's engines synchronously (file locks and
+// descriptors must release before deletion) and hands the chunk
+// directory to rm, so the unlink storm of an unpacked Pebble tree
+// happens off the merge's critical path. Benchmarks on APFS showed
+// in-loop chunk deletion costing a measurable slice of merge time.
+func (c *sourceChunk) closeAsync(rm *asyncRemover) {
+	closeSourceHandles(c.handles)
+	rm.remove(c.dir)
+}
+
+// asyncRemover deletes directory trees on background goroutines.
+// Owners must call wait() before returning so no deletion is still in
+// flight when the compactor's tmp-root cleanup (the crash backstop)
+// sweeps the same parent. Deletion errors are ignored — the tmp-root
+// sweep catches anything left behind.
+type asyncRemover struct {
+	wg sync.WaitGroup
+}
+
+func (d *asyncRemover) remove(path string) {
+	if path == "" {
+		return
+	}
+	d.wg.Add(1)
+	go func() {
+		defer d.wg.Done()
+		_ = os.RemoveAll(path)
+	}()
+}
+
+func (d *asyncRemover) wait() { d.wg.Wait() }
+
+func openSourceChunk(ctx context.Context, tmpDir string, sources []SourceFile, baseRank int) (*sourceChunk, error) {
+	chunk := &sourceChunk{handles: make([]sourceHandle, 0, len(sources))}
+	cleanupOnError := func(err error) error {
+		chunk.close()
+		return err
+	}
+	for i, source := range sources {
+		if source.Engine != nil {
+			chunk.handles = append(chunk.handles, sourceHandle{
+				rank:   baseRank + i,
+				syncID: source.SyncID,
+				engine: source.Engine,
+			})
+			continue
+		}
+		if source.DBDir != "" {
+			// Caller-owned directory: reopen in place, never delete.
+			eng, err := enginepkg.Open(ctx, source.DBDir, enginepkg.WithReadOnly(true))
+			if err != nil {
+				return nil, cleanupOnError(err)
+			}
+			chunk.handles = append(chunk.handles, sourceHandle{
+				rank:   baseRank + i,
+				syncID: source.SyncID,
+				engine: eng,
+				close:  eng.Close,
+			})
+			continue
+		}
+		if chunk.dir == "" {
+			dir, err := os.MkdirTemp(tmpDir, "kway-chunk-")
+			if err != nil {
+				return nil, cleanupOnError(err)
+			}
+			chunk.dir = dir
+		}
+		w, err := dotc1z.NewStore(ctx, source.Path, dotc1z.WithReadOnly(true), dotc1z.WithTmpDir(chunk.dir), dotc1z.WithDecoderPool(source.DecoderPool))
+		if err != nil {
+			return nil, cleanupOnError(err)
+		}
+		eng, ok := enginepkg.AsEngine(w)
+		if !ok {
+			_ = w.Close(ctx)
+			return nil, cleanupOnError(fmt.Errorf("kway merge: input is not pebble: %s", source.Path))
+		}
+		store := w
+		chunk.handles = append(chunk.handles, sourceHandle{
+			rank:   baseRank + i,
+			syncID: source.SyncID,
+			engine: eng,
+			// CloseEngineOnly: the unpacked directory lives under
+			// chunk.dir and is removed wholesale by sourceChunk.close().
+			close: func() error { return enginepkg.CloseEngineOnly(store) },
+		})
+	}
+	return chunk, nil
+}
+
+func closeSourceHandles(handles []sourceHandle) {
+	for _, handle := range handles {
+		if handle.close != nil {
+			_ = handle.close()
+		}
+	}
+}
+
+func buildChunkRunFileFromSources(
+	ctx context.Context,
+	tmpDir string,
+	sources []SourceFile,
+	baseRank int,
+	name string,
+	destSyncID string,
+	destSyncBytes []byte,
+	buckets []bucketSpec,
+	rm *asyncRemover,
+) (runFile, error) {
+	chunk, err := openSourceChunk(ctx, tmpDir, sources, baseRank)
+	if err != nil {
+		return runFile{}, err
+	}
+	defer chunk.closeAsync(rm)
+	return buildChunkRunFileFromHandles(ctx, tmpDir, chunk.handles, name, destSyncID, destSyncBytes, buckets)
+}
+
+func buildChunkRunFileFromHandles(
+	ctx context.Context,
+	tmpDir string,
+	handles []sourceHandle,
+	name string,
+	destSyncID string,
+	destSyncBytes []byte,
+	buckets []bucketSpec,
+) (runFile, error) {
+	path := filepath.Join(tmpDir, "kway-run-"+name+".bin")
+	f, err := os.Create(path)
+	if err != nil {
+		return runFile{}, err
+	}
+	cw := &countingWriter{w: bufio.NewWriterSize(f, runFileBufferSize)}
+	success := false
+	defer func() {
+		_ = f.Close()
+		if !success {
+			_ = os.Remove(path)
+		}
+	}()
+	run := runFile{path: path}
+	for _, bucket := range buckets {
+		if err := mergeSourceBucketToRunSection(ctx, cw, handles, bucket, destSyncID, destSyncBytes, &run); err != nil {
+			return runFile{}, err
+		}
+	}
+	if err := cw.Flush(); err != nil {
+		return runFile{}, err
+	}
+	if err := f.Close(); err != nil {
+		return runFile{}, err
+	}
+	success = true
+	return run, nil
+}
+
+func mergeSourceChunkToPebble(
+	ctx context.Context,
+	dest *enginepkg.Engine,
+	tmpDir string,
+	sources []SourceFile,
+	baseRank int,
+	destSyncID string,
+	destSyncBytes []byte,
+	buckets []bucketSpec,
+	stats *mergeStatsAccumulator,
+	rm *asyncRemover,
+) error {
+	chunk, err := openSourceChunk(ctx, tmpDir, sources, baseRank)
+	if err != nil {
+		return err
+	}
+	defer chunk.closeAsync(rm)
+	for _, bucket := range buckets {
+		if err := materializeSourceBucketToPebble(ctx, dest, tmpDir, chunk.handles, bucket, destSyncID, destSyncBytes, stats); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type countingWriter struct {
+	w *bufio.Writer
+	n int64
+	// hdr is the run-record header scratch. It lives here (one heap
+	// allocation per run file) instead of on writeRunRecord's frame
+	// because a stack array passed to an io.Writer interface call
+	// escapes — that was one allocation per record written.
+	hdr [runHeaderSize]byte
+}
+
+func (w *countingWriter) Write(p []byte) (int, error) {
+	n, err := w.w.Write(p)
+	w.n += int64(n)
+	return n, err
+}
+
+func (w *countingWriter) Flush() error {
+	return w.w.Flush()
+}
+
+type bucketSpec struct {
+	id        int
+	name      string
+	newRecord func() proto.Message
+	// syncRange returns the half-open Pebble key range containing every
+	// primary record for this bucket under one sync id.
+	syncRange       func([]byte) ([]byte, []byte)
+	key             func(proto.Message) string
+	ts              func(proto.Message) *timestamppb.Timestamp
+	indexKeys       func([]byte, proto.Message) [][]byte
+	forEachIndexKey func([]byte, proto.Message, func([]byte) error) error
+}
+
+func allBuckets() []bucketSpec {
+	return []bucketSpec{resourceTypeBucket(), resourceBucket(), entitlementBucket(), grantBucket()}
+}
+
+func resourceTypeBucket() bucketSpec {
+	return bucketSpec{
+		id:        runBucketResourceTypes,
+		name:      "resource_types",
+		newRecord: func() proto.Message { return &v3.ResourceTypeRecord{} },
+		syncRange: func(syncBytes []byte) ([]byte, []byte) {
+			return enginepkg.ResourceTypeSyncLowerBound(syncBytes), enginepkg.ResourceTypeSyncUpperBound(syncBytes)
+		},
+		key: func(m proto.Message) string { return m.(*v3.ResourceTypeRecord).GetExternalId() },
+		ts:  func(m proto.Message) *timestamppb.Timestamp { return m.(*v3.ResourceTypeRecord).GetDiscoveredAt() },
+	}
+}
+
+func resourceBucket() bucketSpec {
+	return bucketSpec{
+		id:        runBucketResources,
+		name:      "resources",
+		newRecord: func() proto.Message { return &v3.ResourceRecord{} },
+		syncRange: func(syncBytes []byte) ([]byte, []byte) {
+			return enginepkg.ResourceSyncLowerBound(syncBytes), enginepkg.ResourceSyncUpperBound(syncBytes)
+		},
+		key: func(m proto.Message) string {
+			r := m.(*v3.ResourceRecord)
+			return r.GetResourceTypeId() + "\x00" + r.GetResourceId()
+		},
+		ts: func(m proto.Message) *timestamppb.Timestamp { return m.(*v3.ResourceRecord).GetDiscoveredAt() },
+		indexKeys: func(syncBytes []byte, m proto.Message) [][]byte {
+			return enginepkg.ResourceIndexKeys(syncBytes, m.(*v3.ResourceRecord))
+		},
+		forEachIndexKey: func(syncBytes []byte, m proto.Message, yield func([]byte) error) error {
+			return enginepkg.ForEachResourceIndexKey(syncBytes, m.(*v3.ResourceRecord), yield)
+		},
+	}
+}
+
+func entitlementBucket() bucketSpec {
+	return bucketSpec{
+		id:        runBucketEntitlements,
+		name:      "entitlements",
+		newRecord: func() proto.Message { return &v3.EntitlementRecord{} },
+		syncRange: func(syncBytes []byte) ([]byte, []byte) {
+			return enginepkg.EntitlementSyncLowerBound(syncBytes), enginepkg.EntitlementSyncUpperBound(syncBytes)
+		},
+		key: func(m proto.Message) string { return m.(*v3.EntitlementRecord).GetExternalId() },
+		ts:  func(m proto.Message) *timestamppb.Timestamp { return m.(*v3.EntitlementRecord).GetDiscoveredAt() },
+		indexKeys: func(syncBytes []byte, m proto.Message) [][]byte {
+			return enginepkg.EntitlementIndexKeys(syncBytes, m.(*v3.EntitlementRecord))
+		},
+		forEachIndexKey: func(syncBytes []byte, m proto.Message, yield func([]byte) error) error {
+			return enginepkg.ForEachEntitlementIndexKey(syncBytes, m.(*v3.EntitlementRecord), yield)
+		},
+	}
+}
+
+func grantBucket() bucketSpec {
+	return bucketSpec{
+		id:        runBucketGrants,
+		name:      "grants",
+		newRecord: func() proto.Message { return &v3.GrantRecord{} },
+		syncRange: func(syncBytes []byte) ([]byte, []byte) {
+			return enginepkg.GrantSyncLowerBound(syncBytes), enginepkg.GrantSyncUpperBound(syncBytes)
+		},
+		key: func(m proto.Message) string { return m.(*v3.GrantRecord).GetExternalId() },
+		ts:  func(m proto.Message) *timestamppb.Timestamp { return m.(*v3.GrantRecord).GetDiscoveredAt() },
+		indexKeys: func(syncBytes []byte, m proto.Message) [][]byte {
+			return enginepkg.GrantIndexKeys(syncBytes, m.(*v3.GrantRecord))
+		},
+		forEachIndexKey: func(syncBytes []byte, m proto.Message, yield func([]byte) error) error {
+			return enginepkg.ForEachGrantIndexKey(syncBytes, m.(*v3.GrantRecord), yield)
+		},
+	}
+}
+
+type directStream struct {
+	sourceRank int
+	iter       *cpebble.Iterator
+	bucket     bucketSpec
+	sourceLo   []byte
+	destLo     []byte
+	destSyncID string
+	destBytes  []byte
+
+	// keyBuf/valBuf back the runRecord returned by next(). The merge
+	// loops hold at most one live record per stream (in the heap or
+	// the current dedupe group), and a stream's buffers are only
+	// overwritten by that stream's own next(), which callers invoke
+	// only after the record has been consumed (written to the run
+	// file / SST and index-emitted). Reusing them removes the two
+	// per-record allocations the old copy-out version paid.
+	keyBuf []byte
+	valBuf []byte
+}
+
+func (s *directStream) close() {
+	if s.iter != nil {
+		_ = s.iter.Close()
+	}
+}
+
+func (s *directStream) next() (runRecord, bool, error) {
+	if !s.iter.Valid() {
+		if err := s.iter.Error(); err != nil {
+			return runRecord{}, false, err
+		}
+		return runRecord{}, false, nil
+	}
+	// K-way's source stream is raw by default: copy the stored value, rewrite
+	// the primary key, and shallow-scan only discovered_at. Indexes are
+	// generated once for final winners instead of being carried through every
+	// run-file round; on non-skewed syncs=500, carrying index blobs accounted
+	// for tens of millions of allocations.
+	sourceKey := s.iter.Key()
+	if len(sourceKey) < len(s.sourceLo) {
+		return runRecord{}, false, fmt.Errorf("source key shorter than lower bound prefix: key=%d prefix=%d", len(sourceKey), len(s.sourceLo))
+	}
+	rank, err := checkedUint32(s.sourceRank, "source rank")
+	if err != nil {
+		return runRecord{}, false, err
+	}
+	tsNanos, err := discoveredAtNanosFromRaw(s.bucket, s.iter.Value())
+	if err != nil {
+		return runRecord{}, false, err
+	}
+	s.keyBuf = rewritePrimaryKeyForDestInto(s.keyBuf[:0], sourceKey[len(s.sourceLo):], s.destLo)
+	s.valBuf = append(s.valBuf[:0], s.iter.Value()...)
+	item := runRecord{
+		key:        s.keyBuf,
+		value:      s.valBuf,
+		tsNanos:    tsNanos,
+		sourceRank: rank,
+	}
+	s.iter.Next()
+	return item, true, nil
+}
+
+func mergeSourceBucketToRunSection(
+	ctx context.Context,
+	w *countingWriter,
+	sources []sourceHandle,
+	bucket bucketSpec,
+	destSyncID string,
+	destBytes []byte,
+	run *runFile,
+) error {
+	start := w.n
+	streams := make([]*directStream, 0, len(sources))
+	defer func() {
+		for _, stream := range streams {
+			stream.close()
+		}
+	}()
+	h := &directHeap{}
+	for i, source := range sources {
+		syncBytes, err := codec.EncodeSyncID(source.syncID)
+		if err != nil {
+			return err
+		}
+		lower, upper := bucket.syncRange(syncBytes)
+		destLower, _ := bucket.syncRange(destBytes)
+		iter, err := source.engine.DB().NewIter(&cpebble.IterOptions{LowerBound: lower, UpperBound: upper})
+		if err != nil {
+			return err
+		}
+		iter.First()
+		stream := &directStream{
+			sourceRank: source.rank,
+			iter:       iter,
+			bucket:     bucket,
+			sourceLo:   lower,
+			destLo:     destLower,
+			destSyncID: destSyncID,
+			destBytes:  destBytes,
+		}
+		streams = append(streams, stream)
+		rec, ok, err := stream.next()
+		if err != nil {
+			return err
+		}
+		if ok {
+			h.push(directItem{streamIdx: i, rec: rec})
+		}
+	}
+	for h.Len() > 0 {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		first := h.pop()
+		winner := first.rec
+		group := []directItem{first}
+		for h.Len() > 0 && bytes.Equal((*h)[0].rec.key, first.rec.key) {
+			group = append(group, h.pop())
+		}
+		for _, item := range group[1:] {
+			if runRecordIsNewer(item.rec, winner) {
+				winner = item.rec
+			}
+		}
+		if err := writeRunRecord(w, winner); err != nil {
+			return err
+		}
+		for _, item := range group {
+			next, ok, err := streams[item.streamIdx].next()
+			if err != nil {
+				return err
+			}
+			if ok {
+				h.push(directItem{streamIdx: item.streamIdx, rec: next})
+			}
+		}
+	}
+	run.sections[bucket.id] = runSection{offset: start, length: w.n - start}
+	return nil
+}
+
+func materializeSourceBucketToPebble(
+	ctx context.Context,
+	dest *enginepkg.Engine,
+	tmpDir string,
+	sources []sourceHandle,
+	bucket bucketSpec,
+	destSyncID string,
+	destBytes []byte,
+	stats *mergeStatsAccumulator,
+) error {
+	primaryPath := filepath.Join(tmpDir, fmt.Sprintf("kway-direct-%s-primary.sst", bucket.name))
+	primaryWriter, err := newSSTBuilder(primaryPath)
+	if err != nil {
+		return err
+	}
+	primarySuccess := false
+	defer func() {
+		if !primarySuccess {
+			_ = primaryWriter.Close()
+			_ = os.Remove(primaryPath)
+		}
+	}()
+	indexWriters, err := newIndexWriterSet(tmpDir, bucket.name+"-direct-index")
+	if err != nil {
+		return err
+	}
+	defer indexWriters.cleanup()
+
+	streams := make([]*directStream, 0, len(sources))
+	defer func() {
+		for _, stream := range streams {
+			stream.close()
+		}
+	}()
+	destLower, _ := bucket.syncRange(destBytes)
+	h := &directHeap{}
+	for i, source := range sources {
+		syncBytes, err := codec.EncodeSyncID(source.syncID)
+		if err != nil {
+			return err
+		}
+		lower, upper := bucket.syncRange(syncBytes)
+		iter, err := source.engine.DB().NewIter(&cpebble.IterOptions{LowerBound: lower, UpperBound: upper})
+		if err != nil {
+			return err
+		}
+		iter.First()
+		stream := &directStream{
+			sourceRank: source.rank,
+			iter:       iter,
+			bucket:     bucket,
+			sourceLo:   lower,
+			destLo:     destLower,
+			destSyncID: destSyncID,
+			destBytes:  destBytes,
+		}
+		streams = append(streams, stream)
+		rec, ok, err := stream.next()
+		if err != nil {
+			return err
+		}
+		if ok {
+			h.push(directItem{streamIdx: i, rec: rec})
+		}
+	}
+
+	var lastPrimaryKey []byte
+	var scratch rawIndexScratch
+	// Hoisted bound-method value: creating it inside the loop would
+	// allocate a closure per record.
+	emitIndexKey := indexWriters.writeKey
+	for h.Len() > 0 {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		first := h.pop()
+		winner := first.rec
+		group := []directItem{first}
+		for h.Len() > 0 && bytes.Equal((*h)[0].rec.key, first.rec.key) {
+			group = append(group, h.pop())
+		}
+		for _, item := range group[1:] {
+			if runRecordIsNewer(item.rec, winner) {
+				winner = item.rec
+			}
+		}
+		if !bytes.Equal(winner.key, lastPrimaryKey) {
+			if err := primaryWriter.Set(winner.key, winner.value); err != nil {
+				return err
+			}
+			if err := stats.countWinner(bucket, winner.key, destLower, winner.value); err != nil {
+				return err
+			}
+			lastPrimaryKey = append(lastPrimaryKey[:0], winner.key...)
+			// stats is nil here: counting already happened via countWinner
+			// above (the winner-only contract on forEachIndexKeyFromRaw's
+			// stats parameter is satisfied either way, but counting twice
+			// would double the totals).
+			if err := forEachIndexKeyFromRaw(bucket, destBytes, winner.key, destLower, winner.value, &scratch, nil, emitIndexKey); err != nil {
+				return err
+			}
+		}
+		for _, item := range group {
+			next, ok, err := streams[item.streamIdx].next()
+			if err != nil {
+				return err
+			}
+			if ok {
+				h.push(directItem{streamIdx: item.streamIdx, rec: next})
+			}
+		}
+	}
+	if err := primaryWriter.Close(); err != nil {
+		return err
+	}
+	primarySuccess = true
+	defer func() { _ = os.Remove(primaryPath) }()
+	if err := dest.DB().Ingest(ctx, []string{primaryPath}); err != nil {
+		return fmt.Errorf("ingest direct primary %s: %w", bucket.name, err)
+	}
+	return indexWriters.closeSortAndIngest(ctx, dest)
+}
+
+type directItem struct {
+	streamIdx int
+	rec       runRecord
+}
+
+type directHeap []directItem
+
+func (h directHeap) Len() int { return len(h) }
+func (h directHeap) less(i, j int) bool {
+	cmp := bytes.Compare(h[i].rec.key, h[j].rec.key)
+	if cmp == 0 {
+		return h[i].rec.sourceRank < h[j].rec.sourceRank
+	}
+	return cmp < 0
+}
+func (h directHeap) swap(i, j int) { h[i], h[j] = h[j], h[i] }
+func (h *directHeap) push(item directItem) {
+	*h = append(*h, item)
+	for child := len(*h) - 1; child > 0; {
+		parent := (child - 1) / 2
+		if !h.less(child, parent) {
+			break
+		}
+		h.swap(child, parent)
+		child = parent
+	}
+}
+func (h *directHeap) pop() directItem {
+	old := *h
+	item := old[0]
+	last := old[len(old)-1]
+	*h = old[:len(old)-1]
+	if len(*h) == 0 {
+		return item
+	}
+	(*h)[0] = last
+	h.down(0)
+	return item
+}
+func (h *directHeap) down(parent int) {
+	for {
+		left := 2*parent + 1
+		if left >= len(*h) {
+			return
+		}
+		child := left
+		right := left + 1
+		if right < len(*h) && h.less(right, left) {
+			child = right
+		}
+		if !h.less(child, parent) {
+			return
+		}
+		h.swap(parent, child)
+		parent = child
+	}
+}
+
+type runRecord struct {
+	key        []byte
+	value      []byte
+	tsNanos    int64
+	sourceRank uint32
+}
+
+func writeRunRecord(w *countingWriter, rec runRecord) error {
+	ts, err := checkedUint64FromInt64(rec.tsNanos, "discovered_at nanos")
+	if err != nil {
+		return err
+	}
+	keyLen, err := checkedUint32(len(rec.key), "run record key length")
+	if err != nil {
+		return err
+	}
+	valueLen, err := checkedUint32(len(rec.value), "run record value length")
+	if err != nil {
+		return err
+	}
+	binary.BigEndian.PutUint64(w.hdr[0:8], ts)
+	binary.BigEndian.PutUint32(w.hdr[8:12], rec.sourceRank)
+	binary.BigEndian.PutUint32(w.hdr[12:16], keyLen)
+	binary.BigEndian.PutUint32(w.hdr[16:20], valueLen)
+	if _, err := w.Write(w.hdr[:]); err != nil {
+		return err
+	}
+	if _, err := w.Write(rec.key); err != nil {
+		return err
+	}
+	if _, err := w.Write(rec.value); err != nil {
+		return err
+	}
+	return nil
+}
+
+// readRunRecordInto reads one run record. hdr is caller-owned scratch:
+// a function-local array would escape through the io.Reader interface
+// call and cost one heap allocation per record read.
+func readRunRecordInto(r io.Reader, rec *runRecord, hdr *[runHeaderSize]byte) (bool, error) {
+	_, err := io.ReadFull(r, hdr[:])
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return false, nil
+		}
+		return false, err
+	}
+	keyLen := int(binary.BigEndian.Uint32(hdr[12:16]))
+	valueLen := int(binary.BigEndian.Uint32(hdr[16:20]))
+	ts, err := checkedInt64FromUint64(binary.BigEndian.Uint64(hdr[0:8]), "discovered_at nanos")
+	if err != nil {
+		return false, err
+	}
+	rec.tsNanos = ts
+	rec.sourceRank = binary.BigEndian.Uint32(hdr[8:12])
+	rec.key = growBytes(rec.key, keyLen)
+	rec.value = growBytes(rec.value, valueLen)
+	if _, err := io.ReadFull(r, rec.key); err != nil {
+		return false, err
+	}
+	if _, err := io.ReadFull(r, rec.value); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func growBytes(b []byte, n int) []byte {
+	if cap(b) < n {
+		return make([]byte, n)
+	}
+	return b[:n]
+}
+
+func checkedUint32(n int, label string) (uint32, error) {
+	if n < 0 || n > math.MaxUint32 {
+		return 0, fmt.Errorf("%s exceeds uint32: %d", label, n)
+	}
+	return uint32(n), nil
+}
+
+func checkedUint64FromInt64(n int64, label string) (uint64, error) {
+	if n < 0 {
+		return 0, fmt.Errorf("%s must not be negative: %d", label, n)
+	}
+	return uint64(n), nil
+}
+
+func checkedInt64FromUint64(n uint64, label string) (int64, error) {
+	if n > math.MaxInt64 {
+		return 0, fmt.Errorf("%s exceeds int64: %d", label, n)
+	}
+	return int64(n), nil
+}
+
+func runRecordIsNewer(incoming, existing runRecord) bool {
+	if incoming.tsNanos != existing.tsNanos {
+		return incoming.tsNanos > existing.tsNanos
+	}
+	return incoming.sourceRank < existing.sourceRank
+}
+
+func discoveredAtNanosFromRaw(bucket bucketSpec, value []byte) (int64, error) {
+	field := discoveredAtFieldNumber(bucket)
+	if field == 0 {
+		return 0, nil
+	}
+	for len(value) > 0 {
+		num, typ, n := protowire.ConsumeTag(value)
+		if n < 0 {
+			return 0, protowire.ParseError(n)
+		}
+		value = value[n:]
+		if num != field {
+			n = protowire.ConsumeFieldValue(num, typ, value)
+			if n < 0 {
+				return 0, protowire.ParseError(n)
+			}
+			value = value[n:]
+			continue
+		}
+		if typ != protowire.BytesType {
+			return 0, fmt.Errorf("kway merge: discovered_at has wire type %v", typ)
+		}
+		ts, n := protowire.ConsumeBytes(value)
+		if n < 0 {
+			return 0, protowire.ParseError(n)
+		}
+		return timestampBytesNanosFromRaw(ts)
+	}
+	return 0, nil
+}
+
+func discoveredAtFieldNumber(bucket bucketSpec) protowire.Number {
+	switch bucket.id {
+	case runBucketResourceTypes:
+		return 6
+	case runBucketResources, runBucketEntitlements:
+		return 8
+	case runBucketGrants:
+		return 5
+	default:
+		return 0
+	}
+}
+
+func timestampBytesNanosFromRaw(value []byte) (int64, error) {
+	var seconds int64
+	var nanos int32
+	for len(value) > 0 {
+		num, typ, n := protowire.ConsumeTag(value)
+		if n < 0 {
+			return 0, protowire.ParseError(n)
+		}
+		value = value[n:]
+		switch num {
+		case 1:
+			if typ != protowire.VarintType {
+				return 0, fmt.Errorf("kway merge: timestamp seconds has wire type %v", typ)
+			}
+			v, n := protowire.ConsumeVarint(value)
+			if n < 0 {
+				return 0, protowire.ParseError(n)
+			}
+			checked, err := checkedInt64FromUint64(v, "timestamp seconds")
+			if err != nil {
+				return 0, err
+			}
+			seconds = checked
+			value = value[n:]
+		case 2:
+			if typ != protowire.VarintType {
+				return 0, fmt.Errorf("kway merge: timestamp nanos has wire type %v", typ)
+			}
+			v, n := protowire.ConsumeVarint(value)
+			if n < 0 {
+				return 0, protowire.ParseError(n)
+			}
+			if v > math.MaxInt32 {
+				return 0, fmt.Errorf("timestamp nanos exceeds int32: %d", v)
+			}
+			nanos = int32(v)
+			value = value[n:]
+		default:
+			n = protowire.ConsumeFieldValue(num, typ, value)
+			if n < 0 {
+				return 0, protowire.ParseError(n)
+			}
+			value = value[n:]
+		}
+	}
+	if seconds > math.MaxInt64/int64(time.Second) || seconds < math.MinInt64/int64(time.Second) {
+		return 0, fmt.Errorf("timestamp seconds overflow: %d", seconds)
+	}
+	return seconds*int64(time.Second) + int64(nanos), nil
+}
+
+func rewritePrimaryKeyForDestInto(dst []byte, sourceTail []byte, destLower []byte) []byte {
+	dst = append(dst, destLower...)
+	return append(dst, sourceTail...)
+}
+
+func indexID(key []byte) (byte, bool) {
+	if len(key) < 3 {
+		return 0, false
+	}
+	return key[2], true
+}
+
+func mergeRunFileGroup(ctx context.Context, tmpDir string, inputs []runFile, name string, buckets []bucketSpec) (runFile, error) {
+	outPath := filepath.Join(tmpDir, "kway-run-merge-"+name+".bin")
+	out, err := os.Create(outPath)
+	if err != nil {
+		return runFile{}, err
+	}
+	cw := &countingWriter{w: bufio.NewWriterSize(out, runFileBufferSize)}
+	success := false
+	defer func() {
+		_ = out.Close()
+		if !success {
+			_ = os.Remove(outPath)
+		}
+	}()
+	run := runFile{path: outPath}
+	for _, bucket := range buckets {
+		if err := mergeRunBucketSection(ctx, cw, inputs, bucket, &run); err != nil {
+			return runFile{}, err
+		}
+	}
+	if err := cw.Flush(); err != nil {
+		return runFile{}, err
+	}
+	if err := out.Close(); err != nil {
+		return runFile{}, err
+	}
+	success = true
+	return run, nil
+}
+
+type runHeapItem struct {
+	readerIdx int
+	rec       runRecord
+}
+
+type runRecordHeap []runHeapItem
+
+func (h runRecordHeap) Len() int { return len(h) }
+func (h runRecordHeap) less(i, j int) bool {
+	cmp := bytes.Compare(h[i].rec.key, h[j].rec.key)
+	if cmp == 0 {
+		return h[i].readerIdx < h[j].readerIdx
+	}
+	return cmp < 0
+}
+func (h runRecordHeap) swap(i, j int) { h[i], h[j] = h[j], h[i] }
+func (h *runRecordHeap) push(item runHeapItem) {
+	*h = append(*h, item)
+	for child := len(*h) - 1; child > 0; {
+		parent := (child - 1) / 2
+		if !h.less(child, parent) {
+			break
+		}
+		h.swap(child, parent)
+		child = parent
+	}
+}
+func (h *runRecordHeap) pop() runHeapItem {
+	old := *h
+	item := old[0]
+	last := old[len(old)-1]
+	*h = old[:len(old)-1]
+	if len(*h) == 0 {
+		return item
+	}
+	(*h)[0] = last
+	h.down(0)
+	return item
+}
+func (h *runRecordHeap) down(parent int) {
+	for {
+		left := 2*parent + 1
+		if left >= len(*h) {
+			return
+		}
+		child := left
+		right := left + 1
+		if right < len(*h) && h.less(right, left) {
+			child = right
+		}
+		if !h.less(child, parent) {
+			return
+		}
+		h.swap(parent, child)
+		parent = child
+	}
+}
+
+func mergeRunBucketSection(ctx context.Context, w *countingWriter, inputs []runFile, bucket bucketSpec, run *runFile) error {
+	start := w.n
+	readers := make([]*os.File, 0, len(inputs))
+	bufReaders := make([]*bufio.Reader, 0, len(inputs))
+	readBufs := make([]runRecord, 0, len(inputs))
+	defer func() {
+		for _, r := range readers {
+			_ = r.Close()
+		}
+	}()
+	h := &runRecordHeap{}
+	var hdr [runHeaderSize]byte
+	for i, input := range inputs {
+		f, err := os.Open(input.path)
+		if err != nil {
+			return err
+		}
+		section := input.sections[bucket.id]
+		if _, err := f.Seek(section.offset, io.SeekStart); err != nil {
+			_ = f.Close()
+			return err
+		}
+		readers = append(readers, f)
+		br := bufio.NewReaderSize(io.LimitReader(f, section.length), runFileBufferSize)
+		bufReaders = append(bufReaders, br)
+		readBufs = append(readBufs, runRecord{})
+		ok, err := readRunRecordInto(br, &readBufs[len(readBufs)-1], &hdr)
+		if err != nil {
+			return err
+		}
+		if ok {
+			h.push(runHeapItem{readerIdx: i, rec: readBufs[len(readBufs)-1]})
+		}
+	}
+	for h.Len() > 0 {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		first := h.pop()
+		winner := first.rec
+		group := []runHeapItem{first}
+		for h.Len() > 0 && bytes.Equal((*h)[0].rec.key, first.rec.key) {
+			group = append(group, h.pop())
+		}
+		for _, item := range group[1:] {
+			if runRecordIsNewer(item.rec, winner) {
+				winner = item.rec
+			}
+		}
+		if err := writeRunRecord(w, winner); err != nil {
+			return err
+		}
+		for _, item := range group {
+			ok, err := readRunRecordInto(bufReaders[item.readerIdx], &readBufs[item.readerIdx], &hdr)
+			if err != nil {
+				return err
+			}
+			if ok {
+				h.push(runHeapItem{readerIdx: item.readerIdx, rec: readBufs[item.readerIdx]})
+			}
+		}
+	}
+	run.sections[bucket.id] = runSection{offset: start, length: w.n - start}
+	return nil
+}
+
+func materializeRunFilesToPebble(
+	ctx context.Context,
+	dest *enginepkg.Engine,
+	tmpDir string,
+	inputs []runFile,
+	destBytes []byte,
+	buckets []bucketSpec,
+	stats *mergeStatsAccumulator,
+) error {
+	merged, err := mergeRunFileGroup(ctx, tmpDir, inputs, "final", buckets)
+	if err != nil {
+		return err
+	}
+	defer removeRunFiles([]runFile{merged})
+	for _, bucket := range buckets {
+		if err := materializeRunFileBucket(ctx, dest, tmpDir, merged, bucket, destBytes, stats); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func materializeRunFileBucket(ctx context.Context, dest *enginepkg.Engine, tmpDir string, input runFile, bucket bucketSpec, destBytes []byte, stats *mergeStatsAccumulator) error {
+	f, err := os.Open(input.path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	section := input.sections[bucket.id]
+	if _, err := f.Seek(section.offset, io.SeekStart); err != nil {
+		return err
+	}
+	br := bufio.NewReaderSize(io.LimitReader(f, section.length), runFileBufferSize)
+	indexWriters, err := newIndexWriterSet(tmpDir, bucket.name+"-index")
+	if err != nil {
+		return err
+	}
+	defer indexWriters.cleanup()
+
+	primaryPath := filepath.Join(tmpDir, fmt.Sprintf("kway-%s-primary.sst", bucket.name))
+	primaryWriter, err := newSSTBuilder(primaryPath)
+	if err != nil {
+		return err
+	}
+	primarySuccess := false
+	defer func() {
+		if !primarySuccess {
+			_ = primaryWriter.Close()
+			_ = os.Remove(primaryPath)
+		}
+	}()
+	destLower, _ := bucket.syncRange(destBytes)
+	var lastPrimaryKey []byte
+	var rec runRecord
+	var hdr [runHeaderSize]byte
+	var scratch rawIndexScratch
+	emitIndexKey := indexWriters.writeKey
+	for {
+		ok, err := readRunRecordInto(br, &rec, &hdr)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			break
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if !bytes.Equal(rec.key, lastPrimaryKey) {
+			if err := primaryWriter.Set(rec.key, rec.value); err != nil {
+				return err
+			}
+			if err := stats.countWinner(bucket, rec.key, destLower, rec.value); err != nil {
+				return err
+			}
+			lastPrimaryKey = append(lastPrimaryKey[:0], rec.key...)
+			// stats is nil: counted via countWinner above.
+			if err := forEachIndexKeyFromRaw(bucket, destBytes, rec.key, destLower, rec.value, &scratch, nil, emitIndexKey); err != nil {
+				return err
+			}
+		}
+	}
+	if err := primaryWriter.Close(); err != nil {
+		return err
+	}
+	primarySuccess = true
+	defer func() { _ = os.Remove(primaryPath) }()
+	if err := dest.DB().Ingest(ctx, []string{primaryPath}); err != nil {
+		return fmt.Errorf("ingest primary %s: %w", bucket.name, err)
+	}
+	return indexWriters.closeSortAndIngest(ctx, dest)
+}
+
+type indexWriterSet struct {
+	writers map[byte]*indexRunWriter
+	all     []*indexRunWriter
+}
+
+func newIndexWriterSet(tmpDir string, name string) (*indexWriterSet, error) {
+	set := &indexWriterSet{writers: map[byte]*indexRunWriter{}}
+	for _, idx := range []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07} {
+		w, err := newIndexRunWriter(tmpDir, fmt.Sprintf("%s-%02x", name, idx))
+		if err != nil {
+			set.cleanup()
+			return nil, err
+		}
+		set.writers[idx] = w
+		set.all = append(set.all, w)
+	}
+	return set, nil
+}
+
+// writeKey routes one index key to its family writer. It is the emit
+// callback for forEachIndexKeyFromRaw — callers hoist the bound-method
+// value (emit := set.writeKey) outside their record loops so the
+// closure is allocated once, and keys flow straight to the per-family
+// buffered writer with no intermediate per-record blob buffers.
+func (s *indexWriterSet) writeKey(key []byte) error {
+	idx, ok := indexID(key)
+	if !ok {
+		return nil
+	}
+	w := s.writers[idx]
+	if w == nil {
+		return nil
+	}
+	return w.writeKey(key)
+}
+
+func (s *indexWriterSet) closeSortAndIngest(ctx context.Context, dest *enginepkg.Engine) error {
+	for _, w := range s.all {
+		if err := w.closeSortAndIngest(ctx, dest); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *indexWriterSet) cleanup() {
+	for _, w := range s.all {
+		w.cleanup()
+	}
+}
+
+type indexRunWriter struct {
+	path   string
+	tmpDir string
+	name   string
+	file   *os.File
+	writer *bufio.Writer
+	count  int
+	closed bool
+	lenBuf [4]byte
+}
+
+func newIndexRunWriter(tmpDir string, name string) (*indexRunWriter, error) {
+	path := filepath.Join(tmpDir, "kway-index-run-"+name+".bin")
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, err
+	}
+	return &indexRunWriter{path: path, tmpDir: tmpDir, name: name, file: f, writer: bufio.NewWriterSize(f, runFileBufferSize)}, nil
+}
+
+func (w *indexRunWriter) writeKey(key []byte) error {
+	if err := writeLengthPrefixedBytes(w.writer, key, &w.lenBuf); err != nil {
+		return err
+	}
+	w.count++
+	return nil
+}
+
+func (w *indexRunWriter) close() error {
+	if w.closed {
+		return nil
+	}
+	w.closed = true
+	if err := w.writer.Flush(); err != nil {
+		_ = w.file.Close()
+		return err
+	}
+	return w.file.Close()
+}
+
+func (w *indexRunWriter) cleanup() {
+	_ = w.close()
+	_ = os.Remove(w.path)
+}
+
+func (w *indexRunWriter) closeSortAndIngest(ctx context.Context, dest *enginepkg.Engine) error {
+	if err := w.close(); err != nil {
+		return err
+	}
+	if w.count == 0 {
+		return nil
+	}
+	chunks, err := sortIndexRunChunks(ctx, w.tmpDir, w.name, w.path)
+	if err != nil {
+		removePaths(chunks)
+		return err
+	}
+	defer removePaths(chunks)
+	sstPath := filepath.Join(w.tmpDir, "kway-index-"+w.name+".sst")
+	if err := mergeSortedIndexChunksToSST(ctx, sstPath, chunks); err != nil {
+		return err
+	}
+	defer func() { _ = os.Remove(sstPath) }()
+	if err := dest.DB().Ingest(ctx, []string{sstPath}); err != nil {
+		return fmt.Errorf("ingest index %s: %w", w.name, err)
+	}
+	return nil
+}
+
+func removePaths(paths []string) {
+	for _, p := range paths {
+		_ = os.Remove(p)
+	}
+}
+
+// writeLengthPrefixedBytes / readLengthPrefixedBytes take caller-owned
+// lenBuf scratch for the same escape-analysis reason as
+// readRunRecordInto: a function-local array passed to an io interface
+// call heap-allocates per call.
+func writeLengthPrefixedBytes(w io.Writer, b []byte, lenBuf *[4]byte) error {
+	n, err := checkedUint32(len(b), "length-prefixed bytes length")
+	if err != nil {
+		return err
+	}
+	binary.BigEndian.PutUint32(lenBuf[:], n)
+	if _, err := w.Write(lenBuf[:]); err != nil {
+		return err
+	}
+	_, err = w.Write(b)
+	return err
+}
+
+func readLengthPrefixedBytes(r io.Reader, dst *[]byte, lenBuf *[4]byte) (bool, error) {
+	_, err := io.ReadFull(r, lenBuf[:])
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return false, nil
+		}
+		return false, err
+	}
+	n := int(binary.BigEndian.Uint32(lenBuf[:]))
+	*dst = growBytes(*dst, n)
+	if _, err := io.ReadFull(r, *dst); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// indexKeyView is an (offset, end) view into a sort arena. Sorting
+// views over one contiguous buffer instead of [][]byte avoids one heap
+// copy per index key and gives the GC a pointer-free chunk to skip.
+type indexKeyView struct {
+	off int
+	end int
+}
+
+func sortIndexRunChunks(ctx context.Context, tmpDir string, name string, path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	reader := bufio.NewReaderSize(f, runFileBufferSize)
+	var chunks []string
+	var arena []byte
+	views := make([]indexKeyView, 0, indexSortChunkKeys)
+	var lenBuf [4]byte
+	for {
+		arena = arena[:0]
+		views = views[:0]
+		for len(views) < indexSortChunkKeys {
+			if err := ctx.Err(); err != nil {
+				return chunks, err
+			}
+			ok, err := readLengthPrefixedIntoArena(reader, &arena, &views, &lenBuf)
+			if err != nil {
+				return chunks, err
+			}
+			if !ok {
+				break
+			}
+		}
+		if len(views) == 0 {
+			break
+		}
+		sort.Slice(views, func(i, j int) bool {
+			return bytes.Compare(arena[views[i].off:views[i].end], arena[views[j].off:views[j].end]) < 0
+		})
+		chunkPath := filepath.Join(tmpDir, fmt.Sprintf("kway-index-%s-chunk-%04d.bin", name, len(chunks)))
+		if err := writeSortedIndexChunk(chunkPath, arena, views); err != nil {
+			return chunks, err
+		}
+		chunks = append(chunks, chunkPath)
+		if len(views) < indexSortChunkKeys {
+			break
+		}
+	}
+	return chunks, nil
+}
+
+// readLengthPrefixedIntoArena appends one length-prefixed key from r
+// onto arena and records its view. The arena's capacity is retained
+// across chunks by the caller, so steady-state reads are
+// allocation-free.
+func readLengthPrefixedIntoArena(r io.Reader, arena *[]byte, views *[]indexKeyView, lenBuf *[4]byte) (bool, error) {
+	_, err := io.ReadFull(r, lenBuf[:])
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return false, nil
+		}
+		return false, err
+	}
+	n := int(binary.BigEndian.Uint32(lenBuf[:]))
+	start := len(*arena)
+	*arena = growArenaTail(*arena, n)
+	if _, err := io.ReadFull(r, (*arena)[start:start+n]); err != nil {
+		return false, err
+	}
+	*views = append(*views, indexKeyView{off: start, end: start + n})
+	return true, nil
+}
+
+// growArenaTail extends arena by n bytes, growing capacity
+// geometrically so repeated appends amortize to O(1) allocations.
+func growArenaTail(arena []byte, n int) []byte {
+	cur := len(arena)
+	if cap(arena)-cur >= n {
+		return arena[:cur+n]
+	}
+	newCap := max(2*cap(arena), cur+n)
+	newCap = max(newCap, runFileBufferSize)
+	out := make([]byte, cur+n, newCap)
+	copy(out, arena)
+	return out
+}
+
+func writeSortedIndexChunk(path string, arena []byte, views []indexKeyView) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	writer := bufio.NewWriterSize(f, runFileBufferSize)
+	success := false
+	defer func() {
+		_ = f.Close()
+		if !success {
+			_ = os.Remove(path)
+		}
+	}()
+	var lenBuf [4]byte
+	var last []byte
+	for _, v := range views {
+		key := arena[v.off:v.end]
+		if bytes.Equal(key, last) {
+			continue
+		}
+		if err := writeLengthPrefixedBytes(writer, key, &lenBuf); err != nil {
+			return err
+		}
+		last = key
+	}
+	if err := writer.Flush(); err != nil {
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	success = true
+	return nil
+}
+
+type indexChunkItem struct {
+	chunkIdx int
+	key      []byte
+}
+
+type indexChunkHeap []indexChunkItem
+
+func (h indexChunkHeap) Len() int { return len(h) }
+func (h indexChunkHeap) less(i, j int) bool {
+	cmp := bytes.Compare(h[i].key, h[j].key)
+	if cmp == 0 {
+		return h[i].chunkIdx < h[j].chunkIdx
+	}
+	return cmp < 0
+}
+func (h indexChunkHeap) swap(i, j int) { h[i], h[j] = h[j], h[i] }
+func (h *indexChunkHeap) push(item indexChunkItem) {
+	*h = append(*h, item)
+	for child := len(*h) - 1; child > 0; {
+		parent := (child - 1) / 2
+		if !h.less(child, parent) {
+			break
+		}
+		h.swap(child, parent)
+		child = parent
+	}
+}
+func (h *indexChunkHeap) pop() indexChunkItem {
+	old := *h
+	item := old[0]
+	last := old[len(old)-1]
+	*h = old[:len(old)-1]
+	if len(*h) == 0 {
+		return item
+	}
+	(*h)[0] = last
+	h.down(0)
+	return item
+}
+func (h *indexChunkHeap) down(parent int) {
+	for {
+		left := 2*parent + 1
+		if left >= len(*h) {
+			return
+		}
+		child := left
+		right := left + 1
+		if right < len(*h) && h.less(right, left) {
+			child = right
+		}
+		if !h.less(child, parent) {
+			return
+		}
+		h.swap(parent, child)
+		parent = child
+	}
+}
+
+func mergeSortedIndexChunksToSST(ctx context.Context, sstPath string, chunks []string) error {
+	readers := make([]*os.File, 0, len(chunks))
+	bufReaders := make([]*bufio.Reader, 0, len(chunks))
+	readBufs := make([][]byte, len(chunks))
+	defer func() {
+		for _, r := range readers {
+			_ = r.Close()
+		}
+	}()
+	h := &indexChunkHeap{}
+	var lenBuf [4]byte
+	for i, chunk := range chunks {
+		f, err := os.Open(chunk)
+		if err != nil {
+			return err
+		}
+		readers = append(readers, f)
+		br := bufio.NewReaderSize(f, runFileBufferSize)
+		bufReaders = append(bufReaders, br)
+		ok, err := readLengthPrefixedBytes(br, &readBufs[i], &lenBuf)
+		if err != nil {
+			return err
+		}
+		if ok {
+			h.push(indexChunkItem{chunkIdx: i, key: readBufs[i]})
+		}
+	}
+	writer, err := newSSTBuilder(sstPath)
+	if err != nil {
+		return err
+	}
+	success := false
+	defer func() {
+		if !success {
+			_ = writer.Close()
+			_ = os.Remove(sstPath)
+		}
+	}()
+	var last []byte
+	for h.Len() > 0 {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		item := h.pop()
+		if !bytes.Equal(item.key, last) {
+			if err := writer.Set(item.key, nil); err != nil {
+				return err
+			}
+			last = append(last[:0], item.key...)
+		}
+		ok, err := readLengthPrefixedBytes(bufReaders[item.chunkIdx], &readBufs[item.chunkIdx], &lenBuf)
+		if err != nil {
+			return err
+		}
+		if ok {
+			h.push(indexChunkItem{chunkIdx: item.chunkIdx, key: readBufs[item.chunkIdx]})
+		}
+	}
+	if err := writer.Close(); err != nil {
+		return err
+	}
+	success = true
+	return nil
+}

--- a/pkg/synccompactor/pebble/kway_bench_test.go
+++ b/pkg/synccompactor/pebble/kway_bench_test.go
@@ -1,0 +1,107 @@
+package pebble
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/segmentio/ksuid"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	enginepkg "github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble"
+)
+
+func BenchmarkMergeFilesIntoKWay(b *testing.B) {
+	ctx := context.Background()
+	const sourceCount = 50
+	const grantsPerSource = 2500
+
+	fixtureDir := b.TempDir()
+	sources := make([]SourceFile, 0, sourceCount)
+	for sourceIdx := 0; sourceIdx < sourceCount; sourceIdx++ {
+		path := filepath.Join(fixtureDir, fmt.Sprintf("source-%03d.c1z", sourceIdx))
+		w, err := dotc1z.NewStore(ctx, path, dotc1z.WithEngine(dotc1z.EnginePebble), dotc1z.WithTmpDir(fixtureDir))
+		if err != nil {
+			b.Fatal(err)
+		}
+		store := w
+		src, ok := enginepkg.AsEngine(w)
+		if !ok {
+			b.Fatalf("store is not pebble: %T", w)
+		}
+		syncID, err := store.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+		if err != nil {
+			b.Fatal(err)
+		}
+		if err := src.PutResourceTypeRecords(ctx,
+			v3.ResourceTypeRecord_builder{ExternalId: "user", DiscoveredAt: timestamppb.Now()}.Build(),
+			v3.ResourceTypeRecord_builder{ExternalId: "group", DiscoveredAt: timestamppb.Now()}.Build(),
+		); err != nil {
+			b.Fatal(err)
+		}
+		group := v3.ResourceRecord_builder{
+			ResourceTypeId: "group", ResourceId: "engineering", DiscoveredAt: timestamppb.Now(),
+		}.Build()
+		if err := src.PutResourceRecord(ctx, group); err != nil {
+			b.Fatal(err)
+		}
+		ent := v3.EntitlementRecord_builder{
+			ExternalId:   "member",
+			Resource:     v3.ResourceRef_builder{ResourceTypeId: "group", ResourceId: "engineering"}.Build(),
+			DiscoveredAt: timestamppb.Now(),
+		}.Build()
+		if err := src.PutEntitlementRecord(ctx, ent); err != nil {
+			b.Fatal(err)
+		}
+		batch := make([]*v3.GrantRecord, 0, grantsPerSource)
+		for grantIdx := 0; grantIdx < grantsPerSource; grantIdx++ {
+			// 20% overlap across source syncs, matching the exploratory
+			// benchmark shape and exercising newer-wins replacement.
+			grantID := fmt.Sprintf("source-%03d-grant-%05d", sourceIdx, grantIdx)
+			if grantIdx < grantsPerSource/5 {
+				grantID = fmt.Sprintf("shared-grant-%05d", grantIdx)
+			}
+			batch = append(batch, v3.GrantRecord_builder{
+				ExternalId:   grantID,
+				Entitlement:  v3.EntitlementRef_builder{ResourceTypeId: "group", ResourceId: "engineering", EntitlementId: "member"}.Build(),
+				Principal:    v3.PrincipalRef_builder{ResourceTypeId: "user", ResourceId: fmt.Sprintf("user-%05d", grantIdx)}.Build(),
+				DiscoveredAt: timestamppb.New(time.Unix(int64(1000+sourceIdx), 0).UTC()),
+			}.Build())
+		}
+		if err := src.PutGrantRecords(ctx, batch...); err != nil {
+			b.Fatal(err)
+		}
+		if err := store.EndSync(ctx); err != nil {
+			b.Fatal(err)
+		}
+		if err := store.Close(ctx); err != nil {
+			b.Fatal(err)
+		}
+		sources = append(sources, SourceFile{Path: path, SyncID: syncID})
+	}
+
+	b.ReportAllocs()
+	b.ReportMetric(sourceCount, "sources/op")
+	b.ReportMetric(grantsPerSource, "grants_per_source")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		dest, _ := benchNewEngine(b, fmt.Sprintf("dest-%d", i))
+		destSyncID := ksuid.New().String()
+		tmpDir := filepath.Join(fixtureDir, fmt.Sprintf("tmp-%d", i))
+		if err := os.MkdirAll(tmpDir, 0o755); err != nil {
+			b.Fatal(err)
+		}
+		if _, err := MergeFilesInto(ctx, dest, sources, destSyncID, tmpDir); err != nil {
+			b.Fatal(err)
+		}
+		if err := dest.Close(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/synccompactor/pebble/kway_test.go
+++ b/pkg/synccompactor/pebble/kway_test.go
@@ -1,0 +1,280 @@
+package pebble
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/segmentio/ksuid"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	enginepkg "github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble"
+)
+
+type kwayGrantSpec struct {
+	id          string
+	principalID string
+	entitlement string
+	discovered  time.Time
+	needsExpand bool
+}
+
+type kwaySourceFixture struct {
+	path   string
+	syncID string
+}
+
+func writeKWaySource(t *testing.T, ctx context.Context, path string, grants []kwayGrantSpec, withAsset bool) kwaySourceFixture {
+	t.Helper()
+	w, err := dotc1z.NewStore(ctx, path, dotc1z.WithEngine(dotc1z.EnginePebble), dotc1z.WithTmpDir(t.TempDir()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := w
+	eng, ok := enginepkg.AsEngine(w)
+	if !ok {
+		t.Fatalf("store is not pebble: %T", w)
+	}
+	syncID, err := store.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := timestamppb.New(time.Unix(1, 0).UTC())
+	if err := eng.PutResourceTypeRecords(ctx,
+		v3.ResourceTypeRecord_builder{ExternalId: "user", DisplayName: "User", DiscoveredAt: now}.Build(),
+		v3.ResourceTypeRecord_builder{ExternalId: "group", DisplayName: "Group", DiscoveredAt: now}.Build(),
+	); err != nil {
+		t.Fatal(err)
+	}
+	parent := v3.ResourceRef_builder{ResourceTypeId: "group", ResourceId: "engineering"}.Build()
+	if err := eng.PutResourceRecords(ctx,
+		v3.ResourceRecord_builder{ResourceTypeId: "group", ResourceId: "engineering", DiscoveredAt: now}.Build(),
+		v3.ResourceRecord_builder{ResourceTypeId: "user", ResourceId: "alice", Parent: parent, DiscoveredAt: now}.Build(),
+		v3.ResourceRecord_builder{ResourceTypeId: "user", ResourceId: "bob", Parent: parent, DiscoveredAt: now}.Build(),
+		v3.ResourceRecord_builder{ResourceTypeId: "user", ResourceId: "carol", Parent: parent, DiscoveredAt: now}.Build(),
+	); err != nil {
+		t.Fatal(err)
+	}
+	entRecords := make([]*v3.EntitlementRecord, 0, len(grants))
+	seenEntitlements := map[string]bool{}
+	for _, g := range grants {
+		if seenEntitlements[g.entitlement] {
+			continue
+		}
+		seenEntitlements[g.entitlement] = true
+		entRecords = append(entRecords, v3.EntitlementRecord_builder{
+			ExternalId:   g.entitlement,
+			Resource:     v3.ResourceRef_builder{ResourceTypeId: "group", ResourceId: "engineering"}.Build(),
+			DiscoveredAt: timestamppb.New(g.discovered),
+		}.Build())
+	}
+	if len(entRecords) > 0 {
+		if err := eng.PutEntitlementRecords(ctx, entRecords...); err != nil {
+			t.Fatal(err)
+		}
+	}
+	grantRecords := make([]*v3.GrantRecord, 0, len(grants))
+	for _, g := range grants {
+		grantRecords = append(grantRecords, v3.GrantRecord_builder{
+			ExternalId: g.id,
+			Entitlement: v3.EntitlementRef_builder{
+				ResourceTypeId: "group",
+				ResourceId:     "engineering",
+				EntitlementId:  g.entitlement,
+			}.Build(),
+			Principal:      v3.PrincipalRef_builder{ResourceTypeId: "user", ResourceId: g.principalID}.Build(),
+			NeedsExpansion: g.needsExpand,
+			DiscoveredAt:   timestamppb.New(g.discovered),
+		}.Build())
+	}
+	if len(grantRecords) > 0 {
+		if err := eng.PutGrantRecords(ctx, grantRecords...); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if withAsset {
+		if err := eng.PutAssetRecord(ctx, v3.AssetRecord_builder{SyncId: syncID, ExternalId: "asset-1", ContentType: "text/plain", Data: []byte("asset")}.Build()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := store.EndSync(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(ctx); err != nil {
+		t.Fatal(err)
+	}
+	return kwaySourceFixture{path: path, syncID: syncID}
+}
+
+func mergeKWayFixtures(t *testing.T, ctx context.Context, fixtures []kwaySourceFixture, fanIn int) (*enginepkg.Engine, string) {
+	t.Helper()
+	dest, _ := newEngine(t, "kway-dest")
+	destSyncID := ksuid.New().String()
+	sources := make([]SourceFile, 0, len(fixtures))
+	for _, f := range fixtures {
+		sources = append(sources, SourceFile{Path: f.path, SyncID: f.syncID})
+	}
+	if _, err := MergeFilesInto(ctx, dest, sources, destSyncID, t.TempDir(), WithFanIn(fanIn)); err != nil {
+		t.Fatalf("MergeFilesInto: %v", err)
+	}
+	return dest, destSyncID
+}
+
+func TestMergeFilesIntoKWayNewerWinsTieIndexesAndDropsAssets(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	older := time.Unix(1000, 0).UTC()
+	newer := time.Unix(2000, 0).UTC()
+	tie := time.Unix(3000, 0).UTC()
+	src1 := writeKWaySource(t, ctx, filepath.Join(dir, "src1.c1z"), []kwayGrantSpec{
+		{id: "shared", principalID: "alice", entitlement: "member", discovered: older},
+		{id: "tie", principalID: "alice", entitlement: "member", discovered: tie},
+		{id: "only-src1", principalID: "alice", entitlement: "admin", discovered: older, needsExpand: true},
+	}, true)
+	src2 := writeKWaySource(t, ctx, filepath.Join(dir, "src2.c1z"), []kwayGrantSpec{
+		{id: "shared", principalID: "bob", entitlement: "member", discovered: newer},
+		{id: "tie", principalID: "bob", entitlement: "member", discovered: tie},
+		{id: "only-src2", principalID: "carol", entitlement: "member", discovered: newer},
+	}, true)
+
+	dest, destSyncID := mergeKWayFixtures(t, ctx, []kwaySourceFixture{src1, src2}, 50)
+
+	grants := map[string]*v3.GrantRecord{}
+	if err := dest.IterateGrantsBySync(ctx, destSyncID, func(g *v3.GrantRecord) bool {
+		grants[g.GetExternalId()] = g
+		return true
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(grants) != 4 {
+		t.Fatalf("merged grant count = %d, want 4", len(grants))
+	}
+	if got := grants["shared"].GetPrincipal().GetResourceId(); got != "bob" {
+		t.Fatalf("newer shared grant principal = %q, want bob", got)
+	}
+	if got := grants["tie"].GetPrincipal().GetResourceId(); got != "alice" {
+		t.Fatalf("tie grant principal = %q, want alice from earlier-applied source", got)
+	}
+	var byEntitlement []string
+	if err := dest.IterateGrantsByEntitlement(ctx, destSyncID, "member", func(g *v3.GrantRecord) bool {
+		byEntitlement = append(byEntitlement, g.GetExternalId())
+		return true
+	}); err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(byEntitlement)
+	if got, want := byEntitlement, []string{"only-src2", "shared", "tie"}; fmtSprint(got) != fmtSprint(want) {
+		t.Fatalf("by_entitlement index = %v, want %v", got, want)
+	}
+	var byPrincipal []string
+	if err := dest.IterateGrantsByPrincipal(ctx, destSyncID, "user", "alice", func(g *v3.GrantRecord) bool {
+		byPrincipal = append(byPrincipal, g.GetExternalId())
+		return true
+	}); err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(byPrincipal)
+	if got, want := byPrincipal, []string{"only-src1", "tie"}; fmtSprint(got) != fmtSprint(want) {
+		t.Fatalf("by_principal index = %v, want %v", got, want)
+	}
+	var needsExpansion []string
+	if err := dest.IterateGrantsByNeedsExpansion(ctx, destSyncID, func(g *v3.GrantRecord) bool {
+		needsExpansion = append(needsExpansion, g.GetExternalId())
+		return true
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := needsExpansion, []string{"only-src1"}; fmtSprint(got) != fmtSprint(want) {
+		t.Fatalf("needs_expansion index = %v, want %v", got, want)
+	}
+	var children []string
+	if err := dest.IterateResourcesByParent(ctx, destSyncID, "group", "engineering", func(r *v3.ResourceRecord) bool {
+		children = append(children, r.GetResourceId())
+		return true
+	}); err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(children)
+	if got, want := children, []string{"alice", "bob", "carol"}; fmtSprint(got) != fmtSprint(want) {
+		t.Fatalf("resource_by_parent index = %v, want %v", got, want)
+	}
+	assetCount := 0
+	if err := dest.IterateAssetsBySync(ctx, destSyncID, func(*v3.AssetRecord) bool {
+		assetCount++
+		return true
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if assetCount != 0 {
+		t.Fatalf("asset count = %d, want 0", assetCount)
+	}
+}
+
+func TestMergeFilesIntoKWayRecursiveFanInMatchesSingleRound(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	var fixtures []kwaySourceFixture
+	for i := 0; i < 7; i++ {
+		fixtures = append(fixtures, writeKWaySource(t, ctx, filepath.Join(dir, fmt.Sprintf("src-%d.c1z", i)), []kwayGrantSpec{
+			{id: "shared", principalID: fmt.Sprintf("user-%d", i), entitlement: "member", discovered: time.Unix(int64(1000+i), 0).UTC()},
+			{id: fmt.Sprintf("only-%d", i), principalID: "alice", entitlement: "member", discovered: time.Unix(int64(1000+i), 0).UTC()},
+		}, false))
+	}
+	singleDest, singleSync := mergeKWayFixtures(t, ctx, fixtures, 50)
+	recursiveDest, recursiveSync := mergeKWayFixtures(t, ctx, fixtures, 3)
+
+	single := grantPrincipalMap(t, ctx, singleDest, singleSync)
+	recursive := grantPrincipalMap(t, ctx, recursiveDest, recursiveSync)
+	if fmtSprint(single) != fmtSprint(recursive) {
+		t.Fatalf("recursive fan-in result = %v, want %v", recursive, single)
+	}
+	if got := recursive["shared"]; got != "user-6" {
+		t.Fatalf("recursive shared winner = %q, want user-6", got)
+	}
+}
+
+func TestReadRunRecordIntoRejectsPartialHeader(t *testing.T) {
+	var hdr [runHeaderSize]byte
+	ok, err := readRunRecordInto(bytes.NewReader([]byte{1, 2, 3}), &runRecord{}, &hdr)
+	if err == nil {
+		t.Fatal("readRunRecordInto partial header error = nil")
+	}
+	if ok {
+		t.Fatal("readRunRecordInto partial header ok = true")
+	}
+}
+
+func TestReadLengthPrefixedBytesRejectsPartialHeader(t *testing.T) {
+	var dst []byte
+	var lenBuf [4]byte
+	ok, err := readLengthPrefixedBytes(bytes.NewReader([]byte{1, 2}), &dst, &lenBuf)
+	if err == nil {
+		t.Fatal("readLengthPrefixedBytes partial header error = nil")
+	}
+	if ok {
+		t.Fatal("readLengthPrefixedBytes partial header ok = true")
+	}
+}
+
+func grantPrincipalMap(t *testing.T, ctx context.Context, e *enginepkg.Engine, syncID string) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	if err := e.IterateGrantsBySync(ctx, syncID, func(g *v3.GrantRecord) bool {
+		out[g.GetExternalId()] = g.GetPrincipal().GetResourceId()
+		return true
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+func fmtSprint(v any) string {
+	return fmt.Sprint(v)
+}

--- a/pkg/synccompactor/pebble/merge.go
+++ b/pkg/synccompactor/pebble/merge.go
@@ -28,7 +28,11 @@ type SourceSync struct {
 //
 // destSyncID must already exist in dest (created by StartNewSync) and
 // be empty — MergeInto only adds records, it never excises, so no
-// pre-existing data under destSyncID is assumed.
+// pre-existing data under destSyncID is assumed. MergeInto binds the
+// dest engine's current sync to destSyncID before writing: v3 record
+// values do not carry sync_id, so the engine's keep-newer write path
+// keys every record off the current sync. The binding is left in
+// place when MergeInto returns.
 //
 // Only the four primary record buckets are copied: resource_types,
 // resources, entitlements, grants. Assets are intentionally NOT copied
@@ -49,6 +53,9 @@ func MergeInto(ctx context.Context, dest *enginepkg.Engine, sources []SourceSync
 	}
 	if destSyncID == "" {
 		return errors.New("synccompactor/pebble.MergeInto: destSyncID is required")
+	}
+	if err := dest.SetCurrentSync(destSyncID); err != nil {
+		return fmt.Errorf("synccompactor/pebble.MergeInto: bind dest sync: %w", err)
 	}
 	for i := range sources {
 		if err := ctx.Err(); err != nil {

--- a/pkg/synccompactor/pebble/merge.go
+++ b/pkg/synccompactor/pebble/merge.go
@@ -89,7 +89,6 @@ func mergeOneSource(ctx context.Context, dest *enginepkg.Engine, s SourceSync, d
 	if err := streamBucket(ctx, srcDB,
 		enginepkg.ResourceTypeSyncLowerBound(srcBytes), enginepkg.ResourceTypeSyncUpperBound(srcBytes),
 		func() *v3.ResourceTypeRecord { return &v3.ResourceTypeRecord{} },
-		func(r *v3.ResourceTypeRecord) { r.SetSyncId(destSyncID) },
 		dest.PutResourceTypeRecordsIfNewer,
 	); err != nil {
 		return fmt.Errorf("merge resource_types: %w", err)
@@ -98,7 +97,6 @@ func mergeOneSource(ctx context.Context, dest *enginepkg.Engine, s SourceSync, d
 	if err := streamBucket(ctx, srcDB,
 		enginepkg.ResourceSyncLowerBound(srcBytes), enginepkg.ResourceSyncUpperBound(srcBytes),
 		func() *v3.ResourceRecord { return &v3.ResourceRecord{} },
-		func(r *v3.ResourceRecord) { r.SetSyncId(destSyncID) },
 		dest.PutResourceRecordsIfNewer,
 	); err != nil {
 		return fmt.Errorf("merge resources: %w", err)
@@ -107,7 +105,6 @@ func mergeOneSource(ctx context.Context, dest *enginepkg.Engine, s SourceSync, d
 	if err := streamBucket(ctx, srcDB,
 		enginepkg.EntitlementSyncLowerBound(srcBytes), enginepkg.EntitlementSyncUpperBound(srcBytes),
 		func() *v3.EntitlementRecord { return &v3.EntitlementRecord{} },
-		func(r *v3.EntitlementRecord) { r.SetSyncId(destSyncID) },
 		dest.PutEntitlementRecordsIfNewer,
 	); err != nil {
 		return fmt.Errorf("merge entitlements: %w", err)
@@ -116,7 +113,6 @@ func mergeOneSource(ctx context.Context, dest *enginepkg.Engine, s SourceSync, d
 	if err := streamBucket(ctx, srcDB,
 		enginepkg.GrantSyncLowerBound(srcBytes), enginepkg.GrantSyncUpperBound(srcBytes),
 		func() *v3.GrantRecord { return &v3.GrantRecord{} },
-		func(r *v3.GrantRecord) { r.SetSyncId(destSyncID) },
 		dest.PutGrantRecordsIfNewer,
 	); err != nil {
 		return fmt.Errorf("merge grants: %w", err)
@@ -127,16 +123,15 @@ func mergeOneSource(ctx context.Context, dest *enginepkg.Engine, s SourceSync, d
 
 // streamBucket drains a primary bucket's [lower, upper) key range,
 // unmarshalling each value into a fresh T (the stored value is a
-// deterministic proto marshal of the v3 record), applying rekey to
-// stamp the destination sync id, and flushing fixed-size batches into
-// put. Peak memory is bounded by mergeBatchSize rather than the bucket
-// size.
+// deterministic proto marshal of the v3 record) and flushing fixed-size
+// batches into put. The destination sync id is supplied by the engine's
+// current-sync key context; data record values do not carry sync_id.
+// Peak memory is bounded by mergeBatchSize rather than the bucket size.
 func streamBucket[T proto.Message](
 	ctx context.Context,
 	db *pebble.DB,
 	lower, upper []byte,
 	mk func() T,
-	rekey func(T),
 	put func(context.Context, ...T) error,
 ) error {
 	iter, err := db.NewIter(&pebble.IterOptions{LowerBound: lower, UpperBound: upper})
@@ -165,7 +160,6 @@ func streamBucket[T proto.Message](
 		if err := proto.Unmarshal(iter.Value(), rec); err != nil {
 			return fmt.Errorf("unmarshal record: %w", err)
 		}
-		rekey(rec)
 		batch = append(batch, rec)
 		if len(batch) >= mergeBatchSize {
 			if err := flush(); err != nil {

--- a/pkg/synccompactor/pebble/merge_stats.go
+++ b/pkg/synccompactor/pebble/merge_stats.go
@@ -1,0 +1,159 @@
+package pebble
+
+import (
+	"bytes"
+
+	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
+)
+
+// mergeStatsAccumulator builds the dest sync's stats sidecar while the
+// compactor writes merge winners, so compactPebble can persist stats
+// without re-scanning the freshly written output (the old
+// PersistSyncStats post-pass).
+//
+// Counting contract: exactly one total increment per record that lands
+// in the dest sync. The overlay path piggybacks grouping on the index
+// key scan (forEachIndexKeyFromRaw already extracts the resource type
+// / entitlement resource type for winners); the K-way path uses
+// countWinner at its final dedupe sites, because there the index scan
+// also ran for losing records and can't be reused for counting.
+//
+// Group maps are map[string]*int64 so the per-record []byte->string
+// map read stays allocation-free (the compiler only elides the
+// conversion for reads); a key string is materialized only on the
+// first occurrence of each resource type.
+type mergeStatsAccumulator struct {
+	totals        [runBucketCount]int64
+	resourcesByRT map[string]*int64
+	grantsByEntRT map[string]*int64
+	scratch       rawIndexScratch
+}
+
+func newMergeStatsAccumulator() *mergeStatsAccumulator {
+	return &mergeStatsAccumulator{
+		resourcesByRT: map[string]*int64{},
+		grantsByEntRT: map[string]*int64{},
+	}
+}
+
+func incrGroup(m map[string]*int64, key []byte) {
+	if p, ok := m[string(key)]; ok {
+		*p++
+		return
+	}
+	n := int64(1)
+	m[string(key)] = &n
+}
+
+// countWinnerTotal records a winning record's existence without
+// grouping. Used by the overlay path, where grouping happens inside
+// forEachIndexKeyFromRaw via groupResource / groupGrant.
+func (a *mergeStatsAccumulator) countWinnerTotal(bucketID int) {
+	if a == nil {
+		return
+	}
+	a.totals[bucketID]++
+}
+
+func (a *mergeStatsAccumulator) groupResource(rt []byte) {
+	if a == nil {
+		return
+	}
+	incrGroup(a.resourcesByRT, rt)
+}
+
+func (a *mergeStatsAccumulator) groupGrant(entRT []byte) {
+	if a == nil {
+		return
+	}
+	incrGroup(a.grantsByEntRT, entRT)
+}
+
+// regroupGrant moves one grant from oldRT's group to newRT's when an
+// overlay replacement swaps in a value with a different entitlement
+// resource type. Totals are untouched — the replacement targets the
+// same logical key, which was counted at first admission.
+func (a *mergeStatsAccumulator) regroupGrant(oldRT, newRT []byte) {
+	if a == nil || bytes.Equal(oldRT, newRT) {
+		return
+	}
+	if p, ok := a.grantsByEntRT[string(oldRT)]; ok {
+		*p--
+	}
+	incrGroup(a.grantsByEntRT, newRT)
+}
+
+// countWinner is the K-way variant: total plus grouping derived from
+// the winner's key (resources) or value (grants).
+func (a *mergeStatsAccumulator) countWinner(bucket bucketSpec, destKey []byte, destLower []byte, value []byte) error {
+	if a == nil {
+		return nil
+	}
+	a.totals[bucket.id]++
+	switch bucket.id {
+	case runBucketResources:
+		rt, _, err := decodePrimaryTailBytes2(destKey, destLower, &a.scratch)
+		if err != nil {
+			return err
+		}
+		incrGroup(a.resourcesByRT, rt)
+	case runBucketGrants:
+		entRT, _, _, _, _, _, err := scanGrantIndexFieldsBytes(value)
+		if err != nil {
+			return err
+		}
+		incrGroup(a.grantsByEntRT, entRT)
+	default:
+	}
+	return nil
+}
+
+// record renders the accumulated counts as the engine sidecar record.
+// Assets are always zero: compaction does not copy assets, matching
+// what a post-merge recompute would produce. SyncId / WrittenAt are
+// filled by Engine.PersistComputedSyncStats.
+func (a *mergeStatsAccumulator) record() *v3.SyncStatsRecord {
+	rec := &v3.SyncStatsRecord{}
+	rec.SetResourceTypes(a.totals[runBucketResourceTypes])
+	rec.SetResources(a.totals[runBucketResources])
+	rec.SetEntitlements(a.totals[runBucketEntitlements])
+	rec.SetGrants(a.totals[runBucketGrants])
+	rec.SetAssets(0)
+	resourcesByRT := make(map[string]int64, len(a.resourcesByRT))
+	for rt, p := range a.resourcesByRT {
+		resourcesByRT[rt] = *p
+	}
+	grantsByEntRT := make(map[string]int64, len(a.grantsByEntRT))
+	for rt, p := range a.grantsByEntRT {
+		grantsByEntRT[rt] = *p
+	}
+	rec.SetResourcesByResourceType(resourcesByRT)
+	rec.SetGrantsByEntitlementResourceType(grantsByEntRT)
+	return rec
+}
+
+func (a *mergeStatsAccumulator) addRecord(rec *v3.SyncStatsRecord) {
+	if a == nil || rec == nil {
+		return
+	}
+	a.totals[runBucketResourceTypes] += rec.GetResourceTypes()
+	a.totals[runBucketResources] += rec.GetResources()
+	a.totals[runBucketEntitlements] += rec.GetEntitlements()
+	a.totals[runBucketGrants] += rec.GetGrants()
+	for rt, count := range rec.GetResourcesByResourceType() {
+		if p, ok := a.resourcesByRT[rt]; ok {
+			*p += count
+			continue
+		}
+		n := count
+		a.resourcesByRT[rt] = &n
+	}
+	for rt, count := range rec.GetGrantsByEntitlementResourceType() {
+		if p, ok := a.grantsByEntRT[rt]; ok {
+			*p += count
+			continue
+		}
+		n := count
+		a.grantsByEntRT[rt] = &n
+	}
+}

--- a/pkg/synccompactor/pebble/merge_stats_test.go
+++ b/pkg/synccompactor/pebble/merge_stats_test.go
@@ -1,0 +1,264 @@
+package pebble
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/segmentio/ksuid"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	enginepkg "github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble"
+)
+
+type statsGrantSpec struct {
+	id          string
+	entRT       string
+	entRID      string
+	entID       string
+	principalID string
+}
+
+// writeStatsSource writes a Pebble c1z with two resource types, three
+// resources (engineering group + alice/bob users), member/admin
+// entitlements, and the given grants. The fixed records are identical
+// across sources so cross-source dedupe is exercised by every bucket.
+func writeStatsSource(t *testing.T, ctx context.Context, path string, grants []statsGrantSpec) kwaySourceFixture {
+	t.Helper()
+	w, err := dotc1z.NewStore(ctx, path, dotc1z.WithEngine(dotc1z.EnginePebble), dotc1z.WithTmpDir(t.TempDir()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := w
+	eng, ok := enginepkg.AsEngine(w)
+	if !ok {
+		t.Fatalf("store is not pebble: %T", w)
+	}
+	syncID, err := store.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := timestamppb.New(time.Unix(1, 0).UTC())
+	if err := eng.PutResourceTypeRecords(ctx,
+		v3.ResourceTypeRecord_builder{ExternalId: "user", DisplayName: "User", DiscoveredAt: now}.Build(),
+		v3.ResourceTypeRecord_builder{ExternalId: "group", DisplayName: "Group", DiscoveredAt: now}.Build(),
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := eng.PutResourceRecords(ctx,
+		v3.ResourceRecord_builder{ResourceTypeId: "group", ResourceId: "engineering", DiscoveredAt: now}.Build(),
+		v3.ResourceRecord_builder{ResourceTypeId: "user", ResourceId: "alice", DiscoveredAt: now}.Build(),
+		v3.ResourceRecord_builder{ResourceTypeId: "user", ResourceId: "bob", DiscoveredAt: now}.Build(),
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := eng.PutEntitlementRecords(ctx,
+		v3.EntitlementRecord_builder{
+			ExternalId:   "member",
+			Resource:     v3.ResourceRef_builder{ResourceTypeId: "group", ResourceId: "engineering"}.Build(),
+			DiscoveredAt: now,
+		}.Build(),
+		v3.EntitlementRecord_builder{
+			ExternalId:   "admin",
+			Resource:     v3.ResourceRef_builder{ResourceTypeId: "group", ResourceId: "engineering"}.Build(),
+			DiscoveredAt: now,
+		}.Build(),
+	); err != nil {
+		t.Fatal(err)
+	}
+	for _, g := range grants {
+		rec := v3.GrantRecord_builder{
+			ExternalId: g.id,
+			Entitlement: v3.EntitlementRef_builder{
+				ResourceTypeId: g.entRT,
+				ResourceId:     g.entRID,
+				EntitlementId:  g.entID,
+			}.Build(),
+			Principal:    v3.PrincipalRef_builder{ResourceTypeId: "user", ResourceId: g.principalID}.Build(),
+			DiscoveredAt: now,
+		}.Build()
+		if err := eng.PutGrantRecords(ctx, rec); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := store.EndSync(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(ctx); err != nil {
+		t.Fatal(err)
+	}
+	return kwaySourceFixture{path: path, syncID: syncID}
+}
+
+func requireSyncStatsEqual(t *testing.T, want, got *v3.SyncStatsRecord, label string) {
+	t.Helper()
+	if got.GetResourceTypes() != want.GetResourceTypes() {
+		t.Errorf("%s: resource_types=%d, want %d", label, got.GetResourceTypes(), want.GetResourceTypes())
+	}
+	if got.GetResources() != want.GetResources() {
+		t.Errorf("%s: resources=%d, want %d", label, got.GetResources(), want.GetResources())
+	}
+	if got.GetEntitlements() != want.GetEntitlements() {
+		t.Errorf("%s: entitlements=%d, want %d", label, got.GetEntitlements(), want.GetEntitlements())
+	}
+	if got.GetGrants() != want.GetGrants() {
+		t.Errorf("%s: grants=%d, want %d", label, got.GetGrants(), want.GetGrants())
+	}
+	if got.GetAssets() != want.GetAssets() {
+		t.Errorf("%s: assets=%d, want %d", label, got.GetAssets(), want.GetAssets())
+	}
+	requireCountMapEqual(t, want.GetResourcesByResourceType(), got.GetResourcesByResourceType(), label+": resources_by_resource_type")
+	requireCountMapEqual(t, want.GetGrantsByEntitlementResourceType(), got.GetGrantsByEntitlementResourceType(), label+": grants_by_entitlement_resource_type")
+}
+
+// requireCountMapEqual treats nil and empty maps as equal — empty
+// proto maps round-trip through marshal/unmarshal as nil.
+func requireCountMapEqual(t *testing.T, want, got map[string]int64, label string) {
+	t.Helper()
+	if len(want) != len(got) {
+		t.Errorf("%s: got %v, want %v", label, got, want)
+		return
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("%s[%q]=%d, want %d", label, k, got[k], v)
+		}
+	}
+}
+
+// TestMergeStatsSidecarMatchesRecompute pins that the stats record
+// accumulated at merge time equals what a full post-merge recompute
+// (PersistSyncStats) produces, for every merge strategy. The fixtures
+// include overlapping keys across sources (dedupe must not double
+// count) and a grant whose entitlement ref has no resource — that
+// grant must still count, grouped under the empty resource type, to
+// stay in parity with the SQLite GROUP BY semantics.
+func TestMergeStatsSidecarMatchesRecompute(t *testing.T) {
+	ctx := context.Background()
+
+	mkThreeSources := func(t *testing.T) []SourceFile {
+		dir := t.TempDir()
+		newest := writeStatsSource(t, ctx, filepath.Join(dir, "src0.c1z"), []statsGrantSpec{
+			{id: "shared", entRT: "group", entRID: "engineering", entID: "member", principalID: "alice"},
+			{id: "only0", entRT: "group", entRID: "engineering", entID: "admin", principalID: "bob"},
+			{id: "noent", entID: "ghost", principalID: "alice"},
+		})
+		mid := writeStatsSource(t, ctx, filepath.Join(dir, "src1.c1z"), []statsGrantSpec{
+			{id: "shared", entRT: "group", entRID: "engineering", entID: "member", principalID: "bob"},
+			{id: "only1", entRT: "group", entRID: "engineering", entID: "member", principalID: "bob"},
+		})
+		oldest := writeStatsSource(t, ctx, filepath.Join(dir, "src2.c1z"), []statsGrantSpec{
+			{id: "only2", entRT: "group", entRID: "engineering", entID: "member", principalID: "alice"},
+		})
+		return []SourceFile{
+			{Path: newest.path, SyncID: newest.syncID},
+			{Path: mid.path, SyncID: mid.syncID},
+			{Path: oldest.path, SyncID: oldest.syncID},
+		}
+	}
+
+	// Two sources where the newest has no grants, so the grants bucket
+	// hits the overlay whole-source SST fast path on the oldest source.
+	mkWholeSourceSources := func(t *testing.T) []SourceFile {
+		dir := t.TempDir()
+		newest := writeStatsSource(t, ctx, filepath.Join(dir, "src0.c1z"), nil)
+		oldest := writeStatsSource(t, ctx, filepath.Join(dir, "src1.c1z"), []statsGrantSpec{
+			{id: "base-a", entRT: "group", entRID: "engineering", entID: "member", principalID: "alice"},
+			{id: "base-b", entRT: "group", entRID: "engineering", entID: "admin", principalID: "bob"},
+		})
+		return []SourceFile{
+			{Path: newest.path, SyncID: newest.syncID},
+			{Path: oldest.path, SyncID: oldest.syncID},
+		}
+	}
+
+	threeSourceWant := v3.SyncStatsRecord_builder{
+		ResourceTypes:                   2,
+		Resources:                       3,
+		Entitlements:                    2,
+		Grants:                          5,
+		ResourcesByResourceType:         map[string]int64{"group": 1, "user": 2},
+		GrantsByEntitlementResourceType: map[string]int64{"group": 4, "": 1},
+	}.Build()
+
+	cases := []struct {
+		name    string
+		sources func(*testing.T) []SourceFile
+		merge   func(ctx context.Context, dest *enginepkg.Engine, sources []SourceFile, destSyncID string, tmpDir string) (*v3.SyncStatsRecord, error)
+		want    *v3.SyncStatsRecord
+	}{
+		{
+			name:    "overlay",
+			sources: mkThreeSources,
+			merge: func(ctx context.Context, dest *enginepkg.Engine, sources []SourceFile, destSyncID string, tmpDir string) (*v3.SyncStatsRecord, error) {
+				return MergeFilesIntoOverlay(ctx, dest, sources, destSyncID, tmpDir)
+			},
+			want: threeSourceWant,
+		},
+		{
+			name:    "overlay whole-source fast path",
+			sources: mkWholeSourceSources,
+			merge: func(ctx context.Context, dest *enginepkg.Engine, sources []SourceFile, destSyncID string, tmpDir string) (*v3.SyncStatsRecord, error) {
+				return MergeFilesIntoOverlay(ctx, dest, sources, destSyncID, tmpDir)
+			},
+		},
+		{
+			name:    "kway direct",
+			sources: mkThreeSources,
+			merge: func(ctx context.Context, dest *enginepkg.Engine, sources []SourceFile, destSyncID string, tmpDir string) (*v3.SyncStatsRecord, error) {
+				return MergeFilesInto(ctx, dest, sources, destSyncID, tmpDir)
+			},
+			want: threeSourceWant,
+		},
+		{
+			name:    "kway multi-round",
+			sources: mkThreeSources,
+			merge: func(ctx context.Context, dest *enginepkg.Engine, sources []SourceFile, destSyncID string, tmpDir string) (*v3.SyncStatsRecord, error) {
+				return MergeFilesInto(ctx, dest, sources, destSyncID, tmpDir, WithFanIn(2))
+			},
+			want: threeSourceWant,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dest, _ := newEngine(t, "stats-dest")
+			destSyncID := ksuid.New().String()
+			got, err := tc.merge(ctx, dest, tc.sources(t), destSyncID, t.TempDir())
+			if err != nil {
+				t.Fatalf("merge: %v", err)
+			}
+			if got == nil {
+				t.Fatal("merge returned nil stats")
+			}
+			if tc.want != nil {
+				requireSyncStatsEqual(t, tc.want, got, "accumulated vs expected")
+			}
+
+			// Persist the accumulated record, read it back, then
+			// overwrite with a full recompute and compare: the
+			// merge-time accumulation must match the scan exactly.
+			if err := dest.PersistComputedSyncStats(ctx, destSyncID, got); err != nil {
+				t.Fatalf("PersistComputedSyncStats: %v", err)
+			}
+			stored, err := enginepkg.ReadSyncStatsRecord(ctx, dest, destSyncID)
+			if err != nil {
+				t.Fatalf("ReadSyncStatsRecord (accumulated): %v", err)
+			}
+			if stored == nil {
+				t.Fatal("accumulated sidecar missing after persist")
+			}
+			if err := dest.PersistSyncStats(ctx, destSyncID); err != nil {
+				t.Fatalf("PersistSyncStats: %v", err)
+			}
+			recomputed, err := enginepkg.ReadSyncStatsRecord(ctx, dest, destSyncID)
+			if err != nil {
+				t.Fatalf("ReadSyncStatsRecord (recomputed): %v", err)
+			}
+			requireSyncStatsEqual(t, recomputed, stored, "accumulated vs recompute")
+		})
+	}
+}

--- a/pkg/synccompactor/pebble/merge_test.go
+++ b/pkg/synccompactor/pebble/merge_test.go
@@ -13,7 +13,6 @@ import (
 
 func grantAt(syncID, externalID string, at time.Time) *v3.GrantRecord {
 	return v3.GrantRecord_builder{
-		SyncId:     syncID,
 		ExternalId: externalID,
 		Entitlement: v3.EntitlementRef_builder{
 			ResourceTypeId: "app", ResourceId: "github", EntitlementId: "ent-A",
@@ -70,13 +69,10 @@ func TestMergeIntoUnionNewerWins(t *testing.T) {
 		t.Fatalf("merged grant count = %d, want 3 (union, deduped)", got)
 	}
 
-	// Every survivor is re-keyed to destSync, and g-shared kept the
-	// newer discovered_at.
+	// Iterating under destSync proves every survivor is re-keyed there,
+	// and g-shared kept the newer discovered_at.
 	seen := map[string]*v3.GrantRecord{}
 	if err := dst.IterateGrantsBySync(ctx, destSync, func(r *v3.GrantRecord) bool {
-		if r.GetSyncId() != destSync {
-			t.Errorf("grant %q sync_id = %q, want destSync %q", r.GetExternalId(), r.GetSyncId(), destSync)
-		}
 		seen[r.GetExternalId()] = r
 		return true
 	}); err != nil {

--- a/pkg/synccompactor/pebble/merge_test.go
+++ b/pkg/synccompactor/pebble/merge_test.go
@@ -57,9 +57,9 @@ func TestMergeIntoUnionNewerWins(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := dst.SetCurrentSync(destSync); err != nil {
-		t.Fatal(err)
-	}
+	// No SetCurrentSync here: MergeInto must bind the dest engine to
+	// destSyncID itself (record values carry no sync_id, so a stale
+	// binding would silently write into the wrong sync's keyspace).
 	if err := MergeInto(ctx, dst, []SourceSync{{Engine: src1, SyncID: syncA}, {Engine: src2, SyncID: syncB}}, destSync); err != nil {
 		t.Fatalf("MergeInto: %v", err)
 	}
@@ -120,9 +120,8 @@ func TestMergeIntoTieKeepsIncumbent(t *testing.T) {
 	if err := src2.PutGrantRecords(ctx, g2); err != nil {
 		t.Fatal(err)
 	}
-	_ = dst.SetCurrentSync(destSync)
-
-	// src1 applied first → incumbent wins the tie.
+	// src1 applied first → incumbent wins the tie. MergeInto binds the
+	// dest sync itself.
 	if err := MergeInto(ctx, dst, []SourceSync{{Engine: src1, SyncID: syncA}, {Engine: src2, SyncID: syncB}}, destSync); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/synccompactor/pebble/overlay.go
+++ b/pkg/synccompactor/pebble/overlay.go
@@ -1,0 +1,1015 @@
+package pebble
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"hash/maphash"
+	"os"
+	"path/filepath"
+
+	cpebble "github.com/cockroachdb/pebble/v2"
+	"google.golang.org/protobuf/encoding/protowire"
+
+	reader_v2 "github.com/conductorone/baton-sdk/pb/c1/reader/v2"
+	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	enginepkg "github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/codec"
+)
+
+const defaultOverlayRecordChunkSize = 32768
+const defaultOverlaySeenKeyLimit = 375000
+
+// overlayConfig carries the overlay merge tunables. The defaults are
+// the production values; explicit options exist for benchmarks and
+// tests.
+type overlayConfig struct {
+	seenKeyLimit    int64
+	recordChunkSize int
+}
+
+// OverlayOption tunes the overlay merge.
+type OverlayOption func(*overlayConfig)
+
+// WithOverlaySeenKeyLimit caps the estimated per-bucket key count
+// admitted to the overlay path; buckets above the cap route to the
+// K-way run-file fallback (overlayPlanBuckets). Each seen-set entry
+// costs ~40B with map overhead, so the cap bounds per-bucket memory.
+// Non-positive values are ignored.
+func WithOverlaySeenKeyLimit(n int64) OverlayOption {
+	return func(c *overlayConfig) {
+		if n > 0 {
+			c.seenKeyLimit = n
+		}
+	}
+}
+
+// WithOverlayRecordChunkSize sets how many winner records are buffered
+// per raw write batch while streaming into the dest. Non-positive
+// values are ignored.
+func WithOverlayRecordChunkSize(n int) OverlayOption {
+	return func(c *overlayConfig) {
+		if n > 0 {
+			c.recordChunkSize = n
+		}
+	}
+}
+
+// seenSuffixSet tracks, per admitted primary-key suffix, the
+// discovered_at (UnixNano) of the record currently admitted for that
+// key. Keys are 128-bit hashes of the suffix instead of the suffix
+// bytes themselves: lookups are allocation-free (a map[string] set
+// materialized one string per scanned record, the single biggest
+// overlay-specific allocator), and the fixed 16-byte pointer-free keys
+// are cheaper for the GC to scan and smaller in memory than retained
+// suffix strings.
+//
+// Trade-off: a hash collision makes a never-seen key look seen, so a
+// record that should have won is dropped (or wrongly compared) in the
+// dest sync. The 128-bit key is built from two independently-seeded
+// 64-bit maphash values; at the 250k-key seen limit the collision
+// probability per merge is ~(n^2/2)/2^128 ≈ 1e-28 — negligible against
+// the hardware error floor. Seeds are per-process random, which is
+// fine: the set never persists and never crosses processes.
+type seenSuffixSet struct {
+	m     map[[16]byte]int64
+	seed1 maphash.Seed
+	seed2 maphash.Seed
+}
+
+func newSeenSuffixSet() *seenSuffixSet {
+	return &seenSuffixSet{
+		m:     map[[16]byte]int64{},
+		seed1: maphash.MakeSeed(),
+		seed2: maphash.MakeSeed(),
+	}
+}
+
+// keyOf hashes a primary-key suffix into the set's key space.
+func (s *seenSuffixSet) keyOf(suffix []byte) [16]byte {
+	var k [16]byte
+	binary.BigEndian.PutUint64(k[0:8], maphash.Bytes(s.seed1, suffix))
+	binary.BigEndian.PutUint64(k[8:16], maphash.Bytes(s.seed2, suffix))
+	return k
+}
+
+// get returns the discovered_at nanos recorded for k, if any.
+func (s *seenSuffixSet) get(k [16]byte) (int64, bool) {
+	ts, ok := s.m[k]
+	return ts, ok
+}
+
+// put records (or updates) the discovered_at nanos for k.
+func (s *seenSuffixSet) put(k [16]byte, ts int64) {
+	s.m[k] = ts
+}
+
+func (s *seenSuffixSet) size() int { return len(s.m) }
+
+// MergeFilesIntoOverlay is a sqlite-shaped compactor:
+//
+//   - keep a bounded in-memory seen map (suffix hash → discovered_at)
+//     for each bucket while scanning sources newest-to-oldest;
+//   - per key, admit the record with the strictly newest discovered_at;
+//     ties keep the earliest admission (the newest source). This is the
+//     same winner rule as the K-way merge (runRecordIsNewer) and the
+//     sqlite attached compactor (`a.discovered_at > m.discovered_at`),
+//     enforced via a shallow discovered_at scan of each candidate value;
+//   - write winners through raw Pebble batches so secondary indexes are
+//     materialized once; and
+//   - route buckets whose estimated key count exceeds the in-memory
+//     limit through the K-way run-file path instead (overlayPlanBuckets).
+//
+// On success it returns the dest sync's stats record, accumulated as
+// winners were written, so the caller can persist the stats sidecar
+// without re-scanning the output.
+func MergeFilesIntoOverlay(ctx context.Context, dest *enginepkg.Engine, sources []SourceFile, destSyncID string, tmpDir string, opts ...OverlayOption) (*v3.SyncStatsRecord, error) {
+	if dest == nil {
+		return nil, fmt.Errorf("overlay merge: dest engine is nil")
+	}
+	if destSyncID == "" {
+		return nil, fmt.Errorf("overlay merge: destSyncID is required")
+	}
+	cfg := overlayConfig{
+		seenKeyLimit:    defaultOverlaySeenKeyLimit,
+		recordChunkSize: defaultOverlayRecordChunkSize,
+	}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	destSyncBytes, err := codec.EncodeSyncID(destSyncID)
+	if err != nil {
+		return nil, err
+	}
+	buckets := allBuckets()
+	overlayBuckets, kwayBuckets, err := overlayPlanBuckets(ctx, sources, buckets, tmpDir, cfg.seenKeyLimit)
+	if err != nil {
+		return nil, err
+	}
+
+	stats := newMergeStatsAccumulator()
+	rm := &asyncRemover{}
+	defer rm.wait()
+	var kwayRunFiles []runFile
+	defer func() {
+		removeRunFiles(kwayRunFiles)
+	}()
+	writers := make([]*overlayBucketRawWriter, len(overlayBuckets))
+	seenByBucket := make([]*seenSuffixSet, len(overlayBuckets))
+	for i, bucket := range overlayBuckets {
+		writers[i] = newOverlayBucketRawWriter(dest, bucket, stats, cfg.recordChunkSize)
+		seenByBucket[i] = newSeenSuffixSet()
+	}
+	defer func() {
+		for _, writer := range writers {
+			writer.cleanup()
+		}
+	}()
+
+	// Process a bounded chunk of source engines through all buckets before
+	// closing it. This preserves the K-way FD bound while avoiding the old
+	// bucket-major reopen pattern; same-size syncs=50 overlay dropped from
+	// ~5.4s to ~2.9s when source opens stopped multiplying by bucket count.
+	for start := 0; start < len(sources); start += defaultKWayFanIn {
+		end := min(start+defaultKWayFanIn, len(sources))
+		chunk, err := openSourceChunk(ctx, tmpDir, sources[start:end], start)
+		if err != nil {
+			return nil, err
+		}
+		if err := func() error {
+			defer chunk.closeAsync(rm)
+			for _, source := range chunk.handles {
+				sourceSyncBytes, err := codec.EncodeSyncID(source.syncID)
+				if err != nil {
+					return err
+				}
+				for bucketIdx, bucket := range overlayBuckets {
+					seen := seenByBucket[bucketIdx]
+					if source.rank == len(sources)-1 && seen.size() == 0 {
+						if err := overlayMaterializeWholeSourceBucketSST(ctx, dest, source.engine, bucket, sourceSyncBytes, destSyncBytes, tmpDir, stats); err != nil {
+							return err
+						}
+						continue
+					}
+					if err := overlaySinglePassBucket(ctx, source.engine, bucket, writers[bucketIdx], seen, sourceSyncBytes, destSyncBytes); err != nil {
+						return err
+					}
+				}
+			}
+			if len(kwayBuckets) > 0 {
+				run, err := buildChunkRunFileFromHandles(
+					ctx,
+					tmpDir,
+					chunk.handles,
+					fmt.Sprintf("overlay-fallback-%04d", len(kwayRunFiles)),
+					destSyncID,
+					destSyncBytes,
+					kwayBuckets,
+				)
+				if err != nil {
+					return err
+				}
+				kwayRunFiles = append(kwayRunFiles, run)
+			}
+			return nil
+		}(); err != nil {
+			return nil, err
+		}
+	}
+
+	for _, writer := range writers {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if err := writer.flush(ctx); err != nil {
+			return nil, err
+		}
+	}
+	if len(kwayBuckets) > 0 {
+		kwayStats := newMergeStatsAccumulator()
+		if err := materializeRunFilesToPebble(ctx, dest, tmpDir, kwayRunFiles, destSyncBytes, kwayBuckets, kwayStats); err != nil {
+			return nil, err
+		}
+		stats.addRecord(kwayStats.record())
+	}
+	return stats.record(), nil
+}
+
+func overlayPlanBuckets(ctx context.Context, sources []SourceFile, buckets []bucketSpec, tmpDir string, limit int64) ([]bucketSpec, []bucketSpec, error) {
+	overlayBuckets := make([]bucketSpec, 0, len(buckets))
+	kwayBuckets := make([]bucketSpec, 0, len(buckets))
+	for _, bucket := range buckets {
+		if total, ok := overlayEstimatedBucketKeys(sources, bucket); ok {
+			if total > limit {
+				kwayBuckets = append(kwayBuckets, bucket)
+			} else {
+				overlayBuckets = append(overlayBuckets, bucket)
+			}
+			continue
+		}
+		total, err := overlayCountBucketKeysUpTo(ctx, sources, bucket, tmpDir, limit)
+		if err != nil {
+			return nil, nil, err
+		}
+		if total > limit {
+			kwayBuckets = append(kwayBuckets, bucket)
+		} else {
+			overlayBuckets = append(overlayBuckets, bucket)
+		}
+	}
+	return overlayBuckets, kwayBuckets, nil
+}
+
+func overlayCountBucketKeysUpTo(ctx context.Context, sources []SourceFile, bucket bucketSpec, tmpDir string, limit int64) (int64, error) {
+	var total int64
+	for _, source := range sources {
+		if err := ctx.Err(); err != nil {
+			return 0, err
+		}
+		err := withSourceEngine(ctx, tmpDir, source, func(eng *enginepkg.Engine) error {
+			sourceSyncBytes, err := codec.EncodeSyncID(source.SyncID)
+			if err != nil {
+				return err
+			}
+			sourceLower, sourceUpper := bucket.syncRange(sourceSyncBytes)
+			iter, err := eng.DB().NewIter(&cpebble.IterOptions{LowerBound: sourceLower, UpperBound: sourceUpper})
+			if err != nil {
+				return err
+			}
+			defer iter.Close()
+			for iter.First(); iter.Valid(); iter.Next() {
+				total++
+				if total > limit {
+					return nil
+				}
+			}
+			return iter.Error()
+		})
+		if err != nil {
+			return 0, err
+		}
+		if total > limit {
+			return total, nil
+		}
+	}
+	return total, nil
+}
+
+func overlayEstimatedBucketKeys(sources []SourceFile, bucket bucketSpec) (int64, bool) {
+	var total int64
+	for _, source := range sources {
+		if source.Stats == nil {
+			return 0, false
+		}
+		n, ok := syncStatsBucketKeys(source.Stats, bucket)
+		if !ok {
+			return 0, false
+		}
+		total += n
+	}
+	return total, true
+}
+
+func syncStatsBucketKeys(stats *reader_v2.SyncStats, bucket bucketSpec) (int64, bool) {
+	switch bucket.id {
+	case runBucketResourceTypes:
+		return stats.GetResourceTypes(), true
+	case runBucketResources:
+		return stats.GetResources(), true
+	case runBucketEntitlements:
+		return stats.GetEntitlements(), true
+	case runBucketGrants:
+		return stats.GetGrants(), true
+	default:
+		return 0, false
+	}
+}
+
+func overlaySinglePassBucket(
+	ctx context.Context,
+	source *enginepkg.Engine,
+	bucket bucketSpec,
+	writer *overlayBucketRawWriter,
+	seen *seenSuffixSet,
+	sourceSyncBytes []byte,
+	destSyncBytes []byte,
+) error {
+	destLower, _ := bucket.syncRange(destSyncBytes)
+	sourceLower, sourceUpper := bucket.syncRange(sourceSyncBytes)
+	iter, err := source.DB().NewIter(&cpebble.IterOptions{LowerBound: sourceLower, UpperBound: sourceUpper})
+	if err != nil {
+		return err
+	}
+	defer iter.Close()
+	var destKey []byte
+	for iter.First(); iter.Valid(); iter.Next() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		// Dedupe on the primary-key suffix before constructing the
+		// destination key. Admission is hash-based and allocation-free
+		// (see seenSuffixSet); the shallow discovered_at scan keeps the
+		// winner rule identical to K-way / sqlite.
+		sourceSuffix := iter.Key()[len(sourceLower):]
+		k := seen.keyOf(sourceSuffix)
+		ts, err := discoveredAtNanosFromRaw(bucket, iter.Value())
+		if err != nil {
+			return err
+		}
+		if prevTs, ok := seen.get(k); ok {
+			// Key already admitted by an earlier (newer) source. Replace
+			// only on a strictly newer discovered_at; ties keep the
+			// earlier admission — matching runRecordIsNewer's
+			// (ts, then source rank) ordering.
+			if ts <= prevTs {
+				continue
+			}
+			destKey = rewritePrimaryKeyForDestInto(destKey[:0], sourceSuffix, destLower)
+			if err := writer.replaceRaw(ctx, bucket, destSyncBytes, destKey, destLower, iter.Value()); err != nil {
+				return err
+			}
+			seen.put(k, ts)
+			continue
+		}
+		seen.put(k, ts)
+		destKey = rewritePrimaryKeyForDestInto(destKey[:0], sourceSuffix, destLower)
+		if err := writer.addRaw(ctx, bucket, destSyncBytes, destKey, destLower, iter.Value()); err != nil {
+			return err
+		}
+	}
+	return iter.Error()
+}
+
+func overlayMaterializeWholeSourceBucketSST(
+	ctx context.Context,
+	dest *enginepkg.Engine,
+	source *enginepkg.Engine,
+	bucket bucketSpec,
+	sourceSyncBytes []byte,
+	destSyncBytes []byte,
+	tmpDir string,
+	stats *mergeStatsAccumulator,
+) error {
+	sourceLower, sourceUpper := bucket.syncRange(sourceSyncBytes)
+	destLower, _ := bucket.syncRange(destSyncBytes)
+	iter, err := source.DB().NewIter(&cpebble.IterOptions{LowerBound: sourceLower, UpperBound: sourceUpper})
+	if err != nil {
+		return err
+	}
+	defer iter.Close()
+
+	primaryPath := filepath.Join(tmpDir, fmt.Sprintf("overlay-whole-%s-primary.sst", bucket.name))
+	primaryWriter, err := newSSTBuilder(primaryPath)
+	if err != nil {
+		return err
+	}
+	primarySuccess := false
+	defer func() {
+		if !primarySuccess {
+			_ = primaryWriter.Close()
+			_ = os.Remove(primaryPath)
+		}
+	}()
+	indexWriters, err := newIndexWriterSet(tmpDir, bucket.name+"-overlay-whole-index")
+	if err != nil {
+		return err
+	}
+	defer indexWriters.cleanup()
+
+	wrotePrimary := false
+	var destKey []byte
+	var scratch rawIndexScratch
+	emitIndexKey := indexWriters.writeKey
+	for iter.First(); iter.Valid(); iter.Next() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		sourceKey := iter.Key()
+		if len(sourceKey) < len(sourceLower) {
+			return fmt.Errorf("overlay merge: source key shorter than lower bound prefix: key=%d prefix=%d", len(sourceKey), len(sourceLower))
+		}
+		destKey = rewritePrimaryKeyForDestInto(destKey[:0], sourceKey[len(sourceLower):], destLower)
+		if err := primaryWriter.Set(destKey, iter.Value()); err != nil {
+			return err
+		}
+		wrotePrimary = true
+		// Every key in this path is a winner: this fast path only runs
+		// for the last source when nothing was admitted before it.
+		stats.countWinnerTotal(bucket.id)
+		if bucket.forEachIndexKey != nil {
+			if err := forEachIndexKeyFromRaw(bucket, destSyncBytes, destKey, destLower, iter.Value(), &scratch, stats, emitIndexKey); err != nil {
+				return err
+			}
+		}
+	}
+	if err := iter.Error(); err != nil {
+		return err
+	}
+	if err := primaryWriter.Close(); err != nil {
+		return err
+	}
+	primarySuccess = true
+	defer func() { _ = os.Remove(primaryPath) }()
+	if wrotePrimary {
+		if err := dest.DB().Ingest(ctx, []string{primaryPath}); err != nil {
+			return fmt.Errorf("overlay merge: ingest whole primary %s: %w", bucket.name, err)
+		}
+	}
+	return indexWriters.closeSortAndIngest(ctx, dest)
+}
+
+type rawIndexScratch struct {
+	key   []byte
+	tail1 []byte
+	tail2 []byte
+}
+
+// Build secondary index keys from borrowed protobuf string bytes and reusable
+// tuple-decode scratch instead of materializing Go strings. Together with the
+// raw batch writer, this moved the bad same-size syncs=50 overlay case from
+// ~2.69s / 2.4M allocs to ~2.08s / 0.79M allocs.
+//
+// When stats is non-nil, per-resource-type stats grouping piggybacks on the
+// field extraction this scan already does for winners (resources: the key
+// tail decode; grants: the entitlement ref scan), so the accumulator costs
+// no additional value parsing. Callers must only pass stats when every
+// record passed in is a merge winner.
+func forEachIndexKeyFromRaw(
+	bucket bucketSpec,
+	syncBytes []byte,
+	destKey []byte,
+	destLower []byte,
+	value []byte,
+	scratch *rawIndexScratch,
+	stats *mergeStatsAccumulator,
+	emit func([]byte) error,
+) error {
+	if bucket.forEachIndexKey == nil {
+		return nil
+	}
+	switch bucket.id {
+	case runBucketResources:
+		rt, id, err := decodePrimaryTailBytes2(destKey, destLower, scratch)
+		if err != nil {
+			return err
+		}
+		stats.groupResource(rt)
+		parentRT, parentID, err := scanResourceParentBytes(value)
+		if err != nil {
+			return err
+		}
+		if len(parentID) == 0 {
+			return nil
+		}
+		scratch.key = enginepkg.AppendResourceIndexKeyRawBytes(scratch.key[:0], syncBytes, parentRT, parentID, rt, id)
+		return emit(scratch.key)
+	case runBucketEntitlements:
+		ext, err := decodePrimaryTailBytes1(destKey, destLower, scratch)
+		if err != nil {
+			return err
+		}
+		resourceRT, resourceID, err := scanEntitlementResourceBytes(value)
+		if err != nil {
+			return err
+		}
+		if len(resourceID) == 0 {
+			return nil
+		}
+		scratch.key = enginepkg.AppendEntitlementIndexKeyRawBytes(scratch.key[:0], syncBytes, resourceRT, resourceID, ext)
+		return emit(scratch.key)
+	case runBucketGrants:
+		ext, err := decodePrimaryTailBytes1(destKey, destLower, scratch)
+		if err != nil {
+			return err
+		}
+		entRT, entRID, entID, principalRT, principalID, needsExpansion, err := scanGrantIndexFieldsBytes(value)
+		if err != nil {
+			return err
+		}
+		stats.groupGrant(entRT)
+		if len(entID) != 0 && len(principalRT) != 0 && len(principalID) != 0 {
+			scratch.key = enginepkg.AppendGrantByEntitlementIndexKeyRawBytes(scratch.key[:0], syncBytes, entID, principalRT, principalID, ext)
+			if err := emit(scratch.key); err != nil {
+				return err
+			}
+		}
+		if len(entRID) != 0 {
+			scratch.key = enginepkg.AppendGrantByEntitlementResourceIndexKeyRawBytes(scratch.key[:0], syncBytes, entRT, entRID, ext)
+			if err := emit(scratch.key); err != nil {
+				return err
+			}
+		}
+		if len(principalRT) != 0 && len(principalID) != 0 {
+			scratch.key = enginepkg.AppendGrantByPrincipalIndexKeyRawBytes(scratch.key[:0], syncBytes, principalRT, principalID, ext)
+			if err := emit(scratch.key); err != nil {
+				return err
+			}
+			scratch.key = enginepkg.AppendGrantByPrincipalResourceTypeIndexKeyRawBytes(scratch.key[:0], syncBytes, principalRT, ext)
+			if err := emit(scratch.key); err != nil {
+				return err
+			}
+		}
+		if needsExpansion {
+			scratch.key = enginepkg.AppendGrantByNeedsExpansionIndexKeyRawBytes(scratch.key[:0], syncBytes, ext)
+			if err := emit(scratch.key); err != nil {
+				return err
+			}
+		}
+		return nil
+	default:
+		return nil
+	}
+}
+
+func decodePrimaryTailBytes1(key []byte, lower []byte, scratch *rawIndexScratch) ([]byte, error) {
+	tail, err := primaryTail(key, lower)
+	if err != nil {
+		return nil, err
+	}
+	scratch.tail1, _, err = codec.DecodeTupleStringTo(scratch.tail1[:0], tail, 0)
+	if err != nil {
+		return nil, err
+	}
+	return scratch.tail1, nil
+}
+
+func decodePrimaryTailBytes2(key []byte, lower []byte, scratch *rawIndexScratch) ([]byte, []byte, error) {
+	tail, err := primaryTail(key, lower)
+	if err != nil {
+		return nil, nil, err
+	}
+	var next int
+	scratch.tail1, next, err = codec.DecodeTupleStringTo(scratch.tail1[:0], tail, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	if next >= len(tail) {
+		return scratch.tail1, nil, nil
+	}
+	scratch.tail2, _, err = codec.DecodeTupleStringTo(scratch.tail2[:0], tail, next+1)
+	if err != nil {
+		return nil, nil, err
+	}
+	return scratch.tail1, scratch.tail2, nil
+}
+
+func primaryTail(key []byte, lower []byte) ([]byte, error) {
+	if len(key) <= len(lower) {
+		return nil, fmt.Errorf("overlay raw index: key shorter than expected lower bound")
+	}
+	return key[len(lower)+1:], nil
+}
+
+// The shallow message-field scanners below keep the LAST occurrence of
+// the target field, approximating proto merge semantics (a shallow scan
+// cannot field-merge repeated submessage occurrences, but values written
+// by this SDK carry at most one occurrence). All shallow scanners in
+// this package and in the engine's raw_records.go follow this rule.
+func scanResourceParentBytes(value []byte) ([]byte, []byte, error) {
+	var rt, id []byte
+	for len(value) > 0 {
+		num, typ, n := protowire.ConsumeTag(value)
+		if n < 0 {
+			return nil, nil, protowire.ParseError(n)
+		}
+		value = value[n:]
+		if num != 6 {
+			n = protowire.ConsumeFieldValue(num, typ, value)
+			if n < 0 {
+				return nil, nil, protowire.ParseError(n)
+			}
+			value = value[n:]
+			continue
+		}
+		if typ != protowire.BytesType {
+			return nil, nil, fmt.Errorf("overlay raw index: resource parent wire type %v", typ)
+		}
+		msg, n := protowire.ConsumeBytes(value)
+		if n < 0 {
+			return nil, nil, protowire.ParseError(n)
+		}
+		var err error
+		rt, id, err = scanResourceRefBytes(msg)
+		if err != nil {
+			return nil, nil, err
+		}
+		value = value[n:]
+	}
+	return rt, id, nil
+}
+
+func scanEntitlementResourceBytes(value []byte) ([]byte, []byte, error) {
+	var rt, id []byte
+	for len(value) > 0 {
+		num, typ, n := protowire.ConsumeTag(value)
+		if n < 0 {
+			return nil, nil, protowire.ParseError(n)
+		}
+		value = value[n:]
+		if num != 3 {
+			n = protowire.ConsumeFieldValue(num, typ, value)
+			if n < 0 {
+				return nil, nil, protowire.ParseError(n)
+			}
+			value = value[n:]
+			continue
+		}
+		if typ != protowire.BytesType {
+			return nil, nil, fmt.Errorf("overlay raw index: entitlement resource wire type %v", typ)
+		}
+		msg, n := protowire.ConsumeBytes(value)
+		if n < 0 {
+			return nil, nil, protowire.ParseError(n)
+		}
+		var err error
+		rt, id, err = scanResourceRefBytes(msg)
+		if err != nil {
+			return nil, nil, err
+		}
+		value = value[n:]
+	}
+	return rt, id, nil
+}
+
+func scanGrantIndexFieldsBytes(value []byte) ([]byte, []byte, []byte, []byte, []byte, bool, error) {
+	var entRT, entRID, entID, principalRT, principalID []byte
+	var needsExpansion bool
+	for len(value) > 0 {
+		num, typ, n := protowire.ConsumeTag(value)
+		if n < 0 {
+			return nil, nil, nil, nil, nil, false, protowire.ParseError(n)
+		}
+		value = value[n:]
+		switch num {
+		case 3:
+			if typ != protowire.BytesType {
+				return nil, nil, nil, nil, nil, false, fmt.Errorf("overlay raw index: grant entitlement wire type %v", typ)
+			}
+			msg, n := protowire.ConsumeBytes(value)
+			if n < 0 {
+				return nil, nil, nil, nil, nil, false, protowire.ParseError(n)
+			}
+			var err error
+			entRT, entRID, entID, err = scanEntitlementRefBytes(msg)
+			if err != nil {
+				return nil, nil, nil, nil, nil, false, err
+			}
+			value = value[n:]
+		case 4:
+			if typ != protowire.BytesType {
+				return nil, nil, nil, nil, nil, false, fmt.Errorf("overlay raw index: grant principal wire type %v", typ)
+			}
+			msg, n := protowire.ConsumeBytes(value)
+			if n < 0 {
+				return nil, nil, nil, nil, nil, false, protowire.ParseError(n)
+			}
+			var err error
+			principalRT, principalID, err = scanPrincipalRefBytes(msg)
+			if err != nil {
+				return nil, nil, nil, nil, nil, false, err
+			}
+			value = value[n:]
+		case 7:
+			if typ != protowire.VarintType {
+				return nil, nil, nil, nil, nil, false, fmt.Errorf("overlay raw index: grant needs_expansion wire type %v", typ)
+			}
+			v, n := protowire.ConsumeVarint(value)
+			if n < 0 {
+				return nil, nil, nil, nil, nil, false, protowire.ParseError(n)
+			}
+			needsExpansion = v != 0
+			value = value[n:]
+		default:
+			n = protowire.ConsumeFieldValue(num, typ, value)
+			if n < 0 {
+				return nil, nil, nil, nil, nil, false, protowire.ParseError(n)
+			}
+			value = value[n:]
+		}
+	}
+	return entRT, entRID, entID, principalRT, principalID, needsExpansion, nil
+}
+
+// The byte scanners borrow protobuf string field slices directly from the
+// source value. They do not validate UTF-8: these values were written by our
+// protobuf encoder on the trusted c1z path, and the scanner's job is only to
+// avoid allocations while deriving secondary index keys.
+func scanResourceRefBytes(value []byte) ([]byte, []byte, error) {
+	var rt, id []byte
+	for len(value) > 0 {
+		num, typ, n := protowire.ConsumeTag(value)
+		if n < 0 {
+			return nil, nil, protowire.ParseError(n)
+		}
+		value = value[n:]
+		if typ != protowire.BytesType {
+			n = protowire.ConsumeFieldValue(num, typ, value)
+			if n < 0 {
+				return nil, nil, protowire.ParseError(n)
+			}
+			value = value[n:]
+			continue
+		}
+		b, n := protowire.ConsumeBytes(value)
+		if n < 0 {
+			return nil, nil, protowire.ParseError(n)
+		}
+		switch num {
+		case 1:
+			rt = b
+		case 2:
+			id = b
+		default:
+		}
+		value = value[n:]
+	}
+	return rt, id, nil
+}
+
+func scanEntitlementRefBytes(value []byte) ([]byte, []byte, []byte, error) {
+	var rt, rid, eid []byte
+	for len(value) > 0 {
+		num, typ, n := protowire.ConsumeTag(value)
+		if n < 0 {
+			return nil, nil, nil, protowire.ParseError(n)
+		}
+		value = value[n:]
+		if typ != protowire.BytesType {
+			n = protowire.ConsumeFieldValue(num, typ, value)
+			if n < 0 {
+				return nil, nil, nil, protowire.ParseError(n)
+			}
+			value = value[n:]
+			continue
+		}
+		b, n := protowire.ConsumeBytes(value)
+		if n < 0 {
+			return nil, nil, nil, protowire.ParseError(n)
+		}
+		switch num {
+		case 1:
+			rt = b
+		case 2:
+			rid = b
+		case 3:
+			eid = b
+		default:
+		}
+		value = value[n:]
+	}
+	return rt, rid, eid, nil
+}
+
+func scanPrincipalRefBytes(value []byte) ([]byte, []byte, error) {
+	var rt, id []byte
+	for len(value) > 0 {
+		num, typ, n := protowire.ConsumeTag(value)
+		if n < 0 {
+			return nil, nil, protowire.ParseError(n)
+		}
+		value = value[n:]
+		if typ != protowire.BytesType {
+			n = protowire.ConsumeFieldValue(num, typ, value)
+			if n < 0 {
+				return nil, nil, protowire.ParseError(n)
+			}
+			value = value[n:]
+			continue
+		}
+		b, n := protowire.ConsumeBytes(value)
+		if n < 0 {
+			return nil, nil, protowire.ParseError(n)
+		}
+		switch num {
+		case 1:
+			rt = b
+		case 2:
+			id = b
+		default:
+		}
+		value = value[n:]
+	}
+	return rt, id, nil
+}
+
+func withSourceEngine(ctx context.Context, tmpDir string, source SourceFile, fn func(*enginepkg.Engine) error) error {
+	if source.Engine != nil {
+		return fn(source.Engine)
+	}
+	if source.DBDir != "" {
+		eng, err := enginepkg.Open(ctx, source.DBDir, enginepkg.WithReadOnly(true))
+		if err != nil {
+			return err
+		}
+		defer eng.Close()
+		return fn(eng)
+	}
+	w, err := dotc1z.NewStore(ctx, source.Path, dotc1z.WithReadOnly(true), dotc1z.WithTmpDir(tmpDir), dotc1z.WithDecoderPool(source.DecoderPool))
+	if err != nil {
+		return err
+	}
+	// Full Close removes the read-only store's unpacked temp directory;
+	// callers iterate sources one at a time, so planning never holds
+	// more than one unpacked source on disk.
+	defer func() { _ = w.Close(ctx) }()
+	eng, ok := enginepkg.AsEngine(w)
+	if !ok {
+		return fmt.Errorf("overlay merge: input is not pebble: %s", source.Path)
+	}
+	return fn(eng)
+}
+
+type overlayBucketRawWriter struct {
+	dest      *enginepkg.Engine
+	bucket    bucketSpec
+	chunkSize int
+	primary   *cpebble.Batch
+	index     *cpebble.Batch
+	count     int
+	scratch   rawIndexScratch
+	stats     *mergeStatsAccumulator
+}
+
+// The normal overlay path writes raw primary values and raw secondary index
+// keys directly into Pebble batches. This avoids proto.Unmarshal + Put*Records
+// remarshal/index generation; same-size syncs=50 improved from ~2.9s / 3.8M
+// allocs to ~2.25s / 3.1M allocs before the later byte-slice reductions.
+func newOverlayBucketRawWriter(dest *enginepkg.Engine, bucket bucketSpec, stats *mergeStatsAccumulator, chunkSize int) *overlayBucketRawWriter {
+	return &overlayBucketRawWriter{
+		dest:      dest,
+		bucket:    bucket,
+		chunkSize: chunkSize,
+		primary:   dest.DB().NewBatch(),
+		index:     dest.DB().NewBatch(),
+		stats:     stats,
+	}
+}
+
+func (w *overlayBucketRawWriter) addRaw(ctx context.Context, bucket bucketSpec, syncBytes []byte, destKey []byte, destLower []byte, value []byte) error {
+	if err := w.primary.Set(destKey, value, nil); err != nil {
+		return err
+	}
+	// Every addRaw call is a winner (the seen-set dedupe happens before
+	// admission), so totals count here; per-RT grouping piggybacks on
+	// the index-key field scan below.
+	w.stats.countWinnerTotal(bucket.id)
+	if bucket.forEachIndexKey == nil {
+		w.count++
+		if w.count >= w.chunkSize {
+			return w.flush(ctx)
+		}
+		return nil
+	}
+	if err := forEachIndexKeyFromRaw(bucket, syncBytes, destKey, destLower, value, &w.scratch, w.stats, func(key []byte) error {
+		return w.index.Set(key, nil, nil)
+	}); err != nil {
+		return err
+	}
+	w.count++
+	if w.count >= w.chunkSize {
+		return w.flush(ctx)
+	}
+	return nil
+}
+
+// replaceRaw overwrites a previously admitted record with a strictly
+// newer one — an older source carried a newer discovered_at than the
+// admitted record. Rare in practice (normal syncs stamp discovered_at
+// in sync order, so the newest source wins at first admission), which
+// is why this path can afford to be expensive: the old value's derived
+// index keys must be deleted, and the old value may still sit in an
+// uncommitted batch, so we flush first and read it back from the DB.
+//
+// Totals are unchanged (same logical key, already counted at first
+// admission); only the grant per-RT grouping can move, because the
+// entitlement resource type lives in the value.
+func (w *overlayBucketRawWriter) replaceRaw(ctx context.Context, bucket bucketSpec, syncBytes []byte, destKey []byte, destLower []byte, value []byte) error {
+	if err := w.flush(ctx); err != nil {
+		return err
+	}
+	oldVal, closer, err := w.dest.DB().Get(destKey)
+	if err != nil {
+		if errors.Is(err, cpebble.ErrNotFound) {
+			// Seen-set hash collision: the admitted record was a different
+			// key (probability ~1e-28, see seenSuffixSet). Treat the
+			// candidate as a fresh admission.
+			return w.addRaw(ctx, bucket, syncBytes, destKey, destLower, value)
+		}
+		return err
+	}
+	// Drop the index keys derived from the old value and move the grant
+	// stats grouping before the closer invalidates oldVal. Deleting and
+	// re-setting an identical index key within the same batch is fine —
+	// batch ops apply in order, so the Set below wins.
+	if bucket.forEachIndexKey != nil {
+		if err := forEachIndexKeyFromRaw(bucket, syncBytes, destKey, destLower, oldVal, &w.scratch, nil, func(key []byte) error {
+			return w.index.Delete(key, nil)
+		}); err != nil {
+			closer.Close()
+			return err
+		}
+	}
+	if bucket.id == runBucketGrants {
+		oldEntRT, _, _, _, _, _, err := scanGrantIndexFieldsBytes(oldVal)
+		if err != nil {
+			closer.Close()
+			return err
+		}
+		newEntRT, _, _, _, _, _, err := scanGrantIndexFieldsBytes(value)
+		if err != nil {
+			closer.Close()
+			return err
+		}
+		w.stats.regroupGrant(oldEntRT, newEntRT)
+	}
+	closer.Close()
+	if err := w.primary.Set(destKey, value, nil); err != nil {
+		return err
+	}
+	if bucket.forEachIndexKey != nil {
+		if err := forEachIndexKeyFromRaw(bucket, syncBytes, destKey, destLower, value, &w.scratch, nil, func(key []byte) error {
+			return w.index.Set(key, nil, nil)
+		}); err != nil {
+			return err
+		}
+	}
+	w.count++
+	if w.count >= w.chunkSize {
+		return w.flush(ctx)
+	}
+	return nil
+}
+
+func (w *overlayBucketRawWriter) flush(ctx context.Context) error {
+	if w == nil || w.count == 0 {
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	opts := cpebble.NoSync
+	if err := w.primary.Commit(opts); err != nil {
+		return err
+	}
+	if err := w.index.Commit(opts); err != nil {
+		return err
+	}
+	w.primary = w.dest.DB().NewBatch()
+	w.index = w.dest.DB().NewBatch()
+	w.count = 0
+	return nil
+}
+
+func (w *overlayBucketRawWriter) cleanup() {
+	if w == nil {
+		return
+	}
+	if w.primary != nil {
+		_ = w.primary.Close()
+	}
+	if w.index != nil {
+		_ = w.index.Close()
+	}
+}

--- a/pkg/synccompactor/pebble/overlay_winner_test.go
+++ b/pkg/synccompactor/pebble/overlay_winner_test.go
@@ -1,0 +1,89 @@
+package pebble
+
+import (
+	"context"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/segmentio/ksuid"
+
+	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
+)
+
+// TestMergeFilesIntoOverlayNewerDiscoveredAtWins locks in the overlay
+// winner rule: per key, the record with the strictly newest
+// discovered_at wins regardless of source order, and ties keep the
+// earliest admission (the newest source) — identical to K-way's
+// runRecordIsNewer and the sqlite attached compactor. This exercises
+// the replaceRaw path: sources[1] (the OLDER source) carries a newer
+// discovered_at for "shared", so it must replace sources[0]'s
+// already-admitted record, including its derived index keys.
+func TestMergeFilesIntoOverlayNewerDiscoveredAtWins(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	older := time.Unix(1000, 0).UTC()
+	newer := time.Unix(2000, 0).UTC()
+	tie := time.Unix(3000, 0).UTC()
+	// sources[0]: scanned first (overlay goes newest-to-oldest).
+	src1 := writeKWaySource(t, ctx, filepath.Join(dir, "src1.c1z"), []kwayGrantSpec{
+		{id: "shared", principalID: "alice", entitlement: "member", discovered: older},
+		{id: "tie", principalID: "alice", entitlement: "member", discovered: tie},
+	}, false)
+	// sources[1]: older source with a strictly newer discovered_at for
+	// "shared" and an equal one for "tie".
+	src2 := writeKWaySource(t, ctx, filepath.Join(dir, "src2.c1z"), []kwayGrantSpec{
+		{id: "shared", principalID: "bob", entitlement: "member", discovered: newer},
+		{id: "tie", principalID: "bob", entitlement: "member", discovered: tie},
+	}, false)
+
+	dest, _ := newEngine(t, "overlay-winner-dest")
+	destSyncID := ksuid.New().String()
+	stats, err := MergeFilesIntoOverlay(ctx, dest, []SourceFile{
+		{Path: src1.path, SyncID: src1.syncID},
+		{Path: src2.path, SyncID: src2.syncID},
+	}, destSyncID, t.TempDir())
+	if err != nil {
+		t.Fatalf("MergeFilesIntoOverlay: %v", err)
+	}
+
+	grants := map[string]*v3.GrantRecord{}
+	if err := dest.IterateGrantsBySync(ctx, destSyncID, func(g *v3.GrantRecord) bool {
+		grants[g.GetExternalId()] = g
+		return true
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(grants) != 2 {
+		t.Fatalf("merged grant count = %d, want 2", len(grants))
+	}
+	if got := grants["shared"].GetPrincipal().GetResourceId(); got != "bob" {
+		t.Fatalf("shared grant principal = %q, want bob (older source, newer discovered_at)", got)
+	}
+	if got := grants["tie"].GetPrincipal().GetResourceId(); got != "alice" {
+		t.Fatalf("tie grant principal = %q, want alice (first admission keeps ties)", got)
+	}
+	if got := stats.GetGrants(); got != 2 {
+		t.Fatalf("stats grants = %d, want 2 (replacement must not double count)", got)
+	}
+
+	// Index correctness after replacement: the stale by_principal entry
+	// for alice/"shared" must be gone, and bob's must exist.
+	byPrincipal := map[string][]string{}
+	for _, principal := range []string{"alice", "bob"} {
+		if err := dest.IterateGrantsByPrincipal(ctx, destSyncID, "user", principal, func(g *v3.GrantRecord) bool {
+			byPrincipal[principal] = append(byPrincipal[principal], g.GetExternalId())
+			return true
+		}); err != nil {
+			t.Fatal(err)
+		}
+		sort.Strings(byPrincipal[principal])
+	}
+	if got, want := byPrincipal["alice"], []string{"tie"}; fmtSprint(got) != fmtSprint(want) {
+		t.Fatalf("by_principal[alice] = %v, want %v (stale index entry after replacement)", got, want)
+	}
+	if got, want := byPrincipal["bob"], []string{"shared"}; fmtSprint(got) != fmtSprint(want) {
+		t.Fatalf("by_principal[bob] = %v, want %v", got, want)
+	}
+}

--- a/pkg/synccompactor/pebble/raw_index_alloc_test.go
+++ b/pkg/synccompactor/pebble/raw_index_alloc_test.go
@@ -1,0 +1,140 @@
+package pebble
+
+import (
+	"testing"
+
+	"github.com/segmentio/ksuid"
+	"google.golang.org/protobuf/proto"
+
+	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
+	enginepkg "github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/codec"
+)
+
+// rawIndexAllocFixture builds the inputs forEachIndexKeyFromRaw sees
+// for one grant winner: the raw record value, its dest primary key,
+// and the bucket's dest lower bound.
+type rawIndexAllocFixture struct {
+	bucket    bucketSpec
+	syncBytes []byte
+	destKey   []byte
+	destLower []byte
+	value     []byte
+}
+
+func newGrantRawIndexAllocFixture(tb testing.TB) rawIndexAllocFixture {
+	tb.Helper()
+	syncID := ksuid.New().String()
+	syncBytes, err := codec.EncodeSyncID(syncID)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	const externalID = "grant-ext-1"
+	rec := v3.GrantRecord_builder{
+		ExternalId: externalID,
+		Entitlement: v3.EntitlementRef_builder{
+			ResourceTypeId: "group",
+			ResourceId:     "g1",
+			EntitlementId:  "group:g1:member",
+		}.Build(),
+		Principal: v3.PrincipalRef_builder{
+			ResourceTypeId: "user",
+			ResourceId:     "u1",
+		}.Build(),
+		NeedsExpansion: true,
+	}.Build()
+	value, err := proto.Marshal(rec)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	return rawIndexAllocFixture{
+		bucket:    grantBucket(),
+		syncBytes: syncBytes,
+		destKey:   enginepkg.GrantRecordKey(syncBytes, externalID),
+		destLower: enginepkg.GrantSyncLowerBound(syncBytes),
+		value:     value,
+	}
+}
+
+// TestForEachIndexKeyFromRawAllocs locks in the zero-allocation
+// contract of the raw index-key scan: with warm scratch buffers and
+// warm stats maps, generating all five grant index keys for a winner
+// must not allocate. The raw field scanners (scanGrantIndexFieldsBytes
+// et al.) return borrowed sub-slices of the value; the tuple decode
+// and key construction write into caller-owned scratch. A regression
+// here silently multiplies compactor allocations by the record count
+// (tens of millions on production-scale merges).
+func TestForEachIndexKeyFromRawAllocs(t *testing.T) {
+	fx := newGrantRawIndexAllocFixture(t)
+	stats := newMergeStatsAccumulator()
+	var scratch rawIndexScratch
+	var emitted int
+	emit := func(key []byte) error {
+		emitted++
+		if len(key) == 0 {
+			t.Error("emitted empty index key")
+		}
+		return nil
+	}
+	run := func() {
+		if err := forEachIndexKeyFromRaw(fx.bucket, fx.syncBytes, fx.destKey, fx.destLower, fx.value, &scratch, stats, emit); err != nil {
+			t.Fatal(err)
+		}
+	}
+	run()
+	if emitted != 5 {
+		t.Fatalf("emitted %d grant index keys, want 5", emitted)
+	}
+	allocs := testing.AllocsPerRun(100, run)
+	if allocs != 0 {
+		t.Fatalf("forEachIndexKeyFromRaw allocs/op = %v, want 0 (scratch reuse regressed)", allocs)
+	}
+}
+
+// TestSeenSuffixSetLookupAllocs locks in the allocation-free lookup
+// contract of the overlay dedupe set: hashing a suffix and reading the
+// recorded discovered_at must not allocate (the old map[string] set
+// materialized a string per scanned record). Fresh inserts only pay
+// amortized map growth.
+func TestSeenSuffixSetLookupAllocs(t *testing.T) {
+	seen := newSeenSuffixSet()
+	suffix := []byte("group\x00g1\x00grant-ext-1")
+	k := seen.keyOf(suffix)
+	if _, ok := seen.get(k); ok {
+		t.Fatal("fresh key reported as seen")
+	}
+	seen.put(k, 42)
+	allocs := testing.AllocsPerRun(100, func() {
+		k := seen.keyOf(suffix)
+		ts, ok := seen.get(k)
+		if !ok || ts != 42 {
+			t.Errorf("lookup = (%d, %v), want (42, true)", ts, ok)
+		}
+		seen.put(k, 42)
+	})
+	if allocs != 0 {
+		t.Fatalf("seenSuffixSet lookup allocs/op = %v, want 0", allocs)
+	}
+	if seen.size() != 1 {
+		t.Fatalf("seen.size() = %d, want 1", seen.size())
+	}
+}
+
+func BenchmarkForEachIndexKeyFromRaw(b *testing.B) {
+	fx := newGrantRawIndexAllocFixture(b)
+	stats := newMergeStatsAccumulator()
+	var scratch rawIndexScratch
+	var sink int
+	emit := func(key []byte) error {
+		sink += len(key)
+		return nil
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := forEachIndexKeyFromRaw(fx.bucket, fx.syncBytes, fx.destKey, fx.destLower, fx.value, &scratch, stats, emit); err != nil {
+			b.Fatal(err)
+		}
+	}
+	_ = sink
+}

--- a/proto/c1/c1z/v3/manifest.proto
+++ b/proto/c1/c1z/v3/manifest.proto
@@ -89,6 +89,13 @@ message SyncRunSummary {
   c1.storage.v3.SyncType type = 2;
   google.protobuf.Timestamp started_at = 3;
   google.protobuf.Timestamp ended_at = 4;
+  string parent_sync_id = 5;
+  // Projection of the engine's stats sidecar for this sync, when one
+  // exists. Lets readers (compaction source selection, overlay bucket
+  // planning, tooling) get row counts from the envelope header without
+  // unpacking the payload. Absent for syncs whose sidecar was never
+  // written (e.g. interrupted syncs).
+  c1.storage.v3.SyncStatsRecord stats = 6;
 }
 
 // PebbleEngineConfig is the value placed inside C1ZManifestV3.engine_config

--- a/proto/c1/storage/v3/records.proto
+++ b/proto/c1/storage/v3/records.proto
@@ -55,12 +55,12 @@ message ResourceTypeRecord {
   option (table) = {
     name: "resource_types"
     primary_key: [
-      "sync_id",
       "external_id"
     ]
   };
 
-  string sync_id = 1;
+  reserved 1;
+  reserved "sync_id";
   string external_id = 2;
   string display_name = 3;
   repeated string traits = 4;
@@ -79,13 +79,13 @@ message ResourceRecord {
   option (table) = {
     name: "resources"
     primary_key: [
-      "sync_id",
       "resource_type_id",
       "resource_id"
     ]
   };
 
-  string sync_id = 1;
+  reserved 1;
+  reserved "sync_id";
   string resource_type_id = 2;
   string resource_id = 3;
   string display_name = 4;
@@ -111,12 +111,12 @@ message EntitlementRecord {
   option (table) = {
     name: "entitlements"
     primary_key: [
-      "sync_id",
       "external_id"
     ]
   };
 
-  string sync_id = 1;
+  reserved 1;
+  reserved "sync_id";
   string external_id = 2;
   ResourceRef resource = 3 [(index) = {
     name: "by_resource"
@@ -152,12 +152,12 @@ message GrantRecord {
   option (table) = {
     name: "grants"
     primary_key: [
-      "sync_id",
       "external_id"
     ]
   };
 
-  string sync_id = 1;
+  reserved 1;
+  reserved "sync_id";
   string external_id = 2;
   // entitlement carries TWO indexes:
   //   by_entitlement              — keyed (entitlement_id, principal_rt, principal_id);


### PR DESCRIPTION
Two benches: one with very small incrementals, and the other, with large ones.  We use the "overlay" algo if we can fit everything into memory, otherwise, we fall back to kway (which is much more disk intensive).   I expect to squeeze out another 20-30% on both pebble paths.


## Non-Skewed / Same-Size - middle 6 /8

| syncs | engine | avg time/op | avg bytes/op | avg allocs/op |
|---:|---|---:|---:|---:|
| 10 | sqlite | 391.1ms | 55.7MB | 30,972 |
| 10 | kway | 511.1ms | 109.1MB | 22,557 |
| 10 | overlay | 404.1ms | 75.2MB | 15,800 |
| 50 | sqlite | 2.09s | 239.1MB | 144,272 |
| 50 | kway | 824.9ms | 214.3MB | 66,099 |
| 50 | overlay | 784.8ms | 213.8MB | 55,658 |
| 500 | sqlite | 25.93s | 2.30GB | 1,419,838 |
| 500 | kway | 4.72s | 869.7MB | 579,807 |
| 500 | overlay | 4.76s | 844.6MB | 555,171 |

## Skewed - middle 6 / 8

| syncs | engine | avg time/op | avg bytes/op | avg allocs/op |
|---:|---|---:|---:|---:|
| 10 | sqlite | 163.1ms | 21.3MB | 30,241 |
| 10 | kway | 505.0ms | 96.7MB | 18,792 |
| 10 | overlay | 310.5ms | 41.4MB | 15,200 |
| 50 | sqlite | 456.4ms | 51.3MB | 140,314 |
| 50 | kway | 490.2ms | 113.3MB | 56,668 |
| 50 | overlay | 354.8ms | 57.3MB | 52,354 |
| 500 | sqlite | 3.98s | 390.0MB | 1,379,003 |
| 500 | kway | 1.10s | 355.0MB | 484,927 |
| 500 | overlay | 896.0ms | 233.4MB | 467,478 |