### PR TITLE
Pebble/c1zstore cleanup.

### DIFF
--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -767,6 +767,9 @@ func (c *C1File) closeRawDB(ctx context.Context) error {
 	_, span := tracer.Start(ctx, "C1File.closeRawDB")
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
+	if c.rawDb == nil {
+		return nil
+	}
 	// Copy the rawDb to a local variable to avoid race conditions.
 	rawDb := c.rawDb
 	c.rawDb = nil

--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -109,6 +109,7 @@ type C1File struct {
 var (
 	_ connectorstore.Writer                      = (*C1File)(nil)
 	_ connectorstore.LatestFinishedSyncIDFetcher = (*C1File)(nil)
+	_ C1ZStore                                   = (*C1File)(nil)
 )
 
 type C1FOption func(*C1File)
@@ -766,8 +767,10 @@ func (c *C1File) closeRawDB(ctx context.Context) error {
 	_, span := tracer.Start(ctx, "C1File.closeRawDB")
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
-	err = c.rawDb.Close()
+	// Copy the rawDb to a local variable to avoid race conditions.
+	rawDb := c.rawDb
 	c.rawDb = nil
+	err = rawDb.Close()
 	c.db = nil
 	return err
 }

--- a/pkg/dotc1z/convert_open_test.go
+++ b/pkg/dotc1z/convert_open_test.go
@@ -35,9 +35,7 @@ func TestNewStoreConvertsExistingSQLiteToPebble(t *testing.T) {
 	_, ok := store.(*dotc1z.C1File)
 	require.False(t, ok)
 
-	format, err := dotc1z.ReadHeaderFormat(mustOpenFile(t, c1zPath))
-	require.NoError(t, err)
-	require.Equal(t, dotc1z.C1ZFormatV3, format)
+	require.Equal(t, dotc1z.C1ZFormatV3, mustReadHeaderFormat(t, c1zPath))
 
 	md := store.Metadata()
 	require.Equal(t, string(dotc1z.EnginePebble), md.Engine)
@@ -65,9 +63,7 @@ func TestNewStoreRejectsPebbleEngineOnExistingSQLite(t *testing.T) {
 	)
 	require.Error(t, err)
 
-	format, err := dotc1z.ReadHeaderFormat(mustOpenFile(t, c1zPath))
-	require.NoError(t, err)
-	require.Equal(t, dotc1z.C1ZFormatV1, format, "rejected NewStore must leave the v1 file untouched")
+	require.Equal(t, dotc1z.C1ZFormatV1, mustReadHeaderFormat(t, c1zPath), "rejected NewStore must leave the v1 file untouched")
 
 	store, err := dotc1z.NewStore(ctx, c1zPath,
 		dotc1z.WithEngine(dotc1z.EnginePebble),
@@ -118,9 +114,7 @@ func TestNewC1ZFileDoesNotConvertExistingSQLiteWhenEngineSQLite(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { require.NoError(t, f.Close(ctx)) }()
 
-	format, err := dotc1z.ReadHeaderFormat(mustOpenFile(t, c1zPath))
-	require.NoError(t, err)
-	require.Equal(t, dotc1z.C1ZFormatV1, format)
+	require.Equal(t, dotc1z.C1ZFormatV1, mustReadHeaderFormat(t, c1zPath))
 	require.Equal(t, string(dotc1z.EngineSQLite), f.Metadata().Engine)
 }
 
@@ -143,9 +137,7 @@ func TestNewC1ZFileReadOnlyDoesNotConvertExistingSQLite(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { require.NoError(t, f.Close(ctx)) }()
 
-	format, err := dotc1z.ReadHeaderFormat(mustOpenFile(t, c1zPath))
-	require.NoError(t, err)
-	require.Equal(t, dotc1z.C1ZFormatV1, format)
+	require.Equal(t, dotc1z.C1ZFormatV1, mustReadHeaderFormat(t, c1zPath))
 }
 
 func seedFinishedSQLiteSync(ctx context.Context, t *testing.T, store connectorstore.Writer) error {
@@ -175,10 +167,15 @@ func seedFinishedSQLiteSync(ctx context.Context, t *testing.T, store connectorst
 	return store.EndSync(ctx)
 }
 
-func mustOpenFile(t *testing.T, path string) *os.File {
+// mustReadHeaderFormat reads the c1z header format and closes the file
+// immediately. Holding the handle open (e.g. via t.Cleanup) breaks later
+// rename-over-file operations on Windows.
+func mustReadHeaderFormat(t *testing.T, path string) dotc1z.C1ZFormat {
 	t.Helper()
 	f, err := os.Open(path)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = f.Close() })
-	return f
+	defer func() { require.NoError(t, f.Close()) }()
+	format, err := dotc1z.ReadHeaderFormat(f)
+	require.NoError(t, err)
+	return format
 }

--- a/pkg/dotc1z/engine/pebble/adapter_clone_sync.go
+++ b/pkg/dotc1z/engine/pebble/adapter_clone_sync.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 
 	"github.com/cockroachdb/pebble/v2"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
 
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
@@ -35,12 +37,13 @@ func cloneSync(
 	a *Adapter,
 	encoding c1zstore.PayloadEncoding,
 	outPath, syncID string,
-	_ ...c1zstore.CloneSyncOption,
+	opts ...c1zstore.CloneSyncOption,
 ) error {
-	//TODO: Support options in pebble.
 	if _, err := os.Stat(outPath); err == nil || !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("clone-sync: output path (%s) must not exist for cloning to proceed", outPath)
 	}
+
+	cloneOpts := c1zstore.NewCloneSyncOptions(opts...)
 
 	resolved := syncID
 	if resolved == "" {
@@ -70,11 +73,16 @@ func cloneSync(
 		return fmt.Errorf("clone-sync: encode sync_id: %w", err)
 	}
 
-	cloneTmp, err := os.MkdirTemp("", "c1z-clone")
+	cloneTmp, err := os.MkdirTemp(cloneOpts.TmpDir, "c1z-clone")
 	if err != nil {
 		return err
 	}
-	defer os.RemoveAll(cloneTmp)
+	defer func() {
+		cleanupErr := os.RemoveAll(cloneTmp)
+		if cleanupErr != nil {
+			ctxzap.Extract(ctx).Warn("clone-sync: error cleaning up temp dir", zap.Error(cleanupErr))
+		}
+	}()
 	destDBDir := filepath.Join(cloneTmp, "db")
 
 	dest, err := Open(ctx, destDBDir)

--- a/pkg/dotc1z/engine_registry.go
+++ b/pkg/dotc1z/engine_registry.go
@@ -192,7 +192,11 @@ func selectStoreDriver(ctx context.Context, outputFilePath string, options *c1zO
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer func() {
+		if f != nil {
+			_ = f.Close()
+		}
+	}()
 
 	format, err := ReadHeaderFormat(f)
 	if err != nil {
@@ -205,9 +209,12 @@ func selectStoreDriver(ctx context.Context, outputFilePath string, options *c1zO
 		if shouldConvertSQLiteToPebble(requested, options.readOnly, true) {
 			// Close our header-read handle before converting: the conversion
 			// renames a temp file over outputFilePath, which fails on Windows
-			// if any handle to the destination is still open.
-			if err := f.Close(); err != nil {
-				return nil, err
+			// if any handle to the destination is still open. Nil out f so
+			// the deferred close doesn't double-close.
+			closeErr := f.Close()
+			f = nil
+			if closeErr != nil {
+				return nil, closeErr
 			}
 			l.Debug("converting existing v1 c1z to pebble", zap.String("output_file_path", outputFilePath))
 			if err := convertExistingV1C1ZFile(ctx, outputFilePath, pebbleOpenOptionsFromC1Z(options)); err != nil {

--- a/pkg/dotc1z/engine_registry.go
+++ b/pkg/dotc1z/engine_registry.go
@@ -203,6 +203,12 @@ func selectStoreDriver(ctx context.Context, outputFilePath string, options *c1zO
 	switch format {
 	case C1ZFormatV1:
 		if shouldConvertSQLiteToPebble(requested, options.readOnly, true) {
+			// Close our header-read handle before converting: the conversion
+			// renames a temp file over outputFilePath, which fails on Windows
+			// if any handle to the destination is still open.
+			if err := f.Close(); err != nil {
+				return nil, err
+			}
 			l.Debug("converting existing v1 c1z to pebble", zap.String("output_file_path", outputFilePath))
 			if err := convertExistingV1C1ZFile(ctx, outputFilePath, pebbleOpenOptionsFromC1Z(options)); err != nil {
 				return nil, fmt.Errorf("select-store-driver: convert existing v1 c1z to pebble: %w", err)

--- a/pkg/dotc1z/pebble_store.go
+++ b/pkg/dotc1z/pebble_store.go
@@ -18,10 +18,11 @@ import (
 	formatv3 "github.com/conductorone/baton-sdk/pkg/dotc1z/format/v3"
 )
 
-// pebbleDriver is the EngineDriver for the Pebble v3 engine. It is
-// registered statically alongside sqliteDriver — both file formats are
-// always supported, no side-effect imports required.
+// pebbleDriver is the EngineDriver for the Pebble v3 engine.
 type pebbleDriver struct{}
+
+var _ C1ZStore = (*pebbleStore)(nil)
+var _ connectorstore.Writer = (*pebbleStore)(nil)
 
 func (pebbleDriver) Engine() Engine    { return EnginePebble }
 func (pebbleDriver) Format() C1ZFormat { return C1ZFormatV3 }

--- a/pkg/dotc1z/sync_runs.go
+++ b/pkg/dotc1z/sync_runs.go
@@ -365,6 +365,8 @@ func (c *C1File) ListSyncRuns(ctx context.Context, pageToken string, pageSize ui
 	return ret, nextPageToken, nil
 }
 
+// LatestSyncID returns the ID of the most recently finished sync of the given type.
+// If syncType is connectorstore.SyncTypeAny, it will return the most recently finished sync of any type.
 func (c *C1File) LatestSyncID(ctx context.Context, syncType connectorstore.SyncType) (string, error) {
 	ctx, span := tracer.Start(ctx, "C1File.LatestSyncID")
 	var err error

--- a/pkg/tasks/local/differ.go
+++ b/pkg/tasks/local/differ.go
@@ -54,12 +54,12 @@ func (m *localDiffer) Process(ctx context.Context, task *v1.Task, cc types.Conne
 		return errors.New("missing base sync ID or applied sync ID")
 	}
 
-	file, err := dotc1z.NewC1ZFile(ctx, m.dbPath)
+	file, err := dotc1z.NewStore(ctx, m.dbPath)
 	if err != nil {
 		return err
 	}
 
-	newSyncID, err := file.GenerateSyncDiff(ctx, m.baseSyncID, m.appliedSyncID)
+	newSyncID, err := file.FileOps().GenerateSyncDiff(ctx, m.baseSyncID, m.appliedSyncID)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Add some type assertions to make sure that both C1File and Pebble driver are connectorWriters and C1ZStores.
- Add support for clone sync options in pebble.
- C1File closeRawDB(): Set rawDb to nil before closing so that new DB operations aren't started during close. Should help with some race conditions.
- Differ task: Add support for pebble.
- Fix error converting sqlite c1zs to pebble on windows.