### PR TITLE
feat(sync): add no_grants sync type

### DIFF
--- a/pb/c1/storage/v3/records.pb.go
+++ b/pb/c1/storage/v3/records.pb.go
@@ -45,6 +45,7 @@ const (
 	SyncType_SYNC_TYPE_RESOURCES_ONLY    SyncType = 3
 	SyncType_SYNC_TYPE_PARTIAL_UPSERTS   SyncType = 4
 	SyncType_SYNC_TYPE_PARTIAL_DELETIONS SyncType = 5
+	SyncType_SYNC_TYPE_NO_GRANTS         SyncType = 6
 )
 
 // Enum value maps for SyncType.
@@ -56,6 +57,7 @@ var (
 		3: "SYNC_TYPE_RESOURCES_ONLY",
 		4: "SYNC_TYPE_PARTIAL_UPSERTS",
 		5: "SYNC_TYPE_PARTIAL_DELETIONS",
+		6: "SYNC_TYPE_NO_GRANTS",
 	}
 	SyncType_value = map[string]int32{
 		"SYNC_TYPE_UNSPECIFIED":       0,
@@ -64,6 +66,7 @@ var (
 		"SYNC_TYPE_RESOURCES_ONLY":    3,
 		"SYNC_TYPE_PARTIAL_UPSERTS":   4,
 		"SYNC_TYPE_PARTIAL_DELETIONS": 5,
+		"SYNC_TYPE_NO_GRANTS":         6,
 	}
 )
 
@@ -1712,14 +1715,15 @@ const file_c1_storage_v3_records_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\x03R\x05value:\x028\x01\x1aR\n" +
 	"$GrantsByEntitlementResourceTypeEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\x03R\x05value:\x028\x01*\xae\x01\n" +
+	"\x05value\x18\x02 \x01(\x03R\x05value:\x028\x01*\xc7\x01\n" +
 	"\bSyncType\x12\x19\n" +
 	"\x15SYNC_TYPE_UNSPECIFIED\x10\x00\x12\x12\n" +
 	"\x0eSYNC_TYPE_FULL\x10\x01\x12\x15\n" +
 	"\x11SYNC_TYPE_PARTIAL\x10\x02\x12\x1c\n" +
 	"\x18SYNC_TYPE_RESOURCES_ONLY\x10\x03\x12\x1d\n" +
 	"\x19SYNC_TYPE_PARTIAL_UPSERTS\x10\x04\x12\x1f\n" +
-	"\x1bSYNC_TYPE_PARTIAL_DELETIONS\x10\x05B4Z2github.com/conductorone/baton-sdk/pb/c1/storage/v3b\x06proto3"
+	"\x1bSYNC_TYPE_PARTIAL_DELETIONS\x10\x05\x12\x17\n" +
+	"\x13SYNC_TYPE_NO_GRANTS\x10\x06B4Z2github.com/conductorone/baton-sdk/pb/c1/storage/v3b\x06proto3"
 
 var file_c1_storage_v3_records_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
 var file_c1_storage_v3_records_proto_msgTypes = make([]protoimpl.MessageInfo, 12)

--- a/pb/c1/storage/v3/records_protoopaque.pb.go
+++ b/pb/c1/storage/v3/records_protoopaque.pb.go
@@ -45,6 +45,7 @@ const (
 	SyncType_SYNC_TYPE_RESOURCES_ONLY    SyncType = 3
 	SyncType_SYNC_TYPE_PARTIAL_UPSERTS   SyncType = 4
 	SyncType_SYNC_TYPE_PARTIAL_DELETIONS SyncType = 5
+	SyncType_SYNC_TYPE_NO_GRANTS         SyncType = 6
 )
 
 // Enum value maps for SyncType.
@@ -56,6 +57,7 @@ var (
 		3: "SYNC_TYPE_RESOURCES_ONLY",
 		4: "SYNC_TYPE_PARTIAL_UPSERTS",
 		5: "SYNC_TYPE_PARTIAL_DELETIONS",
+		6: "SYNC_TYPE_NO_GRANTS",
 	}
 	SyncType_value = map[string]int32{
 		"SYNC_TYPE_UNSPECIFIED":       0,
@@ -64,6 +66,7 @@ var (
 		"SYNC_TYPE_RESOURCES_ONLY":    3,
 		"SYNC_TYPE_PARTIAL_UPSERTS":   4,
 		"SYNC_TYPE_PARTIAL_DELETIONS": 5,
+		"SYNC_TYPE_NO_GRANTS":         6,
 	}
 )
 
@@ -1682,14 +1685,15 @@ const file_c1_storage_v3_records_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\x03R\x05value:\x028\x01\x1aR\n" +
 	"$GrantsByEntitlementResourceTypeEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\x03R\x05value:\x028\x01*\xae\x01\n" +
+	"\x05value\x18\x02 \x01(\x03R\x05value:\x028\x01*\xc7\x01\n" +
 	"\bSyncType\x12\x19\n" +
 	"\x15SYNC_TYPE_UNSPECIFIED\x10\x00\x12\x12\n" +
 	"\x0eSYNC_TYPE_FULL\x10\x01\x12\x15\n" +
 	"\x11SYNC_TYPE_PARTIAL\x10\x02\x12\x1c\n" +
 	"\x18SYNC_TYPE_RESOURCES_ONLY\x10\x03\x12\x1d\n" +
 	"\x19SYNC_TYPE_PARTIAL_UPSERTS\x10\x04\x12\x1f\n" +
-	"\x1bSYNC_TYPE_PARTIAL_DELETIONS\x10\x05B4Z2github.com/conductorone/baton-sdk/pb/c1/storage/v3b\x06proto3"
+	"\x1bSYNC_TYPE_PARTIAL_DELETIONS\x10\x05\x12\x17\n" +
+	"\x13SYNC_TYPE_NO_GRANTS\x10\x06B4Z2github.com/conductorone/baton-sdk/pb/c1/storage/v3b\x06proto3"
 
 var file_c1_storage_v3_records_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
 var file_c1_storage_v3_records_proto_msgTypes = make([]protoimpl.MessageInfo, 12)

--- a/pkg/connectorstore/connectorstore.go
+++ b/pkg/connectorstore/connectorstore.go
@@ -14,6 +14,7 @@ const (
 	SyncTypeFull             SyncType = "full"
 	SyncTypePartial          SyncType = "partial"
 	SyncTypeResourcesOnly    SyncType = "resources_only"
+	SyncTypeNoGrants         SyncType = "no_grants"         // everything but grants
 	SyncTypePartialUpserts   SyncType = "partial_upserts"   // Diff sync: additions and modifications
 	SyncTypePartialDeletions SyncType = "partial_deletions" // Diff sync: deletions
 	SyncTypeAny              SyncType = ""
@@ -24,6 +25,7 @@ var AllSyncTypes = []SyncType{
 	SyncTypeFull,
 	SyncTypePartial,
 	SyncTypeResourcesOnly,
+	SyncTypeNoGrants,
 	SyncTypePartialUpserts,
 	SyncTypePartialDeletions,
 }

--- a/pkg/dotc1z/c1file_attached.go
+++ b/pkg/dotc1z/c1file_attached.go
@@ -150,6 +150,8 @@ func unionSyncTypes(a, b connectorstore.SyncType) connectorstore.SyncType {
 	switch {
 	case a == connectorstore.SyncTypeFull || b == connectorstore.SyncTypeFull:
 		return connectorstore.SyncTypeFull
+	case a == connectorstore.SyncTypeNoGrants || b == connectorstore.SyncTypeNoGrants:
+		return connectorstore.SyncTypeNoGrants
 	case a == connectorstore.SyncTypeResourcesOnly || b == connectorstore.SyncTypeResourcesOnly:
 		return connectorstore.SyncTypeResourcesOnly
 	default:

--- a/pkg/dotc1z/cleanup_policy.go
+++ b/pkg/dotc1z/cleanup_policy.go
@@ -51,7 +51,7 @@ func SelectSyncsToDelete(candidates []SyncRun, currentSyncID string, syncLimit i
 			continue
 		}
 		switch sr.Type {
-		case connectorstore.SyncTypePartial, connectorstore.SyncTypeResourcesOnly:
+		case connectorstore.SyncTypePartial, connectorstore.SyncTypeResourcesOnly, connectorstore.SyncTypeNoGrants:
 			partials = append(partials, sr)
 		case connectorstore.SyncTypePartialUpserts, connectorstore.SyncTypePartialDeletions:
 			diffSyncs = append(diffSyncs, sr)

--- a/pkg/dotc1z/engine/pebble/adapter.go
+++ b/pkg/dotc1z/engine/pebble/adapter.go
@@ -888,6 +888,8 @@ func v2SyncTypeToV3(t connectorstore.SyncType) v3.SyncType {
 		return v3.SyncType_SYNC_TYPE_PARTIAL_UPSERTS
 	case connectorstore.SyncTypePartialDeletions:
 		return v3.SyncType_SYNC_TYPE_PARTIAL_DELETIONS
+	case connectorstore.SyncTypeNoGrants:
+		return v3.SyncType_SYNC_TYPE_NO_GRANTS
 	default:
 		return v3.SyncType_SYNC_TYPE_UNSPECIFIED
 	}

--- a/pkg/dotc1z/engine/pebble/adapter_reader.go
+++ b/pkg/dotc1z/engine/pebble/adapter_reader.go
@@ -510,6 +510,8 @@ func v3SyncTypeToString(t v3.SyncType) string {
 		return string(connectorstore.SyncTypePartialUpserts)
 	case v3.SyncType_SYNC_TYPE_PARTIAL_DELETIONS:
 		return string(connectorstore.SyncTypePartialDeletions)
+	case v3.SyncType_SYNC_TYPE_NO_GRANTS:
+		return string(connectorstore.SyncTypeNoGrants)
 	case v3.SyncType_SYNC_TYPE_UNSPECIFIED:
 		return ""
 	}

--- a/pkg/dotc1z/engine/pebble/adapter_sync_meta.go
+++ b/pkg/dotc1z/engine/pebble/adapter_sync_meta.go
@@ -125,6 +125,8 @@ func syncTypeV3ToConnectorstore(t v3.SyncType) connectorstore.SyncType {
 		return connectorstore.SyncTypePartialUpserts
 	case v3.SyncType_SYNC_TYPE_PARTIAL_DELETIONS:
 		return connectorstore.SyncTypePartialDeletions
+	case v3.SyncType_SYNC_TYPE_NO_GRANTS:
+		return connectorstore.SyncTypeNoGrants
 	default:
 		return ""
 	}

--- a/pkg/dotc1z/engine/pebble/sync_type_no_grants_test.go
+++ b/pkg/dotc1z/engine/pebble/sync_type_no_grants_test.go
@@ -1,0 +1,22 @@
+package pebble
+
+import (
+	"testing"
+
+	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+)
+
+// no_grants must survive the v2 -> v3 -> v2 round-trip, not collapse to unspecified.
+func TestNoGrantsV3RoundTrip(t *testing.T) {
+	enum := v2SyncTypeToV3(connectorstore.SyncTypeNoGrants)
+	if enum != v3.SyncType_SYNC_TYPE_NO_GRANTS {
+		t.Fatalf("v2SyncTypeToV3: got %v, want SYNC_TYPE_NO_GRANTS", enum)
+	}
+	if got := syncTypeV3ToConnectorstore(enum); got != connectorstore.SyncTypeNoGrants {
+		t.Errorf("syncTypeV3ToConnectorstore: got %q, want no_grants", got)
+	}
+	if got := v3SyncTypeToString(enum); got != string(connectorstore.SyncTypeNoGrants) {
+		t.Errorf("v3SyncTypeToString: got %q, want no_grants", got)
+	}
+}

--- a/pkg/dotc1z/no_grants_test.go
+++ b/pkg/dotc1z/no_grants_test.go
@@ -1,0 +1,53 @@
+package dotc1z
+
+import (
+	"testing"
+
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+)
+
+// ranking is full > no_grants > resources_only > partial
+func TestUnionSyncTypes(t *testing.T) {
+	full := connectorstore.SyncTypeFull
+	ng := connectorstore.SyncTypeNoGrants
+	ro := connectorstore.SyncTypeResourcesOnly
+	partial := connectorstore.SyncTypePartial
+
+	tests := []struct {
+		name string
+		a, b connectorstore.SyncType
+		want connectorstore.SyncType
+	}{
+		{"full beats no_grants", full, ng, full},
+		{"no_grants beats resources_only", ng, ro, ng},
+		{"no_grants beats partial", ng, partial, ng},
+		{"no_grants with no_grants", ng, ng, ng},
+		{"resources_only beats partial (unchanged)", ro, partial, ro},
+		{"partial with partial (unchanged)", partial, partial, partial},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := unionSyncTypes(tt.a, tt.b); got != tt.want {
+				t.Errorf("unionSyncTypes(%q, %q) = %q, want %q", tt.a, tt.b, got, tt.want)
+			}
+			// Union must be order-independent.
+			if got := unionSyncTypes(tt.b, tt.a); got != tt.want {
+				t.Errorf("unionSyncTypes(%q, %q) [swapped] = %q, want %q", tt.b, tt.a, got, tt.want)
+			}
+		})
+	}
+}
+
+// no_grants should prune like a partial, not stick around like a full sync
+func TestSelectSyncsToDelete_NoGrantsIsPartial(t *testing.T) {
+	cands := []SyncRun{
+		makeCandidate("f1", connectorstore.SyncTypeFull, 0, true),
+		makeCandidate("ng_old", connectorstore.SyncTypeNoGrants, 5, true),
+		makeCandidate("f2", connectorstore.SyncTypeFull, 10, true),
+		makeCandidate("ng_recent", connectorstore.SyncTypeNoGrants, 15, true),
+		makeCandidate("f3", connectorstore.SyncTypeFull, 20, true),
+	}
+	// limit 2 drops f1; kept full sync is f2 (t=10), so ng_old goes, ng_recent stays
+	got := SelectSyncsToDelete(cands, "", 2)
+	assertDeletes(t, got, []string{"f1", "ng_old"})
+}

--- a/pkg/dotc1z/no_grants_test.go
+++ b/pkg/dotc1z/no_grants_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
 )
 
-// ranking is full > no_grants > resources_only > partial
+// ranking is full > no_grants > resources_only > partial.
 func TestUnionSyncTypes(t *testing.T) {
 	full := connectorstore.SyncTypeFull
 	ng := connectorstore.SyncTypeNoGrants
@@ -38,7 +38,7 @@ func TestUnionSyncTypes(t *testing.T) {
 	}
 }
 
-// no_grants should prune like a partial, not stick around like a full sync
+// no_grants should prune like a partial, not stick around like a full sync.
 func TestSelectSyncsToDelete_NoGrantsIsPartial(t *testing.T) {
 	cands := []SyncRun{
 		makeCandidate("f1", connectorstore.SyncTypeFull, 0, true),

--- a/pkg/dotc1z/start_no_grants_test.go
+++ b/pkg/dotc1z/start_no_grants_test.go
@@ -1,0 +1,34 @@
+package dotc1z_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	"github.com/stretchr/testify/require"
+)
+
+// no_grants is a top-level snapshot like full: no parent allowed
+func TestStartNewSyncNoGrants(t *testing.T) {
+	ctx := t.Context()
+
+	t.Run("parent-less succeeds", func(t *testing.T) {
+		f, err := dotc1z.NewC1ZFile(ctx, filepath.Join(t.TempDir(), "test.c1z"))
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = f.Close(ctx) })
+
+		syncID, err := f.StartNewSync(ctx, connectorstore.SyncTypeNoGrants, "")
+		require.NoError(t, err)
+		require.NotEmpty(t, syncID)
+	})
+
+	t.Run("rejects a parent sync id", func(t *testing.T) {
+		f, err := dotc1z.NewC1ZFile(ctx, filepath.Join(t.TempDir(), "test.c1z"))
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = f.Close(ctx) })
+
+		_, err = f.StartNewSync(ctx, connectorstore.SyncTypeNoGrants, "some-parent")
+		require.Error(t, err)
+	})
+}

--- a/pkg/dotc1z/start_no_grants_test.go
+++ b/pkg/dotc1z/start_no_grants_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// no_grants is a top-level snapshot like full: no parent allowed
+// no_grants is a top-level snapshot like full: no parent allowed.
 func TestStartNewSyncNoGrants(t *testing.T) {
 	ctx := t.Context()
 

--- a/pkg/dotc1z/sync_runs.go
+++ b/pkg/dotc1z/sync_runs.go
@@ -635,6 +635,10 @@ func (c *C1File) StartNewSync(ctx context.Context, syncType connectorstore.SyncT
 		if parentSyncID != "" {
 			return "", status.Errorf(codes.InvalidArgument, "parent sync id must be empty for resources only sync")
 		}
+	case connectorstore.SyncTypeNoGrants:
+		if parentSyncID != "" {
+			return "", status.Errorf(codes.InvalidArgument, "parent sync id must be empty for no grants sync")
+		}
 	case connectorstore.SyncTypePartial:
 	case connectorstore.SyncTypePartialUpserts, connectorstore.SyncTypePartialDeletions:
 		// Diff syncs carry the base sync as their parent; the linked

--- a/pkg/synccompactor/attached/attached.go
+++ b/pkg/synccompactor/attached/attached.go
@@ -44,6 +44,7 @@ func latestFinishedCompactableSync(ctx context.Context, f *dotc1z.C1File) (*read
 	// We want the latest finished "snapshot-like" sync.
 	candidates := []connectorstore.SyncType{
 		connectorstore.SyncTypeFull,
+		connectorstore.SyncTypeNoGrants,
 		connectorstore.SyncTypeResourcesOnly,
 		connectorstore.SyncTypePartial,
 	}

--- a/proto/c1/storage/v3/records.proto
+++ b/proto/c1/storage/v3/records.proto
@@ -28,6 +28,7 @@ enum SyncType {
   SYNC_TYPE_RESOURCES_ONLY = 3;
   SYNC_TYPE_PARTIAL_UPSERTS = 4;
   SYNC_TYPE_PARTIAL_DELETIONS = 5;
+  SYNC_TYPE_NO_GRANTS = 6;
 }
 
 // GrantExpandableRecord mirrors c1.connector.v2.GrantExpandable.


### PR DESCRIPTION
New `no_grants` sync type, a full snapshot that skips grants, so we can run a fast grant-free sweep instead of a full sync.

`WithSkipGrants` already existed, this just makes the type first class so it's tracked through the c1z lifecycle (start, union, compaction base, cleanup)

PS: Grants handled only on Full sync path. `no_grants` sync helps us get the non-grants stuff at incremental sync speed.