### PR TITLE
c1zsanitize: replace per-annotation log spam with structured progress logging

### DIFF
--- a/pkg/c1zsanitize/annotations.go
+++ b/pkg/c1zsanitize/annotations.go
@@ -38,9 +38,16 @@ func typeURL(m proto.Message) string {
 }
 
 // transformAnnotations walks the slice once, dispatching each entry
-// on its Any type URL. Unknown types are dropped by default (with a
-// log line naming the URL) or passed through unchanged if the
-// operator opted in via Options.AllowUnknownAnnotations=true.
+// on its Any type URL. Unknown types are dropped by default or passed
+// through unchanged if the operator opted in via
+// Options.AllowUnknownAnnotations=true.
+//
+// The dropped / passed counts and a per-type-URL breakdown are
+// accumulated on the sanitizer struct and surfaced in the per-phase
+// progress + end-of-run summary log lines. Per-annotation logging is
+// intentionally absent: a real sanitize run iterates tens of millions
+// of records each carrying multiple annotations, so a one-line-per-
+// annotation log produced millions of entries with no progress signal.
 func (s *sanitizer) transformAnnotations(in []*anypb.Any, refs *assetRefSet) []*anypb.Any {
 	if len(in) == 0 {
 		return nil
@@ -57,10 +64,12 @@ func (s *sanitizer) transformAnnotations(in []*anypb.Any, refs *assetRefSet) []*
 			// could leak un-sanitized customer data. Pass-through is opt-in
 			// via Options.AllowUnknownAnnotations, for development only.
 			if s.dropUnknownAnnotations {
-				s.log.Debug("c1zsanitize: dropping unknown annotation", zap.String("type_url", a.GetTypeUrl()))
+				s.droppedUnknownAnnotations++
+				s.droppedUnknownAnnotationTypes[a.GetTypeUrl()]++
 				continue
 			}
-			s.log.Warn("c1zsanitize: passing unknown annotation through unchanged", zap.String("type_url", a.GetTypeUrl()))
+			s.passedUnknownAnnotations++
+			s.passedUnknownAnnotationTypes[a.GetTypeUrl()]++
 			out = append(out, a)
 			continue
 		}

--- a/pkg/c1zsanitize/assets.go
+++ b/pkg/c1zsanitize/assets.go
@@ -103,6 +103,11 @@ func (s *sanitizer) copyAssets(
 	refs *assetRefSet,
 ) error {
 	ids := refs.drain()
+	// copyAssets runs once per source sync over an already-drained
+	// set, so the total IS known up front — pass it through startPhase
+	// for true N-of-M progress on this phase.
+	pp := s.startPhase("assets", "", int64(len(ids)))
+	defer pp.done()
 	for _, srcID := range ids {
 		req := v2.AssetServiceGetAssetRequest_builder{
 			Asset: v2.AssetRef_builder{Id: srcID}.Build(),
@@ -114,6 +119,7 @@ func (s *sanitizer) copyAssets(
 			// rows because the cross-reference invariant treats it
 			// as a known dangling pointer in the source.
 			s.log.Debug("c1zsanitize: asset ref not found in source", zap.String("asset_id", srcID), zap.Error(err))
+			pp.page(1)
 			continue
 		}
 		if err := drainAndClose(r); err != nil && !errors.Is(err, io.EOF) {
@@ -123,6 +129,7 @@ func (s *sanitizer) copyAssets(
 		if err := dst.PutAsset(ctx, v2.AssetRef_builder{Id: dstID}.Build(), contentType, placeholderForContentType(contentType)); err != nil {
 			return fmt.Errorf("put dst asset %s: %w", dstID, err)
 		}
+		pp.page(1)
 	}
 	return nil
 }

--- a/pkg/c1zsanitize/sanitize.go
+++ b/pkg/c1zsanitize/sanitize.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"hash"
+	"math"
 	"time"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
@@ -108,16 +109,21 @@ func Sanitize(ctx context.Context, src connectorstore.Reader, dst connectorstore
 	}
 
 	s := &sanitizer{
-		secret:                 opts.Secret,
-		idHmac:                 hmac.New(sha256.New, opts.Secret),
-		domains:                newDomainMap(),
-		shifter:                newTimestampShifter(anchor, findTMax(srcSyncs)),
-		dropUnknownAnnotations: !opts.AllowUnknownAnnotations,
-		log:                    ctxzap.Extract(ctx),
-		handlers:               defaultAnnotationHandlers(),
-		syncIDMap:              map[string]string{},
-		knownResourceTypes:     map[string]struct{}{},
+		secret:                        opts.Secret,
+		idHmac:                        hmac.New(sha256.New, opts.Secret),
+		domains:                       newDomainMap(),
+		shifter:                       newTimestampShifter(anchor, findTMax(srcSyncs)),
+		dropUnknownAnnotations:        !opts.AllowUnknownAnnotations,
+		log:                           ctxzap.Extract(ctx),
+		handlers:                      defaultAnnotationHandlers(),
+		syncIDMap:                     map[string]string{},
+		knownResourceTypes:            map[string]struct{}{},
+		droppedUnknownAnnotationTypes: map[string]uint64{},
+		passedUnknownAnnotationTypes:  map[string]uint64{},
 	}
+
+	s.log.Info("c1zsanitize: starting", zap.Int("source_syncs", len(srcSyncs)))
+	overallStart := time.Now()
 
 	for _, sr := range srcSyncs {
 		if err := s.sanitizeSync(ctx, src, dst, sr); err != nil {
@@ -128,7 +134,72 @@ func Sanitize(ctx context.Context, src connectorstore.Reader, dst connectorstore
 	if err := s.preserveSyncGraphMetadata(ctx, src, dst); err != nil {
 		return fmt.Errorf("c1zsanitize: preserve sync graph metadata: %w", err)
 	}
+
+	s.log.Info("c1zsanitize: complete",
+		zap.Duration("elapsed", time.Since(overallStart)),
+		zap.Uint64("dropped_unknown_annotations_total", s.droppedUnknownAnnotations),
+		zap.Uint64("passed_unknown_annotations_total", s.passedUnknownAnnotations),
+		zap.Any("dropped_unknown_annotation_types", s.droppedUnknownAnnotationTypes),
+		zap.Any("passed_unknown_annotation_types", s.passedUnknownAnnotationTypes),
+	)
 	return nil
+}
+
+// syncStatsReader is the optional source capability the per-sync phase
+// progress uses to resolve true N-of-M totals (resource_types,
+// resources, entitlements, grants) before each phase starts.
+// *dotc1z.C1File implements it — Stats reads the cached sync_runs row
+// for a completed sync, so the call is O(1) and not a table scan.
+// Sources that don't implement it (test fakes) fall through to
+// running-count progress logging.
+type syncStatsReader interface {
+	Stats(ctx context.Context, syncType connectorstore.SyncType, syncId string) (map[string]int64, error)
+}
+
+// phaseTotals holds the up-front per-record-type counts the progress
+// logger uses to emit N-of-M / percent / ETA. Zero values mean "not
+// known" — the progress logger falls back to running-count + rate.
+type phaseTotals struct {
+	resourceTypes int64
+	resources     int64
+	entitlements  int64
+	grants        int64
+}
+
+// resolvePhaseTotals returns the per-record-type totals for a source
+// sync via the optional syncStatsReader capability. A failure or an
+// uncapable reader returns zero totals; the progress logger then
+// reports running-count rather than failing the run.
+func (s *sanitizer) resolvePhaseTotals(ctx context.Context, src connectorstore.Reader, srcSyncID string, syncType connectorstore.SyncType) phaseTotals {
+	sr, ok := src.(syncStatsReader)
+	if !ok {
+		s.log.Debug("c1zsanitize: source does not expose Stats; progress will be running-count only",
+			zap.String("src_sync_id", srcSyncID))
+		return phaseTotals{}
+	}
+	m, err := sr.Stats(ctx, syncType, srcSyncID)
+	if err != nil {
+		s.log.Warn("c1zsanitize: source Stats lookup failed; progress will be running-count only",
+			zap.String("src_sync_id", srcSyncID), zap.Error(err))
+		return phaseTotals{}
+	}
+	// Resources are returned as a per-resource-type breakdown plus the
+	// well-known reserved keys. Sum the non-reserved entries to get the
+	// resource grand total.
+	totals := phaseTotals{
+		resourceTypes: m["resource_types"],
+		entitlements:  m["entitlements"],
+		grants:        m["grants"],
+	}
+	for k, v := range m {
+		switch k {
+		case "resource_types", "entitlements", "grants":
+			// reserved keys, not per-resource-type counts
+		default:
+			totals.resources += v
+		}
+	}
+	return totals
 }
 
 type sanitizer struct {
@@ -141,6 +212,156 @@ type sanitizer struct {
 	handlers               map[string]annotationHandler
 	syncIDMap              map[string]string
 	knownResourceTypes     map[string]struct{}
+
+	// Cumulative across the whole Sanitize() call. The per-phase
+	// progress helper diffs these between phase start and end to
+	// attribute the dropped/passed totals to the phase that incurred
+	// them. Sanitize runs single-threaded, so no synchronization is
+	// needed.
+	droppedUnknownAnnotations     uint64
+	droppedUnknownAnnotationTypes map[string]uint64
+	passedUnknownAnnotations      uint64
+	passedUnknownAnnotationTypes  map[string]uint64
+}
+
+// phaseProgress emits structured log lines for one copy* phase: a
+// start marker, periodic running progress, and a done summary. When
+// the per-record-type total is known up front (via the optional
+// syncStatsReader capability on the source) progress includes
+// percent-complete, items remaining, items/sec rate, and ETA. When
+// the total is not known, progress falls back to a running count plus
+// rate so an operator can still extrapolate "how much longer?"
+//
+// Periodic logs are throttled to one per tick, so a multi-hour
+// sanitize emits dozens of progress lines, not millions — the failure
+// mode the per-annotation log produced.
+type phaseProgress struct {
+	log            *zap.Logger
+	phase          string
+	srcSyncID      string
+	total          int64
+	started        time.Time
+	lastLog        time.Time
+	tick           time.Duration
+	items          uint64
+	pages          uint64
+	droppedAtStart uint64
+	passedAtStart  uint64
+	s              *sanitizer
+}
+
+// phaseProgressTick is the throttle interval for the periodic
+// per-phase progress log. 10 seconds is short enough that an operator
+// watching the log sees regular advancement and long enough that a
+// fast phase doesn't flood the log.
+const phaseProgressTick = 10 * time.Second
+
+func (s *sanitizer) startPhase(phase, srcSyncID string, total int64) *phaseProgress {
+	now := time.Now()
+	if total > 0 {
+		s.log.Info("c1zsanitize: phase start",
+			zap.String("phase", phase),
+			zap.String("src_sync_id", srcSyncID),
+			zap.Int64("total", total),
+		)
+	} else {
+		s.log.Info("c1zsanitize: phase start",
+			zap.String("phase", phase),
+			zap.String("src_sync_id", srcSyncID),
+		)
+	}
+	return &phaseProgress{
+		log:            s.log,
+		phase:          phase,
+		srcSyncID:      srcSyncID,
+		total:          total,
+		started:        now,
+		lastLog:        now,
+		tick:           phaseProgressTick,
+		droppedAtStart: s.droppedUnknownAnnotations,
+		passedAtStart:  s.passedUnknownAnnotations,
+		s:              s,
+	}
+}
+
+// page increments the running count by the size of the page just
+// processed and emits a periodic progress log line if the tick
+// interval has elapsed since the last one. Called once per page
+// boundary inside the copy* loops.
+func (p *phaseProgress) page(n int) {
+	if p == nil {
+		return
+	}
+	p.pages++
+	if n > 0 {
+		p.items += uint64(n)
+	}
+	now := time.Now()
+	if now.Sub(p.lastLog) < p.tick {
+		return
+	}
+	p.emit(now, "c1zsanitize: phase progress")
+	p.lastLog = now
+}
+
+// done emits the per-phase summary log line: total processed, total
+// elapsed, average rate, dropped/passed annotation aggregates scoped
+// to this phase (diff against the sanitizer-level counters).
+func (p *phaseProgress) done() {
+	if p == nil {
+		return
+	}
+	p.emit(time.Now(), "c1zsanitize: phase done")
+}
+
+func (p *phaseProgress) emit(now time.Time, msg string) {
+	elapsed := now.Sub(p.started)
+	rate := 0.0
+	if secs := elapsed.Seconds(); secs > 0 {
+		rate = float64(p.items) / secs
+	}
+	fields := []zap.Field{
+		zap.String("phase", p.phase),
+		zap.String("src_sync_id", p.srcSyncID),
+		zap.Uint64("processed", p.items),
+		zap.Uint64("pages", p.pages),
+		zap.Duration("elapsed", elapsed),
+		zap.Float64("items_per_sec", rate),
+		zap.Uint64("dropped_unknown_annotations", p.s.droppedUnknownAnnotations-p.droppedAtStart),
+		zap.Uint64("passed_unknown_annotations", p.s.passedUnknownAnnotations-p.passedAtStart),
+	}
+	if p.total > 0 {
+		// p.items is a uint64 counter that monotonically increases as
+		// the loop pages; over-clamp to math.MaxInt64 before subtract
+		// so the conversion can never wrap negative.
+		var processed int64
+		if p.items > math.MaxInt64 {
+			processed = math.MaxInt64
+		} else {
+			processed = int64(p.items)
+		}
+		remaining := p.total - processed
+		if remaining < 0 {
+			remaining = 0
+		}
+		percent := 0.0
+		if p.total > 0 {
+			percent = float64(p.items) / float64(p.total) * 100.0
+		}
+		fields = append(fields,
+			zap.Int64("total", p.total),
+			zap.Int64("remaining", remaining),
+			zap.Float64("percent_complete", percent),
+		)
+		// ETA only meaningful when we've seen some throughput AND we
+		// don't already have everything. Truncate to a whole second
+		// so the log value reads cleanly.
+		if rate > 0 && remaining > 0 {
+			etaSec := float64(remaining) / rate
+			fields = append(fields, zap.Duration("eta", time.Duration(etaSec*float64(time.Second)).Round(time.Second)))
+		}
+	}
+	p.log.Info(msg, fields...)
 }
 
 // id is the per-sanitizer hot path. SanitizeID stays as the
@@ -184,23 +405,41 @@ func (s *sanitizer) sanitizeSync(ctx context.Context, src connectorstore.Reader,
 	}
 	s.syncIDMap[srcSyncID] = dstSyncID
 
+	totals := s.resolvePhaseTotals(ctx, src, srcSyncID, syncType)
+	s.log.Info("c1zsanitize: sync start",
+		zap.String("src_sync_id", srcSyncID),
+		zap.String("dst_sync_id", dstSyncID),
+		zap.String("sync_type", string(syncType)),
+		zap.Int64("resource_types_total", totals.resourceTypes),
+		zap.Int64("resources_total", totals.resources),
+		zap.Int64("entitlements_total", totals.entitlements),
+		zap.Int64("grants_total", totals.grants),
+	)
+	syncStart := time.Now()
+
 	assetRefs := newAssetRefSet()
 
-	if err := s.copyResourceTypes(ctx, src, dst, srcSyncID, assetRefs); err != nil {
+	if err := s.copyResourceTypes(ctx, src, dst, srcSyncID, assetRefs, totals.resourceTypes); err != nil {
 		return err
 	}
-	if err := s.copyResources(ctx, src, dst, srcSyncID, assetRefs); err != nil {
+	if err := s.copyResources(ctx, src, dst, srcSyncID, assetRefs, totals.resources); err != nil {
 		return err
 	}
-	if err := s.copyEntitlements(ctx, src, dst, srcSyncID, assetRefs); err != nil {
+	if err := s.copyEntitlements(ctx, src, dst, srcSyncID, assetRefs, totals.entitlements); err != nil {
 		return err
 	}
-	if err := s.copyGrants(ctx, src, dst, srcSyncID, assetRefs); err != nil {
+	if err := s.copyGrants(ctx, src, dst, srcSyncID, assetRefs, totals.grants); err != nil {
 		return err
 	}
 	if err := s.copyAssets(ctx, src, dst, assetRefs); err != nil {
 		return err
 	}
+
+	s.log.Info("c1zsanitize: sync done",
+		zap.String("src_sync_id", srcSyncID),
+		zap.String("dst_sync_id", dstSyncID),
+		zap.Duration("elapsed", time.Since(syncStart)),
+	)
 
 	if err := dst.EndSync(ctx); err != nil {
 		return fmt.Errorf("end dst sync: %w", err)

--- a/pkg/c1zsanitize/sanitize_test.go
+++ b/pkg/c1zsanitize/sanitize_test.go
@@ -6,7 +6,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -515,4 +519,151 @@ func buildFixture(t *testing.T, ctx context.Context, path string) {
 
 	require.NoError(t, f.EndSync(ctx))
 	require.NoError(t, f.Close(ctx))
+}
+
+// TestSanitizeAggregatesDroppedAnnotations is the regression lock for
+// the per-annotation log spam: the sanitizer must NOT emit one log
+// line per dropped annotation. The fix accumulates the dropped count
+// on the sanitizer struct and surfaces it via the per-phase progress
+// + end-of-run summary log lines instead.
+//
+// The fixture writes N resources, each carrying one unknown
+// annotation. After Sanitize, the captured log must contain ZERO
+// lines whose message is the old per-annotation string, and at least
+// one "c1zsanitize: complete" line whose dropped_unknown_annotations_total
+// field equals N.
+func TestSanitizeAggregatesDroppedAnnotations(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	srcPath := filepath.Join(tmp, "src.c1z")
+	dstPath := filepath.Join(tmp, "dst.c1z")
+	secret := bytes32("anno-aggregate")
+
+	const n = 50
+	src := mustOpen(t, ctx, srcPath, false)
+	_, err := src.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+
+	require.NoError(t, src.PutResourceTypes(ctx, v2.ResourceType_builder{
+		Id:          "user",
+		DisplayName: "User",
+		Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_USER},
+	}.Build()))
+
+	unknownAnno := &anypb.Any{
+		TypeUrl: "type.googleapis.com/c1.connector.v2.NotARealAnnotation",
+		Value:   []byte{0x08, 0x01},
+	}
+	for i := 0; i < n; i++ {
+		require.NoError(t, src.PutResources(ctx, v2.Resource_builder{
+			Id:          v2.ResourceId_builder{ResourceType: "user", Resource: stringID(i)}.Build(),
+			Annotations: []*anypb.Any{unknownAnno},
+		}.Build()))
+	}
+	require.NoError(t, src.EndSync(ctx))
+	require.NoError(t, src.Close(ctx))
+
+	srcRO := mustOpen(t, ctx, srcPath, true)
+	defer srcRO.Close(ctx)
+	dst := mustOpen(t, ctx, dstPath, false)
+
+	// Inject an observed logger so we can inspect every log line the
+	// sanitizer emits. ctxzap.Extract returns the context-attached
+	// logger if one is set, which is exactly what the production code
+	// path uses.
+	core, recorded := observer.New(zapcore.DebugLevel)
+	observedLogger := zap.New(core)
+	loggedCtx := ctxzap.ToContext(ctx, observedLogger)
+
+	require.NoError(t, Sanitize(loggedCtx, srcRO, dst, Options{Secret: secret}))
+	require.NoError(t, dst.Close(ctx))
+
+	// Regression: the per-annotation log MUST be gone.
+	for _, entry := range recorded.All() {
+		require.NotEqual(t, "c1zsanitize: dropping unknown annotation", entry.Message,
+			"per-annotation log fired — regression to spam behavior")
+		require.NotEqual(t, "c1zsanitize: passing unknown annotation through unchanged", entry.Message,
+			"per-annotation pass-through log fired — regression to spam behavior")
+	}
+
+	// The end-of-run summary must carry the aggregate.
+	completeEntries := recorded.FilterMessage("c1zsanitize: complete").All()
+	require.Len(t, completeEntries, 1, "exactly one complete-summary log line per Sanitize call")
+	gotTotal, ok := completeEntries[0].ContextMap()["dropped_unknown_annotations_total"]
+	require.True(t, ok, "complete summary must carry dropped_unknown_annotations_total")
+	require.Equal(t, uint64(n), gotTotal,
+		"aggregate dropped count must equal the number of unknown annotations seen")
+
+	// Per-phase progress / done lines must exist for the loops we
+	// expect: resource_types, resources, entitlements, grants, assets.
+	for _, phase := range []string{"resource_types", "resources", "entitlements", "grants", "assets"} {
+		hits := 0
+		for _, entry := range recorded.All() {
+			if entry.Message == "c1zsanitize: phase start" || entry.Message == "c1zsanitize: phase done" {
+				if v, ok := entry.ContextMap()["phase"]; ok && v == phase {
+					hits++
+				}
+			}
+		}
+		require.GreaterOrEqual(t, hits, 2, "phase %q must emit at least start + done", phase)
+	}
+}
+
+// TestSanitizeProgressIncludesTotalsWhenSourceHasStats locks the N-of-M
+// behavior: when the source implements syncStatsReader (which
+// *dotc1z.C1File does), the phase-start log MUST carry a non-zero
+// "total" field so an operator can answer "how much longer?" When the
+// fixture is empty the totals are zero, so the test seeds a single
+// resource of each kind and asserts each phase-start carries total>0.
+func TestSanitizeProgressIncludesTotalsWhenSourceHasStats(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	srcPath := filepath.Join(tmp, "src.c1z")
+	dstPath := filepath.Join(tmp, "dst.c1z")
+	secret := bytes32("progress-totals")
+
+	buildFixture(t, ctx, srcPath)
+
+	srcRO := mustOpen(t, ctx, srcPath, true)
+	defer srcRO.Close(ctx)
+	dst := mustOpen(t, ctx, dstPath, false)
+
+	core, recorded := observer.New(zapcore.DebugLevel)
+	loggedCtx := ctxzap.ToContext(ctx, zap.New(core))
+
+	require.NoError(t, Sanitize(loggedCtx, srcRO, dst, Options{Secret: secret}))
+	require.NoError(t, dst.Close(ctx))
+
+	// The grants phase is the one operators care about most (~57M
+	// rows in the motivating run). Make sure its start log carries a
+	// "total" field with a positive value.
+	for _, entry := range recorded.FilterMessage("c1zsanitize: phase start").All() {
+		phase, _ := entry.ContextMap()["phase"].(string)
+		if phase != "grants" {
+			continue
+		}
+		total, ok := entry.ContextMap()["total"]
+		require.True(t, ok, "grants phase start must carry total when source exposes Stats")
+		require.Greater(t, total, int64(0), "grants total must be > 0 against the fixture")
+		return
+	}
+	t.Fatal("no phase start log line for grants phase")
+}
+
+// stringID is a tiny helper so the aggregate-dropped test can stamp
+// unique resource ids without dragging in fmt.Sprintf.
+func stringID(i int) string {
+	const digits = "0123456789"
+	if i == 0 {
+		return "u0"
+	}
+	out := []byte{'u'}
+	buf := [16]byte{}
+	bi := len(buf)
+	for i > 0 {
+		bi--
+		buf[bi] = digits[i%10]
+		i /= 10
+	}
+	return string(append(out, buf[bi:]...))
 }

--- a/pkg/c1zsanitize/transform.go
+++ b/pkg/c1zsanitize/transform.go
@@ -62,7 +62,10 @@ func (s *sanitizer) copyResourceTypes(
 	dst connectorstore.Writer,
 	srcSyncID string,
 	refs *assetRefSet,
+	total int64,
 ) error {
+	pp := s.startPhase("resource_types", srcSyncID, total)
+	defer pp.done()
 	pageToken := ""
 	for {
 		req := v2.ResourceTypesServiceListResourceTypesRequest_builder{
@@ -83,6 +86,7 @@ func (s *sanitizer) copyResourceTypes(
 				return fmt.Errorf("put resource types: %w", err)
 			}
 		}
+		pp.page(len(out))
 		if resp.GetNextPageToken() == "" {
 			return nil
 		}
@@ -96,7 +100,10 @@ func (s *sanitizer) copyResources(
 	dst connectorstore.Writer,
 	srcSyncID string,
 	refs *assetRefSet,
+	total int64,
 ) error {
+	pp := s.startPhase("resources", srcSyncID, total)
+	defer pp.done()
 	pageToken := ""
 	for {
 		req := v2.ResourcesServiceListResourcesRequest_builder{
@@ -117,6 +124,7 @@ func (s *sanitizer) copyResources(
 				return fmt.Errorf("put resources: %w", err)
 			}
 		}
+		pp.page(len(out))
 		if resp.GetNextPageToken() == "" {
 			return nil
 		}
@@ -130,7 +138,10 @@ func (s *sanitizer) copyEntitlements(
 	dst connectorstore.Writer,
 	srcSyncID string,
 	refs *assetRefSet,
+	total int64,
 ) error {
+	pp := s.startPhase("entitlements", srcSyncID, total)
+	defer pp.done()
 	pageToken := ""
 	for {
 		req := v2.EntitlementsServiceListEntitlementsRequest_builder{
@@ -151,6 +162,7 @@ func (s *sanitizer) copyEntitlements(
 				return fmt.Errorf("put entitlements: %w", err)
 			}
 		}
+		pp.page(len(out))
 		if resp.GetNextPageToken() == "" {
 			return nil
 		}
@@ -164,7 +176,10 @@ func (s *sanitizer) copyGrants(
 	dst connectorstore.Writer,
 	srcSyncID string,
 	refs *assetRefSet,
+	total int64,
 ) error {
+	pp := s.startPhase("grants", srcSyncID, total)
+	defer pp.done()
 	pageToken := ""
 	for {
 		req := v2.GrantsServiceListGrantsRequest_builder{
@@ -185,6 +200,7 @@ func (s *sanitizer) copyGrants(
 				return fmt.Errorf("put grants: %w", err)
 			}
 		}
+		pp.page(len(out))
 		if resp.GetNextPageToken() == "" {
 			return nil
 		}

--- a/vendor/go.uber.org/zap/zaptest/observer/logged_entry.go
+++ b/vendor/go.uber.org/zap/zaptest/observer/logged_entry.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package observer
+
+import "go.uber.org/zap/zapcore"
+
+// A LoggedEntry is an encoding-agnostic representation of a log message.
+// Field availability is context dependent.
+type LoggedEntry struct {
+	zapcore.Entry
+	Context []zapcore.Field
+}
+
+// ContextMap returns a map for all fields in Context.
+func (e LoggedEntry) ContextMap() map[string]interface{} {
+	encoder := zapcore.NewMapObjectEncoder()
+	for _, f := range e.Context {
+		f.AddTo(encoder)
+	}
+	return encoder.Fields
+}

--- a/vendor/go.uber.org/zap/zaptest/observer/observer.go
+++ b/vendor/go.uber.org/zap/zaptest/observer/observer.go
@@ -1,0 +1,203 @@
+// Copyright (c) 2016-2022 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package observer provides a zapcore.Core that keeps an in-memory,
+// encoding-agnostic representation of log entries. It's useful for
+// applications that want to unit test their log output without tying their
+// tests to a particular output encoding.
+package observer // import "go.uber.org/zap/zaptest/observer"
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"go.uber.org/zap/internal"
+	"go.uber.org/zap/zapcore"
+)
+
+// ObservedLogs is a concurrency-safe, ordered collection of observed logs.
+type ObservedLogs struct {
+	mu   sync.RWMutex
+	logs []LoggedEntry
+}
+
+// Len returns the number of items in the collection.
+func (o *ObservedLogs) Len() int {
+	o.mu.RLock()
+	n := len(o.logs)
+	o.mu.RUnlock()
+	return n
+}
+
+// All returns a copy of all the observed logs.
+func (o *ObservedLogs) All() []LoggedEntry {
+	o.mu.RLock()
+	ret := make([]LoggedEntry, len(o.logs))
+	copy(ret, o.logs)
+	o.mu.RUnlock()
+	return ret
+}
+
+// TakeAll returns a copy of all the observed logs, and truncates the observed
+// slice.
+func (o *ObservedLogs) TakeAll() []LoggedEntry {
+	o.mu.Lock()
+	ret := o.logs
+	o.logs = nil
+	o.mu.Unlock()
+	return ret
+}
+
+// AllUntimed returns a copy of all the observed logs, but overwrites the
+// observed timestamps with time.Time's zero value. This is useful when making
+// assertions in tests.
+func (o *ObservedLogs) AllUntimed() []LoggedEntry {
+	ret := o.All()
+	for i := range ret {
+		ret[i].Time = time.Time{}
+	}
+	return ret
+}
+
+// FilterLevelExact filters entries to those logged at exactly the given level.
+func (o *ObservedLogs) FilterLevelExact(level zapcore.Level) *ObservedLogs {
+	return o.Filter(func(e LoggedEntry) bool {
+		return e.Level == level
+	})
+}
+
+// FilterMessage filters entries to those that have the specified message.
+func (o *ObservedLogs) FilterMessage(msg string) *ObservedLogs {
+	return o.Filter(func(e LoggedEntry) bool {
+		return e.Message == msg
+	})
+}
+
+// FilterLoggerName filters entries to those logged through logger with the specified logger name.
+func (o *ObservedLogs) FilterLoggerName(name string) *ObservedLogs {
+	return o.Filter(func(e LoggedEntry) bool {
+		return e.LoggerName == name
+	})
+}
+
+// FilterMessageSnippet filters entries to those that have a message containing the specified snippet.
+func (o *ObservedLogs) FilterMessageSnippet(snippet string) *ObservedLogs {
+	return o.Filter(func(e LoggedEntry) bool {
+		return strings.Contains(e.Message, snippet)
+	})
+}
+
+// FilterField filters entries to those that have the specified field.
+func (o *ObservedLogs) FilterField(field zapcore.Field) *ObservedLogs {
+	return o.Filter(func(e LoggedEntry) bool {
+		for _, ctxField := range e.Context {
+			if ctxField.Equals(field) {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+// FilterFieldKey filters entries to those that have the specified key.
+func (o *ObservedLogs) FilterFieldKey(key string) *ObservedLogs {
+	return o.Filter(func(e LoggedEntry) bool {
+		for _, ctxField := range e.Context {
+			if ctxField.Key == key {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+// Filter returns a copy of this ObservedLogs containing only those entries
+// for which the provided function returns true.
+func (o *ObservedLogs) Filter(keep func(LoggedEntry) bool) *ObservedLogs {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+
+	var filtered []LoggedEntry
+	for _, entry := range o.logs {
+		if keep(entry) {
+			filtered = append(filtered, entry)
+		}
+	}
+	return &ObservedLogs{logs: filtered}
+}
+
+func (o *ObservedLogs) add(log LoggedEntry) {
+	o.mu.Lock()
+	o.logs = append(o.logs, log)
+	o.mu.Unlock()
+}
+
+// New creates a new Core that buffers logs in memory (without any encoding).
+// It's particularly useful in tests.
+func New(enab zapcore.LevelEnabler) (zapcore.Core, *ObservedLogs) {
+	ol := &ObservedLogs{}
+	return &contextObserver{
+		LevelEnabler: enab,
+		logs:         ol,
+	}, ol
+}
+
+type contextObserver struct {
+	zapcore.LevelEnabler
+	logs    *ObservedLogs
+	context []zapcore.Field
+}
+
+var (
+	_ zapcore.Core            = (*contextObserver)(nil)
+	_ internal.LeveledEnabler = (*contextObserver)(nil)
+)
+
+func (co *contextObserver) Level() zapcore.Level {
+	return zapcore.LevelOf(co.LevelEnabler)
+}
+
+func (co *contextObserver) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	if co.Enabled(ent.Level) {
+		return ce.AddCore(ent, co)
+	}
+	return ce
+}
+
+func (co *contextObserver) With(fields []zapcore.Field) zapcore.Core {
+	return &contextObserver{
+		LevelEnabler: co.LevelEnabler,
+		logs:         co.logs,
+		context:      append(co.context[:len(co.context):len(co.context)], fields...),
+	}
+}
+
+func (co *contextObserver) Write(ent zapcore.Entry, fields []zapcore.Field) error {
+	all := make([]zapcore.Field, 0, len(fields)+len(co.context))
+	all = append(all, co.context...)
+	all = append(all, fields...)
+	co.logs.add(LoggedEntry{ent, all})
+	return nil
+}
+
+func (co *contextObserver) Sync() error {
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -955,6 +955,7 @@ go.uber.org/zap/internal/exit
 go.uber.org/zap/internal/pool
 go.uber.org/zap/internal/stacktrace
 go.uber.org/zap/zapcore
+go.uber.org/zap/zaptest/observer
 # golang.org/x/arch v0.25.0
 ## explicit; go 1.25.0
 golang.org/x/arch/x86/x86asm


### PR DESCRIPTION
## Summary

The c1zsanitize transform emitted a `c1zsanitize: dropping unknown annotation` Debug log on every dropped annotation inside `transformAnnotations`. On a real sanitize run that iterates tens of millions of records (the motivating case was a ~7 GB c1z with ~57M grants), that produced 3M+ log lines and gave an operator zero progress signal — which phase was running, how far it had gotten, or how much longer it had to go.

This PR removes the per-annotation log lines and replaces them with two pieces of structured logging that match the existing zap+ctxzap conventions in the package.

## Changes

- **Aggregate the dropped-annotation signal**: `transformAnnotations` now increments two `uint64` counters on the sanitizer struct (`droppedUnknownAnnotations`, `passedUnknownAnnotations`) plus a per-type-URL breakdown map. No information is lost — only the volume.
- **Per-phase progress logging**: each `copy*` function (`resource_types`, `resources`, `entitlements`, `grants`, `assets`) opens a `phaseProgress` at start, calls `page(n)` per page boundary, and emits a done summary on return. Periodic progress logs are throttled to one per 10-second tick — a multi-hour run emits dozens of lines, not millions.
- **Real N-of-M / percent / ETA when totals are known**: a new optional `syncStatsReader` interface lets the sanitizer ask the source for per-record-type totals before each phase. `*dotc1z.C1File` already implements `Stats()`, which reads the cached `sync_runs` row in O(1). When the source exposes it, progress logs carry `total`, `remaining`, `percent_complete`, `items_per_sec`, and `eta`. When the source doesn't (test fakes), the logger falls back to a running count + rate so an operator can still extrapolate.
- **copyAssets** has the total known up front from `refs.drain()` length, so N-of-M progress is always available there.
- **End-of-run summary**: `Sanitize()` emits one `c1zsanitize: complete` log line with the wall-clock elapsed time, the cumulative dropped / passed counts, and the per-type-URL breakdown.

No change to sanitize semantics; logging only.

## Volume impact

- **Before**: one Debug line per dropped annotation. 57M grants × N annotations each = millions of log lines per run, no progress.
- **After**: 1 start + 1 done per phase (5 phases × 1+ syncs) + 1 throttled progress line per 10 seconds while a phase is running + 1 end-of-run summary. A multi-hour run is dozens of log lines.

## Tests

- `TestSanitizeAggregatesDroppedAnnotations` — locks the regression: zero per-annotation log lines emitted, and the end-of-run summary carries the exact aggregate count.
- `TestSanitizeProgressIncludesTotalsWhenSourceHasStats` — locks that when the source is a `*dotc1z.C1File` the `grants` phase-start log carries a non-zero `total` field, so an operator can answer "how much longer?"
- Existing tests (cross-reference integrity, graph integrity, drop-unknown-by-default, etc.) pass unchanged.

## Test plan

- [x] `go build ./...` — passes
- [x] `go test ./pkg/c1zsanitize/...` — passes including the two new tests
- [x] `go test -short ./pkg/dotc1z/...` — passes (used by c1zsanitize via the optional `Stats()` capability)
- [x] `golangci-lint run ./pkg/c1zsanitize/...` — 0 issues

## Vendor note

`go.uber.org/zap/zaptest/observer` is now vendored — the new tests inspect emitted log lines via the observed-logger pattern. The repo is `-mod=vendor`, so `go mod vendor` was re-run to pull it in.

## Downstream

ductone/c1 vendors this package. A follow-up `go get github.com/conductorone/baton-sdk@<new>` + `go mod vendor` bump in c1 will pick this up after merge.

---

_(satellite) Built with stargate._ 🛰