### PR TITLE
Prevent formula injection in CSV/XLSX exports

### DIFF
--- a/cmd/baton/csv.go
+++ b/cmd/baton/csv.go
@@ -220,18 +220,18 @@ type csvRow struct {
 
 func (c csvRow) Row() []string {
 	return []string{
-		c.rowType,
-		c.lastName,
-		c.firstName,
-		c.userID,
-		c.userStatus,
-		c.emailAddress,
-		c.entitlementDisplayName,
-		c.entitlement,
-		c.resourceType,
-		c.resourceName,
-		c.entitlementDescription,
-		c.entitlementSlug,
+		sanitizeCell(c.rowType),
+		sanitizeCell(c.lastName),
+		sanitizeCell(c.firstName),
+		sanitizeCell(c.userID),
+		sanitizeCell(c.userStatus),
+		sanitizeCell(c.emailAddress),
+		sanitizeCell(c.entitlementDisplayName),
+		sanitizeCell(c.entitlement),
+		sanitizeCell(c.resourceType),
+		sanitizeCell(c.resourceName),
+		sanitizeCell(c.entitlementDescription),
+		sanitizeCell(c.entitlementSlug),
 	}
 }
 

--- a/cmd/baton/export.go
+++ b/cmd/baton/export.go
@@ -1,8 +1,37 @@
 package main
 
 import (
+	"strings"
+	"unicode"
+
 	"github.com/spf13/cobra"
 )
+
+// sanitizeCell neutralizes spreadsheet formula injection in exported CSV/XLSX
+// files. Spreadsheet applications (Excel, Google Sheets, LibreOffice, etc.)
+// interpret a cell whose value begins with =, +, -, or @ as a formula. Because
+// export values originate from upstream identity systems and are attacker
+// controllable (e.g. a user's display name), any such value is prefixed with a
+// single quote so the spreadsheet renders it as literal text. Embedded control
+// characters — including tabs, carriage returns, and newlines that could be
+// used to smuggle content or lead a formula — are stripped first.
+func sanitizeCell(s string) string {
+	s = strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, s)
+
+	if s != "" {
+		switch s[0] {
+		case '=', '+', '-', '@':
+			return "'" + s
+		}
+	}
+
+	return s
+}
 
 type header int
 

--- a/cmd/baton/xlsx.go
+++ b/cmd/baton/xlsx.go
@@ -48,7 +48,7 @@ func (c excelRow) Row(sheet string, row int, f *excelize.File) error {
 			if err != nil {
 				return err
 			}
-			err = f.SetCellValue(sheet, cell, c.rowType)
+			err = f.SetCellValue(sheet, cell, sanitizeCell(c.rowType))
 			if err != nil {
 				return err
 			}
@@ -58,7 +58,7 @@ func (c excelRow) Row(sheet string, row int, f *excelize.File) error {
 			if err != nil {
 				return err
 			}
-			err = f.SetCellValue(sheet, cell, c.lastName)
+			err = f.SetCellValue(sheet, cell, sanitizeCell(c.lastName))
 			if err != nil {
 				return err
 			}
@@ -67,7 +67,7 @@ func (c excelRow) Row(sheet string, row int, f *excelize.File) error {
 			if err != nil {
 				return err
 			}
-			err = f.SetCellValue(sheet, cell, c.firstName)
+			err = f.SetCellValue(sheet, cell, sanitizeCell(c.firstName))
 			if err != nil {
 				return err
 			}
@@ -76,7 +76,7 @@ func (c excelRow) Row(sheet string, row int, f *excelize.File) error {
 			if err != nil {
 				return err
 			}
-			err = f.SetCellValue(sheet, cell, c.userID)
+			err = f.SetCellValue(sheet, cell, sanitizeCell(c.userID))
 			if err != nil {
 				return err
 			}
@@ -85,7 +85,7 @@ func (c excelRow) Row(sheet string, row int, f *excelize.File) error {
 			if err != nil {
 				return err
 			}
-			err = f.SetCellValue(sheet, cell, c.userStatus)
+			err = f.SetCellValue(sheet, cell, sanitizeCell(c.userStatus))
 			if err != nil {
 				return err
 			}
@@ -94,7 +94,7 @@ func (c excelRow) Row(sheet string, row int, f *excelize.File) error {
 			if err != nil {
 				return err
 			}
-			err = f.SetCellValue(sheet, cell, c.emailAddress)
+			err = f.SetCellValue(sheet, cell, sanitizeCell(c.emailAddress))
 			if err != nil {
 				return err
 			}
@@ -103,7 +103,7 @@ func (c excelRow) Row(sheet string, row int, f *excelize.File) error {
 			if err != nil {
 				return err
 			}
-			err = f.SetCellValue(sheet, cell, c.entitlementDisplayName)
+			err = f.SetCellValue(sheet, cell, sanitizeCell(c.entitlementDisplayName))
 			if err != nil {
 				return err
 			}
@@ -112,7 +112,7 @@ func (c excelRow) Row(sheet string, row int, f *excelize.File) error {
 			if err != nil {
 				return err
 			}
-			err = f.SetCellValue(sheet, cell, c.entitlement)
+			err = f.SetCellValue(sheet, cell, sanitizeCell(c.entitlement))
 			if err != nil {
 				return err
 			}
@@ -121,7 +121,7 @@ func (c excelRow) Row(sheet string, row int, f *excelize.File) error {
 			if err != nil {
 				return err
 			}
-			err = f.SetCellValue(sheet, cell, c.resourceType)
+			err = f.SetCellValue(sheet, cell, sanitizeCell(c.resourceType))
 			if err != nil {
 				return err
 			}
@@ -130,7 +130,7 @@ func (c excelRow) Row(sheet string, row int, f *excelize.File) error {
 			if err != nil {
 				return err
 			}
-			err = f.SetCellValue(sheet, cell, c.resourceName)
+			err = f.SetCellValue(sheet, cell, sanitizeCell(c.resourceName))
 			if err != nil {
 				return err
 			}
@@ -139,7 +139,7 @@ func (c excelRow) Row(sheet string, row int, f *excelize.File) error {
 			if err != nil {
 				return err
 			}
-			err = f.SetCellValue(sheet, cell, c.entitlementDescription)
+			err = f.SetCellValue(sheet, cell, sanitizeCell(c.entitlementDescription))
 			if err != nil {
 				return err
 			}
@@ -150,7 +150,7 @@ func (c excelRow) Row(sheet string, row int, f *excelize.File) error {
 				return err
 			}
 
-			err = f.SetCellValue(sheet, cell, c.entitlementSlug)
+			err = f.SetCellValue(sheet, cell, sanitizeCell(c.entitlementSlug))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Summary
Add sanitization to exported CSV and XLSX files to prevent spreadsheet formula injection attacks. User-controlled data from upstream identity systems is now validated before export to prevent malicious formulas from being executed when files are opened in Excel, Google Sheets, LibreOffice, or other spreadsheet applications.

## Changes
- **New `sanitizeCell()` function** in `export.go`: Removes control characters (tabs, carriage returns, newlines) and prefixes cells starting with `=`, `+`, `-`, or `@` with a single quote to force literal text rendering
- **CSV export** (`csv.go`): Wrap all 12 cell values in the `csvRow.Row()` method with `sanitizeCell()`
- **XLSX export** (`xlsx.go`): Wrap all 12 cell values in the `excelRow.Row()` method with `sanitizeCell()`

## Implementation Details
The `sanitizeCell()` function:
1. Strips embedded control characters using `strings.Map()` with `unicode.IsControl()`
2. Checks if the resulting string begins with a formula indicator (`=`, `+`, `-`, `@`)
3. Prefixes with a single quote if needed, which spreadsheet applications interpret as a literal text marker
4. Returns the sanitized string

This approach ensures that attacker-controllable values (e.g., user display names, resource names) cannot be weaponized as formulas when exported data is opened in spreadsheet applications.

https://claude.ai/code/session_01Jxcdh6eSR6V8JX9G6iSefs