### PR TITLE
perf(c1zsanitize): parallel per-page transform + resumable sanitization

### DIFF
--- a/pkg/c1zsanitize/annotations.go
+++ b/pkg/c1zsanitize/annotations.go
@@ -72,28 +72,25 @@ func (s *sanitizer) transformAnnotations(in []*anypb.Any, refs *assetRefSet) []*
 			// could leak un-sanitized customer data. Pass-through is opt-in
 			// via Options.AllowUnknownAnnotations, for development only.
 			if s.dropUnknownAnnotations {
-				if s.droppedAnnotations[a.GetTypeUrl()] == 0 {
+				if s.recordAnnotation(s.droppedAnnotations, a.GetTypeUrl()) {
 					s.log.Warn("c1zsanitize: dropping unknown annotation type (first occurrence; counted thereafter)",
 						zap.String("type_url", a.GetTypeUrl()))
 				}
-				s.droppedAnnotations[a.GetTypeUrl()]++
 				continue
 			}
-			if s.passedAnnotations[a.GetTypeUrl()] == 0 {
+			if s.recordAnnotation(s.passedAnnotations, a.GetTypeUrl()) {
 				s.log.Warn("c1zsanitize: passing unknown annotation through unchanged (first occurrence; counted thereafter)",
 					zap.String("type_url", a.GetTypeUrl()))
 			}
-			s.passedAnnotations[a.GetTypeUrl()]++
 			out = append(out, a)
 			continue
 		}
 		msg, err := a.UnmarshalNew()
 		if err != nil {
-			if s.failedAnnotations[a.GetTypeUrl()] == 0 {
+			if s.recordAnnotation(s.failedAnnotations, a.GetTypeUrl()) {
 				s.log.Warn("c1zsanitize: annotation transform failed (first occurrence; counted thereafter)",
 					zap.String("type_url", a.GetTypeUrl()), zap.Error(err))
 			}
-			s.failedAnnotations[a.GetTypeUrl()]++
 			continue
 		}
 		sanitized := handler(s, msg, refs)
@@ -102,11 +99,10 @@ func (s *sanitizer) transformAnnotations(in []*anypb.Any, refs *assetRefSet) []*
 		}
 		repacked, err := anypb.New(sanitized)
 		if err != nil {
-			if s.failedAnnotations[a.GetTypeUrl()] == 0 {
+			if s.recordAnnotation(s.failedAnnotations, a.GetTypeUrl()) {
 				s.log.Warn("c1zsanitize: annotation transform failed (first occurrence; counted thereafter)",
 					zap.String("type_url", a.GetTypeUrl()), zap.Error(err))
 			}
-			s.failedAnnotations[a.GetTypeUrl()]++
 			continue
 		}
 		out = append(out, repacked)

--- a/pkg/c1zsanitize/parallel_checkpoint_test.go
+++ b/pkg/c1zsanitize/parallel_checkpoint_test.go
@@ -1,0 +1,214 @@
+package c1zsanitize
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+)
+
+var fixedAnchor = time.Date(2025, 1, 2, 3, 4, 5, 0, time.UTC)
+
+// anyTB packs a proto into an Any, failing the test/benchmark on error.
+func anyTB(tb testing.TB, m proto.Message) *anypb.Any {
+	a, err := anypb.New(m)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	return a
+}
+
+// buildSyncFixture writes a c1z with nSyncs independent syncs, each carrying a
+// couple resource types, resources (with trait annotations), entitlements, and
+// grants embedding a full entitlement + principal. Enough shape to exercise
+// every copy* phase and the per-page transform fan-out.
+func buildSyncFixture(t testing.TB, ctx context.Context, path string, nSyncs, grantsPerSync int) {
+	f, err := dotc1z.NewC1ZFile(ctx, path)
+	require.NoError(t, err)
+	for sIdx := 0; sIdx < nSyncs; sIdx++ {
+		_, err := f.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+		require.NoError(t, err)
+		p := fmt.Sprintf("s%d-", sIdx)
+
+		require.NoError(t, f.PutResourceTypes(ctx,
+			v2.ResourceType_builder{Id: "user", DisplayName: "User", Traits: []v2.ResourceType_Trait{v2.ResourceType_TRAIT_USER}}.Build(),
+			v2.ResourceType_builder{Id: "role", DisplayName: "Role", Traits: []v2.ResourceType_Trait{v2.ResourceType_TRAIT_ROLE}}.Build(),
+		))
+
+		var resources []*v2.Resource
+		for i := 0; i < grantsPerSync; i++ {
+			resources = append(resources, v2.Resource_builder{
+				Id:          v2.ResourceId_builder{ResourceType: "user", Resource: fmt.Sprintf("%su%d", p, i)}.Build(),
+				DisplayName: fmt.Sprintf("User %d", i),
+				Annotations: []*anypb.Any{anyTB(t, v2.UserTrait_builder{
+					Login:  fmt.Sprintf("user%d@acme.com", i),
+					Emails: []*v2.UserTrait_Email{v2.UserTrait_Email_builder{Address: fmt.Sprintf("user%d@acme.com", i), IsPrimary: true}.Build()},
+				}.Build())},
+			}.Build())
+		}
+		role := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "role", Resource: p + "admin"}.Build(), DisplayName: "Admin"}.Build()
+		resources = append(resources, role)
+		require.NoError(t, f.PutResources(ctx, resources...))
+
+		ent := v2.Entitlement_builder{Id: p + "ent-admin", Resource: role, DisplayName: "admin", Slug: "admin"}.Build()
+		require.NoError(t, f.PutEntitlements(ctx, ent))
+
+		var grants []*v2.Grant
+		for i := 0; i < grantsPerSync; i++ {
+			principal := resources[i]
+			grants = append(grants, v2.Grant_builder{
+				Id:          fmt.Sprintf("%sgrant-%d", p, i),
+				Entitlement: ent,
+				Principal:   principal,
+				Annotations: []*anypb.Any{anyTB(t, v2.ETag_builder{Value: fmt.Sprintf("etag-%d", i), EntitlementId: p + "ent-admin"}.Build())},
+			}.Build())
+		}
+		require.NoError(t, f.PutGrants(ctx, grants...))
+		require.NoError(t, f.EndSync(ctx))
+	}
+	require.NoError(t, f.Close(ctx))
+}
+
+func sanitizeToFile(t *testing.T, ctx context.Context, srcPath, dstPath string, secret []byte, opts Options) {
+	src := mustOpen(t, ctx, srcPath, true)
+	defer src.Close(ctx)
+	dst := mustOpen(t, ctx, dstPath, false)
+	opts.Secret = secret
+	opts.TimestampAnchor = fixedAnchor
+	require.NoError(t, Sanitize(ctx, src, dst, opts))
+	require.NoError(t, dst.Close(ctx))
+}
+
+// TestSanitizeParallelMultiSync exercises the per-page transform fan-out across
+// a multi-sync fixture. Run under -race, it is the concurrency guard for the
+// parallel transform stage; it also confirms output is correct (record counts
+// preserved) under fan-out.
+func TestSanitizeParallelMultiSync(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	srcPath := filepath.Join(tmp, "src.c1z")
+	dstPath := filepath.Join(tmp, "dst.c1z")
+	buildSyncFixture(t, ctx, srcPath, 2, 50)
+
+	sanitizeToFile(t, ctx, srcPath, dstPath, bytes32("parallel-multisync"), Options{})
+
+	srcRO := mustOpen(t, ctx, srcPath, true)
+	defer srcRO.Close(ctx)
+	dstRO := mustOpen(t, ctx, dstPath, true)
+	defer dstRO.Close(ctx)
+	srcRec := collectRecords(t, ctx, srcRO)
+	dstRec := collectRecords(t, ctx, dstRO)
+	require.Equal(t, len(srcRec.grants), len(dstRec.grants), "grant count preserved across fan-out")
+	require.Equal(t, len(srcRec.resources), len(dstRec.resources))
+	require.Equal(t, len(srcRec.entitlements), len(dstRec.entitlements))
+	require.NotZero(t, len(dstRec.grants))
+}
+
+// interruptingWriter wraps a real C1File and fails the Nth PutGrants call,
+// simulating a process kill at the start of the grant phase. Embedding the
+// concrete *C1File promotes every method (including the optional sync-link /
+// supports-diff capabilities) so Sanitize behaves as against a real writer.
+type interruptingWriter struct {
+	*dotc1z.C1File
+	failOnPutGrantsCall int
+	putGrantsCalls      int
+}
+
+func (w *interruptingWriter) PutGrants(ctx context.Context, grants ...*v2.Grant) error {
+	w.putGrantsCalls++
+	if w.putGrantsCalls >= w.failOnPutGrantsCall {
+		return errors.New("simulated interruption")
+	}
+	return w.C1File.PutGrants(ctx, grants...)
+}
+
+// TestSanitizeCheckpointResume interrupts a resumable run at the grant phase,
+// persists the partial destination, then resumes — and asserts the resumed
+// output is record-identical to an uninterrupted run with the same secret and
+// anchor.
+func TestSanitizeCheckpointResume(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	srcPath := filepath.Join(tmp, "src.c1z")
+	cleanDst := filepath.Join(tmp, "clean.c1z")
+	resumeDst := filepath.Join(tmp, "resume.c1z")
+	secret := bytes32("checkpoint-resume")
+	buildSyncFixture(t, ctx, srcPath, 1, 40)
+
+	// Reference: a single uninterrupted resumable run.
+	sanitizeToFile(t, ctx, srcPath, cleanDst, secret, Options{Resumable: true})
+
+	// Interrupted run: fail on the first PutGrants (resources + entitlements
+	// were written and checkpointed; grants did not start).
+	func() {
+		src := mustOpen(t, ctx, srcPath, true)
+		defer src.Close(ctx)
+		w := &interruptingWriter{C1File: mustOpen(t, ctx, resumeDst, false), failOnPutGrantsCall: 1}
+		err := Sanitize(ctx, src, w, Options{Secret: secret, TimestampAnchor: fixedAnchor, Resumable: true})
+		require.Error(t, err, "run must be interrupted at the grant phase")
+		require.NoError(t, w.Close(ctx)) // persist the partial destination
+	}()
+
+	// Resume into the persisted partial destination.
+	func() {
+		src := mustOpen(t, ctx, srcPath, true)
+		defer src.Close(ctx)
+		dst := mustOpen(t, ctx, resumeDst, false)
+		require.NoError(t, Sanitize(ctx, src, dst, Options{Secret: secret, TimestampAnchor: fixedAnchor, Resumable: true}))
+		require.NoError(t, dst.Close(ctx))
+	}()
+
+	cleanRO := mustOpen(t, ctx, cleanDst, true)
+	defer cleanRO.Close(ctx)
+	resumeRO := mustOpen(t, ctx, resumeDst, true)
+	defer resumeRO.Close(ctx)
+	clean := collectRecords(t, ctx, cleanRO)
+	resumed := collectRecords(t, ctx, resumeRO)
+
+	require.NotZero(t, len(clean.grants))
+	require.Equal(t, len(clean.grants), len(resumed.grants), "resumed grant count must match the uninterrupted run")
+	require.Equal(t, len(clean.resources), len(resumed.resources))
+	require.Equal(t, len(clean.entitlements), len(resumed.entitlements))
+	require.Equal(t, clean.idOccurrences, resumed.idOccurrences, "resumed output must be record-identical to the uninterrupted run")
+}
+
+// BenchmarkSanitize tracks end-to-end sanitize throughput. genGrants is the
+// tracked size knob; the headline number is G=1_000_000 (raise genGrants for a
+// real measurement — kept modest here so the benchmark is runnable in CI).
+func BenchmarkSanitize(b *testing.B) {
+	const genGrants = 2000
+	ctx := context.Background()
+	tmp := b.TempDir()
+	srcPath := filepath.Join(tmp, "bench-src.c1z")
+	buildSyncFixture(b, ctx, srcPath, 1, genGrants)
+	secret := bytes32("bench-sanitize")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		dstPath := filepath.Join(tmp, fmt.Sprintf("bench-dst-%d.c1z", i))
+		src, err := dotc1z.NewC1ZFile(ctx, srcPath, dotc1z.WithReadOnly(true))
+		if err != nil {
+			b.Fatal(err)
+		}
+		dst, err := dotc1z.NewC1ZFile(ctx, dstPath)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if err := Sanitize(ctx, src, dst, Options{Secret: secret, TimestampAnchor: fixedAnchor}); err != nil {
+			b.Fatal(err)
+		}
+		_ = dst.Close(ctx)
+		_ = src.Close(ctx)
+	}
+}

--- a/pkg/c1zsanitize/perf_test.go
+++ b/pkg/c1zsanitize/perf_test.go
@@ -1,8 +1,6 @@
 package c1zsanitize
 
 import (
-	"crypto/hmac"
-	"crypto/sha256"
 	"strconv"
 	"testing"
 	"time"
@@ -30,7 +28,7 @@ func mustAnyB(m proto.Message) *anypb.Any {
 func newTestSanitizer(secret []byte) *sanitizer {
 	return &sanitizer{
 		secret:                 secret,
-		idHmac:                 hmac.New(sha256.New, secret),
+		hmacPool:               newHMACPool(secret),
 		domains:                newDomainMap(),
 		shifter:                newTimestampShifter(time.Time{}, time.Time{}),
 		dropUnknownAnnotations: true,

--- a/pkg/c1zsanitize/sanitize.go
+++ b/pkg/c1zsanitize/sanitize.go
@@ -18,9 +18,11 @@ import (
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"hash"
+	"sync"
 	"time"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
@@ -87,6 +89,18 @@ type Options struct {
 	// It catches a source that violates the one-object-per-id assumption the
 	// cache relies on. Adds CPU; intended for diagnostics, not production runs.
 	VerifyGrantCache bool
+
+	// Resumable enables checkpointing so an interrupted run continues instead
+	// of restarting. Progress is recorded in each destination sync's
+	// sync_token (a fingerprint of Secret+TimestampAnchor, the source sync id,
+	// the next phase, and the grant page token). On a later run against the
+	// SAME destination file, completed phases are skipped and the grant phase
+	// resumes from its last committed page. A destination carrying checkpoints
+	// from a different Secret/TimestampAnchor is rejected (fail-closed: never
+	// mix transforms from two secrets). The destination's durability between
+	// runs is the caller's responsibility (Sanitize does not own the file
+	// lifecycle); resume only finds progress that a prior run persisted to disk.
+	Resumable bool
 }
 
 // Sanitize copies records from src to dst, transforming identifiers,
@@ -117,7 +131,7 @@ func Sanitize(ctx context.Context, src connectorstore.Reader, dst connectorstore
 
 	s := &sanitizer{
 		secret:                 opts.Secret,
-		idHmac:                 hmac.New(sha256.New, opts.Secret),
+		hmacPool:               newHMACPool(opts.Secret),
 		domains:                newDomainMap(),
 		shifter:                newTimestampShifter(anchor, findTMax(srcSyncs)),
 		dropUnknownAnnotations: !opts.AllowUnknownAnnotations,
@@ -130,7 +144,9 @@ func Sanitize(ctx context.Context, src connectorstore.Reader, dst connectorstore
 		droppedAnnotations:     map[string]uint64{},
 		passedAnnotations:      map[string]uint64{},
 		failedAnnotations:      map[string]uint64{},
+		resumable:              opts.Resumable,
 	}
+	s.fingerprint = s.checkpointFingerprint(anchor)
 
 	// One structured summary line per run instead of a log line per dropped
 	// annotation / missing asset (which fired tens of millions of times on
@@ -138,8 +154,26 @@ func Sanitize(ctx context.Context, src connectorstore.Reader, dst connectorstore
 	// an error or panic exit — an aborted run's telemetry is valid and wanted.
 	defer s.logDropSummary()
 
+	// When resuming, read whatever progress a prior run committed to the
+	// destination. A destination carrying checkpoints under a different secret
+	// or anchor is rejected here — never mix transforms from two secrets.
+	resume := map[string]*resumeState{}
+	if s.resumable {
+		resume, err = s.loadResumeStates(ctx, dst)
+		if err != nil {
+			return fmt.Errorf("c1zsanitize: load checkpoint: %w", err)
+		}
+	}
+
 	for _, sr := range srcSyncs {
-		if err := s.sanitizeSync(ctx, src, dst, sr); err != nil {
+		rs := resume[sr.GetId()]
+		if rs != nil && rs.ended {
+			// This source sync was fully copied in a prior run; keep its dst
+			// sync id for parent linkage and graph-metadata, skip the work.
+			s.syncIDMap[sr.GetId()] = rs.dstSyncID
+			continue
+		}
+		if err := s.sanitizeSync(ctx, src, dst, sr, rs); err != nil {
 			return fmt.Errorf("c1zsanitize: sanitize sync %s: %w", sr.GetId(), err)
 		}
 	}
@@ -154,7 +188,7 @@ func Sanitize(ctx context.Context, src connectorstore.Reader, dst connectorstore
 
 type sanitizer struct {
 	secret                 []byte
-	idHmac                 hash.Hash
+	hmacPool               *sync.Pool
 	domains                *domainMap
 	shifter                *timestampShifter
 	dropUnknownAnnotations bool
@@ -173,6 +207,13 @@ type sanitizer struct {
 	// each such token is logged at most once per run.
 	warnedUndeclaredTypes map[string]struct{}
 
+	// statsMu guards the per-run counter maps, warnedUndeclaredTypes, and
+	// missingAssets. The transform stage fans out across workers, so these
+	// otherwise-tiny bookkeeping updates need a lock; the critical sections are
+	// map increments and a once-per-key first-occurrence-log decision, so
+	// contention is negligible relative to the HMAC/proto work outside it.
+	statsMu sync.Mutex
+
 	// Per-run annotation/asset drop counters. transformAnnotations and
 	// copyAssets increment these instead of logging per item; logDropSummary
 	// emits a single structured line at the end of the run. droppedAnnotations
@@ -188,6 +229,121 @@ type sanitizer struct {
 	// is deferred, so it also fires on an error/panic exit; run_completed lets
 	// a reader tell a full run from a partial one (partial counts are valid).
 	completed bool
+
+	// resumable enables checkpointing; fingerprint binds a checkpoint to this
+	// run's (secret, anchor) so a destination written under a different secret
+	// or anchor is never resumed into. See Options.Resumable.
+	resumable   bool
+	fingerprint string
+}
+
+// Checkpoint phases recorded in a destination sync's token. The value names
+// the NEXT phase to run, so resume skips everything before it. resource_types
+// always re-runs (it is cheap and repopulates the known-type set the id
+// transform needs), so it is not a checkpoint phase.
+const (
+	phaseResources    = "resources"
+	phaseEntitlements = "entitlements"
+	phaseGrants       = "grants"
+)
+
+// resumeState is the decoded checkpoint for one source sync's destination sync.
+type resumeState struct {
+	dstSyncID      string
+	ended          bool   // dst sync was EndSync'd in a prior run → fully done
+	phase          string // next phase to run
+	grantPageToken string // resume point within the grant phase
+}
+
+// checkpointToken is the JSON payload stored in a destination sync's
+// sync_token. Fingerprint binds it to (secret, anchor); SrcSyncID correlates
+// the destination sync back to its source.
+type checkpointToken struct {
+	Fingerprint string `json:"fp"`
+	SrcSyncID   string `json:"src"`
+	Phase       string `json:"phase"`
+	GrantPage   string `json:"gpt,omitempty"`
+}
+
+// checkpointFingerprint derives a non-reversible binding of (secret, anchor).
+// It never stores the secret; a different secret or anchor yields a different
+// fingerprint, so loadResumeStates rejects a mismatched destination.
+func (s *sanitizer) checkpointFingerprint(anchor time.Time) string {
+	h := s.hmacPool.Get().(hash.Hash)
+	h.Reset()
+	_, _ = h.Write([]byte("c1zsanitize-ckpt-v1\x00" + anchor.UTC().Format(time.RFC3339Nano)))
+	sum := h.Sum(nil)
+	s.hmacPool.Put(h)
+	return idEncoding.EncodeToString(sum)
+}
+
+// checkpoint records progress on the current destination sync. No-op unless
+// resumable. phase names the next phase to run; gpt is the grant page to
+// resume from (only meaningful for phaseGrants).
+func (s *sanitizer) checkpoint(ctx context.Context, dst connectorstore.Writer, srcSyncID, phase, gpt string) error {
+	if !s.resumable {
+		return nil
+	}
+	tok, err := json.Marshal(checkpointToken{Fingerprint: s.fingerprint, SrcSyncID: srcSyncID, Phase: phase, GrantPage: gpt})
+	if err != nil {
+		return err
+	}
+	return dst.CheckpointSync(ctx, string(tok))
+}
+
+// loadResumeStates scans the destination's existing syncs for checkpoint
+// tokens written by a prior resumable run. A token whose fingerprint matches
+// this run yields a resumeState; a token whose fingerprint does NOT match
+// means the destination holds output from a different secret/anchor, which is
+// rejected (fail-closed). Destinations with no tokens (fresh, or written by a
+// non-resumable run) yield an empty map and a clean full run.
+func (s *sanitizer) loadResumeStates(ctx context.Context, dst connectorstore.Writer) (map[string]*resumeState, error) {
+	dstSyncs, err := listAllSyncs(ctx, dst)
+	if err != nil {
+		return nil, err
+	}
+	out := map[string]*resumeState{}
+	for _, ds := range dstSyncs {
+		if err := dst.SetCurrentSync(ctx, ds.GetId()); err != nil {
+			return nil, err
+		}
+		raw, err := dst.CurrentSyncStep(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if raw == "" {
+			continue
+		}
+		var ct checkpointToken
+		if json.Unmarshal([]byte(raw), &ct) != nil {
+			continue // not our token shape; ignore
+		}
+		if ct.Fingerprint == "" {
+			continue
+		}
+		if ct.Fingerprint != s.fingerprint {
+			return nil, fmt.Errorf("destination has a checkpoint for a different secret/anchor; clear the destination before resuming")
+		}
+		out[ct.SrcSyncID] = &resumeState{
+			dstSyncID:      ds.GetId(),
+			ended:          ds.HasEndedAt(),
+			phase:          ct.Phase,
+			grantPageToken: ct.GrantPage,
+		}
+	}
+	return out, nil
+}
+
+// recordAnnotation increments the per-type-URL counter under statsMu (the
+// transform stage is concurrent) and reports whether this was the first
+// occurrence, so the caller can emit a single first-occurrence log line per
+// type URL outside the lock.
+func (s *sanitizer) recordAnnotation(m map[string]uint64, typeURL string) bool {
+	s.statsMu.Lock()
+	first := m[typeURL] == 0
+	m[typeURL]++
+	s.statsMu.Unlock()
+	return first
 }
 
 // logDropSummary emits exactly one structured line per run summarizing the
@@ -204,44 +360,75 @@ func (s *sanitizer) logDropSummary() {
 	)
 }
 
-// id is the per-sanitizer hot path. SanitizeID stays as the
-// allocation-y reference implementation; this one reuses a single
-// hmac.Hash so the SHA-256 key schedule isn't redone every call.
-// Sanitize runs single-threaded, so no locking is needed.
+// id is the per-sanitizer hot path. SanitizeID stays as the allocation-y
+// reference implementation; this one borrows a pre-keyed hmac.Hash from a pool
+// so the SHA-256 key schedule isn't redone every call, and so the transform
+// stage can fan out across workers without sharing hash state. Output depends
+// only on (secret, input): each call Resets a hasher it exclusively owns for
+// the duration, so goroutine scheduling cannot affect the result.
 func (s *sanitizer) id(input string) string {
 	if input == "" {
 		return ""
 	}
-	s.idHmac.Reset()
-	_, _ = s.idHmac.Write([]byte(input))
-	sum := s.idHmac.Sum(nil)
+	h := s.hmacPool.Get().(hash.Hash)
+	h.Reset()
+	_, _ = h.Write([]byte(input))
+	sum := h.Sum(nil)
+	s.hmacPool.Put(h)
 	return idEncoding.EncodeToString(sum[:idTruncationBytes])
 }
 
-func (s *sanitizer) sanitizeSync(ctx context.Context, src connectorstore.Reader, dst connectorstore.Writer, sr *reader_v2.SyncRun) error {
+// newHMACPool returns a sync.Pool of HMAC-SHA256 hashers keyed on secret. The
+// key schedule is paid once per pooled hasher, not per id() call, and pooling
+// lets concurrent transform workers each hold their own hasher.
+func newHMACPool(secret []byte) *sync.Pool {
+	return &sync.Pool{New: func() any { return hmac.New(sha256.New, secret) }}
+}
+
+func (s *sanitizer) sanitizeSync(ctx context.Context, src connectorstore.Reader, dst connectorstore.Writer, sr *reader_v2.SyncRun, rs *resumeState) error {
 	srcSyncID := sr.GetId()
 	syncType := connectorstore.SyncType(sr.GetSyncType())
 	if syncType == connectorstore.SyncTypeAny || syncType == "" {
 		syncType = connectorstore.SyncTypeFull
 	}
 
-	parentDst := ""
-	if parentSrc := sr.GetParentSyncId(); parentSrc != "" {
-		parentDst = s.syncIDMap[parentSrc]
-		if parentDst == "" {
-			// The parent is not a sync in this c1z — a diff c1z built
-			// by GenerateSyncDiffFromFile records the OTHER file's
-			// base sync id as the pair's parent. HMAC the external
-			// reference instead of dropping it: provenance structure
-			// survives, the raw id does not, and two files sanitized
-			// under the same secret still cross-reference.
-			parentDst = s.id(parentSrc)
+	// Resume an unfinished destination sync from a prior run, or start a new
+	// one. The phase to start at comes from the checkpoint; a fresh sync starts
+	// at phaseResources.
+	startPhase := phaseResources
+	startGrantPage := ""
+	var dstSyncID string
+	if rs != nil {
+		if err := dst.SetCurrentSync(ctx, rs.dstSyncID); err != nil {
+			return fmt.Errorf("resume dst sync: %w", err)
 		}
-	}
-
-	dstSyncID, err := dst.StartNewSync(ctx, syncType, parentDst)
-	if err != nil {
-		return fmt.Errorf("start dst sync: %w", err)
+		dstSyncID = rs.dstSyncID
+		startPhase = rs.phase
+		startGrantPage = rs.grantPageToken
+	} else {
+		parentDst := ""
+		if parentSrc := sr.GetParentSyncId(); parentSrc != "" {
+			parentDst = s.syncIDMap[parentSrc]
+			if parentDst == "" {
+				// The parent is not a sync in this c1z — a diff c1z built
+				// by GenerateSyncDiffFromFile records the OTHER file's
+				// base sync id as the pair's parent. HMAC the external
+				// reference instead of dropping it: provenance structure
+				// survives, the raw id does not, and two files sanitized
+				// under the same secret still cross-reference.
+				parentDst = s.id(parentSrc)
+			}
+		}
+		newID, err := dst.StartNewSync(ctx, syncType, parentDst)
+		if err != nil {
+			return fmt.Errorf("start dst sync: %w", err)
+		}
+		dstSyncID = newID
+		// Write an initial checkpoint so an interruption before any phase
+		// completes still correlates this dst sync to its source on resume.
+		if err := s.checkpoint(ctx, dst, srcSyncID, phaseResources, ""); err != nil {
+			return fmt.Errorf("checkpoint: %w", err)
+		}
 	}
 	s.syncIDMap[srcSyncID] = dstSyncID
 
@@ -252,16 +439,32 @@ func (s *sanitizer) sanitizeSync(ctx context.Context, src connectorstore.Reader,
 	// distinct entitlements, not the whole file.
 	grantCache := newGrantSubCache(s.verifyGrantCache)
 
+	// resource_types always runs: it is cheap and repopulates knownResourceTypes
+	// (which the id transform consults), so it must be rebuilt even when its
+	// rows were already written in a prior run. PutResourceTypes upserts, so the
+	// re-write is idempotent.
 	if err := s.copyResourceTypes(ctx, src, dst, srcSyncID, assetRefs); err != nil {
 		return err
 	}
-	if err := s.copyResources(ctx, src, dst, srcSyncID, assetRefs); err != nil {
-		return err
+
+	if phaseAtOrBefore(startPhase, phaseResources) {
+		if err := s.copyResources(ctx, src, dst, srcSyncID, assetRefs); err != nil {
+			return err
+		}
+		if err := s.checkpoint(ctx, dst, srcSyncID, phaseEntitlements, ""); err != nil {
+			return fmt.Errorf("checkpoint: %w", err)
+		}
 	}
-	if err := s.copyEntitlements(ctx, src, dst, srcSyncID, assetRefs); err != nil {
-		return err
+	if phaseAtOrBefore(startPhase, phaseEntitlements) {
+		if err := s.copyEntitlements(ctx, src, dst, srcSyncID, assetRefs); err != nil {
+			return err
+		}
+		if err := s.checkpoint(ctx, dst, srcSyncID, phaseGrants, ""); err != nil {
+			return fmt.Errorf("checkpoint: %w", err)
+		}
+		startGrantPage = "" // entitlements just finished; grants start at the top
 	}
-	if err := s.copyGrants(ctx, src, dst, srcSyncID, assetRefs, grantCache); err != nil {
+	if err := s.copyGrants(ctx, src, dst, srcSyncID, assetRefs, grantCache, startGrantPage); err != nil {
 		return err
 	}
 	if err := s.copyAssets(ctx, src, dst, assetRefs); err != nil {
@@ -272,6 +475,27 @@ func (s *sanitizer) sanitizeSync(ctx context.Context, src connectorstore.Reader,
 		return fmt.Errorf("end dst sync: %w", err)
 	}
 	return nil
+}
+
+// phaseAtOrBefore reports whether the run should execute `target`, given the
+// phase it is starting from. Phases are ordered resources < entitlements <
+// grants; a start phase at or before the target means the target still needs
+// to run.
+func phaseAtOrBefore(start, target string) bool {
+	return phaseRank(start) <= phaseRank(target)
+}
+
+func phaseRank(p string) int {
+	switch p {
+	case phaseResources:
+		return 0
+	case phaseEntitlements:
+		return 1
+	case phaseGrants:
+		return 2
+	default:
+		return 0 // unknown/empty → treat as the earliest phase (run everything)
+	}
 }
 
 // preserveSyncGraphMetadata carries the sync-run linkage the proto

--- a/pkg/c1zsanitize/transform.go
+++ b/pkg/c1zsanitize/transform.go
@@ -3,8 +3,11 @@ package c1zsanitize
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"sort"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
@@ -13,6 +16,42 @@ import (
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
 )
+
+// parallelTransform applies fn to each index [0,n) using up to GOMAXPROCS
+// workers that pull indices off a shared counter. fn must write only to its
+// own index i of a pre-sized output slice, so order is preserved with no
+// channels. The transform is CPU-bound (HMAC + proto marshal/unmarshal) and
+// touches only concurrency-safe shared state (pooled HMAC, mutex-guarded
+// caches), so fanning it out is safe; reads and writes around it stay
+// sequential because SQLite is a single writer.
+func parallelTransform(n int, fn func(i int)) {
+	workers := runtime.GOMAXPROCS(0)
+	if workers > n {
+		workers = n
+	}
+	if workers <= 1 {
+		for i := 0; i < n; i++ {
+			fn(i)
+		}
+		return
+	}
+	var idx int64 = -1
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for w := 0; w < workers; w++ {
+		go func() {
+			defer wg.Done()
+			for {
+				i := int(atomic.AddInt64(&idx, 1))
+				if i >= n {
+					return
+				}
+				fn(i)
+			}
+		}()
+	}
+	wg.Wait()
+}
 
 // listPageSize is the source read page, which also bounds how many
 // rows each dst Put batches into one transaction. Larger pages mean
@@ -105,10 +144,8 @@ func (s *sanitizer) copyResourceTypes(
 	}
 
 	xformStart := time.Now()
-	out := make([]*v2.ResourceType, 0, len(rows))
-	for _, rt := range rows {
-		out = append(out, s.transformResourceType(rt, refs))
-	}
+	out := make([]*v2.ResourceType, len(rows))
+	parallelTransform(len(rows), func(i int) { out[i] = s.transformResourceType(rows[i], refs) })
 	xformDur := time.Since(xformStart)
 	// Sort by output id for destination unique-index locality.
 	sort.Slice(out, func(i, j int) bool { return out[i].GetId() < out[j].GetId() })
@@ -144,10 +181,9 @@ func (s *sanitizer) copyResources(
 			return fmt.Errorf("list resources: %w", err)
 		}
 		xformStart := time.Now()
-		out := make([]*v2.Resource, 0, len(resp.GetList()))
-		for _, r := range resp.GetList() {
-			out = append(out, s.transformResource(r, refs))
-		}
+		list := resp.GetList()
+		out := make([]*v2.Resource, len(list))
+		parallelTransform(len(list), func(i int) { out[i] = s.transformResource(list[i], refs) })
 		xformDur := time.Since(xformStart)
 		sortByResourceID(out)
 		putStart := time.Now()
@@ -187,10 +223,9 @@ func (s *sanitizer) copyEntitlements(
 			return fmt.Errorf("list entitlements: %w", err)
 		}
 		xformStart := time.Now()
-		out := make([]*v2.Entitlement, 0, len(resp.GetList()))
-		for _, e := range resp.GetList() {
-			out = append(out, s.transformEntitlement(e, refs))
-		}
+		list := resp.GetList()
+		out := make([]*v2.Entitlement, len(list))
+		parallelTransform(len(list), func(i int) { out[i] = s.transformEntitlement(list[i], refs) })
 		xformDur := time.Since(xformStart)
 		sort.Slice(out, func(i, j int) bool { return out[i].GetId() < out[j].GetId() })
 		putStart := time.Now()
@@ -215,8 +250,9 @@ func (s *sanitizer) copyGrants(
 	srcSyncID string,
 	refs *assetRefSet,
 	cache *grantSubCache,
+	startPageToken string,
 ) error {
-	pageToken := ""
+	pageToken := startPageToken
 	page := 0
 	for {
 		req := v2.GrantsServiceListGrantsRequest_builder{
@@ -231,10 +267,9 @@ func (s *sanitizer) copyGrants(
 			return fmt.Errorf("list grants: %w", err)
 		}
 		xformStart := time.Now()
-		out := make([]*v2.Grant, 0, len(resp.GetList()))
-		for _, g := range resp.GetList() {
-			out = append(out, s.transformGrant(g, refs, cache))
-		}
+		list := resp.GetList()
+		out := make([]*v2.Grant, len(list))
+		parallelTransform(len(list), func(i int) { out[i] = s.transformGrant(list[i], refs, cache) })
 		xformDur := time.Since(xformStart)
 		sort.Slice(out, func(i, j int) bool { return out[i].GetId() < out[j].GetId() })
 		putStart := time.Now()
@@ -244,7 +279,16 @@ func (s *sanitizer) copyGrants(
 			}
 		}
 		s.logPage(srcSyncID, "grants", page, len(resp.GetList()), readDur, xformDur, time.Since(putStart))
-		if resp.GetNextPageToken() == "" {
+		next := resp.GetNextPageToken()
+		// Record the next grant page as the resume point. The grants already
+		// written this page are durable in the dst sync; on resume the loop
+		// restarts at `next` (PutGrants upserts, so even a re-written boundary
+		// page is idempotent). Keyset pagination on the source rowid makes the
+		// token stable across runs.
+		if err := s.checkpoint(ctx, dst, srcSyncID, phaseGrants, next); err != nil {
+			return fmt.Errorf("checkpoint: %w", err)
+		}
+		if next == "" {
 			if cache != nil {
 				s.log.Info("c1zsanitize: grant sub-cache stats",
 					zap.String("sync_id", srcSyncID),
@@ -253,7 +297,7 @@ func (s *sanitizer) copyGrants(
 			}
 			return nil
 		}
-		pageToken = resp.GetNextPageToken()
+		pageToken = next
 		page++
 	}
 }
@@ -336,17 +380,20 @@ func (s *sanitizer) transformResourceID(in *v2.ResourceId) *v2.ResourceId {
 }
 
 // warnUndeclaredResourceType logs once per resource-type token that appears in
-// a resource id but was never declared in copyResourceTypes. Not safe for
-// concurrent callers — the transform stage is sequential today; revisit the
-// dedup map if it is ever parallelized.
+// a resource id but was never declared in copyResourceTypes. Called from the
+// concurrent transform workers, so the dedup set is guarded by statsMu; the
+// log fires outside the lock.
 func (s *sanitizer) warnUndeclaredResourceType(rt string) {
 	if rt == "" || s.isKnownResourceType(rt) {
 		return
 	}
+	s.statsMu.Lock()
 	if _, seen := s.warnedUndeclaredTypes[rt]; seen {
+		s.statsMu.Unlock()
 		return
 	}
 	s.warnedUndeclaredTypes[rt] = struct{}{}
+	s.statsMu.Unlock()
 	s.log.Warn("c1zsanitize: resource id references an undeclared resource type; preserved verbatim here but HMAC'd inside composite ids",
 		zap.String("resource_type", rt))
 }
@@ -417,6 +464,13 @@ const maxCachedPrincipals = 1_000_000
 // proto.Equal cross-check against a fresh transform for the first
 // verifySampleLimit hits — cheap insurance, off by default.
 type grantSubCache struct {
+	// mu guards the maps and the verify counters. The grant transform fans out
+	// across workers, so the cache is shared. The expensive transform on a miss
+	// runs OUTSIDE the lock (double-checked insert), so the critical sections
+	// are only map lookups/inserts — a plain Mutex is enough and avoids the
+	// RWMutex bookkeeping for what is, after warmup, a tiny read-mostly map
+	// (entitlement cardinality is orders of magnitude below grant count).
+	mu sync.Mutex
 	// SHARED: the cached *v2.Entitlement / *v2.Resource values below are
 	// referenced by multiple output grants. Never mutate one after Build().
 	// Mutation after caching = cross-grant corruption.
@@ -452,19 +506,29 @@ func (s *sanitizer) cachedEntitlement(in *v2.Entitlement, refs *assetRefSet, cac
 		return s.transformEntitlement(in, refs)
 	}
 	key := in.GetId()
-	if key != "" {
-		if got, ok := cache.entitlements[key]; ok {
-			s.verifyCachedEntitlement(in, refs, got, cache)
-			// SHARED: returned to many output grants — never mutate after Build().
-			return got
-		}
+	if key == "" {
+		return s.transformEntitlement(in, refs) // nothing to key on
 	}
+	cache.mu.Lock()
+	got, ok := cache.entitlements[key]
+	cache.mu.Unlock()
+	if ok {
+		s.verifyCachedEntitlement(in, refs, got, cache)
+		// SHARED: returned to many output grants — never mutate after Build().
+		return got
+	}
+	// Transform outside the lock. Two workers may race to fill the same key;
+	// both produce proto-equal results (the transform is a pure function of
+	// (secret, input)), so the double-check below just keeps one shared pointer.
 	out := s.transformEntitlement(in, refs)
-	if key != "" {
+	cache.mu.Lock()
+	if existing, ok := cache.entitlements[key]; ok {
+		out = existing
+	} else {
 		// SHARED once stored: referenced by every later grant with this id.
-		// Never mutate after Build() — mutation = cross-grant corruption.
 		cache.entitlements[key] = out
 	}
+	cache.mu.Unlock()
 	return out
 }
 
@@ -486,19 +550,26 @@ func (s *sanitizer) cachedPrincipal(in *v2.Resource, refs *assetRefSet, cache *g
 	if id := in.GetId(); id != nil && id.GetResource() != "" {
 		key = id.GetResourceType() + "\x00" + id.GetResource()
 	}
-	if key != "" {
-		if got, ok := cache.principals[key]; ok {
-			s.verifyCachedPrincipal(in, refs, got, cache)
-			// SHARED: returned to many output grants — never mutate after Build().
-			return got
-		}
+	if key == "" {
+		return s.transformResource(in, refs) // uncacheable empty id
+	}
+	cache.mu.Lock()
+	got, ok := cache.principals[key]
+	cache.mu.Unlock()
+	if ok {
+		s.verifyCachedPrincipal(in, refs, got, cache)
+		// SHARED: returned to many output grants — never mutate after Build().
+		return got
 	}
 	out := s.transformResource(in, refs)
-	if key != "" && len(cache.principals) < maxCachedPrincipals {
+	cache.mu.Lock()
+	if existing, ok := cache.principals[key]; ok {
+		out = existing
+	} else if len(cache.principals) < maxCachedPrincipals {
 		// SHARED once stored: referenced by every later grant with this id.
-		// Never mutate after Build() — mutation = cross-grant corruption.
 		cache.principals[key] = out
 	}
+	cache.mu.Unlock()
 	return out
 }
 
@@ -507,10 +578,16 @@ func (s *sanitizer) cachedPrincipal(in *v2.Resource, refs *assetRefSet, cache *g
 // differs from the fresh one, catching any source that violates the
 // one-object-per-id assumption.
 func (s *sanitizer) verifyCachedEntitlement(in *v2.Entitlement, refs *assetRefSet, cached *v2.Entitlement, cache *grantSubCache) {
-	if !cache.verify || cache.verifySeenEntitlements >= verifySampleLimit {
+	if !cache.verify {
+		return
+	}
+	cache.mu.Lock()
+	if cache.verifySeenEntitlements >= verifySampleLimit {
+		cache.mu.Unlock()
 		return
 	}
 	cache.verifySeenEntitlements++
+	cache.mu.Unlock()
 	fresh := s.transformEntitlement(in, refs)
 	if !proto.Equal(fresh, cached) {
 		s.log.Warn("c1zsanitize: grant sub-cache mismatch; embedded entitlement differs across grants for the same id",
@@ -523,10 +600,16 @@ func (s *sanitizer) verifyCachedEntitlement(in *v2.Entitlement, refs *assetRefSe
 // contract, catching any source that emits diverging principal objects for the
 // same resource id within a sync.
 func (s *sanitizer) verifyCachedPrincipal(in *v2.Resource, refs *assetRefSet, cached *v2.Resource, cache *grantSubCache) {
-	if !cache.verify || cache.verifySeenPrincipals >= verifySampleLimit {
+	if !cache.verify {
+		return
+	}
+	cache.mu.Lock()
+	if cache.verifySeenPrincipals >= verifySampleLimit {
+		cache.mu.Unlock()
 		return
 	}
 	cache.verifySeenPrincipals++
+	cache.mu.Unlock()
 	fresh := s.transformResource(in, refs)
 	if !proto.Equal(fresh, cached) {
 		s.log.Warn("c1zsanitize: grant sub-cache mismatch; embedded principal differs across grants for the same id",


### PR DESCRIPTION
## Summary

Two changes to `pkg/c1zsanitize`, building on the memoization + bulk-load work in v0.12.7:

1. **Parallelize the per-page transform stage.** Each fetched page's record transforms fan out across `GOMAXPROCS` workers; reads and writes stay sequential (SQLite is a single writer). Only the CPU-bound HMAC + proto marshal/unmarshal work parallelizes.
2. **Resumable sanitization (checkpointing).** An interrupted run resumes from its last committed position instead of restarting.

## Parallel transform

- Each page allocates a pre-sized output slice; workers pull indices off a shared atomic counter and write `out[i]`, so order is preserved with no channels. After the workers join, the single `Put*` runs as before.
- **Per-worker HMAC:** `s.id` now borrows a pre-keyed HMAC-SHA256 hasher from a `sync.Pool` rather than sharing one `hash.Hash`. Each call Resets a hasher it exclusively owns, so output depends only on `(secret, input)` — never on scheduling.
- **Concurrency-safe caches:** the grant sub-cache gets a mutex with a double-checked insert (the expensive transform on a miss runs *outside* the lock — entitlement cardinality is orders of magnitude below grant count, so the map is read-mostly after warmup and a plain `Mutex` suffices). The per-run drop counters and the undeclared-type dedup set are guarded by a stats mutex (tiny critical sections). The domain map and asset-ref set were already mutex-guarded. `knownResourceTypes` is populated only in the resource-types pre-pass and read-only afterward, so the concurrent phases read it lock-free.

## C-2 fix (behavior fix, not just a parallelism prerequisite)

Resource types are registered **only** during their own buffering pre-pass, and the known-type set is read-only for the rest of the sync. Previously an embedded resource type (e.g. in a grant's `GrantableTo`) could become "known" mid-run, so the id transform would HMAC that token before the encounter and preserve it after — the same token, two representations, dependent on row order, producing order-dependent output and broken cross-references. Freezing the set after the pre-pass makes the transform's known-type decision deterministic. This is strictly a correctness improvement (it also removes a data race the fan-out would otherwise expose).

## Checkpoint design

- **Storage:** each destination sync's existing `sync_token` (via `CheckpointSync` / `CurrentSyncStep`). It lives inside the destination c1z — no sidecar file, no schema change — and is the same mechanism connector syncs already use for resumption. It is persisted with the rest of the c1z, so resume only finds progress a prior run actually committed to disk.
- **Granularity:** per source sync, per phase, and **per page within the grant phase**. The token records `{fingerprint, source sync id, next phase, grant page token}`. `resource_types` always re-runs (cheap, and it repopulates the known-type set the id transform consults); `resources` and `entitlements` are skipped once complete; the grant phase resumes from its last committed page (keyset pagination on the source rowid makes that token stable across runs).
- **Resume semantics:** on a `Resumable` start, existing destination syncs are scanned; a token whose fingerprint matches this run yields a resume point. A fully-`EndSync`'d source sync is skipped entirely (its dst id is kept for parent linkage); an unfinished one is re-entered via `SetCurrentSync` and continued from its phase/page.
- **Mismatch handling:** the fingerprint is `HMAC-SHA256(secret, "…" + anchor)` (the secret is never stored). A destination carrying a checkpoint whose fingerprint does not match the current run's secret/anchor is **rejected with an error** rather than appended to — fail-closed, never mixing transforms from two secrets. A destination with no tokens (fresh, or written by a non-resumable run) yields a clean full run.
- **Idempotence / cleanup:** all `Put*` calls upsert, so re-writing a boundary page or the always-rerun `resource_types` phase is idempotent and the resumed output is record-identical to an uninterrupted run. Completed source syncs are `EndSync`'d; their tokens mark them done, so a resumable re-run against a finished destination skips rather than duplicating. For a genuinely clean run, use a fresh destination path.
- **Lifecycle note (documented tradeoff):** `Sanitize` receives a `connectorstore.Writer` and does not own the destination file's open/close, so it cannot itself force a mid-run flush. Resume therefore recovers whatever the caller persisted (the caller closes/saves the c1z at its own cadence). This is why the granularity is "last committed page of the persisted destination," not "every page regardless of persistence."

## Guardrails preserved

Determinism (same `(secret, input)` → same output regardless of scheduling/cache state); fail-closed `transformID`; `AllowUnknownAnnotations` default false; public API signatures unchanged (`Sanitize`, `Options`, `SanitizeID`, `MinSecretBytes`, `LoadOrGenerateSecret` — `Options` only gains the additive `Resumable` field); no new dependencies.

## Tests

- Determinism golden + cache-equivalence (existing) still pass.
- `TestSanitizeParallelMultiSync` — multi-sync fan-out, run under `-race`.
- `TestSanitizeCheckpointResume` — interrupt a resumable run at the grant phase, persist, resume; asserts the resumed output is record-identical to an uninterrupted run with the same secret/anchor.
- `BenchmarkSanitize` — end-to-end over a synthetic c1z (the tracked headline is `G=1M`; the committed `genGrants` is modest so the benchmark is CI-runnable).

`go build ./...`, `go test ./pkg/c1zsanitize/... -race -count=1`, `go test ./pkg/dotc1z/ -count=1`, `gofmt`, and `make lint` are all green on the touched files.

---

_🛰️ Built with stargate._