### PR TITLE
perf(synccompactor): raise compaction SST BlockSize 4KiB→32KiB (OPS-1875)

### DIFF
--- a/pkg/synccompactor/pebble/sst_writer.go
+++ b/pkg/synccompactor/pebble/sst_writer.go
@@ -45,7 +45,14 @@ func newSSTBuilder(path string) (*sstBuilder, error) {
 	// engine running the same or newer SDK release.
 	w := sstable.NewWriter(writable, sstable.WriterOptions{
 		TableFormat: enginepkg.SDKPebbleFormat.MaxTableFormat(),
-		BlockSize:   4 << 10,
+		// 32 KiB blocks (was 4 KiB) cut per-block index/framing CPU when building
+		// compaction SSTs over millions of grants. BenchmarkCompactionFlow at 2M
+		// grants: -8.7% wall-time for +13% on-disk. 32K is the speed/space knee —
+		// 64K/128K buy a few % more speed for sharply more storage (ZFS lz4
+		// compresses larger Snappy blocks less, so on-disk grows fast). These SSTs
+		// are write-once and read sequentially during IngestAndExcise, so the
+		// larger block costs nothing on the read side. See OPS-1875.
+		BlockSize: 32 << 10,
 	})
 	return &sstBuilder{
 		w:    w,


### PR DESCRIPTION
## What

Bump the cross-engine compaction SST writer block size from **4 KiB → 32 KiB** (`pkg/synccompactor/pebble/sst_writer.go`).

Linear: [OPS-1875](https://linear.app/ductone/issue/OPS-1875) (companion to the ops dedicated-Pebble-c1z-PV change).

## Why

The compactor builds SSTs with a hardcoded 4 KiB block size. Over millions of grants, that burns CPU on per-block index/framing — compaction is CPU/alloc-bound, and this is the dominant config lever (engine `options.go` LSM knobs barely move cross-engine `Compact()`, which is `IngestAndExcise` of prebuilt SSTs).

## Numbers (BenchmarkCompactionFlow, 2M grants, Graviton box, zpool0 local NVMe, disk-pressured/ARC-capped)

**Speed (count=5):** 4K = 2640 ms → **32K = 2409 ms (−8.7%)**.

**Speed/space knee** — on a 128k/lz4 PV, compacted-output on-disk:

| SST block | compaction | on-disk |
|---|---|---|
| 4K (today) | 2640 ms | 32 MiB |
| **32K (this PR)** | **2409 ms (−8.7%)** | **36 MiB (+13%)** |
| 64K | 2362 ms (−9.7%) | 40 MiB (+25%) |
| 128K | 2299 ms (−12.1%) | 54 MiB (+69%) |

I picked **32K** deliberately: 64K/128K buy a few % more speed for sharply more storage. ZFS lz4 compresses larger Snappy blocks *less* (2.54× at 4K → 1.42× at 128K), so on-disk grows fast past 32K. 32K is most of the speed for +13% on-disk.

**Snappy retained** — `NoCompression` was ~2% more speed but ~2.2× on-disk; not worth it (ZFS lz4 covers on-disk).

## Risk / scope

- One constant; SSTs are write-once and read sequentially during `IngestAndExcise`, so the larger block costs nothing on the read side.
- On-disk format unchanged (`TableFormat` untouched). Existing c1z files unaffected; only newly-compacted SSTs use the new block size.
- No prod Pebble traffic yet — this is benchmark-derived; revisit with live telemetry.

## Test
`go build ./pkg/synccompactor/pebble/` + bench compile pass. Re-run: `go test -tags=baton_lambda_support,batonsdkv2 -bench=BenchmarkCompactionFlow -benchtime=1x ./pkg/synccompactor/pebble`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)