### PR TITLE
feat(dotc1z): preserve grant-expansion topology when streaming grants

### DIFF
--- a/pkg/connectorstore/streaming.go
+++ b/pkg/connectorstore/streaming.go
@@ -38,10 +38,19 @@ type StreamingReader interface {
 
 // StreamGrantsOptions narrows the stream to a single entitlement
 // and/or principal. Empty fields mean no filter.
+//
+// IncludeExpansion re-attaches each grant's GrantExpandable annotation when
+// set. The SQLite engine strips GrantExpandable into a side column on write,
+// so without this the SQLite stream yields grants with their expansion
+// topology missing — a faithful round-trip (cross-engine copy, rollback /
+// replay, or an external grant consumer) must set it. Default false preserves
+// the existing data-only stream. The Pebble engine reconstructs the
+// annotation from its record either way, so the option is a no-op there.
 type StreamGrantsOptions struct {
 	EntitlementID         string
 	PrincipalResourceType string
 	PrincipalResourceID   string
+	IncludeExpansion      bool
 }
 
 // StreamResourcesOptions narrows the stream by resource_type.

--- a/pkg/dotc1z/streaming.go
+++ b/pkg/dotc1z/streaming.go
@@ -6,9 +6,12 @@ import (
 	"iter"
 
 	"github.com/doug-martin/goqu/v9"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
 )
 
@@ -31,7 +34,13 @@ func (c *C1File) StreamGrants(
 			yield(nil, err)
 			return
 		}
-		q := c.db.From(grants.Name()).Prepared(true).Select("data")
+		cols := []interface{}{"data"}
+		if opts.IncludeExpansion {
+			// The serialized GrantExpandable lives in a side column (stripped
+			// from data on write); pull it so we can re-attach it.
+			cols = append(cols, "expansion")
+		}
+		q := c.db.From(grants.Name()).Prepared(true).Select(cols...)
 		if resolved != "" {
 			q = q.Where(goqu.C("sync_id").Eq(resolved))
 		}
@@ -45,14 +54,82 @@ func (c *C1File) StreamGrants(
 			q = q.Where(goqu.C("principal_resource_id").Eq(opts.PrincipalResourceID))
 		}
 		q = q.Order(goqu.C("id").Asc())
-		streamRows(ctx, c, q, func(data []byte) bool {
-			m := &v2.Grant{}
-			if err := proto.Unmarshal(data, m); err != nil {
-				return yield(nil, err)
-			}
-			return yield(m, nil)
-		}, yield)
+
+		if !opts.IncludeExpansion {
+			streamRows(ctx, c, q, func(data []byte) bool {
+				m := &v2.Grant{}
+				if err := proto.Unmarshal(data, m); err != nil {
+					return yield(nil, err)
+				}
+				return yield(m, nil)
+			}, yield)
+			return
+		}
+		c.streamGrantsWithExpansion(ctx, q, yield)
 	}
+}
+
+// streamGrantsWithExpansion runs the two-column (data, expansion) scan and
+// re-attaches the GrantExpandable annotation that the SQLite writer strips
+// into the expansion column, so the streamed grant carries its full expansion
+// topology. Reattached/total counts are logged once when the scan completes.
+func (c *C1File) streamGrantsWithExpansion(
+	ctx context.Context,
+	q *goqu.SelectDataset,
+	yield func(*v2.Grant, error) bool,
+) {
+	query, args, err := q.ToSQL()
+	if err != nil {
+		yield(nil, err)
+		return
+	}
+	rows, err := c.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		yield(nil, err)
+		return
+	}
+	defer rows.Close()
+
+	var total, reattached int
+	for rows.Next() {
+		if err := ctx.Err(); err != nil {
+			yield(nil, err)
+			return
+		}
+		var data, expansion sql.RawBytes
+		if err := rows.Scan(&data, &expansion); err != nil {
+			yield(nil, err)
+			return
+		}
+		g := &v2.Grant{}
+		if err := proto.Unmarshal(data, g); err != nil {
+			yield(nil, err)
+			return
+		}
+		total++
+		if len(expansion) > 0 {
+			expandable := &v2.GrantExpandable{}
+			if err := proto.Unmarshal(expansion, expandable); err != nil {
+				yield(nil, err)
+				return
+			}
+			annos := annotations.Annotations(g.GetAnnotations())
+			annos.Update(expandable)
+			g.SetAnnotations(annos)
+			reattached++
+		}
+		if !yield(g, nil) {
+			return
+		}
+	}
+	if err := rows.Err(); err != nil {
+		yield(nil, err)
+		return
+	}
+	ctxzap.Extract(ctx).Debug("c1z: streamed grants with expansion re-attached",
+		zap.Int("grants", total),
+		zap.Int("expansion_reattached", reattached),
+	)
 }
 
 // StreamResources yields resources optionally filtered by RT.

--- a/pkg/dotc1z/streaming_expansion_test.go
+++ b/pkg/dotc1z/streaming_expansion_test.go
@@ -1,0 +1,119 @@
+package dotc1z
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+)
+
+// pickExpandable returns the GrantExpandable annotation on a grant, or nil.
+func pickExpandable(t *testing.T, g *v2.Grant) *v2.GrantExpandable {
+	t.Helper()
+	exp := &v2.GrantExpandable{}
+	annos := annotations.Annotations(g.GetAnnotations())
+	ok, err := annos.Pick(exp)
+	require.NoError(t, err)
+	if !ok {
+		return nil
+	}
+	return exp
+}
+
+func collectStream(t *testing.T, seq func(func(*v2.Grant, error) bool)) []*v2.Grant {
+	t.Helper()
+	var out []*v2.Grant
+	for g, err := range seq {
+		require.NoError(t, err)
+		out = append(out, g)
+	}
+	return out
+}
+
+// TestStreamGrantsIncludeExpansionRoundTrip is the rollback/replay round-trip
+// guard: a grant written with a GrantExpandable annotation is stripped into the
+// expansion side column on write; streaming it back without IncludeExpansion
+// drops the topology (the documented default), and streaming with
+// IncludeExpansion restores the exact GrantExpandable so a replay/copy
+// re-emits the same expansion edges.
+func TestStreamGrantsIncludeExpansionRoundTrip(t *testing.T) {
+	ctx := context.Background()
+
+	tmpFile, err := os.CreateTemp("", "test-stream-expansion-*.c1z")
+	require.NoError(t, err)
+	tmpPath := tmpFile.Name()
+	require.NoError(t, tmpFile.Close())
+	defer os.Remove(tmpPath)
+
+	wantEntitlementIDs := []string{"ent:a", "ent:b"}
+
+	func() {
+		c1f, err := NewC1ZFile(ctx, tmpPath)
+		require.NoError(t, err)
+		_, err = c1f.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+		require.NoError(t, err)
+
+		groupRT := v2.ResourceType_builder{Id: "group"}.Build()
+		userRT := v2.ResourceType_builder{Id: "user"}.Build()
+		require.NoError(t, c1f.PutResourceTypes(ctx, groupRT, userRT))
+
+		g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+		u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build()}.Build()
+		require.NoError(t, c1f.PutResources(ctx, g1, u1))
+		ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1}.Build()
+		require.NoError(t, c1f.PutEntitlements(ctx, ent1))
+
+		expandableGrant := v2.Grant_builder{
+			Id:          "grant-expandable",
+			Entitlement: ent1,
+			Principal:   u1,
+			Annotations: annotations.New(v2.GrantExpandable_builder{
+				EntitlementIds:  wantEntitlementIDs,
+				Shallow:         true,
+				ResourceTypeIds: []string{"user"},
+			}.Build()),
+		}.Build()
+		plainGrant := v2.Grant_builder{Id: "grant-plain", Entitlement: ent1, Principal: u1}.Build()
+		require.NoError(t, c1f.PutGrants(ctx, expandableGrant, plainGrant))
+		require.NoError(t, c1f.EndSync(ctx))
+		require.NoError(t, c1f.Close(ctx))
+	}()
+
+	c1f, err := NewC1ZFile(ctx, tmpPath)
+	require.NoError(t, err)
+	defer c1f.Close(ctx)
+
+	byID := func(grants []*v2.Grant, id string) *v2.Grant {
+		for _, g := range grants {
+			if g.GetId() == id {
+				return g
+			}
+		}
+		return nil
+	}
+
+	// Default stream: expansion topology is absent (data blob was stripped).
+	defaultGrants := collectStream(t, c1f.StreamGrants(ctx, "", connectorstore.StreamGrantsOptions{}))
+	require.Len(t, defaultGrants, 2)
+	require.Nil(t, pickExpandable(t, byID(defaultGrants, "grant-expandable")),
+		"default stream must not carry the stripped GrantExpandable annotation")
+
+	// IncludeExpansion: the GrantExpandable annotation is restored exactly.
+	expandedGrants := collectStream(t, c1f.StreamGrants(ctx, "", connectorstore.StreamGrantsOptions{IncludeExpansion: true}))
+	require.Len(t, expandedGrants, 2)
+
+	restored := pickExpandable(t, byID(expandedGrants, "grant-expandable"))
+	require.NotNil(t, restored, "IncludeExpansion must re-attach the GrantExpandable annotation")
+	require.Equal(t, wantEntitlementIDs, restored.GetEntitlementIds())
+	require.True(t, restored.GetShallow())
+	require.Equal(t, []string{"user"}, restored.GetResourceTypeIds())
+
+	// A non-expandable grant gains nothing under IncludeExpansion.
+	require.Nil(t, pickExpandable(t, byID(expandedGrants, "grant-plain")),
+		"a grant with no expansion must stay unchanged under IncludeExpansion")
+}

--- a/pkg/dotc1z/to_pebble.go
+++ b/pkg/dotc1z/to_pebble.go
@@ -260,7 +260,10 @@ func (c *C1File) copyGrants(ctx context.Context, dest connectorstore.Writer, syn
 	if fw, ok := dest.(uniqueGrantWriter); ok {
 		put = fw.UnsafePutUniqueGrants
 	}
-	return copyStream(ctx, c.StreamGrants(ctx, syncID, connectorstore.StreamGrantsOptions{}), batchSize, stage, put)
+	// Preserve grant-expansion topology across the engine copy: the SQLite
+	// source strips GrantExpandable into a side column, so the stream must
+	// re-attach it or the Pebble copy loses the expansion edges.
+	return copyStream(ctx, c.StreamGrants(ctx, syncID, connectorstore.StreamGrantsOptions{IncludeExpansion: true}), batchSize, stage, put)
 }
 
 // copyStream drains a streaming reader into the destination in batches of


### PR DESCRIPTION
## Problem

The SQLite engine strips a grant's `GrantExpandable` annotation into a side `expansion` column on write (`extractAndStripExpansion`). `C1File.StreamGrants` reads only the `data` blob, so it yields grants with their **expansion topology missing**. The Pebble engine reconstructs the annotation from its record (`V3GrantToV2` → `expansionRecordToV2`), so the two engines disagree — and the SQLite→Pebble engine copy (`to_pebble` `copyGrants`) silently drops the expansion edges.

## Change

Add an opt-in `StreamGrantsOptions.IncludeExpansion` (default `false`, so the existing data-only stream is byte-for-byte unchanged). When set, the SQLite stream selects the `expansion` column alongside `data` and re-attaches the deserialized `GrantExpandable` annotation onto each yielded grant, restoring the exact expansion edges. The cross-engine copy opts in so copied grants keep their topology; the Pebble stream already includes expansion, so the option is a no-op there. A debug line reports per-stream `grants` / `expansion_reattached` counts.

## Steering mechanism — why `StreamGrantsOptions`

Of the three options:
- **`StreamGrantsOptions` field (chosen)** — purely additive, opt-in, default-off, changes no existing behavior, and `StreamGrants`/the Pebble adapter already branch on `opts` fields. Least-invasive.
- **interface-widening** (a new `StreamGrantsWithExpansion` method on `StreamingReader`) — forces every implementer (SQLite `C1File`, Pebble `Adapter`) to add a method; more surface for no benefit.
- **request-annotation** — the unary `ListGrants` path uses request annotations, but `StreamGrants` is not request-driven, so it does not fit.

## Observability

`streamGrantsWithExpansion` logs once per completed scan at debug: `grants` (total streamed) and `expansion_reattached` (count that carried a stored `GrantExpandable`).

## Tests

`TestStreamGrantsIncludeExpansionRoundTrip` (rollback/replay round-trip guard): write a grant carrying a `GrantExpandable` (which is stripped into the side column), then stream it back — `IncludeExpansion:false` yields it **without** the annotation (the documented default), and `IncludeExpansion:true` restores the **exact** `GrantExpandable` (entitlement ids, shallow, resource-type ids). A non-expandable grant is unchanged either way.

`go build ./...`, `go vet`, `gofmt`, and `go test ./pkg/dotc1z/ ./pkg/connectorstore/...` are green.

## go.mod pin-delta note (for the be-temporal-sync reviewer)

This is a baton-sdk-only change. A grant consumer such as **be-temporal-sync** that wants the expansion topology preserved must (1) bump its `github.com/conductorone/baton-sdk` pin to the release containing this commit (`5297629`), and (2) pass `connectorstore.StreamGrantsOptions{IncludeExpansion: true}` at its `StreamGrants` call site. No be-temporal-sync code is changed here; the default-off option means existing consumers are unaffected until they opt in.

---

_🛰️ Built with stargate._