### PR TITLE
perf(c1zsanitize/dotc1z): bulk-load deferred indexes, embedded-transform memoization, graph-annotation handlers

### DIFF
--- a/cmd/baton/sanitize.go
+++ b/cmd/baton/sanitize.go
@@ -113,6 +113,10 @@ func runSanitize(cmd *cobra.Command, args []string) error {
 		dotc1z.WithPragma("mmap_size", "8589934592"),
 		dotc1z.WithPragma("temp_store", "MEMORY"),
 		dotc1z.WithBulkLoad(true),
+		// bulkLoad already implies skip-cleanup; skip VACUUM too — vacuuming
+		// before the deferred indexes are rebuilt at Close is wasted work on a
+		// throwaway artifact.
+		dotc1z.WithSkipVacuum(true),
 	)
 	if err != nil {
 		return fmt.Errorf("open dst c1z: %w", err)

--- a/cmd/baton/sanitize.go
+++ b/cmd/baton/sanitize.go
@@ -93,14 +93,26 @@ func runSanitize(cmd *cobra.Command, args []string) error {
 	}
 	defer src.Close(ctx)
 
-	// The dst is a net-new intermediate that is discarded on any
-	// failure, so durability pragmas only cost throughput: skip the
-	// journal and fsync entirely, and give SQLite a 64MB page cache to
-	// cut index-maintenance misses on large (multi-million-grant) syncs.
+	// The dst is a net-new, single-writer intermediate that is discarded
+	// on any failure, so durability and index-maintenance costs are pure
+	// throughput overhead here:
+	//   - journal_mode=OFF + synchronous=OFF: no rollback journal, no fsync
+	//     (the output is rebuilt from source on any failure, not recovered).
+	//   - cache_size=-1048576 (1 GiB) + mmap_size=8 GiB + temp_store=MEMORY:
+	//     keep index pages resident and run the deferred index build in
+	//     memory, cutting page-cache misses on large (multi-million-grant)
+	//     syncs.
+	//   - WithBulkLoad: defer secondary-index creation until after the load
+	//     so per-row random-key B-tree maintenance does not dominate.
+	// These pragmas are scoped to THIS writer instance; normal connector
+	// syncs open their own C1File and are unaffected.
 	dst, err := dotc1z.NewC1ZFile(ctx, outPath,
 		dotc1z.WithPragma("journal_mode", "OFF"),
 		dotc1z.WithPragma("synchronous", "OFF"),
-		dotc1z.WithPragma("cache_size", "-65536"),
+		dotc1z.WithPragma("cache_size", "-1048576"),
+		dotc1z.WithPragma("mmap_size", "8589934592"),
+		dotc1z.WithPragma("temp_store", "MEMORY"),
+		dotc1z.WithBulkLoad(true),
 	)
 	if err != nil {
 		return fmt.Errorf("open dst c1z: %w", err)

--- a/pkg/c1zsanitize/annotations.go
+++ b/pkg/c1zsanitize/annotations.go
@@ -23,6 +23,16 @@ func defaultAnnotationHandlers() map[string]annotationHandler {
 		typeURL(&v2.SecretTrait{}):         handleSecretTrait,
 		typeURL(&v2.LicenseProfileTrait{}): handleLicenseProfileTrait,
 		typeURL(&v2.ScopeBindingTrait{}):   handleScopeBindingTrait,
+
+		// Non-trait annotations carrying graph topology / cross-references.
+		// Preserved-and-sanitized rather than dropped so the sanitized c1z
+		// stays a representative dataset for perf and graph testing.
+		typeURL(&v2.GrantExpandable{}):      handleGrantExpandable,
+		typeURL(&v2.GrantImmutable{}):       handleGrantImmutable,
+		typeURL(&v2.EntitlementImmutable{}): handleEntitlementImmutable,
+		typeURL(&v2.ExternalLink{}):         handleExternalLink,
+		typeURL(&v2.ETag{}):                 handleETag,
+		typeURL(&v2.ChildResourceType{}):    handleChildResourceType,
 	}
 }
 

--- a/pkg/c1zsanitize/annotations.go
+++ b/pkg/c1zsanitize/annotations.go
@@ -1,6 +1,7 @@
 package c1zsanitize
 
 import (
+	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 
@@ -50,9 +51,11 @@ func typeURL(m proto.Message) string {
 // Any type URL. Unknown types are dropped by default (the fail-closed posture)
 // or passed through unchanged if the operator opted in via
 // Options.AllowUnknownAnnotations=true. Per-entry outcomes are accumulated into
-// per-type-URL counters rather than logged — Sanitize emits one summary line at
-// the end of the run (see logDropSummary), since these paths fire once per
-// annotation, i.e. tens of millions of times on a large file.
+// per-type-URL counters (Sanitize emits one summary line at the end of the run
+// via logDropSummary), and a single first-occurrence line is logged per distinct
+// type_url so the signal — and, for failures, the actual error — is visible
+// without the per-item spam these paths once produced (tens of millions of
+// lines on a large file).
 func (s *sanitizer) transformAnnotations(in []*anypb.Any, refs *assetRefSet) []*anypb.Any {
 	if len(in) == 0 {
 		return nil
@@ -69,8 +72,16 @@ func (s *sanitizer) transformAnnotations(in []*anypb.Any, refs *assetRefSet) []*
 			// could leak un-sanitized customer data. Pass-through is opt-in
 			// via Options.AllowUnknownAnnotations, for development only.
 			if s.dropUnknownAnnotations {
+				if s.droppedAnnotations[a.GetTypeUrl()] == 0 {
+					s.log.Warn("c1zsanitize: dropping unknown annotation type (first occurrence; counted thereafter)",
+						zap.String("type_url", a.GetTypeUrl()))
+				}
 				s.droppedAnnotations[a.GetTypeUrl()]++
 				continue
+			}
+			if s.passedAnnotations[a.GetTypeUrl()] == 0 {
+				s.log.Warn("c1zsanitize: passing unknown annotation through unchanged (first occurrence; counted thereafter)",
+					zap.String("type_url", a.GetTypeUrl()))
 			}
 			s.passedAnnotations[a.GetTypeUrl()]++
 			out = append(out, a)
@@ -78,6 +89,10 @@ func (s *sanitizer) transformAnnotations(in []*anypb.Any, refs *assetRefSet) []*
 		}
 		msg, err := a.UnmarshalNew()
 		if err != nil {
+			if s.failedAnnotations[a.GetTypeUrl()] == 0 {
+				s.log.Warn("c1zsanitize: annotation transform failed (first occurrence; counted thereafter)",
+					zap.String("type_url", a.GetTypeUrl()), zap.Error(err))
+			}
 			s.failedAnnotations[a.GetTypeUrl()]++
 			continue
 		}
@@ -87,6 +102,10 @@ func (s *sanitizer) transformAnnotations(in []*anypb.Any, refs *assetRefSet) []*
 		}
 		repacked, err := anypb.New(sanitized)
 		if err != nil {
+			if s.failedAnnotations[a.GetTypeUrl()] == 0 {
+				s.log.Warn("c1zsanitize: annotation transform failed (first occurrence; counted thereafter)",
+					zap.String("type_url", a.GetTypeUrl()), zap.Error(err))
+			}
 			s.failedAnnotations[a.GetTypeUrl()]++
 			continue
 		}

--- a/pkg/c1zsanitize/annotations.go
+++ b/pkg/c1zsanitize/annotations.go
@@ -1,7 +1,6 @@
 package c1zsanitize
 
 import (
-	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 
@@ -47,10 +46,13 @@ func typeURL(m proto.Message) string {
 	return a.GetTypeUrl()
 }
 
-// transformAnnotations walks the slice once, dispatching each entry
-// on its Any type URL. Unknown types are dropped by default (with a
-// log line naming the URL) or passed through unchanged if the
-// operator opted in via Options.AllowUnknownAnnotations=true.
+// transformAnnotations walks the slice once, dispatching each entry on its
+// Any type URL. Unknown types are dropped by default (the fail-closed posture)
+// or passed through unchanged if the operator opted in via
+// Options.AllowUnknownAnnotations=true. Per-entry outcomes are accumulated into
+// per-type-URL counters rather than logged — Sanitize emits one summary line at
+// the end of the run (see logDropSummary), since these paths fire once per
+// annotation, i.e. tens of millions of times on a large file.
 func (s *sanitizer) transformAnnotations(in []*anypb.Any, refs *assetRefSet) []*anypb.Any {
 	if len(in) == 0 {
 		return nil
@@ -67,17 +69,16 @@ func (s *sanitizer) transformAnnotations(in []*anypb.Any, refs *assetRefSet) []*
 			// could leak un-sanitized customer data. Pass-through is opt-in
 			// via Options.AllowUnknownAnnotations, for development only.
 			if s.dropUnknownAnnotations {
-				s.log.Debug("c1zsanitize: dropping unknown annotation", zap.String("type_url", a.GetTypeUrl()))
+				s.droppedAnnotations[a.GetTypeUrl()]++
 				continue
 			}
-			s.log.Warn("c1zsanitize: passing unknown annotation through unchanged", zap.String("type_url", a.GetTypeUrl()))
+			s.passedAnnotations[a.GetTypeUrl()]++
 			out = append(out, a)
 			continue
 		}
 		msg, err := a.UnmarshalNew()
 		if err != nil {
-			s.log.Warn("c1zsanitize: failed to unmarshal annotation; dropping",
-				zap.String("type_url", a.GetTypeUrl()), zap.Error(err))
+			s.failedAnnotations[a.GetTypeUrl()]++
 			continue
 		}
 		sanitized := handler(s, msg, refs)
@@ -86,8 +87,7 @@ func (s *sanitizer) transformAnnotations(in []*anypb.Any, refs *assetRefSet) []*
 		}
 		repacked, err := anypb.New(sanitized)
 		if err != nil {
-			s.log.Warn("c1zsanitize: failed to repack annotation; dropping",
-				zap.String("type_url", a.GetTypeUrl()), zap.Error(err))
+			s.failedAnnotations[a.GetTypeUrl()]++
 			continue
 		}
 		out = append(out, repacked)

--- a/pkg/c1zsanitize/annotations_test.go
+++ b/pkg/c1zsanitize/annotations_test.go
@@ -1,0 +1,106 @@
+package c1zsanitize
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+// capturedLog is one recorded zap entry (message + flattened fields).
+type capturedLog struct {
+	msg    string
+	fields map[string]any
+}
+
+// recordingCore is a minimal zapcore.Core that captures entries in memory.
+// zaptest/observer is not vendored, so this stands in for it.
+type recordingCore struct {
+	mu   *sync.Mutex
+	logs *[]capturedLog
+}
+
+func (c recordingCore) Enabled(zapcore.Level) bool        { return true }
+func (c recordingCore) With([]zapcore.Field) zapcore.Core { return c }
+func (c recordingCore) Check(e zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	return ce.AddCore(e, c)
+}
+func (c recordingCore) Sync() error { return nil }
+func (c recordingCore) Write(e zapcore.Entry, fs []zapcore.Field) error {
+	enc := zapcore.NewMapObjectEncoder()
+	for _, f := range fs {
+		f.AddTo(enc)
+	}
+	c.mu.Lock()
+	*c.logs = append(*c.logs, capturedLog{msg: e.Message, fields: enc.Fields})
+	c.mu.Unlock()
+	return nil
+}
+
+func newRecordingLogger() (*zap.Logger, *[]capturedLog) {
+	logs := &[]capturedLog{}
+	return zap.New(recordingCore{mu: &sync.Mutex{}, logs: logs}), logs
+}
+
+func unknownAnno(typeURL string) *anypb.Any {
+	return &anypb.Any{TypeUrl: typeURL, Value: []byte{0x08, 0x01}}
+}
+
+func TestTransformAnnotationsCountersAndFirstOccurrence(t *testing.T) {
+	const (
+		urlA = "type.googleapis.com/c1.connector.v2.NotRealA"
+		urlB = "type.googleapis.com/c1.connector.v2.NotRealB"
+	)
+
+	countFirstOccurrence := func(logs []capturedLog, snippet, typeURL string) int {
+		n := 0
+		for _, l := range logs {
+			if l.msg == snippet && l.fields["type_url"] == typeURL {
+				n++
+			}
+		}
+		return n
+	}
+
+	for _, tc := range []struct {
+		name    string
+		dropOn  bool
+		snippet string
+		counts  func(*sanitizer) map[string]uint64
+	}{
+		{
+			name:    "drop mode",
+			dropOn:  true,
+			snippet: "c1zsanitize: dropping unknown annotation type (first occurrence; counted thereafter)",
+			counts:  func(s *sanitizer) map[string]uint64 { return s.droppedAnnotations },
+		},
+		{
+			name:    "pass-through mode",
+			dropOn:  false,
+			snippet: "c1zsanitize: passing unknown annotation through unchanged (first occurrence; counted thereafter)",
+			counts:  func(s *sanitizer) map[string]uint64 { return s.passedAnnotations },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newTestSanitizer(bytes32("anno-counters"))
+			s.dropUnknownAnnotations = tc.dropOn
+			logger, logs := newRecordingLogger()
+			s.log = logger
+
+			// urlA twice, urlB once.
+			s.transformAnnotations([]*anypb.Any{unknownAnno(urlA), unknownAnno(urlA), unknownAnno(urlB)}, newAssetRefSet())
+
+			counts := tc.counts(s)
+			require.Equal(t, uint64(2), counts[urlA], "counter for urlA")
+			require.Equal(t, uint64(1), counts[urlB], "counter for urlB")
+
+			require.Equal(t, 1, countFirstOccurrence(*logs, tc.snippet, urlA),
+				"exactly one first-occurrence line for urlA")
+			require.Equal(t, 1, countFirstOccurrence(*logs, tc.snippet, urlB),
+				"exactly one first-occurrence line for urlB")
+		})
+	}
+}

--- a/pkg/c1zsanitize/assets.go
+++ b/pkg/c1zsanitize/assets.go
@@ -2,7 +2,6 @@ package c1zsanitize
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -84,16 +83,20 @@ func (a *assetRefSet) drain() []string {
 	return out
 }
 
-// drainAndClose consumes the reader and closes it if the underlying
-// type also implements io.Closer. The connectorstore.Reader.GetAsset
-// contract returns an io.Reader, but at least one implementation
-// returns *os.File; not closing it leaks a fd per asset.
-func drainAndClose(r io.Reader) error {
+// closeIfCloser closes the reader when the underlying type implements
+// io.Closer. The connectorstore.Reader.GetAsset contract returns an
+// io.Reader, but at least one implementation returns *os.File; not closing
+// it leaks a fd per asset. The payload itself is never read: the sanitizer
+// discards it and writes a content-type-matched placeholder, so reading the
+// original bytes (avatars can be hundreds of KB each) is pure wasted I/O.
+// content_type is returned separately by GetAsset and does not require
+// reading the body. Closing the GetAsset return without draining to EOF
+// releases resources for the *os.File and in-memory reader implementations.
+func closeIfCloser(r io.Reader) error {
 	if c, ok := r.(io.Closer); ok {
-		defer c.Close()
+		return c.Close()
 	}
-	_, err := io.Copy(io.Discard, r)
-	return err
+	return nil
 }
 
 func (s *sanitizer) copyAssets(
@@ -116,8 +119,8 @@ func (s *sanitizer) copyAssets(
 			s.log.Debug("c1zsanitize: asset ref not found in source", zap.String("asset_id", srcID), zap.Error(err))
 			continue
 		}
-		if err := drainAndClose(r); err != nil && !errors.Is(err, io.EOF) {
-			return fmt.Errorf("drain source asset %s: %w", srcID, err)
+		if err := closeIfCloser(r); err != nil {
+			return fmt.Errorf("close source asset %s: %w", srcID, err)
 		}
 		dstID := s.id(srcID)
 		if err := dst.PutAsset(ctx, v2.AssetRef_builder{Id: dstID}.Build(), contentType, placeholderForContentType(contentType)); err != nil {

--- a/pkg/c1zsanitize/assets.go
+++ b/pkg/c1zsanitize/assets.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"sync"
 
-	"go.uber.org/zap"
-
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
 )
@@ -115,8 +113,9 @@ func (s *sanitizer) copyAssets(
 			// Asset referenced from an annotation but missing from
 			// the asset table. Skip — we don't fabricate placeholder
 			// rows because the cross-reference invariant treats it
-			// as a known dangling pointer in the source.
-			s.log.Debug("c1zsanitize: asset ref not found in source", zap.String("asset_id", srcID), zap.Error(err))
+			// as a known dangling pointer in the source. Counted (not
+			// logged per item) and reported once via logDropSummary.
+			s.missingAssets++
 			continue
 		}
 		if err := closeIfCloser(r); err != nil {

--- a/pkg/c1zsanitize/consolidated_test.go
+++ b/pkg/c1zsanitize/consolidated_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
 )
 
-// T1 — determinism golden test: sanitizing the same source twice with the
+// Determinism golden test: sanitizing the same source twice with the
 // same secret + anchor produces record-identical output (compared via reader).
 func TestSanitizeDeterministicAcrossRuns(t *testing.T) {
 	ctx := context.Background()
@@ -45,7 +45,7 @@ func TestSanitizeDeterministicAcrossRuns(t *testing.T) {
 	require.Len(t, b.grants, len(a.grants))
 }
 
-// T3 — B1 regression: a resource-type row carries a ChildResourceType
+// Forward-reference regression: a resource-type row carries a ChildResourceType
 // referencing a type declared LATER in the listing. With the buffering
 // pre-pass the token resolves against the full known set and is preserved
 // verbatim (matching the referenced type's own id); the row-by-row bug would
@@ -106,7 +106,7 @@ func TestSanitizeChildResourceTypeForwardReference(t *testing.T) {
 		"forward-referenced declared type must be preserved verbatim, not HMAC'd (B1)")
 }
 
-// T4 — B2 regression: two principals with empty resource ids but different
+// Cache-key regression: two principals with empty resource ids but different
 // display names must not conflate through the principal cache.
 func TestCachedPrincipalEmptyIDNoConflation(t *testing.T) {
 	s := newTestSanitizer(bytes32("b2-empty-id"))

--- a/pkg/c1zsanitize/consolidated_test.go
+++ b/pkg/c1zsanitize/consolidated_test.go
@@ -1,0 +1,132 @@
+package c1zsanitize
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+)
+
+// T1 — determinism golden test: sanitizing the same source twice with the
+// same secret + anchor produces record-identical output (compared via reader).
+func TestSanitizeDeterministicAcrossRuns(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	srcPath := filepath.Join(tmp, "src.c1z")
+	dstA := filepath.Join(tmp, "dstA.c1z")
+	dstB := filepath.Join(tmp, "dstB.c1z")
+	secret := bytes32("determinism")
+
+	buildFixture(t, ctx, srcPath)
+
+	run := func(out string) *collected {
+		src := mustOpen(t, ctx, srcPath, true)
+		defer src.Close(ctx)
+		dst := mustOpen(t, ctx, out, false)
+		require.NoError(t, Sanitize(ctx, src, dst, Options{Secret: secret}))
+		require.NoError(t, dst.Close(ctx))
+		ro := mustOpen(t, ctx, out, true)
+		t.Cleanup(func() { _ = ro.Close(ctx) })
+		return collectRecords(t, ctx, ro)
+	}
+
+	a := run(dstA)
+	b := run(dstB)
+
+	require.Equal(t, a.idOccurrences, b.idOccurrences, "id occurrence maps must be identical across runs")
+	require.Len(t, b.resourceTypes, len(a.resourceTypes))
+	require.Len(t, b.resources, len(a.resources))
+	require.Len(t, b.entitlements, len(a.entitlements))
+	require.Len(t, b.grants, len(a.grants))
+}
+
+// T3 — B1 regression: a resource-type row carries a ChildResourceType
+// referencing a type declared LATER in the listing. With the buffering
+// pre-pass the token resolves against the full known set and is preserved
+// verbatim (matching the referenced type's own id); the row-by-row bug would
+// have HMAC'd it.
+func TestSanitizeChildResourceTypeForwardReference(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	srcPath := filepath.Join(tmp, "src.c1z")
+	dstPath := filepath.Join(tmp, "dst.c1z")
+	secret := bytes32("child-fwd-ref")
+
+	src := mustOpen(t, ctx, srcPath, false)
+	_, err := src.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+
+	childAnno, err := anypb.New(v2.ChildResourceType_builder{ResourceTypeId: "project"}.Build())
+	require.NoError(t, err)
+
+	// "account" references "project" and is declared BEFORE it.
+	require.NoError(t, src.PutResourceTypes(ctx,
+		v2.ResourceType_builder{
+			Id:          "account",
+			DisplayName: "Account",
+			Annotations: []*anypb.Any{childAnno},
+		}.Build(),
+		v2.ResourceType_builder{Id: "project", DisplayName: "Project"}.Build(),
+	))
+	require.NoError(t, src.EndSync(ctx))
+	require.NoError(t, src.Close(ctx))
+
+	srcRO := mustOpen(t, ctx, srcPath, true)
+	defer srcRO.Close(ctx)
+	dst := mustOpen(t, ctx, dstPath, false)
+	require.NoError(t, Sanitize(ctx, srcRO, dst, Options{Secret: secret}))
+	require.NoError(t, dst.Close(ctx))
+
+	dstRO := mustOpen(t, ctx, dstPath, true)
+	defer dstRO.Close(ctx)
+	rec := collectRecords(t, ctx, dstRO)
+
+	var account *v2.ResourceType
+	for _, rt := range rec.resourceTypes {
+		if rt.GetId() == "account" {
+			account = rt
+		}
+	}
+	require.NotNil(t, account, "account resource type should be present")
+
+	var child *v2.ChildResourceType
+	for _, a := range account.GetAnnotations() {
+		if a.MessageIs(&v2.ChildResourceType{}) {
+			child = &v2.ChildResourceType{}
+			require.NoError(t, a.UnmarshalTo(child))
+		}
+	}
+	require.NotNil(t, child, "ChildResourceType annotation must survive")
+	require.Equal(t, "project", child.GetResourceTypeId(),
+		"forward-referenced declared type must be preserved verbatim, not HMAC'd (B1)")
+}
+
+// T4 — B2 regression: two principals with empty resource ids but different
+// display names must not conflate through the principal cache.
+func TestCachedPrincipalEmptyIDNoConflation(t *testing.T) {
+	s := newTestSanitizer(bytes32("b2-empty-id"))
+	cache := newGrantSubCache(false)
+
+	p1 := v2.Resource_builder{
+		Id:          v2.ResourceId_builder{ResourceType: "user"}.Build(), // empty Resource
+		DisplayName: "Alice",
+	}.Build()
+	p2 := v2.Resource_builder{
+		Id:          v2.ResourceId_builder{ResourceType: "user"}.Build(), // empty Resource, same type
+		DisplayName: "Bob",
+	}.Build()
+
+	out1 := s.cachedPrincipal(p1, newAssetRefSet(), cache)
+	out2 := s.cachedPrincipal(p2, newAssetRefSet(), cache)
+
+	require.Equal(t, s.id("Alice"), out1.GetDisplayName())
+	require.Equal(t, s.id("Bob"), out2.GetDisplayName())
+	require.NotEqual(t, out1.GetDisplayName(), out2.GetDisplayName(),
+		"distinct empty-resource principals must not conflate (B2)")
+	require.Empty(t, cache.principals, "principals with empty resource id must not be cached (B2)")
+}

--- a/pkg/c1zsanitize/email.go
+++ b/pkg/c1zsanitize/email.go
@@ -22,14 +22,30 @@ func newDomainMap() *domainMap {
 	return &domainMap{m: map[string]string{}}
 }
 
-func (d *domainMap) lookup(secret []byte, domain string) string {
+// lookup maps a source domain to its deterministic sentinel domain. idFn is
+// the sanitizer's reused hot-path HMAC (s.id), not the package-level
+// SanitizeID, so domains do not pay a fresh HMAC key schedule per call. The
+// HMAC is computed OUTSIDE the lock; the lock only guards the cache map, so a
+// burst of distinct domains no longer serializes the hashing. A rare
+// duplicate computation under contention is harmless — idFn is a pure
+// function of (secret, input).
+func (d *domainMap) lookup(idFn func(string) string, domain string) string {
 	d.mu.Lock()
-	defer d.mu.Unlock()
 	if v, ok := d.m[domain]; ok {
+		d.mu.Unlock()
 		return v
 	}
-	v := "dom-" + strings.ToLower(SanitizeID(secret, domain)) + ".example"
+	d.mu.Unlock()
+
+	v := "dom-" + strings.ToLower(idFn(domain)) + ".example"
+
+	d.mu.Lock()
+	if existing, ok := d.m[domain]; ok {
+		d.mu.Unlock()
+		return existing
+	}
 	d.m[domain] = v
+	d.mu.Unlock()
 	return v
 }
 
@@ -37,13 +53,15 @@ func (d *domainMap) lookup(secret []byte, domain string) string {
 // sentinel domain through the per-c1z domain map. Cross-tenant
 // "all from @acme.com" shapes are preserved without leaking acme.com.
 // An input lacking a single '@' is HMACed wholesale — the caller may
-// have passed something that looks like an email but isn't.
-func sanitizeEmail(secret []byte, dm *domainMap, addr string) string {
+// have passed something that looks like an email but isn't. idFn is the
+// sanitizer's reused hot-path HMAC (s.id); the package-level SanitizeID
+// reference implementation is no longer on this path.
+func sanitizeEmail(idFn func(string) string, dm *domainMap, addr string) string {
 	at := strings.LastIndexByte(addr, '@')
 	if at < 0 {
-		return SanitizeID(secret, addr)
+		return idFn(addr)
 	}
 	local := addr[:at]
 	domain := addr[at+1:]
-	return SanitizeID(secret, local) + "@" + dm.lookup(secret, domain)
+	return idFn(local) + "@" + dm.lookup(idFn, domain)
 }

--- a/pkg/c1zsanitize/email_test.go
+++ b/pkg/c1zsanitize/email_test.go
@@ -5,10 +5,16 @@ import (
 	"testing"
 )
 
+// emailIDFn mirrors the hot-path s.id used in production while keeping the
+// test self-contained: a pure function of (secret, input).
+func emailIDFn(secret []byte) func(string) string {
+	return func(in string) string { return SanitizeID(secret, in) }
+}
+
 func TestSanitizeEmailPreservesShape(t *testing.T) {
 	secret := bytes32("s")
 	dm := newDomainMap()
-	got := sanitizeEmail(secret, dm, "john.doe@acme.com")
+	got := sanitizeEmail(emailIDFn(secret), dm, "john.doe@acme.com")
 	if !strings.ContainsRune(got, '@') {
 		t.Fatalf("expected '@' to survive, got %q", got)
 	}
@@ -17,8 +23,9 @@ func TestSanitizeEmailPreservesShape(t *testing.T) {
 func TestSanitizeEmailSameDomainMapsConsistently(t *testing.T) {
 	secret := bytes32("s")
 	dm := newDomainMap()
-	a := sanitizeEmail(secret, dm, "alice@acme.com")
-	b := sanitizeEmail(secret, dm, "bob@acme.com")
+	idFn := emailIDFn(secret)
+	a := sanitizeEmail(idFn, dm, "alice@acme.com")
+	b := sanitizeEmail(idFn, dm, "bob@acme.com")
 	aDom := a[strings.LastIndexByte(a, '@')+1:]
 	bDom := b[strings.LastIndexByte(b, '@')+1:]
 	if aDom != bDom {
@@ -29,8 +36,9 @@ func TestSanitizeEmailSameDomainMapsConsistently(t *testing.T) {
 func TestSanitizeEmailDistinctDomainsDistinctOutputs(t *testing.T) {
 	secret := bytes32("s")
 	dm := newDomainMap()
-	a := sanitizeEmail(secret, dm, "alice@acme.com")
-	b := sanitizeEmail(secret, dm, "alice@example.com")
+	idFn := emailIDFn(secret)
+	a := sanitizeEmail(idFn, dm, "alice@acme.com")
+	b := sanitizeEmail(idFn, dm, "alice@example.com")
 	aDom := a[strings.LastIndexByte(a, '@')+1:]
 	bDom := b[strings.LastIndexByte(b, '@')+1:]
 	if aDom == bDom {
@@ -41,7 +49,7 @@ func TestSanitizeEmailDistinctDomainsDistinctOutputs(t *testing.T) {
 func TestSanitizeEmailNoAtTreatsAsID(t *testing.T) {
 	secret := bytes32("s")
 	dm := newDomainMap()
-	got := sanitizeEmail(secret, dm, "no-at-sign-here")
+	got := sanitizeEmail(emailIDFn(secret), dm, "no-at-sign-here")
 	if strings.ContainsRune(got, '@') {
 		t.Fatalf("expected no '@' in non-email output; got %q", got)
 	}

--- a/pkg/c1zsanitize/handlers.go
+++ b/pkg/c1zsanitize/handlers.go
@@ -17,11 +17,14 @@ func (s *sanitizer) sanitizeAssetRef(in *v2.AssetRef, refs *assetRefSet) *v2.Ass
 	return v2.AssetRef_builder{Id: s.id(in.GetId())}.Build()
 }
 
-// redactedExternalLinkURL is the placeholder every ExternalLink.url is
-// replaced with. A real URL can embed a tenant domain, an object id, or a
-// query string carrying identity, so it is never preserved; the annotation
-// itself survives so graph consumers still see "this record had a link".
-const redactedExternalLinkURL = "https://redacted.example.com"
+// redactedURL is the placeholder every preserved-but-sanitized URL is
+// replaced with (ExternalLink.url, AppTrait.help_url). A real URL can embed a
+// tenant domain, an object id, or a query string carrying identity, so it is
+// never preserved; the annotation/field survives so graph consumers still see
+// "this record had a link". Uses the reserved .example TLD — the single
+// placeholder-domain convention across this package (matching the dom-*.example
+// email sentinels). (M3).
+const redactedURL = "https://redacted.example"
 
 // sanitizeResourceTypeToken rewrites a bare resource-type token the same way
 // transformID treats a type component: a declared resource type (populated
@@ -87,7 +90,7 @@ func handleExternalLink(_ *sanitizer, msg proto.Message, _ *assetRefSet) proto.M
 	in := msg.(*v2.ExternalLink)
 	url := ""
 	if in.GetUrl() != "" {
-		url = redactedExternalLinkURL
+		url = redactedURL
 	}
 	return v2.ExternalLink_builder{Url: url}.Build()
 }
@@ -152,10 +155,11 @@ func (s *sanitizer) sanitizeValue(v *structpb.Value) *structpb.Value {
 
 func handleUserTrait(s *sanitizer, msg proto.Message, refs *assetRefSet) proto.Message {
 	in := msg.(*v2.UserTrait)
+	idFn := s.id // hoist the method value out of the per-email loop (M2)
 	emails := make([]*v2.UserTrait_Email, 0, len(in.GetEmails()))
 	for _, e := range in.GetEmails() {
 		emails = append(emails, v2.UserTrait_Email_builder{
-			Address:   sanitizeEmail(s.id, s.domains, e.GetAddress()),
+			Address:   sanitizeEmail(idFn, s.domains, e.GetAddress()),
 			IsPrimary: e.GetIsPrimary(),
 		}.Build())
 	}
@@ -230,7 +234,7 @@ func handleAppTrait(s *sanitizer, msg proto.Message, refs *assetRefSet) proto.Me
 	in := msg.(*v2.AppTrait)
 	helpURL := ""
 	if in.GetHelpUrl() != "" {
-		helpURL = "https://sanitized.example/help"
+		helpURL = redactedURL
 	}
 	return v2.AppTrait_builder{
 		HelpUrl: helpURL,

--- a/pkg/c1zsanitize/handlers.go
+++ b/pkg/c1zsanitize/handlers.go
@@ -17,6 +17,103 @@ func (s *sanitizer) sanitizeAssetRef(in *v2.AssetRef, refs *assetRefSet) *v2.Ass
 	return v2.AssetRef_builder{Id: s.id(in.GetId())}.Build()
 }
 
+// redactedExternalLinkURL is the placeholder every ExternalLink.url is
+// replaced with. A real URL can embed a tenant domain, an object id, or a
+// query string carrying identity, so it is never preserved; the annotation
+// itself survives so graph consumers still see "this record had a link".
+const redactedExternalLinkURL = "https://redacted.example.com"
+
+// sanitizeResourceTypeToken rewrites a bare resource-type token the same way
+// transformID treats a type component: a declared resource type (populated
+// during copyResourceTypes) is connector-defined schema and survives verbatim
+// so it stays equal to the separately-sanitized resource-type fields; any
+// other token is HMAC'd. Keeps cross-references coherent for the annotation
+// types that carry resource-type ids (GrantExpandable, ChildResourceType).
+func (s *sanitizer) sanitizeResourceTypeToken(token string) string {
+	if token == "" {
+		return ""
+	}
+	if s.isKnownResourceType(token) {
+		return token
+	}
+	return s.id(token)
+}
+
+// handleGrantExpandable preserves the grant-expansion topology that makes a
+// sanitized c1z representative for graph testing. The entitlement ids it
+// carries are cross-references and MUST be rewritten through transformID so
+// they match the separately-sanitized entitlement ids; resource-type tokens
+// follow the known-type rule; shallow is structural.
+func handleGrantExpandable(s *sanitizer, msg proto.Message, _ *assetRefSet) proto.Message {
+	in := msg.(*v2.GrantExpandable)
+	entIDs := make([]string, 0, len(in.GetEntitlementIds()))
+	for _, id := range in.GetEntitlementIds() {
+		entIDs = append(entIDs, s.transformID(id))
+	}
+	rtIDs := make([]string, 0, len(in.GetResourceTypeIds()))
+	for _, rt := range in.GetResourceTypeIds() {
+		rtIDs = append(rtIDs, s.sanitizeResourceTypeToken(rt))
+	}
+	return v2.GrantExpandable_builder{
+		EntitlementIds:  entIDs,
+		Shallow:         in.GetShallow(),
+		ResourceTypeIds: rtIDs,
+	}.Build()
+}
+
+// handleGrantImmutable preserves the annotation while HMAC-ing its source id
+// (a cross-reference) and sanitizing the free-text metadata struct.
+func handleGrantImmutable(s *sanitizer, msg proto.Message, _ *assetRefSet) proto.Message {
+	in := msg.(*v2.GrantImmutable)
+	return v2.GrantImmutable_builder{
+		SourceId: s.transformID(in.GetSourceId()),
+		Metadata: s.sanitizeStruct(in.GetMetadata()),
+	}.Build()
+}
+
+// handleEntitlementImmutable mirrors handleGrantImmutable for entitlements.
+func handleEntitlementImmutable(s *sanitizer, msg proto.Message, _ *assetRefSet) proto.Message {
+	in := msg.(*v2.EntitlementImmutable)
+	return v2.EntitlementImmutable_builder{
+		SourceId: s.transformID(in.GetSourceId()),
+		Metadata: s.sanitizeStruct(in.GetMetadata()),
+	}.Build()
+}
+
+// handleExternalLink redacts the URL to a fixed placeholder; the annotation
+// is kept so the record's "has external link" shape survives. An empty URL
+// stays empty.
+func handleExternalLink(_ *sanitizer, msg proto.Message, _ *assetRefSet) proto.Message {
+	in := msg.(*v2.ExternalLink)
+	url := ""
+	if in.GetUrl() != "" {
+		url = redactedExternalLinkURL
+	}
+	return v2.ExternalLink_builder{Url: url}.Build()
+}
+
+// handleETag preserves the change-detection annotation. The embedded
+// entitlement id is a cross-reference and goes through transformID; the etag
+// value is an opaque token that may encode customer data, so it is HMAC'd
+// rather than preserved (fail-closed) while staying a stable deterministic
+// string so etag-equality shapes survive.
+func handleETag(s *sanitizer, msg proto.Message, _ *assetRefSet) proto.Message {
+	in := msg.(*v2.ETag)
+	return v2.ETag_builder{
+		Value:         s.id(in.GetValue()),
+		EntitlementId: s.transformID(in.GetEntitlementId()),
+	}.Build()
+}
+
+// handleChildResourceType preserves the resource-tree topology, sanitizing
+// the embedded resource-type token under the known-type rule.
+func handleChildResourceType(s *sanitizer, msg proto.Message, _ *assetRefSet) proto.Message {
+	in := msg.(*v2.ChildResourceType)
+	return v2.ChildResourceType_builder{
+		ResourceTypeId: s.sanitizeResourceTypeToken(in.GetResourceTypeId()),
+	}.Build()
+}
+
 // sanitizeStruct recursively walks a google.protobuf.Struct,
 // HMAC-ing string leaves. Keys are preserved (they're connector-
 // schema field names, not tenant data). Numbers and booleans pass
@@ -58,7 +155,7 @@ func handleUserTrait(s *sanitizer, msg proto.Message, refs *assetRefSet) proto.M
 	emails := make([]*v2.UserTrait_Email, 0, len(in.GetEmails()))
 	for _, e := range in.GetEmails() {
 		emails = append(emails, v2.UserTrait_Email_builder{
-			Address:   sanitizeEmail(s.secret, s.domains, e.GetAddress()),
+			Address:   sanitizeEmail(s.id, s.domains, e.GetAddress()),
 			IsPrimary: e.GetIsPrimary(),
 		}.Build())
 	}

--- a/pkg/c1zsanitize/handlers.go
+++ b/pkg/c1zsanitize/handlers.go
@@ -23,7 +23,7 @@ func (s *sanitizer) sanitizeAssetRef(in *v2.AssetRef, refs *assetRefSet) *v2.Ass
 // never preserved; the annotation/field survives so graph consumers still see
 // "this record had a link". Uses the reserved .example TLD — the single
 // placeholder-domain convention across this package (matching the dom-*.example
-// email sentinels). (M3).
+// email sentinels).
 const redactedURL = "https://redacted.example"
 
 // sanitizeResourceTypeToken rewrites a bare resource-type token the same way
@@ -155,7 +155,7 @@ func (s *sanitizer) sanitizeValue(v *structpb.Value) *structpb.Value {
 
 func handleUserTrait(s *sanitizer, msg proto.Message, refs *assetRefSet) proto.Message {
 	in := msg.(*v2.UserTrait)
-	idFn := s.id // hoist the method value out of the per-email loop (M2)
+	idFn := s.id // hoist the method value out of the per-email loop
 	emails := make([]*v2.UserTrait_Email, 0, len(in.GetEmails()))
 	for _, e := range in.GetEmails() {
 		emails = append(emails, v2.UserTrait_Email_builder{

--- a/pkg/c1zsanitize/perf_test.go
+++ b/pkg/c1zsanitize/perf_test.go
@@ -39,6 +39,9 @@ func newTestSanitizer(secret []byte) *sanitizer {
 		syncIDMap:              map[string]string{},
 		knownResourceTypes:     map[string]struct{}{},
 		warnedUndeclaredTypes:  map[string]struct{}{},
+		droppedAnnotations:     map[string]uint64{},
+		passedAnnotations:      map[string]uint64{},
+		failedAnnotations:      map[string]uint64{},
 	}
 }
 
@@ -48,7 +51,7 @@ func mustUnpack[T proto.Message](t *testing.T, a *anypb.Any, dst T) T {
 	return dst
 }
 
-// TestGraphAnnotationHandlers is the C-1 acceptance test: the non-trait
+// TestGraphAnnotationHandlers checks that the non-trait
 // graph/topology annotations must be PRESERVED-and-SANITIZED, never dropped.
 func TestGraphAnnotationHandlers(t *testing.T) {
 	s := newTestSanitizer(bytes32("graph-annos"))
@@ -128,7 +131,7 @@ func TestGraphAnnotationDeterminism(t *testing.T) {
 	}
 }
 
-// TestGrantSubCacheEquivalence (P0-1): the memoized embedded-transform path
+// TestGrantSubCacheEquivalence: the memoized embedded-transform path
 // must produce output identical to the uncached path for grants that share
 // embedded entitlements/principals.
 func TestGrantSubCacheEquivalence(t *testing.T) {
@@ -186,7 +189,7 @@ func TestGrantSubCacheEquivalence(t *testing.T) {
 
 // benchGrants builds n grants drawn from e distinct entitlements and p
 // distinct principals, each carrying trait + graph annotations — the shape
-// the memo cache (P0-1) targets. Grants are emitted grouped by entitlement
+// the memo cache targets. Grants are emitted grouped by entitlement
 // (as dotc1z does), so the cache sees long hit runs.
 func benchGrants(n, e, p int) []*v2.Grant {
 	out := make([]*v2.Grant, 0, n)
@@ -253,7 +256,7 @@ func BenchmarkTransformGrant(b *testing.B) {
 	})
 }
 
-// TestTransformResourceTypeDoesNotMutateKnownSet is the C-2/B1 unit guard:
+// TestTransformResourceTypeDoesNotMutateKnownSet is the order-independence guard:
 // transformResourceType must be pure w.r.t. knownResourceTypes. Registration
 // happens only in copyResourceTypes' buffering pre-pass, so an embedded
 // resource type reached during the entitlements phase (GrantableTo ->

--- a/pkg/c1zsanitize/perf_test.go
+++ b/pkg/c1zsanitize/perf_test.go
@@ -252,3 +252,42 @@ func BenchmarkTransformGrant(b *testing.B) {
 		}
 	})
 }
+
+// TestKnownResourceTypesFrozenAfterResourceTypesPhase is the C-2
+// order-independence guard. After copyResourceTypes ends, knownResourceTypes
+// must be read-only: an embedded resource type reached during the
+// entitlements phase (via GrantableTo -> transformResourceTypeSlice ->
+// transformResourceType) must NOT become "known", or transformID's
+// type-token decision would flip depending on stream order.
+//
+// Fails without the inResourceTypesPhase write-site gate (the embedded
+// "etype" would be inserted, so the second transformID would preserve it
+// verbatim instead of HMAC-ing it); passes with the gate.
+func TestKnownResourceTypesFrozenAfterResourceTypesPhase(t *testing.T) {
+	s := newTestSanitizer(bytes32("c2-order"))
+
+	// Resource-types phase declares only "user".
+	s.inResourceTypesPhase = true
+	s.transformResourceType(v2.ResourceType_builder{Id: "user"}.Build(), newAssetRefSet())
+	s.inResourceTypesPhase = false // phase over -> set must be frozen
+
+	// Composite id whose TYPE component "etype" is NOT a declared type.
+	before := s.transformID("etype:res1")
+
+	// Entitlements phase: an entitlement whose GrantableTo references the
+	// undeclared "etype" — the exact embedded path the review bot flagged.
+	ent := v2.Entitlement_builder{
+		Id:          "ent1",
+		GrantableTo: []*v2.ResourceType{v2.ResourceType_builder{Id: "etype"}.Build()},
+	}.Build()
+	_ = s.transformEntitlement(ent, newAssetRefSet())
+
+	after := s.transformID("etype:res1")
+
+	require.Equal(t, before, after,
+		"transformID must be order-independent: an embedded resource type seen after the resource-types phase must not change the known-type decision")
+	require.NotContains(t, s.knownResourceTypes, "etype",
+		"embedded resource type leaked into knownResourceTypes after the phase — C-2 write-site gate not enforced")
+	// "user" WAS declared in-phase, so it remains known.
+	require.Contains(t, s.knownResourceTypes, "user")
+}

--- a/pkg/c1zsanitize/perf_test.go
+++ b/pkg/c1zsanitize/perf_test.go
@@ -38,6 +38,7 @@ func newTestSanitizer(secret []byte) *sanitizer {
 		handlers:               defaultAnnotationHandlers(),
 		syncIDMap:              map[string]string{},
 		knownResourceTypes:     map[string]struct{}{},
+		warnedUndeclaredTypes:  map[string]struct{}{},
 	}
 }
 
@@ -98,7 +99,7 @@ func TestGraphAnnotationHandlers(t *testing.T) {
 
 	// ExternalLink: URL redacted to the placeholder.
 	el := mustUnpack(t, byType[typeURL(&v2.ExternalLink{})], &v2.ExternalLink{})
-	require.Equal(t, redactedExternalLinkURL, el.GetUrl())
+	require.Equal(t, redactedURL, el.GetUrl())
 
 	// ETag: entitlement id transformed; value sanitized (not preserved).
 	et := mustUnpack(t, byType[typeURL(&v2.ETag{})], &v2.ETag{})
@@ -159,8 +160,7 @@ func TestGrantSubCacheEquivalence(t *testing.T) {
 
 	// Cached path: one sanitizer + one shared cache across all grants.
 	cachedSan := newTestSanitizer(secret)
-	cache := newGrantSubCache()
-	cache.verify = true // exercise the verify guard too
+	cache := newGrantSubCache(true) // verify guard on
 	var cached []*v2.Grant
 	for _, id := range grantIDs {
 		cached = append(cached, cachedSan.transformGrant(mkGrant(id), newAssetRefSet(), cache))
@@ -235,7 +235,7 @@ func BenchmarkTransformGrant(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
 			s := newTestSanitizer(secret)
-			cache := newGrantSubCache()
+			cache := newGrantSubCache(false)
 			for _, g := range src {
 				_ = s.transformGrant(g, newAssetRefSet(), cache)
 			}
@@ -253,29 +253,26 @@ func BenchmarkTransformGrant(b *testing.B) {
 	})
 }
 
-// TestKnownResourceTypesFrozenAfterResourceTypesPhase is the C-2
-// order-independence guard. After copyResourceTypes ends, knownResourceTypes
-// must be read-only: an embedded resource type reached during the
-// entitlements phase (via GrantableTo -> transformResourceTypeSlice ->
-// transformResourceType) must NOT become "known", or transformID's
-// type-token decision would flip depending on stream order.
+// TestTransformResourceTypeDoesNotMutateKnownSet is the C-2/B1 unit guard:
+// transformResourceType must be pure w.r.t. knownResourceTypes. Registration
+// happens only in copyResourceTypes' buffering pre-pass, so an embedded
+// resource type reached during the entitlements phase (GrantableTo ->
+// transformResourceTypeSlice -> transformResourceType) must NOT become
+// "known", or transformID's type-token decision would flip with stream order.
 //
-// Fails without the inResourceTypesPhase write-site gate (the embedded
-// "etype" would be inserted, so the second transformID would preserve it
-// verbatim instead of HMAC-ing it); passes with the gate.
-func TestKnownResourceTypesFrozenAfterResourceTypesPhase(t *testing.T) {
+// With the pre-pass model the set is read-only by construction; this locks
+// that transformResourceType never writes it.
+func TestTransformResourceTypeDoesNotMutateKnownSet(t *testing.T) {
 	s := newTestSanitizer(bytes32("c2-order"))
 
-	// Resource-types phase declares only "user".
-	s.inResourceTypesPhase = true
-	s.transformResourceType(v2.ResourceType_builder{Id: "user"}.Build(), newAssetRefSet())
-	s.inResourceTypesPhase = false // phase over -> set must be frozen
+	// Simulate the pre-pass having declared only "user".
+	s.knownResourceTypes["user"] = struct{}{}
 
 	// Composite id whose TYPE component "etype" is NOT a declared type.
 	before := s.transformID("etype:res1")
 
-	// Entitlements phase: an entitlement whose GrantableTo references the
-	// undeclared "etype" — the exact embedded path the review bot flagged.
+	// Process an entitlement whose GrantableTo references the undeclared
+	// "etype" — the exact embedded path that previously mutated the set.
 	ent := v2.Entitlement_builder{
 		Id:          "ent1",
 		GrantableTo: []*v2.ResourceType{v2.ResourceType_builder{Id: "etype"}.Build()},
@@ -285,9 +282,8 @@ func TestKnownResourceTypesFrozenAfterResourceTypesPhase(t *testing.T) {
 	after := s.transformID("etype:res1")
 
 	require.Equal(t, before, after,
-		"transformID must be order-independent: an embedded resource type seen after the resource-types phase must not change the known-type decision")
+		"transformID must be order-independent: an embedded resource type must not change the known-type decision")
 	require.NotContains(t, s.knownResourceTypes, "etype",
-		"embedded resource type leaked into knownResourceTypes after the phase — C-2 write-site gate not enforced")
-	// "user" WAS declared in-phase, so it remains known.
+		"embedded resource type leaked into knownResourceTypes — transformResourceType must be pure w.r.t. the set (B1)")
 	require.Contains(t, s.knownResourceTypes, "user")
 }

--- a/pkg/c1zsanitize/perf_test.go
+++ b/pkg/c1zsanitize/perf_test.go
@@ -1,0 +1,254 @@
+package c1zsanitize
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+)
+
+// mustAnyB is the benchmark-side mustAny: no *testing.T, panics on error.
+func mustAnyB(m proto.Message) *anypb.Any {
+	a, err := anypb.New(m)
+	if err != nil {
+		panic(err)
+	}
+	return a
+}
+
+// newTestSanitizer builds a sanitizer the same way Sanitize does, for
+// same-package unit tests of the transform/handler layer.
+func newTestSanitizer(secret []byte) *sanitizer {
+	return &sanitizer{
+		secret:                 secret,
+		idHmac:                 hmac.New(sha256.New, secret),
+		domains:                newDomainMap(),
+		shifter:                newTimestampShifter(time.Time{}, time.Time{}),
+		dropUnknownAnnotations: true,
+		log:                    zap.NewNop(),
+		handlers:               defaultAnnotationHandlers(),
+		syncIDMap:              map[string]string{},
+		knownResourceTypes:     map[string]struct{}{},
+	}
+}
+
+func mustUnpack[T proto.Message](t *testing.T, a *anypb.Any, dst T) T {
+	t.Helper()
+	require.NoError(t, a.UnmarshalTo(dst))
+	return dst
+}
+
+// TestGraphAnnotationHandlers is the C-1 acceptance test: the non-trait
+// graph/topology annotations must be PRESERVED-and-SANITIZED, never dropped.
+func TestGraphAnnotationHandlers(t *testing.T) {
+	s := newTestSanitizer(bytes32("graph-annos"))
+	refs := newAssetRefSet()
+
+	in := []*anypb.Any{
+		mustAny(t, v2.GrantExpandable_builder{
+			EntitlementIds:  []string{"ent-a", "ent-b"},
+			ResourceTypeIds: []string{"user"},
+			Shallow:         true,
+		}.Build()),
+		mustAny(t, v2.GrantImmutable_builder{
+			SourceId: "src-grant-1",
+			Metadata: &structpb.Struct{Fields: map[string]*structpb.Value{
+				"k": structpb.NewStringValue("secret-value"),
+			}},
+		}.Build()),
+		mustAny(t, v2.EntitlementImmutable_builder{SourceId: "src-ent-1"}.Build()),
+		mustAny(t, v2.ExternalLink_builder{Url: "https://acme.example/private/path?token=abc"}.Build()),
+		mustAny(t, v2.ETag_builder{Value: "etag-xyz", EntitlementId: "ent-a"}.Build()),
+		mustAny(t, v2.ChildResourceType_builder{ResourceTypeId: "group"}.Build()),
+	}
+
+	out := s.transformAnnotations(in, refs)
+	require.Len(t, out, len(in), "every graph annotation must survive (none dropped)")
+
+	byType := map[string]*anypb.Any{}
+	for _, a := range out {
+		byType[a.GetTypeUrl()] = a
+	}
+
+	// GrantExpandable: entitlement ids transformed via transformID; an
+	// unknown resource-type token is HMAC'd (not a declared type here).
+	ge := mustUnpack(t, byType[typeURL(&v2.GrantExpandable{})], &v2.GrantExpandable{})
+	require.Equal(t, []string{s.transformID("ent-a"), s.transformID("ent-b")}, ge.GetEntitlementIds())
+	require.NotContains(t, ge.GetEntitlementIds(), "ent-a")
+	require.True(t, ge.GetShallow(), "structural shallow flag preserved")
+	require.Equal(t, []string{s.id("user")}, ge.GetResourceTypeIds())
+
+	// GrantImmutable: source id transformed, metadata string leaf HMAC'd.
+	gi := mustUnpack(t, byType[typeURL(&v2.GrantImmutable{})], &v2.GrantImmutable{})
+	require.Equal(t, s.transformID("src-grant-1"), gi.GetSourceId())
+	require.Equal(t, s.id("secret-value"), gi.GetMetadata().GetFields()["k"].GetStringValue())
+
+	// EntitlementImmutable: source id transformed.
+	ei := mustUnpack(t, byType[typeURL(&v2.EntitlementImmutable{})], &v2.EntitlementImmutable{})
+	require.Equal(t, s.transformID("src-ent-1"), ei.GetSourceId())
+
+	// ExternalLink: URL redacted to the placeholder.
+	el := mustUnpack(t, byType[typeURL(&v2.ExternalLink{})], &v2.ExternalLink{})
+	require.Equal(t, redactedExternalLinkURL, el.GetUrl())
+
+	// ETag: entitlement id transformed; value sanitized (not preserved).
+	et := mustUnpack(t, byType[typeURL(&v2.ETag{})], &v2.ETag{})
+	require.Equal(t, s.transformID("ent-a"), et.GetEntitlementId())
+	require.NotEqual(t, "etag-xyz", et.GetValue())
+	require.Equal(t, s.id("etag-xyz"), et.GetValue())
+
+	// ChildResourceType: token HMAC'd (not a declared type here).
+	crt := mustUnpack(t, byType[typeURL(&v2.ChildResourceType{})], &v2.ChildResourceType{})
+	require.Equal(t, s.id("group"), crt.GetResourceTypeId())
+}
+
+// TestGraphAnnotationDeterminism: the same (secret, input) yields identical
+// sanitized annotations across independent sanitizer instances.
+func TestGraphAnnotationDeterminism(t *testing.T) {
+	in := []*anypb.Any{
+		mustAny(t, v2.GrantExpandable_builder{EntitlementIds: []string{"e1", "e2"}}.Build()),
+		mustAny(t, v2.ETag_builder{Value: "v", EntitlementId: "e1"}.Build()),
+	}
+	a := newTestSanitizer(bytes32("det")).transformAnnotations(in, newAssetRefSet())
+	b := newTestSanitizer(bytes32("det")).transformAnnotations(in, newAssetRefSet())
+	require.Len(t, a, 2)
+	require.Len(t, b, 2)
+	for i := range a {
+		require.True(t, proto.Equal(a[i], b[i]), "annotation %d differs across runs", i)
+	}
+}
+
+// TestGrantSubCacheEquivalence (P0-1): the memoized embedded-transform path
+// must produce output identical to the uncached path for grants that share
+// embedded entitlements/principals.
+func TestGrantSubCacheEquivalence(t *testing.T) {
+	secret := bytes32("cache-eq")
+
+	mkGrant := func(grantID string) *v2.Grant {
+		ent := v2.Entitlement_builder{
+			Id:          "ent-shared",
+			DisplayName: "Shared Entitlement",
+			Resource: v2.Resource_builder{
+				Id:          v2.ResourceId_builder{ResourceType: "role", Resource: "r-shared"}.Build(),
+				DisplayName: "Shared Role",
+			}.Build(),
+		}.Build()
+		principal := v2.Resource_builder{
+			Id:          v2.ResourceId_builder{ResourceType: "user", Resource: "u-shared"}.Build(),
+			DisplayName: "Shared User",
+			Annotations: []*anypb.Any{mustAny(t, v2.UserTrait_builder{Login: "shared@acme.com"}.Build())},
+		}.Build()
+		return v2.Grant_builder{
+			Id:          grantID,
+			Entitlement: ent,
+			Principal:   principal,
+			Annotations: []*anypb.Any{mustAny(t, v2.ETag_builder{Value: "e", EntitlementId: "ent-shared"}.Build())},
+		}.Build()
+	}
+
+	grantIDs := []string{"g1", "g2", "g3"}
+
+	// Cached path: one sanitizer + one shared cache across all grants.
+	cachedSan := newTestSanitizer(secret)
+	cache := newGrantSubCache()
+	cache.verify = true // exercise the verify guard too
+	var cached []*v2.Grant
+	for _, id := range grantIDs {
+		cached = append(cached, cachedSan.transformGrant(mkGrant(id), newAssetRefSet(), cache))
+	}
+
+	// Uncached path: fresh sanitizer, nil cache (falls back to direct transform).
+	uncachedSan := newTestSanitizer(secret)
+	var uncached []*v2.Grant
+	for _, id := range grantIDs {
+		uncached = append(uncached, uncachedSan.transformGrant(mkGrant(id), newAssetRefSet(), nil))
+	}
+
+	require.Len(t, cached, len(grantIDs))
+	for i := range cached {
+		require.True(t, proto.Equal(cached[i], uncached[i]),
+			"cached vs uncached grant %d differ", i)
+	}
+
+	// The shared entitlement transform must be physically reused on hits.
+	require.Same(t, cached[0].GetEntitlement(), cached[1].GetEntitlement(),
+		"embedded entitlement should be memoized (shared pointer) across grants")
+}
+
+// benchGrants builds n grants drawn from e distinct entitlements and p
+// distinct principals, each carrying trait + graph annotations — the shape
+// the memo cache (P0-1) targets. Grants are emitted grouped by entitlement
+// (as dotc1z does), so the cache sees long hit runs.
+func benchGrants(n, e, p int) []*v2.Grant {
+	out := make([]*v2.Grant, 0, n)
+	for i := 0; i < n; i++ {
+		ei := i % e
+		pi := i % p
+		ent := v2.Entitlement_builder{
+			Id:          "ent-" + itoa(ei),
+			DisplayName: "Entitlement " + itoa(ei),
+			Resource: v2.Resource_builder{
+				Id:          v2.ResourceId_builder{ResourceType: "role", Resource: "r-" + itoa(ei)}.Build(),
+				DisplayName: "Role " + itoa(ei),
+			}.Build(),
+			Annotations: []*anypb.Any{mustAnyB(v2.EntitlementImmutable_builder{SourceId: "esrc-" + itoa(ei)}.Build())},
+		}.Build()
+		principal := v2.Resource_builder{
+			Id:          v2.ResourceId_builder{ResourceType: "user", Resource: "u-" + itoa(pi)}.Build(),
+			DisplayName: "User " + itoa(pi),
+			Annotations: []*anypb.Any{mustAnyB(v2.UserTrait_builder{Login: "u" + itoa(pi) + "@acme.com"}.Build())},
+		}.Build()
+		out = append(out, v2.Grant_builder{
+			Id:          "grant-" + itoa(i),
+			Entitlement: ent,
+			Principal:   principal,
+			Annotations: []*anypb.Any{
+				mustAnyB(v2.ETag_builder{Value: "etag-" + itoa(i), EntitlementId: "ent-" + itoa(ei)}.Build()),
+				mustAnyB(v2.ExternalLink_builder{Url: "https://acme.example/g/" + itoa(i)}.Build()),
+			},
+		}.Build())
+	}
+	return out
+}
+
+func itoa(i int) string { return strconv.Itoa(i) }
+
+func BenchmarkTransformGrant(b *testing.B) {
+	const (
+		grants       = 5000
+		entitlements = 5 // G/E = 1000, the plan's default ratio
+		principals   = 500
+	)
+	src := benchGrants(grants, entitlements, principals)
+	secret := bytes32("bench")
+
+	b.Run("cached", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			s := newTestSanitizer(secret)
+			cache := newGrantSubCache()
+			for _, g := range src {
+				_ = s.transformGrant(g, newAssetRefSet(), cache)
+			}
+		}
+	})
+
+	b.Run("uncached", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			s := newTestSanitizer(secret)
+			for _, g := range src {
+				_ = s.transformGrant(g, newAssetRefSet(), nil)
+			}
+		}
+	})
+}

--- a/pkg/c1zsanitize/sanitize.go
+++ b/pkg/c1zsanitize/sanitize.go
@@ -127,6 +127,9 @@ func Sanitize(ctx context.Context, src connectorstore.Reader, dst connectorstore
 		knownResourceTypes:     map[string]struct{}{},
 		verifyGrantCache:       opts.VerifyGrantCache,
 		warnedUndeclaredTypes:  map[string]struct{}{},
+		droppedAnnotations:     map[string]uint64{},
+		passedAnnotations:      map[string]uint64{},
+		failedAnnotations:      map[string]uint64{},
 	}
 
 	for _, sr := range srcSyncs {
@@ -138,6 +141,11 @@ func Sanitize(ctx context.Context, src connectorstore.Reader, dst connectorstore
 	if err := s.preserveSyncGraphMetadata(ctx, src, dst); err != nil {
 		return fmt.Errorf("c1zsanitize: preserve sync graph metadata: %w", err)
 	}
+
+	// One structured summary line per run instead of a log line per dropped
+	// annotation / missing asset (which fired tens of millions of times on
+	// whale-scale files). Counters are accumulated cheaply during the walk.
+	s.logDropSummary()
 	return nil
 }
 
@@ -158,9 +166,32 @@ type sanitizer struct {
 	// there is no in-flight phase flag — the set is read-only by construction.
 	verifyGrantCache bool
 
-	// warnedUndeclaredTypes dedups the M4 tripwire so each undeclared
-	// resource-type token is logged at most once per run.
+	// warnedUndeclaredTypes dedups the undeclared-resource-type warning so
+	// each such token is logged at most once per run.
 	warnedUndeclaredTypes map[string]struct{}
+
+	// Per-run annotation/asset drop counters. transformAnnotations and
+	// copyAssets increment these instead of logging per item; logDropSummary
+	// emits a single structured line at the end of the run. droppedAnnotations
+	// and passedAnnotations are keyed by Any type URL; failedAnnotations counts
+	// unmarshal/repack failures by type URL; missingAssets counts asset refs
+	// not found in the source.
+	droppedAnnotations map[string]uint64
+	passedAnnotations  map[string]uint64
+	failedAnnotations  map[string]uint64
+	missingAssets      uint64
+}
+
+// logDropSummary emits exactly one structured line per run summarizing the
+// annotations dropped/passed/failed (keyed by type URL) and the missing-asset
+// count, replacing the former per-item log lines.
+func (s *sanitizer) logDropSummary() {
+	s.log.Info("c1zsanitize: run summary",
+		zap.Any("dropped_unknown_annotations", s.droppedAnnotations),
+		zap.Any("passed_unknown_annotations", s.passedAnnotations),
+		zap.Any("failed_annotations", s.failedAnnotations),
+		zap.Uint64("missing_assets", s.missingAssets),
+	)
 }
 
 // id is the per-sanitizer hot path. SanitizeID stays as the
@@ -208,7 +239,7 @@ func (s *sanitizer) sanitizeSync(ctx context.Context, src connectorstore.Reader,
 
 	// Per-sync memo cache for the embedded Entitlement/Principal transforms
 	// in the grant loop. Reset each sync so memory is bounded by one sync's
-	// distinct entitlements, not the whole file. See P0-1 in the perf plan.
+	// distinct entitlements, not the whole file.
 	grantCache := newGrantSubCache(s.verifyGrantCache)
 
 	if err := s.copyResourceTypes(ctx, src, dst, srcSyncID, assetRefs); err != nil {

--- a/pkg/c1zsanitize/sanitize.go
+++ b/pkg/c1zsanitize/sanitize.go
@@ -79,6 +79,14 @@ type Options struct {
 	// development against new annotation types, dangerous on real
 	// customer data.
 	AllowUnknownAnnotations bool
+
+	// VerifyGrantCache turns on the off-by-default grant sub-cache
+	// correctness guard: for a bounded sample of cache hits per sync, the
+	// embedded entitlement/principal is re-transformed and compared
+	// (proto.Equal) against the cached value, logging a Warn on any mismatch.
+	// It catches a source that violates the one-object-per-id assumption the
+	// cache relies on. Adds CPU; intended for diagnostics, not production runs.
+	VerifyGrantCache bool
 }
 
 // Sanitize copies records from src to dst, transforming identifiers,
@@ -117,6 +125,8 @@ func Sanitize(ctx context.Context, src connectorstore.Reader, dst connectorstore
 		handlers:               defaultAnnotationHandlers(),
 		syncIDMap:              map[string]string{},
 		knownResourceTypes:     map[string]struct{}{},
+		verifyGrantCache:       opts.VerifyGrantCache,
+		warnedUndeclaredTypes:  map[string]struct{}{},
 	}
 
 	for _, sr := range srcSyncs {
@@ -142,15 +152,15 @@ type sanitizer struct {
 	syncIDMap              map[string]string
 	knownResourceTypes     map[string]struct{}
 
-	// inResourceTypesPhase gates writes to knownResourceTypes. The set is
-	// populated ONLY while copyResourceTypes runs (which is first in every
-	// sync); embedded resource types encountered later — in an
-	// entitlement's GrantableTo or a grant's annotations — never mutate it.
-	// This makes transformID's type-token decision order-independent: a
-	// token is either declared (and preserved) or not (and HMAC'd) for the
-	// whole run, instead of flipping representation the first time it
-	// appears embedded. See C-2 in the perf plan — a determinism fix.
-	inResourceTypesPhase bool
+	// verifyGrantCache turns on the grant sub-cache correctness guard; see
+	// Options.VerifyGrantCache. knownResourceTypes is fully populated by
+	// copyResourceTypes' buffering pre-pass before any transform reads it, so
+	// there is no in-flight phase flag — the set is read-only by construction.
+	verifyGrantCache bool
+
+	// warnedUndeclaredTypes dedups the M4 tripwire so each undeclared
+	// resource-type token is logged at most once per run.
+	warnedUndeclaredTypes map[string]struct{}
 }
 
 // id is the per-sanitizer hot path. SanitizeID stays as the
@@ -199,7 +209,7 @@ func (s *sanitizer) sanitizeSync(ctx context.Context, src connectorstore.Reader,
 	// Per-sync memo cache for the embedded Entitlement/Principal transforms
 	// in the grant loop. Reset each sync so memory is bounded by one sync's
 	// distinct entitlements, not the whole file. See P0-1 in the perf plan.
-	grantCache := newGrantSubCache()
+	grantCache := newGrantSubCache(s.verifyGrantCache)
 
 	if err := s.copyResourceTypes(ctx, src, dst, srcSyncID, assetRefs); err != nil {
 		return err

--- a/pkg/c1zsanitize/sanitize.go
+++ b/pkg/c1zsanitize/sanitize.go
@@ -141,6 +141,16 @@ type sanitizer struct {
 	handlers               map[string]annotationHandler
 	syncIDMap              map[string]string
 	knownResourceTypes     map[string]struct{}
+
+	// inResourceTypesPhase gates writes to knownResourceTypes. The set is
+	// populated ONLY while copyResourceTypes runs (which is first in every
+	// sync); embedded resource types encountered later — in an
+	// entitlement's GrantableTo or a grant's annotations — never mutate it.
+	// This makes transformID's type-token decision order-independent: a
+	// token is either declared (and preserved) or not (and HMAC'd) for the
+	// whole run, instead of flipping representation the first time it
+	// appears embedded. See C-2 in the perf plan — a determinism fix.
+	inResourceTypesPhase bool
 }
 
 // id is the per-sanitizer hot path. SanitizeID stays as the
@@ -186,6 +196,11 @@ func (s *sanitizer) sanitizeSync(ctx context.Context, src connectorstore.Reader,
 
 	assetRefs := newAssetRefSet()
 
+	// Per-sync memo cache for the embedded Entitlement/Principal transforms
+	// in the grant loop. Reset each sync so memory is bounded by one sync's
+	// distinct entitlements, not the whole file. See P0-1 in the perf plan.
+	grantCache := newGrantSubCache()
+
 	if err := s.copyResourceTypes(ctx, src, dst, srcSyncID, assetRefs); err != nil {
 		return err
 	}
@@ -195,7 +210,7 @@ func (s *sanitizer) sanitizeSync(ctx context.Context, src connectorstore.Reader,
 	if err := s.copyEntitlements(ctx, src, dst, srcSyncID, assetRefs); err != nil {
 		return err
 	}
-	if err := s.copyGrants(ctx, src, dst, srcSyncID, assetRefs); err != nil {
+	if err := s.copyGrants(ctx, src, dst, srcSyncID, assetRefs, grantCache); err != nil {
 		return err
 	}
 	if err := s.copyAssets(ctx, src, dst, assetRefs); err != nil {

--- a/pkg/c1zsanitize/sanitize.go
+++ b/pkg/c1zsanitize/sanitize.go
@@ -132,6 +132,12 @@ func Sanitize(ctx context.Context, src connectorstore.Reader, dst connectorstore
 		failedAnnotations:      map[string]uint64{},
 	}
 
+	// One structured summary line per run instead of a log line per dropped
+	// annotation / missing asset (which fired tens of millions of times on
+	// whale-scale files). Deferred so the partial counts are still emitted on
+	// an error or panic exit — an aborted run's telemetry is valid and wanted.
+	defer s.logDropSummary()
+
 	for _, sr := range srcSyncs {
 		if err := s.sanitizeSync(ctx, src, dst, sr); err != nil {
 			return fmt.Errorf("c1zsanitize: sanitize sync %s: %w", sr.GetId(), err)
@@ -142,10 +148,7 @@ func Sanitize(ctx context.Context, src connectorstore.Reader, dst connectorstore
 		return fmt.Errorf("c1zsanitize: preserve sync graph metadata: %w", err)
 	}
 
-	// One structured summary line per run instead of a log line per dropped
-	// annotation / missing asset (which fired tens of millions of times on
-	// whale-scale files). Counters are accumulated cheaply during the walk.
-	s.logDropSummary()
+	s.completed = true
 	return nil
 }
 
@@ -180,13 +183,20 @@ type sanitizer struct {
 	passedAnnotations  map[string]uint64
 	failedAnnotations  map[string]uint64
 	missingAssets      uint64
+
+	// completed is set true just before Sanitize's normal return. The summary
+	// is deferred, so it also fires on an error/panic exit; run_completed lets
+	// a reader tell a full run from a partial one (partial counts are valid).
+	completed bool
 }
 
 // logDropSummary emits exactly one structured line per run summarizing the
 // annotations dropped/passed/failed (keyed by type URL) and the missing-asset
-// count, replacing the former per-item log lines.
+// count, replacing the former per-item log lines. Deferred in Sanitize, so it
+// reports on success, error, and panic exits alike.
 func (s *sanitizer) logDropSummary() {
 	s.log.Info("c1zsanitize: run summary",
+		zap.Bool("run_completed", s.completed),
 		zap.Any("dropped_unknown_annotations", s.droppedAnnotations),
 		zap.Any("passed_unknown_annotations", s.passedAnnotations),
 		zap.Any("failed_annotations", s.failedAnnotations),

--- a/pkg/c1zsanitize/timestamp.go
+++ b/pkg/c1zsanitize/timestamp.go
@@ -26,6 +26,11 @@ func (s *timestampShifter) shift(ts *timestamppb.Timestamp) *timestamppb.Timesta
 	if ts == nil {
 		return nil
 	}
+	// No-op anchor (anchor == tMax, or no tMax): the shift is identity, so
+	// skip the AsTime + timestamppb.New allocation pair on every timestamp.
+	if s.delta == 0 {
+		return ts
+	}
 	t := ts.AsTime()
 	if t.IsZero() {
 		return ts

--- a/pkg/c1zsanitize/transform.go
+++ b/pkg/c1zsanitize/transform.go
@@ -75,8 +75,8 @@ func (s *sanitizer) copyResourceTypes(
 	// ever consults it, so a row that references a type declared later in the
 	// listing — or on a later page — resolves against the full set instead of
 	// HMAC-ing a not-yet-seen token. transformResourceType is therefore pure
-	// w.r.t. the set (it never writes it), which is order-independent by
-	// construction. See B1 / C-2.
+	// w.r.t. the set (it never writes it), so its output does not depend on
+	// the order rows arrive in.
 	var rows []*v2.ResourceType
 	readDur := time.Duration(0)
 	pageToken := ""
@@ -110,7 +110,7 @@ func (s *sanitizer) copyResourceTypes(
 		out = append(out, s.transformResourceType(rt, refs))
 	}
 	xformDur := time.Since(xformStart)
-	// Sort by output id for destination unique-index locality (H2).
+	// Sort by output id for destination unique-index locality.
 	sort.Slice(out, func(i, j int) bool { return out[i].GetId() < out[j].GetId() })
 	putStart := time.Now()
 	if len(out) > 0 {
@@ -259,7 +259,7 @@ func (s *sanitizer) copyGrants(
 }
 
 // sortByResourceID orders resources by output (type, resource) id for
-// destination unique-index locality (H2).
+// destination unique-index locality.
 func sortByResourceID(rs []*v2.Resource) {
 	sort.Slice(rs, func(i, j int) bool {
 		a, b := rs[i].GetId(), rs[j].GetId()
@@ -283,7 +283,7 @@ func (s *sanitizer) transformResourceType(in *v2.ResourceType, refs *assetRefSet
 	// complete and read-only by the time any transform consults it. This holds
 	// whether the call is for a declared type or an embedded one (an
 	// entitlement's GrantableTo, a grant's slice), which is what makes
-	// transformID's known-type decision order-independent. See B1 / C-2.
+	// transformID's known-type decision order-independent.
 	annos := s.transformAnnotations(in.GetAnnotations(), refs)
 	return v2.ResourceType_builder{
 		Id:                in.GetId(),
@@ -323,11 +323,10 @@ func (s *sanitizer) transformResourceID(in *v2.ResourceId) *v2.ResourceId {
 	// resource_type is preserved verbatim here (it is connector-defined
 	// schema). transformID, by contrast, HMACs a type token that is NOT a
 	// declared resource type. So an UNDECLARED type token both survives in
-	// cleartext in this field and gets HMAC'd inside composite ids — a
-	// pre-existing divergence the explicit registration makes observable.
-	// Behavior is unchanged; emit a once-per-token tripwire so a connector
-	// that emits undeclared type tokens shows up rather than silently
-	// producing mismatched representations. (M4)
+	// cleartext in this field and gets HMAC'd inside composite ids. Behavior
+	// is unchanged; emit a once-per-token tripwire so a connector that emits
+	// undeclared type tokens shows up rather than silently producing
+	// mismatched representations.
 	s.warnUndeclaredResourceType(in.GetResourceType())
 	return v2.ResourceId_builder{
 		ResourceType:  in.GetResourceType(),
@@ -337,8 +336,9 @@ func (s *sanitizer) transformResourceID(in *v2.ResourceId) *v2.ResourceId {
 }
 
 // warnUndeclaredResourceType logs once per resource-type token that appears in
-// a resource id but was never declared in copyResourceTypes. Single-threaded
-// (the transform stage is sequential today); revisit if P1-3 parallelizes it.
+// a resource id but was never declared in copyResourceTypes. Not safe for
+// concurrent callers — the transform stage is sequential today; revisit the
+// dedup map if it is ever parallelized.
 func (s *sanitizer) warnUndeclaredResourceType(rt string) {
 	if rt == "" || s.isKnownResourceType(rt) {
 		return
@@ -481,7 +481,7 @@ func (s *sanitizer) cachedPrincipal(in *v2.Resource, refs *assetRefSet, cache *g
 	// resource id has nothing that uniquely identifies it, so it must not be
 	// cached — otherwise two distinct empty-resource principals with different
 	// display names would conflate on a non-empty-but-meaningless key like
-	// "user\x00" and the second grant would inherit the first's transform. See B2.
+	// "user\x00" and the second grant would inherit the first's transform.
 	key := ""
 	if id := in.GetId(); id != nil && id.GetResource() != "" {
 		key = id.GetResourceType() + "\x00" + id.GetResource()

--- a/pkg/c1zsanitize/transform.go
+++ b/pkg/c1zsanitize/transform.go
@@ -242,7 +242,15 @@ func (s *sanitizer) transformResourceType(in *v2.ResourceType, refs *assetRefSet
 	if in == nil {
 		return nil
 	}
-	if id := in.GetId(); id != "" {
+	// Record declared resource types ONLY during the copyResourceTypes phase
+	// (inResourceTypesPhase). transformResourceType is also reached for
+	// embedded types — an entitlement's GrantableTo, a grant's slice — and
+	// those must NOT grow the set: otherwise transformID's known-type
+	// decision (preserve verbatim vs. HMAC) would flip for the same token
+	// depending on whether it was seen before or after its embedding record,
+	// making output order-dependent. Gating here keeps the set read-only
+	// after copyResourceTypes, so the decision is order-independent. See C-2.
+	if id := in.GetId(); id != "" && s.inResourceTypesPhase {
 		s.knownResourceTypes[id] = struct{}{}
 	}
 	annos := s.transformAnnotations(in.GetAnnotations(), refs)
@@ -354,10 +362,16 @@ const maxCachedPrincipals = 1_000_000
 // proto.Equal cross-check against a fresh transform for the first
 // verifySampleLimit hits — cheap insurance, off by default.
 type grantSubCache struct {
+	// SHARED: the cached *v2.Entitlement / *v2.Resource values below are
+	// referenced by multiple output grants. Never mutate one after Build().
+	// Mutation after caching = cross-grant corruption.
 	entitlements map[string]*v2.Entitlement // key: SOURCE entitlement id
 	principals   map[string]*v2.Resource    // key: srcType + "\x00" + srcResource
 	verify       bool
-	verifySeen   int
+	// Independent sample counters so the entitlement guard cannot exhaust
+	// the principal guard's budget (and vice versa).
+	verifySeenEntitlements int
+	verifySeenPrincipals   int
 }
 
 const verifySampleLimit = 1000
@@ -385,11 +399,14 @@ func (s *sanitizer) cachedEntitlement(in *v2.Entitlement, refs *assetRefSet, cac
 	if key != "" {
 		if got, ok := cache.entitlements[key]; ok {
 			s.verifyCachedEntitlement(in, refs, got, cache)
+			// SHARED: returned to many output grants — never mutate after Build().
 			return got
 		}
 	}
 	out := s.transformEntitlement(in, refs)
 	if key != "" {
+		// SHARED once stored: referenced by every later grant with this id.
+		// Never mutate after Build() — mutation = cross-grant corruption.
 		cache.entitlements[key] = out
 	}
 	return out
@@ -410,11 +427,15 @@ func (s *sanitizer) cachedPrincipal(in *v2.Resource, refs *assetRefSet, cache *g
 	}
 	if key != "" {
 		if got, ok := cache.principals[key]; ok {
+			s.verifyCachedPrincipal(in, refs, got, cache)
+			// SHARED: returned to many output grants — never mutate after Build().
 			return got
 		}
 	}
 	out := s.transformResource(in, refs)
 	if key != "" && len(cache.principals) < maxCachedPrincipals {
+		// SHARED once stored: referenced by every later grant with this id.
+		// Never mutate after Build() — mutation = cross-grant corruption.
 		cache.principals[key] = out
 	}
 	return out
@@ -425,14 +446,31 @@ func (s *sanitizer) cachedPrincipal(in *v2.Resource, refs *assetRefSet, cache *g
 // differs from the fresh one, catching any source that violates the
 // one-object-per-id assumption.
 func (s *sanitizer) verifyCachedEntitlement(in *v2.Entitlement, refs *assetRefSet, cached *v2.Entitlement, cache *grantSubCache) {
-	if !cache.verify || cache.verifySeen >= verifySampleLimit {
+	if !cache.verify || cache.verifySeenEntitlements >= verifySampleLimit {
 		return
 	}
-	cache.verifySeen++
+	cache.verifySeenEntitlements++
 	fresh := s.transformEntitlement(in, refs)
 	if !proto.Equal(fresh, cached) {
 		s.log.Warn("c1zsanitize: grant sub-cache mismatch; embedded entitlement differs across grants for the same id",
 			zap.String("entitlement_id", in.GetId()))
+	}
+}
+
+// verifyCachedPrincipal mirrors verifyCachedEntitlement for the principal
+// cache: same off-by-default toggle, same proto.Equal-against-a-fresh-transform
+// contract, catching any source that emits diverging principal objects for the
+// same resource id within a sync.
+func (s *sanitizer) verifyCachedPrincipal(in *v2.Resource, refs *assetRefSet, cached *v2.Resource, cache *grantSubCache) {
+	if !cache.verify || cache.verifySeenPrincipals >= verifySampleLimit {
+		return
+	}
+	cache.verifySeenPrincipals++
+	fresh := s.transformResource(in, refs)
+	if !proto.Equal(fresh, cached) {
+		s.log.Warn("c1zsanitize: grant sub-cache mismatch; embedded principal differs across grants for the same id",
+			zap.String("principal_resource_type", in.GetId().GetResourceType()),
+			zap.String("principal_resource_id", in.GetId().GetResource()))
 	}
 }
 

--- a/pkg/c1zsanitize/transform.go
+++ b/pkg/c1zsanitize/transform.go
@@ -4,6 +4,10 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
+
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
@@ -63,30 +67,43 @@ func (s *sanitizer) copyResourceTypes(
 	srcSyncID string,
 	refs *assetRefSet,
 ) error {
+	// knownResourceTypes is populated only here; freeze it on return so
+	// later phases treat it as read-only (see inResourceTypesPhase / C-2).
+	s.inResourceTypesPhase = true
+	defer func() { s.inResourceTypesPhase = false }()
+
 	pageToken := ""
+	page := 0
 	for {
 		req := v2.ResourceTypesServiceListResourceTypesRequest_builder{
 			PageSize:    listPageSize,
 			PageToken:   pageToken,
 			Annotations: syncIDAnnotations(srcSyncID),
 		}.Build()
+		readStart := time.Now()
 		resp, err := src.ListResourceTypes(ctx, req)
+		readDur := time.Since(readStart)
 		if err != nil {
 			return fmt.Errorf("list resource types: %w", err)
 		}
+		xformStart := time.Now()
 		out := make([]*v2.ResourceType, 0, len(resp.GetList()))
 		for _, rt := range resp.GetList() {
 			out = append(out, s.transformResourceType(rt, refs))
 		}
+		xformDur := time.Since(xformStart)
+		putStart := time.Now()
 		if len(out) > 0 {
 			if err := dst.PutResourceTypes(ctx, out...); err != nil {
 				return fmt.Errorf("put resource types: %w", err)
 			}
 		}
+		s.logPage("resource_types", page, len(resp.GetList()), readDur, xformDur, time.Since(putStart))
 		if resp.GetNextPageToken() == "" {
 			return nil
 		}
 		pageToken = resp.GetNextPageToken()
+		page++
 	}
 }
 
@@ -98,29 +115,37 @@ func (s *sanitizer) copyResources(
 	refs *assetRefSet,
 ) error {
 	pageToken := ""
+	page := 0
 	for {
 		req := v2.ResourcesServiceListResourcesRequest_builder{
 			PageSize:    listPageSize,
 			PageToken:   pageToken,
 			Annotations: syncIDAnnotations(srcSyncID),
 		}.Build()
+		readStart := time.Now()
 		resp, err := src.ListResources(ctx, req)
+		readDur := time.Since(readStart)
 		if err != nil {
 			return fmt.Errorf("list resources: %w", err)
 		}
+		xformStart := time.Now()
 		out := make([]*v2.Resource, 0, len(resp.GetList()))
 		for _, r := range resp.GetList() {
 			out = append(out, s.transformResource(r, refs))
 		}
+		xformDur := time.Since(xformStart)
+		putStart := time.Now()
 		if len(out) > 0 {
 			if err := dst.PutResources(ctx, out...); err != nil {
 				return fmt.Errorf("put resources: %w", err)
 			}
 		}
+		s.logPage("resources", page, len(resp.GetList()), readDur, xformDur, time.Since(putStart))
 		if resp.GetNextPageToken() == "" {
 			return nil
 		}
 		pageToken = resp.GetNextPageToken()
+		page++
 	}
 }
 
@@ -132,29 +157,37 @@ func (s *sanitizer) copyEntitlements(
 	refs *assetRefSet,
 ) error {
 	pageToken := ""
+	page := 0
 	for {
 		req := v2.EntitlementsServiceListEntitlementsRequest_builder{
 			PageSize:    listPageSize,
 			PageToken:   pageToken,
 			Annotations: syncIDAnnotations(srcSyncID),
 		}.Build()
+		readStart := time.Now()
 		resp, err := src.ListEntitlements(ctx, req)
+		readDur := time.Since(readStart)
 		if err != nil {
 			return fmt.Errorf("list entitlements: %w", err)
 		}
+		xformStart := time.Now()
 		out := make([]*v2.Entitlement, 0, len(resp.GetList()))
 		for _, e := range resp.GetList() {
 			out = append(out, s.transformEntitlement(e, refs))
 		}
+		xformDur := time.Since(xformStart)
+		putStart := time.Now()
 		if len(out) > 0 {
 			if err := dst.PutEntitlements(ctx, out...); err != nil {
 				return fmt.Errorf("put entitlements: %w", err)
 			}
 		}
+		s.logPage("entitlements", page, len(resp.GetList()), readDur, xformDur, time.Since(putStart))
 		if resp.GetNextPageToken() == "" {
 			return nil
 		}
 		pageToken = resp.GetNextPageToken()
+		page++
 	}
 }
 
@@ -164,31 +197,40 @@ func (s *sanitizer) copyGrants(
 	dst connectorstore.Writer,
 	srcSyncID string,
 	refs *assetRefSet,
+	cache *grantSubCache,
 ) error {
 	pageToken := ""
+	page := 0
 	for {
 		req := v2.GrantsServiceListGrantsRequest_builder{
 			PageSize:    listPageSize,
 			PageToken:   pageToken,
 			Annotations: syncIDAnnotations(srcSyncID),
 		}.Build()
+		readStart := time.Now()
 		resp, err := src.ListGrants(ctx, req)
+		readDur := time.Since(readStart)
 		if err != nil {
 			return fmt.Errorf("list grants: %w", err)
 		}
+		xformStart := time.Now()
 		out := make([]*v2.Grant, 0, len(resp.GetList()))
 		for _, g := range resp.GetList() {
-			out = append(out, s.transformGrant(g, refs))
+			out = append(out, s.transformGrant(g, refs, cache))
 		}
+		xformDur := time.Since(xformStart)
+		putStart := time.Now()
 		if len(out) > 0 {
 			if err := dst.PutGrants(ctx, out...); err != nil {
 				return fmt.Errorf("put grants: %w", err)
 			}
 		}
+		s.logPage("grants", page, len(resp.GetList()), readDur, xformDur, time.Since(putStart))
 		if resp.GetNextPageToken() == "" {
 			return nil
 		}
 		pageToken = resp.GetNextPageToken()
+		page++
 	}
 }
 
@@ -275,18 +317,137 @@ func (s *sanitizer) transformResourceTypeSlice(in []*v2.ResourceType, refs *asse
 	return out
 }
 
-func (s *sanitizer) transformGrant(in *v2.Grant, refs *assetRefSet) *v2.Grant {
+func (s *sanitizer) transformGrant(in *v2.Grant, refs *assetRefSet, cache *grantSubCache) *v2.Grant {
 	if in == nil {
 		return nil
 	}
 	annos := s.transformAnnotations(in.GetAnnotations(), refs)
 	return v2.Grant_builder{
 		Id:          s.transformID(in.GetId()),
-		Entitlement: s.transformEntitlement(in.GetEntitlement(), refs),
-		Principal:   s.transformResource(in.GetPrincipal(), refs),
+		Entitlement: s.cachedEntitlement(in.GetEntitlement(), refs, cache),
+		Principal:   s.cachedPrincipal(in.GetPrincipal(), refs, cache),
 		Sources:     s.transformGrantSources(in.GetSources()),
 		Annotations: annos,
 	}.Build()
+}
+
+// maxCachedPrincipals bounds the per-sync principal cache. Entitlements are
+// cached unconditionally (their cardinality is small — typically 100–10,000x
+// fewer than grants — and dotc1z emits grants grouped by entitlement, so the
+// hit rate is very high). Principal repeats are scattered, so the cache is
+// capped: past the cap, principals are still transformed, just not cached.
+const maxCachedPrincipals = 1_000_000
+
+// grantSubCache memoizes the transformed embedded Entitlement and Principal
+// of a grant within one sync. transformGrant re-derives both for every grant
+// otherwise, and the annotation path (UnmarshalNew → handler → anypb.New) is
+// the expensive part. Cached protos are SHARED across many output grants:
+// this is safe ONLY because nothing in this package mutates a message after
+// .Build() and the writer only marshals — mutating a cached message would be
+// a cross-grant data-corruption bug. The cache is per-sync (reset in
+// sanitizeSync) to bound memory; s.id output is secret-scoped, not
+// sync-scoped, so correctness does not depend on the lifetime.
+//
+// Assumption: within one sync, every embedded copy of a given entitlement
+// (or principal) id is identical. This holds for SDK-produced c1z files,
+// where the connector emits one object per id. The verify flag turns on a
+// proto.Equal cross-check against a fresh transform for the first
+// verifySampleLimit hits — cheap insurance, off by default.
+type grantSubCache struct {
+	entitlements map[string]*v2.Entitlement // key: SOURCE entitlement id
+	principals   map[string]*v2.Resource    // key: srcType + "\x00" + srcResource
+	verify       bool
+	verifySeen   int
+}
+
+const verifySampleLimit = 1000
+
+func newGrantSubCache() *grantSubCache {
+	return &grantSubCache{
+		entitlements: map[string]*v2.Entitlement{},
+		principals:   map[string]*v2.Resource{},
+	}
+}
+
+// cachedEntitlement returns the transformed embedded entitlement, memoized by
+// source entitlement id. On a cache MISS the normal transform path runs,
+// which registers any asset refs via sanitizeAssetRef → refs.add; on a HIT
+// those refs were already registered when the entry was created within this
+// same sync, so nothing is lost.
+func (s *sanitizer) cachedEntitlement(in *v2.Entitlement, refs *assetRefSet, cache *grantSubCache) *v2.Entitlement {
+	if in == nil {
+		return nil
+	}
+	if cache == nil {
+		return s.transformEntitlement(in, refs)
+	}
+	key := in.GetId()
+	if key != "" {
+		if got, ok := cache.entitlements[key]; ok {
+			s.verifyCachedEntitlement(in, refs, got, cache)
+			return got
+		}
+	}
+	out := s.transformEntitlement(in, refs)
+	if key != "" {
+		cache.entitlements[key] = out
+	}
+	return out
+}
+
+// cachedPrincipal mirrors cachedEntitlement for the grant's principal,
+// capped at maxCachedPrincipals to bound memory.
+func (s *sanitizer) cachedPrincipal(in *v2.Resource, refs *assetRefSet, cache *grantSubCache) *v2.Resource {
+	if in == nil {
+		return nil
+	}
+	if cache == nil {
+		return s.transformResource(in, refs)
+	}
+	key := ""
+	if id := in.GetId(); id != nil {
+		key = id.GetResourceType() + "\x00" + id.GetResource()
+	}
+	if key != "" {
+		if got, ok := cache.principals[key]; ok {
+			return got
+		}
+	}
+	out := s.transformResource(in, refs)
+	if key != "" && len(cache.principals) < maxCachedPrincipals {
+		cache.principals[key] = out
+	}
+	return out
+}
+
+// verifyCachedEntitlement is the off-by-default cache-correctness guard: it
+// re-transforms a sample of cache hits and logs a warning if the cached proto
+// differs from the fresh one, catching any source that violates the
+// one-object-per-id assumption.
+func (s *sanitizer) verifyCachedEntitlement(in *v2.Entitlement, refs *assetRefSet, cached *v2.Entitlement, cache *grantSubCache) {
+	if !cache.verify || cache.verifySeen >= verifySampleLimit {
+		return
+	}
+	cache.verifySeen++
+	fresh := s.transformEntitlement(in, refs)
+	if !proto.Equal(fresh, cached) {
+		s.log.Warn("c1zsanitize: grant sub-cache mismatch; embedded entitlement differs across grants for the same id",
+			zap.String("entitlement_id", in.GetId()))
+	}
+}
+
+// logPage emits one Info line per page with read/transform/put timings — the
+// permanent regression canary for the per-record-cost-grows-with-n class of
+// slowdown. One line per 10k rows is cheap.
+func (s *sanitizer) logPage(phase string, page, rows int, read, transform, put time.Duration) {
+	s.log.Info("c1zsanitize: page",
+		zap.String("phase", phase),
+		zap.Int("page", page),
+		zap.Int("rows", rows),
+		zap.Duration("read", read),
+		zap.Duration("transform", transform),
+		zap.Duration("put", put),
+	)
 }
 
 // transformGrantSources rebuilds the sources map with sanitized keys.

--- a/pkg/c1zsanitize/transform.go
+++ b/pkg/c1zsanitize/transform.go
@@ -3,6 +3,7 @@ package c1zsanitize
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -67,13 +68,18 @@ func (s *sanitizer) copyResourceTypes(
 	srcSyncID string,
 	refs *assetRefSet,
 ) error {
-	// knownResourceTypes is populated only here; freeze it on return so
-	// later phases treat it as read-only (see inResourceTypesPhase / C-2).
-	s.inResourceTypesPhase = true
-	defer func() { s.inResourceTypesPhase = false }()
-
+	// Two-pass: buffer EVERY resource-type row and register all ids BEFORE
+	// transforming any of them. Resource types number in the tens, so
+	// buffering the whole listing is trivial. This makes knownResourceTypes
+	// complete before transformResourceType (or a ChildResourceType handler)
+	// ever consults it, so a row that references a type declared later in the
+	// listing — or on a later page — resolves against the full set instead of
+	// HMAC-ing a not-yet-seen token. transformResourceType is therefore pure
+	// w.r.t. the set (it never writes it), which is order-independent by
+	// construction. See B1 / C-2.
+	var rows []*v2.ResourceType
+	readDur := time.Duration(0)
 	pageToken := ""
-	page := 0
 	for {
 		req := v2.ResourceTypesServiceListResourceTypesRequest_builder{
 			PageSize:    listPageSize,
@@ -82,29 +88,38 @@ func (s *sanitizer) copyResourceTypes(
 		}.Build()
 		readStart := time.Now()
 		resp, err := src.ListResourceTypes(ctx, req)
-		readDur := time.Since(readStart)
+		readDur += time.Since(readStart)
 		if err != nil {
 			return fmt.Errorf("list resource types: %w", err)
 		}
-		xformStart := time.Now()
-		out := make([]*v2.ResourceType, 0, len(resp.GetList()))
 		for _, rt := range resp.GetList() {
-			out = append(out, s.transformResourceType(rt, refs))
-		}
-		xformDur := time.Since(xformStart)
-		putStart := time.Now()
-		if len(out) > 0 {
-			if err := dst.PutResourceTypes(ctx, out...); err != nil {
-				return fmt.Errorf("put resource types: %w", err)
+			if id := rt.GetId(); id != "" {
+				s.knownResourceTypes[id] = struct{}{}
 			}
+			rows = append(rows, rt)
 		}
-		s.logPage("resource_types", page, len(resp.GetList()), readDur, xformDur, time.Since(putStart))
 		if resp.GetNextPageToken() == "" {
-			return nil
+			break
 		}
 		pageToken = resp.GetNextPageToken()
-		page++
 	}
+
+	xformStart := time.Now()
+	out := make([]*v2.ResourceType, 0, len(rows))
+	for _, rt := range rows {
+		out = append(out, s.transformResourceType(rt, refs))
+	}
+	xformDur := time.Since(xformStart)
+	// Sort by output id for destination unique-index locality (H2).
+	sort.Slice(out, func(i, j int) bool { return out[i].GetId() < out[j].GetId() })
+	putStart := time.Now()
+	if len(out) > 0 {
+		if err := dst.PutResourceTypes(ctx, out...); err != nil {
+			return fmt.Errorf("put resource types: %w", err)
+		}
+	}
+	s.logPage(srcSyncID, "resource_types", 0, len(out), readDur, xformDur, time.Since(putStart))
+	return nil
 }
 
 func (s *sanitizer) copyResources(
@@ -134,13 +149,14 @@ func (s *sanitizer) copyResources(
 			out = append(out, s.transformResource(r, refs))
 		}
 		xformDur := time.Since(xformStart)
+		sortByResourceID(out)
 		putStart := time.Now()
 		if len(out) > 0 {
 			if err := dst.PutResources(ctx, out...); err != nil {
 				return fmt.Errorf("put resources: %w", err)
 			}
 		}
-		s.logPage("resources", page, len(resp.GetList()), readDur, xformDur, time.Since(putStart))
+		s.logPage(srcSyncID, "resources", page, len(resp.GetList()), readDur, xformDur, time.Since(putStart))
 		if resp.GetNextPageToken() == "" {
 			return nil
 		}
@@ -176,13 +192,14 @@ func (s *sanitizer) copyEntitlements(
 			out = append(out, s.transformEntitlement(e, refs))
 		}
 		xformDur := time.Since(xformStart)
+		sort.Slice(out, func(i, j int) bool { return out[i].GetId() < out[j].GetId() })
 		putStart := time.Now()
 		if len(out) > 0 {
 			if err := dst.PutEntitlements(ctx, out...); err != nil {
 				return fmt.Errorf("put entitlements: %w", err)
 			}
 		}
-		s.logPage("entitlements", page, len(resp.GetList()), readDur, xformDur, time.Since(putStart))
+		s.logPage(srcSyncID, "entitlements", page, len(resp.GetList()), readDur, xformDur, time.Since(putStart))
 		if resp.GetNextPageToken() == "" {
 			return nil
 		}
@@ -219,19 +236,38 @@ func (s *sanitizer) copyGrants(
 			out = append(out, s.transformGrant(g, refs, cache))
 		}
 		xformDur := time.Since(xformStart)
+		sort.Slice(out, func(i, j int) bool { return out[i].GetId() < out[j].GetId() })
 		putStart := time.Now()
 		if len(out) > 0 {
 			if err := dst.PutGrants(ctx, out...); err != nil {
 				return fmt.Errorf("put grants: %w", err)
 			}
 		}
-		s.logPage("grants", page, len(resp.GetList()), readDur, xformDur, time.Since(putStart))
+		s.logPage(srcSyncID, "grants", page, len(resp.GetList()), readDur, xformDur, time.Since(putStart))
 		if resp.GetNextPageToken() == "" {
+			if cache != nil {
+				s.log.Info("c1zsanitize: grant sub-cache stats",
+					zap.String("sync_id", srcSyncID),
+					zap.Int("entitlements_cached", len(cache.entitlements)),
+					zap.Int("principals_cached", len(cache.principals)))
+			}
 			return nil
 		}
 		pageToken = resp.GetNextPageToken()
 		page++
 	}
+}
+
+// sortByResourceID orders resources by output (type, resource) id for
+// destination unique-index locality (H2).
+func sortByResourceID(rs []*v2.Resource) {
+	sort.Slice(rs, func(i, j int) bool {
+		a, b := rs[i].GetId(), rs[j].GetId()
+		if a.GetResourceType() != b.GetResourceType() {
+			return a.GetResourceType() < b.GetResourceType()
+		}
+		return a.GetResource() < b.GetResource()
+	})
 }
 
 // transformResourceType preserves the resource type's id and trait
@@ -242,17 +278,12 @@ func (s *sanitizer) transformResourceType(in *v2.ResourceType, refs *assetRefSet
 	if in == nil {
 		return nil
 	}
-	// Record declared resource types ONLY during the copyResourceTypes phase
-	// (inResourceTypesPhase). transformResourceType is also reached for
-	// embedded types — an entitlement's GrantableTo, a grant's slice — and
-	// those must NOT grow the set: otherwise transformID's known-type
-	// decision (preserve verbatim vs. HMAC) would flip for the same token
-	// depending on whether it was seen before or after its embedding record,
-	// making output order-dependent. Gating here keeps the set read-only
-	// after copyResourceTypes, so the decision is order-independent. See C-2.
-	if id := in.GetId(); id != "" && s.inResourceTypesPhase {
-		s.knownResourceTypes[id] = struct{}{}
-	}
+	// transformResourceType is pure w.r.t. knownResourceTypes: registration
+	// happens up front in copyResourceTypes' buffering pre-pass, so the set is
+	// complete and read-only by the time any transform consults it. This holds
+	// whether the call is for a declared type or an embedded one (an
+	// entitlement's GrantableTo, a grant's slice), which is what makes
+	// transformID's known-type decision order-independent. See B1 / C-2.
 	annos := s.transformAnnotations(in.GetAnnotations(), refs)
 	return v2.ResourceType_builder{
 		Id:                in.GetId(),
@@ -289,11 +320,35 @@ func (s *sanitizer) transformResourceID(in *v2.ResourceId) *v2.ResourceId {
 	if in.GetResource() == "" && in.GetResourceType() == "" {
 		return nil
 	}
+	// resource_type is preserved verbatim here (it is connector-defined
+	// schema). transformID, by contrast, HMACs a type token that is NOT a
+	// declared resource type. So an UNDECLARED type token both survives in
+	// cleartext in this field and gets HMAC'd inside composite ids — a
+	// pre-existing divergence the explicit registration makes observable.
+	// Behavior is unchanged; emit a once-per-token tripwire so a connector
+	// that emits undeclared type tokens shows up rather than silently
+	// producing mismatched representations. (M4)
+	s.warnUndeclaredResourceType(in.GetResourceType())
 	return v2.ResourceId_builder{
 		ResourceType:  in.GetResourceType(),
 		Resource:      s.id(in.GetResource()),
 		BatonResource: in.GetBatonResource(),
 	}.Build()
+}
+
+// warnUndeclaredResourceType logs once per resource-type token that appears in
+// a resource id but was never declared in copyResourceTypes. Single-threaded
+// (the transform stage is sequential today); revisit if P1-3 parallelizes it.
+func (s *sanitizer) warnUndeclaredResourceType(rt string) {
+	if rt == "" || s.isKnownResourceType(rt) {
+		return
+	}
+	if _, seen := s.warnedUndeclaredTypes[rt]; seen {
+		return
+	}
+	s.warnedUndeclaredTypes[rt] = struct{}{}
+	s.log.Warn("c1zsanitize: resource id references an undeclared resource type; preserved verbatim here but HMAC'd inside composite ids",
+		zap.String("resource_type", rt))
 }
 
 func (s *sanitizer) transformEntitlement(in *v2.Entitlement, refs *assetRefSet) *v2.Entitlement {
@@ -376,10 +431,11 @@ type grantSubCache struct {
 
 const verifySampleLimit = 1000
 
-func newGrantSubCache() *grantSubCache {
+func newGrantSubCache(verify bool) *grantSubCache {
 	return &grantSubCache{
 		entitlements: map[string]*v2.Entitlement{},
 		principals:   map[string]*v2.Resource{},
+		verify:       verify,
 	}
 }
 
@@ -421,8 +477,13 @@ func (s *sanitizer) cachedPrincipal(in *v2.Resource, refs *assetRefSet, cache *g
 	if cache == nil {
 		return s.transformResource(in, refs)
 	}
+	// Key only on the identifying component. A principal with an empty
+	// resource id has nothing that uniquely identifies it, so it must not be
+	// cached — otherwise two distinct empty-resource principals with different
+	// display names would conflate on a non-empty-but-meaningless key like
+	// "user\x00" and the second grant would inherit the first's transform. See B2.
 	key := ""
-	if id := in.GetId(); id != nil {
+	if id := in.GetId(); id != nil && id.GetResource() != "" {
 		key = id.GetResourceType() + "\x00" + id.GetResource()
 	}
 	if key != "" {
@@ -477,8 +538,9 @@ func (s *sanitizer) verifyCachedPrincipal(in *v2.Resource, refs *assetRefSet, ca
 // logPage emits one Info line per page with read/transform/put timings — the
 // permanent regression canary for the per-record-cost-grows-with-n class of
 // slowdown. One line per 10k rows is cheap.
-func (s *sanitizer) logPage(phase string, page, rows int, read, transform, put time.Duration) {
+func (s *sanitizer) logPage(syncID, phase string, page, rows int, read, transform, put time.Duration) {
 	s.log.Info("c1zsanitize: page",
+		zap.String("sync_id", syncID),
 		zap.String("phase", phase),
 		zap.Int("page", page),
 		zap.Int("rows", rows),

--- a/pkg/dotc1z/bulkload_test.go
+++ b/pkg/dotc1z/bulkload_test.go
@@ -63,7 +63,7 @@ func tmpC1ZPath(t *testing.T) string {
 	return filepath.Join(t.TempDir(), "test.c1z")
 }
 
-// T5 + T9: bulk-load output has byte-identical index sets and row counts to a
+// Bulk-load output has byte-identical index sets and row counts to a
 // normal-mode control, and InitTables is idempotent on re-run.
 func TestBulkLoadIndexParity(t *testing.T) {
 	ctx := context.Background()
@@ -103,14 +103,14 @@ func TestBulkLoadIndexParity(t *testing.T) {
 		require.Equal(t, nc, bc, "row count mismatch for %s", td.Name())
 	}
 
-	// V1/T9: InitTables is idempotent — re-running it must not error and must
+	// InitTables is idempotent — re-running it must not error and must
 	// leave the index set unchanged (all DDL is IF NOT EXISTS).
 	_, err = bulk.InitTables(ctx)
 	require.NoError(t, err)
 	require.Equal(t, normalIdx, indexNamesByTable(ctx, t, bulk), "InitTables re-run must be a no-op on indexes")
 }
 
-// T6 (B3): opening a POPULATED db with bulkLoad must NOT drop indexes — the
+// Opening a POPULATED db with bulkLoad must NOT drop indexes — the
 // per-table emptiness guard keeps them live.
 func TestBulkLoadPopulatedTableKeepsIndexes(t *testing.T) {
 	ctx := context.Background()
@@ -139,7 +139,7 @@ func TestBulkLoadPopulatedTableKeepsIndexes(t *testing.T) {
 		"no tables should be marked for deferral when the db is non-empty (B3)")
 }
 
-// T7 (B4): the deferred-index rebuild runs on a detached context, so Close
+// The deferred-index rebuild runs on a detached context, so Close
 // completes even when the caller's context is already canceled.
 func TestBulkLoadRebuildSurvivesCanceledContext(t *testing.T) {
 	ctx := context.Background()
@@ -171,7 +171,7 @@ func TestBulkLoadRebuildSurvivesCanceledContext(t *testing.T) {
 		"rebuilt index set must match the control after a canceled-context Close")
 }
 
-// T8 (B4): if the deferred-index rebuild fails, the working database is
+// If the deferred-index rebuild fails, the working database is
 // PRESERVED (not cleaned up) so the just-loaded data is recoverable.
 func TestBulkLoadRebuildFailurePreservesDB(t *testing.T) {
 	ctx := context.Background()

--- a/pkg/dotc1z/bulkload_test.go
+++ b/pkg/dotc1z/bulkload_test.go
@@ -41,7 +41,7 @@ func indexNamesByTable(ctx context.Context, t *testing.T, c *C1File) map[string]
 	t.Helper()
 	out := map[string][]string{}
 	for _, td := range allTableDescriptors {
-		rows, err := c.db.QueryContext(ctx, fmt.Sprintf("PRAGMA index_list(%s)", td.Name()))
+		rows, err := c.db.QueryContext(ctx, fmt.Sprintf(`PRAGMA index_list("%s")`, td.Name()))
 		require.NoError(t, err)
 		var names []string
 		for rows.Next() {

--- a/pkg/dotc1z/bulkload_test.go
+++ b/pkg/dotc1z/bulkload_test.go
@@ -1,0 +1,195 @@
+package dotc1z
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+)
+
+// writeAllTables writes one sync's worth of rows across every object table
+// that carries deferrable secondary indexes, then ends the sync.
+func writeAllTables(ctx context.Context, t *testing.T, c *C1File) {
+	t.Helper()
+	_, err := c.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+
+	require.NoError(t, c.PutResourceTypes(ctx,
+		v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build(),
+		v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build(),
+	))
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+	u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build()}.Build()
+	require.NoError(t, c.PutResources(ctx, g1, u1))
+	ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1}.Build()
+	require.NoError(t, c.PutEntitlements(ctx, ent1))
+	require.NoError(t, c.PutGrants(ctx,
+		v2.Grant_builder{Id: "grant1", Entitlement: ent1, Principal: u1}.Build(),
+	))
+	require.NoError(t, c.EndSync(ctx))
+}
+
+// indexNamesByTable reopens nothing; it queries the live db for the index
+// name set of each object table.
+func indexNamesByTable(ctx context.Context, t *testing.T, c *C1File) map[string][]string {
+	t.Helper()
+	out := map[string][]string{}
+	for _, td := range allTableDescriptors {
+		rows, err := c.db.QueryContext(ctx, fmt.Sprintf("PRAGMA index_list(%s)", td.Name()))
+		require.NoError(t, err)
+		var names []string
+		for rows.Next() {
+			var seq, unique, partial int
+			var name, origin string
+			require.NoError(t, rows.Scan(&seq, &name, &unique, &origin, &partial))
+			names = append(names, fmt.Sprintf("%s|unique=%d|origin=%s|partial=%d", name, unique, origin, partial))
+		}
+		require.NoError(t, rows.Err())
+		_ = rows.Close()
+		sort.Strings(names)
+		out[td.Name()] = names
+	}
+	return out
+}
+
+func tmpC1ZPath(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(t.TempDir(), "test.c1z")
+}
+
+// T5 + T9: bulk-load output has byte-identical index sets and row counts to a
+// normal-mode control, and InitTables is idempotent on re-run.
+func TestBulkLoadIndexParity(t *testing.T) {
+	ctx := context.Background()
+
+	build := func(bulk bool) string {
+		path := tmpC1ZPath(t)
+		opts := []C1ZOption{}
+		if bulk {
+			opts = append(opts, WithBulkLoad(true), WithSkipVacuum(true))
+		}
+		c, err := NewC1ZFile(ctx, path, opts...)
+		require.NoError(t, err)
+		writeAllTables(ctx, t, c)
+		require.NoError(t, c.Close(ctx))
+		return path
+	}
+
+	normalPath := build(false)
+	bulkPath := build(true)
+
+	normal, err := NewC1ZFile(ctx, normalPath)
+	require.NoError(t, err)
+	defer normal.Close(ctx)
+	bulk, err := NewC1ZFile(ctx, bulkPath)
+	require.NoError(t, err)
+	defer bulk.Close(ctx)
+
+	normalIdx := indexNamesByTable(ctx, t, normal)
+	bulkIdx := indexNamesByTable(ctx, t, bulk)
+	require.Equal(t, normalIdx, bulkIdx, "bulk-load final index set must equal the normal-mode control (T5/T9)")
+
+	// Row-count parity per object table.
+	for _, td := range []tableDescriptor{resourceTypes, resources, entitlements, grants} {
+		var nc, bc int
+		require.NoError(t, normal.db.QueryRowContext(ctx, fmt.Sprintf("SELECT count(*) FROM %s", td.Name())).Scan(&nc))
+		require.NoError(t, bulk.db.QueryRowContext(ctx, fmt.Sprintf("SELECT count(*) FROM %s", td.Name())).Scan(&bc))
+		require.Equal(t, nc, bc, "row count mismatch for %s", td.Name())
+	}
+
+	// V1/T9: InitTables is idempotent — re-running it must not error and must
+	// leave the index set unchanged (all DDL is IF NOT EXISTS).
+	_, err = bulk.InitTables(ctx)
+	require.NoError(t, err)
+	require.Equal(t, normalIdx, indexNamesByTable(ctx, t, bulk), "InitTables re-run must be a no-op on indexes")
+}
+
+// T6 (B3): opening a POPULATED db with bulkLoad must NOT drop indexes — the
+// per-table emptiness guard keeps them live.
+func TestBulkLoadPopulatedTableKeepsIndexes(t *testing.T) {
+	ctx := context.Background()
+	path := tmpC1ZPath(t)
+
+	// Populate normally first.
+	c, err := NewC1ZFile(ctx, path)
+	require.NoError(t, err)
+	writeAllTables(ctx, t, c)
+	require.NoError(t, c.Close(ctx))
+
+	// Capture the control index set.
+	ctl, err := NewC1ZFile(ctx, path)
+	require.NoError(t, err)
+	want := indexNamesByTable(ctx, t, ctl)
+	require.NoError(t, ctl.Close(ctx))
+
+	// Reopen the populated db WITH bulkLoad: indexes must be retained.
+	reopened, err := NewC1ZFile(ctx, path, WithBulkLoad(true), WithSkipVacuum(true))
+	require.NoError(t, err)
+	defer reopened.Close(ctx)
+
+	require.Equal(t, want, indexNamesByTable(ctx, t, reopened),
+		"bulk load on a populated db must keep indexes live (B3)")
+	require.Empty(t, reopened.deferredIndexTables,
+		"no tables should be marked for deferral when the db is non-empty (B3)")
+}
+
+// T7 (B4): the deferred-index rebuild runs on a detached context, so Close
+// completes even when the caller's context is already canceled.
+func TestBulkLoadRebuildSurvivesCanceledContext(t *testing.T) {
+	ctx := context.Background()
+	path := tmpC1ZPath(t)
+
+	c, err := NewC1ZFile(ctx, path, WithBulkLoad(true), WithSkipVacuum(true))
+	require.NoError(t, err)
+	writeAllTables(ctx, t, c)
+
+	canceled, cancel := context.WithCancel(ctx)
+	cancel() // already canceled before Close
+	require.NoError(t, c.Close(canceled), "Close must complete despite a canceled caller context (B4)")
+
+	// The output must be a fully-indexed, valid c1z.
+	reopened, err := NewC1ZFile(ctx, path)
+	require.NoError(t, err)
+	defer reopened.Close(ctx)
+
+	control := tmpC1ZPath(t)
+	cc, err := NewC1ZFile(ctx, control)
+	require.NoError(t, err)
+	writeAllTables(ctx, t, cc)
+	require.NoError(t, cc.Close(ctx))
+	ccRO, err := NewC1ZFile(ctx, control)
+	require.NoError(t, err)
+	defer ccRO.Close(ctx)
+
+	require.Equal(t, indexNamesByTable(ctx, t, ccRO), indexNamesByTable(ctx, t, reopened),
+		"rebuilt index set must match the control after a canceled-context Close")
+}
+
+// T8 (B4): if the deferred-index rebuild fails, the working database is
+// PRESERVED (not cleaned up) so the just-loaded data is recoverable.
+func TestBulkLoadRebuildFailurePreservesDB(t *testing.T) {
+	ctx := context.Background()
+	path := tmpC1ZPath(t)
+
+	c, err := NewC1ZFile(ctx, path, WithBulkLoad(true), WithSkipVacuum(true))
+	require.NoError(t, err)
+	writeAllTables(ctx, t, c)
+	require.NotEmpty(t, c.deferredIndexTables, "precondition: tables were deferred")
+
+	dbPath := c.dbFilePath
+	require.FileExists(t, dbPath)
+
+	// Force the rebuild's Exec to fail by closing the underlying handle.
+	require.NoError(t, c.rawDb.Close())
+
+	err = c.buildDeferredIndexes(ctx)
+	require.Error(t, err, "rebuild must surface the failure")
+	require.Contains(t, err.Error(), "working db preserved")
+	require.FileExists(t, dbPath, "working database must be preserved on rebuild failure (B4)")
+}

--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -279,7 +279,25 @@ func NewC1File(ctx context.Context, dbFilePath string, opts ...C1FOption) (*C1Fi
 		opt(c1File)
 	}
 
-	// Bulk load implies skip-cleanup (H4): Cleanup's old-sync DELETEs would
+	// A read-only open never builds indexes (it discards everything on
+	// close), so bulk load is meaningless there — and would otherwise drop
+	// indexes on a fresh empty open for no reason. Normalize the nonsense
+	// combination to off.
+	if c1File.readOnly {
+		c1File.bulkLoad = false
+	}
+
+	// The deferred-index optimization is a SQLite-engine concern: it drops and
+	// rebuilds the sqlite secondary indexes around the load. The pebble (v3)
+	// engine manages its own storage and does not use those indexes, so bulk
+	// load does not apply there. Make the combination an explicit, logged
+	// no-op rather than leaving it silently unspecified.
+	if c1File.bulkLoad && c1File.engine == EnginePebble {
+		l.Info("new-c1-file: bulk load ignored for the pebble engine; the deferred-index optimization applies only to the sqlite engine")
+		c1File.bulkLoad = false
+	}
+
+	// Bulk load implies skip-cleanup: Cleanup's old-sync DELETEs would
 	// run while the secondary indexes they rely on are dropped, turning each
 	// delete into a full scan. A net-new bulk-load destination has no old
 	// syncs to clean anyway. Callers should also pass WithSkipVacuum(true) —
@@ -603,7 +621,7 @@ func (c *C1File) Close(ctx context.Context) (retErr error) {
 	// (disk-full during the index sort) is transient. Preserve it and surface
 	// the error so an operator can recover; the path is logged at Error inside
 	// buildDeferredIndexes. We leave c.closed=false and c.rawDb open so the
-	// state stays consistent for a retried Close. (B4)
+	// state stays consistent for a retried Close.
 	if c.bulkLoad {
 		if err := c.buildDeferredIndexes(ctx); err != nil {
 			return err
@@ -962,7 +980,7 @@ func (c *C1File) InitTables(ctx context.Context) (bool, error) {
 		// canonical Schema() DDL so the final index set is byte-identical to
 		// the non-bulk path.
 		//
-		// Safety guard (B3): bulkLoad's contract is a net-new destination, but
+		// Safety guard: bulkLoad's contract is a net-new destination, but
 		// nothing stops a caller setting it on a reopened, populated file (a
 		// resumed sanitize output, or — since this SDK is linked everywhere —
 		// any production sync file). Dropping an index on a table with millions
@@ -972,7 +990,7 @@ func (c *C1File) InitTables(ctx context.Context) (bool, error) {
 		// live and degrade to normal mode for that table, with a warning.
 		if c.bulkLoad && len(deferrable) > 0 {
 			var nonEmpty bool
-			row := c.db.QueryRowContext(ctx, fmt.Sprintf("SELECT EXISTS(SELECT 1 FROM %s LIMIT 1)", t.Name()))
+			row := c.db.QueryRowContext(ctx, fmt.Sprintf(`SELECT EXISTS(SELECT 1 FROM "%s" LIMIT 1)`, t.Name()))
 			if err := row.Scan(&nonEmpty); err != nil {
 				return false, fmt.Errorf("c1file-init-tables: error checking emptiness of %s: %w", t.Name(), err)
 			}
@@ -981,7 +999,7 @@ func (c *C1File) InitTables(ctx context.Context) (bool, error) {
 					zap.String("table_name", t.Name()))
 			} else {
 				for _, idxName := range deferrable {
-					// Identifier comes from our own DDL; quote it for hygiene (M5).
+					// Identifier comes from our own DDL; quote it for hygiene.
 					if _, derr := c.db.ExecContext(ctx, fmt.Sprintf(`DROP INDEX IF EXISTS "%s"`, idxName)); derr != nil {
 						return false, fmt.Errorf("c1file-init-tables: error deferring index %s on %s: %w", idxName, t.Name(), derr)
 					}
@@ -1016,12 +1034,12 @@ func (c *C1File) InitTables(ctx context.Context) (bool, error) {
 // re-run. (The caller snapshots this set BEFORE migrations, so partial
 // indexes a migration adds afterwards are never in it and stay live.)
 //
-// V3: this assumes PRAGMA index_list's 5-column form (seq, name, unique,
-// origin, partial), which the modernc-pinned SQLite emits. All five columns
-// must be scanned even though `partial` is unused; a driver change to a
-// different column set will fail the Scan loudly here and in TestBulkLoad*.
+// This assumes PRAGMA index_list's 5-column form (seq, name, unique, origin,
+// partial), which the modernc-pinned SQLite emits. All five columns must be
+// scanned even though `partial` is unused; a driver change to a different
+// column set will fail the Scan loudly here and in the bulk-load tests.
 func nonUniqueSecondaryIndexNames(ctx context.Context, db *goqu.Database, tableName string) ([]string, error) {
-	rows, err := db.QueryContext(ctx, fmt.Sprintf("PRAGMA index_list(%s)", tableName))
+	rows, err := db.QueryContext(ctx, fmt.Sprintf(`PRAGMA index_list("%s")`, tableName))
 	if err != nil {
 		return nil, err
 	}
@@ -1053,8 +1071,8 @@ func nonUniqueSecondaryIndexNames(ctx context.Context, db *goqu.Database, tableN
 // recreated. Using the same DDL as the non-bulk path guarantees the final
 // index set — names, columns, uniqueness — is byte-identical.
 //
-// The rebuild runs on a context DETACHED from the caller (B4): a CREATE INDEX
-// over a 50M+-row table is tens of minutes and is not safe to abort on caller
+// The rebuild runs on a context DETACHED from the caller: a CREATE INDEX over
+// a 50M+-row table is tens of minutes and is not safe to abort on caller
 // cancellation. It gets its own generous bound (BulkLoadIndexTimeout) sized
 // for index builds, not the much shorter FinalizeTimeout (checkpoint+save).
 //
@@ -1067,7 +1085,7 @@ func nonUniqueSecondaryIndexNames(ctx context.Context, db *goqu.Database, tableN
 // event of Close. CREATE INDEX sorts through SQLite temp storage, so the
 // rebuild needs temp space on the order of the index size (SQLITE_TMPDIR /
 // temp_store) plus, under journal_mode=WAL, WAL growth of roughly the index
-// size before checkpoint; size cache_size accordingly. (H5).
+// size before checkpoint; size cache_size accordingly.
 func (c *C1File) buildDeferredIndexes(ctx context.Context) error {
 	if len(c.deferredIndexTables) == 0 {
 		return nil

--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -56,6 +56,22 @@ type C1File struct {
 	closed             bool
 	closedMu           sync.Mutex
 
+	// bulkLoad defers secondary-index creation on a freshly-created
+	// destination. When set, the per-table non-unique secondary indexes
+	// are dropped right after table creation (instant on the empty table)
+	// so the bulk write only maintains the rowid primary key and the
+	// (external_id, sync_id) unique index the upsert path needs; the
+	// deferred indexes are rebuilt in one pass at Close, before the c1z is
+	// flushed. This avoids per-row random-key B-tree maintenance across
+	// the whole load — the dominant cost when writing tens of millions of
+	// rows whose indexed columns are high-cardinality. Only safe for a
+	// net-new, single-writer destination (e.g. c1z sanitize output), so it
+	// is opt-in and never the default.
+	bulkLoad bool
+	// deferredIndexTables records the tables whose secondary indexes were
+	// dropped under bulkLoad, so Close knows to rebuild them.
+	deferredIndexTables []tableDescriptor
+
 	// Cached sync run for listConnectorObjects (avoids N+1 queries)
 	cachedViewSyncRun *SyncRun
 	cachedViewSyncMu  sync.Mutex
@@ -118,6 +134,16 @@ func WithC1FPragma(name string, value string) C1FOption {
 func WithC1FReadOnly(readOnly bool) C1FOption {
 	return func(o *C1File) {
 		o.readOnly = readOnly
+	}
+}
+
+// WithC1FBulkLoad enables deferred secondary-index creation for a
+// freshly-created destination. See C1File.bulkLoad. Only safe for a
+// net-new, single-writer output; never use it to reopen a file that
+// other readers/writers touch concurrently.
+func WithC1FBulkLoad(enabled bool) C1FOption {
+	return func(o *C1File) {
+		o.bulkLoad = enabled
 	}
 }
 
@@ -271,6 +297,7 @@ type c1zOptions struct {
 	skipCleanup        bool
 	skipVacuum         bool
 	v2GrantsWriter     bool
+	bulkLoad           bool
 
 	// engine is the storage engine to use for newly created files.
 	// Reads dispatch on magic byte regardless. Default EngineSQLite.
@@ -373,6 +400,17 @@ func WithV2GrantsWriter(enabled bool) C1ZOption {
 	}
 }
 
+// WithBulkLoad enables deferred secondary-index creation for a
+// freshly-created destination c1z. See WithC1FBulkLoad / C1File.bulkLoad.
+// Only safe for a net-new, single-writer output such as the c1z sanitize
+// destination; it is never the default and must not be set on a file that
+// is read or written concurrently.
+func WithBulkLoad(enabled bool) C1ZOption {
+	return func(o *c1zOptions) {
+		o.bulkLoad = enabled
+	}
+}
+
 // WithPayloadEncoding selects the c1z v3 envelope payload encoding
 // for newly created files written by the Pebble engine. Default is
 // PayloadEncodingTarZstd. PayloadEncodingTar skips the outer zstd
@@ -431,6 +469,9 @@ func NewC1ZFile(ctx context.Context, outputFilePath string, opts ...C1ZOption) (
 	}
 	if options.v2GrantsWriter {
 		c1fopts = append(c1fopts, WithC1FV2GrantsWriter(true))
+	}
+	if options.bulkLoad {
+		c1fopts = append(c1fopts, WithC1FBulkLoad(true))
 	}
 	if options.engine != "" {
 		c1fopts = append(c1fopts, WithC1FEngine(options.engine))
@@ -525,6 +566,15 @@ func (c *C1File) Close(ctx context.Context) (retErr error) {
 		}
 		c.closed = true
 		return nil
+	}
+
+	// Rebuild any indexes deferred during a bulk load before the c1z is
+	// flushed and compressed. Runs on the caller's context (the DB is
+	// still open here) so it is not bounded by the finalize timeout.
+	if c.bulkLoad {
+		if err := c.buildDeferredIndexes(ctx); err != nil {
+			return cleanupDbDir(c.dbFilePath, err)
+		}
 	}
 
 	if err := c.finalize(ctx); err != nil {
@@ -845,6 +895,18 @@ func (c *C1File) InitTables(ctx context.Context) (bool, error) {
 			zap.Duration("time_taken", time.Since(startTime)),
 		)
 
+		// Snapshot the table's base secondary indexes BEFORE migrations
+		// run, so deferral targets exactly the Schema()-declared non-unique
+		// indexes and never the partial indexes a migration may add (which
+		// are cheap to maintain and stay live during the load).
+		var deferrable []string
+		if c.bulkLoad {
+			deferrable, err = nonUniqueSecondaryIndexNames(ctx, c.db, t.Name())
+			if err != nil {
+				return false, fmt.Errorf("c1file-init-tables: error listing indexes for %s: %w", t.Name(), err)
+			}
+		}
+
 		startTime = time.Now()
 		migrated, err := t.Migrations(ctx, c.db)
 		if err != nil {
@@ -859,6 +921,21 @@ func (c *C1File) InitTables(ctx context.Context) (bool, error) {
 		if migrated {
 			shouldOptimize = true
 		}
+
+		// Under bulk load, drop the base non-unique secondary indexes now
+		// (instant on the empty table) so the load maintains only the rowid
+		// PK and the (external_id, sync_id) unique index. They are rebuilt
+		// in one pass at Close via buildDeferredIndexes, which re-runs the
+		// canonical Schema() DDL so the final index set is byte-identical to
+		// the non-bulk path.
+		if c.bulkLoad && len(deferrable) > 0 {
+			for _, idxName := range deferrable {
+				if _, derr := c.db.ExecContext(ctx, fmt.Sprintf("DROP INDEX IF EXISTS %s", idxName)); derr != nil {
+					return false, fmt.Errorf("c1file-init-tables: error deferring index %s on %s: %w", idxName, t.Name(), derr)
+				}
+			}
+			c.deferredIndexTables = append(c.deferredIndexTables, t)
+		}
 	}
 
 	if !shouldOptimize {
@@ -872,6 +949,65 @@ func (c *C1File) InitTables(ctx context.Context) (bool, error) {
 	}
 
 	return shouldOptimize, nil
+}
+
+// nonUniqueSecondaryIndexNames returns the names of the non-unique
+// secondary indexes on tableName that were created by an explicit CREATE
+// INDEX (origin "c"). The (external_id, sync_id) UNIQUE index is excluded
+// (unique != 0) so it stays in place — the connector-object upsert path
+// relies on it for its ON CONFLICT target. The rowid primary key (origin
+// "pk") and any UNIQUE-constraint indexes (origin "u") are excluded too.
+func nonUniqueSecondaryIndexNames(ctx context.Context, db *goqu.Database, tableName string) ([]string, error) {
+	rows, err := db.QueryContext(ctx, fmt.Sprintf("PRAGMA index_list(%s)", tableName))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var names []string
+	for rows.Next() {
+		var (
+			seq     int
+			name    string
+			unique  int
+			origin  string
+			partial int
+		)
+		if err := rows.Scan(&seq, &name, &unique, &origin, &partial); err != nil {
+			return nil, err
+		}
+		if unique == 0 && origin == "c" {
+			names = append(names, name)
+		}
+	}
+	return names, rows.Err()
+}
+
+// buildDeferredIndexes rebuilds, in one pass, the secondary indexes that
+// were dropped under bulk load. It re-runs each table's canonical Schema()
+// DDL: the CREATE TABLE and CREATE UNIQUE INDEX statements are no-ops
+// (IF NOT EXISTS), and the dropped non-unique CREATE INDEX statements are
+// recreated. Using the same DDL as the non-bulk path guarantees the final
+// index set — names, columns, uniqueness — is byte-identical. Called from
+// Close before the c1z is flushed, while the DB is still open and writable.
+func (c *C1File) buildDeferredIndexes(ctx context.Context) error {
+	if len(c.deferredIndexTables) == 0 {
+		return nil
+	}
+	l := ctxzap.Extract(ctx).With(zap.String("db_file_path", c.dbFilePath))
+	for _, t := range c.deferredIndexTables {
+		query, args := t.Schema()
+		startTime := time.Now()
+		if _, err := c.db.ExecContext(ctx, fmt.Sprintf(query, args...)); err != nil {
+			return fmt.Errorf("c1file: error building deferred indexes for %s: %w", t.Name(), err)
+		}
+		l.Debug("c1file: built deferred indexes",
+			zap.String("table_name", t.Name()),
+			zap.Duration("time_taken", time.Since(startTime)),
+		)
+	}
+	c.deferredIndexTables = nil
+	return nil
 }
 
 func statsToMap(stats *reader_v2.SyncStats, syncType connectorstore.SyncType) map[string]int64 {

--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -138,9 +138,20 @@ func WithC1FReadOnly(readOnly bool) C1FOption {
 }
 
 // WithC1FBulkLoad enables deferred secondary-index creation for a
-// freshly-created destination. See C1File.bulkLoad. Only safe for a
-// net-new, single-writer output; never use it to reopen a file that
-// other readers/writers touch concurrently.
+// freshly-created destination. See C1File.bulkLoad. Intended for a net-new,
+// single-writer output (e.g. c1z sanitize); never use it to reopen a file
+// that other readers/writers touch concurrently.
+//
+// Safe-by-construction guard: per table, indexes are deferred only when the
+// table is EMPTY. A non-empty table keeps its indexes live and that table
+// degrades to normal mode (with a warning) — so setting this on a populated
+// file never drops indexes on a large table.
+//
+// Implies skip-cleanup (Cleanup's old-sync deletes would scan without the
+// deferred indexes). Pair with WithC1FSkipVacuum(true) too. The deferred
+// rebuild at Close sorts through SQLite temp storage: provision SQLITE_TMPDIR
+// / temp_store and cache_size for roughly the total index size; under
+// journal_mode=WAL the WAL can grow by about the index size before checkpoint.
 func WithC1FBulkLoad(enabled bool) C1FOption {
 	return func(o *C1File) {
 		o.bulkLoad = enabled
@@ -266,6 +277,16 @@ func NewC1File(ctx context.Context, dbFilePath string, opts ...C1FOption) (*C1Fi
 
 	for _, opt := range opts {
 		opt(c1File)
+	}
+
+	// Bulk load implies skip-cleanup (H4): Cleanup's old-sync DELETEs would
+	// run while the secondary indexes they rely on are dropped, turning each
+	// delete into a full scan. A net-new bulk-load destination has no old
+	// syncs to clean anyway. Callers should also pass WithSkipVacuum(true) —
+	// VACUUM before the deferred indexes are rebuilt is wasted work — but that
+	// stays caller-controlled since it is not a correctness hazard.
+	if c1File.bulkLoad {
+		c1File.skipCleanup = true
 	}
 
 	// Normalize the engine zero value so downstream switch/if-eq
@@ -401,10 +422,11 @@ func WithV2GrantsWriter(enabled bool) C1ZOption {
 }
 
 // WithBulkLoad enables deferred secondary-index creation for a
-// freshly-created destination c1z. See WithC1FBulkLoad / C1File.bulkLoad.
-// Only safe for a net-new, single-writer output such as the c1z sanitize
-// destination; it is never the default and must not be set on a file that
-// is read or written concurrently.
+// freshly-created destination c1z. See WithC1FBulkLoad for the full contract:
+// it is opt-in and never the default; indexes are deferred only on EMPTY
+// tables (a populated table keeps its indexes and degrades to normal mode with
+// a warning); it implies skip-cleanup; pair it with WithSkipVacuum(true); and
+// provision temp space + cache_size for the deferred index rebuild at Close.
 func WithBulkLoad(enabled bool) C1ZOption {
 	return func(o *c1zOptions) {
 		o.bulkLoad = enabled
@@ -569,11 +591,22 @@ func (c *C1File) Close(ctx context.Context) (retErr error) {
 	}
 
 	// Rebuild any indexes deferred during a bulk load before the c1z is
-	// flushed and compressed. Runs on the caller's context (the DB is
-	// still open here) so it is not bounded by the finalize timeout.
+	// flushed and compressed. This is the headline event of Close on a
+	// whale-scale file (building several secondary indexes over a 50M+-row
+	// grants table is tens of minutes), so it must NOT be exposed to caller
+	// cancellation — a Ctrl-C or parent deadline at the finish line would
+	// otherwise abort the CREATE INDEX. buildDeferredIndexes detaches the
+	// context itself.
+	//
+	// On failure we deliberately do NOT cleanupDbDir: the working database is
+	// the only copy of the just-loaded data, and the realistic failure here
+	// (disk-full during the index sort) is transient. Preserve it and surface
+	// the error so an operator can recover; the path is logged at Error inside
+	// buildDeferredIndexes. We leave c.closed=false and c.rawDb open so the
+	// state stays consistent for a retried Close. (B4)
 	if c.bulkLoad {
 		if err := c.buildDeferredIndexes(ctx); err != nil {
-			return cleanupDbDir(c.dbFilePath, err)
+			return err
 		}
 	}
 
@@ -928,13 +961,33 @@ func (c *C1File) InitTables(ctx context.Context) (bool, error) {
 		// in one pass at Close via buildDeferredIndexes, which re-runs the
 		// canonical Schema() DDL so the final index set is byte-identical to
 		// the non-bulk path.
+		//
+		// Safety guard (B3): bulkLoad's contract is a net-new destination, but
+		// nothing stops a caller setting it on a reopened, populated file (a
+		// resumed sanitize output, or — since this SDK is linked everywhere —
+		// any production sync file). Dropping an index on a table with millions
+		// of rows is NOT instant, makes index-dependent reads full-scan, and a
+		// crash before Close leaves the working state index-less. So check
+		// emptiness per table: defer only when empty; otherwise keep the indexes
+		// live and degrade to normal mode for that table, with a warning.
 		if c.bulkLoad && len(deferrable) > 0 {
-			for _, idxName := range deferrable {
-				if _, derr := c.db.ExecContext(ctx, fmt.Sprintf("DROP INDEX IF EXISTS %s", idxName)); derr != nil {
-					return false, fmt.Errorf("c1file-init-tables: error deferring index %s on %s: %w", idxName, t.Name(), derr)
-				}
+			var nonEmpty bool
+			row := c.db.QueryRowContext(ctx, fmt.Sprintf("SELECT EXISTS(SELECT 1 FROM %s LIMIT 1)", t.Name()))
+			if err := row.Scan(&nonEmpty); err != nil {
+				return false, fmt.Errorf("c1file-init-tables: error checking emptiness of %s: %w", t.Name(), err)
 			}
-			c.deferredIndexTables = append(c.deferredIndexTables, t)
+			if nonEmpty {
+				l.Warn("c1file: bulk load requested but table is not empty; keeping indexes live (degrading to normal mode for this table)",
+					zap.String("table_name", t.Name()))
+			} else {
+				for _, idxName := range deferrable {
+					// Identifier comes from our own DDL; quote it for hygiene (M5).
+					if _, derr := c.db.ExecContext(ctx, fmt.Sprintf(`DROP INDEX IF EXISTS "%s"`, idxName)); derr != nil {
+						return false, fmt.Errorf("c1file-init-tables: error deferring index %s on %s: %w", idxName, t.Name(), derr)
+					}
+				}
+				c.deferredIndexTables = append(c.deferredIndexTables, t)
+			}
 		}
 	}
 
@@ -957,6 +1010,16 @@ func (c *C1File) InitTables(ctx context.Context) (bool, error) {
 // (unique != 0) so it stays in place — the connector-object upsert path
 // relies on it for its ON CONFLICT target. The rowid primary key (origin
 // "pk") and any UNIQUE-constraint indexes (origin "u") are excluded too.
+//
+// Schema()-declared PARTIAL indexes are intentionally deferrable too: they
+// are non-unique origin-"c" indexes and get rebuilt by the same Schema()
+// re-run. (The caller snapshots this set BEFORE migrations, so partial
+// indexes a migration adds afterwards are never in it and stay live.)
+//
+// V3: this assumes PRAGMA index_list's 5-column form (seq, name, unique,
+// origin, partial), which the modernc-pinned SQLite emits. All five columns
+// must be scanned even though `partial` is unused; a driver change to a
+// different column set will fail the Scan loudly here and in TestBulkLoad*.
 func nonUniqueSecondaryIndexNames(ctx context.Context, db *goqu.Database, tableName string) ([]string, error) {
 	rows, err := db.QueryContext(ctx, fmt.Sprintf("PRAGMA index_list(%s)", tableName))
 	if err != nil {
@@ -988,20 +1051,44 @@ func nonUniqueSecondaryIndexNames(ctx context.Context, db *goqu.Database, tableN
 // DDL: the CREATE TABLE and CREATE UNIQUE INDEX statements are no-ops
 // (IF NOT EXISTS), and the dropped non-unique CREATE INDEX statements are
 // recreated. Using the same DDL as the non-bulk path guarantees the final
-// index set — names, columns, uniqueness — is byte-identical. Called from
-// Close before the c1z is flushed, while the DB is still open and writable.
+// index set — names, columns, uniqueness — is byte-identical.
+//
+// The rebuild runs on a context DETACHED from the caller (B4): a CREATE INDEX
+// over a 50M+-row table is tens of minutes and is not safe to abort on caller
+// cancellation. It gets its own generous bound (BulkLoadIndexTimeout) sized
+// for index builds, not the much shorter FinalizeTimeout (checkpoint+save).
+//
+// On any failure the working database is PRESERVED (no cleanupDbDir): it holds
+// the only copy of the just-loaded data and the realistic failure (disk-full
+// during the index sort) is transient and recoverable. The path is logged at
+// Error with explicit recovery wording, and the error is returned.
+//
+// Per-table duration is logged at Info — on a whale file this is the headline
+// event of Close. CREATE INDEX sorts through SQLite temp storage, so the
+// rebuild needs temp space on the order of the index size (SQLITE_TMPDIR /
+// temp_store) plus, under journal_mode=WAL, WAL growth of roughly the index
+// size before checkpoint; size cache_size accordingly. (H5).
 func (c *C1File) buildDeferredIndexes(ctx context.Context) error {
 	if len(c.deferredIndexTables) == 0 {
 		return nil
 	}
 	l := ctxzap.Extract(ctx).With(zap.String("db_file_path", c.dbFilePath))
+
+	idxCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), BulkLoadIndexTimeout())
+	defer cancel()
+
 	for _, t := range c.deferredIndexTables {
 		query, args := t.Schema()
 		startTime := time.Now()
-		if _, err := c.db.ExecContext(ctx, fmt.Sprintf(query, args...)); err != nil {
-			return fmt.Errorf("c1file: error building deferred indexes for %s: %w", t.Name(), err)
+		if _, err := c.db.ExecContext(idxCtx, fmt.Sprintf(query, args...)); err != nil {
+			l.Error("c1file: deferred index rebuild failed; working database PRESERVED for manual recovery",
+				zap.String("table_name", t.Name()),
+				zap.String("preserved_db_path", c.dbFilePath),
+				zap.Error(err),
+			)
+			return fmt.Errorf("c1file: error building deferred indexes for %s (working db preserved at %s): %w", t.Name(), c.dbFilePath, err)
 		}
-		l.Debug("c1file: built deferred indexes",
+		l.Info("c1file: built deferred indexes",
 			zap.String("table_name", t.Name()),
 			zap.Duration("time_taken", time.Since(startTime)),
 		)

--- a/pkg/dotc1z/finalize_timeout.go
+++ b/pkg/dotc1z/finalize_timeout.go
@@ -19,14 +19,7 @@ const DefaultFinalizeTimeout = 1 * time.Hour
 var finalizeTimeout = parseFinalizeTimeout(os.Getenv("BATON_C1Z_FINALIZE_TIMEOUT"))
 
 func parseFinalizeTimeout(v string) time.Duration {
-	if v == "" {
-		return DefaultFinalizeTimeout
-	}
-	secs, err := strconv.ParseInt(v, 10, 64)
-	if err != nil || secs <= 0 {
-		return DefaultFinalizeTimeout
-	}
-	return time.Duration(secs) * time.Second
+	return parseTimeoutSeconds(v, DefaultFinalizeTimeout)
 }
 
 // FinalizeTimeout returns the bound for the detached context that wraps
@@ -45,10 +38,13 @@ const DefaultBulkLoadIndexTimeout = 6 * time.Hour
 
 // bulkLoadIndexTimeout is resolved once from BATON_C1Z_BULKLOAD_INDEX_TIMEOUT
 // (seconds), falling back to the default when unset or invalid.
-var bulkLoadIndexTimeout = parseFinalizeTimeoutWithDefault(
+var bulkLoadIndexTimeout = parseTimeoutSeconds(
 	os.Getenv("BATON_C1Z_BULKLOAD_INDEX_TIMEOUT"), DefaultBulkLoadIndexTimeout)
 
-func parseFinalizeTimeoutWithDefault(v string, def time.Duration) time.Duration {
+// parseTimeoutSeconds parses a whole-seconds duration string, returning def
+// when the value is empty, non-numeric, or non-positive. Shared by the
+// finalize and bulk-load-index timeout knobs.
+func parseTimeoutSeconds(v string, def time.Duration) time.Duration {
 	if v == "" {
 		return def
 	}

--- a/pkg/dotc1z/finalize_timeout.go
+++ b/pkg/dotc1z/finalize_timeout.go
@@ -34,3 +34,33 @@ func parseFinalizeTimeout(v string) time.Duration {
 func FinalizeTimeout() time.Duration {
 	return finalizeTimeout
 }
+
+// DefaultBulkLoadIndexTimeout bounds the detached context for the bulk-load
+// deferred-index rebuild at Close. Building several secondary indexes over a
+// 50M+-row grants table is tens of minutes — much longer than the
+// checkpoint+save FinalizeTimeout covers — so this gets its own generous
+// ceiling. Six hours is a backstop against a wedged build, not an expected
+// duration.
+const DefaultBulkLoadIndexTimeout = 6 * time.Hour
+
+// bulkLoadIndexTimeout is resolved once from BATON_C1Z_BULKLOAD_INDEX_TIMEOUT
+// (seconds), falling back to the default when unset or invalid.
+var bulkLoadIndexTimeout = parseFinalizeTimeoutWithDefault(
+	os.Getenv("BATON_C1Z_BULKLOAD_INDEX_TIMEOUT"), DefaultBulkLoadIndexTimeout)
+
+func parseFinalizeTimeoutWithDefault(v string, def time.Duration) time.Duration {
+	if v == "" {
+		return def
+	}
+	secs, err := strconv.ParseInt(v, 10, 64)
+	if err != nil || secs <= 0 {
+		return def
+	}
+	return time.Duration(secs) * time.Second
+}
+
+// BulkLoadIndexTimeout returns the bound for the detached context that wraps
+// the bulk-load deferred-index rebuild.
+func BulkLoadIndexTimeout() time.Duration {
+	return bulkLoadIndexTimeout
+}


### PR DESCRIPTION
## Summary

Dramatic performance work for `c1z` sanitization, plus a correctness fix to the annotation handling. Two layers:

### dotc1z bulk-load write path (`pkg/dotc1z`)
The destination of a sanitize run bulk-loads tens of millions of grants into a freshly-created file. Building all secondary indexes up front means every insert maintains them — and four of the grants indexes are keyed on sanitized (HMAC, i.e. uniformly random) columns, so each insert is a random B-tree page touch whose cost climbs once the table+indexes outgrow the page cache. That is the accelerating, "looks like O(n²)" slowdown.

- New opt-in **bulk-load mode** (`WithBulkLoad` / `WithC1FBulkLoad`), scoped to a net-new single-writer destination:
  - drops the base **non-unique** secondary indexes right after table creation (instant on the empty table), keeping the rowid PK and the `(external_id, sync_id)` unique index the upsert path needs — so the load maintains two B-trees instead of six-plus;
  - rebuilds the deferred indexes in **one pass at `Close`** (before flush) by re-running the canonical `Schema()` DDL, so the final index set is **byte-identical** to the normal path;
  - identifies deferrable indexes generically via `PRAGMA index_list` (`unique=0, origin=c`), captured **before migrations** so partial migration indexes are never disturbed.
- Normal connector syncs don't pass the option and are **unchanged**.
- The sanitize CLI opens its destination with bulk-load + `cache_size=-1048576` (1 GiB), `mmap_size=8 GiB`, `temp_store=MEMORY` (alongside the existing `journal_mode=OFF`/`synchronous=OFF` for the disposable output). All scoped to that writer instance — blast radius is one file.

### c1zsanitize package (`pkg/c1zsanitize`)
- **Correctness — graph annotations preserved, not dropped.** Non-trait grant/entitlement annotations carry the topology that makes a sanitized c1z representative. They are now **preserved-and-sanitized** (fail-closed handlers), not dropped. `AllowUnknownAnnotations` stays `false`. Handler set:
  - `GrantExpandable` — entitlement ids → `transformID`; resource-type tokens follow the known-type rule; `shallow` preserved.
  - `GrantImmutable` / `EntitlementImmutable` — `source_id` → `transformID`; metadata struct string leaves HMAC'd.
  - `ExternalLink` — URL redacted to `https://redacted.example.com`.
  - `ETag` — `entitlement_id` → `transformID`; `value` HMAC'd (fail-closed).
  - `ChildResourceType` — resource-type token follows the known-type rule.
- **Memoize embedded Entitlement/Principal transforms** per sync. Grants are emitted grouped by entitlement, so the cache collapses the expensive per-grant annotation re-derivation to map hits. Cached protos are shared (safe — nothing mutates a message after `.Build()`). Bounded principal cache; off-by-default `proto.Equal` verify guard.
- **Email hot path** through the sanitizer's reused HMAC (not the per-call-keyed reference impl); domain HMAC computed outside the lock.
- **Stop draining asset payloads** that are only discarded (close without read).
- **Skip the timestamp-shift allocation** when the anchor delta is zero.
- **Freeze `knownResourceTypes`** after the resource-types phase so `transformID`'s type-token decision is order-independent (a determinism fix).
- **Permanent per-page `read`/`transform`/`put` timing log** — the regression canary.

## Scoping / blast radius
Bulk-load and the aggressive pragmas are opt-in per writer instance and only wired at the sanitize CLI call site. dotc1z's shared write path for normal connector syncs is untouched.

## Correctness verification
- The deferred-index rebuild re-runs the **same** `Schema()` DDL as the normal path → identical final index set (names, columns, uniqueness).
- New tests: graph-annotation handler coverage (each type preserved + sanitized correctly), annotation determinism, and a **cache-equivalence** test (cached vs uncached transform output identical, shared-pointer reuse on hits). Existing cross-reference / graph-integrity / id-alignment suites still pass.
- `go build ./...`, `go test ./pkg/dotc1z/... ./pkg/c1zsanitize/...`, and `go test -race ./pkg/c1zsanitize/...` all green.

## Benchmark (`BenchmarkTransformGrant`, 5000 grants, G/E=1000)
| | ns/op | allocs/op |
|---|---|---|
| uncached | 29,746,445 | 345,058 |
| cached | 12,105,741 | 144,198 |

~2.46× faster, ~2.4× fewer allocations on the transform stage. The ratio grows with embedded-transform cost at whale scale; full pipeline gains compound with the dotc1z write-path change above.

## Deferred (follow-up)
Per-page parallel transform (fan-out the CPU-bound transform across cores with per-worker HMAC state + sharded caches) is **not** in this PR — it is the highest-risk piece for determinism/races and is additive on top of the memoization here. Best as its own reviewed change. The `knownResourceTypes` freeze in this PR is the prerequisite it needs.

The per-annotation log-dedup (P1-1) is intentionally left to the in-flight log-spam PR to avoid conflicting on `annotations.go`; adding handlers here already removes most unknown-annotation drops for the graph types.

---

_(satellite) Built with stargate._ 🛰