### PR TITLE
perf+fix(c1zsanitize): parallel/resumable sanitize with preserved grant-expansion topology

### DIFF
--- a/pkg/c1zsanitize/annotations.go
+++ b/pkg/c1zsanitize/annotations.go
@@ -72,28 +72,25 @@ func (s *sanitizer) transformAnnotations(in []*anypb.Any, refs *assetRefSet) []*
 			// could leak un-sanitized customer data. Pass-through is opt-in
 			// via Options.AllowUnknownAnnotations, for development only.
 			if s.dropUnknownAnnotations {
-				if s.droppedAnnotations[a.GetTypeUrl()] == 0 {
+				if s.recordAnnotation(s.droppedAnnotations, a.GetTypeUrl()) {
 					s.log.Warn("c1zsanitize: dropping unknown annotation type (first occurrence; counted thereafter)",
 						zap.String("type_url", a.GetTypeUrl()))
 				}
-				s.droppedAnnotations[a.GetTypeUrl()]++
 				continue
 			}
-			if s.passedAnnotations[a.GetTypeUrl()] == 0 {
+			if s.recordAnnotation(s.passedAnnotations, a.GetTypeUrl()) {
 				s.log.Warn("c1zsanitize: passing unknown annotation through unchanged (first occurrence; counted thereafter)",
 					zap.String("type_url", a.GetTypeUrl()))
 			}
-			s.passedAnnotations[a.GetTypeUrl()]++
 			out = append(out, a)
 			continue
 		}
 		msg, err := a.UnmarshalNew()
 		if err != nil {
-			if s.failedAnnotations[a.GetTypeUrl()] == 0 {
+			if s.recordAnnotation(s.failedAnnotations, a.GetTypeUrl()) {
 				s.log.Warn("c1zsanitize: annotation transform failed (first occurrence; counted thereafter)",
 					zap.String("type_url", a.GetTypeUrl()), zap.Error(err))
 			}
-			s.failedAnnotations[a.GetTypeUrl()]++
 			continue
 		}
 		sanitized := handler(s, msg, refs)
@@ -102,11 +99,10 @@ func (s *sanitizer) transformAnnotations(in []*anypb.Any, refs *assetRefSet) []*
 		}
 		repacked, err := anypb.New(sanitized)
 		if err != nil {
-			if s.failedAnnotations[a.GetTypeUrl()] == 0 {
+			if s.recordAnnotation(s.failedAnnotations, a.GetTypeUrl()) {
 				s.log.Warn("c1zsanitize: annotation transform failed (first occurrence; counted thereafter)",
 					zap.String("type_url", a.GetTypeUrl()), zap.Error(err))
 			}
-			s.failedAnnotations[a.GetTypeUrl()]++
 			continue
 		}
 		out = append(out, repacked)

--- a/pkg/c1zsanitize/expansion_roundtrip_test.go
+++ b/pkg/c1zsanitize/expansion_roundtrip_test.go
@@ -1,0 +1,176 @@
+package c1zsanitize
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+)
+
+// pickGrantExpandable returns the GrantExpandable annotation on a grant, or nil.
+func pickGrantExpandable(t *testing.T, g *v2.Grant) *v2.GrantExpandable {
+	t.Helper()
+	exp := &v2.GrantExpandable{}
+	annos := annotations.Annotations(g.GetAnnotations())
+	ok, err := annos.Pick(exp)
+	require.NoError(t, err)
+	if !ok {
+		return nil
+	}
+	return exp
+}
+
+// listGrantsWithExpansion reads every grant of r's resolved sync through the
+// expansion-aware paginated path, so the GrantExpandable annotation that the
+// SQLite writer strips into the side column is re-attached.
+func listGrantsWithExpansion(t *testing.T, ctx context.Context, r *dotc1z.C1File) []*v2.Grant {
+	t.Helper()
+	var out []*v2.Grant
+	pageToken := ""
+	for {
+		req := v2.GrantsServiceListGrantsRequest_builder{
+			PageSize:  1000,
+			PageToken: pageToken,
+		}.Build()
+		resp, err := r.ListGrantsWithExpansion(ctx, req)
+		require.NoError(t, err)
+		out = append(out, resp.GetList()...)
+		if resp.GetNextPageToken() == "" {
+			return out
+		}
+		pageToken = resp.GetNextPageToken()
+	}
+}
+
+// TestSanitizeGrantExpansionRoundTrip is the real SQLite source->sanitize->dest
+// round-trip fidelity check that the in-memory annotation test (perf_test.go's
+// TestGraphAnnotationHandlers) could not catch.
+//
+// The fixture grant is written through the REAL SQLite writer (PutGrants), so —
+// exactly as in production files — its GrantExpandable annotation is stripped
+// out of the data blob and into the side `expansion` column. The sanitizer must
+// therefore read that column back (ListGrantsWithExpansion) for the annotation
+// to reach handleGrantExpandable; otherwise the topology is silently dropped.
+//
+// This test FAILS without the ListGrants expansion-reattach wiring (copyGrants
+// would read only the data blob, the annotation would never surface, and the
+// sanitized dst grant's expansion column would be NULL) and PASSES with it.
+func TestSanitizeGrantExpansionRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	srcPath := filepath.Join(tmp, "src.c1z")
+	dstPath := filepath.Join(tmp, "dst.c1z")
+
+	secret := bytes32("expansion-roundtrip")
+
+	const (
+		entA       = "ent-admin"
+		entB       = "ent-reader"
+		knownRT    = "user"  // declared resource type -> token preserved verbatim
+		unknownRT  = "group" // not declared -> token HMAC'd
+		expGrantID = "grant-expandable"
+		plainID    = "grant-plain"
+	)
+
+	// Build the source through the real SQLite writer so GrantExpandable lands
+	// in the expansion side column, as production c1z files store it.
+	func() {
+		f, err := dotc1z.NewC1ZFile(ctx, srcPath)
+		require.NoError(t, err)
+		_, err = f.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+		require.NoError(t, err)
+
+		require.NoError(t, f.PutResourceTypes(ctx,
+			v2.ResourceType_builder{Id: "user", DisplayName: "User", Traits: []v2.ResourceType_Trait{v2.ResourceType_TRAIT_USER}}.Build(),
+			v2.ResourceType_builder{Id: "role", DisplayName: "Role", Traits: []v2.ResourceType_Trait{v2.ResourceType_TRAIT_ROLE}}.Build(),
+		))
+
+		role := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "role", Resource: "admin"}.Build(), DisplayName: "Admin"}.Build()
+		user := v2.Resource_builder{
+			Id:          v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(),
+			DisplayName: "User 1",
+			Annotations: []*anypb.Any{anyTB(t, v2.UserTrait_builder{Login: "u1@acme.com"}.Build())},
+		}.Build()
+		require.NoError(t, f.PutResources(ctx, role, user))
+
+		ent := v2.Entitlement_builder{Id: entA, Resource: role, DisplayName: "admin", Slug: "admin"}.Build()
+		require.NoError(t, f.PutEntitlements(ctx, ent))
+
+		expandableGrant := v2.Grant_builder{
+			Id:          expGrantID,
+			Entitlement: ent,
+			Principal:   user,
+			Annotations: annotations.New(v2.GrantExpandable_builder{
+				EntitlementIds:  []string{entA, entB},
+				Shallow:         true,
+				ResourceTypeIds: []string{knownRT, unknownRT},
+			}.Build()),
+		}.Build()
+		plainGrant := v2.Grant_builder{Id: plainID, Entitlement: ent, Principal: user}.Build()
+		require.NoError(t, f.PutGrants(ctx, expandableGrant, plainGrant))
+		require.NoError(t, f.EndSync(ctx))
+		require.NoError(t, f.Close(ctx))
+	}()
+
+	// Sanitize src -> dst.
+	src := mustOpen(t, ctx, srcPath, true)
+	dst := mustOpen(t, ctx, dstPath, false)
+	require.NoError(t, Sanitize(ctx, src, dst, Options{Secret: secret, TimestampAnchor: fixedAnchor}))
+	require.NoError(t, dst.Close(ctx))
+	require.NoError(t, src.Close(ctx))
+
+	// Reference sanitizer with the same secret + the declared known types, used
+	// to compute the expected sanitized cross-reference tokens. s.id/transformID
+	// depend only on the secret, so this reproduces the real run's output.
+	ref := newTestSanitizer(secret)
+	ref.knownResourceTypes[knownRT] = struct{}{}
+	ref.knownResourceTypes["role"] = struct{}{}
+
+	// Read the sanitized grants back through the expansion-aware path.
+	dstRO := mustOpen(t, ctx, dstPath, true)
+	defer dstRO.Close(ctx)
+	grants := listGrantsWithExpansion(t, ctx, dstRO)
+	require.Len(t, grants, 2)
+
+	var sanitizedExpandable, sanitizedPlain *v2.GrantExpandable
+	var expandableCount int
+	for _, g := range grants {
+		if ge := pickGrantExpandable(t, g); ge != nil {
+			expandableCount++
+			sanitizedExpandable = ge
+		} else {
+			sanitizedPlain = ge // stays nil
+		}
+	}
+
+	// Exactly one grant carries a (sanitized) GrantExpandable — proving the
+	// annotation survived the real-SQLite strip -> sanitize -> re-read round trip.
+	require.Equal(t, 1, expandableCount,
+		"the expandable grant must carry a GrantExpandable after sanitize (this fails without the ListGrants expansion-reattach wiring)")
+	require.NotNil(t, sanitizedExpandable)
+	require.Nil(t, sanitizedPlain, "the non-expandable grant must stay NULL (no GrantExpandable)")
+
+	// Entitlement ids: rewritten through transformID (cross-references).
+	require.Equal(t,
+		[]string{ref.transformID(entA), ref.transformID(entB)},
+		sanitizedExpandable.GetEntitlementIds())
+	require.NotContains(t, sanitizedExpandable.GetEntitlementIds(), entA)
+	require.NotContains(t, sanitizedExpandable.GetEntitlementIds(), entB)
+
+	// Resource-type tokens: known type preserved verbatim; unknown HMAC'd.
+	require.Equal(t,
+		[]string{knownRT, ref.sanitizeResourceTypeToken(unknownRT)},
+		sanitizedExpandable.GetResourceTypeIds())
+	require.NotEqual(t, unknownRT, sanitizedExpandable.GetResourceTypeIds()[1],
+		"undeclared resource-type token must be sanitized")
+
+	// Structural shallow flag preserved.
+	require.True(t, sanitizedExpandable.GetShallow(), "shallow flag preserved")
+}

--- a/pkg/c1zsanitize/parallel_checkpoint_test.go
+++ b/pkg/c1zsanitize/parallel_checkpoint_test.go
@@ -1,0 +1,214 @@
+package c1zsanitize
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+)
+
+var fixedAnchor = time.Date(2025, 1, 2, 3, 4, 5, 0, time.UTC)
+
+// anyTB packs a proto into an Any, failing the test/benchmark on error.
+func anyTB(tb testing.TB, m proto.Message) *anypb.Any {
+	a, err := anypb.New(m)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	return a
+}
+
+// buildSyncFixture writes a c1z with nSyncs independent syncs, each carrying a
+// couple resource types, resources (with trait annotations), entitlements, and
+// grants embedding a full entitlement + principal. Enough shape to exercise
+// every copy* phase and the per-page transform fan-out.
+func buildSyncFixture(t testing.TB, ctx context.Context, path string, nSyncs, grantsPerSync int) {
+	f, err := dotc1z.NewC1ZFile(ctx, path)
+	require.NoError(t, err)
+	for sIdx := 0; sIdx < nSyncs; sIdx++ {
+		_, err := f.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+		require.NoError(t, err)
+		p := fmt.Sprintf("s%d-", sIdx)
+
+		require.NoError(t, f.PutResourceTypes(ctx,
+			v2.ResourceType_builder{Id: "user", DisplayName: "User", Traits: []v2.ResourceType_Trait{v2.ResourceType_TRAIT_USER}}.Build(),
+			v2.ResourceType_builder{Id: "role", DisplayName: "Role", Traits: []v2.ResourceType_Trait{v2.ResourceType_TRAIT_ROLE}}.Build(),
+		))
+
+		var resources []*v2.Resource
+		for i := 0; i < grantsPerSync; i++ {
+			resources = append(resources, v2.Resource_builder{
+				Id:          v2.ResourceId_builder{ResourceType: "user", Resource: fmt.Sprintf("%su%d", p, i)}.Build(),
+				DisplayName: fmt.Sprintf("User %d", i),
+				Annotations: []*anypb.Any{anyTB(t, v2.UserTrait_builder{
+					Login:  fmt.Sprintf("user%d@acme.com", i),
+					Emails: []*v2.UserTrait_Email{v2.UserTrait_Email_builder{Address: fmt.Sprintf("user%d@acme.com", i), IsPrimary: true}.Build()},
+				}.Build())},
+			}.Build())
+		}
+		role := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "role", Resource: p + "admin"}.Build(), DisplayName: "Admin"}.Build()
+		resources = append(resources, role)
+		require.NoError(t, f.PutResources(ctx, resources...))
+
+		ent := v2.Entitlement_builder{Id: p + "ent-admin", Resource: role, DisplayName: "admin", Slug: "admin"}.Build()
+		require.NoError(t, f.PutEntitlements(ctx, ent))
+
+		var grants []*v2.Grant
+		for i := 0; i < grantsPerSync; i++ {
+			principal := resources[i]
+			grants = append(grants, v2.Grant_builder{
+				Id:          fmt.Sprintf("%sgrant-%d", p, i),
+				Entitlement: ent,
+				Principal:   principal,
+				Annotations: []*anypb.Any{anyTB(t, v2.ETag_builder{Value: fmt.Sprintf("etag-%d", i), EntitlementId: p + "ent-admin"}.Build())},
+			}.Build())
+		}
+		require.NoError(t, f.PutGrants(ctx, grants...))
+		require.NoError(t, f.EndSync(ctx))
+	}
+	require.NoError(t, f.Close(ctx))
+}
+
+func sanitizeToFile(t *testing.T, ctx context.Context, srcPath, dstPath string, secret []byte, opts Options) {
+	src := mustOpen(t, ctx, srcPath, true)
+	defer src.Close(ctx)
+	dst := mustOpen(t, ctx, dstPath, false)
+	opts.Secret = secret
+	opts.TimestampAnchor = fixedAnchor
+	require.NoError(t, Sanitize(ctx, src, dst, opts))
+	require.NoError(t, dst.Close(ctx))
+}
+
+// TestSanitizeParallelMultiSync exercises the per-page transform fan-out across
+// a multi-sync fixture. Run under -race, it is the concurrency guard for the
+// parallel transform stage; it also confirms output is correct (record counts
+// preserved) under fan-out.
+func TestSanitizeParallelMultiSync(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	srcPath := filepath.Join(tmp, "src.c1z")
+	dstPath := filepath.Join(tmp, "dst.c1z")
+	buildSyncFixture(t, ctx, srcPath, 2, 50)
+
+	sanitizeToFile(t, ctx, srcPath, dstPath, bytes32("parallel-multisync"), Options{})
+
+	srcRO := mustOpen(t, ctx, srcPath, true)
+	defer srcRO.Close(ctx)
+	dstRO := mustOpen(t, ctx, dstPath, true)
+	defer dstRO.Close(ctx)
+	srcRec := collectRecords(t, ctx, srcRO)
+	dstRec := collectRecords(t, ctx, dstRO)
+	require.Equal(t, len(srcRec.grants), len(dstRec.grants), "grant count preserved across fan-out")
+	require.Equal(t, len(srcRec.resources), len(dstRec.resources))
+	require.Equal(t, len(srcRec.entitlements), len(dstRec.entitlements))
+	require.NotZero(t, len(dstRec.grants))
+}
+
+// interruptingWriter wraps a real C1File and fails the Nth PutGrants call,
+// simulating a process kill at the start of the grant phase. Embedding the
+// concrete *C1File promotes every method (including the optional sync-link /
+// supports-diff capabilities) so Sanitize behaves as against a real writer.
+type interruptingWriter struct {
+	*dotc1z.C1File
+	failOnPutGrantsCall int
+	putGrantsCalls      int
+}
+
+func (w *interruptingWriter) PutGrants(ctx context.Context, grants ...*v2.Grant) error {
+	w.putGrantsCalls++
+	if w.putGrantsCalls >= w.failOnPutGrantsCall {
+		return errors.New("simulated interruption")
+	}
+	return w.C1File.PutGrants(ctx, grants...)
+}
+
+// TestSanitizeCheckpointResume interrupts a resumable run at the grant phase,
+// persists the partial destination, then resumes — and asserts the resumed
+// output is record-identical to an uninterrupted run with the same secret and
+// anchor.
+func TestSanitizeCheckpointResume(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	srcPath := filepath.Join(tmp, "src.c1z")
+	cleanDst := filepath.Join(tmp, "clean.c1z")
+	resumeDst := filepath.Join(tmp, "resume.c1z")
+	secret := bytes32("checkpoint-resume")
+	buildSyncFixture(t, ctx, srcPath, 1, 40)
+
+	// Reference: a single uninterrupted resumable run.
+	sanitizeToFile(t, ctx, srcPath, cleanDst, secret, Options{Resumable: true})
+
+	// Interrupted run: fail on the first PutGrants (resources + entitlements
+	// were written and checkpointed; grants did not start).
+	func() {
+		src := mustOpen(t, ctx, srcPath, true)
+		defer src.Close(ctx)
+		w := &interruptingWriter{C1File: mustOpen(t, ctx, resumeDst, false), failOnPutGrantsCall: 1}
+		err := Sanitize(ctx, src, w, Options{Secret: secret, TimestampAnchor: fixedAnchor, Resumable: true})
+		require.Error(t, err, "run must be interrupted at the grant phase")
+		require.NoError(t, w.Close(ctx)) // persist the partial destination
+	}()
+
+	// Resume into the persisted partial destination.
+	func() {
+		src := mustOpen(t, ctx, srcPath, true)
+		defer src.Close(ctx)
+		dst := mustOpen(t, ctx, resumeDst, false)
+		require.NoError(t, Sanitize(ctx, src, dst, Options{Secret: secret, TimestampAnchor: fixedAnchor, Resumable: true}))
+		require.NoError(t, dst.Close(ctx))
+	}()
+
+	cleanRO := mustOpen(t, ctx, cleanDst, true)
+	defer cleanRO.Close(ctx)
+	resumeRO := mustOpen(t, ctx, resumeDst, true)
+	defer resumeRO.Close(ctx)
+	clean := collectRecords(t, ctx, cleanRO)
+	resumed := collectRecords(t, ctx, resumeRO)
+
+	require.NotZero(t, len(clean.grants))
+	require.Equal(t, len(clean.grants), len(resumed.grants), "resumed grant count must match the uninterrupted run")
+	require.Equal(t, len(clean.resources), len(resumed.resources))
+	require.Equal(t, len(clean.entitlements), len(resumed.entitlements))
+	require.Equal(t, clean.idOccurrences, resumed.idOccurrences, "resumed output must be record-identical to the uninterrupted run")
+}
+
+// BenchmarkSanitize tracks end-to-end sanitize throughput. genGrants is the
+// tracked size knob; the headline number is G=1_000_000 (raise genGrants for a
+// real measurement — kept modest here so the benchmark is runnable in CI).
+func BenchmarkSanitize(b *testing.B) {
+	const genGrants = 2000
+	ctx := context.Background()
+	tmp := b.TempDir()
+	srcPath := filepath.Join(tmp, "bench-src.c1z")
+	buildSyncFixture(b, ctx, srcPath, 1, genGrants)
+	secret := bytes32("bench-sanitize")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		dstPath := filepath.Join(tmp, fmt.Sprintf("bench-dst-%d.c1z", i))
+		src, err := dotc1z.NewC1ZFile(ctx, srcPath, dotc1z.WithReadOnly(true))
+		if err != nil {
+			b.Fatal(err)
+		}
+		dst, err := dotc1z.NewC1ZFile(ctx, dstPath)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if err := Sanitize(ctx, src, dst, Options{Secret: secret, TimestampAnchor: fixedAnchor}); err != nil {
+			b.Fatal(err)
+		}
+		_ = dst.Close(ctx)
+		_ = src.Close(ctx)
+	}
+}

--- a/pkg/c1zsanitize/parallel_checkpoint_test.go
+++ b/pkg/c1zsanitize/parallel_checkpoint_test.go
@@ -45,20 +45,36 @@ func buildSyncFixture(t testing.TB, ctx context.Context, path string, nSyncs, gr
 			v2.ResourceType_builder{Id: "role", DisplayName: "Role", Traits: []v2.ResourceType_Trait{v2.ResourceType_TRAIT_ROLE}}.Build(),
 		))
 
+		// Each user carries a UserTrait Icon AssetRef, so the resource phase is
+		// the source of resource-trait asset refs. copyAssets must reproduce
+		// these on every run — including a resume that skips the resource WRITE —
+		// or the sanitized output holds dangling AssetRefs. iconID below is the
+		// source asset id; the corresponding asset row is written after.
 		var resources []*v2.Resource
+		var iconIDs []string
 		for i := 0; i < grantsPerSync; i++ {
+			iconID := fmt.Sprintf("%sicon-%d", p, i)
+			iconIDs = append(iconIDs, iconID)
 			resources = append(resources, v2.Resource_builder{
 				Id:          v2.ResourceId_builder{ResourceType: "user", Resource: fmt.Sprintf("%su%d", p, i)}.Build(),
 				DisplayName: fmt.Sprintf("User %d", i),
 				Annotations: []*anypb.Any{anyTB(t, v2.UserTrait_builder{
 					Login:  fmt.Sprintf("user%d@acme.com", i),
 					Emails: []*v2.UserTrait_Email{v2.UserTrait_Email_builder{Address: fmt.Sprintf("user%d@acme.com", i), IsPrimary: true}.Build()},
+					Icon:   v2.AssetRef_builder{Id: iconID}.Build(),
 				}.Build())},
 			}.Build())
 		}
 		role := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "role", Resource: p + "admin"}.Build(), DisplayName: "Admin"}.Build()
 		resources = append(resources, role)
 		require.NoError(t, f.PutResources(ctx, resources...))
+
+		// The asset rows the resource icons reference. Without these the source
+		// would carry dangling refs; with them, the sanitizer's copyAssets has a
+		// real asset to fetch, placeholder, and re-write per icon.
+		for _, iconID := range iconIDs {
+			require.NoError(t, f.PutAsset(ctx, v2.AssetRef_builder{Id: iconID}.Build(), "image/png", []byte{0x89, 0x50, 0x4e, 0x47}))
+		}
 
 		ent := v2.Entitlement_builder{Id: p + "ent-admin", Resource: role, DisplayName: "admin", Slug: "admin"}.Build()
 		require.NoError(t, f.PutEntitlements(ctx, ent))
@@ -180,6 +196,213 @@ func TestSanitizeCheckpointResume(t *testing.T) {
 	require.Equal(t, len(clean.resources), len(resumed.resources))
 	require.Equal(t, len(clean.entitlements), len(resumed.entitlements))
 	require.Equal(t, clean.idOccurrences, resumed.idOccurrences, "resumed output must be record-identical to the uninterrupted run")
+}
+
+// startSyncInterruptingWriter wraps a real C1File and fails the Nth
+// StartNewSync call, simulating a process kill after one source sync fully
+// completed (EndSync ran) but before the next source sync's destination sync is
+// created. Embedding the concrete *C1File promotes every other method,
+// including ListSyncRuns, so resume reads checkpoints through it.
+type startSyncInterruptingWriter struct {
+	*dotc1z.C1File
+	failOnStartCall int
+	startCalls      int
+}
+
+func (w *startSyncInterruptingWriter) StartNewSync(ctx context.Context, syncType connectorstore.SyncType, parentSyncID string) (string, error) {
+	w.startCalls++
+	if w.startCalls >= w.failOnStartCall {
+		return "", errors.New("simulated interruption at sync start")
+	}
+	return w.C1File.StartNewSync(ctx, syncType, parentSyncID)
+}
+
+// grantsPerDstSync returns the grant count of each destination sync, keyed by
+// dst sync id. It is the B1 guard: a run that wrote a later source sync's
+// records into an earlier (ended) sync would show one sync with a doubled count
+// and a missing sibling.
+func grantsPerDstSync(t *testing.T, ctx context.Context, r connectorstore.Reader) map[string]int {
+	t.Helper()
+	syncs, err := listAllSyncs(ctx, r)
+	require.NoError(t, err)
+	out := map[string]int{}
+	for _, sr := range syncs {
+		page := ""
+		for {
+			resp, err := r.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{
+				PageSize:    1000,
+				PageToken:   page,
+				Annotations: syncIDAnnotations(sr.GetId()),
+			}.Build())
+			require.NoError(t, err)
+			out[sr.GetId()] += len(resp.GetList())
+			if resp.GetNextPageToken() == "" {
+				break
+			}
+			page = resp.GetNextPageToken()
+		}
+	}
+	return out
+}
+
+// TestSanitizeResumeMultiSyncNoCrossWrite proves B1: when run 1 finishes the
+// first source sync and dies before the second source sync's destination sync
+// exists, the resume must create a fresh destination sync for the second
+// source — never append its records to the already-ended first sync. Before the
+// fix, loadResumeStates left the destination's current-sync pointer on the
+// ended sync and StartNewSync handed it back, so the second sync's records
+// landed in the first.
+func TestSanitizeResumeMultiSyncNoCrossWrite(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	srcPath := filepath.Join(tmp, "src.c1z")
+	cleanDst := filepath.Join(tmp, "clean.c1z")
+	resumeDst := filepath.Join(tmp, "resume.c1z")
+	secret := bytes32("multisync-b1")
+	const perSync = 8
+	buildSyncFixture(t, ctx, srcPath, 2, perSync)
+
+	// Reference: a single uninterrupted run over both syncs.
+	sanitizeToFile(t, ctx, srcPath, cleanDst, secret, Options{Resumable: true})
+
+	// Interrupted run: complete the first source sync, then fail when the second
+	// source sync tries to start (2nd StartNewSync). The persisted destination
+	// holds exactly one ended sync.
+	func() {
+		src := mustOpen(t, ctx, srcPath, true)
+		defer src.Close(ctx)
+		w := &startSyncInterruptingWriter{C1File: mustOpen(t, ctx, resumeDst, false), failOnStartCall: 2}
+		err := Sanitize(ctx, src, w, Options{Secret: secret, TimestampAnchor: fixedAnchor, Resumable: true})
+		require.Error(t, err, "run must be interrupted at the second sync's start")
+		require.NoError(t, w.Close(ctx))
+	}()
+
+	// Sanity: the partial destination has exactly one (ended) sync.
+	func() {
+		ro := mustOpen(t, ctx, resumeDst, true)
+		defer ro.Close(ctx)
+		syncs, err := listAllSyncs(ctx, ro)
+		require.NoError(t, err)
+		require.Len(t, syncs, 1, "interrupted run persisted exactly the first sync")
+	}()
+
+	// Resume: the second source sync must get its OWN destination sync.
+	func() {
+		src := mustOpen(t, ctx, srcPath, true)
+		defer src.Close(ctx)
+		dst := mustOpen(t, ctx, resumeDst, false)
+		require.NoError(t, Sanitize(ctx, src, dst, Options{Secret: secret, TimestampAnchor: fixedAnchor, Resumable: true}))
+		require.NoError(t, dst.Close(ctx))
+	}()
+
+	cleanRO := mustOpen(t, ctx, cleanDst, true)
+	defer cleanRO.Close(ctx)
+	resumeRO := mustOpen(t, ctx, resumeDst, true)
+	defer resumeRO.Close(ctx)
+
+	cleanPer := grantsPerDstSync(t, ctx, cleanRO)
+	resumePer := grantsPerDstSync(t, ctx, resumeRO)
+	require.Len(t, resumePer, 2, "resume must produce two destination syncs, not one overloaded sync")
+	require.Len(t, cleanPer, 2)
+	for id, n := range resumePer {
+		require.Equal(t, perSync, n, "dst sync %s must hold exactly one source sync's grants (no cross-write)", id)
+	}
+
+	clean := collectRecords(t, ctx, cleanRO)
+	resumed := collectRecords(t, ctx, resumeRO)
+	require.Equal(t, len(clean.grants), len(resumed.grants))
+	require.Equal(t, clean.idOccurrences, resumed.idOccurrences, "resumed multi-sync output must be record-identical to the uninterrupted run")
+}
+
+// TestSanitizeResumePreservesAssetRefs proves B2: a resume that skips the
+// resource WRITE must still re-collect resource-trait asset refs so copyAssets
+// reproduces them. The interrupted run dies at the grant phase before copyAssets
+// ever runs, so the asset rows exist only if the resume's read-only resource
+// walk re-collected their refs. Before the fix, resume skipped copyResources
+// entirely and the icon assets were never written.
+func TestSanitizeResumePreservesAssetRefs(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	srcPath := filepath.Join(tmp, "src.c1z")
+	resumeDst := filepath.Join(tmp, "resume.c1z")
+	secret := bytes32("asset-refs-b2")
+	buildSyncFixture(t, ctx, srcPath, 1, 6)
+
+	// Interrupted run: resources + entitlements written, grants fail (copyAssets
+	// never reached).
+	func() {
+		src := mustOpen(t, ctx, srcPath, true)
+		defer src.Close(ctx)
+		w := &interruptingWriter{C1File: mustOpen(t, ctx, resumeDst, false), failOnPutGrantsCall: 1}
+		err := Sanitize(ctx, src, w, Options{Secret: secret, TimestampAnchor: fixedAnchor, Resumable: true})
+		require.Error(t, err)
+		require.NoError(t, w.Close(ctx))
+	}()
+
+	// Resume to completion.
+	func() {
+		src := mustOpen(t, ctx, srcPath, true)
+		defer src.Close(ctx)
+		dst := mustOpen(t, ctx, resumeDst, false)
+		require.NoError(t, Sanitize(ctx, src, dst, Options{Secret: secret, TimestampAnchor: fixedAnchor, Resumable: true}))
+		require.NoError(t, dst.Close(ctx))
+	}()
+
+	// Every source icon asset must be present in the resumed destination under
+	// its sanitized id. The sanitized id is s.id(srcIconID) under the same
+	// secret.
+	idHelper := &sanitizer{secret: secret, hmacPool: newHMACPool(secret)}
+	resumeRO := mustOpen(t, ctx, resumeDst, true)
+	defer resumeRO.Close(ctx)
+	for i := 0; i < 6; i++ {
+		dstAssetID := idHelper.id(fmt.Sprintf("s0-icon-%d", i))
+		_, r, err := resumeRO.GetAsset(ctx, v2.AssetServiceGetAssetRequest_builder{
+			Asset: v2.AssetRef_builder{Id: dstAssetID}.Build(),
+		}.Build())
+		require.NoError(t, err, "resumed output must contain the resource-trait icon asset %d (B2: asset refs survive resume)", i)
+		require.NoError(t, closeIfCloser(r))
+	}
+}
+
+// TestSanitizeDefaultAnchorResume proves B3: a resumable run that does NOT pass
+// an explicit TimestampAnchor must still resume. Before the fix the checkpoint
+// fingerprint bound the anchor, and run 2's default time.Now() anchor produced
+// a different fingerprint, so resume hard-failed. Now the anchor is persisted in
+// the token and adopted on resume.
+func TestSanitizeDefaultAnchorResume(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	srcPath := filepath.Join(tmp, "src.c1z")
+	resumeDst := filepath.Join(tmp, "resume.c1z")
+	secret := bytes32("default-anchor-b3")
+	buildSyncFixture(t, ctx, srcPath, 1, 10)
+
+	// Interrupted run with a ZERO TimestampAnchor (anchor defaults to now).
+	func() {
+		src := mustOpen(t, ctx, srcPath, true)
+		defer src.Close(ctx)
+		w := &interruptingWriter{C1File: mustOpen(t, ctx, resumeDst, false), failOnPutGrantsCall: 1}
+		err := Sanitize(ctx, src, w, Options{Secret: secret, Resumable: true})
+		require.Error(t, err)
+		require.NoError(t, w.Close(ctx))
+	}()
+
+	// Resume, again with a ZERO TimestampAnchor. This must succeed by adopting
+	// the anchor the first run persisted, not fail on a fingerprint mismatch.
+	func() {
+		src := mustOpen(t, ctx, srcPath, true)
+		defer src.Close(ctx)
+		dst := mustOpen(t, ctx, resumeDst, false)
+		require.NoError(t, Sanitize(ctx, src, dst, Options{Secret: secret, Resumable: true}),
+			"a default-anchor resumable run must resume, not fail on an anchor-bound fingerprint")
+		require.NoError(t, dst.Close(ctx))
+	}()
+
+	resumeRO := mustOpen(t, ctx, resumeDst, true)
+	defer resumeRO.Close(ctx)
+	rec := collectRecords(t, ctx, resumeRO)
+	require.NotZero(t, len(rec.grants), "resumed default-anchor run must have completed the grant phase")
+	require.Equal(t, 10, len(rec.grants))
 }
 
 // BenchmarkSanitize tracks end-to-end sanitize throughput. genGrants is the

--- a/pkg/c1zsanitize/perf_test.go
+++ b/pkg/c1zsanitize/perf_test.go
@@ -1,8 +1,6 @@
 package c1zsanitize
 
 import (
-	"crypto/hmac"
-	"crypto/sha256"
 	"strconv"
 	"testing"
 	"time"
@@ -30,7 +28,7 @@ func mustAnyB(m proto.Message) *anypb.Any {
 func newTestSanitizer(secret []byte) *sanitizer {
 	return &sanitizer{
 		secret:                 secret,
-		idHmac:                 hmac.New(sha256.New, secret),
+		hmacPool:               newHMACPool(secret),
 		domains:                newDomainMap(),
 		shifter:                newTimestampShifter(time.Time{}, time.Time{}),
 		dropUnknownAnnotations: true,

--- a/pkg/c1zsanitize/real_rollback_roundtrip_test.go
+++ b/pkg/c1zsanitize/real_rollback_roundtrip_test.go
@@ -1,0 +1,232 @@
+package c1zsanitize
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	"github.com/conductorone/baton-sdk/pkg/sdk"
+	"github.com/conductorone/baton-sdk/pkg/sync"
+)
+
+// buildNestedExpandableC1Z writes a pre-expansion c1z modeling nested groups:
+// g2 is a member of g1 (an expandable grant via group:g2:member) and g3 is a
+// member of g2 (expandable via group:g3:member); alice is a direct member of g3
+// and bob a direct member of g2. The sync is started but NOT finished and NOT
+// expanded — expandViaRealSyncer below finishes and expands it.
+//
+// Unlike cmd/baton's buildPreExpansionC1Z, this fixture sets NO hand-built
+// GrantSources: every Sources map in the resulting file is produced by the real
+// expander, so "GrantSources topology" here means precisely the expansion
+// topology under test. The nested shape forces multi-hop derivation (alice and
+// bob reach g1 through g2), giving several derived grants rather than one.
+func buildNestedExpandableC1Z(t *testing.T, ctx context.Context, path string) string {
+	t.Helper()
+	f, err := dotc1z.NewC1ZFile(ctx, path)
+	require.NoError(t, err)
+	syncID, err := f.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+
+	require.NoError(t, f.PutResourceTypes(ctx,
+		v2.ResourceType_builder{Id: "group", DisplayName: "Group", Traits: []v2.ResourceType_Trait{v2.ResourceType_TRAIT_GROUP}}.Build(),
+		v2.ResourceType_builder{Id: "user", DisplayName: "User", Traits: []v2.ResourceType_Trait{v2.ResourceType_TRAIT_USER}}.Build(),
+	))
+
+	g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(), DisplayName: "G1"}.Build()
+	g2 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g2"}.Build(), DisplayName: "G2"}.Build()
+	g3 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g3"}.Build(), DisplayName: "G3"}.Build()
+	alice := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "alice"}.Build(), DisplayName: "Alice"}.Build()
+	bob := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "bob"}.Build(), DisplayName: "Bob"}.Build()
+	require.NoError(t, f.PutResources(ctx, g1, g2, g3, alice, bob))
+
+	g1Member := v2.Entitlement_builder{Id: "group:g1:member", DisplayName: "g1 member", Resource: g1, Slug: "member"}.Build()
+	g2Member := v2.Entitlement_builder{Id: "group:g2:member", DisplayName: "g2 member", Resource: g2, Slug: "member"}.Build()
+	g3Member := v2.Entitlement_builder{Id: "group:g3:member", DisplayName: "g3 member", Resource: g3, Slug: "member"}.Build()
+	require.NoError(t, f.PutEntitlements(ctx, g1Member, g2Member, g3Member))
+
+	// g2 member of g1, expandable into g1:member from g2:member.
+	nestG2InG1 := v2.Grant_builder{
+		Id:          "group:g1:member:group:g2",
+		Entitlement: g1Member,
+		Principal:   g2,
+		Annotations: []*anypb.Any{anyTB(t, v2.GrantExpandable_builder{EntitlementIds: []string{"group:g2:member"}}.Build())},
+	}.Build()
+	// g3 member of g2, expandable into g2:member from g3:member.
+	nestG3InG2 := v2.Grant_builder{
+		Id:          "group:g2:member:group:g3",
+		Entitlement: g2Member,
+		Principal:   g3,
+		Annotations: []*anypb.Any{anyTB(t, v2.GrantExpandable_builder{EntitlementIds: []string{"group:g3:member"}}.Build())},
+	}.Build()
+	aliceG3 := v2.Grant_builder{Id: "group:g3:member:user:alice", Entitlement: g3Member, Principal: alice}.Build()
+	bobG2 := v2.Grant_builder{Id: "group:g2:member:user:bob", Entitlement: g2Member, Principal: bob}.Build()
+	require.NoError(t, f.PutGrants(ctx, nestG2InG1, nestG3InG2, aliceG3, bobG2))
+
+	require.NoError(t, f.Close(ctx))
+	return syncID
+}
+
+// expandViaRealSyncer runs the production grant expander over an existing c1z
+// by path, exactly as cmd/baton's rollback_expansion_test.expandViaSyncer does:
+// an empty connector with WithOnlyExpandGrants, so only the expansion phase runs
+// over the data already in the file. It finishes the sync with a non-empty
+// completed token, sets the supports_diff marker, and writes the derived grants.
+// WithConnectorStore is deliberately NOT used (it double-closes the store).
+func expandViaRealSyncer(t *testing.T, ctx context.Context, path, syncID string) {
+	t.Helper()
+	conn, err := sdk.NewEmptyConnector()
+	require.NoError(t, err)
+	syncer, err := sync.NewSyncer(ctx, conn,
+		sync.WithC1ZPath(path),
+		sync.WithSyncID(syncID),
+		sync.WithOnlyExpandGrants(),
+		sync.WithTmpDir(t.TempDir()),
+	)
+	require.NoError(t, err)
+	require.NoError(t, syncer.Sync(ctx))
+	require.NoError(t, syncer.Close(ctx))
+}
+
+// singleSyncID returns the id of the one sync in path, failing if there is not
+// exactly one. Sanitize emits one destination sync per source sync, with a NEW
+// (sanitized) id, so the rollback/replay must target this id, not the source's.
+func singleSyncID(t *testing.T, ctx context.Context, path string) string {
+	t.Helper()
+	ro := mustOpen(t, ctx, path, true)
+	defer ro.Close(ctx)
+	syncs, err := listAllSyncs(ctx, ro)
+	require.NoError(t, err)
+	require.Len(t, syncs, 1)
+	return syncs[0].GetId()
+}
+
+// loadGrantsBySync reads every grant of syncID keyed by grant id, with the
+// GrantSources the writer persisted. ListGrants returns Sources on the grant
+// (cmd/baton's loadGrant relies on the same), which is the topology this test
+// compares across the roundtrip.
+func loadGrantsBySync(t *testing.T, ctx context.Context, path, syncID string) map[string]*v2.Grant {
+	t.Helper()
+	ro := mustOpen(t, ctx, path, true)
+	defer ro.Close(ctx)
+	require.NoError(t, ro.SetCurrentSync(ctx, syncID))
+	out := map[string]*v2.Grant{}
+	pageToken := ""
+	for {
+		resp, err := ro.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{PageSize: 1000, PageToken: pageToken}.Build())
+		require.NoError(t, err)
+		for _, g := range resp.GetList() {
+			out[g.GetId()] = g
+		}
+		if resp.GetNextPageToken() == "" {
+			return out
+		}
+		pageToken = resp.GetNextPageToken()
+	}
+}
+
+// rollbackDeleteCount returns how many grants a dry-run rollback would delete on
+// syncID — the count of purely expander-derived rows still present.
+func rollbackDeleteCount(t *testing.T, ctx context.Context, path, syncID string) int {
+	t.Helper()
+	ro := mustOpen(t, ctx, path, true)
+	defer ro.Close(ctx)
+	res, err := ro.RollbackExpansion(ctx, syncID, true)
+	require.NoError(t, err)
+	return res.GrantsDeleted
+}
+
+// TestSanitizeRealRollbackReplayRoundtrip exercises the REAL rollback+replay
+// mechanism — dotc1z.RollbackExpansion plus the production grant expander —
+// through a sanitized c1z, rather than the resume-checkpoint proxy that
+// TestSanitizeRoundtripPreservesGrantExpansionTopology uses. The two tests guard
+// different concerns and both must pass.
+//
+// Real APIs used (signatures confirmed against the PR #938 tree):
+//   - (*dotc1z.C1File).RollbackExpansion(ctx, syncID string, dryRun bool, ...RollbackOption) (*RollbackResult, error)
+//   - dotc1z.WithSyncTokenRewrite(func(token string) (string, error)) RollbackOption
+//   - sync.PrepareExpansionReplayToken(stateStr string) (string, error) — re-marks
+//     a finished sync's token for expansion so the replay re-derives instead of no-oping.
+//   - sync.WithOnlyExpandGrants() — runs only the expansion phase over existing data.
+//
+// Flow:
+//
+//	a. PRE-EXPANSION FIXTURE — buildNestedExpandableC1Z: nested groups with
+//	   GrantExpandable annotations and no hand-set Sources.
+//	b. REAL SYNCER EXPANSION — expandViaRealSyncer: derives grants, sets
+//	   supports_diff, finishes the sync.
+//	c. SANITIZE — Sanitize the expanded c1z to a new file. Sanitize carries the
+//	   supports_diff marker and ends the destination sync, so the output is a
+//	   finished, expansion-marked sync RollbackExpansion accepts; the GrantSources
+//	   keys and GrantExpandable ids are relabeled consistently under the secret.
+//	d. ROLLBACK — RollbackExpansion(..., WithSyncTokenRewrite(PrepareExpansionReplayToken))
+//	   on the sanitized output: deletes the derived grants, clears self-sources,
+//	   and rewrites the token so the sync is replayable.
+//	e. REPLAY — expandViaRealSyncer again on the rolled-back output.
+//	f. ASSERT — the replayed grants match the pre-rollback (post-sanitize)
+//	   expanded state: identical id set, identical per-grant GrantSources
+//	   (proto.Equal), and the same number of grants a fresh rollback would
+//	   delete. Because sanitize is a consistent relabeling, expanding the
+//	   rolled-back sanitized base reproduces exactly the sanitized expansion.
+func TestSanitizeRealRollbackReplayRoundtrip(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	srcPath := filepath.Join(tmp, "src.c1z")
+	sanPath := filepath.Join(tmp, "sanitized.c1z")
+	secret := bytes32("real-rollback-replay-roundtrip")
+
+	// a + b: pre-expansion fixture, then real expansion.
+	origSyncID := buildNestedExpandableC1Z(t, ctx, srcPath)
+	expandViaRealSyncer(t, ctx, srcPath, origSyncID)
+
+	// c: sanitize the expanded file. sanitizeToFile pins the fixed anchor.
+	sanitizeToFile(t, ctx, srcPath, sanPath, secret, Options{})
+	sanSyncID := singleSyncID(t, ctx, sanPath)
+
+	// Pre-rollback expanded state, in sanitized id-space.
+	preRollback := loadGrantsBySync(t, ctx, sanPath, sanSyncID)
+	derivedDeletable := rollbackDeleteCount(t, ctx, sanPath, sanSyncID)
+	require.Positive(t, derivedDeletable,
+		"the real expansion through a sanitized file must leave derived grants to roll back")
+
+	// d: rollback in place on the sanitized output, rewriting the token so the
+	// sync can be replayed.
+	func() {
+		store := mustOpen(t, ctx, sanPath, false)
+		defer store.Close(ctx)
+		res, err := store.RollbackExpansion(ctx, sanSyncID, false,
+			dotc1z.WithSyncTokenRewrite(sync.PrepareExpansionReplayToken))
+		require.NoError(t, err)
+		require.Equal(t, derivedDeletable, res.GrantsDeleted,
+			"rollback must delete exactly the derived grants the dry run counted")
+	}()
+
+	postRollback := loadGrantsBySync(t, ctx, sanPath, sanSyncID)
+	require.Less(t, len(postRollback), len(preRollback),
+		"rollback must remove the derived grants from the sanitized output")
+	require.Zero(t, rollbackDeleteCount(t, ctx, sanPath, sanSyncID),
+		"a rolled-back sync has no derived grants left to delete")
+
+	// e: replay — re-expand the rolled-back sanitized output.
+	expandViaRealSyncer(t, ctx, sanPath, sanSyncID)
+
+	// f: the replayed expansion reproduces the pre-rollback sanitized topology.
+	replayed := loadGrantsBySync(t, ctx, sanPath, sanSyncID)
+	require.Equal(t, len(preRollback), len(replayed),
+		"replay must restore the full grant count")
+	require.Equal(t, derivedDeletable, rollbackDeleteCount(t, ctx, sanPath, sanSyncID),
+		"replay must re-derive exactly the grants the rollback removed")
+
+	for id, pre := range preRollback {
+		got, ok := replayed[id]
+		require.Truef(t, ok, "grant %q must be re-derived by replay", id)
+		require.Truef(t, proto.Equal(pre.GetSources(), got.GetSources()),
+			"grant %q GrantSources topology must survive the rollback->replay roundtrip", id)
+	}
+}

--- a/pkg/c1zsanitize/resume_expansion_roundtrip_test.go
+++ b/pkg/c1zsanitize/resume_expansion_roundtrip_test.go
@@ -1,0 +1,196 @@
+package c1zsanitize
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+)
+
+// buildExpandedGrantFixture writes a single-sync c1z whose grants each carry a
+// GrantExpandable annotation — i.e. an expanded grant-expansion topology. The
+// grants are written through the real SQLite writer, so (as in production
+// files) PutGrants strips each GrantExpandable out of the data blob and into the
+// side `expansion` column. nGrants grants share one entitlement on a role and
+// each bind a distinct user principal.
+//
+// expEntIDs/expRTIDs are the GrantExpandable cross-reference fields used so the
+// test can assert how the sanitizer rewrites them: a declared resource type
+// ("user") is preserved verbatim under the known-type rule, while an undeclared
+// token ("group") is HMAC'd.
+func buildExpandedGrantFixture(t *testing.T, ctx context.Context, path string, nGrants int) {
+	t.Helper()
+	f, err := dotc1z.NewC1ZFile(ctx, path)
+	require.NoError(t, err)
+
+	_, err = f.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+
+	require.NoError(t, f.PutResourceTypes(ctx,
+		v2.ResourceType_builder{Id: "user", DisplayName: "User", Traits: []v2.ResourceType_Trait{v2.ResourceType_TRAIT_USER}}.Build(),
+		v2.ResourceType_builder{Id: "role", DisplayName: "Role", Traits: []v2.ResourceType_Trait{v2.ResourceType_TRAIT_ROLE}}.Build(),
+	))
+
+	role := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "role", Resource: "admin"}.Build(), DisplayName: "Admin"}.Build()
+	resources := []*v2.Resource{role}
+	for i := 0; i < nGrants; i++ {
+		resources = append(resources, v2.Resource_builder{
+			Id:          v2.ResourceId_builder{ResourceType: "user", Resource: fmt.Sprintf("u%d", i)}.Build(),
+			DisplayName: fmt.Sprintf("User %d", i),
+			Annotations: []*anypb.Any{anyTB(t, v2.UserTrait_builder{Login: fmt.Sprintf("u%d@acme.com", i)}.Build())},
+		}.Build())
+	}
+	require.NoError(t, f.PutResources(ctx, resources...))
+
+	ent := v2.Entitlement_builder{Id: "ent-admin", Resource: role, DisplayName: "admin", Slug: "admin"}.Build()
+	require.NoError(t, f.PutEntitlements(ctx, ent))
+
+	var grants []*v2.Grant
+	for i := 0; i < nGrants; i++ {
+		principal := resources[i+1] // resources[0] is the role
+		grants = append(grants, v2.Grant_builder{
+			Id:          fmt.Sprintf("grant-%d", i),
+			Entitlement: ent,
+			Principal:   principal,
+			Annotations: annotations.New(v2.GrantExpandable_builder{
+				EntitlementIds:  []string{"ent-admin", fmt.Sprintf("ent-other-%d", i)},
+				Shallow:         true,
+				ResourceTypeIds: []string{"user", "group"}, // user: declared -> verbatim; group: undeclared -> HMAC'd
+			}.Build()),
+		}.Build())
+	}
+	require.NoError(t, f.PutGrants(ctx, grants...))
+	require.NoError(t, f.EndSync(ctx))
+	require.NoError(t, f.Close(ctx))
+}
+
+// TestSanitizeRoundtripPreservesGrantExpansionTopology is the resumable
+// sanitize roundtrip fidelity check for grant-expansion topology.
+//
+// The c1zsanitize package has no literal "rollback"/"replay" verbs — sanitize is
+// a one-directional src->dst transform. The roundtrip the spec asks for maps
+// onto the package's REAL resumable-checkpoint mechanism (Options.Resumable):
+//
+//   - SANITIZE -> Sanitize(ctx, src, dst, Options{Resumable: true}).
+//   - "ROLLBACK" -> an interruption at the grant phase (interruptingWriter fails
+//     the first PutGrants). The partial destination is persisted; the incomplete
+//     grant-phase work is effectively rolled back to the last checkpoint (the
+//     resources/entitlements checkpoint), with no grants committed.
+//   - "REPLAY" -> the resume run: Sanitize(...) again into the persisted partial
+//     destination. loadResumeStates reads the checkpoint and replays the
+//     read-only resource/entitlement walk plus the full grant phase from the
+//     checkpointed page cursor to completion.
+//
+// The fixture's grants each carry a GrantExpandable (stripped into the SQLite
+// side column on write). The assertion is that after the full
+// sanitize -> interrupt(rollback) -> resume(replay) roundtrip, every sanitized
+// destination grant still carries its GrantExpandable, sanitized correctly:
+// entitlement ids rewritten via transformID, the declared resource-type token
+// preserved verbatim and the undeclared one HMAC'd, and shallow preserved. This
+// exercises the PR #938 ListGrants expansion-reattach wiring specifically on the
+// resume/replay read path.
+func TestSanitizeRoundtripPreservesGrantExpansionTopology(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	srcPath := filepath.Join(tmp, "src.c1z")
+	cleanDst := filepath.Join(tmp, "clean.c1z")
+	resumeDst := filepath.Join(tmp, "resume.c1z")
+	secret := bytes32("expansion-resume-roundtrip")
+
+	const nGrants = 12
+	buildExpandedGrantFixture(t, ctx, srcPath, nGrants)
+
+	// Reference: a single uninterrupted resumable run, for record-identity.
+	sanitizeToFile(t, ctx, srcPath, cleanDst, secret, Options{Resumable: true})
+
+	// SANITIZE + "ROLLBACK": interrupt the resumable run at the grant phase
+	// (first PutGrants fails). Resources + entitlements were written and
+	// checkpointed; no grants are committed. Persist the partial destination.
+	func() {
+		src := mustOpen(t, ctx, srcPath, true)
+		defer src.Close(ctx)
+		w := &interruptingWriter{C1File: mustOpen(t, ctx, resumeDst, false), failOnPutGrantsCall: 1}
+		err := Sanitize(ctx, src, w, Options{Secret: secret, TimestampAnchor: fixedAnchor, Resumable: true})
+		require.Error(t, err, "run must be interrupted at the grant phase (rollback point)")
+		require.NoError(t, w.Close(ctx))
+	}()
+
+	// Sanity: the partial destination has no committed grants yet — the grant
+	// phase truly rolled back to the checkpoint.
+	func() {
+		ro := mustOpen(t, ctx, resumeDst, true)
+		defer ro.Close(ctx)
+		rec := collectRecords(t, ctx, ro)
+		require.Zero(t, len(rec.grants), "interrupted run must have committed no grants (rolled back to checkpoint)")
+	}()
+
+	// "REPLAY": resume into the persisted partial destination, replaying the
+	// grant phase to completion.
+	func() {
+		src := mustOpen(t, ctx, srcPath, true)
+		defer src.Close(ctx)
+		dst := mustOpen(t, ctx, resumeDst, false)
+		require.NoError(t, Sanitize(ctx, src, dst, Options{Secret: secret, TimestampAnchor: fixedAnchor, Resumable: true}))
+		require.NoError(t, dst.Close(ctx))
+	}()
+
+	// Reference sanitizer (same secret + declared known types) to compute the
+	// expected sanitized cross-reference tokens. s.id/transformID depend only on
+	// the secret, so this reproduces the real run's output.
+	ref := newTestSanitizer(secret)
+	ref.knownResourceTypes["user"] = struct{}{}
+	ref.knownResourceTypes["role"] = struct{}{}
+
+	resumeRO := mustOpen(t, ctx, resumeDst, true)
+	defer resumeRO.Close(ctx)
+
+	// Record-identity with the uninterrupted run (counts + id occurrences).
+	cleanRO := mustOpen(t, ctx, cleanDst, true)
+	defer cleanRO.Close(ctx)
+	clean := collectRecords(t, ctx, cleanRO)
+	resumed := collectRecords(t, ctx, resumeRO)
+	require.Equal(t, nGrants, len(clean.grants))
+	require.Equal(t, len(clean.grants), len(resumed.grants), "resumed grant count must match the uninterrupted run")
+	require.Equal(t, clean.idOccurrences, resumed.idOccurrences, "resumed output must be record-identical to the uninterrupted run")
+
+	// The topology assertion: every resumed destination grant carries a
+	// sanitized GrantExpandable. Read through the expansion-aware path (the dst
+	// SQLite writer re-stripped it into the side column).
+	grants := listGrantsWithExpansion(t, ctx, resumeRO)
+	require.Len(t, grants, nGrants)
+
+	expandableCount := 0
+	for _, g := range grants {
+		ge := pickGrantExpandable(t, g)
+		if ge == nil {
+			continue
+		}
+		expandableCount++
+
+		// Entitlement ids rewritten via transformID (cross-references).
+		require.Len(t, ge.GetEntitlementIds(), 2)
+		require.Equal(t, ref.transformID("ent-admin"), ge.GetEntitlementIds()[0])
+		require.NotContains(t, ge.GetEntitlementIds(), "ent-admin",
+			"entitlement id must be sanitized, not passed through")
+
+		// Resource-type tokens: declared "user" verbatim, undeclared "group" HMAC'd.
+		require.Equal(t,
+			[]string{"user", ref.sanitizeResourceTypeToken("group")},
+			ge.GetResourceTypeIds())
+		require.NotEqual(t, "group", ge.GetResourceTypeIds()[1],
+			"undeclared resource-type token must be sanitized")
+
+		// Structural shallow flag preserved.
+		require.True(t, ge.GetShallow(), "shallow flag must survive the roundtrip")
+	}
+	require.Equal(t, nGrants, expandableCount,
+		"every grant's expansion topology must survive sanitize -> rollback -> replay intact")
+}

--- a/pkg/c1zsanitize/sanitize.go
+++ b/pkg/c1zsanitize/sanitize.go
@@ -18,9 +18,11 @@ import (
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"hash"
+	"sync"
 	"time"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
@@ -87,6 +89,18 @@ type Options struct {
 	// It catches a source that violates the one-object-per-id assumption the
 	// cache relies on. Adds CPU; intended for diagnostics, not production runs.
 	VerifyGrantCache bool
+
+	// Resumable enables checkpointing so an interrupted run continues instead
+	// of restarting. Progress is recorded in each destination sync's
+	// sync_token (a fingerprint of Secret+TimestampAnchor, the source sync id,
+	// the next phase, and the grant page token). On a later run against the
+	// SAME destination file, completed phases are skipped and the grant phase
+	// resumes from its last committed page. A destination carrying checkpoints
+	// from a different Secret/TimestampAnchor is rejected (fail-closed: never
+	// mix transforms from two secrets). The destination's durability between
+	// runs is the caller's responsibility (Sanitize does not own the file
+	// lifecycle); resume only finds progress that a prior run persisted to disk.
+	Resumable bool
 }
 
 // Sanitize copies records from src to dst, transforming identifiers,
@@ -117,7 +131,7 @@ func Sanitize(ctx context.Context, src connectorstore.Reader, dst connectorstore
 
 	s := &sanitizer{
 		secret:                 opts.Secret,
-		idHmac:                 hmac.New(sha256.New, opts.Secret),
+		hmacPool:               newHMACPool(opts.Secret),
 		domains:                newDomainMap(),
 		shifter:                newTimestampShifter(anchor, findTMax(srcSyncs)),
 		dropUnknownAnnotations: !opts.AllowUnknownAnnotations,
@@ -130,7 +144,9 @@ func Sanitize(ctx context.Context, src connectorstore.Reader, dst connectorstore
 		droppedAnnotations:     map[string]uint64{},
 		passedAnnotations:      map[string]uint64{},
 		failedAnnotations:      map[string]uint64{},
+		resumable:              opts.Resumable,
 	}
+	s.fingerprint = s.checkpointFingerprint(anchor)
 
 	// One structured summary line per run instead of a log line per dropped
 	// annotation / missing asset (which fired tens of millions of times on
@@ -138,8 +154,26 @@ func Sanitize(ctx context.Context, src connectorstore.Reader, dst connectorstore
 	// an error or panic exit — an aborted run's telemetry is valid and wanted.
 	defer s.logDropSummary()
 
+	// When resuming, read whatever progress a prior run committed to the
+	// destination. A destination carrying checkpoints under a different secret
+	// or anchor is rejected here — never mix transforms from two secrets.
+	resume := map[string]*resumeState{}
+	if s.resumable {
+		resume, err = s.loadResumeStates(ctx, dst)
+		if err != nil {
+			return fmt.Errorf("c1zsanitize: load checkpoint: %w", err)
+		}
+	}
+
 	for _, sr := range srcSyncs {
-		if err := s.sanitizeSync(ctx, src, dst, sr); err != nil {
+		rs := resume[sr.GetId()]
+		if rs != nil && rs.ended {
+			// This source sync was fully copied in a prior run; keep its dst
+			// sync id for parent linkage and graph-metadata, skip the work.
+			s.syncIDMap[sr.GetId()] = rs.dstSyncID
+			continue
+		}
+		if err := s.sanitizeSync(ctx, src, dst, sr, rs); err != nil {
 			return fmt.Errorf("c1zsanitize: sanitize sync %s: %w", sr.GetId(), err)
 		}
 	}
@@ -154,7 +188,7 @@ func Sanitize(ctx context.Context, src connectorstore.Reader, dst connectorstore
 
 type sanitizer struct {
 	secret                 []byte
-	idHmac                 hash.Hash
+	hmacPool               *sync.Pool
 	domains                *domainMap
 	shifter                *timestampShifter
 	dropUnknownAnnotations bool
@@ -173,6 +207,13 @@ type sanitizer struct {
 	// each such token is logged at most once per run.
 	warnedUndeclaredTypes map[string]struct{}
 
+	// statsMu guards the per-run counter maps, warnedUndeclaredTypes, and
+	// missingAssets. The transform stage fans out across workers, so these
+	// otherwise-tiny bookkeeping updates need a lock; the critical sections are
+	// map increments and a once-per-key first-occurrence-log decision, so
+	// contention is negligible relative to the HMAC/proto work outside it.
+	statsMu sync.Mutex
+
 	// Per-run annotation/asset drop counters. transformAnnotations and
 	// copyAssets increment these instead of logging per item; logDropSummary
 	// emits a single structured line at the end of the run. droppedAnnotations
@@ -188,6 +229,121 @@ type sanitizer struct {
 	// is deferred, so it also fires on an error/panic exit; run_completed lets
 	// a reader tell a full run from a partial one (partial counts are valid).
 	completed bool
+
+	// resumable enables checkpointing; fingerprint binds a checkpoint to this
+	// run's (secret, anchor) so a destination written under a different secret
+	// or anchor is never resumed into. See Options.Resumable.
+	resumable   bool
+	fingerprint string
+}
+
+// Checkpoint phases recorded in a destination sync's token. The value names
+// the NEXT phase to run, so resume skips everything before it. resource_types
+// always re-runs (it is cheap and repopulates the known-type set the id
+// transform needs), so it is not a checkpoint phase.
+const (
+	phaseResources    = "resources"
+	phaseEntitlements = "entitlements"
+	phaseGrants       = "grants"
+)
+
+// resumeState is the decoded checkpoint for one source sync's destination sync.
+type resumeState struct {
+	dstSyncID      string
+	ended          bool   // dst sync was EndSync'd in a prior run → fully done
+	phase          string // next phase to run
+	grantPageToken string // resume point within the grant phase
+}
+
+// checkpointToken is the JSON payload stored in a destination sync's
+// sync_token. Fingerprint binds it to (secret, anchor); SrcSyncID correlates
+// the destination sync back to its source.
+type checkpointToken struct {
+	Fingerprint string `json:"fp"`
+	SrcSyncID   string `json:"src"`
+	Phase       string `json:"phase"`
+	GrantPage   string `json:"gpt,omitempty"`
+}
+
+// checkpointFingerprint derives a non-reversible binding of (secret, anchor).
+// It never stores the secret; a different secret or anchor yields a different
+// fingerprint, so loadResumeStates rejects a mismatched destination.
+func (s *sanitizer) checkpointFingerprint(anchor time.Time) string {
+	h := s.hmacPool.Get().(hash.Hash)
+	h.Reset()
+	_, _ = h.Write([]byte("c1zsanitize-ckpt-v1\x00" + anchor.UTC().Format(time.RFC3339Nano)))
+	sum := h.Sum(nil)
+	s.hmacPool.Put(h)
+	return idEncoding.EncodeToString(sum)
+}
+
+// checkpoint records progress on the current destination sync. No-op unless
+// resumable. phase names the next phase to run; gpt is the grant page to
+// resume from (only meaningful for phaseGrants).
+func (s *sanitizer) checkpoint(ctx context.Context, dst connectorstore.Writer, srcSyncID, phase, gpt string) error {
+	if !s.resumable {
+		return nil
+	}
+	tok, err := json.Marshal(checkpointToken{Fingerprint: s.fingerprint, SrcSyncID: srcSyncID, Phase: phase, GrantPage: gpt})
+	if err != nil {
+		return err
+	}
+	return dst.CheckpointSync(ctx, string(tok))
+}
+
+// loadResumeStates scans the destination's existing syncs for checkpoint
+// tokens written by a prior resumable run. A token whose fingerprint matches
+// this run yields a resumeState; a token whose fingerprint does NOT match
+// means the destination holds output from a different secret/anchor, which is
+// rejected (fail-closed). Destinations with no tokens (fresh, or written by a
+// non-resumable run) yield an empty map and a clean full run.
+func (s *sanitizer) loadResumeStates(ctx context.Context, dst connectorstore.Writer) (map[string]*resumeState, error) {
+	dstSyncs, err := listAllSyncs(ctx, dst)
+	if err != nil {
+		return nil, err
+	}
+	out := map[string]*resumeState{}
+	for _, ds := range dstSyncs {
+		if err := dst.SetCurrentSync(ctx, ds.GetId()); err != nil {
+			return nil, err
+		}
+		raw, err := dst.CurrentSyncStep(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if raw == "" {
+			continue
+		}
+		var ct checkpointToken
+		if json.Unmarshal([]byte(raw), &ct) != nil {
+			continue // not our token shape; ignore
+		}
+		if ct.Fingerprint == "" {
+			continue
+		}
+		if ct.Fingerprint != s.fingerprint {
+			return nil, fmt.Errorf("destination has a checkpoint for a different secret/anchor; clear the destination before resuming")
+		}
+		out[ct.SrcSyncID] = &resumeState{
+			dstSyncID:      ds.GetId(),
+			ended:          ds.HasEndedAt(),
+			phase:          ct.Phase,
+			grantPageToken: ct.GrantPage,
+		}
+	}
+	return out, nil
+}
+
+// recordAnnotation increments the per-type-URL counter under statsMu (the
+// transform stage is concurrent) and reports whether this was the first
+// occurrence, so the caller can emit a single first-occurrence log line per
+// type URL outside the lock.
+func (s *sanitizer) recordAnnotation(m map[string]uint64, typeURL string) bool {
+	s.statsMu.Lock()
+	first := m[typeURL] == 0
+	m[typeURL]++
+	s.statsMu.Unlock()
+	return first
 }
 
 // logDropSummary emits exactly one structured line per run summarizing the
@@ -204,44 +360,75 @@ func (s *sanitizer) logDropSummary() {
 	)
 }
 
-// id is the per-sanitizer hot path. SanitizeID stays as the
-// allocation-y reference implementation; this one reuses a single
-// hmac.Hash so the SHA-256 key schedule isn't redone every call.
-// Sanitize runs single-threaded, so no locking is needed.
+// id is the per-sanitizer hot path. SanitizeID stays as the allocation-y
+// reference implementation; this one borrows a pre-keyed hmac.Hash from a pool
+// so the SHA-256 key schedule isn't redone every call, and so the transform
+// stage can fan out across workers without sharing hash state. Output depends
+// only on (secret, input): each call Resets a hasher it exclusively owns for
+// the duration, so goroutine scheduling cannot affect the result.
 func (s *sanitizer) id(input string) string {
 	if input == "" {
 		return ""
 	}
-	s.idHmac.Reset()
-	_, _ = s.idHmac.Write([]byte(input))
-	sum := s.idHmac.Sum(nil)
+	h := s.hmacPool.Get().(hash.Hash)
+	h.Reset()
+	_, _ = h.Write([]byte(input))
+	sum := h.Sum(nil)
+	s.hmacPool.Put(h)
 	return idEncoding.EncodeToString(sum[:idTruncationBytes])
 }
 
-func (s *sanitizer) sanitizeSync(ctx context.Context, src connectorstore.Reader, dst connectorstore.Writer, sr *reader_v2.SyncRun) error {
+// newHMACPool returns a sync.Pool of HMAC-SHA256 hashers keyed on secret. The
+// key schedule is paid once per pooled hasher, not per id() call, and pooling
+// lets concurrent transform workers each hold their own hasher.
+func newHMACPool(secret []byte) *sync.Pool {
+	return &sync.Pool{New: func() any { return hmac.New(sha256.New, secret) }}
+}
+
+func (s *sanitizer) sanitizeSync(ctx context.Context, src connectorstore.Reader, dst connectorstore.Writer, sr *reader_v2.SyncRun, rs *resumeState) error {
 	srcSyncID := sr.GetId()
 	syncType := connectorstore.SyncType(sr.GetSyncType())
 	if syncType == connectorstore.SyncTypeAny || syncType == "" {
 		syncType = connectorstore.SyncTypeFull
 	}
 
-	parentDst := ""
-	if parentSrc := sr.GetParentSyncId(); parentSrc != "" {
-		parentDst = s.syncIDMap[parentSrc]
-		if parentDst == "" {
-			// The parent is not a sync in this c1z — a diff c1z built
-			// by GenerateSyncDiffFromFile records the OTHER file's
-			// base sync id as the pair's parent. HMAC the external
-			// reference instead of dropping it: provenance structure
-			// survives, the raw id does not, and two files sanitized
-			// under the same secret still cross-reference.
-			parentDst = s.id(parentSrc)
+	// Resume an unfinished destination sync from a prior run, or start a new
+	// one. The phase to start at comes from the checkpoint; a fresh sync starts
+	// at phaseResources.
+	startPhase := phaseResources
+	startGrantPage := ""
+	var dstSyncID string
+	if rs != nil {
+		if err := dst.SetCurrentSync(ctx, rs.dstSyncID); err != nil {
+			return fmt.Errorf("resume dst sync: %w", err)
 		}
-	}
-
-	dstSyncID, err := dst.StartNewSync(ctx, syncType, parentDst)
-	if err != nil {
-		return fmt.Errorf("start dst sync: %w", err)
+		dstSyncID = rs.dstSyncID
+		startPhase = rs.phase
+		startGrantPage = rs.grantPageToken
+	} else {
+		parentDst := ""
+		if parentSrc := sr.GetParentSyncId(); parentSrc != "" {
+			parentDst = s.syncIDMap[parentSrc]
+			if parentDst == "" {
+				// The parent is not a sync in this c1z — a diff c1z built
+				// by GenerateSyncDiffFromFile records the OTHER file's
+				// base sync id as the pair's parent. HMAC the external
+				// reference instead of dropping it: provenance structure
+				// survives, the raw id does not, and two files sanitized
+				// under the same secret still cross-reference.
+				parentDst = s.id(parentSrc)
+			}
+		}
+		newID, err := dst.StartNewSync(ctx, syncType, parentDst)
+		if err != nil {
+			return fmt.Errorf("start dst sync: %w", err)
+		}
+		dstSyncID = newID
+		// Write an initial checkpoint so an interruption before any phase
+		// completes still correlates this dst sync to its source on resume.
+		if err := s.checkpoint(ctx, dst, srcSyncID, phaseResources, ""); err != nil {
+			return fmt.Errorf("checkpoint: %w", err)
+		}
 	}
 	s.syncIDMap[srcSyncID] = dstSyncID
 
@@ -252,16 +439,32 @@ func (s *sanitizer) sanitizeSync(ctx context.Context, src connectorstore.Reader,
 	// distinct entitlements, not the whole file.
 	grantCache := newGrantSubCache(s.verifyGrantCache)
 
+	// resource_types always runs: it is cheap and repopulates knownResourceTypes
+	// (which the id transform consults), so it must be rebuilt even when its
+	// rows were already written in a prior run. PutResourceTypes upserts, so the
+	// re-write is idempotent.
 	if err := s.copyResourceTypes(ctx, src, dst, srcSyncID, assetRefs); err != nil {
 		return err
 	}
-	if err := s.copyResources(ctx, src, dst, srcSyncID, assetRefs); err != nil {
-		return err
+
+	if phaseAtOrBefore(startPhase, phaseResources) {
+		if err := s.copyResources(ctx, src, dst, srcSyncID, assetRefs); err != nil {
+			return err
+		}
+		if err := s.checkpoint(ctx, dst, srcSyncID, phaseEntitlements, ""); err != nil {
+			return fmt.Errorf("checkpoint: %w", err)
+		}
 	}
-	if err := s.copyEntitlements(ctx, src, dst, srcSyncID, assetRefs); err != nil {
-		return err
+	if phaseAtOrBefore(startPhase, phaseEntitlements) {
+		if err := s.copyEntitlements(ctx, src, dst, srcSyncID, assetRefs); err != nil {
+			return err
+		}
+		if err := s.checkpoint(ctx, dst, srcSyncID, phaseGrants, ""); err != nil {
+			return fmt.Errorf("checkpoint: %w", err)
+		}
+		startGrantPage = "" // entitlements just finished; grants start at the top
 	}
-	if err := s.copyGrants(ctx, src, dst, srcSyncID, assetRefs, grantCache); err != nil {
+	if err := s.copyGrants(ctx, src, dst, srcSyncID, assetRefs, grantCache, startGrantPage); err != nil {
 		return err
 	}
 	if err := s.copyAssets(ctx, src, dst, assetRefs); err != nil {
@@ -272,6 +475,27 @@ func (s *sanitizer) sanitizeSync(ctx context.Context, src connectorstore.Reader,
 		return fmt.Errorf("end dst sync: %w", err)
 	}
 	return nil
+}
+
+// phaseAtOrBefore reports whether the run should execute `target`, given the
+// phase it is starting from. Phases are ordered resources < entitlements <
+// grants; a start phase at or before the target means the target still needs
+// to run.
+func phaseAtOrBefore(start, target string) bool {
+	return phaseRank(start) <= phaseRank(target)
+}
+
+func phaseRank(p string) int {
+	switch p {
+	case phaseResources:
+		return 0
+	case phaseEntitlements:
+		return 1
+	case phaseGrants:
+		return 2
+	default:
+		return 0 // unknown/empty → treat as the earliest phase (run everything)
+	}
 }
 
 // preserveSyncGraphMetadata carries the sync-run linkage the proto

--- a/pkg/c1zsanitize/sanitize.go
+++ b/pkg/c1zsanitize/sanitize.go
@@ -92,14 +92,23 @@ type Options struct {
 
 	// Resumable enables checkpointing so an interrupted run continues instead
 	// of restarting. Progress is recorded in each destination sync's
-	// sync_token (a fingerprint of Secret+TimestampAnchor, the source sync id,
-	// the next phase, and the grant page token). On a later run against the
+	// sync_token (a secret fingerprint, the persisted anchor, the source sync
+	// id, the next phase, and the grant page token). On a later run against the
 	// SAME destination file, completed phases are skipped and the grant phase
 	// resumes from its last committed page. A destination carrying checkpoints
-	// from a different Secret/TimestampAnchor is rejected (fail-closed: never
-	// mix transforms from two secrets). The destination's durability between
-	// runs is the caller's responsibility (Sanitize does not own the file
-	// lifecycle); resume only finds progress that a prior run persisted to disk.
+	// from a different Secret is rejected (fail-closed: never mix transforms
+	// from two secrets). The anchor is persisted and adopted on resume when this
+	// run passed a zero TimestampAnchor, so a default-anchor resumable run
+	// resumes cleanly; a resume that passes a DIFFERENT explicit anchor is
+	// rejected. The destination's durability between runs is the caller's
+	// responsibility (Sanitize does not own the file lifecycle); resume only
+	// finds progress that a prior run persisted to disk.
+	//
+	// Resumable requires the sqlite-backed destination (*dotc1z.C1File). A
+	// destination engine that cannot enumerate checkpoints without mutating
+	// sync state — currently the pebble engine, whose SetCurrentSync does not
+	// rehydrate the persisted step — is rejected with a clear error rather than
+	// silently restarting from scratch.
 	Resumable bool
 }
 
@@ -119,8 +128,9 @@ func Sanitize(ctx context.Context, src connectorstore.Reader, dst connectorstore
 		return fmt.Errorf("c1zsanitize: secret too short: got %d bytes, want at least %d", len(opts.Secret), MinSecretBytes)
 	}
 
+	anchorExplicit := !opts.TimestampAnchor.IsZero()
 	anchor := opts.TimestampAnchor
-	if anchor.IsZero() {
+	if !anchorExplicit {
 		anchor = time.Now().UTC()
 	}
 
@@ -128,12 +138,13 @@ func Sanitize(ctx context.Context, src connectorstore.Reader, dst connectorstore
 	if err != nil {
 		return fmt.Errorf("c1zsanitize: list source syncs: %w", err)
 	}
+	tMax := findTMax(srcSyncs)
 
 	s := &sanitizer{
 		secret:                 opts.Secret,
 		hmacPool:               newHMACPool(opts.Secret),
 		domains:                newDomainMap(),
-		shifter:                newTimestampShifter(anchor, findTMax(srcSyncs)),
+		shifter:                newTimestampShifter(anchor, tMax),
 		dropUnknownAnnotations: !opts.AllowUnknownAnnotations,
 		log:                    ctxzap.Extract(ctx),
 		handlers:               defaultAnnotationHandlers(),
@@ -145,8 +156,11 @@ func Sanitize(ctx context.Context, src connectorstore.Reader, dst connectorstore
 		passedAnnotations:      map[string]uint64{},
 		failedAnnotations:      map[string]uint64{},
 		resumable:              opts.Resumable,
+		anchor:                 anchor,
+		anchorExplicit:         anchorExplicit,
+		tMax:                   tMax,
 	}
-	s.fingerprint = s.checkpointFingerprint(anchor)
+	s.fingerprint = s.checkpointFingerprint()
 
 	// One structured summary line per run instead of a log line per dropped
 	// annotation / missing asset (which fired tens of millions of times on
@@ -231,10 +245,20 @@ type sanitizer struct {
 	completed bool
 
 	// resumable enables checkpointing; fingerprint binds a checkpoint to this
-	// run's (secret, anchor) so a destination written under a different secret
-	// or anchor is never resumed into. See Options.Resumable.
+	// run's secret so a destination written under a different secret is never
+	// resumed into. See Options.Resumable.
 	resumable   bool
 	fingerprint string
+
+	// anchor is the timestamp anchor in force for this run; it is persisted in
+	// every checkpoint token. anchorExplicit records whether the caller passed
+	// it (vs. it defaulting): a resume that did not pass an explicit anchor
+	// adopts the persisted one, while a resume that passed a DIFFERENT explicit
+	// anchor is rejected. tMax is the source's newest timestamp, retained so the
+	// shifter can be rebuilt if the anchor is adopted on resume.
+	anchor         time.Time
+	anchorExplicit bool
+	tMax           time.Time
 }
 
 // Checkpoint phases recorded in a destination sync's token. The value names
@@ -245,6 +269,13 @@ const (
 	phaseResources    = "resources"
 	phaseEntitlements = "entitlements"
 	phaseGrants       = "grants"
+	// phaseAssets is the terminal phase, written once grants complete. It marks
+	// "all records written; only copyAssets + EndSync remain" so a crash after
+	// grants resumes into copyAssets instead of re-running the whole grant phase
+	// (a phaseGrants token with an empty page is indistinguishable from "grants
+	// not started"). On resume at this phase the resource/entitlement walks still
+	// run read-only to repopulate asset refs before copyAssets.
+	phaseAssets = "assets"
 )
 
 // resumeState is the decoded checkpoint for one source sync's destination sync.
@@ -256,22 +287,29 @@ type resumeState struct {
 }
 
 // checkpointToken is the JSON payload stored in a destination sync's
-// sync_token. Fingerprint binds it to (secret, anchor); SrcSyncID correlates
-// the destination sync back to its source.
+// sync_token. Fingerprint binds it to the secret; SrcSyncID correlates the
+// destination sync back to its source. Anchor records the timestamp anchor the
+// run used so a later resume that did not pass an explicit anchor can adopt it
+// (the anchor is not secret — it is the visible newest output timestamp — so
+// persisting it is safe and is what makes a default-anchor run resumable).
 type checkpointToken struct {
 	Fingerprint string `json:"fp"`
 	SrcSyncID   string `json:"src"`
 	Phase       string `json:"phase"`
 	GrantPage   string `json:"gpt,omitempty"`
+	Anchor      string `json:"anchor,omitempty"`
 }
 
-// checkpointFingerprint derives a non-reversible binding of (secret, anchor).
-// It never stores the secret; a different secret or anchor yields a different
-// fingerprint, so loadResumeStates rejects a mismatched destination.
-func (s *sanitizer) checkpointFingerprint(anchor time.Time) string {
+// checkpointFingerprint derives a non-reversible binding of the secret. It
+// never stores the secret; a different secret yields a different fingerprint,
+// so loadResumeStates rejects a destination written under a different secret.
+// The anchor is NOT bound here: it is persisted in the token and validated
+// separately (adopt-if-zero, fail-closed on a different explicit anchor), so a
+// run that let the anchor default can still resume.
+func (s *sanitizer) checkpointFingerprint() string {
 	h := s.hmacPool.Get().(hash.Hash)
 	h.Reset()
-	_, _ = h.Write([]byte("c1zsanitize-ckpt-v1\x00" + anchor.UTC().Format(time.RFC3339Nano)))
+	_, _ = h.Write([]byte("c1zsanitize-ckpt-v2\x00secret-only"))
 	sum := h.Sum(nil)
 	s.hmacPool.Put(h)
 	return idEncoding.EncodeToString(sum)
@@ -284,54 +322,118 @@ func (s *sanitizer) checkpoint(ctx context.Context, dst connectorstore.Writer, s
 	if !s.resumable {
 		return nil
 	}
-	tok, err := json.Marshal(checkpointToken{Fingerprint: s.fingerprint, SrcSyncID: srcSyncID, Phase: phase, GrantPage: gpt})
+	tok, err := json.Marshal(checkpointToken{
+		Fingerprint: s.fingerprint,
+		SrcSyncID:   srcSyncID,
+		Phase:       phase,
+		GrantPage:   gpt,
+		Anchor:      s.anchor.UTC().Format(time.RFC3339Nano),
+	})
 	if err != nil {
 		return err
 	}
 	return dst.CheckpointSync(ctx, string(tok))
 }
 
+// dstSyncLister is the destination capability for enumerating sync runs with
+// their persisted sync_token and ended_at WITHOUT mutating the current-sync
+// pointer. *dotc1z.C1File (the sqlite engine) provides it. Reading checkpoints
+// this way avoids the SetCurrentSync+CurrentSyncStep scan, which would leave
+// the destination's current sync pointing at an already-ended sync — a state
+// that previously caused StartNewSync to hand a fresh sync's records to an
+// ended sync.
+type dstSyncLister interface {
+	ListSyncRuns(ctx context.Context, pageToken string, pageSize uint32) ([]*dotc1z.SyncRun, string, error)
+}
+
 // loadResumeStates scans the destination's existing syncs for checkpoint
-// tokens written by a prior resumable run. A token whose fingerprint matches
-// this run yields a resumeState; a token whose fingerprint does NOT match
-// means the destination holds output from a different secret/anchor, which is
-// rejected (fail-closed). Destinations with no tokens (fresh, or written by a
-// non-resumable run) yield an empty map and a clean full run.
+// tokens written by a prior resumable run, reading them through ListSyncRuns so
+// the destination's current-sync pointer is never mutated. A token whose
+// fingerprint matches this run yields a resumeState; a token whose fingerprint
+// does NOT match means the destination holds output from a different secret,
+// which is rejected (fail-closed). The persisted anchor is adopted when this
+// run did not pass an explicit one, and a different explicit anchor is rejected
+// — so a default-anchor run resumes while a deliberate anchor change cannot
+// silently mix two transforms. Destinations with no tokens yield an empty map
+// and a clean full run.
+//
+// A destination that cannot enumerate sync tokens this way (e.g. the pebble
+// engine, whose SetCurrentSync/CurrentSyncStep do not round-trip the persisted
+// step) is rejected with a clear error rather than silently restarting from
+// scratch; resumable runs require the sqlite-backed destination.
 func (s *sanitizer) loadResumeStates(ctx context.Context, dst connectorstore.Writer) (map[string]*resumeState, error) {
-	dstSyncs, err := listAllSyncs(ctx, dst)
-	if err != nil {
-		return nil, err
+	lister, ok := dst.(dstSyncLister)
+	if !ok {
+		return nil, fmt.Errorf("resumable runs require a destination that can enumerate checkpoints without mutating sync state (sqlite-backed); this destination cannot, so resume would silently restart")
 	}
+
 	out := map[string]*resumeState{}
-	for _, ds := range dstSyncs {
-		if err := dst.SetCurrentSync(ctx, ds.GetId()); err != nil {
-			return nil, err
-		}
-		raw, err := dst.CurrentSyncStep(ctx)
+	pageToken := ""
+	for {
+		runs, next, err := lister.ListSyncRuns(ctx, pageToken, 0)
 		if err != nil {
 			return nil, err
 		}
-		if raw == "" {
-			continue
+		for _, ds := range runs {
+			if ds.SyncToken == "" {
+				continue
+			}
+			var ct checkpointToken
+			if json.Unmarshal([]byte(ds.SyncToken), &ct) != nil {
+				continue // not our token shape; ignore
+			}
+			if ct.Fingerprint == "" {
+				continue
+			}
+			if ct.Fingerprint != s.fingerprint {
+				return nil, fmt.Errorf("destination has a checkpoint for a different secret; clear the destination before resuming")
+			}
+			if err := s.reconcileAnchor(ct.Anchor); err != nil {
+				return nil, err
+			}
+			out[ct.SrcSyncID] = &resumeState{
+				dstSyncID:      ds.ID,
+				ended:          ds.EndedAt != nil,
+				phase:          ct.Phase,
+				grantPageToken: ct.GrantPage,
+			}
 		}
-		var ct checkpointToken
-		if json.Unmarshal([]byte(raw), &ct) != nil {
-			continue // not our token shape; ignore
+		if next == "" {
+			return out, nil
 		}
-		if ct.Fingerprint == "" {
-			continue
-		}
-		if ct.Fingerprint != s.fingerprint {
-			return nil, fmt.Errorf("destination has a checkpoint for a different secret/anchor; clear the destination before resuming")
-		}
-		out[ct.SrcSyncID] = &resumeState{
-			dstSyncID:      ds.GetId(),
-			ended:          ds.HasEndedAt(),
-			phase:          ct.Phase,
-			grantPageToken: ct.GrantPage,
-		}
+		pageToken = next
 	}
-	return out, nil
+}
+
+// reconcileAnchor handles the persisted checkpoint anchor. When the caller did
+// not pass an explicit anchor, the persisted one is adopted and the timestamp
+// shifter rebuilt so resumed output lands on the same anchor as the original
+// run (without this, a default-anchor run could never resume — run 2's
+// time.Now() anchor would not match run 1's). When the caller DID pass an
+// explicit anchor, a mismatch is fail-closed: two different anchors must never
+// be mixed into one destination. An empty persisted anchor (older token) is
+// ignored.
+func (s *sanitizer) reconcileAnchor(persisted string) error {
+	if persisted == "" {
+		return nil
+	}
+	pa, err := time.Parse(time.RFC3339Nano, persisted)
+	if err != nil {
+		return fmt.Errorf("checkpoint has an unparseable anchor %q: %w", persisted, err)
+	}
+	pa = pa.UTC()
+	if s.anchorExplicit {
+		if !s.anchor.Equal(pa) {
+			return fmt.Errorf("destination was checkpointed with anchor %s but this run was given anchor %s; clear the destination or pass the original anchor", pa.Format(time.RFC3339Nano), s.anchor.Format(time.RFC3339Nano))
+		}
+		return nil
+	}
+	if s.anchor.Equal(pa) {
+		return nil
+	}
+	s.anchor = pa
+	s.shifter = newTimestampShifter(pa, s.tMax)
+	return nil
 }
 
 // recordAnnotation increments the per-type-URL counter under statsMu (the
@@ -447,26 +549,43 @@ func (s *sanitizer) sanitizeSync(ctx context.Context, src connectorstore.Reader,
 		return err
 	}
 
-	if phaseAtOrBefore(startPhase, phaseResources) {
-		if err := s.copyResources(ctx, src, dst, srcSyncID, assetRefs); err != nil {
-			return err
-		}
+	// Resources and entitlements always walk so their trait icon/logo asset refs
+	// land in assetRefs before copyAssets runs — the in-memory ref set does not
+	// survive a process restart, so on resume the refs collected by a prior run
+	// are gone and must be rebuilt. The WRITE is gated on the phase: a phase a
+	// prior run already completed re-collects refs read-only instead of
+	// re-writing rows that are already durable in the destination. This mirrors
+	// copyResourceTypes, which always runs to rebuild knownResourceTypes.
+	writeResources := phaseAtOrBefore(startPhase, phaseResources)
+	if err := s.copyResources(ctx, src, dst, srcSyncID, assetRefs, writeResources); err != nil {
+		return err
+	}
+	if writeResources {
 		if err := s.checkpoint(ctx, dst, srcSyncID, phaseEntitlements, ""); err != nil {
 			return fmt.Errorf("checkpoint: %w", err)
 		}
 	}
-	if phaseAtOrBefore(startPhase, phaseEntitlements) {
-		if err := s.copyEntitlements(ctx, src, dst, srcSyncID, assetRefs); err != nil {
-			return err
-		}
+
+	writeEntitlements := phaseAtOrBefore(startPhase, phaseEntitlements)
+	if err := s.copyEntitlements(ctx, src, dst, srcSyncID, assetRefs, writeEntitlements); err != nil {
+		return err
+	}
+	if writeEntitlements {
 		if err := s.checkpoint(ctx, dst, srcSyncID, phaseGrants, ""); err != nil {
 			return fmt.Errorf("checkpoint: %w", err)
 		}
 		startGrantPage = "" // entitlements just finished; grants start at the top
 	}
-	if err := s.copyGrants(ctx, src, dst, srcSyncID, assetRefs, grantCache, startGrantPage); err != nil {
-		return err
+
+	// Grants run unless a prior run already finished them (checkpoint advanced
+	// to the terminal assets phase). copyGrants writes the phaseAssets checkpoint
+	// itself once its final page lands.
+	if phaseAtOrBefore(startPhase, phaseGrants) {
+		if err := s.copyGrants(ctx, src, dst, srcSyncID, assetRefs, grantCache, startGrantPage); err != nil {
+			return err
+		}
 	}
+
 	if err := s.copyAssets(ctx, src, dst, assetRefs); err != nil {
 		return err
 	}
@@ -493,6 +612,8 @@ func phaseRank(p string) int {
 		return 1
 	case phaseGrants:
 		return 2
+	case phaseAssets:
+		return 3
 	default:
 		return 0 // unknown/empty → treat as the earliest phase (run everything)
 	}

--- a/pkg/c1zsanitize/sanitize.go
+++ b/pkg/c1zsanitize/sanitize.go
@@ -364,7 +364,10 @@ type dstSyncLister interface {
 func (s *sanitizer) loadResumeStates(ctx context.Context, dst connectorstore.Writer) (map[string]*resumeState, error) {
 	lister, ok := dst.(dstSyncLister)
 	if !ok {
-		return nil, fmt.Errorf("resumable runs require a destination that can enumerate checkpoints without mutating sync state (sqlite-backed); this destination cannot, so resume would silently restart")
+		return nil, fmt.Errorf(
+			"resumable runs require a destination that can enumerate checkpoints " +
+				"without mutating sync state (sqlite-backed); this destination cannot, " +
+				"so resume would silently restart")
 	}
 
 	out := map[string]*resumeState{}
@@ -424,7 +427,10 @@ func (s *sanitizer) reconcileAnchor(persisted string) error {
 	pa = pa.UTC()
 	if s.anchorExplicit {
 		if !s.anchor.Equal(pa) {
-			return fmt.Errorf("destination was checkpointed with anchor %s but this run was given anchor %s; clear the destination or pass the original anchor", pa.Format(time.RFC3339Nano), s.anchor.Format(time.RFC3339Nano))
+			return fmt.Errorf(
+				"destination was checkpointed with anchor %s but this run was given "+
+					"anchor %s; clear the destination or pass the original anchor",
+				pa.Format(time.RFC3339Nano), s.anchor.Format(time.RFC3339Nano))
 		}
 		return nil
 	}

--- a/pkg/c1zsanitize/transform.go
+++ b/pkg/c1zsanitize/transform.go
@@ -3,8 +3,11 @@ package c1zsanitize
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"sort"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
@@ -13,6 +16,42 @@ import (
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
 )
+
+// parallelTransform applies fn to each index [0,n) using up to GOMAXPROCS
+// workers that pull indices off a shared counter. fn must write only to its
+// own index i of a pre-sized output slice, so order is preserved with no
+// channels. The transform is CPU-bound (HMAC + proto marshal/unmarshal) and
+// touches only concurrency-safe shared state (pooled HMAC, mutex-guarded
+// caches), so fanning it out is safe; reads and writes around it stay
+// sequential because SQLite is a single writer.
+func parallelTransform(n int, fn func(i int)) {
+	workers := runtime.GOMAXPROCS(0)
+	if workers > n {
+		workers = n
+	}
+	if workers <= 1 {
+		for i := 0; i < n; i++ {
+			fn(i)
+		}
+		return
+	}
+	var idx int64 = -1
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for w := 0; w < workers; w++ {
+		go func() {
+			defer wg.Done()
+			for {
+				i := int(atomic.AddInt64(&idx, 1))
+				if i >= n {
+					return
+				}
+				fn(i)
+			}
+		}()
+	}
+	wg.Wait()
+}
 
 // listPageSize is the source read page, which also bounds how many
 // rows each dst Put batches into one transaction. Larger pages mean
@@ -105,10 +144,8 @@ func (s *sanitizer) copyResourceTypes(
 	}
 
 	xformStart := time.Now()
-	out := make([]*v2.ResourceType, 0, len(rows))
-	for _, rt := range rows {
-		out = append(out, s.transformResourceType(rt, refs))
-	}
+	out := make([]*v2.ResourceType, len(rows))
+	parallelTransform(len(rows), func(i int) { out[i] = s.transformResourceType(rows[i], refs) })
 	xformDur := time.Since(xformStart)
 	// Sort by output id for destination unique-index locality.
 	sort.Slice(out, func(i, j int) bool { return out[i].GetId() < out[j].GetId() })
@@ -144,10 +181,9 @@ func (s *sanitizer) copyResources(
 			return fmt.Errorf("list resources: %w", err)
 		}
 		xformStart := time.Now()
-		out := make([]*v2.Resource, 0, len(resp.GetList()))
-		for _, r := range resp.GetList() {
-			out = append(out, s.transformResource(r, refs))
-		}
+		list := resp.GetList()
+		out := make([]*v2.Resource, len(list))
+		parallelTransform(len(list), func(i int) { out[i] = s.transformResource(list[i], refs) })
 		xformDur := time.Since(xformStart)
 		sortByResourceID(out)
 		putStart := time.Now()
@@ -187,10 +223,9 @@ func (s *sanitizer) copyEntitlements(
 			return fmt.Errorf("list entitlements: %w", err)
 		}
 		xformStart := time.Now()
-		out := make([]*v2.Entitlement, 0, len(resp.GetList()))
-		for _, e := range resp.GetList() {
-			out = append(out, s.transformEntitlement(e, refs))
-		}
+		list := resp.GetList()
+		out := make([]*v2.Entitlement, len(list))
+		parallelTransform(len(list), func(i int) { out[i] = s.transformEntitlement(list[i], refs) })
 		xformDur := time.Since(xformStart)
 		sort.Slice(out, func(i, j int) bool { return out[i].GetId() < out[j].GetId() })
 		putStart := time.Now()
@@ -215,8 +250,9 @@ func (s *sanitizer) copyGrants(
 	srcSyncID string,
 	refs *assetRefSet,
 	cache *grantSubCache,
+	startPageToken string,
 ) error {
-	pageToken := ""
+	pageToken := startPageToken
 	page := 0
 	for {
 		req := v2.GrantsServiceListGrantsRequest_builder{
@@ -231,10 +267,9 @@ func (s *sanitizer) copyGrants(
 			return fmt.Errorf("list grants: %w", err)
 		}
 		xformStart := time.Now()
-		out := make([]*v2.Grant, 0, len(resp.GetList()))
-		for _, g := range resp.GetList() {
-			out = append(out, s.transformGrant(g, refs, cache))
-		}
+		list := resp.GetList()
+		out := make([]*v2.Grant, len(list))
+		parallelTransform(len(list), func(i int) { out[i] = s.transformGrant(list[i], refs, cache) })
 		xformDur := time.Since(xformStart)
 		sort.Slice(out, func(i, j int) bool { return out[i].GetId() < out[j].GetId() })
 		putStart := time.Now()
@@ -244,7 +279,16 @@ func (s *sanitizer) copyGrants(
 			}
 		}
 		s.logPage(srcSyncID, "grants", page, len(resp.GetList()), readDur, xformDur, time.Since(putStart))
-		if resp.GetNextPageToken() == "" {
+		next := resp.GetNextPageToken()
+		// Record the next grant page as the resume point. The grants already
+		// written this page are durable in the dst sync; on resume the loop
+		// restarts at `next` (PutGrants upserts, so even a re-written boundary
+		// page is idempotent). Keyset pagination on the source rowid makes the
+		// token stable across runs.
+		if err := s.checkpoint(ctx, dst, srcSyncID, phaseGrants, next); err != nil {
+			return fmt.Errorf("checkpoint: %w", err)
+		}
+		if next == "" {
 			if cache != nil {
 				s.log.Info("c1zsanitize: grant sub-cache stats",
 					zap.String("sync_id", srcSyncID),
@@ -253,7 +297,7 @@ func (s *sanitizer) copyGrants(
 			}
 			return nil
 		}
-		pageToken = resp.GetNextPageToken()
+		pageToken = next
 		page++
 	}
 }
@@ -336,17 +380,20 @@ func (s *sanitizer) transformResourceID(in *v2.ResourceId) *v2.ResourceId {
 }
 
 // warnUndeclaredResourceType logs once per resource-type token that appears in
-// a resource id but was never declared in copyResourceTypes. Not safe for
-// concurrent callers — the transform stage is sequential today; revisit the
-// dedup map if it is ever parallelized.
+// a resource id but was never declared in copyResourceTypes. Called from the
+// concurrent transform workers, so the dedup set is guarded by statsMu; the
+// log fires outside the lock.
 func (s *sanitizer) warnUndeclaredResourceType(rt string) {
 	if rt == "" || s.isKnownResourceType(rt) {
 		return
 	}
+	s.statsMu.Lock()
 	if _, seen := s.warnedUndeclaredTypes[rt]; seen {
+		s.statsMu.Unlock()
 		return
 	}
 	s.warnedUndeclaredTypes[rt] = struct{}{}
+	s.statsMu.Unlock()
 	s.log.Warn("c1zsanitize: resource id references an undeclared resource type; preserved verbatim here but HMAC'd inside composite ids",
 		zap.String("resource_type", rt))
 }
@@ -417,6 +464,13 @@ const maxCachedPrincipals = 1_000_000
 // proto.Equal cross-check against a fresh transform for the first
 // verifySampleLimit hits — cheap insurance, off by default.
 type grantSubCache struct {
+	// mu guards the maps and the verify counters. The grant transform fans out
+	// across workers, so the cache is shared. The expensive transform on a miss
+	// runs OUTSIDE the lock (double-checked insert), so the critical sections
+	// are only map lookups/inserts — a plain Mutex is enough and avoids the
+	// RWMutex bookkeeping for what is, after warmup, a tiny read-mostly map
+	// (entitlement cardinality is orders of magnitude below grant count).
+	mu sync.Mutex
 	// SHARED: the cached *v2.Entitlement / *v2.Resource values below are
 	// referenced by multiple output grants. Never mutate one after Build().
 	// Mutation after caching = cross-grant corruption.
@@ -452,19 +506,29 @@ func (s *sanitizer) cachedEntitlement(in *v2.Entitlement, refs *assetRefSet, cac
 		return s.transformEntitlement(in, refs)
 	}
 	key := in.GetId()
-	if key != "" {
-		if got, ok := cache.entitlements[key]; ok {
-			s.verifyCachedEntitlement(in, refs, got, cache)
-			// SHARED: returned to many output grants — never mutate after Build().
-			return got
-		}
+	if key == "" {
+		return s.transformEntitlement(in, refs) // nothing to key on
 	}
+	cache.mu.Lock()
+	got, ok := cache.entitlements[key]
+	cache.mu.Unlock()
+	if ok {
+		s.verifyCachedEntitlement(in, refs, got, cache)
+		// SHARED: returned to many output grants — never mutate after Build().
+		return got
+	}
+	// Transform outside the lock. Two workers may race to fill the same key;
+	// both produce proto-equal results (the transform is a pure function of
+	// (secret, input)), so the double-check below just keeps one shared pointer.
 	out := s.transformEntitlement(in, refs)
-	if key != "" {
+	cache.mu.Lock()
+	if existing, ok := cache.entitlements[key]; ok {
+		out = existing
+	} else {
 		// SHARED once stored: referenced by every later grant with this id.
-		// Never mutate after Build() — mutation = cross-grant corruption.
 		cache.entitlements[key] = out
 	}
+	cache.mu.Unlock()
 	return out
 }
 
@@ -486,19 +550,26 @@ func (s *sanitizer) cachedPrincipal(in *v2.Resource, refs *assetRefSet, cache *g
 	if id := in.GetId(); id != nil && id.GetResource() != "" {
 		key = id.GetResourceType() + "\x00" + id.GetResource()
 	}
-	if key != "" {
-		if got, ok := cache.principals[key]; ok {
-			s.verifyCachedPrincipal(in, refs, got, cache)
-			// SHARED: returned to many output grants — never mutate after Build().
-			return got
-		}
+	if key == "" {
+		return s.transformResource(in, refs) // uncacheable empty id
+	}
+	cache.mu.Lock()
+	got, ok := cache.principals[key]
+	cache.mu.Unlock()
+	if ok {
+		s.verifyCachedPrincipal(in, refs, got, cache)
+		// SHARED: returned to many output grants — never mutate after Build().
+		return got
 	}
 	out := s.transformResource(in, refs)
-	if key != "" && len(cache.principals) < maxCachedPrincipals {
+	cache.mu.Lock()
+	if existing, ok := cache.principals[key]; ok {
+		out = existing
+	} else if len(cache.principals) < maxCachedPrincipals {
 		// SHARED once stored: referenced by every later grant with this id.
-		// Never mutate after Build() — mutation = cross-grant corruption.
 		cache.principals[key] = out
 	}
+	cache.mu.Unlock()
 	return out
 }
 
@@ -507,10 +578,16 @@ func (s *sanitizer) cachedPrincipal(in *v2.Resource, refs *assetRefSet, cache *g
 // differs from the fresh one, catching any source that violates the
 // one-object-per-id assumption.
 func (s *sanitizer) verifyCachedEntitlement(in *v2.Entitlement, refs *assetRefSet, cached *v2.Entitlement, cache *grantSubCache) {
-	if !cache.verify || cache.verifySeenEntitlements >= verifySampleLimit {
+	if !cache.verify {
+		return
+	}
+	cache.mu.Lock()
+	if cache.verifySeenEntitlements >= verifySampleLimit {
+		cache.mu.Unlock()
 		return
 	}
 	cache.verifySeenEntitlements++
+	cache.mu.Unlock()
 	fresh := s.transformEntitlement(in, refs)
 	if !proto.Equal(fresh, cached) {
 		s.log.Warn("c1zsanitize: grant sub-cache mismatch; embedded entitlement differs across grants for the same id",
@@ -523,10 +600,16 @@ func (s *sanitizer) verifyCachedEntitlement(in *v2.Entitlement, refs *assetRefSe
 // contract, catching any source that emits diverging principal objects for the
 // same resource id within a sync.
 func (s *sanitizer) verifyCachedPrincipal(in *v2.Resource, refs *assetRefSet, cached *v2.Resource, cache *grantSubCache) {
-	if !cache.verify || cache.verifySeenPrincipals >= verifySampleLimit {
+	if !cache.verify {
+		return
+	}
+	cache.mu.Lock()
+	if cache.verifySeenPrincipals >= verifySampleLimit {
+		cache.mu.Unlock()
 		return
 	}
 	cache.verifySeenPrincipals++
+	cache.mu.Unlock()
 	fresh := s.transformResource(in, refs)
 	if !proto.Equal(fresh, cached) {
 		s.log.Warn("c1zsanitize: grant sub-cache mismatch; embedded principal differs across grants for the same id",

--- a/pkg/c1zsanitize/transform.go
+++ b/pkg/c1zsanitize/transform.go
@@ -252,6 +252,19 @@ func (s *sanitizer) copyGrants(
 	cache *grantSubCache,
 	startPageToken string,
 ) error {
+	// Preserve grant-expansion topology end-to-end. Plain ListGrants reads only
+	// the data blob, but the SQLite writer strips GrantExpandable into a side
+	// column — so without the expansion-aware read the sanitizer never sees the
+	// annotation and handleGrantExpandable never fires, silently dropping the
+	// expansion edges. ListGrantsWithExpansion re-attaches it while keeping the
+	// resumable page-cursor semantics this phase's checkpointing relies on
+	// (switching to StreamGrants would change those). Readers without the
+	// capability (already-expanded stores) fall back to plain ListGrants.
+	listGrants := src.ListGrants
+	if exp, ok := src.(connectorstore.ExpansionGrantLister); ok {
+		listGrants = exp.ListGrantsWithExpansion
+	}
+
 	pageToken := startPageToken
 	page := 0
 	for {
@@ -261,7 +274,7 @@ func (s *sanitizer) copyGrants(
 			Annotations: syncIDAnnotations(srcSyncID),
 		}.Build()
 		readStart := time.Now()
-		resp, err := src.ListGrants(ctx, req)
+		resp, err := listGrants(ctx, req)
 		readDur := time.Since(readStart)
 		if err != nil {
 			return fmt.Errorf("list grants: %w", err)

--- a/pkg/c1zsanitize/transform.go
+++ b/pkg/c1zsanitize/transform.go
@@ -37,10 +37,22 @@ func parallelTransform(n int, fn func(i int)) {
 	}
 	var idx int64 = -1
 	var wg sync.WaitGroup
+	// A panic in fn must unwind to the caller, not crash the process from an
+	// unrecovered worker goroutine. Capture the first panic, stop handing out
+	// work, and re-panic on the calling goroutine after the workers drain — the
+	// same failure path a sequential fn would take.
+	var panicOnce sync.Once
+	var panicVal any
 	wg.Add(workers)
 	for w := 0; w < workers; w++ {
 		go func() {
 			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					panicOnce.Do(func() { panicVal = r })
+					atomic.StoreInt64(&idx, int64(n)) // halt remaining pulls
+				}
+			}()
 			for {
 				i := int(atomic.AddInt64(&idx, 1))
 				if i >= n {
@@ -51,6 +63,9 @@ func parallelTransform(n int, fn func(i int)) {
 		}()
 	}
 	wg.Wait()
+	if panicVal != nil {
+		panic(panicVal)
+	}
 }
 
 // listPageSize is the source read page, which also bounds how many
@@ -159,12 +174,19 @@ func (s *sanitizer) copyResourceTypes(
 	return nil
 }
 
+// copyResources walks the source resources for srcSyncID, transforming each
+// (which registers its trait icon/logo asset refs into refs). When write is
+// true the transformed rows are written to dst; when false the walk runs purely
+// to repopulate refs — the resume path where resources were already written in
+// a prior run but their asset refs (lost with the prior process) must be
+// re-collected before copyAssets, mirroring how copyResourceTypes always runs.
 func (s *sanitizer) copyResources(
 	ctx context.Context,
 	src connectorstore.Reader,
 	dst connectorstore.Writer,
 	srcSyncID string,
 	refs *assetRefSet,
+	write bool,
 ) error {
 	pageToken := ""
 	page := 0
@@ -187,7 +209,7 @@ func (s *sanitizer) copyResources(
 		xformDur := time.Since(xformStart)
 		sortByResourceID(out)
 		putStart := time.Now()
-		if len(out) > 0 {
+		if write && len(out) > 0 {
 			if err := dst.PutResources(ctx, out...); err != nil {
 				return fmt.Errorf("put resources: %w", err)
 			}
@@ -201,12 +223,16 @@ func (s *sanitizer) copyResources(
 	}
 }
 
+// copyEntitlements mirrors copyResources: it always walks (registering any
+// entitlement asset refs into refs) and writes only when write is true, so the
+// resume path re-collects asset refs for an already-written entitlement phase.
 func (s *sanitizer) copyEntitlements(
 	ctx context.Context,
 	src connectorstore.Reader,
 	dst connectorstore.Writer,
 	srcSyncID string,
 	refs *assetRefSet,
+	write bool,
 ) error {
 	pageToken := ""
 	page := 0
@@ -229,7 +255,7 @@ func (s *sanitizer) copyEntitlements(
 		xformDur := time.Since(xformStart)
 		sort.Slice(out, func(i, j int) bool { return out[i].GetId() < out[j].GetId() })
 		putStart := time.Now()
-		if len(out) > 0 {
+		if write && len(out) > 0 {
 			if err := dst.PutEntitlements(ctx, out...); err != nil {
 				return fmt.Errorf("put entitlements: %w", err)
 			}
@@ -302,6 +328,13 @@ func (s *sanitizer) copyGrants(
 			return fmt.Errorf("checkpoint: %w", err)
 		}
 		if next == "" {
+			// Grants are fully written. Advance the checkpoint to the terminal
+			// assets phase so a crash before EndSync resumes straight into
+			// copyAssets instead of re-running every grant page (an empty
+			// phaseGrants token is indistinguishable from "grants not started").
+			if err := s.checkpoint(ctx, dst, srcSyncID, phaseAssets, ""); err != nil {
+				return fmt.Errorf("checkpoint: %w", err)
+			}
 			if cache != nil {
 				s.log.Info("c1zsanitize: grant sub-cache stats",
 					zap.String("sync_id", srcSyncID),

--- a/pkg/connectorstore/connectorstore.go
+++ b/pkg/connectorstore/connectorstore.go
@@ -116,6 +116,19 @@ type DBSizeProvider interface {
 	CurrentDBSizeBytes() (int64, error)
 }
 
+// ExpansionGrantLister is an optional capability for stores whose ListGrants
+// strips the GrantExpandable annotation into a side column on write (the SQLite
+// engine does; see dotc1z). ListGrantsWithExpansion is the paginated read that
+// re-attaches it, so a copy/sanitize that keeps ListGrants' resumable
+// page-cursor semantics (rather than switching to StreamGrants) still preserves
+// the grant-expansion topology end-to-end. Mirrors
+// StreamGrantsOptions.IncludeExpansion for the unary paginated read path.
+// Discovered by type assertion; readers that don't strip expansion (e.g. the
+// Pebble adapter, whose ListGrants already carries it) need not implement it.
+type ExpansionGrantLister interface {
+	ListGrantsWithExpansion(ctx context.Context, request *v2.GrantsServiceListGrantsRequest) (*v2.GrantsServiceListGrantsResponse, error)
+}
+
 // GrantUpsertMode controls how grant conflicts are resolved during upsert.
 type GrantUpsertMode int
 

--- a/pkg/connectorstore/streaming.go
+++ b/pkg/connectorstore/streaming.go
@@ -38,10 +38,19 @@ type StreamingReader interface {
 
 // StreamGrantsOptions narrows the stream to a single entitlement
 // and/or principal. Empty fields mean no filter.
+//
+// IncludeExpansion re-attaches each grant's GrantExpandable annotation when
+// set. The SQLite engine strips GrantExpandable into a side column on write,
+// so without this the SQLite stream yields grants with their expansion
+// topology missing — a faithful round-trip (cross-engine copy, rollback /
+// replay, or an external grant consumer) must set it. Default false preserves
+// the existing data-only stream. The Pebble engine reconstructs the
+// annotation from its record either way, so the option is a no-op there.
 type StreamGrantsOptions struct {
 	EntitlementID         string
 	PrincipalResourceType string
 	PrincipalResourceID   string
+	IncludeExpansion      bool
 }
 
 // StreamResourcesOptions narrows the stream by resource_type.

--- a/pkg/dotc1z/grants.go
+++ b/pkg/dotc1z/grants.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/doug-martin/goqu/v9"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
@@ -135,7 +137,7 @@ func (c *C1File) ListGrants(ctx context.Context, request *v2.GrantsServiceListGr
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
-	ret, nextPageToken, err := listGrantsGeneric(ctx, c, request)
+	ret, nextPageToken, err := listGrantsGeneric(ctx, c, request, false)
 	if err != nil {
 		return nil, fmt.Errorf("error listing grants: %w", err)
 	}
@@ -146,9 +148,35 @@ func (c *C1File) ListGrants(ctx context.Context, request *v2.GrantsServiceListGr
 	}.Build(), nil
 }
 
+// ListGrantsWithExpansion is ListGrants that also re-attaches each grant's
+// GrantExpandable annotation, which PutGrants strips into the `expansion` side
+// column on write. Plain ListGrants reads only the data blob and so drops the
+// expansion topology; a faithful copy/sanitize over the paginated read path
+// (which must keep ListGrants' resumable page-cursor semantics rather than
+// switch to StreamGrants) uses this instead. Implements
+// connectorstore.ExpansionGrantLister.
+func (c *C1File) ListGrantsWithExpansion(ctx context.Context, request *v2.GrantsServiceListGrantsRequest) (*v2.GrantsServiceListGrantsResponse, error) {
+	ctx, span := tracer.Start(ctx, "C1File.ListGrantsWithExpansion")
+	var err error
+	defer func() { uotel.EndSpanWithError(span, err) }()
+
+	ret, nextPageToken, err := listGrantsGeneric(ctx, c, request, true)
+	if err != nil {
+		return nil, fmt.Errorf("error listing grants with expansion: %w", err)
+	}
+
+	return v2.GrantsServiceListGrantsResponse_builder{
+		List:          ret,
+		NextPageToken: nextPageToken,
+	}.Build(), nil
+}
+
 // listGrantsGeneric pulls the grant identity columns inline so slim-blob
-// rows can be hydrated without a second query.
-func listGrantsGeneric(ctx context.Context, c *C1File, req listRequest) ([]*v2.Grant, string, error) {
+// rows can be hydrated without a second query. When includeExpansion is set it
+// also selects the side `expansion` column and re-attaches each grant's
+// GrantExpandable annotation (stripped on write); default false keeps the
+// data-only read byte-identical for existing callers.
+func listGrantsGeneric(ctx context.Context, c *C1File, req listRequest, includeExpansion bool) ([]*v2.Grant, string, error) {
 	if err := c.validateDb(ctx); err != nil {
 		return nil, "", err
 	}
@@ -159,7 +187,7 @@ func listGrantsGeneric(ctx context.Context, c *C1File, req listRequest) ([]*v2.G
 	}
 
 	tableName := grants.Name()
-	q := c.db.From(tableName).Prepared(true).Select(
+	selectCols := []interface{}{
 		"id",
 		"data",
 		"entitlement_id",
@@ -167,7 +195,13 @@ func listGrantsGeneric(ctx context.Context, c *C1File, req listRequest) ([]*v2.G
 		"resource_id",
 		"principal_resource_type_id",
 		"principal_resource_id",
-	)
+	}
+	if includeExpansion {
+		// The serialized GrantExpandable lives in a side column (stripped from
+		// data on write); pull it so we can re-attach it.
+		selectCols = append(selectCols, "expansion")
+	}
+	q := c.db.From(tableName).Prepared(true).Select(selectCols...)
 
 	// Filter predicates — mirrors listConnectorObjects.
 	if resourceTypeReq, ok := req.(hasResourceTypeListRequest); ok {
@@ -251,15 +285,21 @@ func listGrantsGeneric(ctx context.Context, c *C1File, req listRequest) ([]*v2.G
 		entRRaw        sql.RawBytes
 		principalRTRaw sql.RawBytes
 		principalRRaw  sql.RawBytes
+		expansionRaw   sql.RawBytes
 		count          uint32
 		lastRow        int64
+		reattached     int
 	)
+	scanDest := []any{&rowID, &data, &entIDRaw, &entRTRaw, &entRRaw, &principalRTRaw, &principalRRaw}
+	if includeExpansion {
+		scanDest = append(scanDest, &expansionRaw)
+	}
 	for rows.Next() {
 		count++
 		if count > pageSize {
 			break
 		}
-		if err := rows.Scan(&rowID, &data, &entIDRaw, &entRTRaw, &entRRaw, &principalRTRaw, &principalRRaw); err != nil {
+		if err := rows.Scan(scanDest...); err != nil {
 			return nil, "", err
 		}
 		lastRow = rowID
@@ -267,6 +307,15 @@ func listGrantsGeneric(ctx context.Context, c *C1File, req listRequest) ([]*v2.G
 		g := &v2.Grant{}
 		if err := unmarshal.Unmarshal(data, g); err != nil {
 			return nil, "", err
+		}
+		if includeExpansion {
+			attached, err := reattachExpansion(g, expansionRaw)
+			if err != nil {
+				return nil, "", err
+			}
+			if attached {
+				reattached++
+			}
 		}
 		out = append(out, g)
 		if g.GetEntitlement() == nil || g.GetPrincipal() == nil {
@@ -286,6 +335,13 @@ func listGrantsGeneric(ctx context.Context, c *C1File, req listRequest) ([]*v2.G
 
 	if len(slimGrants) > 0 {
 		hydrateGrants(slimGrants, slimKeys)
+	}
+
+	if includeExpansion {
+		ctxzap.Extract(ctx).Debug("c1z: listed grants with expansion re-attached",
+			zap.Int("grants", len(out)),
+			zap.Int("expansion_reattached", reattached),
+		)
 	}
 
 	nextPageToken := ""
@@ -362,7 +418,7 @@ func (c *C1File) ListGrantsForEntitlement(
 	ctx, span := tracer.Start(ctx, "C1File.ListGrantsForEntitlement")
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
-	ret, nextPageToken, err := listGrantsGeneric(ctx, c, request)
+	ret, nextPageToken, err := listGrantsGeneric(ctx, c, request, false)
 	if err != nil {
 		return nil, fmt.Errorf("error listing grants for entitlement '%s': %w", request.GetEntitlement().GetId(), err)
 	}
@@ -381,7 +437,7 @@ func (c *C1File) ListGrantsForPrincipal(
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
-	ret, nextPageToken, err := listGrantsGeneric(ctx, c, request)
+	ret, nextPageToken, err := listGrantsGeneric(ctx, c, request, false)
 	if err != nil {
 		return nil, fmt.Errorf("error listing grants for principal '%s': %w", request.GetPrincipalId(), err) //nolint:staticcheck // ignore deprecated field
 	}
@@ -400,7 +456,7 @@ func (c *C1File) ListGrantsForResourceType(
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
-	ret, nextPageToken, err := listGrantsGeneric(ctx, c, request)
+	ret, nextPageToken, err := listGrantsGeneric(ctx, c, request, false)
 	if err != nil {
 		return nil, fmt.Errorf("error listing grants for resource type '%s': %w", request.GetResourceTypeId(), err)
 	}
@@ -637,6 +693,26 @@ func extractAndStripExpansion(grant *v2.Grant) ([]byte, bool) {
 		return nil, false
 	}
 	return data, true
+}
+
+// reattachExpansion deserializes the GrantExpandable bytes that the SQLite
+// writer stripped into the side `expansion` column (see extractAndStripExpansion)
+// and re-attaches it as an annotation on g. It is the read-side inverse of the
+// write-side strip, shared by the StreamGrants IncludeExpansion path and the
+// ListGrants expansion-reattach path so both restore topology identically.
+// Empty expansion is a no-op. Returns true when an annotation was attached.
+func reattachExpansion(g *v2.Grant, expansion []byte) (bool, error) {
+	if len(expansion) == 0 {
+		return false, nil
+	}
+	expandable := &v2.GrantExpandable{}
+	if err := proto.Unmarshal(expansion, expandable); err != nil {
+		return false, err
+	}
+	annos := annotations.Annotations(g.GetAnnotations())
+	annos.Update(expandable)
+	g.SetAnnotations(annos)
+	return true, nil
 }
 
 func backfillGrantExpansionColumn(ctx context.Context, db *goqu.Database, tableName string) (bool, error) {

--- a/pkg/dotc1z/streaming.go
+++ b/pkg/dotc1z/streaming.go
@@ -11,7 +11,6 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
-	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
 )
 
@@ -107,15 +106,12 @@ func (c *C1File) streamGrantsWithExpansion(
 			return
 		}
 		total++
-		if len(expansion) > 0 {
-			expandable := &v2.GrantExpandable{}
-			if err := proto.Unmarshal(expansion, expandable); err != nil {
-				yield(nil, err)
-				return
-			}
-			annos := annotations.Annotations(g.GetAnnotations())
-			annos.Update(expandable)
-			g.SetAnnotations(annos)
+		attached, err := reattachExpansion(g, expansion)
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+		if attached {
 			reattached++
 		}
 		if !yield(g, nil) {

--- a/pkg/dotc1z/streaming.go
+++ b/pkg/dotc1z/streaming.go
@@ -6,9 +6,12 @@ import (
 	"iter"
 
 	"github.com/doug-martin/goqu/v9"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
 )
 
@@ -31,7 +34,13 @@ func (c *C1File) StreamGrants(
 			yield(nil, err)
 			return
 		}
-		q := c.db.From(grants.Name()).Prepared(true).Select("data")
+		cols := []interface{}{"data"}
+		if opts.IncludeExpansion {
+			// The serialized GrantExpandable lives in a side column (stripped
+			// from data on write); pull it so we can re-attach it.
+			cols = append(cols, "expansion")
+		}
+		q := c.db.From(grants.Name()).Prepared(true).Select(cols...)
 		if resolved != "" {
 			q = q.Where(goqu.C("sync_id").Eq(resolved))
 		}
@@ -45,14 +54,82 @@ func (c *C1File) StreamGrants(
 			q = q.Where(goqu.C("principal_resource_id").Eq(opts.PrincipalResourceID))
 		}
 		q = q.Order(goqu.C("id").Asc())
-		streamRows(ctx, c, q, func(data []byte) bool {
-			m := &v2.Grant{}
-			if err := proto.Unmarshal(data, m); err != nil {
-				return yield(nil, err)
-			}
-			return yield(m, nil)
-		}, yield)
+
+		if !opts.IncludeExpansion {
+			streamRows(ctx, c, q, func(data []byte) bool {
+				m := &v2.Grant{}
+				if err := proto.Unmarshal(data, m); err != nil {
+					return yield(nil, err)
+				}
+				return yield(m, nil)
+			}, yield)
+			return
+		}
+		c.streamGrantsWithExpansion(ctx, q, yield)
 	}
+}
+
+// streamGrantsWithExpansion runs the two-column (data, expansion) scan and
+// re-attaches the GrantExpandable annotation that the SQLite writer strips
+// into the expansion column, so the streamed grant carries its full expansion
+// topology. Reattached/total counts are logged once when the scan completes.
+func (c *C1File) streamGrantsWithExpansion(
+	ctx context.Context,
+	q *goqu.SelectDataset,
+	yield func(*v2.Grant, error) bool,
+) {
+	query, args, err := q.ToSQL()
+	if err != nil {
+		yield(nil, err)
+		return
+	}
+	rows, err := c.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		yield(nil, err)
+		return
+	}
+	defer rows.Close()
+
+	var total, reattached int
+	for rows.Next() {
+		if err := ctx.Err(); err != nil {
+			yield(nil, err)
+			return
+		}
+		var data, expansion sql.RawBytes
+		if err := rows.Scan(&data, &expansion); err != nil {
+			yield(nil, err)
+			return
+		}
+		g := &v2.Grant{}
+		if err := proto.Unmarshal(data, g); err != nil {
+			yield(nil, err)
+			return
+		}
+		total++
+		if len(expansion) > 0 {
+			expandable := &v2.GrantExpandable{}
+			if err := proto.Unmarshal(expansion, expandable); err != nil {
+				yield(nil, err)
+				return
+			}
+			annos := annotations.Annotations(g.GetAnnotations())
+			annos.Update(expandable)
+			g.SetAnnotations(annos)
+			reattached++
+		}
+		if !yield(g, nil) {
+			return
+		}
+	}
+	if err := rows.Err(); err != nil {
+		yield(nil, err)
+		return
+	}
+	ctxzap.Extract(ctx).Debug("c1z: streamed grants with expansion re-attached",
+		zap.Int("grants", total),
+		zap.Int("expansion_reattached", reattached),
+	)
 }
 
 // StreamResources yields resources optionally filtered by RT.

--- a/pkg/dotc1z/streaming_expansion_test.go
+++ b/pkg/dotc1z/streaming_expansion_test.go
@@ -1,0 +1,119 @@
+package dotc1z
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+)
+
+// pickExpandable returns the GrantExpandable annotation on a grant, or nil.
+func pickExpandable(t *testing.T, g *v2.Grant) *v2.GrantExpandable {
+	t.Helper()
+	exp := &v2.GrantExpandable{}
+	annos := annotations.Annotations(g.GetAnnotations())
+	ok, err := annos.Pick(exp)
+	require.NoError(t, err)
+	if !ok {
+		return nil
+	}
+	return exp
+}
+
+func collectStream(t *testing.T, seq func(func(*v2.Grant, error) bool)) []*v2.Grant {
+	t.Helper()
+	var out []*v2.Grant
+	for g, err := range seq {
+		require.NoError(t, err)
+		out = append(out, g)
+	}
+	return out
+}
+
+// TestStreamGrantsIncludeExpansionRoundTrip is the rollback/replay round-trip
+// guard: a grant written with a GrantExpandable annotation is stripped into the
+// expansion side column on write; streaming it back without IncludeExpansion
+// drops the topology (the documented default), and streaming with
+// IncludeExpansion restores the exact GrantExpandable so a replay/copy
+// re-emits the same expansion edges.
+func TestStreamGrantsIncludeExpansionRoundTrip(t *testing.T) {
+	ctx := context.Background()
+
+	tmpFile, err := os.CreateTemp("", "test-stream-expansion-*.c1z")
+	require.NoError(t, err)
+	tmpPath := tmpFile.Name()
+	require.NoError(t, tmpFile.Close())
+	defer os.Remove(tmpPath)
+
+	wantEntitlementIDs := []string{"ent:a", "ent:b"}
+
+	func() {
+		c1f, err := NewC1ZFile(ctx, tmpPath)
+		require.NoError(t, err)
+		_, err = c1f.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+		require.NoError(t, err)
+
+		groupRT := v2.ResourceType_builder{Id: "group"}.Build()
+		userRT := v2.ResourceType_builder{Id: "user"}.Build()
+		require.NoError(t, c1f.PutResourceTypes(ctx, groupRT, userRT))
+
+		g1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build()}.Build()
+		u1 := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build()}.Build()
+		require.NoError(t, c1f.PutResources(ctx, g1, u1))
+		ent1 := v2.Entitlement_builder{Id: "ent1", Resource: g1}.Build()
+		require.NoError(t, c1f.PutEntitlements(ctx, ent1))
+
+		expandableGrant := v2.Grant_builder{
+			Id:          "grant-expandable",
+			Entitlement: ent1,
+			Principal:   u1,
+			Annotations: annotations.New(v2.GrantExpandable_builder{
+				EntitlementIds:  wantEntitlementIDs,
+				Shallow:         true,
+				ResourceTypeIds: []string{"user"},
+			}.Build()),
+		}.Build()
+		plainGrant := v2.Grant_builder{Id: "grant-plain", Entitlement: ent1, Principal: u1}.Build()
+		require.NoError(t, c1f.PutGrants(ctx, expandableGrant, plainGrant))
+		require.NoError(t, c1f.EndSync(ctx))
+		require.NoError(t, c1f.Close(ctx))
+	}()
+
+	c1f, err := NewC1ZFile(ctx, tmpPath)
+	require.NoError(t, err)
+	defer c1f.Close(ctx)
+
+	byID := func(grants []*v2.Grant, id string) *v2.Grant {
+		for _, g := range grants {
+			if g.GetId() == id {
+				return g
+			}
+		}
+		return nil
+	}
+
+	// Default stream: expansion topology is absent (data blob was stripped).
+	defaultGrants := collectStream(t, c1f.StreamGrants(ctx, "", connectorstore.StreamGrantsOptions{}))
+	require.Len(t, defaultGrants, 2)
+	require.Nil(t, pickExpandable(t, byID(defaultGrants, "grant-expandable")),
+		"default stream must not carry the stripped GrantExpandable annotation")
+
+	// IncludeExpansion: the GrantExpandable annotation is restored exactly.
+	expandedGrants := collectStream(t, c1f.StreamGrants(ctx, "", connectorstore.StreamGrantsOptions{IncludeExpansion: true}))
+	require.Len(t, expandedGrants, 2)
+
+	restored := pickExpandable(t, byID(expandedGrants, "grant-expandable"))
+	require.NotNil(t, restored, "IncludeExpansion must re-attach the GrantExpandable annotation")
+	require.Equal(t, wantEntitlementIDs, restored.GetEntitlementIds())
+	require.True(t, restored.GetShallow())
+	require.Equal(t, []string{"user"}, restored.GetResourceTypeIds())
+
+	// A non-expandable grant gains nothing under IncludeExpansion.
+	require.Nil(t, pickExpandable(t, byID(expandedGrants, "grant-plain")),
+		"a grant with no expansion must stay unchanged under IncludeExpansion")
+}

--- a/pkg/dotc1z/sync_runs.go
+++ b/pkg/dotc1z/sync_runs.go
@@ -620,10 +620,19 @@ func (c *C1File) StartNewSync(ctx context.Context, syncType connectorstore.SyncT
 		if err != nil {
 			return "", err
 		}
-		if cur != nil && cur.EndedAt == nil && cur.Type != syncType {
-			return "", status.Errorf(codes.FailedPrecondition, "current sync (id %s) is type %s. cannot start %s", cur.ID, cur.Type, syncType)
+		// Only adopt the current sync as the started one when it actually exists
+		// and is still open. An ENDED (cur.EndedAt != nil) or missing (cur == nil)
+		// current sync must NOT be returned here: a caller that scanned existing
+		// syncs and left currentSyncID pointing at a finished sync would otherwise
+		// get that finished sync back and write a fresh sync's records into it.
+		// Fall through to create a brand-new sync instead.
+		if cur != nil && cur.EndedAt == nil {
+			if cur.Type != syncType {
+				return "", status.Errorf(codes.FailedPrecondition, "current sync (id %s) is type %s. cannot start %s", cur.ID, cur.Type, syncType)
+			}
+			return c.currentSyncID, nil
 		}
-		return c.currentSyncID, nil
+		c.currentSyncID = ""
 	}
 
 	switch syncType {

--- a/pkg/dotc1z/to_pebble.go
+++ b/pkg/dotc1z/to_pebble.go
@@ -261,7 +261,10 @@ func (c *C1File) copyGrants(ctx context.Context, dest connectorstore.Writer, syn
 	if fw, ok := dest.(uniqueGrantWriter); ok {
 		put = fw.UnsafePutUniqueGrants
 	}
-	return copyStream(ctx, c.StreamGrants(ctx, syncID, connectorstore.StreamGrantsOptions{}), batchSize, stage, put)
+	// Preserve grant-expansion topology across the engine copy: the SQLite
+	// source strips GrantExpandable into a side column, so the stream must
+	// re-attach it or the Pebble copy loses the expansion edges.
+	return copyStream(ctx, c.StreamGrants(ctx, syncID, connectorstore.StreamGrantsOptions{IncludeExpansion: true}), batchSize, stage, put)
 }
 
 // copyStream drains a streaming reader into the destination in batches of


### PR DESCRIPTION
## Scope

A single PR folding two in-flight c1zsanitize branches into one reviewable unit, plus the load-bearing wiring that ties them together:

1. **Parallel + resumable sanitize** (was #936) — per-page transform fan-out and resumable checkpoint/resume runs.
2. **Grant-expansion topology preserved on the engine paths** (was #937) — `StreamGrantsOptions.IncludeExpansion` + the cross-engine `to_pebble` `copyGrants` fix.
3. **Grant-expansion topology preserved end-to-end through *sanitize*** (new here) — the part neither branch had.

## The gap this closes

The SQLite writer strips a grant's `GrantExpandable` annotation into a side `expansion` column (`extractAndStripExpansion`). #937 fixed the `StreamGrants` / `to_pebble` copy path, but the **sanitizer reads grants a different way**: `copyGrants` → `src.ListGrants` → `listGrantsGeneric`, which selects only the `data` blob. So the annotation never reached `transformGrant`, `handleGrantExpandable` (`handlers.go:50`) never fired, and the sanitized output **silently dropped every expansion edge**. `perf_test.go` falsely passed because it fed the handler an in-memory annotation that a real SQLite round-trip never produces.

## The wiring (mirrors #937's `IncludeExpansion`, default-off)

- `listGrantsGeneric` gains an `includeExpansion bool` — **default false, so existing `ListGrants`/`ListGrantsFor*` callers are byte-identical**. When set, it selects the `expansion` column and re-attaches the deserialized `GrantExpandable` via a shared `reattachExpansion` helper (now also used by `streamGrantsWithExpansion`, so the stream and paginated read paths restore topology identically).
- New `C1File.ListGrantsWithExpansion` + optional capability interface `connectorstore.ExpansionGrantLister` (discovered by type assertion, like the existing `StreamingReader` / `LatestFinishedSyncIDFetcher` capabilities).
- The sanitizer's `copyGrants` type-asserts `ExpansionGrantLister` and uses the expansion-aware read when available. This deliberately keeps the **resumable page-cursor semantics** the checkpoint phase relies on — switching the sanitizer to `StreamGrants` would change #936's resume cursor, so it is avoided.

I chose the optional-capability variant over a request-annotation marker because `ListGrants`'s signature is fixed by the generated `GrantsServiceServer` interface and the codebase already models optional store capabilities this way; it stays additive and forces nothing on other implementers (the Pebble adapter's `ListGrants` already carries expansion, so it needn't implement it).

## New test (the gap that hid this)

`TestSanitizeGrantExpansionRoundTrip` is a real SQLite **source → sanitize → dest** round-trip: the fixture grant is written through the real `PutGrants` (so `GrantExpandable` is stripped into the `expansion` column, exactly as production files store it), sanitized, then read back through the expansion-aware path and asserted:
- the sanitized grant carries a `GrantExpandable` — entitlement ids rewritten via `transformID`, resource-type tokens per the known-type rule (declared `user` preserved verbatim, undeclared `group` HMAC'd), `shallow` preserved;
- a non-expandable grant stays NULL.

**Verified it FAILS without the step-2 wiring and PASSES with it** (temporarily forcing the plain `ListGrants` path makes the `GrantExpandable`-present assertion fail). This is the rollback/replay round-trip fidelity check.

## Tests / build / lint

- `go build ./...` — OK
- `go vet ./pkg/dotc1z/... ./pkg/c1zsanitize/... ./pkg/connectorstore/...` — clean
- `gofmt -l` — clean
- `go test ./pkg/dotc1z/... ./pkg/c1zsanitize/... ./pkg/connectorstore/...` — **all pass** (incl. #936's `parallel_checkpoint_test.go` + `perf_test.go`, #937's `streaming_expansion_test.go`, and the new round-trip test)
- `go test ./pkg/c1zsanitize/ -race` — clean (parallel transform)

## Supersedes #936 and #937

This PR contains both branches' commits plus the connecting wiring, so it **supersedes #936 and #937** — please close both in favor of this one:
- #936 — parallel per-page transform + resumable checkpointing
- #937 — `StreamGrantsOptions.IncludeExpansion` + `to_pebble` cross-engine fix

## go.mod pin delta (for the be-temporal-sync reviewer)

This is a baton-sdk-only change. A grant consumer such as **be-temporal-sync** that wants the expansion topology preserved must (1) bump its `github.com/conductorone/baton-sdk` pin to the release containing this PR's head commit, and (2) opt in at its call site — `StreamGrantsOptions{IncludeExpansion: true}` for the streaming reader, or `ListGrantsWithExpansion` (type-asserting `connectorstore.ExpansionGrantLister`) for the paginated reader. Default-off means existing consumers are unaffected until they opt in. **Documented here, not done** — no be-temporal-sync code is changed in this PR.

## Follow-up (not in this PR)

The etag-replay expansion-NULL issue in the syncer/grants read path (`pkg/sync/syncer.go`, `pkg/connectorstore`/grants) is pre-existing on `main` and out of scope here. It is tracked as a separate follow-up and is intentionally not changed in this PR.

---

_🛰️ Built with stargate._
