### PR TITLE
Detar

### DIFF
--- a/cmd/baton/dump_db.go
+++ b/cmd/baton/dump_db.go
@@ -51,15 +51,12 @@ func runDumpDB(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if format == dotc1z.C1ZFormatV3 {
-		env, err := formatv3.ReadEnvelope(f)
-		if err != nil {
-			return err
-		}
-		defer env.Close()
 		if err := os.MkdirAll(outPath, 0o755); err != nil {
 			return err
 		}
-		if err := formatv3.ExtractZstdTar(env.PayloadReader, outPath); err != nil {
+		// ExtractEnvelopePayload dispatches on the manifest's payload
+		// encoding (tar, tar_zstd, indexed_zstd).
+		if _, _, err := formatv3.ExtractEnvelopePayload(f, outPath); err != nil {
 			return err
 		}
 		_, _ = fmt.Fprintf(os.Stdout, "Extracted Pebble payload directory to %s\n", outPath)

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.17
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.88.5
+	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/cockroachdb/pebble/v2 v2.1.5
 	github.com/conductorone/dpop v0.2.6
 	github.com/conductorone/dpop/integrations/dpop_grpc v0.2.4
@@ -93,7 +94,6 @@ require (
 	github.com/bytedance/sonic v1.15.0 // indirect
 	github.com/bytedance/sonic/loader v0.5.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
-	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/cockroachdb/crlib v0.0.0-20251122031428-fe658a2dbda1 // indirect

--- a/pb/c1/c1z/v3/manifest.pb.go
+++ b/pb/c1/c1z/v3/manifest.pb.go
@@ -42,13 +42,25 @@ type PayloadEncoding int32
 const (
 	PayloadEncoding_PAYLOAD_ENCODING_UNSPECIFIED PayloadEncoding = 0
 	// Tar of a Pebble directory, compressed with zstd. The
-	// production default.
+	// production default in older v3 writers.
 	PayloadEncoding_PAYLOAD_ENCODING_TAR_ZSTD PayloadEncoding = 1
 	// Tar of a Pebble directory, uncompressed. For tenants whose
 	// Pebble L5/L6 SSTs are already zstd-compressed at the engine
 	// layer and want to avoid double-compression CPU at envelope
 	// time, or for object-storage targets that compress in-transit.
 	PayloadEncoding_PAYLOAD_ENCODING_TAR PayloadEncoding = 2
+	// Per-file zstd frames, each preceded by a self-describing binary
+	// header (name, raw size, compressed size, xxh64 of raw bytes),
+	// terminated by a zero-length-name sentinel. No tar layer.
+	//
+	// Enables (a) parallel frame decode at open — the single-stream
+	// encodings decode sequentially on one core — and (b) frame
+	// splicing at save: a writer that knows a payload file is
+	// byte-identical to one in the source envelope copies its
+	// compressed frame verbatim instead of re-encoding (Pebble SSTs
+	// are immutable and checkpoints hard-link them, so incremental
+	// folds reuse almost every frame).
+	PayloadEncoding_PAYLOAD_ENCODING_INDEXED_ZSTD PayloadEncoding = 5
 )
 
 // Enum value maps for PayloadEncoding.
@@ -57,11 +69,13 @@ var (
 		0: "PAYLOAD_ENCODING_UNSPECIFIED",
 		1: "PAYLOAD_ENCODING_TAR_ZSTD",
 		2: "PAYLOAD_ENCODING_TAR",
+		5: "PAYLOAD_ENCODING_INDEXED_ZSTD",
 	}
 	PayloadEncoding_value = map[string]int32{
-		"PAYLOAD_ENCODING_UNSPECIFIED": 0,
-		"PAYLOAD_ENCODING_TAR_ZSTD":    1,
-		"PAYLOAD_ENCODING_TAR":         2,
+		"PAYLOAD_ENCODING_UNSPECIFIED":  0,
+		"PAYLOAD_ENCODING_TAR_ZSTD":     1,
+		"PAYLOAD_ENCODING_TAR":          2,
+		"PAYLOAD_ENCODING_INDEXED_ZSTD": 5,
 	}
 )
 
@@ -668,11 +682,12 @@ const file_c1_c1z_v3_manifest_proto_rawDesc = "" +
 	"\x05stats\x18\x06 \x01(\v2\x1e.c1.storage.v3.SyncStatsRecordR\x05stats\"p\n" +
 	"\x12PebbleEngineConfig\x120\n" +
 	"\x14format_major_version\x18\x01 \x01(\rR\x12formatMajorVersion\x12(\n" +
-	"\x10cache_size_bytes\x18\x02 \x01(\x04R\x0ecacheSizeBytes*l\n" +
+	"\x10cache_size_bytes\x18\x02 \x01(\x04R\x0ecacheSizeBytes*\x9b\x01\n" +
 	"\x0fPayloadEncoding\x12 \n" +
 	"\x1cPAYLOAD_ENCODING_UNSPECIFIED\x10\x00\x12\x1d\n" +
 	"\x19PAYLOAD_ENCODING_TAR_ZSTD\x10\x01\x12\x18\n" +
-	"\x14PAYLOAD_ENCODING_TAR\x10\x02B0Z.github.com/conductorone/baton-sdk/pb/c1/c1z/v3b\x06proto3"
+	"\x14PAYLOAD_ENCODING_TAR\x10\x02\x12!\n" +
+	"\x1dPAYLOAD_ENCODING_INDEXED_ZSTD\x10\x05\"\x04\b\x03\x10\x03\"\x04\b\x04\x10\x04B0Z.github.com/conductorone/baton-sdk/pb/c1/c1z/v3b\x06proto3"
 
 var file_c1_c1z_v3_manifest_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
 var file_c1_c1z_v3_manifest_proto_msgTypes = make([]protoimpl.MessageInfo, 4)

--- a/pb/c1/c1z/v3/manifest.pb.go
+++ b/pb/c1/c1z/v3/manifest.pb.go
@@ -49,17 +49,19 @@ const (
 	// layer and want to avoid double-compression CPU at envelope
 	// time, or for object-storage targets that compress in-transit.
 	PayloadEncoding_PAYLOAD_ENCODING_TAR PayloadEncoding = 2
-	// Per-file zstd frames, each preceded by a self-describing binary
-	// header (name, raw size, compressed size, xxh64 of raw bytes),
-	// terminated by a zero-length-name sentinel. No tar layer.
+	// Per-file zstd frames written back-to-back, indexed by a trailing
+	// IndexedFrameIndex and fixed-size footer (see that message for
+	// the layout). No tar layer, no per-frame inline headers.
 	//
 	// Enables (a) parallel frame decode at open — the single-stream
-	// encodings decode sequentially on one core — and (b) frame
-	// splicing at save: a writer that knows a payload file is
-	// byte-identical to one in the source envelope copies its
-	// compressed frame verbatim instead of re-encoding (Pebble SSTs
-	// are immutable and checkpoints hard-link them, so incremental
-	// folds reuse almost every frame).
+	// encodings decode sequentially on one core; (b) frame splicing at
+	// save: a writer that knows a payload file is byte-identical to one
+	// in the source envelope copies its compressed frame verbatim
+	// instead of re-encoding (Pebble SSTs are immutable and checkpoints
+	// hard-link them, so incremental folds reuse almost every frame);
+	// and (c) chunked object storage: the index carries every frame's
+	// byte range and SHA-256 content identity, so a store can upload
+	// only the frames a parent sync doesn't already hold.
 	PayloadEncoding_PAYLOAD_ENCODING_INDEXED_ZSTD PayloadEncoding = 5
 )
 
@@ -310,6 +312,315 @@ func (b0 C1ZManifestV3_builder) Build() *C1ZManifestV3 {
 	return m0
 }
 
+// IndexedFrameIndex is the sole frame table for
+// PAYLOAD_ENCODING_INDEXED_ZSTD payloads. It is serialized (binary
+// proto) immediately after the last frame, followed by a fixed-size
+// footer carrying the index's absolute file offset, length, xxh64,
+// and a trailing magic:
+//
+//	payload := frame* | index | footer
+//	footer  := u64 indexOffset | u32 indexLen | u64 xxh64(index) | "C1ZIDX1\0"
+//
+// Frames carry no framing of their own — each is the bare zstd
+// stream of one payload file, with Frame_Content_Size advertised —
+// so the writer is single-pass (streamable to a non-seekable sink)
+// and a frame's byte range is directly usable as a standalone
+// object. The whole table is fetchable in O(1) reads — footer, then
+// index — which is what makes ranged reads over object storage
+// practical: fetch exactly the frames you want, no per-frame round
+// trips. A payload without a valid footer is corruption-class, the
+// same policy as a torn tar payload.
+//
+// Being a proto message, the index is the extension point for future
+// per-frame metadata (compression algorithm, dictionary IDs,
+// encryption) without a layout revision.
+type IndexedFrameIndex struct {
+	state   protoimpl.MessageState `protogen:"hybrid.v1"`
+	Entries []*IndexedFrameEntry   `protobuf:"bytes,1,rep,name=entries,proto3" json:"entries,omitempty"`
+	// Sum of raw_size over entries. Lets a reader budget extraction
+	// without summing.
+	TotalRawSize int64 `protobuf:"varint,2,opt,name=total_raw_size,json=totalRawSize,proto3" json:"total_raw_size,omitempty"`
+	// Sum of compressed_size over entries.
+	TotalCompressedSize int64 `protobuf:"varint,3,opt,name=total_compressed_size,json=totalCompressedSize,proto3" json:"total_compressed_size,omitempty"`
+	// xxh64 of the marshaled manifest bytes (the region between the
+	// length prefix and the first frame). The manifest is otherwise
+	// the only unprotected byte region — frames carry zstd CRCs and
+	// raw-byte hashes, the index is covered by the footer's xxh64 —
+	// and the header-only manifest decode skips the descriptor
+	// closure, so a flipped bit there would otherwise go unnoticed.
+	// Also lets a chunked store verify reassembly of the envelope
+	// head. Zero means "not recorded".
+	ManifestXxh64 uint64 `protobuf:"fixed64,4,opt,name=manifest_xxh64,json=manifestXxh64,proto3" json:"manifest_xxh64,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *IndexedFrameIndex) Reset() {
+	*x = IndexedFrameIndex{}
+	mi := &file_c1_c1z_v3_manifest_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *IndexedFrameIndex) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*IndexedFrameIndex) ProtoMessage() {}
+
+func (x *IndexedFrameIndex) ProtoReflect() protoreflect.Message {
+	mi := &file_c1_c1z_v3_manifest_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *IndexedFrameIndex) GetEntries() []*IndexedFrameEntry {
+	if x != nil {
+		return x.Entries
+	}
+	return nil
+}
+
+func (x *IndexedFrameIndex) GetTotalRawSize() int64 {
+	if x != nil {
+		return x.TotalRawSize
+	}
+	return 0
+}
+
+func (x *IndexedFrameIndex) GetTotalCompressedSize() int64 {
+	if x != nil {
+		return x.TotalCompressedSize
+	}
+	return 0
+}
+
+func (x *IndexedFrameIndex) GetManifestXxh64() uint64 {
+	if x != nil {
+		return x.ManifestXxh64
+	}
+	return 0
+}
+
+func (x *IndexedFrameIndex) SetEntries(v []*IndexedFrameEntry) {
+	x.Entries = v
+}
+
+func (x *IndexedFrameIndex) SetTotalRawSize(v int64) {
+	x.TotalRawSize = v
+}
+
+func (x *IndexedFrameIndex) SetTotalCompressedSize(v int64) {
+	x.TotalCompressedSize = v
+}
+
+func (x *IndexedFrameIndex) SetManifestXxh64(v uint64) {
+	x.ManifestXxh64 = v
+}
+
+type IndexedFrameIndex_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	Entries []*IndexedFrameEntry
+	// Sum of raw_size over entries. Lets a reader budget extraction
+	// without summing.
+	TotalRawSize int64
+	// Sum of compressed_size over entries.
+	TotalCompressedSize int64
+	// xxh64 of the marshaled manifest bytes (the region between the
+	// length prefix and the first frame). The manifest is otherwise
+	// the only unprotected byte region — frames carry zstd CRCs and
+	// raw-byte hashes, the index is covered by the footer's xxh64 —
+	// and the header-only manifest decode skips the descriptor
+	// closure, so a flipped bit there would otherwise go unnoticed.
+	// Also lets a chunked store verify reassembly of the envelope
+	// head. Zero means "not recorded".
+	ManifestXxh64 uint64
+}
+
+func (b0 IndexedFrameIndex_builder) Build() *IndexedFrameIndex {
+	m0 := &IndexedFrameIndex{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Entries = b.Entries
+	x.TotalRawSize = b.TotalRawSize
+	x.TotalCompressedSize = b.TotalCompressedSize
+	x.ManifestXxh64 = b.ManifestXxh64
+	return m0
+}
+
+type IndexedFrameEntry struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// Slash-separated relative path of the payload file, identical to
+	// the name in the frame's inline header.
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// Absolute offset of the frame's compressed zstd bytes from the
+	// start of the envelope file (NOT from the payload start), so a
+	// ranged read needs no other context.
+	FrameOffset    int64 `protobuf:"varint,2,opt,name=frame_offset,json=frameOffset,proto3" json:"frame_offset,omitempty"`
+	CompressedSize int64 `protobuf:"varint,3,opt,name=compressed_size,json=compressedSize,proto3" json:"compressed_size,omitempty"`
+	RawSize        int64 `protobuf:"varint,4,opt,name=raw_size,json=rawSize,proto3" json:"raw_size,omitempty"`
+	// xxh64 of the raw (decompressed) bytes. Matches the inline
+	// header; used for corruption detection and splice matching.
+	RawXxh64 uint64 `protobuf:"fixed64,5,opt,name=raw_xxh64,json=rawXxh64,proto3" json:"raw_xxh64,omitempty"`
+	// SHA-256 of the raw bytes. Content-address identity for chunked
+	// object storage: compressed bytes are not stable across encoder
+	// versions, and xxh64 is too weak to key a fleet-wide chunk store.
+	//
+	// REQUIRED: readers reject entries whose value is not exactly 32
+	// bytes. Writers must always compute it, even when content
+	// addressing is not in play — a partially-identified index can't
+	// serve chunk dedupe later, and allowing absence would let
+	// truncated identities propagate through frame splicing. A future
+	// writer that genuinely cannot afford SHA-256 should introduce a
+	// new payload encoding (or footer version) rather than omit this.
+	RawSha256     []byte `protobuf:"bytes,6,opt,name=raw_sha256,json=rawSha256,proto3" json:"raw_sha256,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *IndexedFrameEntry) Reset() {
+	*x = IndexedFrameEntry{}
+	mi := &file_c1_c1z_v3_manifest_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *IndexedFrameEntry) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*IndexedFrameEntry) ProtoMessage() {}
+
+func (x *IndexedFrameEntry) ProtoReflect() protoreflect.Message {
+	mi := &file_c1_c1z_v3_manifest_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *IndexedFrameEntry) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *IndexedFrameEntry) GetFrameOffset() int64 {
+	if x != nil {
+		return x.FrameOffset
+	}
+	return 0
+}
+
+func (x *IndexedFrameEntry) GetCompressedSize() int64 {
+	if x != nil {
+		return x.CompressedSize
+	}
+	return 0
+}
+
+func (x *IndexedFrameEntry) GetRawSize() int64 {
+	if x != nil {
+		return x.RawSize
+	}
+	return 0
+}
+
+func (x *IndexedFrameEntry) GetRawXxh64() uint64 {
+	if x != nil {
+		return x.RawXxh64
+	}
+	return 0
+}
+
+func (x *IndexedFrameEntry) GetRawSha256() []byte {
+	if x != nil {
+		return x.RawSha256
+	}
+	return nil
+}
+
+func (x *IndexedFrameEntry) SetName(v string) {
+	x.Name = v
+}
+
+func (x *IndexedFrameEntry) SetFrameOffset(v int64) {
+	x.FrameOffset = v
+}
+
+func (x *IndexedFrameEntry) SetCompressedSize(v int64) {
+	x.CompressedSize = v
+}
+
+func (x *IndexedFrameEntry) SetRawSize(v int64) {
+	x.RawSize = v
+}
+
+func (x *IndexedFrameEntry) SetRawXxh64(v uint64) {
+	x.RawXxh64 = v
+}
+
+func (x *IndexedFrameEntry) SetRawSha256(v []byte) {
+	if v == nil {
+		v = []byte{}
+	}
+	x.RawSha256 = v
+}
+
+type IndexedFrameEntry_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// Slash-separated relative path of the payload file, identical to
+	// the name in the frame's inline header.
+	Name string
+	// Absolute offset of the frame's compressed zstd bytes from the
+	// start of the envelope file (NOT from the payload start), so a
+	// ranged read needs no other context.
+	FrameOffset    int64
+	CompressedSize int64
+	RawSize        int64
+	// xxh64 of the raw (decompressed) bytes. Matches the inline
+	// header; used for corruption detection and splice matching.
+	RawXxh64 uint64
+	// SHA-256 of the raw bytes. Content-address identity for chunked
+	// object storage: compressed bytes are not stable across encoder
+	// versions, and xxh64 is too weak to key a fleet-wide chunk store.
+	//
+	// REQUIRED: readers reject entries whose value is not exactly 32
+	// bytes. Writers must always compute it, even when content
+	// addressing is not in play — a partially-identified index can't
+	// serve chunk dedupe later, and allowing absence would let
+	// truncated identities propagate through frame splicing. A future
+	// writer that genuinely cannot afford SHA-256 should introduce a
+	// new payload encoding (or footer version) rather than omit this.
+	RawSha256 []byte
+}
+
+func (b0 IndexedFrameEntry_builder) Build() *IndexedFrameEntry {
+	m0 := &IndexedFrameEntry{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Name = b.Name
+	x.FrameOffset = b.FrameOffset
+	x.CompressedSize = b.CompressedSize
+	x.RawSize = b.RawSize
+	x.RawXxh64 = b.RawXxh64
+	x.RawSha256 = b.RawSha256
+	return m0
+}
+
 type RecordTypeInfo struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
 	// Proto FullName — e.g. "c1.storage.v3.GrantRecord".
@@ -326,7 +637,7 @@ type RecordTypeInfo struct {
 
 func (x *RecordTypeInfo) Reset() {
 	*x = RecordTypeInfo{}
-	mi := &file_c1_c1z_v3_manifest_proto_msgTypes[1]
+	mi := &file_c1_c1z_v3_manifest_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -338,7 +649,7 @@ func (x *RecordTypeInfo) String() string {
 func (*RecordTypeInfo) ProtoMessage() {}
 
 func (x *RecordTypeInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_c1z_v3_manifest_proto_msgTypes[1]
+	mi := &file_c1_c1z_v3_manifest_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -424,7 +735,7 @@ type SyncRunSummary struct {
 
 func (x *SyncRunSummary) Reset() {
 	*x = SyncRunSummary{}
-	mi := &file_c1_c1z_v3_manifest_proto_msgTypes[2]
+	mi := &file_c1_c1z_v3_manifest_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -436,7 +747,7 @@ func (x *SyncRunSummary) String() string {
 func (*SyncRunSummary) ProtoMessage() {}
 
 func (x *SyncRunSummary) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_c1z_v3_manifest_proto_msgTypes[2]
+	mi := &file_c1_c1z_v3_manifest_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -590,7 +901,7 @@ type PebbleEngineConfig struct {
 
 func (x *PebbleEngineConfig) Reset() {
 	*x = PebbleEngineConfig{}
-	mi := &file_c1_c1z_v3_manifest_proto_msgTypes[3]
+	mi := &file_c1_c1z_v3_manifest_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -602,7 +913,7 @@ func (x *PebbleEngineConfig) String() string {
 func (*PebbleEngineConfig) ProtoMessage() {}
 
 func (x *PebbleEngineConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_c1z_v3_manifest_proto_msgTypes[3]
+	mi := &file_c1_c1z_v3_manifest_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -667,7 +978,20 @@ const file_c1_c1z_v3_manifest_proto_rawDesc = "" +
 	"\vdescriptors\x18\n" +
 	" \x01(\v2\".google.protobuf.FileDescriptorSetR\vdescriptors\x12<\n" +
 	"\frecord_types\x18\v \x03(\v2\x19.c1.c1z.v3.RecordTypeInfoR\vrecordTypes\x126\n" +
-	"\tsync_runs\x18( \x03(\v2\x19.c1.c1z.v3.SyncRunSummaryR\bsyncRuns\"\x8c\x01\n" +
+	"\tsync_runs\x18( \x03(\v2\x19.c1.c1z.v3.SyncRunSummaryR\bsyncRuns\"\xcc\x01\n" +
+	"\x11IndexedFrameIndex\x126\n" +
+	"\aentries\x18\x01 \x03(\v2\x1c.c1.c1z.v3.IndexedFrameEntryR\aentries\x12$\n" +
+	"\x0etotal_raw_size\x18\x02 \x01(\x03R\ftotalRawSize\x122\n" +
+	"\x15total_compressed_size\x18\x03 \x01(\x03R\x13totalCompressedSize\x12%\n" +
+	"\x0emanifest_xxh64\x18\x04 \x01(\x06R\rmanifestXxh64\"\xca\x01\n" +
+	"\x11IndexedFrameEntry\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12!\n" +
+	"\fframe_offset\x18\x02 \x01(\x03R\vframeOffset\x12'\n" +
+	"\x0fcompressed_size\x18\x03 \x01(\x03R\x0ecompressedSize\x12\x19\n" +
+	"\braw_size\x18\x04 \x01(\x03R\arawSize\x12\x1b\n" +
+	"\traw_xxh64\x18\x05 \x01(\x06R\brawXxh64\x12\x1d\n" +
+	"\n" +
+	"raw_sha256\x18\x06 \x01(\fR\trawSha256\"\x8c\x01\n" +
 	"\x0eRecordTypeInfo\x12*\n" +
 	"\x11message_full_name\x18\x01 \x01(\tR\x0fmessageFullName\x12%\n" +
 	"\x0eschema_version\x18\x02 \x01(\rR\rschemaVersion\x12'\n" +
@@ -690,34 +1014,37 @@ const file_c1_c1z_v3_manifest_proto_rawDesc = "" +
 	"\x1dPAYLOAD_ENCODING_INDEXED_ZSTD\x10\x05\"\x04\b\x03\x10\x03\"\x04\b\x04\x10\x04B0Z.github.com/conductorone/baton-sdk/pb/c1/c1z/v3b\x06proto3"
 
 var file_c1_c1z_v3_manifest_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_c1_c1z_v3_manifest_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_c1_c1z_v3_manifest_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
 var file_c1_c1z_v3_manifest_proto_goTypes = []any{
 	(PayloadEncoding)(0),                   // 0: c1.c1z.v3.PayloadEncoding
 	(*C1ZManifestV3)(nil),                  // 1: c1.c1z.v3.C1ZManifestV3
-	(*RecordTypeInfo)(nil),                 // 2: c1.c1z.v3.RecordTypeInfo
-	(*SyncRunSummary)(nil),                 // 3: c1.c1z.v3.SyncRunSummary
-	(*PebbleEngineConfig)(nil),             // 4: c1.c1z.v3.PebbleEngineConfig
-	(*anypb.Any)(nil),                      // 5: google.protobuf.Any
-	(*descriptorpb.FileDescriptorSet)(nil), // 6: google.protobuf.FileDescriptorSet
-	(v3.SyncType)(0),                       // 7: c1.storage.v3.SyncType
-	(*timestamppb.Timestamp)(nil),          // 8: google.protobuf.Timestamp
-	(*v3.SyncStatsRecord)(nil),             // 9: c1.storage.v3.SyncStatsRecord
+	(*IndexedFrameIndex)(nil),              // 2: c1.c1z.v3.IndexedFrameIndex
+	(*IndexedFrameEntry)(nil),              // 3: c1.c1z.v3.IndexedFrameEntry
+	(*RecordTypeInfo)(nil),                 // 4: c1.c1z.v3.RecordTypeInfo
+	(*SyncRunSummary)(nil),                 // 5: c1.c1z.v3.SyncRunSummary
+	(*PebbleEngineConfig)(nil),             // 6: c1.c1z.v3.PebbleEngineConfig
+	(*anypb.Any)(nil),                      // 7: google.protobuf.Any
+	(*descriptorpb.FileDescriptorSet)(nil), // 8: google.protobuf.FileDescriptorSet
+	(v3.SyncType)(0),                       // 9: c1.storage.v3.SyncType
+	(*timestamppb.Timestamp)(nil),          // 10: google.protobuf.Timestamp
+	(*v3.SyncStatsRecord)(nil),             // 11: c1.storage.v3.SyncStatsRecord
 }
 var file_c1_c1z_v3_manifest_proto_depIdxs = []int32{
-	5, // 0: c1.c1z.v3.C1ZManifestV3.engine_config:type_name -> google.protobuf.Any
-	0, // 1: c1.c1z.v3.C1ZManifestV3.payload_encoding:type_name -> c1.c1z.v3.PayloadEncoding
-	6, // 2: c1.c1z.v3.C1ZManifestV3.descriptors:type_name -> google.protobuf.FileDescriptorSet
-	2, // 3: c1.c1z.v3.C1ZManifestV3.record_types:type_name -> c1.c1z.v3.RecordTypeInfo
-	3, // 4: c1.c1z.v3.C1ZManifestV3.sync_runs:type_name -> c1.c1z.v3.SyncRunSummary
-	7, // 5: c1.c1z.v3.SyncRunSummary.type:type_name -> c1.storage.v3.SyncType
-	8, // 6: c1.c1z.v3.SyncRunSummary.started_at:type_name -> google.protobuf.Timestamp
-	8, // 7: c1.c1z.v3.SyncRunSummary.ended_at:type_name -> google.protobuf.Timestamp
-	9, // 8: c1.c1z.v3.SyncRunSummary.stats:type_name -> c1.storage.v3.SyncStatsRecord
-	9, // [9:9] is the sub-list for method output_type
-	9, // [9:9] is the sub-list for method input_type
-	9, // [9:9] is the sub-list for extension type_name
-	9, // [9:9] is the sub-list for extension extendee
-	0, // [0:9] is the sub-list for field type_name
+	7,  // 0: c1.c1z.v3.C1ZManifestV3.engine_config:type_name -> google.protobuf.Any
+	0,  // 1: c1.c1z.v3.C1ZManifestV3.payload_encoding:type_name -> c1.c1z.v3.PayloadEncoding
+	8,  // 2: c1.c1z.v3.C1ZManifestV3.descriptors:type_name -> google.protobuf.FileDescriptorSet
+	4,  // 3: c1.c1z.v3.C1ZManifestV3.record_types:type_name -> c1.c1z.v3.RecordTypeInfo
+	5,  // 4: c1.c1z.v3.C1ZManifestV3.sync_runs:type_name -> c1.c1z.v3.SyncRunSummary
+	3,  // 5: c1.c1z.v3.IndexedFrameIndex.entries:type_name -> c1.c1z.v3.IndexedFrameEntry
+	9,  // 6: c1.c1z.v3.SyncRunSummary.type:type_name -> c1.storage.v3.SyncType
+	10, // 7: c1.c1z.v3.SyncRunSummary.started_at:type_name -> google.protobuf.Timestamp
+	10, // 8: c1.c1z.v3.SyncRunSummary.ended_at:type_name -> google.protobuf.Timestamp
+	11, // 9: c1.c1z.v3.SyncRunSummary.stats:type_name -> c1.storage.v3.SyncStatsRecord
+	10, // [10:10] is the sub-list for method output_type
+	10, // [10:10] is the sub-list for method input_type
+	10, // [10:10] is the sub-list for extension type_name
+	10, // [10:10] is the sub-list for extension extendee
+	0,  // [0:10] is the sub-list for field type_name
 }
 
 func init() { file_c1_c1z_v3_manifest_proto_init() }
@@ -731,7 +1058,7 @@ func file_c1_c1z_v3_manifest_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_c1_c1z_v3_manifest_proto_rawDesc), len(file_c1_c1z_v3_manifest_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   4,
+			NumMessages:   6,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pb/c1/c1z/v3/manifest.pb.validate.go
+++ b/pb/c1/c1z/v3/manifest.pb.validate.go
@@ -271,6 +271,262 @@ var _ interface {
 	ErrorName() string
 } = C1ZManifestV3ValidationError{}
 
+// Validate checks the field values on IndexedFrameIndex with the rules defined
+// in the proto definition for this message. If any rules are violated, the
+// first error encountered is returned, or nil if there are no violations.
+func (m *IndexedFrameIndex) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on IndexedFrameIndex with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// IndexedFrameIndexMultiError, or nil if none found.
+func (m *IndexedFrameIndex) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *IndexedFrameIndex) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	for idx, item := range m.GetEntries() {
+		_, _ = idx, item
+
+		if all {
+			switch v := interface{}(item).(type) {
+			case interface{ ValidateAll() error }:
+				if err := v.ValidateAll(); err != nil {
+					errors = append(errors, IndexedFrameIndexValidationError{
+						field:  fmt.Sprintf("Entries[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			case interface{ Validate() error }:
+				if err := v.Validate(); err != nil {
+					errors = append(errors, IndexedFrameIndexValidationError{
+						field:  fmt.Sprintf("Entries[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			}
+		} else if v, ok := interface{}(item).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return IndexedFrameIndexValidationError{
+					field:  fmt.Sprintf("Entries[%v]", idx),
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
+	}
+
+	// no validation rules for TotalRawSize
+
+	// no validation rules for TotalCompressedSize
+
+	// no validation rules for ManifestXxh64
+
+	if len(errors) > 0 {
+		return IndexedFrameIndexMultiError(errors)
+	}
+
+	return nil
+}
+
+// IndexedFrameIndexMultiError is an error wrapping multiple validation errors
+// returned by IndexedFrameIndex.ValidateAll() if the designated constraints
+// aren't met.
+type IndexedFrameIndexMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m IndexedFrameIndexMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m IndexedFrameIndexMultiError) AllErrors() []error { return m }
+
+// IndexedFrameIndexValidationError is the validation error returned by
+// IndexedFrameIndex.Validate if the designated constraints aren't met.
+type IndexedFrameIndexValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e IndexedFrameIndexValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e IndexedFrameIndexValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e IndexedFrameIndexValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e IndexedFrameIndexValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e IndexedFrameIndexValidationError) ErrorName() string {
+	return "IndexedFrameIndexValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e IndexedFrameIndexValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sIndexedFrameIndex.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = IndexedFrameIndexValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = IndexedFrameIndexValidationError{}
+
+// Validate checks the field values on IndexedFrameEntry with the rules defined
+// in the proto definition for this message. If any rules are violated, the
+// first error encountered is returned, or nil if there are no violations.
+func (m *IndexedFrameEntry) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on IndexedFrameEntry with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// IndexedFrameEntryMultiError, or nil if none found.
+func (m *IndexedFrameEntry) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *IndexedFrameEntry) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	// no validation rules for Name
+
+	// no validation rules for FrameOffset
+
+	// no validation rules for CompressedSize
+
+	// no validation rules for RawSize
+
+	// no validation rules for RawXxh64
+
+	// no validation rules for RawSha256
+
+	if len(errors) > 0 {
+		return IndexedFrameEntryMultiError(errors)
+	}
+
+	return nil
+}
+
+// IndexedFrameEntryMultiError is an error wrapping multiple validation errors
+// returned by IndexedFrameEntry.ValidateAll() if the designated constraints
+// aren't met.
+type IndexedFrameEntryMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m IndexedFrameEntryMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m IndexedFrameEntryMultiError) AllErrors() []error { return m }
+
+// IndexedFrameEntryValidationError is the validation error returned by
+// IndexedFrameEntry.Validate if the designated constraints aren't met.
+type IndexedFrameEntryValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e IndexedFrameEntryValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e IndexedFrameEntryValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e IndexedFrameEntryValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e IndexedFrameEntryValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e IndexedFrameEntryValidationError) ErrorName() string {
+	return "IndexedFrameEntryValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e IndexedFrameEntryValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sIndexedFrameEntry.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = IndexedFrameEntryValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = IndexedFrameEntryValidationError{}
+
 // Validate checks the field values on RecordTypeInfo with the rules defined in
 // the proto definition for this message. If any rules are violated, the first
 // error encountered is returned, or nil if there are no violations.

--- a/pb/c1/c1z/v3/manifest_protoopaque.pb.go
+++ b/pb/c1/c1z/v3/manifest_protoopaque.pb.go
@@ -49,17 +49,19 @@ const (
 	// layer and want to avoid double-compression CPU at envelope
 	// time, or for object-storage targets that compress in-transit.
 	PayloadEncoding_PAYLOAD_ENCODING_TAR PayloadEncoding = 2
-	// Per-file zstd frames, each preceded by a self-describing binary
-	// header (name, raw size, compressed size, xxh64 of raw bytes),
-	// terminated by a zero-length-name sentinel. No tar layer.
+	// Per-file zstd frames written back-to-back, indexed by a trailing
+	// IndexedFrameIndex and fixed-size footer (see that message for
+	// the layout). No tar layer, no per-frame inline headers.
 	//
 	// Enables (a) parallel frame decode at open — the single-stream
-	// encodings decode sequentially on one core — and (b) frame
-	// splicing at save: a writer that knows a payload file is
-	// byte-identical to one in the source envelope copies its
-	// compressed frame verbatim instead of re-encoding (Pebble SSTs
-	// are immutable and checkpoints hard-link them, so incremental
-	// folds reuse almost every frame).
+	// encodings decode sequentially on one core; (b) frame splicing at
+	// save: a writer that knows a payload file is byte-identical to one
+	// in the source envelope copies its compressed frame verbatim
+	// instead of re-encoding (Pebble SSTs are immutable and checkpoints
+	// hard-link them, so incremental folds reuse almost every frame);
+	// and (c) chunked object storage: the index carries every frame's
+	// byte range and SHA-256 content identity, so a store can upload
+	// only the frames a parent sync doesn't already hold.
 	PayloadEncoding_PAYLOAD_ENCODING_INDEXED_ZSTD PayloadEncoding = 5
 )
 
@@ -291,6 +293,288 @@ func (b0 C1ZManifestV3_builder) Build() *C1ZManifestV3 {
 	return m0
 }
 
+// IndexedFrameIndex is the sole frame table for
+// PAYLOAD_ENCODING_INDEXED_ZSTD payloads. It is serialized (binary
+// proto) immediately after the last frame, followed by a fixed-size
+// footer carrying the index's absolute file offset, length, xxh64,
+// and a trailing magic:
+//
+//	payload := frame* | index | footer
+//	footer  := u64 indexOffset | u32 indexLen | u64 xxh64(index) | "C1ZIDX1\0"
+//
+// Frames carry no framing of their own — each is the bare zstd
+// stream of one payload file, with Frame_Content_Size advertised —
+// so the writer is single-pass (streamable to a non-seekable sink)
+// and a frame's byte range is directly usable as a standalone
+// object. The whole table is fetchable in O(1) reads — footer, then
+// index — which is what makes ranged reads over object storage
+// practical: fetch exactly the frames you want, no per-frame round
+// trips. A payload without a valid footer is corruption-class, the
+// same policy as a torn tar payload.
+//
+// Being a proto message, the index is the extension point for future
+// per-frame metadata (compression algorithm, dictionary IDs,
+// encryption) without a layout revision.
+type IndexedFrameIndex struct {
+	state                          protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Entries             *[]*IndexedFrameEntry  `protobuf:"bytes,1,rep,name=entries,proto3"`
+	xxx_hidden_TotalRawSize        int64                  `protobuf:"varint,2,opt,name=total_raw_size,json=totalRawSize,proto3"`
+	xxx_hidden_TotalCompressedSize int64                  `protobuf:"varint,3,opt,name=total_compressed_size,json=totalCompressedSize,proto3"`
+	xxx_hidden_ManifestXxh64       uint64                 `protobuf:"fixed64,4,opt,name=manifest_xxh64,json=manifestXxh64,proto3"`
+	unknownFields                  protoimpl.UnknownFields
+	sizeCache                      protoimpl.SizeCache
+}
+
+func (x *IndexedFrameIndex) Reset() {
+	*x = IndexedFrameIndex{}
+	mi := &file_c1_c1z_v3_manifest_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *IndexedFrameIndex) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*IndexedFrameIndex) ProtoMessage() {}
+
+func (x *IndexedFrameIndex) ProtoReflect() protoreflect.Message {
+	mi := &file_c1_c1z_v3_manifest_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *IndexedFrameIndex) GetEntries() []*IndexedFrameEntry {
+	if x != nil {
+		if x.xxx_hidden_Entries != nil {
+			return *x.xxx_hidden_Entries
+		}
+	}
+	return nil
+}
+
+func (x *IndexedFrameIndex) GetTotalRawSize() int64 {
+	if x != nil {
+		return x.xxx_hidden_TotalRawSize
+	}
+	return 0
+}
+
+func (x *IndexedFrameIndex) GetTotalCompressedSize() int64 {
+	if x != nil {
+		return x.xxx_hidden_TotalCompressedSize
+	}
+	return 0
+}
+
+func (x *IndexedFrameIndex) GetManifestXxh64() uint64 {
+	if x != nil {
+		return x.xxx_hidden_ManifestXxh64
+	}
+	return 0
+}
+
+func (x *IndexedFrameIndex) SetEntries(v []*IndexedFrameEntry) {
+	x.xxx_hidden_Entries = &v
+}
+
+func (x *IndexedFrameIndex) SetTotalRawSize(v int64) {
+	x.xxx_hidden_TotalRawSize = v
+}
+
+func (x *IndexedFrameIndex) SetTotalCompressedSize(v int64) {
+	x.xxx_hidden_TotalCompressedSize = v
+}
+
+func (x *IndexedFrameIndex) SetManifestXxh64(v uint64) {
+	x.xxx_hidden_ManifestXxh64 = v
+}
+
+type IndexedFrameIndex_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	Entries []*IndexedFrameEntry
+	// Sum of raw_size over entries. Lets a reader budget extraction
+	// without summing.
+	TotalRawSize int64
+	// Sum of compressed_size over entries.
+	TotalCompressedSize int64
+	// xxh64 of the marshaled manifest bytes (the region between the
+	// length prefix and the first frame). The manifest is otherwise
+	// the only unprotected byte region — frames carry zstd CRCs and
+	// raw-byte hashes, the index is covered by the footer's xxh64 —
+	// and the header-only manifest decode skips the descriptor
+	// closure, so a flipped bit there would otherwise go unnoticed.
+	// Also lets a chunked store verify reassembly of the envelope
+	// head. Zero means "not recorded".
+	ManifestXxh64 uint64
+}
+
+func (b0 IndexedFrameIndex_builder) Build() *IndexedFrameIndex {
+	m0 := &IndexedFrameIndex{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Entries = &b.Entries
+	x.xxx_hidden_TotalRawSize = b.TotalRawSize
+	x.xxx_hidden_TotalCompressedSize = b.TotalCompressedSize
+	x.xxx_hidden_ManifestXxh64 = b.ManifestXxh64
+	return m0
+}
+
+type IndexedFrameEntry struct {
+	state                     protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Name           string                 `protobuf:"bytes,1,opt,name=name,proto3"`
+	xxx_hidden_FrameOffset    int64                  `protobuf:"varint,2,opt,name=frame_offset,json=frameOffset,proto3"`
+	xxx_hidden_CompressedSize int64                  `protobuf:"varint,3,opt,name=compressed_size,json=compressedSize,proto3"`
+	xxx_hidden_RawSize        int64                  `protobuf:"varint,4,opt,name=raw_size,json=rawSize,proto3"`
+	xxx_hidden_RawXxh64       uint64                 `protobuf:"fixed64,5,opt,name=raw_xxh64,json=rawXxh64,proto3"`
+	xxx_hidden_RawSha256      []byte                 `protobuf:"bytes,6,opt,name=raw_sha256,json=rawSha256,proto3"`
+	unknownFields             protoimpl.UnknownFields
+	sizeCache                 protoimpl.SizeCache
+}
+
+func (x *IndexedFrameEntry) Reset() {
+	*x = IndexedFrameEntry{}
+	mi := &file_c1_c1z_v3_manifest_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *IndexedFrameEntry) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*IndexedFrameEntry) ProtoMessage() {}
+
+func (x *IndexedFrameEntry) ProtoReflect() protoreflect.Message {
+	mi := &file_c1_c1z_v3_manifest_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *IndexedFrameEntry) GetName() string {
+	if x != nil {
+		return x.xxx_hidden_Name
+	}
+	return ""
+}
+
+func (x *IndexedFrameEntry) GetFrameOffset() int64 {
+	if x != nil {
+		return x.xxx_hidden_FrameOffset
+	}
+	return 0
+}
+
+func (x *IndexedFrameEntry) GetCompressedSize() int64 {
+	if x != nil {
+		return x.xxx_hidden_CompressedSize
+	}
+	return 0
+}
+
+func (x *IndexedFrameEntry) GetRawSize() int64 {
+	if x != nil {
+		return x.xxx_hidden_RawSize
+	}
+	return 0
+}
+
+func (x *IndexedFrameEntry) GetRawXxh64() uint64 {
+	if x != nil {
+		return x.xxx_hidden_RawXxh64
+	}
+	return 0
+}
+
+func (x *IndexedFrameEntry) GetRawSha256() []byte {
+	if x != nil {
+		return x.xxx_hidden_RawSha256
+	}
+	return nil
+}
+
+func (x *IndexedFrameEntry) SetName(v string) {
+	x.xxx_hidden_Name = v
+}
+
+func (x *IndexedFrameEntry) SetFrameOffset(v int64) {
+	x.xxx_hidden_FrameOffset = v
+}
+
+func (x *IndexedFrameEntry) SetCompressedSize(v int64) {
+	x.xxx_hidden_CompressedSize = v
+}
+
+func (x *IndexedFrameEntry) SetRawSize(v int64) {
+	x.xxx_hidden_RawSize = v
+}
+
+func (x *IndexedFrameEntry) SetRawXxh64(v uint64) {
+	x.xxx_hidden_RawXxh64 = v
+}
+
+func (x *IndexedFrameEntry) SetRawSha256(v []byte) {
+	if v == nil {
+		v = []byte{}
+	}
+	x.xxx_hidden_RawSha256 = v
+}
+
+type IndexedFrameEntry_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// Slash-separated relative path of the payload file, identical to
+	// the name in the frame's inline header.
+	Name string
+	// Absolute offset of the frame's compressed zstd bytes from the
+	// start of the envelope file (NOT from the payload start), so a
+	// ranged read needs no other context.
+	FrameOffset    int64
+	CompressedSize int64
+	RawSize        int64
+	// xxh64 of the raw (decompressed) bytes. Matches the inline
+	// header; used for corruption detection and splice matching.
+	RawXxh64 uint64
+	// SHA-256 of the raw bytes. Content-address identity for chunked
+	// object storage: compressed bytes are not stable across encoder
+	// versions, and xxh64 is too weak to key a fleet-wide chunk store.
+	//
+	// REQUIRED: readers reject entries whose value is not exactly 32
+	// bytes. Writers must always compute it, even when content
+	// addressing is not in play — a partially-identified index can't
+	// serve chunk dedupe later, and allowing absence would let
+	// truncated identities propagate through frame splicing. A future
+	// writer that genuinely cannot afford SHA-256 should introduce a
+	// new payload encoding (or footer version) rather than omit this.
+	RawSha256 []byte
+}
+
+func (b0 IndexedFrameEntry_builder) Build() *IndexedFrameEntry {
+	m0 := &IndexedFrameEntry{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Name = b.Name
+	x.xxx_hidden_FrameOffset = b.FrameOffset
+	x.xxx_hidden_CompressedSize = b.CompressedSize
+	x.xxx_hidden_RawSize = b.RawSize
+	x.xxx_hidden_RawXxh64 = b.RawXxh64
+	x.xxx_hidden_RawSha256 = b.RawSha256
+	return m0
+}
+
 type RecordTypeInfo struct {
 	state                      protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_MessageFullName string                 `protobuf:"bytes,1,opt,name=message_full_name,json=messageFullName,proto3"`
@@ -302,7 +586,7 @@ type RecordTypeInfo struct {
 
 func (x *RecordTypeInfo) Reset() {
 	*x = RecordTypeInfo{}
-	mi := &file_c1_c1z_v3_manifest_proto_msgTypes[1]
+	mi := &file_c1_c1z_v3_manifest_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -314,7 +598,7 @@ func (x *RecordTypeInfo) String() string {
 func (*RecordTypeInfo) ProtoMessage() {}
 
 func (x *RecordTypeInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_c1z_v3_manifest_proto_msgTypes[1]
+	mi := &file_c1_c1z_v3_manifest_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -395,7 +679,7 @@ type SyncRunSummary struct {
 
 func (x *SyncRunSummary) Reset() {
 	*x = SyncRunSummary{}
-	mi := &file_c1_c1z_v3_manifest_proto_msgTypes[2]
+	mi := &file_c1_c1z_v3_manifest_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -407,7 +691,7 @@ func (x *SyncRunSummary) String() string {
 func (*SyncRunSummary) ProtoMessage() {}
 
 func (x *SyncRunSummary) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_c1z_v3_manifest_proto_msgTypes[2]
+	mi := &file_c1_c1z_v3_manifest_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -558,7 +842,7 @@ type PebbleEngineConfig struct {
 
 func (x *PebbleEngineConfig) Reset() {
 	*x = PebbleEngineConfig{}
-	mi := &file_c1_c1z_v3_manifest_proto_msgTypes[3]
+	mi := &file_c1_c1z_v3_manifest_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -570,7 +854,7 @@ func (x *PebbleEngineConfig) String() string {
 func (*PebbleEngineConfig) ProtoMessage() {}
 
 func (x *PebbleEngineConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_c1_c1z_v3_manifest_proto_msgTypes[3]
+	mi := &file_c1_c1z_v3_manifest_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -635,7 +919,20 @@ const file_c1_c1z_v3_manifest_proto_rawDesc = "" +
 	"\vdescriptors\x18\n" +
 	" \x01(\v2\".google.protobuf.FileDescriptorSetR\vdescriptors\x12<\n" +
 	"\frecord_types\x18\v \x03(\v2\x19.c1.c1z.v3.RecordTypeInfoR\vrecordTypes\x126\n" +
-	"\tsync_runs\x18( \x03(\v2\x19.c1.c1z.v3.SyncRunSummaryR\bsyncRuns\"\x8c\x01\n" +
+	"\tsync_runs\x18( \x03(\v2\x19.c1.c1z.v3.SyncRunSummaryR\bsyncRuns\"\xcc\x01\n" +
+	"\x11IndexedFrameIndex\x126\n" +
+	"\aentries\x18\x01 \x03(\v2\x1c.c1.c1z.v3.IndexedFrameEntryR\aentries\x12$\n" +
+	"\x0etotal_raw_size\x18\x02 \x01(\x03R\ftotalRawSize\x122\n" +
+	"\x15total_compressed_size\x18\x03 \x01(\x03R\x13totalCompressedSize\x12%\n" +
+	"\x0emanifest_xxh64\x18\x04 \x01(\x06R\rmanifestXxh64\"\xca\x01\n" +
+	"\x11IndexedFrameEntry\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12!\n" +
+	"\fframe_offset\x18\x02 \x01(\x03R\vframeOffset\x12'\n" +
+	"\x0fcompressed_size\x18\x03 \x01(\x03R\x0ecompressedSize\x12\x19\n" +
+	"\braw_size\x18\x04 \x01(\x03R\arawSize\x12\x1b\n" +
+	"\traw_xxh64\x18\x05 \x01(\x06R\brawXxh64\x12\x1d\n" +
+	"\n" +
+	"raw_sha256\x18\x06 \x01(\fR\trawSha256\"\x8c\x01\n" +
 	"\x0eRecordTypeInfo\x12*\n" +
 	"\x11message_full_name\x18\x01 \x01(\tR\x0fmessageFullName\x12%\n" +
 	"\x0eschema_version\x18\x02 \x01(\rR\rschemaVersion\x12'\n" +
@@ -658,34 +955,37 @@ const file_c1_c1z_v3_manifest_proto_rawDesc = "" +
 	"\x1dPAYLOAD_ENCODING_INDEXED_ZSTD\x10\x05\"\x04\b\x03\x10\x03\"\x04\b\x04\x10\x04B0Z.github.com/conductorone/baton-sdk/pb/c1/c1z/v3b\x06proto3"
 
 var file_c1_c1z_v3_manifest_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_c1_c1z_v3_manifest_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_c1_c1z_v3_manifest_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
 var file_c1_c1z_v3_manifest_proto_goTypes = []any{
 	(PayloadEncoding)(0),                   // 0: c1.c1z.v3.PayloadEncoding
 	(*C1ZManifestV3)(nil),                  // 1: c1.c1z.v3.C1ZManifestV3
-	(*RecordTypeInfo)(nil),                 // 2: c1.c1z.v3.RecordTypeInfo
-	(*SyncRunSummary)(nil),                 // 3: c1.c1z.v3.SyncRunSummary
-	(*PebbleEngineConfig)(nil),             // 4: c1.c1z.v3.PebbleEngineConfig
-	(*anypb.Any)(nil),                      // 5: google.protobuf.Any
-	(*descriptorpb.FileDescriptorSet)(nil), // 6: google.protobuf.FileDescriptorSet
-	(v3.SyncType)(0),                       // 7: c1.storage.v3.SyncType
-	(*timestamppb.Timestamp)(nil),          // 8: google.protobuf.Timestamp
-	(*v3.SyncStatsRecord)(nil),             // 9: c1.storage.v3.SyncStatsRecord
+	(*IndexedFrameIndex)(nil),              // 2: c1.c1z.v3.IndexedFrameIndex
+	(*IndexedFrameEntry)(nil),              // 3: c1.c1z.v3.IndexedFrameEntry
+	(*RecordTypeInfo)(nil),                 // 4: c1.c1z.v3.RecordTypeInfo
+	(*SyncRunSummary)(nil),                 // 5: c1.c1z.v3.SyncRunSummary
+	(*PebbleEngineConfig)(nil),             // 6: c1.c1z.v3.PebbleEngineConfig
+	(*anypb.Any)(nil),                      // 7: google.protobuf.Any
+	(*descriptorpb.FileDescriptorSet)(nil), // 8: google.protobuf.FileDescriptorSet
+	(v3.SyncType)(0),                       // 9: c1.storage.v3.SyncType
+	(*timestamppb.Timestamp)(nil),          // 10: google.protobuf.Timestamp
+	(*v3.SyncStatsRecord)(nil),             // 11: c1.storage.v3.SyncStatsRecord
 }
 var file_c1_c1z_v3_manifest_proto_depIdxs = []int32{
-	5, // 0: c1.c1z.v3.C1ZManifestV3.engine_config:type_name -> google.protobuf.Any
-	0, // 1: c1.c1z.v3.C1ZManifestV3.payload_encoding:type_name -> c1.c1z.v3.PayloadEncoding
-	6, // 2: c1.c1z.v3.C1ZManifestV3.descriptors:type_name -> google.protobuf.FileDescriptorSet
-	2, // 3: c1.c1z.v3.C1ZManifestV3.record_types:type_name -> c1.c1z.v3.RecordTypeInfo
-	3, // 4: c1.c1z.v3.C1ZManifestV3.sync_runs:type_name -> c1.c1z.v3.SyncRunSummary
-	7, // 5: c1.c1z.v3.SyncRunSummary.type:type_name -> c1.storage.v3.SyncType
-	8, // 6: c1.c1z.v3.SyncRunSummary.started_at:type_name -> google.protobuf.Timestamp
-	8, // 7: c1.c1z.v3.SyncRunSummary.ended_at:type_name -> google.protobuf.Timestamp
-	9, // 8: c1.c1z.v3.SyncRunSummary.stats:type_name -> c1.storage.v3.SyncStatsRecord
-	9, // [9:9] is the sub-list for method output_type
-	9, // [9:9] is the sub-list for method input_type
-	9, // [9:9] is the sub-list for extension type_name
-	9, // [9:9] is the sub-list for extension extendee
-	0, // [0:9] is the sub-list for field type_name
+	7,  // 0: c1.c1z.v3.C1ZManifestV3.engine_config:type_name -> google.protobuf.Any
+	0,  // 1: c1.c1z.v3.C1ZManifestV3.payload_encoding:type_name -> c1.c1z.v3.PayloadEncoding
+	8,  // 2: c1.c1z.v3.C1ZManifestV3.descriptors:type_name -> google.protobuf.FileDescriptorSet
+	4,  // 3: c1.c1z.v3.C1ZManifestV3.record_types:type_name -> c1.c1z.v3.RecordTypeInfo
+	5,  // 4: c1.c1z.v3.C1ZManifestV3.sync_runs:type_name -> c1.c1z.v3.SyncRunSummary
+	3,  // 5: c1.c1z.v3.IndexedFrameIndex.entries:type_name -> c1.c1z.v3.IndexedFrameEntry
+	9,  // 6: c1.c1z.v3.SyncRunSummary.type:type_name -> c1.storage.v3.SyncType
+	10, // 7: c1.c1z.v3.SyncRunSummary.started_at:type_name -> google.protobuf.Timestamp
+	10, // 8: c1.c1z.v3.SyncRunSummary.ended_at:type_name -> google.protobuf.Timestamp
+	11, // 9: c1.c1z.v3.SyncRunSummary.stats:type_name -> c1.storage.v3.SyncStatsRecord
+	10, // [10:10] is the sub-list for method output_type
+	10, // [10:10] is the sub-list for method input_type
+	10, // [10:10] is the sub-list for extension type_name
+	10, // [10:10] is the sub-list for extension extendee
+	0,  // [0:10] is the sub-list for field type_name
 }
 
 func init() { file_c1_c1z_v3_manifest_proto_init() }
@@ -699,7 +999,7 @@ func file_c1_c1z_v3_manifest_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_c1_c1z_v3_manifest_proto_rawDesc), len(file_c1_c1z_v3_manifest_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   4,
+			NumMessages:   6,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pb/c1/c1z/v3/manifest_protoopaque.pb.go
+++ b/pb/c1/c1z/v3/manifest_protoopaque.pb.go
@@ -42,13 +42,25 @@ type PayloadEncoding int32
 const (
 	PayloadEncoding_PAYLOAD_ENCODING_UNSPECIFIED PayloadEncoding = 0
 	// Tar of a Pebble directory, compressed with zstd. The
-	// production default.
+	// production default in older v3 writers.
 	PayloadEncoding_PAYLOAD_ENCODING_TAR_ZSTD PayloadEncoding = 1
 	// Tar of a Pebble directory, uncompressed. For tenants whose
 	// Pebble L5/L6 SSTs are already zstd-compressed at the engine
 	// layer and want to avoid double-compression CPU at envelope
 	// time, or for object-storage targets that compress in-transit.
 	PayloadEncoding_PAYLOAD_ENCODING_TAR PayloadEncoding = 2
+	// Per-file zstd frames, each preceded by a self-describing binary
+	// header (name, raw size, compressed size, xxh64 of raw bytes),
+	// terminated by a zero-length-name sentinel. No tar layer.
+	//
+	// Enables (a) parallel frame decode at open — the single-stream
+	// encodings decode sequentially on one core — and (b) frame
+	// splicing at save: a writer that knows a payload file is
+	// byte-identical to one in the source envelope copies its
+	// compressed frame verbatim instead of re-encoding (Pebble SSTs
+	// are immutable and checkpoints hard-link them, so incremental
+	// folds reuse almost every frame).
+	PayloadEncoding_PAYLOAD_ENCODING_INDEXED_ZSTD PayloadEncoding = 5
 )
 
 // Enum value maps for PayloadEncoding.
@@ -57,11 +69,13 @@ var (
 		0: "PAYLOAD_ENCODING_UNSPECIFIED",
 		1: "PAYLOAD_ENCODING_TAR_ZSTD",
 		2: "PAYLOAD_ENCODING_TAR",
+		5: "PAYLOAD_ENCODING_INDEXED_ZSTD",
 	}
 	PayloadEncoding_value = map[string]int32{
-		"PAYLOAD_ENCODING_UNSPECIFIED": 0,
-		"PAYLOAD_ENCODING_TAR_ZSTD":    1,
-		"PAYLOAD_ENCODING_TAR":         2,
+		"PAYLOAD_ENCODING_UNSPECIFIED":  0,
+		"PAYLOAD_ENCODING_TAR_ZSTD":     1,
+		"PAYLOAD_ENCODING_TAR":          2,
+		"PAYLOAD_ENCODING_INDEXED_ZSTD": 5,
 	}
 )
 
@@ -636,11 +650,12 @@ const file_c1_c1z_v3_manifest_proto_rawDesc = "" +
 	"\x05stats\x18\x06 \x01(\v2\x1e.c1.storage.v3.SyncStatsRecordR\x05stats\"p\n" +
 	"\x12PebbleEngineConfig\x120\n" +
 	"\x14format_major_version\x18\x01 \x01(\rR\x12formatMajorVersion\x12(\n" +
-	"\x10cache_size_bytes\x18\x02 \x01(\x04R\x0ecacheSizeBytes*l\n" +
+	"\x10cache_size_bytes\x18\x02 \x01(\x04R\x0ecacheSizeBytes*\x9b\x01\n" +
 	"\x0fPayloadEncoding\x12 \n" +
 	"\x1cPAYLOAD_ENCODING_UNSPECIFIED\x10\x00\x12\x1d\n" +
 	"\x19PAYLOAD_ENCODING_TAR_ZSTD\x10\x01\x12\x18\n" +
-	"\x14PAYLOAD_ENCODING_TAR\x10\x02B0Z.github.com/conductorone/baton-sdk/pb/c1/c1z/v3b\x06proto3"
+	"\x14PAYLOAD_ENCODING_TAR\x10\x02\x12!\n" +
+	"\x1dPAYLOAD_ENCODING_INDEXED_ZSTD\x10\x05\"\x04\b\x03\x10\x03\"\x04\b\x04\x10\x04B0Z.github.com/conductorone/baton-sdk/pb/c1/c1z/v3b\x06proto3"
 
 var file_c1_c1z_v3_manifest_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
 var file_c1_c1z_v3_manifest_proto_msgTypes = make([]protoimpl.MessageInfo, 4)

--- a/pkg/dotc1z/c1zstore/engine.go
+++ b/pkg/dotc1z/c1zstore/engine.go
@@ -1,6 +1,10 @@
 package c1zstore
 
-import "fmt"
+import (
+	"fmt"
+
+	c1zv3 "github.com/conductorone/baton-sdk/pb/c1/c1z/v3"
+)
 
 // Engine identifies a storage engine implementation. The engine is
 // chosen by callers via dotc1z.WithEngine(...) on write; on read, the
@@ -20,28 +24,29 @@ const (
 )
 
 // PayloadEncoding selects the v3 envelope payload framing. Only the
-// Pebble engine consults this; SQLite engines ignore it. The wire
-// numbers match the matching proto enum values in
-// c1.c1z.v3.PayloadEncoding.
+// Pebble engine consults this; SQLite engines ignore it. Every value
+// is DERIVED from the matching c1.c1z.v3.PayloadEncoding proto enum
+// value, so the Go constants cannot drift from the wire format.
 type PayloadEncoding int
 
 const (
 	// PayloadEncodingUnspecified is the zero value. Means "use the
-	// engine's default" — TarZstd for Pebble.
-	PayloadEncodingUnspecified PayloadEncoding = 0
+	// engine's default" — IndexedZstd for Pebble.
+	PayloadEncodingUnspecified = PayloadEncoding(c1zv3.PayloadEncoding_PAYLOAD_ENCODING_UNSPECIFIED)
 
-	// 1 and 2 are reserved in the proto (formerly RAW + single-stream
-	// ZSTD). Don't reuse.
-
-	// PayloadEncodingTarZstd is the default Pebble v3 envelope
+	// PayloadEncodingTarZstd is the classic Pebble v3 envelope
 	// encoding: tar of the Pebble directory, compressed with zstd.
-	PayloadEncodingTarZstd PayloadEncoding = 3
+	PayloadEncodingTarZstd = PayloadEncoding(c1zv3.PayloadEncoding_PAYLOAD_ENCODING_TAR_ZSTD)
 
 	// PayloadEncodingTar is uncompressed tar. Useful when Pebble's
 	// L5/L6 SSTs are already zstd-compressed at the engine layer
 	// (avoids double-compression CPU), or when the storage target
 	// compresses in transit.
-	PayloadEncodingTar PayloadEncoding = 4
+	PayloadEncodingTar = PayloadEncoding(c1zv3.PayloadEncoding_PAYLOAD_ENCODING_TAR)
+
+	// PayloadEncodingIndexedZstd stores each payload file as an
+	// independent zstd frame with a self-describing header.
+	PayloadEncodingIndexedZstd = PayloadEncoding(c1zv3.PayloadEncoding_PAYLOAD_ENCODING_INDEXED_ZSTD)
 )
 
 // String returns a stable human-readable name for the encoding.
@@ -51,6 +56,8 @@ func (e PayloadEncoding) String() string {
 		return "tar_zstd"
 	case PayloadEncodingTar:
 		return "tar"
+	case PayloadEncodingIndexedZstd:
+		return "indexed_zstd"
 	case PayloadEncodingUnspecified:
 		return "unspecified"
 	default:

--- a/pkg/dotc1z/c1zstore/engine.go
+++ b/pkg/dotc1z/c1zstore/engine.go
@@ -45,7 +45,9 @@ const (
 	PayloadEncodingTar = PayloadEncoding(c1zv3.PayloadEncoding_PAYLOAD_ENCODING_TAR)
 
 	// PayloadEncodingIndexedZstd stores each payload file as an
-	// independent zstd frame with a self-describing header.
+	// independent zstd frame, indexed by a trailing frame table
+	// (byte ranges, sizes, SHA-256 identities) for parallel decode,
+	// frame splicing, and ranged/chunked object storage.
 	PayloadEncodingIndexedZstd = PayloadEncoding(c1zv3.PayloadEncoding_PAYLOAD_ENCODING_INDEXED_ZSTD)
 )
 

--- a/pkg/dotc1z/decoder.go
+++ b/pkg/dotc1z/decoder.go
@@ -365,18 +365,41 @@ func NewDecoder(f io.Reader, opts ...DecoderOption) (*decoder, error) {
 		}
 	}
 
-	o := &decoderOptions{
-		decoderConcurrency: 1,
-	}
-	for _, opt := range opts {
-		err := opt(o)
-		if err != nil {
-			return nil, err
-		}
+	o, err := applyDecoderOptions(opts...)
+	if err != nil {
+		return nil, err
 	}
 
 	return &decoder{
 		o: o,
 		f: f,
 	}, nil
+}
+
+func applyDecoderOptions(opts ...DecoderOption) (*decoderOptions, error) {
+	o := &decoderOptions{
+		decoderConcurrency: 1,
+	}
+	for _, opt := range opts {
+		if err := opt(o); err != nil {
+			return nil, err
+		}
+	}
+	return o, nil
+}
+
+func explicitMaxDecodedSizeForDecoderOptions(opts ...DecoderOption) (uint64, error) {
+	o, err := applyDecoderOptions(opts...)
+	if err != nil {
+		return 0, err
+	}
+	return o.maxDecodedSize, nil
+}
+
+func explicitMaxMemorySizeForDecoderOptions(opts ...DecoderOption) (uint64, error) {
+	o, err := applyDecoderOptions(opts...)
+	if err != nil {
+		return 0, err
+	}
+	return o.maxMemorySize, nil
 }

--- a/pkg/dotc1z/engine/pebble/indexed_payload_test.go
+++ b/pkg/dotc1z/engine/pebble/indexed_payload_test.go
@@ -1,0 +1,103 @@
+package pebble_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble"
+	formatv3 "github.com/conductorone/baton-sdk/pkg/dotc1z/format/v3"
+)
+
+// TestIndexedPayloadStoreLifecycle covers the indexed encoding through
+// the full store path: write a sync with
+// WithPayloadEncoding(IndexedZstd), reopen the file WITHOUT specifying
+// an encoding (the store must adopt indexed from the file), run a
+// second sync, save again, and read everything back. The second save
+// goes through the splice path since the first sync's SSTs are
+// unchanged hard-links in the checkpoint.
+func TestIndexedPayloadStoreLifecycle(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "indexed.c1z")
+
+	runSync := func(rtID string, opts ...dotc1z.C1ZOption) string {
+		t.Helper()
+		opts = append(opts, dotc1z.WithTmpDir(t.TempDir()))
+		w, err := dotc1z.NewStore(ctx, path, opts...)
+		if err != nil {
+			t.Fatal(err)
+		}
+		syncID, err := w.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := w.PutResourceTypes(ctx, v2.ResourceType_builder{Id: rtID}.Build()); err != nil {
+			t.Fatal(err)
+		}
+		res := v2.Resource_builder{
+			Id: v2.ResourceId_builder{ResourceType: rtID, Resource: rtID + "-1"}.Build(),
+		}.Build()
+		if err := w.PutResources(ctx, res); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.EndSync(ctx); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.Close(ctx); err != nil {
+			t.Fatal(err)
+		}
+		return syncID
+	}
+
+	first := runSync("user", dotc1z.WithEngine(dotc1z.EnginePebble), dotc1z.WithPayloadEncoding(dotc1z.PayloadEncodingIndexedZstd))
+
+	// The file on disk must carry the indexed encoding.
+	requireFileEncoding := func() {
+		t.Helper()
+		f, err := os.Open(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer f.Close()
+		m, err := formatv3.ReadManifestHeader(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := m.GetPayloadEncoding().String(); got != "PAYLOAD_ENCODING_INDEXED_ZSTD" {
+			t.Fatalf("file payload encoding = %s, want PAYLOAD_ENCODING_INDEXED_ZSTD", got)
+		}
+	}
+	requireFileEncoding()
+
+	// Reopen with NO explicit encoding: the store must adopt the
+	// file's indexed encoding so the rewrite stays indexed (and the
+	// splice path stays viable for future rewrites).
+	second := runSync("group")
+	requireFileEncoding()
+
+	// Both syncs readable after the spliced rewrite.
+	w, err := dotc1z.NewStore(ctx, path, dotc1z.WithReadOnly(true), dotc1z.WithTmpDir(t.TempDir()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close(ctx)
+	eng, ok := pebble.AsEngine(w)
+	if !ok {
+		t.Fatalf("not pebble: %T", w)
+	}
+	for _, syncID := range []string{first, second} {
+		if _, err := eng.GetSyncRunRecord(ctx, syncID); err != nil {
+			t.Fatalf("sync %s missing after indexed round trips: %v", syncID, err)
+		}
+	}
+	if _, err := eng.GetResourceRecord(ctx, first, "user", "user-1"); err != nil {
+		t.Fatalf("first sync's resource missing after spliced rewrite: %v", err)
+	}
+	if _, err := eng.GetResourceRecord(ctx, second, "group", "group-1"); err != nil {
+		t.Fatalf("second sync's resource missing: %v", err)
+	}
+}

--- a/pkg/dotc1z/engine/pebble/manifest.go
+++ b/pkg/dotc1z/engine/pebble/manifest.go
@@ -84,18 +84,17 @@ func syncRunSummaries(ctx context.Context, e *Engine) ([]*c1zv3.SyncRunSummary, 
 
 // payloadEncodingToProto maps the public c1zstore.PayloadEncoding to
 // the c1zv3 enum. PayloadEncodingUnspecified means "engine default"
-// for our purposes: TAR_ZSTD.
+// for our purposes: INDEXED_ZSTD.
 func payloadEncodingToProto(enc c1zstore.PayloadEncoding) c1zv3.PayloadEncoding {
 	switch enc {
 	case c1zstore.PayloadEncodingTar:
 		return c1zv3.PayloadEncoding_PAYLOAD_ENCODING_TAR
-	case c1zstore.PayloadEncodingTarZstd, c1zstore.PayloadEncodingUnspecified:
+	case c1zstore.PayloadEncodingTarZstd:
 		return c1zv3.PayloadEncoding_PAYLOAD_ENCODING_TAR_ZSTD
+	case c1zstore.PayloadEncodingIndexedZstd, c1zstore.PayloadEncodingUnspecified:
+		return c1zv3.PayloadEncoding_PAYLOAD_ENCODING_INDEXED_ZSTD
 	default:
 		// Any non-enumerated value falls back to the default.
-		// WriteEnvelope will reject any non-TAR/non-TAR_ZSTD value
-		// before writing bytes, so a caller setting a bogus
-		// encoding gets an error at save time.
-		return c1zv3.PayloadEncoding_PAYLOAD_ENCODING_TAR_ZSTD
+		return c1zv3.PayloadEncoding_PAYLOAD_ENCODING_INDEXED_ZSTD
 	}
 }

--- a/pkg/dotc1z/engine/pebble/merge_accessor.go
+++ b/pkg/dotc1z/engine/pebble/merge_accessor.go
@@ -95,7 +95,26 @@ type fixtureNormalizer interface {
 	NormalizeForFixtureSave(ctx context.Context, syncID string) error
 }
 
-// CloseEngineOnly closes the Pebble engine inside a store wrapper without
+type storeDirtyMarker interface {
+	MarkDirty()
+}
+
+// MarkStoreDirty flips a registered store's dirty bit so Close drives
+// the save → checkpoint → envelope path. Engine-level writes (raw
+// batches, SST ingest, direct Put*Records) bypass the registered
+// store's markDirty wrappers; merge tooling that mutates the engine
+// directly calls this once so the mutations are persisted at Close.
+// Returns false when w is not a registered Pebble store.
+func MarkStoreDirty(w connectorstore.Writer) bool {
+	s, ok := w.(storeDirtyMarker)
+	if !ok || s == nil {
+		return false
+	}
+	s.MarkDirty()
+	return true
+}
+
+// CloseEngineOnly closes the Pebble engine inside a registered store without
 // removing that store's unpacked temp directory. This is useful when a caller
 // owns a parent temp directory and wants one bulk cleanup after closing many
 // read-only source stores.

--- a/pkg/dotc1z/engine_registry.go
+++ b/pkg/dotc1z/engine_registry.go
@@ -35,13 +35,23 @@ type StoreOptions struct {
 
 	// PayloadEncoding selects the v3 envelope payload framing for
 	// engines that produce a v3 envelope (currently Pebble). Zero
-	// value means "engine default" (PayloadEncodingTarZstd for Pebble).
+	// value means "engine default" (PayloadEncodingIndexedZstd for
+	// Pebble).
 	PayloadEncoding PayloadEncoding
 
 	// DecoderPool optionally scopes v3 payload-decoder reuse to the
 	// caller's operation (see WithDecoderPool). Nil means a one-shot
 	// decoder per open.
 	DecoderPool *EnvelopeDecoderPool
+
+	// MaxDecodedPayloadBytes optionally caps v3 envelope payload extraction.
+	// Zero means use BATON_DECODER_MAX_DECODED_SIZE_MB or the v3 default.
+	MaxDecodedPayloadBytes uint64
+
+	// MaxDecoderMemoryBytes optionally caps zstd decoder memory for v3 envelope
+	// payload extraction. Zero means use BATON_DECODER_MAX_MEMORY_MB or the v3
+	// default.
+	MaxDecoderMemoryBytes uint64
 }
 
 // EnvelopeDecoderPool re-exports the v3 envelope payload decoder pool
@@ -159,21 +169,28 @@ func buildC1ZOptions(opts ...C1ZOption) (*c1zOptions, error) {
 	if options.encoderConcurrency < 0 {
 		return nil, fmt.Errorf("encoder concurrency must not be negative: %d", options.encoderConcurrency)
 	}
+	if _, err := applyDecoderOptions(options.decoderOptions...); err != nil {
+		return nil, err
+	}
 	return options, nil
 }
 
 func storeOptionsFromC1ZOptions(options *c1zOptions) StoreOptions {
+	maxDecodedPayloadBytes, _ := explicitMaxDecodedSizeForDecoderOptions(options.decoderOptions...)
+	maxDecoderMemoryBytes, _ := explicitMaxMemorySizeForDecoderOptions(options.decoderOptions...)
 	out := StoreOptions{
-		TmpDir:             options.tmpDir,
-		DecoderOptions:     append([]DecoderOption(nil), options.decoderOptions...),
-		ReadOnly:           options.readOnly,
-		EncoderConcurrency: options.encoderConcurrency,
-		SyncLimit:          options.syncLimit,
-		SkipCleanup:        options.skipCleanup,
-		V2GrantsWriter:     options.v2GrantsWriter,
-		Engine:             options.engine,
-		PayloadEncoding:    options.payloadEncoding,
-		DecoderPool:        options.decoderPool,
+		TmpDir:                 options.tmpDir,
+		DecoderOptions:         append([]DecoderOption(nil), options.decoderOptions...),
+		ReadOnly:               options.readOnly,
+		EncoderConcurrency:     options.encoderConcurrency,
+		SyncLimit:              options.syncLimit,
+		SkipCleanup:            options.skipCleanup,
+		V2GrantsWriter:         options.v2GrantsWriter,
+		Engine:                 options.engine,
+		PayloadEncoding:        options.payloadEncoding,
+		DecoderPool:            options.decoderPool,
+		MaxDecodedPayloadBytes: maxDecodedPayloadBytes,
+		MaxDecoderMemoryBytes:  maxDecoderMemoryBytes,
 	}
 	if out.Engine == "" {
 		out.Engine = EngineSQLite

--- a/pkg/dotc1z/format.go
+++ b/pkg/dotc1z/format.go
@@ -71,7 +71,7 @@ type PayloadEncoding = c1zstore.PayloadEncoding
 
 const (
 	// PayloadEncodingUnspecified is the zero value. Means "use the
-	// engine's default" — TarZstd for Pebble.
+	// engine's default" — IndexedZstd for Pebble.
 	PayloadEncodingUnspecified = c1zstore.PayloadEncodingUnspecified
 
 	// PayloadEncodingTarZstd is the default Pebble v3 envelope
@@ -83,6 +83,14 @@ const (
 	// (avoids double-compression CPU), or when the storage target
 	// compresses in transit.
 	PayloadEncodingTar = c1zstore.PayloadEncodingTar
+
+	// PayloadEncodingIndexedZstd stores each payload file as an
+	// independent zstd frame with a self-describing header. Opens
+	// decode frames in parallel, and rewrites of a store opened from
+	// an indexed file splice unchanged frames verbatim instead of
+	// re-compressing them (incremental fold compaction relies on
+	// this). Readers older than this encoding reject the file.
+	PayloadEncodingIndexedZstd = c1zstore.PayloadEncodingIndexedZstd
 )
 
 // ReadHeaderFormat reads the first 5 bytes of reader and returns the

--- a/pkg/dotc1z/format/v3/decoder_pool_test.go
+++ b/pkg/dotc1z/format/v3/decoder_pool_test.go
@@ -2,11 +2,13 @@ package v3
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 
 	c1zv3 "github.com/conductorone/baton-sdk/pb/c1/c1z/v3"
+	"github.com/klauspost/compress/zstd"
 )
 
 // buildPoolTestEnvelope writes a tiny TAR_ZSTD envelope and returns its
@@ -99,4 +101,75 @@ func TestDecoderPoolScopedReuse(t *testing.T) {
 		t.Fatal(err)
 	}
 	nilPool.Close()
+}
+
+// writePoolTestEnvelopeFile writes the tiny TAR_ZSTD envelope to disk;
+// ExtractEnvelopePayload requires an *os.File.
+func writePoolTestEnvelopeFile(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "pool.c1z")
+	if err := os.WriteFile(path, buildPoolTestEnvelope(t), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// TestExtractEnvelopePayloadDecoderPoolReuse pins that the Pebble open
+// path's extraction (ExtractEnvelopePayload) draws its tar_zstd
+// streaming decoder from a caller-scoped pool and returns it: one
+// decoder is constructed for the first open and reused (not duplicated)
+// by the second.
+func TestExtractEnvelopePayloadDecoderPoolReuse(t *testing.T) {
+	path := writePoolTestEnvelopeFile(t)
+	pool := NewDecoderPool()
+	defer pool.Close()
+
+	for i := 0; i < 2; i++ {
+		f, err := os.Open(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, _, err = ExtractEnvelopePayload(f, t.TempDir(), WithPayloadDecoderPool(pool))
+		_ = f.Close()
+		if err != nil {
+			t.Fatalf("ExtractEnvelopePayload (open %d): %v", i, err)
+		}
+		// Exactly one idle decoder after each extraction: the first
+		// open constructs and parks it; the second drains and re-parks
+		// the same one. Two idle decoders would mean the pool was
+		// bypassed on get and only used on put.
+		if got := len(pool.idle); got != 1 {
+			t.Fatalf("idle decoders after open %d = %d, want 1", i, got)
+		}
+	}
+}
+
+// TestExtractEnvelopePayloadCustomMemoryCapBypassesPool pins the
+// pool-compatibility gate: a caller-specific decoder memory cap must be
+// honored, which means constructing a fresh decoder instead of using a
+// pooled one (whose cap is baked in at construction). The tiny cap also
+// proves the custom cap took effect.
+func TestExtractEnvelopePayloadCustomMemoryCapBypassesPool(t *testing.T) {
+	path := writePoolTestEnvelopeFile(t)
+	pool := NewDecoderPool()
+	defer pool.Close()
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	_, _, err = ExtractEnvelopePayload(f, t.TempDir(),
+		WithPayloadDecoderPool(pool),
+		WithMaxDecoderMemoryBytes(1),
+	)
+	// Depending on the frame shape, the 1-byte cap surfaces as either the
+	// window-size or decoded-size violation; both prove the custom cap
+	// reached the decoder.
+	if !errors.Is(err, zstd.ErrWindowSizeExceeded) && !errors.Is(err, zstd.ErrDecoderSizeExceeded) {
+		t.Fatalf("ExtractEnvelopePayload error = %v, want a zstd memory-cap violation (custom cap must be honored)", err)
+	}
+	if got := len(pool.idle); got != 0 {
+		t.Fatalf("idle decoders = %d, want 0 (custom-cap decoder must not be pooled)", got)
+	}
 }

--- a/pkg/dotc1z/format/v3/envelope.go
+++ b/pkg/dotc1z/format/v3/envelope.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"sync"
 
+	"github.com/cespare/xxhash/v2"
 	c1zv3 "github.com/conductorone/baton-sdk/pb/c1/c1z/v3"
 	"github.com/klauspost/compress/zstd"
 	"google.golang.org/protobuf/encoding/protowire"
@@ -194,20 +195,21 @@ func (l *limitedPayloadReader) limitErr() error {
 //  1. The 5-byte C1Z3 magic.
 //  2. A uint32 BE length prefix for the marshaled manifest.
 //  3. The marshaled manifest bytes.
-//  4. The payload (tar, or tar then zstd, per the manifest's
-//     PayloadEncoding).
+//  4. The payload, per the manifest's PayloadEncoding.
 //
 // The manifest's PayloadEncoding field selects the payload format:
 //
-//   - PAYLOAD_ENCODING_TAR_ZSTD (3): default; tar then zstd. The
+//   - PAYLOAD_ENCODING_TAR_ZSTD (1): default; tar then zstd. The
 //     manifest can leave PayloadEncoding as the zero value
 //     (UNSPECIFIED) and WriteEnvelope will write TAR_ZSTD and patch
 //     the manifest in place so the reader sees the same value.
-//   - PAYLOAD_ENCODING_TAR (4): uncompressed tar.
+//   - PAYLOAD_ENCODING_TAR (2): uncompressed tar.
+//   - PAYLOAD_ENCODING_INDEXED_ZSTD (5): per-file zstd frames with a
+//     trailing frame index (see indexed.go for the layout).
 //   - PAYLOAD_ENCODING_UNSPECIFIED (0): treated as TAR_ZSTD.
 //
-// Any other value (including the now-reserved 1 and 2) returns an
-// error before any bytes are written to w.
+// Any other value (including the reserved 3 and 4) returns an error
+// before any bytes are written to w.
 //
 // payloadDir is walked in sorted lexical order; file mtimes are NOT
 // normalized (the RFC documents tar as not byte-stable). w is typically
@@ -222,8 +224,8 @@ func WriteEnvelope(w io.Writer, m *c1zv3.C1ZManifestV3, payloadDir string) error
 // INDEXED_ZSTD encoding: payload files proven byte-identical to a
 // frame in reuse's source envelope are copied as compressed bytes
 // instead of re-encoded. reuse is ignored (and stats zero) for the tar
-// encodings. The INDEXED_ZSTD encoding requires w to be an
-// io.WriteSeeker (frame headers are backpatched).
+// encodings. Every encoding writes in a single pass, so w may be any
+// io.Writer — including a non-seekable network sink.
 func WriteEnvelopeWithReuse(w io.Writer, m *c1zv3.C1ZManifestV3, payloadDir string, reuse *PayloadReuse) (SpliceStats, error) {
 	var stats SpliceStats
 	if m == nil {
@@ -237,17 +239,11 @@ func WriteEnvelopeWithReuse(w io.Writer, m *c1zv3.C1ZManifestV3, payloadDir stri
 		enc = c1zv3.PayloadEncoding_PAYLOAD_ENCODING_TAR_ZSTD
 		m.SetPayloadEncoding(enc)
 	}
-	var ws io.WriteSeeker
 	switch enc {
 	case c1zv3.PayloadEncoding_PAYLOAD_ENCODING_TAR_ZSTD,
-		c1zv3.PayloadEncoding_PAYLOAD_ENCODING_TAR:
+		c1zv3.PayloadEncoding_PAYLOAD_ENCODING_TAR,
+		c1zv3.PayloadEncoding_PAYLOAD_ENCODING_INDEXED_ZSTD:
 		// ok
-	case c1zv3.PayloadEncoding_PAYLOAD_ENCODING_INDEXED_ZSTD:
-		var ok bool
-		ws, ok = w.(io.WriteSeeker)
-		if !ok {
-			return stats, errors.New("c1z v3: WriteEnvelope: INDEXED_ZSTD requires a seekable writer")
-		}
 	default:
 		return stats, fmt.Errorf("c1z v3: WriteEnvelope: unsupported payload encoding %v", enc)
 	}
@@ -280,7 +276,8 @@ func WriteEnvelopeWithReuse(w io.Writer, m *c1zv3.C1ZManifestV3, payloadDir stri
 			return stats, fmt.Errorf("c1z v3: write tar payload: %w", err)
 		}
 	case c1zv3.PayloadEncoding_PAYLOAD_ENCODING_INDEXED_ZSTD:
-		stats, err = writeIndexedZstd(ws, payloadDir, reuse)
+		payloadStart := int64(len(C1Z3Magic)) + 4 + int64(len(mb))
+		stats, err = writeIndexedZstd(w, payloadStart, xxhash.Sum64(mb), payloadDir, reuse)
 		if err != nil {
 			return stats, fmt.Errorf("c1z v3: write indexed_zstd payload: %w", err)
 		}
@@ -410,9 +407,11 @@ func (p *DecoderPool) Close() {
 // start of the file (the C1Z3 magic). Returns an Envelope whose
 // PayloadReader streams the uncompressed tar bytes for both
 // PAYLOAD_ENCODING_TAR_ZSTD (transparently decoding zstd first) and
-// PAYLOAD_ENCODING_TAR (passing through unchanged). The reserved
-// values 1 (RAW) and 2 (single-stream ZSTD) return an error — they
-// were never wired and aren't supported.
+// PAYLOAD_ENCODING_TAR (passing through unchanged). For
+// PAYLOAD_ENCODING_INDEXED_ZSTD the payload is not a tar stream and
+// PayloadReader is nil — use ExtractEnvelopePayload (random access
+// over the frame table) or ReadIndexedFrameIndex instead. The
+// reserved values 3 and 4 return an error.
 //
 // The payload is treated as untrusted: the zstd decoder's window
 // memory is capped (BATON_DECODER_MAX_MEMORY_MB, default 128 MiB) and

--- a/pkg/dotc1z/format/v3/envelope.go
+++ b/pkg/dotc1z/format/v3/envelope.go
@@ -58,7 +58,10 @@ const (
 	defaultDecoderMaxMemoryBytes  uint64 = 128 << 20 // 128 MiB zstd window cap
 	maxDecodedSizeEnvVar                 = "BATON_DECODER_MAX_DECODED_SIZE_MB"
 	maxDecoderMemorySizeEnvVar           = "BATON_DECODER_MAX_MEMORY_MB"
+	fcsFailFastDisableEnvVar             = "BATON_DISABLE_FCS_FAIL_FAST"
 )
+
+var fcsFailFastDisabled = os.Getenv(fcsFailFastDisableEnvVar) == "1"
 
 // ErrMaxSizeExceeded is returned (wrapped) when a payload decodes to
 // more bytes than the configured cap. Guards against decompression
@@ -86,6 +89,67 @@ func maxDecodedPayloadBytes() uint64 {
 
 func decoderMaxMemoryBytes() uint64 {
 	return envSizeBytes(maxDecoderMemorySizeEnvVar, defaultDecoderMaxMemoryBytes)
+}
+
+type payloadOptions struct {
+	maxDecodedPayloadBytes uint64
+	maxDecoderMemoryBytes  uint64
+	disableSizeFailFast    bool
+	pool                   *DecoderPool
+}
+
+type PayloadOption func(*payloadOptions)
+
+// WithMaxDecodedPayloadBytes sets the decoded payload byte cap for v3 payload
+// extraction. A zero value means use BATON_DECODER_MAX_DECODED_SIZE_MB or the
+// built-in default.
+func WithMaxDecodedPayloadBytes(n uint64) PayloadOption {
+	return func(o *payloadOptions) {
+		o.maxDecodedPayloadBytes = n
+	}
+}
+
+// WithMaxDecoderMemoryBytes sets the zstd decoder memory cap for v3 payload
+// extraction. A zero value means use BATON_DECODER_MAX_MEMORY_MB or the
+// built-in default.
+func WithMaxDecoderMemoryBytes(n uint64) PayloadOption {
+	return func(o *payloadOptions) {
+		o.maxDecoderMemoryBytes = n
+	}
+}
+
+// WithPayloadDecoderPool scopes zstd payload-decoder reuse to the caller's
+// pool for the tar_zstd encoding (the single-stream decode that dominates
+// when many envelopes are opened in a loop, e.g. compaction source opens).
+//
+// The pool only engages when the resolved decoder memory cap equals the
+// pool's standard construction cap: a pooled decoder's WithDecoderMaxMemory
+// is baked in at construction, so a caller-specific cap must construct a
+// fresh decoder to be honored. The indexed encoding never draws from the
+// pool — its parallel frame workers use cheap concurrency-1 decoders whose
+// settings don't match the pool's. Nil is valid and means no reuse.
+func WithPayloadDecoderPool(pool *DecoderPool) PayloadOption {
+	return func(o *payloadOptions) {
+		o.pool = pool
+	}
+}
+
+func resolvePayloadOptions(opts ...PayloadOption) payloadOptions {
+	out := payloadOptions{
+		maxDecodedPayloadBytes: maxDecodedPayloadBytes(),
+		maxDecoderMemoryBytes:  decoderMaxMemoryBytes(),
+		disableSizeFailFast:    fcsFailFastDisabled,
+	}
+	for _, opt := range opts {
+		opt(&out)
+	}
+	if out.maxDecodedPayloadBytes == 0 {
+		out.maxDecodedPayloadBytes = maxDecodedPayloadBytes()
+	}
+	if out.maxDecoderMemoryBytes == 0 {
+		out.maxDecoderMemoryBytes = decoderMaxMemoryBytes()
+	}
+	return out
 }
 
 // limitedPayloadReader passes through up to limit bytes and then fails
@@ -150,8 +214,20 @@ func (l *limitedPayloadReader) limitErr() error {
 // a *os.File created via os.CreateTemp in the same directory as the
 // final destination so an atomic rename can finalize the write.
 func WriteEnvelope(w io.Writer, m *c1zv3.C1ZManifestV3, payloadDir string) error {
+	_, err := WriteEnvelopeWithReuse(w, m, payloadDir, nil)
+	return err
+}
+
+// WriteEnvelopeWithReuse is WriteEnvelope plus frame splicing for the
+// INDEXED_ZSTD encoding: payload files proven byte-identical to a
+// frame in reuse's source envelope are copied as compressed bytes
+// instead of re-encoded. reuse is ignored (and stats zero) for the tar
+// encodings. The INDEXED_ZSTD encoding requires w to be an
+// io.WriteSeeker (frame headers are backpatched).
+func WriteEnvelopeWithReuse(w io.Writer, m *c1zv3.C1ZManifestV3, payloadDir string, reuse *PayloadReuse) (SpliceStats, error) {
+	var stats SpliceStats
 	if m == nil {
-		return errors.New("c1z v3: WriteEnvelope: nil manifest")
+		return stats, errors.New("c1z v3: WriteEnvelope: nil manifest")
 	}
 
 	// Resolve the encoding. Validate before we write any bytes so a
@@ -161,47 +237,59 @@ func WriteEnvelope(w io.Writer, m *c1zv3.C1ZManifestV3, payloadDir string) error
 		enc = c1zv3.PayloadEncoding_PAYLOAD_ENCODING_TAR_ZSTD
 		m.SetPayloadEncoding(enc)
 	}
+	var ws io.WriteSeeker
 	switch enc {
 	case c1zv3.PayloadEncoding_PAYLOAD_ENCODING_TAR_ZSTD,
 		c1zv3.PayloadEncoding_PAYLOAD_ENCODING_TAR:
 		// ok
+	case c1zv3.PayloadEncoding_PAYLOAD_ENCODING_INDEXED_ZSTD:
+		var ok bool
+		ws, ok = w.(io.WriteSeeker)
+		if !ok {
+			return stats, errors.New("c1z v3: WriteEnvelope: INDEXED_ZSTD requires a seekable writer")
+		}
 	default:
-		return fmt.Errorf("c1z v3: WriteEnvelope: unsupported payload encoding %v", enc)
+		return stats, fmt.Errorf("c1z v3: WriteEnvelope: unsupported payload encoding %v", enc)
 	}
 
 	if _, err := w.Write(C1Z3Magic); err != nil {
-		return fmt.Errorf("c1z v3: write magic: %w", err)
+		return stats, fmt.Errorf("c1z v3: write magic: %w", err)
 	}
 	mb, err := MarshalManifest(m)
 	if err != nil {
-		return fmt.Errorf("c1z v3: marshal manifest: %w", err)
+		return stats, fmt.Errorf("c1z v3: marshal manifest: %w", err)
 	}
 	if len(mb) > maxManifestBytes {
-		return fmt.Errorf("c1z v3: manifest is %d bytes, exceeds %d", len(mb), maxManifestBytes)
+		return stats, fmt.Errorf("c1z v3: manifest is %d bytes, exceeds %d", len(mb), maxManifestBytes)
 	}
 	var lenBuf [4]byte
 	binary.BigEndian.PutUint32(lenBuf[:], uint32(len(mb))) //nolint:gosec // len(mb) is capped at maxManifestBytes above.
 	if _, err := w.Write(lenBuf[:]); err != nil {
-		return fmt.Errorf("c1z v3: write manifest length: %w", err)
+		return stats, fmt.Errorf("c1z v3: write manifest length: %w", err)
 	}
 	if _, err := w.Write(mb); err != nil {
-		return fmt.Errorf("c1z v3: write manifest: %w", err)
+		return stats, fmt.Errorf("c1z v3: write manifest: %w", err)
 	}
 	switch enc {
 	case c1zv3.PayloadEncoding_PAYLOAD_ENCODING_TAR_ZSTD:
 		if err := writeZstdTar(w, payloadDir); err != nil {
-			return fmt.Errorf("c1z v3: write tar_zstd payload: %w", err)
+			return stats, fmt.Errorf("c1z v3: write tar_zstd payload: %w", err)
 		}
 	case c1zv3.PayloadEncoding_PAYLOAD_ENCODING_TAR:
 		if err := writeTar(w, payloadDir); err != nil {
-			return fmt.Errorf("c1z v3: write tar payload: %w", err)
+			return stats, fmt.Errorf("c1z v3: write tar payload: %w", err)
+		}
+	case c1zv3.PayloadEncoding_PAYLOAD_ENCODING_INDEXED_ZSTD:
+		stats, err = writeIndexedZstd(ws, payloadDir, reuse)
+		if err != nil {
+			return stats, fmt.Errorf("c1z v3: write indexed_zstd payload: %w", err)
 		}
 	case c1zv3.PayloadEncoding_PAYLOAD_ENCODING_UNSPECIFIED:
 		// Unreachable: the validation block above normalises
 		// UNSPECIFIED to TAR_ZSTD before this point.
-		return fmt.Errorf("c1z v3: WriteEnvelope: payload encoding was not resolved")
+		return stats, fmt.Errorf("c1z v3: WriteEnvelope: payload encoding was not resolved")
 	}
-	return nil
+	return stats, nil
 }
 
 // Envelope is the parsed result of ReadEnvelope. Manifest holds the
@@ -418,6 +506,10 @@ func readEnvelope(r io.Reader, headerOnly bool, pool *DecoderPool) (*Envelope, e
 		env.PayloadReader = &limitedPayloadReader{r: zr, limit: maxDecodedPayloadBytes()}
 	case c1zv3.PayloadEncoding_PAYLOAD_ENCODING_TAR:
 		env.PayloadReader = &limitedPayloadReader{r: r, limit: maxDecodedPayloadBytes()}
+	case c1zv3.PayloadEncoding_PAYLOAD_ENCODING_INDEXED_ZSTD:
+		// Indexed payloads are not a tar stream; extraction goes
+		// through ExtractEnvelopePayload (random access over the
+		// frame table). PayloadReader stays nil.
 	default:
 		return nil, fmt.Errorf("c1z v3: unsupported payload encoding %v", m.GetPayloadEncoding())
 	}

--- a/pkg/dotc1z/format/v3/indexed.go
+++ b/pkg/dotc1z/format/v3/indexed.go
@@ -1,0 +1,570 @@
+package v3
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"sync"
+
+	"github.com/cespare/xxhash/v2"
+	c1zv3 "github.com/conductorone/baton-sdk/pb/c1/c1z/v3"
+	"github.com/klauspost/compress/zstd"
+)
+
+// PAYLOAD_ENCODING_INDEXED_ZSTD frame stream. Layout, immediately
+// after the manifest:
+//
+//	entry    := u32 nameLen | name | u64 rawSize | u64 xxh64 | u64 compSize | <compSize zstd bytes>
+//	stream   := entry* | u32 0 (terminator)
+//
+// All integers big-endian, matching the envelope's length prefix.
+// Names are slash-separated relative paths (filepath.ToSlash on
+// write, FromSlash on extract) so payloads are portable across
+// macOS/Linux/Windows. xxh64 is over the RAW (decompressed) bytes.
+//
+// Each file is an independent zstd frame, which is what enables:
+//
+//   - parallel decode at open: workers pread their frame's byte range
+//     (io.ReaderAt is safe for concurrent use on all three supported
+//     platforms) and stream-decompress, instead of the single-stream
+//     encodings' one-core sequential decode; and
+//   - frame splicing at save: an unchanged payload file's compressed
+//     frame is copied verbatim from the source envelope. Pebble SSTs
+//     are immutable and checkpoints hard-link them, so incremental
+//     rewrites (the fold compactor) reuse almost every frame and pay
+//     compression only for the handful of new files.
+
+const maxIndexedNameBytes = 4096
+
+// indexedEntryFixedTail is rawSize + xxh64 + compSize.
+const indexedEntryFixedTail = 8 + 8 + 8
+
+// ReuseEntry describes one frame of a source envelope: where its
+// compressed bytes live in the source file, what they decode to, and
+// where the extractor materialized them.
+type ReuseEntry struct {
+	Name           string
+	FrameOffset    int64 // offset of the compressed bytes in the source file
+	CompressedSize int64
+	RawSize        int64
+	XXH64          uint64
+	// ExtractedPath is where extraction wrote the raw bytes. Used for
+	// the zero-read os.SameFile identity check at save time: a
+	// checkpoint hard-link of the extracted file is provably the same
+	// content. Empty when unknown.
+	ExtractedPath string
+}
+
+// PayloadReuse indexes a source envelope's frames for splice-at-save.
+// Returned by ExtractEnvelopePayload for indexed payloads; passed to
+// WriteEnvelopeWithReuse when rewriting a store opened from that
+// source.
+type PayloadReuse struct {
+	srcPath string
+	byName  map[string]*ReuseEntry
+}
+
+// SourcePath returns the envelope file the reuse entries point into.
+func (r *PayloadReuse) SourcePath() string {
+	if r == nil {
+		return ""
+	}
+	return r.srcPath
+}
+
+// match returns the reusable entry for a payload file, or nil when the
+// file is new or changed. The fast path is the os.SameFile identity
+// check against the extracted file (zero reads — covers checkpoint
+// hard-links); the fallback hashes the candidate's raw bytes, covering
+// filesystems where hard-linking wasn't possible and pebble copied.
+func (r *PayloadReuse) match(name string, info os.FileInfo, path string) *ReuseEntry {
+	if r == nil {
+		return nil
+	}
+	e := r.byName[name]
+	if e == nil || e.RawSize != info.Size() {
+		return nil
+	}
+	if e.ExtractedPath != "" {
+		if ei, err := os.Stat(e.ExtractedPath); err == nil && os.SameFile(ei, info) {
+			return e
+		}
+	}
+	h, err := xxh64File(path)
+	if err != nil || h != e.XXH64 {
+		return nil
+	}
+	return e
+}
+
+func xxh64File(path string) (uint64, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+	h := xxhash.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return 0, err
+	}
+	return h.Sum64(), nil
+}
+
+// SpliceStats reports how a WriteEnvelopeWithReuse call split between
+// verbatim frame copies and fresh compression. Exposed so callers can
+// log reuse effectiveness in production.
+type SpliceStats struct {
+	SplicedFrames int
+	SplicedBytes  int64 // compressed bytes copied verbatim
+	EncodedFrames int
+	EncodedBytes  int64 // raw bytes freshly compressed
+}
+
+// writeIndexedZstd writes the indexed frame stream for dir to w.
+// w must be seekable: per-frame headers carry the compressed size and
+// raw-bytes hash, which are only known after encoding, so the header
+// is backpatched. The envelope save path always writes to a temp
+// *os.File, satisfying this.
+func writeIndexedZstd(w io.WriteSeeker, dir string, reuse *PayloadReuse) (SpliceStats, error) {
+	var stats SpliceStats
+
+	var paths []string
+	walkErr := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.Mode().IsRegular() {
+			paths = append(paths, path)
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return stats, walkErr
+	}
+	sort.Strings(paths)
+
+	var srcFile *os.File
+	if reuse != nil && reuse.srcPath != "" {
+		f, err := os.Open(reuse.srcPath)
+		if err != nil {
+			return stats, fmt.Errorf("c1z v3: open splice source: %w", err)
+		}
+		srcFile = f
+		defer srcFile.Close()
+	}
+
+	enc, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedDefault))
+	if err != nil {
+		return stats, err
+	}
+	defer enc.Close()
+
+	var lenBuf [4]byte
+	var tail [indexedEntryFixedTail]byte
+	for _, path := range paths {
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			return stats, err
+		}
+		name := filepath.ToSlash(rel)
+		if len(name) > maxIndexedNameBytes {
+			return stats, fmt.Errorf("c1z v3: payload name too long: %q", name)
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			return stats, err
+		}
+
+		binary.BigEndian.PutUint32(lenBuf[:], uint32(len(name))) //nolint:gosec // capped above.
+		if _, err := w.Write(lenBuf[:]); err != nil {
+			return stats, err
+		}
+		if _, err := io.WriteString(w, name); err != nil {
+			return stats, err
+		}
+
+		if e := reuse.match(name, info, path); e != nil && srcFile != nil {
+			binary.BigEndian.PutUint64(tail[0:8], uint64(e.RawSize)) //nolint:gosec // sizes validated on extract.
+			binary.BigEndian.PutUint64(tail[8:16], e.XXH64)
+			binary.BigEndian.PutUint64(tail[16:24], uint64(e.CompressedSize)) //nolint:gosec // sizes validated on extract.
+			if _, err := w.Write(tail[:]); err != nil {
+				return stats, err
+			}
+			if _, err := io.Copy(w, io.NewSectionReader(srcFile, e.FrameOffset, e.CompressedSize)); err != nil {
+				return stats, fmt.Errorf("c1z v3: splice frame %q: %w", name, err)
+			}
+			stats.SplicedFrames++
+			stats.SplicedBytes += e.CompressedSize
+			continue
+		}
+
+		// Fresh encode: header tail is backpatched once the hash and
+		// compressed size are known.
+		tailPos, err := w.Seek(0, io.SeekCurrent)
+		if err != nil {
+			return stats, err
+		}
+		for i := range tail {
+			tail[i] = 0
+		}
+		if _, err := w.Write(tail[:]); err != nil {
+			return stats, err
+		}
+		f, err := os.Open(path)
+		if err != nil {
+			return stats, err
+		}
+		hasher := xxhash.New()
+		counter := &countingW{w: w}
+		enc.Reset(counter)
+		rawN, err := io.Copy(io.MultiWriter(enc, hasher), f)
+		if cerr := f.Close(); err == nil {
+			err = cerr
+		}
+		if err != nil {
+			return stats, err
+		}
+		if err := enc.Close(); err != nil {
+			return stats, err
+		}
+		end, err := w.Seek(0, io.SeekCurrent)
+		if err != nil {
+			return stats, err
+		}
+		binary.BigEndian.PutUint64(tail[0:8], uint64(rawN)) //nolint:gosec // io.Copy result is non-negative.
+		binary.BigEndian.PutUint64(tail[8:16], hasher.Sum64())
+		binary.BigEndian.PutUint64(tail[16:24], uint64(counter.n)) //nolint:gosec // byte count is non-negative.
+		if _, err := w.Seek(tailPos, io.SeekStart); err != nil {
+			return stats, err
+		}
+		if _, err := w.Write(tail[:]); err != nil {
+			return stats, err
+		}
+		if _, err := w.Seek(end, io.SeekStart); err != nil {
+			return stats, err
+		}
+		stats.EncodedFrames++
+		stats.EncodedBytes += rawN
+	}
+
+	// Terminator.
+	binary.BigEndian.PutUint32(lenBuf[:], 0)
+	if _, err := w.Write(lenBuf[:]); err != nil {
+		return stats, err
+	}
+	return stats, nil
+}
+
+type countingW struct {
+	w io.Writer
+	n int64
+}
+
+func (c *countingW) Write(p []byte) (int, error) {
+	n, err := c.w.Write(p)
+	c.n += int64(n)
+	return n, err
+}
+
+type decodedBudget struct {
+	mu        sync.Mutex
+	remaining uint64
+	limit     uint64
+}
+
+func newDecodedBudget(limit uint64) *decodedBudget {
+	return &decodedBudget{remaining: limit, limit: limit}
+}
+
+func (b *decodedBudget) take(n int) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.remaining == 0 {
+		return 0, b.err()
+	}
+	if uint64(n) > b.remaining { //nolint:gosec // n is len(p), always non-negative.
+		allowed := int(b.remaining) //nolint:gosec // allowed only feeds a slice bound after b.remaining < uint64(len(p)).
+		b.remaining = 0
+		return allowed, b.err()
+	}
+	b.remaining -= uint64(n) //nolint:gosec // n is len(p), always non-negative.
+	return n, nil
+}
+
+func (b *decodedBudget) err() error {
+	return fmt.Errorf("c1z v3: indexed decoded bytes exceed %d bytes: %w", b.limit, ErrMaxSizeExceeded)
+}
+
+type budgetedFrameWriter struct {
+	budget *decodedBudget
+	out    io.Writer
+	hash   io.Writer
+}
+
+func (w budgetedFrameWriter) Write(p []byte) (int, error) {
+	n, err := w.budget.take(len(p))
+	if n > 0 {
+		if _, werr := w.out.Write(p[:n]); werr != nil {
+			return 0, werr
+		}
+		if _, werr := w.hash.Write(p[:n]); werr != nil {
+			return 0, werr
+		}
+	}
+	if err != nil {
+		return n, err
+	}
+	return n, nil
+}
+
+// scanIndexedEntries reads the frame headers without touching frame
+// bytes: one small read per entry plus a relative seek over the
+// compressed data.
+func scanIndexedEntries(f *os.File, payloadStart int64) ([]*ReuseEntry, error) {
+	if _, err := f.Seek(payloadStart, io.SeekStart); err != nil {
+		return nil, err
+	}
+	r := f
+	var entries []*ReuseEntry
+	var lenBuf [4]byte
+	var tail [indexedEntryFixedTail]byte
+	nameBuf := make([]byte, 0, 256)
+	for {
+		if _, err := io.ReadFull(r, lenBuf[:]); err != nil {
+			return nil, fmt.Errorf("%w: indexed entry header: %w", ErrEnvelopeTruncated, err)
+		}
+		nameLen := binary.BigEndian.Uint32(lenBuf[:])
+		if nameLen == 0 {
+			return entries, nil
+		}
+		if nameLen > maxIndexedNameBytes {
+			return nil, fmt.Errorf("c1z v3: indexed entry name length %d exceeds cap", nameLen)
+		}
+		if cap(nameBuf) < int(nameLen) {
+			nameBuf = make([]byte, nameLen)
+		}
+		nameBuf = nameBuf[:nameLen]
+		if _, err := io.ReadFull(r, nameBuf); err != nil {
+			return nil, fmt.Errorf("%w: indexed entry name: %w", ErrEnvelopeTruncated, err)
+		}
+		if _, err := io.ReadFull(r, tail[:]); err != nil {
+			return nil, fmt.Errorf("%w: indexed entry sizes: %w", ErrEnvelopeTruncated, err)
+		}
+		rawSize := int64(binary.BigEndian.Uint64(tail[0:8]))    //nolint:gosec // validated below.
+		compSize := int64(binary.BigEndian.Uint64(tail[16:24])) //nolint:gosec // validated below.
+		if rawSize < 0 || rawSize > maxTarEntryBytes || compSize < 0 || compSize > maxTarEntryBytes {
+			return nil, fmt.Errorf("c1z v3: indexed entry %q sizes out of range (raw=%d comp=%d)", nameBuf, rawSize, compSize)
+		}
+		offset, err := f.Seek(0, io.SeekCurrent)
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, &ReuseEntry{
+			Name:           string(nameBuf),
+			FrameOffset:    offset,
+			CompressedSize: compSize,
+			RawSize:        rawSize,
+			XXH64:          binary.BigEndian.Uint64(tail[8:16]),
+		})
+		if _, err := f.Seek(compSize, io.SeekCurrent); err != nil {
+			return nil, err
+		}
+	}
+}
+
+// extractIndexedZstd materializes an indexed payload into destDir,
+// decoding frames in parallel. Returns the PayloadReuse map so a later
+// save can splice unchanged frames.
+func extractIndexedZstd(f *os.File, payloadStart int64, destDir string, maxDecodedBytes uint64, maxMemoryBytes uint64, disableSizeFailFast bool) (*PayloadReuse, error) {
+	entries, err := scanIndexedEntries(f, payloadStart)
+	if err != nil {
+		return nil, err
+	}
+	if !disableSizeFailFast {
+		var totalRaw uint64
+		for _, e := range entries {
+			if e.RawSize < 0 {
+				return nil, fmt.Errorf("c1z v3: indexed entry %q raw size is negative: %d", e.Name, e.RawSize)
+			}
+			raw := uint64(e.RawSize)
+			if raw > maxDecodedBytes || totalRaw > maxDecodedBytes-raw {
+				return nil, fmt.Errorf("c1z v3: indexed payload exceeds %d bytes: %w", maxDecodedBytes, ErrMaxSizeExceeded)
+			}
+			totalRaw += raw
+		}
+	}
+	budget := newDecodedBudget(maxDecodedBytes)
+
+	// Directories first, on one goroutine, so workers never race a
+	// parent-dir creation.
+	for _, e := range entries {
+		if !filepath.IsLocal(filepath.FromSlash(e.Name)) {
+			return nil, fmt.Errorf("c1z v3: unsafe indexed entry path: %q", e.Name)
+		}
+		target := filepath.Join(destDir, filepath.FromSlash(e.Name))
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return nil, err
+		}
+		e.ExtractedPath = target
+	}
+
+	workers := runtime.GOMAXPROCS(0)
+	if workers > 8 {
+		workers = 8
+	}
+	if workers < 1 {
+		workers = 1
+	}
+	jobs := make(chan *ReuseEntry, workers)
+	var wg sync.WaitGroup
+	var firstErr error
+	var errMu sync.Mutex
+	setErr := func(err error) {
+		errMu.Lock()
+		if firstErr == nil {
+			firstErr = err
+		}
+		errMu.Unlock()
+	}
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			dec, err := zstd.NewReader(nil,
+				zstd.WithDecoderConcurrency(1),
+				zstd.WithDecoderMaxMemory(maxMemoryBytes),
+			)
+			if err != nil {
+				setErr(err)
+				return
+			}
+			defer dec.Close()
+			for e := range jobs {
+				if err := extractOneFrame(f, e, dec, budget); err != nil {
+					setErr(fmt.Errorf("c1z v3: extract %q: %w", e.Name, err))
+				}
+			}
+		}()
+	}
+	for _, e := range entries {
+		jobs <- e
+	}
+	close(jobs)
+	wg.Wait()
+	if firstErr != nil {
+		return nil, firstErr
+	}
+
+	reuse := &PayloadReuse{
+		srcPath: f.Name(),
+		byName:  make(map[string]*ReuseEntry, len(entries)),
+	}
+	for _, e := range entries {
+		reuse.byName[e.Name] = e
+	}
+	return reuse, nil
+}
+
+func extractOneFrame(f *os.File, e *ReuseEntry, dec *zstd.Decoder, budget *decodedBudget) error {
+	out, err := os.OpenFile(e.ExtractedPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	// io.NewSectionReader over the shared *os.File preads the frame's
+	// byte range; concurrent ReadAt is safe on macOS/Linux/Windows.
+	if err := dec.Reset(io.NewSectionReader(f, e.FrameOffset, e.CompressedSize)); err != nil {
+		_ = out.Close()
+		return err
+	}
+	hasher := xxhash.New()
+	n, err := io.CopyN(budgetedFrameWriter{budget: budget, out: out, hash: hasher}, dec, e.RawSize+1)
+	if errors.Is(err, io.EOF) {
+		err = nil
+	}
+	if cerr := out.Close(); err == nil {
+		err = cerr
+	}
+	if err != nil {
+		return err
+	}
+	if n != e.RawSize {
+		return fmt.Errorf("decoded %d bytes, header says %d", n, e.RawSize)
+	}
+	if hasher.Sum64() != e.XXH64 {
+		return fmt.Errorf("raw bytes hash mismatch (corrupt frame)")
+	}
+	return nil
+}
+
+// ExtractEnvelopePayload opens, validates, and extracts a v3
+// envelope's payload from f into destDir, dispatching on the
+// manifest's payload encoding. For indexed payloads it decodes frames
+// in parallel and returns a PayloadReuse for splice-at-save; the tar
+// encodings extract sequentially and return a nil reuse.
+//
+// f must be positioned anywhere (it is rewound); it stays open and
+// owned by the caller.
+func ExtractEnvelopePayload(f *os.File, destDir string, opts ...PayloadOption) (*c1zv3.C1ZManifestV3, *PayloadReuse, error) {
+	cfg := resolvePayloadOptions(opts...)
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return nil, nil, err
+	}
+	mb, err := readManifestBytes(f)
+	if err != nil {
+		return nil, nil, err
+	}
+	m, err := unmarshalManifestHeader(mb)
+	if err != nil {
+		return nil, nil, err
+	}
+	payloadStart := int64(len(C1Z3Magic)) + 4 + int64(len(mb))
+	switch m.GetPayloadEncoding() {
+	case c1zv3.PayloadEncoding_PAYLOAD_ENCODING_INDEXED_ZSTD:
+		reuse, err := extractIndexedZstd(f, payloadStart, destDir, cfg.maxDecodedPayloadBytes, cfg.maxDecoderMemoryBytes, cfg.disableSizeFailFast)
+		if err != nil {
+			return nil, nil, err
+		}
+		return m, reuse, nil
+	case c1zv3.PayloadEncoding_PAYLOAD_ENCODING_TAR_ZSTD:
+		// Draw the streaming decoder from the caller's pool only when the
+		// resolved memory cap matches the pool's standard construction —
+		// a pooled decoder's cap is baked in at construction, so honoring
+		// a custom cap requires a fresh decoder (mirrors the v1 decoder's
+		// pool-compatibility gate in pkg/dotc1z/decoder.go).
+		var zr *zstd.Decoder
+		usePool := cfg.pool != nil && cfg.maxDecoderMemoryBytes == decoderMaxMemoryBytes()
+		if usePool {
+			zr, err = cfg.pool.get(f)
+		} else {
+			zr, err = zstd.NewReader(f, zstd.WithDecoderMaxMemory(cfg.maxDecoderMemoryBytes))
+		}
+		if err != nil {
+			return nil, nil, err
+		}
+		defer func() {
+			if usePool {
+				cfg.pool.put(zr)
+			} else {
+				zr.Close()
+			}
+		}()
+		limited := &limitedPayloadReader{r: zr, limit: cfg.maxDecodedPayloadBytes}
+		if err := ExtractZstdTar(limited, destDir); err != nil {
+			return nil, nil, err
+		}
+		return m, nil, nil
+	case c1zv3.PayloadEncoding_PAYLOAD_ENCODING_TAR:
+		limited := &limitedPayloadReader{r: f, limit: cfg.maxDecodedPayloadBytes}
+		if err := ExtractZstdTar(limited, destDir); err != nil {
+			return nil, nil, err
+		}
+		return m, nil, nil
+	default:
+		return nil, nil, fmt.Errorf("c1z v3: unsupported payload encoding %v", m.GetPayloadEncoding())
+	}
+}

--- a/pkg/dotc1z/format/v3/indexed.go
+++ b/pkg/dotc1z/format/v3/indexed.go
@@ -1,6 +1,8 @@
 package v3
 
 import (
+	"bytes"
+	"crypto/sha256"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -10,39 +12,72 @@ import (
 	"runtime"
 	"sort"
 	"sync"
+	"sync/atomic"
 
 	"github.com/cespare/xxhash/v2"
 	c1zv3 "github.com/conductorone/baton-sdk/pb/c1/c1z/v3"
 	"github.com/klauspost/compress/zstd"
+	"google.golang.org/protobuf/proto"
 )
 
-// PAYLOAD_ENCODING_INDEXED_ZSTD frame stream. Layout, immediately
-// after the manifest:
+// PAYLOAD_ENCODING_INDEXED_ZSTD payload. Layout, immediately after
+// the manifest:
 //
-//	entry    := u32 nameLen | name | u64 rawSize | u64 xxh64 | u64 compSize | <compSize zstd bytes>
-//	stream   := entry* | u32 0 (terminator)
+//	payload := frame* | index | footer
+//	footer  := u64 indexOffset | u32 indexLen | u64 xxh64(index) | "C1ZIDX1\0"
 //
 // All integers big-endian, matching the envelope's length prefix.
-// Names are slash-separated relative paths (filepath.ToSlash on
-// write, FromSlash on extract) so payloads are portable across
-// macOS/Linux/Windows. xxh64 is over the RAW (decompressed) bytes.
+// Each frame is the bare zstd stream of one payload file — no
+// per-frame framing of our own — with Frame_Content_Size advertised,
+// so a frame's byte range is independently meaningful: pread it and
+// you hold a self-describing zstd stream any vanilla consumer can
+// decode. The index is the sole frame table: a binary-proto
+// c1zv3.IndexedFrameIndex carrying, per frame, the slash-separated
+// relative path (filepath.ToSlash on write, FromSlash on extract, so
+// payloads are portable across macOS/Linux/Windows), the absolute
+// byte offset and compressed size, the raw size, an xxh64 of the raw
+// bytes (fast corruption check at extract), and a SHA-256 of the raw
+// bytes (content-address identity for chunked object storage). The
+// proto envelope is the extension point for future per-frame
+// metadata (codec, dictionary, encryption) without a layout rev.
 //
-// Each file is an independent zstd frame, which is what enables:
+// The whole table is fetchable in O(1) reads — fixed-size footer,
+// then index — which is what makes ranged reads over object storage
+// practical. There is deliberately no streaming-scannable framing: a
+// payload without a valid footer is corruption-class
+// (ErrEnvelopeTruncated; invalidate and resync), the same policy as
+// a torn tar payload.
+//
+// This layout is what enables:
 //
 //   - parallel decode at open: workers pread their frame's byte range
 //     (io.ReaderAt is safe for concurrent use on all three supported
 //     platforms) and stream-decompress, instead of the single-stream
-//     encodings' one-core sequential decode; and
+//     encodings' one-core sequential decode;
 //   - frame splicing at save: an unchanged payload file's compressed
 //     frame is copied verbatim from the source envelope. Pebble SSTs
 //     are immutable and checkpoints hard-link them, so incremental
 //     rewrites (the fold compactor) reuse almost every frame and pay
-//     compression only for the handful of new files.
+//     compression only for the handful of new files; and
+//   - single-pass writes: nothing is backpatched, so an envelope can
+//     be encoded straight to a non-seekable sink (a network upload),
+//     and a chunked store can reconstruct the envelope byte range by
+//     byte range from the index alone.
 
 const maxIndexedNameBytes = 4096
 
-// indexedEntryFixedTail is rawSize + xxh64 + compSize.
-const indexedEntryFixedTail = 8 + 8 + 8
+// indexedFooterMagic ends an indexed payload. 8 bytes so the whole
+// footer stays u64-aligned; the trailing "1" is the trailer version.
+var indexedFooterMagic = []byte("C1ZIDX1\x00")
+
+// indexedFooterLen is u64 indexOffset + u32 indexLen + u64 xxh64(index) + magic.
+const indexedFooterLen = 8 + 4 + 8 + 8
+
+// maxIndexedIndexBytes caps the trailer index size we accept on read.
+// ~80 bytes/entry means even a million-frame payload stays an order
+// of magnitude below this; protects against a hostile footer
+// claiming a multi-GiB index.
+const maxIndexedIndexBytes = 64 << 20
 
 // ReuseEntry describes one frame of a source envelope: where its
 // compressed bytes live in the source file, what they decode to, and
@@ -53,6 +88,11 @@ type ReuseEntry struct {
 	CompressedSize int64
 	RawSize        int64
 	XXH64          uint64
+	// SHA256 is the content-address identity of the raw bytes, carried
+	// from the source envelope's trailer index. The splice writer
+	// recomputes it from the local payload file if a caller hands it an
+	// entry without one.
+	SHA256 []byte
 	// ExtractedPath is where extraction wrote the raw bytes. Used for
 	// the zero-read os.SameFile identity check at save time: a
 	// checkpoint hard-link of the extracted file is provably the same
@@ -115,6 +155,19 @@ func xxh64File(path string) (uint64, error) {
 	return h.Sum64(), nil
 }
 
+func sha256File(path string) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return nil, err
+	}
+	return h.Sum(nil), nil
+}
+
 // SpliceStats reports how a WriteEnvelopeWithReuse call split between
 // verbatim frame copies and fresh compression. Exposed so callers can
 // log reuse effectiveness in production.
@@ -125,12 +178,16 @@ type SpliceStats struct {
 	EncodedBytes  int64 // raw bytes freshly compressed
 }
 
-// writeIndexedZstd writes the indexed frame stream for dir to w.
-// w must be seekable: per-frame headers carry the compressed size and
-// raw-bytes hash, which are only known after encoding, so the header
-// is backpatched. The envelope save path always writes to a temp
-// *os.File, satisfying this.
-func writeIndexedZstd(w io.WriteSeeker, dir string, reuse *PayloadReuse) (SpliceStats, error) {
+// writeIndexedZstd writes the indexed payload for dir to w in a
+// single pass: frames back-to-back, then the index, then the footer.
+// Nothing is backpatched, so w can be any io.Writer — including a
+// non-seekable network sink. payloadStart is the absolute file
+// offset of the first payload byte (magic + manifest length prefix +
+// manifest); index offsets are absolute so a ranged reader needs no
+// other context. manifestXXH64 is the hash of the marshaled manifest
+// bytes, recorded in the index so the otherwise-unprotected envelope
+// head is covered too.
+func writeIndexedZstd(w io.Writer, payloadStart int64, manifestXXH64 uint64, dir string, reuse *PayloadReuse) (SpliceStats, error) {
 	var stats SpliceStats
 
 	var paths []string
@@ -158,14 +215,22 @@ func writeIndexedZstd(w io.WriteSeeker, dir string, reuse *PayloadReuse) (Splice
 		defer srcFile.Close()
 	}
 
-	enc, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedDefault))
+	// WithZeroFrames is pinned (it is the library default today, but
+	// documented as optional): zero-length payload files must still
+	// produce complete zstd frames, or the "every byte range is a
+	// standalone decodable stream" property breaks for empty files.
+	enc, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedDefault), zstd.WithZeroFrames(true))
 	if err != nil {
 		return stats, err
 	}
 	defer enc.Close()
 
-	var lenBuf [4]byte
-	var tail [indexedEntryFixedTail]byte
+	var idxEntries []*c1zv3.IndexedFrameEntry
+	var totalRaw, totalComp int64
+
+	// All payload writes go through cw so frame offsets are known
+	// without seeking.
+	cw := &countingW{w: w}
 	for _, path := range paths {
 		rel, err := filepath.Rel(dir, path)
 		if err != nil {
@@ -179,50 +244,50 @@ func writeIndexedZstd(w io.WriteSeeker, dir string, reuse *PayloadReuse) (Splice
 		if err != nil {
 			return stats, err
 		}
-
-		binary.BigEndian.PutUint32(lenBuf[:], uint32(len(name))) //nolint:gosec // capped above.
-		if _, err := w.Write(lenBuf[:]); err != nil {
-			return stats, err
-		}
-		if _, err := io.WriteString(w, name); err != nil {
-			return stats, err
-		}
+		frameOff := payloadStart + cw.n
 
 		if e := reuse.match(name, info, path); e != nil && srcFile != nil {
-			binary.BigEndian.PutUint64(tail[0:8], uint64(e.RawSize)) //nolint:gosec // sizes validated on extract.
-			binary.BigEndian.PutUint64(tail[8:16], e.XXH64)
-			binary.BigEndian.PutUint64(tail[16:24], uint64(e.CompressedSize)) //nolint:gosec // sizes validated on extract.
-			if _, err := w.Write(tail[:]); err != nil {
-				return stats, err
-			}
-			if _, err := io.Copy(w, io.NewSectionReader(srcFile, e.FrameOffset, e.CompressedSize)); err != nil {
+			if _, err := io.Copy(cw, io.NewSectionReader(srcFile, e.FrameOffset, e.CompressedSize)); err != nil {
 				return stats, fmt.Errorf("c1z v3: splice frame %q: %w", name, err)
 			}
+			sha := e.SHA256
+			if len(sha) == 0 {
+				// The local file is proven byte-identical to the spliced
+				// frame's raw bytes (match above), so hash it directly.
+				if sha, err = sha256File(path); err != nil {
+					return stats, err
+				}
+			}
+			idxEntries = append(idxEntries, c1zv3.IndexedFrameEntry_builder{
+				Name:           name,
+				FrameOffset:    frameOff,
+				CompressedSize: e.CompressedSize,
+				RawSize:        e.RawSize,
+				RawXxh64:       e.XXH64,
+				RawSha256:      sha,
+			}.Build())
+			totalRaw += e.RawSize
+			totalComp += e.CompressedSize
 			stats.SplicedFrames++
 			stats.SplicedBytes += e.CompressedSize
 			continue
 		}
 
-		// Fresh encode: header tail is backpatched once the hash and
-		// compressed size are known.
-		tailPos, err := w.Seek(0, io.SeekCurrent)
-		if err != nil {
-			return stats, err
-		}
-		for i := range tail {
-			tail[i] = 0
-		}
-		if _, err := w.Write(tail[:]); err != nil {
-			return stats, err
-		}
 		f, err := os.Open(path)
 		if err != nil {
 			return stats, err
 		}
 		hasher := xxhash.New()
-		counter := &countingW{w: w}
-		enc.Reset(counter)
-		rawN, err := io.Copy(io.MultiWriter(enc, hasher), f)
+		shaHasher := sha256.New()
+		// ResetContentSize advertises Frame_Content_Size in the frame
+		// header, making each frame self-describing to any vanilla zstd
+		// consumer; Close errors if the bytes copied disagree with the
+		// stat size, catching a file mutated mid-encode. (Frames under
+		// 256 bytes omit FCS — the zstd header can't represent sizes
+		// below 256 without the single-segment flag — so the index's
+		// raw_size is the authoritative size everywhere.)
+		enc.ResetContentSize(cw, info.Size())
+		rawN, err := io.Copy(io.MultiWriter(enc, hasher, shaHasher), f)
 		if cerr := f.Close(); err == nil {
 			err = cerr
 		}
@@ -232,29 +297,45 @@ func writeIndexedZstd(w io.WriteSeeker, dir string, reuse *PayloadReuse) (Splice
 		if err := enc.Close(); err != nil {
 			return stats, err
 		}
-		end, err := w.Seek(0, io.SeekCurrent)
-		if err != nil {
-			return stats, err
-		}
-		binary.BigEndian.PutUint64(tail[0:8], uint64(rawN)) //nolint:gosec // io.Copy result is non-negative.
-		binary.BigEndian.PutUint64(tail[8:16], hasher.Sum64())
-		binary.BigEndian.PutUint64(tail[16:24], uint64(counter.n)) //nolint:gosec // byte count is non-negative.
-		if _, err := w.Seek(tailPos, io.SeekStart); err != nil {
-			return stats, err
-		}
-		if _, err := w.Write(tail[:]); err != nil {
-			return stats, err
-		}
-		if _, err := w.Seek(end, io.SeekStart); err != nil {
-			return stats, err
-		}
+		compN := payloadStart + cw.n - frameOff
+		idxEntries = append(idxEntries, c1zv3.IndexedFrameEntry_builder{
+			Name:           name,
+			FrameOffset:    frameOff,
+			CompressedSize: compN,
+			RawSize:        rawN,
+			RawXxh64:       hasher.Sum64(),
+			RawSha256:      shaHasher.Sum(nil),
+		}.Build())
+		totalRaw += rawN
+		totalComp += compN
 		stats.EncodedFrames++
 		stats.EncodedBytes += rawN
 	}
 
-	// Terminator.
-	binary.BigEndian.PutUint32(lenBuf[:], 0)
-	if _, err := w.Write(lenBuf[:]); err != nil {
+	// Index, then footer. See the layout comment at the top of this
+	// file.
+	ib, err := proto.Marshal(c1zv3.IndexedFrameIndex_builder{
+		Entries:             idxEntries,
+		TotalRawSize:        totalRaw,
+		TotalCompressedSize: totalComp,
+		ManifestXxh64:       manifestXXH64,
+	}.Build())
+	if err != nil {
+		return stats, err
+	}
+	if len(ib) > maxIndexedIndexBytes {
+		return stats, fmt.Errorf("c1z v3: trailer index is %d bytes, exceeds %d", len(ib), maxIndexedIndexBytes)
+	}
+	indexOff := payloadStart + cw.n
+	if _, err := cw.Write(ib); err != nil {
+		return stats, err
+	}
+	var footer [indexedFooterLen]byte
+	binary.BigEndian.PutUint64(footer[0:8], uint64(indexOff)) //nolint:gosec // file offsets are non-negative.
+	binary.BigEndian.PutUint32(footer[8:12], uint32(len(ib))) //nolint:gosec // capped at maxIndexedIndexBytes above.
+	binary.BigEndian.PutUint64(footer[12:20], xxhash.Sum64(ib))
+	copy(footer[20:28], indexedFooterMagic)
+	if _, err := cw.Write(footer[:]); err != nil {
 		return stats, err
 	}
 	return stats, nil
@@ -322,68 +403,133 @@ func (w budgetedFrameWriter) Write(p []byte) (int, error) {
 	return n, nil
 }
 
-// scanIndexedEntries reads the frame headers without touching frame
-// bytes: one small read per entry plus a relative seek over the
-// compressed data.
-func scanIndexedEntries(f *os.File, payloadStart int64) ([]*ReuseEntry, error) {
-	if _, err := f.Seek(payloadStart, io.SeekStart); err != nil {
-		return nil, err
+// readIndexedTrailer reads the trailer index — the payload's only
+// frame table — without touching any frame bytes: one pread for the
+// fixed-size footer, one for the index. This is the O(1)-round-trip
+// shape that scales to ranged reads over object storage.
+//
+// A missing or mangled footer is corruption-class
+// (ErrEnvelopeTruncated): there is no other framing to fall back to,
+// by design, and the caller's corruption classifier should
+// invalidate the file and trigger a resync.
+func readIndexedTrailer(f *os.File, payloadStart int64) (*c1zv3.IndexedFrameIndex, []*ReuseEntry, error) {
+	st, err := f.Stat()
+	if err != nil {
+		return nil, nil, err
 	}
-	r := f
-	var entries []*ReuseEntry
-	var lenBuf [4]byte
-	var tail [indexedEntryFixedTail]byte
-	nameBuf := make([]byte, 0, 256)
-	for {
-		if _, err := io.ReadFull(r, lenBuf[:]); err != nil {
-			return nil, fmt.Errorf("%w: indexed entry header: %w", ErrEnvelopeTruncated, err)
+	size := st.Size()
+	if size < payloadStart+indexedFooterLen {
+		return nil, nil, fmt.Errorf("%w: indexed payload too small for trailer footer", ErrEnvelopeTruncated)
+	}
+	var footer [indexedFooterLen]byte
+	if _, err := f.ReadAt(footer[:], size-indexedFooterLen); err != nil {
+		return nil, nil, err
+	}
+	if !bytes.Equal(footer[20:28], indexedFooterMagic) {
+		return nil, nil, fmt.Errorf("%w: indexed payload trailer magic missing (truncated file, or not an indexed payload)", ErrEnvelopeTruncated)
+	}
+	indexOff := int64(binary.BigEndian.Uint64(footer[0:8]))  //nolint:gosec // bounds-checked against the file size below.
+	indexLen := int64(binary.BigEndian.Uint32(footer[8:12])) // u32, cannot overflow int64.
+	if indexLen > maxIndexedIndexBytes {
+		return nil, nil, fmt.Errorf("c1z v3: trailer index claims %d bytes, exceeds cap %d", indexLen, maxIndexedIndexBytes)
+	}
+	if indexOff < payloadStart || indexOff+indexLen+indexedFooterLen != size {
+		return nil, nil, fmt.Errorf("c1z v3: trailer index does not fit the file (off=%d len=%d size=%d)", indexOff, indexLen, size)
+	}
+	ib := make([]byte, indexLen)
+	if _, err := f.ReadAt(ib, indexOff); err != nil {
+		return nil, nil, fmt.Errorf("%w: trailer index: %w", ErrEnvelopeTruncated, err)
+	}
+	if got, want := xxhash.Sum64(ib), binary.BigEndian.Uint64(footer[12:20]); got != want {
+		return nil, nil, errors.New("c1z v3: trailer index hash mismatch (corrupt index)")
+	}
+	idx := &c1zv3.IndexedFrameIndex{}
+	if err := proto.Unmarshal(ib, idx); err != nil {
+		return nil, nil, fmt.Errorf("c1z v3: unmarshal trailer index: %w", err)
+	}
+	entries := make([]*ReuseEntry, 0, len(idx.GetEntries()))
+	seen := make(map[string]struct{}, len(idx.GetEntries()))
+	for _, e := range idx.GetEntries() {
+		name := e.GetName()
+		if name == "" || len(name) > maxIndexedNameBytes {
+			return nil, nil, fmt.Errorf("c1z v3: trailer index entry name invalid: %q", name)
 		}
-		nameLen := binary.BigEndian.Uint32(lenBuf[:])
-		if nameLen == 0 {
-			return entries, nil
+		// Duplicate names would have parallel extraction workers
+		// racing writes to the same target file.
+		if _, dup := seen[name]; dup {
+			return nil, nil, fmt.Errorf("c1z v3: trailer index has duplicate entry %q", name)
 		}
-		if nameLen > maxIndexedNameBytes {
-			return nil, fmt.Errorf("c1z v3: indexed entry name length %d exceeds cap", nameLen)
+		seen[name] = struct{}{}
+		// rawSize 0 is legal (empty payload file), but compSize must be
+		// positive: WithZeroFrames guarantees even an empty file encodes
+		// to a complete zstd frame, so a zero-length frame range can
+		// only come from a corrupt or hand-mangled index.
+		rawSize, compSize := e.GetRawSize(), e.GetCompressedSize()
+		if rawSize < 0 || rawSize > maxTarEntryBytes || compSize <= 0 || compSize > maxTarEntryBytes {
+			return nil, nil, fmt.Errorf("c1z v3: trailer index entry %q sizes out of range (raw=%d comp=%d)", name, rawSize, compSize)
 		}
-		if cap(nameBuf) < int(nameLen) {
-			nameBuf = make([]byte, nameLen)
+		off := e.GetFrameOffset()
+		if off < payloadStart || off+compSize > indexOff {
+			return nil, nil, fmt.Errorf("c1z v3: trailer index entry %q frame range out of bounds (off=%d comp=%d)", name, off, compSize)
 		}
-		nameBuf = nameBuf[:nameLen]
-		if _, err := io.ReadFull(r, nameBuf); err != nil {
-			return nil, fmt.Errorf("%w: indexed entry name: %w", ErrEnvelopeTruncated, err)
-		}
-		if _, err := io.ReadFull(r, tail[:]); err != nil {
-			return nil, fmt.Errorf("%w: indexed entry sizes: %w", ErrEnvelopeTruncated, err)
-		}
-		rawSize := int64(binary.BigEndian.Uint64(tail[0:8]))    //nolint:gosec // validated below.
-		compSize := int64(binary.BigEndian.Uint64(tail[16:24])) //nolint:gosec // validated below.
-		if rawSize < 0 || rawSize > maxTarEntryBytes || compSize < 0 || compSize > maxTarEntryBytes {
-			return nil, fmt.Errorf("c1z v3: indexed entry %q sizes out of range (raw=%d comp=%d)", nameBuf, rawSize, compSize)
-		}
-		offset, err := f.Seek(0, io.SeekCurrent)
-		if err != nil {
-			return nil, err
+		if len(e.GetRawSha256()) != sha256.Size {
+			return nil, nil, fmt.Errorf("c1z v3: trailer index entry %q sha256 is %d bytes, want %d", name, len(e.GetRawSha256()), sha256.Size)
 		}
 		entries = append(entries, &ReuseEntry{
-			Name:           string(nameBuf),
-			FrameOffset:    offset,
+			Name:           name,
+			FrameOffset:    off,
 			CompressedSize: compSize,
 			RawSize:        rawSize,
-			XXH64:          binary.BigEndian.Uint64(tail[8:16]),
+			XXH64:          e.GetRawXxh64(),
+			SHA256:         e.GetRawSha256(),
 		})
-		if _, err := f.Seek(compSize, io.SeekCurrent); err != nil {
-			return nil, err
-		}
 	}
+	return idx, entries, nil
+}
+
+// ReadIndexedFrameIndex returns the frame table of an INDEXED_ZSTD
+// envelope using three small preads (head, footer, index) — no frame
+// bytes are read and the manifest body is never parsed. This is the
+// planning primitive for chunked object storage: every frame's name,
+// absolute byte range, sizes, and content identity (SHA-256 of raw
+// bytes), plus payload totals, without rematerializing the store.
+//
+// Frame offsets are absolute file offsets, so entries can drive
+// ranged reads (or object reassembly) directly. Returns
+// ErrEnvelopeTruncated-wrapped errors for missing trailers and
+// explicit errors for corrupt ones; returns an error for non-v3
+// files. The caller retains ownership of f.
+func ReadIndexedFrameIndex(f *os.File) (*c1zv3.IndexedFrameIndex, error) {
+	head := make([]byte, len(C1Z3Magic)+4)
+	if _, err := f.ReadAt(head, 0); err != nil {
+		return nil, fmt.Errorf("%w: reading magic: %w", ErrEnvelopeTruncated, err)
+	}
+	if !bytes.Equal(head[:len(C1Z3Magic)], C1Z3Magic) {
+		return nil, ErrInvalidV3Magic
+	}
+	mlen := binary.BigEndian.Uint32(head[len(C1Z3Magic):])
+	if mlen > maxManifestBytes {
+		return nil, fmt.Errorf("c1z v3: manifest claims %d bytes, exceeds cap %d", mlen, maxManifestBytes)
+	}
+	payloadStart := int64(len(C1Z3Magic)) + 4 + int64(mlen)
+	idx, _, err := readIndexedTrailer(f, payloadStart)
+	return idx, err
 }
 
 // extractIndexedZstd materializes an indexed payload into destDir,
 // decoding frames in parallel. Returns the PayloadReuse map so a later
-// save can splice unchanged frames.
-func extractIndexedZstd(f *os.File, payloadStart int64, destDir string, maxDecodedBytes uint64, maxMemoryBytes uint64, disableSizeFailFast bool) (*PayloadReuse, error) {
-	entries, err := scanIndexedEntries(f, payloadStart)
+// save can splice unchanged frames. manifestXXH64 is the hash of the
+// manifest bytes the caller just read; it is checked against the hash
+// the index recorded at write time, closing the envelope-head
+// integrity gap (header-only manifest decode skips the descriptor
+// closure, so a flipped bit there would otherwise go unnoticed).
+func extractIndexedZstd(f *os.File, payloadStart int64, manifestXXH64 uint64, destDir string, maxDecodedBytes uint64, maxMemoryBytes uint64, disableSizeFailFast bool) (*PayloadReuse, error) {
+	idx, entries, err := readIndexedTrailer(f, payloadStart)
 	if err != nil {
 		return nil, err
+	}
+	if h := idx.GetManifestXxh64(); h != 0 && h != manifestXXH64 {
+		return nil, fmt.Errorf("c1z v3: manifest bytes hash mismatch (index records %016x, head hashes to %016x): corrupt envelope head", h, manifestXXH64)
 	}
 	if !disableSizeFailFast {
 		var totalRaw uint64
@@ -424,12 +570,14 @@ func extractIndexedZstd(f *os.File, payloadStart int64, destDir string, maxDecod
 	var wg sync.WaitGroup
 	var firstErr error
 	var errMu sync.Mutex
+	var failed atomic.Bool
 	setErr := func(err error) {
 		errMu.Lock()
 		if firstErr == nil {
 			firstErr = err
 		}
 		errMu.Unlock()
+		failed.Store(true)
 	}
 	wg.Add(workers)
 	for i := 0; i < workers; i++ {
@@ -445,6 +593,12 @@ func extractIndexedZstd(f *os.File, payloadStart int64, destDir string, maxDecod
 			}
 			defer dec.Close()
 			for e := range jobs {
+				// The whole extraction fails on firstErr, so once any
+				// worker has failed, drain the queue instead of decoding
+				// frames whose output will be discarded.
+				if failed.Load() {
+					continue
+				}
 				if err := extractOneFrame(f, e, dec, budget); err != nil {
 					setErr(fmt.Errorf("c1z v3: extract %q: %w", e.Name, err))
 				}
@@ -525,7 +679,7 @@ func ExtractEnvelopePayload(f *os.File, destDir string, opts ...PayloadOption) (
 	payloadStart := int64(len(C1Z3Magic)) + 4 + int64(len(mb))
 	switch m.GetPayloadEncoding() {
 	case c1zv3.PayloadEncoding_PAYLOAD_ENCODING_INDEXED_ZSTD:
-		reuse, err := extractIndexedZstd(f, payloadStart, destDir, cfg.maxDecodedPayloadBytes, cfg.maxDecoderMemoryBytes, cfg.disableSizeFailFast)
+		reuse, err := extractIndexedZstd(f, payloadStart, xxhash.Sum64(mb), destDir, cfg.maxDecodedPayloadBytes, cfg.maxDecoderMemoryBytes, cfg.disableSizeFailFast)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/dotc1z/format/v3/indexed_bench_test.go
+++ b/pkg/dotc1z/format/v3/indexed_bench_test.go
@@ -1,0 +1,213 @@
+package v3
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	c1zv3 "github.com/conductorone/baton-sdk/pb/c1/c1z/v3"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/types/descriptorpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// benchPayloadDir writes n files of size bytes each. Content is
+// half-compressible (random first half mirrored into the second) so
+// the zstd encoder does representative work — all-random data turns
+// the encoder into a memcpy and all-zero data overstates it.
+func benchPayloadDir(b *testing.B, n, size int) string {
+	b.Helper()
+	dir := b.TempDir()
+	rng := rand.New(rand.NewSource(1)) //nolint:gosec // deterministic bench data.
+	buf := make([]byte, size)
+	for i := range n {
+		half := buf[:size/2]
+		_, _ = rng.Read(half)
+		copy(buf[size/2:], half)
+		name := filepath.Join(dir, fmt.Sprintf("%06d.sst", i+1))
+		if err := os.WriteFile(name, buf, 0o600); err != nil {
+			b.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func benchEnvelope(b *testing.B, dir string) string {
+	b.Helper()
+	envPath := filepath.Join(b.TempDir(), "bench.c1z")
+	out, err := os.Create(envPath)
+	if err != nil {
+		b.Fatal(err)
+	}
+	if _, err := WriteEnvelopeWithReuse(out, indexedManifest(), dir, nil); err != nil {
+		b.Fatal(err)
+	}
+	if err := out.Close(); err != nil {
+		b.Fatal(err)
+	}
+	return envPath
+}
+
+// BenchmarkReadIndexedFrameIndex measures the chunk-planning
+// primitive at a production-shaped frame count: the whole frame table
+// (names, ranges, hashes) from three preads, no frame bytes touched.
+func BenchmarkReadIndexedFrameIndex(b *testing.B) {
+	dir := benchPayloadDir(b, 1024, 4<<10)
+	envPath := benchEnvelope(b, dir)
+	f, err := os.Open(envPath)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer f.Close()
+	b.ReportAllocs()
+	for b.Loop() {
+		idx, err := ReadIndexedFrameIndex(f)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(idx.GetEntries()) != 1024 {
+			b.Fatalf("entries = %d", len(idx.GetEntries()))
+		}
+	}
+}
+
+// BenchmarkIndexedWriteFresh is the cold-save path: every frame is
+// compressed (and xxh64+SHA-256 hashed). The single-pass writer needs
+// no seeking, so the sink is io.Discard.
+func BenchmarkIndexedWriteFresh(b *testing.B) {
+	const n, size = 32, 256 << 10
+	dir := benchPayloadDir(b, n, size)
+	b.SetBytes(int64(n * size))
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := WriteEnvelopeWithReuse(io.Discard, indexedManifest(), dir, nil); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkIndexedWriteSpliced is the incremental-save path: every
+// frame matches the source envelope via the os.SameFile fast path and
+// is copied as compressed bytes. The fresh/spliced delta is the win
+// the fold compactor (and a chunked uploader) banks on.
+func BenchmarkIndexedWriteSpliced(b *testing.B) {
+	const n, size = 32, 256 << 10
+	dir := benchPayloadDir(b, n, size)
+	envPath := benchEnvelope(b, dir)
+
+	f, err := os.Open(envPath)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer f.Close()
+	extracted := b.TempDir()
+	_, reuse, err := ExtractEnvelopePayload(f, extracted)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.SetBytes(int64(n * size))
+	b.ReportAllocs()
+	for b.Loop() {
+		stats, err := WriteEnvelopeWithReuse(io.Discard, indexedManifest(), extracted, reuse)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if stats.SplicedFrames != n {
+			b.Fatalf("spliced %d frames, want %d", stats.SplicedFrames, n)
+		}
+	}
+}
+
+// BenchmarkIndexedExtract is the open path: parallel pread +
+// decompress of every frame into a fresh directory.
+func BenchmarkIndexedExtract(b *testing.B) {
+	const n, size = 64, 64 << 10
+	dir := benchPayloadDir(b, n, size)
+	envPath := benchEnvelope(b, dir)
+	f, err := os.Open(envPath)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer f.Close()
+
+	root := b.TempDir()
+	i := 0
+	b.SetBytes(int64(n * size))
+	b.ReportAllocs()
+	for b.Loop() {
+		dest := filepath.Join(root, strconv.Itoa(i))
+		i++
+		if err := os.Mkdir(dest, 0o755); err != nil {
+			b.Fatal(err)
+		}
+		if _, _, err := ExtractEnvelopePayload(f, dest); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// benchManifestHead builds a realistic envelope head: a manifest
+// carrying a full descriptor closure (every linked proto file, the
+// dominant manifest cost) and the single sync run the pebble contract
+// allows, prefixed by the v3 magic and length.
+func benchManifestHead(b *testing.B) []byte {
+	b.Helper()
+	fds := &descriptorpb.FileDescriptorSet{}
+	protoregistry.GlobalFiles.RangeFiles(func(fd protoreflect.FileDescriptor) bool {
+		fds.File = append(fds.File, protodesc.ToFileDescriptorProto(fd))
+		return true
+	})
+	now := time.Now()
+	m := c1zv3.C1ZManifestV3_builder{
+		Engine:              "pebble",
+		EngineSchemaVersion: 1,
+		PayloadEncoding:     c1zv3.PayloadEncoding_PAYLOAD_ENCODING_INDEXED_ZSTD,
+		Descriptors:         fds,
+		SyncRuns: []*c1zv3.SyncRunSummary{
+			c1zv3.SyncRunSummary_builder{
+				SyncId:    "01J0000000000000000000SYNC",
+				StartedAt: timestamppb.New(now.Add(-time.Minute)),
+				EndedAt:   timestamppb.New(now),
+			}.Build(),
+		},
+	}.Build()
+	mb, err := MarshalManifest(m)
+	if err != nil {
+		b.Fatal(err)
+	}
+	head := bytes.NewBuffer(nil)
+	_, _ = head.Write(C1Z3Magic)
+	var lenBuf [4]byte
+	binary.BigEndian.PutUint32(lenBuf[:], uint32(len(mb))) //nolint:gosec // bench manifest is small.
+	_, _ = head.Write(lenBuf[:])
+	_, _ = head.Write(mb)
+	return head.Bytes()
+}
+
+// BenchmarkReadManifestHeader measures the header-only open path:
+// the hand-rolled field skip must stay cheap even though the manifest
+// bytes are dominated by the descriptor closure it never decodes.
+func BenchmarkReadManifestHeader(b *testing.B) {
+	head := benchManifestHead(b)
+	b.SetBytes(int64(len(head)))
+	b.ReportAllocs()
+	for b.Loop() {
+		m, err := ReadManifestHeader(bytes.NewReader(head))
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(m.GetSyncRuns()) != 1 {
+			b.Fatal("sync runs not decoded")
+		}
+	}
+}

--- a/pkg/dotc1z/format/v3/indexed_test.go
+++ b/pkg/dotc1z/format/v3/indexed_test.go
@@ -3,13 +3,20 @@ package v3
 import (
 	"bytes"
 	"crypto/rand"
+	"crypto/sha256"
+	"encoding/binary"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/cespare/xxhash/v2"
 	c1zv3 "github.com/conductorone/baton-sdk/pb/c1/c1z/v3"
 	"github.com/klauspost/compress/zstd"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
 )
 
 func writeTestPayloadDir(t *testing.T, files map[string][]byte) string {
@@ -41,6 +48,24 @@ func randomBytes(t *testing.T, n int) []byte {
 		t.Fatal(err)
 	}
 	return b
+}
+
+// writeIndexedEnvelope writes an indexed envelope for dir into a temp
+// file and returns its path.
+func writeIndexedEnvelope(t *testing.T, dir string) string {
+	t.Helper()
+	envPath := filepath.Join(t.TempDir(), "indexed.c1z")
+	out, err := os.Create(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := WriteEnvelopeWithReuse(out, indexedManifest(), dir, nil); err != nil {
+		t.Fatalf("WriteEnvelopeWithReuse: %v", err)
+	}
+	if err := out.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return envPath
 }
 
 // TestIndexedRoundTrip writes an indexed envelope and extracts it,
@@ -369,12 +394,452 @@ func TestIndexedSpliceHashFallback(t *testing.T) {
 	}
 }
 
-// TestIndexedRequiresSeekableWriter locks in the WriteSeeker
-// requirement for the indexed encoding.
-func TestIndexedRequiresSeekableWriter(t *testing.T) {
-	var buf bytes.Buffer
-	_, err := WriteEnvelopeWithReuse(&buf, indexedManifest(), t.TempDir(), nil)
-	if err == nil {
-		t.Fatal("expected error for non-seekable writer")
+// writerOnly hides every method except Write, modeling a non-seekable
+// network sink.
+type writerOnly struct{ io.Writer }
+
+// TestIndexedStreamingWrite locks in the single-pass property: the
+// indexed encoding must accept a non-seekable writer (nothing is
+// backpatched), and the result must extract byte-identically. This is
+// the "encode straight to an upload" path.
+func TestIndexedStreamingWrite(t *testing.T) {
+	files := map[string][]byte{
+		"000001.sst": randomBytes(t, 64<<10),
+		"000002.sst": randomBytes(t, 8<<10),
+	}
+	dir := writeTestPayloadDir(t, files)
+
+	envPath := filepath.Join(t.TempDir(), "streamed.c1z")
+	out, err := os.Create(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := WriteEnvelopeWithReuse(writerOnly{out}, indexedManifest(), dir, nil); err != nil {
+		t.Fatalf("WriteEnvelopeWithReuse via non-seekable writer: %v", err)
+	}
+	if err := out.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := os.Open(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	dest := t.TempDir()
+	if _, _, err := ExtractEnvelopePayload(f, dest); err != nil {
+		t.Fatalf("ExtractEnvelopePayload: %v", err)
+	}
+	for name, want := range files {
+		got, err := os.ReadFile(filepath.Join(dest, name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Fatalf("%s: content mismatch", name)
+		}
+	}
+}
+
+// TestIndexedFrameIndex exercises the trailer as the chunk-store
+// planning primitive: ReadIndexedFrameIndex must return every frame's
+// name, byte range, sizes, hashes, and payload totals — and each byte
+// range must be independently decodable as a bare zstd stream with
+// Frame_Content_Size advertised (the standalone-object property).
+func TestIndexedFrameIndex(t *testing.T) {
+	files := map[string][]byte{
+		"000001.sst":      randomBytes(t, 128<<10),
+		"000002.sst":      randomBytes(t, 4<<10),
+		"MANIFEST-000001": []byte("manifest contents"),
+		"empty.log":       {},
+	}
+	dir := writeTestPayloadDir(t, files)
+	envPath := writeIndexedEnvelope(t, dir)
+
+	f, err := os.Open(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	idx, err := ReadIndexedFrameIndex(f)
+	if err != nil {
+		t.Fatalf("ReadIndexedFrameIndex: %v", err)
+	}
+	if len(idx.GetEntries()) != len(files) {
+		t.Fatalf("index has %d entries, want %d", len(idx.GetEntries()), len(files))
+	}
+
+	dec, err := zstd.NewReader(nil, zstd.WithDecoderConcurrency(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dec.Close()
+
+	var totalRaw, totalComp int64
+	for _, e := range idx.GetEntries() {
+		want, ok := files[e.GetName()]
+		if !ok {
+			t.Fatalf("index names unknown frame %q", e.GetName())
+		}
+		if e.GetRawSize() != int64(len(want)) {
+			t.Fatalf("%s: raw size %d, want %d", e.GetName(), e.GetRawSize(), len(want))
+		}
+		wantSha := sha256.Sum256(want)
+		if !bytes.Equal(e.GetRawSha256(), wantSha[:]) {
+			t.Fatalf("%s: sha256 mismatch", e.GetName())
+		}
+
+		// The byte range alone must be a complete, standalone zstd
+		// stream — exactly what a chunk store preads or PUTs. Even
+		// zero-length files must produce a real frame (WithZeroFrames),
+		// or their chunk objects would be undecodable.
+		if e.GetCompressedSize() <= 0 {
+			t.Fatalf("%s: frame is empty (compressed size %d)", e.GetName(), e.GetCompressedSize())
+		}
+		frame := make([]byte, e.GetCompressedSize())
+		if _, err := f.ReadAt(frame, e.GetFrameOffset()); err != nil {
+			t.Fatalf("%s: pread frame: %v", e.GetName(), err)
+		}
+		// FCS is advertised for frames >= 256 bytes; the zstd frame
+		// header cannot represent smaller sizes without the
+		// single-segment flag, which the encoder only sets for
+		// mid-sized payloads. raw_size in the index is authoritative
+		// either way.
+		if len(want) >= 256 {
+			var hdr zstd.Header
+			if err := hdr.Decode(frame); err != nil {
+				t.Fatalf("%s: decode frame header: %v", e.GetName(), err)
+			}
+			if !hdr.HasFCS || hdr.FrameContentSize != uint64(len(want)) {
+				t.Fatalf("%s: FCS missing or wrong (has=%v fcs=%d want=%d)", e.GetName(), hdr.HasFCS, hdr.FrameContentSize, len(want))
+			}
+		}
+		if err := dec.Reset(bytes.NewReader(frame)); err != nil {
+			t.Fatal(err)
+		}
+		got, err := io.ReadAll(dec)
+		if err != nil {
+			t.Fatalf("%s: standalone decode: %v", e.GetName(), err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Fatalf("%s: standalone decode mismatch (%d vs %d bytes)", e.GetName(), len(got), len(want))
+		}
+		totalRaw += e.GetRawSize()
+		totalComp += e.GetCompressedSize()
+	}
+	if idx.GetTotalRawSize() != totalRaw {
+		t.Fatalf("total raw = %d, entries sum to %d", idx.GetTotalRawSize(), totalRaw)
+	}
+	if idx.GetTotalCompressedSize() != totalComp {
+		t.Fatalf("total compressed = %d, entries sum to %d", idx.GetTotalCompressedSize(), totalComp)
+	}
+}
+
+// TestIndexedTrailerCorruption covers the corruption-class failure
+// modes: a truncated footer, a flipped index byte (caught by the
+// footer's xxh64 of the index), and a flipped frame byte (caught at
+// extract).
+func TestIndexedTrailerCorruption(t *testing.T) {
+	content := randomBytes(t, 32<<10)
+	newEnv := func(t *testing.T) string {
+		dir := writeTestPayloadDir(t, map[string][]byte{"000001.sst": content})
+		return writeIndexedEnvelope(t, dir)
+	}
+	flipByteAt := func(t *testing.T, path string, off int64) {
+		t.Helper()
+		f, err := os.OpenFile(path, os.O_RDWR, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer f.Close()
+		var b [1]byte
+		if _, err := f.ReadAt(b[:], off); err != nil {
+			t.Fatal(err)
+		}
+		b[0] ^= 0xFF
+		if _, err := f.WriteAt(b[:], off); err != nil {
+			t.Fatal(err)
+		}
+	}
+	extract := func(t *testing.T, path string) error {
+		t.Helper()
+		f, err := os.Open(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer f.Close()
+		_, _, err = ExtractEnvelopePayload(f, t.TempDir())
+		return err
+	}
+
+	t.Run("truncated footer", func(t *testing.T) {
+		p := newEnv(t)
+		st, err := os.Stat(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Truncate(p, st.Size()-1); err != nil {
+			t.Fatal(err)
+		}
+		if err := extract(t, p); !errors.Is(err, ErrEnvelopeTruncated) {
+			t.Fatalf("error = %v, want ErrEnvelopeTruncated", err)
+		}
+	})
+
+	t.Run("corrupt index byte", func(t *testing.T) {
+		p := newEnv(t)
+		st, err := os.Stat(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		f, err := os.Open(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var footer [indexedFooterLen]byte
+		if _, err := f.ReadAt(footer[:], st.Size()-indexedFooterLen); err != nil {
+			t.Fatal(err)
+		}
+		f.Close()
+		indexOff := int64(binary.BigEndian.Uint64(footer[0:8])) //nolint:gosec // test reads back the offset our writer wrote.
+		flipByteAt(t, p, indexOff)
+		err = extract(t, p)
+		if err == nil || !strings.Contains(err.Error(), "hash mismatch") {
+			t.Fatalf("error = %v, want index hash mismatch", err)
+		}
+	})
+
+	// A flipped bit inside the manifest's descriptor closure is
+	// invisible to the header-only manifest decode (which skips that
+	// field) — the index's manifest hash must catch it.
+	t.Run("corrupt manifest byte", func(t *testing.T) {
+		dir := writeTestPayloadDir(t, map[string][]byte{"000001.sst": content})
+		sentinel := "zz-hash-sentinel.proto"
+		m := c1zv3.C1ZManifestV3_builder{
+			Engine:          "pebble",
+			PayloadEncoding: c1zv3.PayloadEncoding_PAYLOAD_ENCODING_INDEXED_ZSTD,
+			Descriptors: &descriptorpb.FileDescriptorSet{
+				File: []*descriptorpb.FileDescriptorProto{{Name: proto.String(sentinel)}},
+			},
+		}.Build()
+		p := filepath.Join(t.TempDir(), "m.c1z")
+		out, err := os.Create(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := WriteEnvelopeWithReuse(out, m, dir, nil); err != nil {
+			t.Fatal(err)
+		}
+		if err := out.Close(); err != nil {
+			t.Fatal(err)
+		}
+		raw, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		i := bytes.Index(raw, []byte(sentinel))
+		if i < 0 {
+			t.Fatal("sentinel not found in manifest bytes")
+		}
+		// Flip a content byte inside the sentinel string: the wire
+		// structure stays valid, only the bytes change.
+		flipByteAt(t, p, int64(i)+2)
+		err = extract(t, p)
+		if err == nil || !strings.Contains(err.Error(), "manifest bytes hash mismatch") {
+			t.Fatalf("error = %v, want manifest hash mismatch", err)
+		}
+	})
+
+	// rewriteTrailer rebuilds the envelope's trailer — mutated index,
+	// recomputed footer — so subtests can craft hostile-but-well-formed
+	// indexes that pass the footer hash and fail entry validation.
+	rewriteTrailer := func(t *testing.T, p string, mutate func(idx *c1zv3.IndexedFrameIndex)) {
+		t.Helper()
+		f, err := os.Open(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		idx, err := ReadIndexedFrameIndex(f)
+		_ = f.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		raw, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var footer [indexedFooterLen]byte
+		copy(footer[:], raw[len(raw)-indexedFooterLen:])
+		indexOff := int64(binary.BigEndian.Uint64(footer[0:8])) //nolint:gosec // offset our writer wrote.
+
+		mutate(idx)
+		ib, err := proto.Marshal(idx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		out := append([]byte{}, raw[:indexOff]...)
+		out = append(out, ib...)
+		binary.BigEndian.PutUint64(footer[0:8], uint64(indexOff)) //nolint:gosec // non-negative offset.
+		binary.BigEndian.PutUint32(footer[8:12], uint32(len(ib))) //nolint:gosec // small test index.
+		binary.BigEndian.PutUint64(footer[12:20], xxhash.Sum64(ib))
+		out = append(out, footer[:]...)
+		//nolint:gosec // p is a t.TempDir path created by this test.
+		if err := os.WriteFile(p, out, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// A well-formed footer over a hostile index with duplicate names
+	// must be rejected: duplicates would race parallel extraction
+	// workers onto the same target file.
+	t.Run("duplicate entry name", func(t *testing.T) {
+		p := newEnv(t)
+		rewriteTrailer(t, p, func(idx *c1zv3.IndexedFrameIndex) {
+			idx.SetEntries(append(idx.GetEntries(), idx.GetEntries()[0]))
+		})
+		err := extract(t, p)
+		if err == nil || !strings.Contains(err.Error(), "duplicate") {
+			t.Fatalf("error = %v, want duplicate entry rejection", err)
+		}
+	})
+
+	// compSize == 0 can't come from our writer (WithZeroFrames makes
+	// even empty files encode to a complete frame), so the reader
+	// treats it as index corruption.
+	t.Run("zero-length frame range", func(t *testing.T) {
+		p := newEnv(t)
+		rewriteTrailer(t, p, func(idx *c1zv3.IndexedFrameIndex) {
+			idx.GetEntries()[0].SetCompressedSize(0)
+		})
+		err := extract(t, p)
+		if err == nil || !strings.Contains(err.Error(), "sizes out of range") {
+			t.Fatalf("error = %v, want size-range rejection", err)
+		}
+	})
+
+	t.Run("corrupt frame byte", func(t *testing.T) {
+		p := newEnv(t)
+		f, err := os.Open(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		idx, err := ReadIndexedFrameIndex(f)
+		f.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		e := idx.GetEntries()[0]
+		flipByteAt(t, p, e.GetFrameOffset()+e.GetCompressedSize()/2)
+		if err := extract(t, p); err == nil {
+			t.Fatal("extraction of corrupt frame succeeded")
+		}
+	})
+}
+
+// TestIndexedSpliceCarriesSHA256 verifies content identities survive
+// the splice path: spliced frames keep their SHA-256 from the source
+// index, fresh frames get newly computed ones, and a reuse table with
+// missing identities forces recomputation rather than emitting empty
+// hashes.
+func TestIndexedSpliceCarriesSHA256(t *testing.T) {
+	files := map[string][]byte{
+		"000001.sst": randomBytes(t, 64<<10),
+		"000002.sst": randomBytes(t, 32<<10),
+	}
+	dir := writeTestPayloadDir(t, files)
+	srcPath := writeIndexedEnvelope(t, dir)
+
+	f, err := os.Open(srcPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	extracted := t.TempDir()
+	_, reuse, err := ExtractEnvelopePayload(f, extracted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range reuse.byName {
+		if len(e.SHA256) != sha256.Size {
+			t.Fatalf("%s: reuse entry missing sha256 from trailer", e.Name)
+		}
+	}
+	// Wipe the identities to model a caller-constructed reuse table:
+	// the writer must recompute, not emit empty hashes.
+	for _, e := range reuse.byName {
+		e.SHA256 = nil
+	}
+
+	checkpoint := t.TempDir()
+	for name := range files {
+		if err := os.Link(filepath.Join(extracted, name), filepath.Join(checkpoint, name)); err != nil {
+			t.Skipf("hard links unavailable on this filesystem: %v", err)
+		}
+	}
+	newSST := randomBytes(t, 16<<10)
+	if err := os.WriteFile(filepath.Join(checkpoint, "000003.sst"), newSST, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	dstPath := filepath.Join(t.TempDir(), "dst.c1z")
+	dst, err := os.Create(dstPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stats, err := WriteEnvelopeWithReuse(dst, indexedManifest(), checkpoint, reuse)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := dst.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if stats.SplicedFrames != 2 || stats.EncodedFrames != 1 {
+		t.Fatalf("stats = %+v, want 2 spliced / 1 encoded", stats)
+	}
+
+	expect := map[string][]byte{
+		"000001.sst": files["000001.sst"],
+		"000002.sst": files["000002.sst"],
+		"000003.sst": newSST,
+	}
+	df, err := os.Open(dstPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer df.Close()
+	idx, err := ReadIndexedFrameIndex(df)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(idx.GetEntries()) != len(expect) {
+		t.Fatalf("index has %d entries, want %d", len(idx.GetEntries()), len(expect))
+	}
+	for _, e := range idx.GetEntries() {
+		want := sha256.Sum256(expect[e.GetName()])
+		if !bytes.Equal(e.GetRawSha256(), want[:]) {
+			t.Fatalf("%s: sha256 mismatch in spliced envelope's index", e.GetName())
+		}
+	}
+}
+
+// TestIndexedEmptyPayload locks in the degenerate case: an envelope
+// with zero payload files still carries a valid (empty) index and
+// extracts cleanly.
+func TestIndexedEmptyPayload(t *testing.T) {
+	envPath := writeIndexedEnvelope(t, t.TempDir())
+	f, err := os.Open(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	idx, err := ReadIndexedFrameIndex(f)
+	if err != nil {
+		t.Fatalf("ReadIndexedFrameIndex: %v", err)
+	}
+	if len(idx.GetEntries()) != 0 || idx.GetTotalRawSize() != 0 || idx.GetTotalCompressedSize() != 0 {
+		t.Fatalf("empty payload index not empty: %v", idx)
+	}
+	if _, _, err := ExtractEnvelopePayload(f, t.TempDir()); err != nil {
+		t.Fatalf("ExtractEnvelopePayload: %v", err)
 	}
 }

--- a/pkg/dotc1z/format/v3/indexed_test.go
+++ b/pkg/dotc1z/format/v3/indexed_test.go
@@ -1,0 +1,380 @@
+package v3
+
+import (
+	"bytes"
+	"crypto/rand"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	c1zv3 "github.com/conductorone/baton-sdk/pb/c1/c1z/v3"
+	"github.com/klauspost/compress/zstd"
+)
+
+func writeTestPayloadDir(t *testing.T, files map[string][]byte) string {
+	t.Helper()
+	dir := t.TempDir()
+	for name, content := range files {
+		target := filepath.Join(dir, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(target, content, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func indexedManifest() *c1zv3.C1ZManifestV3 {
+	return c1zv3.C1ZManifestV3_builder{
+		Engine:          "pebble",
+		PayloadEncoding: c1zv3.PayloadEncoding_PAYLOAD_ENCODING_INDEXED_ZSTD,
+	}.Build()
+}
+
+func randomBytes(t *testing.T, n int) []byte {
+	t.Helper()
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+// TestIndexedRoundTrip writes an indexed envelope and extracts it,
+// verifying contents (including a nested path and an empty file) and
+// that the reuse table is populated.
+func TestIndexedRoundTrip(t *testing.T) {
+	files := map[string][]byte{
+		"000001.sst":      randomBytes(t, 256<<10),
+		"000002.sst":      randomBytes(t, 64),
+		"MANIFEST-000001": []byte("manifest contents"),
+		"empty.log":       {},
+		"nested/OPTIONS":  []byte("opts"),
+	}
+	dir := writeTestPayloadDir(t, files)
+
+	envPath := filepath.Join(t.TempDir(), "indexed.c1z")
+	out, err := os.Create(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stats, err := WriteEnvelopeWithReuse(out, indexedManifest(), dir, nil)
+	if err != nil {
+		t.Fatalf("WriteEnvelopeWithReuse: %v", err)
+	}
+	if err := out.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if stats.EncodedFrames != len(files) || stats.SplicedFrames != 0 {
+		t.Fatalf("stats = %+v, want %d encoded / 0 spliced", stats, len(files))
+	}
+
+	f, err := os.Open(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	dest := t.TempDir()
+	m, reuse, err := ExtractEnvelopePayload(f, dest)
+	if err != nil {
+		t.Fatalf("ExtractEnvelopePayload: %v", err)
+	}
+	if m.GetPayloadEncoding() != c1zv3.PayloadEncoding_PAYLOAD_ENCODING_INDEXED_ZSTD {
+		t.Fatalf("encoding = %v", m.GetPayloadEncoding())
+	}
+	if reuse == nil || len(reuse.byName) != len(files) {
+		t.Fatalf("reuse table missing or wrong size: %v", reuse)
+	}
+	for name, want := range files {
+		got, err := os.ReadFile(filepath.Join(dest, filepath.FromSlash(name)))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Fatalf("%s: content mismatch (%d vs %d bytes)", name, len(got), len(want))
+		}
+	}
+}
+
+func TestIndexedRespectsMaxDecodedPayloadLimit(t *testing.T) {
+	files := map[string][]byte{
+		"a.sst": randomBytes(t, 128),
+		"b.sst": randomBytes(t, 128),
+	}
+	dir := writeTestPayloadDir(t, files)
+	envPath := filepath.Join(t.TempDir(), "indexed.c1z")
+	out, err := os.Create(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := WriteEnvelopeWithReuse(out, indexedManifest(), dir, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := out.Close(); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Open(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	_, _, err = ExtractEnvelopePayload(f, t.TempDir(), WithMaxDecodedPayloadBytes(255))
+	if !errors.Is(err, ErrMaxSizeExceeded) {
+		t.Fatalf("ExtractEnvelopePayload error = %v, want ErrMaxSizeExceeded", err)
+	}
+}
+
+func TestIndexedDecodedPayloadFailFastKillSwitch(t *testing.T) {
+	files := map[string][]byte{
+		"a.sst": randomBytes(t, 128),
+		"b.sst": randomBytes(t, 128),
+	}
+	dir := writeTestPayloadDir(t, files)
+	envPath := filepath.Join(t.TempDir(), "indexed.c1z")
+	out, err := os.Create(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := WriteEnvelopeWithReuse(out, indexedManifest(), dir, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := out.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	orig := fcsFailFastDisabled
+	fcsFailFastDisabled = true
+	defer func() { fcsFailFastDisabled = orig }()
+
+	f, err := os.Open(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	_, _, err = ExtractEnvelopePayload(f, t.TempDir(), WithMaxDecodedPayloadBytes(255))
+	if !errors.Is(err, ErrMaxSizeExceeded) {
+		t.Fatalf("ExtractEnvelopePayload error = %v, want ErrMaxSizeExceeded", err)
+	}
+	if err != nil && bytes.Contains([]byte(err.Error()), []byte("indexed payload exceeds")) {
+		t.Fatalf("kill switch should avoid header-size fail-fast error, got %v", err)
+	}
+}
+
+func TestIndexedRespectsMaxDecodedPayloadEnv(t *testing.T) {
+	t.Setenv(maxDecodedSizeEnvVar, "1")
+	files := map[string][]byte{
+		"too-big.sst": randomBytes(t, 1<<20+1),
+	}
+	dir := writeTestPayloadDir(t, files)
+	envPath := filepath.Join(t.TempDir(), "indexed.c1z")
+	out, err := os.Create(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := WriteEnvelopeWithReuse(out, indexedManifest(), dir, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := out.Close(); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Open(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	_, _, err = ExtractEnvelopePayload(f, t.TempDir())
+	if !errors.Is(err, ErrMaxSizeExceeded) {
+		t.Fatalf("ExtractEnvelopePayload error = %v, want ErrMaxSizeExceeded", err)
+	}
+}
+
+func TestIndexedRespectsMaxDecoderMemory(t *testing.T) {
+	files := map[string][]byte{
+		"needs-window.sst": bytes.Repeat([]byte("0123456789abcdef"), 256<<10),
+	}
+	dir := writeTestPayloadDir(t, files)
+	envPath := filepath.Join(t.TempDir(), "indexed.c1z")
+	out, err := os.Create(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := WriteEnvelopeWithReuse(out, indexedManifest(), dir, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := out.Close(); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Open(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	_, _, err = ExtractEnvelopePayload(f, t.TempDir(), WithMaxDecoderMemoryBytes(1))
+	if !errors.Is(err, zstd.ErrWindowSizeExceeded) {
+		t.Fatalf("ExtractEnvelopePayload error = %v, want zstd.ErrWindowSizeExceeded", err)
+	}
+}
+
+// TestIndexedSpliceReuse models the fold save: extract an envelope,
+// hard-link most files into a "checkpoint" dir (what pebble's
+// checkpoint does for immutable SSTs), change one and add one, then
+// rewrite with reuse. Unchanged files must splice; changed/new files
+// must encode; the result must extract byte-identically.
+func TestIndexedSpliceReuse(t *testing.T) {
+	files := map[string][]byte{
+		"000001.sst":      randomBytes(t, 128<<10),
+		"000002.sst":      randomBytes(t, 96<<10),
+		"000003.sst":      randomBytes(t, 32<<10),
+		"MANIFEST-000001": []byte("old manifest"),
+	}
+	dir := writeTestPayloadDir(t, files)
+	srcPath := filepath.Join(t.TempDir(), "src.c1z")
+	out, err := os.Create(srcPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := WriteEnvelopeWithReuse(out, indexedManifest(), dir, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := out.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := os.Open(srcPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	extracted := t.TempDir()
+	_, reuse, err := ExtractEnvelopePayload(f, extracted)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Build the "checkpoint": hard links for the three SSTs, a
+	// rewritten MANIFEST, and a brand-new SST.
+	checkpoint := t.TempDir()
+	for _, name := range []string{"000001.sst", "000002.sst", "000003.sst"} {
+		if err := os.Link(filepath.Join(extracted, name), filepath.Join(checkpoint, name)); err != nil {
+			t.Skipf("hard links unavailable on this filesystem: %v", err)
+		}
+	}
+	newManifest := []byte("NEW manifest, longer than before")
+	if err := os.WriteFile(filepath.Join(checkpoint, "MANIFEST-000001"), newManifest, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	newSST := randomBytes(t, 16<<10)
+	if err := os.WriteFile(filepath.Join(checkpoint, "000004.sst"), newSST, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	dstPath := filepath.Join(t.TempDir(), "dst.c1z")
+	dst, err := os.Create(dstPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stats, err := WriteEnvelopeWithReuse(dst, indexedManifest(), checkpoint, reuse)
+	if err != nil {
+		t.Fatalf("WriteEnvelopeWithReuse: %v", err)
+	}
+	if err := dst.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if stats.SplicedFrames != 3 {
+		t.Fatalf("spliced frames = %d, want 3 (the hard-linked SSTs)", stats.SplicedFrames)
+	}
+	if stats.EncodedFrames != 2 {
+		t.Fatalf("encoded frames = %d, want 2 (new manifest + new sst)", stats.EncodedFrames)
+	}
+
+	df, err := os.Open(dstPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer df.Close()
+	dest := t.TempDir()
+	if _, _, err := ExtractEnvelopePayload(df, dest); err != nil {
+		t.Fatalf("extract spliced envelope: %v", err)
+	}
+	expect := map[string][]byte{
+		"000001.sst":      files["000001.sst"],
+		"000002.sst":      files["000002.sst"],
+		"000003.sst":      files["000003.sst"],
+		"MANIFEST-000001": newManifest,
+		"000004.sst":      newSST,
+	}
+	for name, want := range expect {
+		got, err := os.ReadFile(filepath.Join(dest, name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Fatalf("%s: content mismatch after splice", name)
+		}
+	}
+}
+
+// TestIndexedSpliceHashFallback covers the no-hard-link path: the
+// checkpoint file is a fresh copy (different inode), so SameFile
+// fails and the hash fallback must still splice it.
+func TestIndexedSpliceHashFallback(t *testing.T) {
+	content := randomBytes(t, 64<<10)
+	dir := writeTestPayloadDir(t, map[string][]byte{"000001.sst": content})
+	srcPath := filepath.Join(t.TempDir(), "src.c1z")
+	out, err := os.Create(srcPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := WriteEnvelopeWithReuse(out, indexedManifest(), dir, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := out.Close(); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Open(srcPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if _, _, err := ExtractEnvelopePayload(f, t.TempDir()); err != nil {
+		t.Fatal(err)
+	}
+	// Re-extract for the reuse table, then copy (not link) into the
+	// checkpoint dir so inodes differ.
+	if _, err := f.Seek(0, 0); err != nil {
+		t.Fatal(err)
+	}
+	_, reuse, err := ExtractEnvelopePayload(f, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkpoint := t.TempDir()
+	if err := os.WriteFile(filepath.Join(checkpoint, "000001.sst"), content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dst, err := os.Create(filepath.Join(t.TempDir(), "dst.c1z"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dst.Close()
+	stats, err := WriteEnvelopeWithReuse(dst, indexedManifest(), checkpoint, reuse)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.SplicedFrames != 1 || stats.EncodedFrames != 0 {
+		t.Fatalf("stats = %+v, want 1 spliced / 0 encoded via hash fallback", stats)
+	}
+}
+
+// TestIndexedRequiresSeekableWriter locks in the WriteSeeker
+// requirement for the indexed encoding.
+func TestIndexedRequiresSeekableWriter(t *testing.T) {
+	var buf bytes.Buffer
+	_, err := WriteEnvelopeWithReuse(&buf, indexedManifest(), t.TempDir(), nil)
+	if err == nil {
+		t.Fatal("expected error for non-seekable writer")
+	}
+}

--- a/pkg/dotc1z/metadata_test.go
+++ b/pkg/dotc1z/metadata_test.go
@@ -40,8 +40,8 @@ func TestStoreMetadata(t *testing.T) {
 		md := storeMetadata(t, store)
 		require.Equal(t, "pebble", md.Engine)
 		require.Equal(t, "v3", md.Format)
-		require.Equal(t, "tar_zstd", md.PayloadEncoding,
-			"default Pebble payload encoding is tar+zstd")
+		require.Equal(t, "indexed_zstd", md.PayloadEncoding,
+			"default Pebble payload encoding is per-file indexed zstd")
 	})
 
 	t.Run("Pebble with explicit Tar encoding reports tar", func(t *testing.T) {

--- a/pkg/dotc1z/pebble_store.go
+++ b/pkg/dotc1z/pebble_store.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
 
+	c1zv3 "github.com/conductorone/baton-sdk/pb/c1/c1z/v3"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble"
@@ -40,7 +41,8 @@ func (pebbleDriver) OpenStore(ctx context.Context, outputFilePath string, opts S
 	}
 
 	dbDir := filepath.Join(tmpDir, "db")
-	if err := unpackExistingPebbleC1Z(outputFilePath, dbDir, opts.DecoderPool); err != nil {
+	reuse, fileEncoding, err := unpackExistingPebbleC1Z(outputFilePath, dbDir, opts.MaxDecodedPayloadBytes, opts.MaxDecoderMemoryBytes, opts.DecoderPool)
+	if err != nil {
 		return nil, cleanupOnError(err)
 	}
 
@@ -48,50 +50,80 @@ func (pebbleDriver) OpenStore(ctx context.Context, outputFilePath string, opts S
 	if err != nil {
 		return nil, cleanupOnError(err)
 	}
+	encoding := opts.PayloadEncoding
+	if encoding == PayloadEncodingUnspecified {
+		encoding = fileEncoding
+	}
 	return &pebbleStore{
 		Adapter:         pebble.NewAdapter(e),
 		engine:          e,
 		outputFilePath:  outputFilePath,
 		tmpDir:          tmpDir,
 		readOnly:        opts.ReadOnly,
-		payloadEncoding: opts.PayloadEncoding,
+		payloadEncoding: encoding,
+		payloadReuse:    reuse,
 		syncLimit:       opts.SyncLimit,
 		skipCleanup:     opts.SkipCleanup,
 	}, nil
 }
 
-func unpackExistingPebbleC1Z(outputFilePath string, dbDir string, pool *EnvelopeDecoderPool) error {
+func unpackExistingPebbleC1Z(
+	outputFilePath string,
+	dbDir string,
+	maxDecodedPayloadBytes uint64,
+	maxDecoderMemoryBytes uint64,
+	pool *EnvelopeDecoderPool,
+) (*formatv3.PayloadReuse, PayloadEncoding, error) {
 	stat, err := os.Stat(outputFilePath)
 	switch {
 	case errors.Is(err, os.ErrNotExist):
-		return nil
+		return nil, PayloadEncodingUnspecified, nil
 	case err != nil:
-		return err
+		return nil, PayloadEncodingUnspecified, err
 	case stat.Size() == 0:
-		return nil
+		return nil, PayloadEncodingUnspecified, nil
 	}
 
 	f, err := os.Open(outputFilePath)
 	if err != nil {
-		return err
+		return nil, PayloadEncodingUnspecified, err
 	}
 	defer f.Close()
 
-	env, err := formatv3.ReadEnvelopeHeaderWithPool(f, pool)
+	header, err := formatv3.ReadManifestHeader(f)
 	if err != nil {
-		return err
+		return nil, PayloadEncodingUnspecified, err
 	}
-	defer env.Close()
-	if Engine(env.Manifest.GetEngine()) != EnginePebble {
-		return fmt.Errorf("%w: %s", pebble.ErrUnknownEngine, env.Manifest.GetEngine())
+	if Engine(header.GetEngine()) != EnginePebble {
+		return nil, PayloadEncodingUnspecified, fmt.Errorf("%w: %s", pebble.ErrUnknownEngine, header.GetEngine())
 	}
 	if err := os.MkdirAll(dbDir, 0o755); err != nil {
-		return err
+		return nil, PayloadEncodingUnspecified, err
 	}
-	if err := formatv3.ExtractZstdTar(env.PayloadReader, dbDir); err != nil {
-		return err
+	manifest, reuse, err := formatv3.ExtractEnvelopePayload(f, dbDir,
+		formatv3.WithMaxDecodedPayloadBytes(maxDecodedPayloadBytes),
+		formatv3.WithMaxDecoderMemoryBytes(maxDecoderMemoryBytes),
+		formatv3.WithPayloadDecoderPool(pool),
+	)
+	if err != nil {
+		return nil, PayloadEncodingUnspecified, err
 	}
-	return nil
+	return reuse, payloadEncodingFromProto(manifest.GetPayloadEncoding()), nil
+}
+
+func payloadEncodingFromProto(enc c1zv3.PayloadEncoding) PayloadEncoding {
+	switch enc {
+	case c1zv3.PayloadEncoding_PAYLOAD_ENCODING_TAR:
+		return PayloadEncodingTar
+	case c1zv3.PayloadEncoding_PAYLOAD_ENCODING_INDEXED_ZSTD:
+		return PayloadEncodingIndexedZstd
+	case c1zv3.PayloadEncoding_PAYLOAD_ENCODING_TAR_ZSTD:
+		return PayloadEncodingTarZstd
+	case c1zv3.PayloadEncoding_PAYLOAD_ENCODING_UNSPECIFIED:
+		return PayloadEncodingUnspecified
+	default:
+		return PayloadEncodingUnspecified
+	}
 }
 
 type pebbleStore struct {
@@ -101,6 +133,7 @@ type pebbleStore struct {
 	tmpDir          string
 	readOnly        bool
 	payloadEncoding PayloadEncoding
+	payloadReuse    *formatv3.PayloadReuse
 
 	// syncLimit and skipCleanup mirror StoreOptions and feed into
 	// Cleanup. The Adapter intentionally has no awareness of these
@@ -161,14 +194,14 @@ func (f pebbleStoreFileOps) GenerateSyncDiff(ctx context.Context, baseSyncID, ap
 // (not the inner Adapter) because it's a writer-side option threaded
 // through the envelope, not a property of the Pebble engine itself.
 //
-// Unspecified is resolved to the engine's effective default (TarZstd
+// Unspecified is resolved to the engine's effective default (IndexedZstd
 // — see pebble.BuildManifest). Callers see the value the writer
 // will actually use, not the literal option supplied.
 func (s *pebbleStore) Metadata() connectorstore.StoreMetadata {
 	md := s.Adapter.Metadata()
 	enc := s.payloadEncoding
 	if enc == PayloadEncodingUnspecified {
-		enc = PayloadEncodingTarZstd
+		enc = PayloadEncodingIndexedZstd
 	}
 	md.PayloadEncoding = enc.String()
 	return md
@@ -233,11 +266,20 @@ func (s *pebbleStore) NormalizeForFixtureSave(ctx context.Context, syncID string
 	return nil
 }
 
+func (s *pebbleStore) MarkDirty() {
+	if s == nil {
+		return
+	}
+	s.closeMu.Lock()
+	if !s.closed {
+		s.dirty = true
+	}
+	s.closeMu.Unlock()
+}
+
 func (s *pebbleStore) markDirty(err error) error {
 	if err == nil {
-		s.closeMu.Lock()
-		s.dirty = true
-		s.closeMu.Unlock()
+		s.MarkDirty()
 	}
 	return err
 }
@@ -535,7 +577,7 @@ func (s *pebbleStore) save(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	if err := formatv3.WriteEnvelope(out, manifest, checkpointDir); err != nil {
+	if _, err := formatv3.WriteEnvelopeWithReuse(out, manifest, checkpointDir, s.payloadReuse); err != nil {
 		return err
 	}
 	if err := out.Sync(); err != nil {

--- a/pkg/dotc1z/pebble_store_registry_test.go
+++ b/pkg/dotc1z/pebble_store_registry_test.go
@@ -3,6 +3,7 @@ package dotc1z
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,6 +14,7 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble"
 	formatv3 "github.com/conductorone/baton-sdk/pkg/dotc1z/format/v3"
+	"github.com/klauspost/compress/zstd"
 )
 
 func c1zFormat(path string) (C1ZFormat, error) {
@@ -67,8 +69,8 @@ func TestRegisteredPebbleNewStoreRoundtrip(t *testing.T) {
 	if env.Manifest.GetEngineSchemaVersion() != uint32(pebble.SDKPebbleFormat) {
 		t.Fatalf("manifest schema = %d, want %d", env.Manifest.GetEngineSchemaVersion(), pebble.SDKPebbleFormat)
 	}
-	if env.Manifest.GetPayloadEncoding() != c1zv3.PayloadEncoding_PAYLOAD_ENCODING_TAR_ZSTD {
-		t.Fatalf("payload encoding = %v, want tar_zstd", env.Manifest.GetPayloadEncoding())
+	if env.Manifest.GetPayloadEncoding() != c1zv3.PayloadEncoding_PAYLOAD_ENCODING_INDEXED_ZSTD {
+		t.Fatalf("payload encoding = %v, want indexed_zstd (engine default)", env.Manifest.GetPayloadEncoding())
 	}
 	if env.Manifest.GetDescriptors() == nil || len(env.Manifest.GetDescriptors().GetFile()) == 0 {
 		t.Fatal("manifest descriptor closure is empty")
@@ -172,9 +174,10 @@ func TestPebbleStoreWithPayloadEncodingTar(t *testing.T) {
 	}
 }
 
-// TestPebbleStoreDefaultsToTarZstd confirms that omitting
-// WithPayloadEncoding gives TAR_ZSTD (current production default).
-func TestPebbleStoreDefaultsToTarZstd(t *testing.T) {
+// TestPebbleRegisteredStoreDefaultsToIndexedZstd confirms that
+// omitting dotc1z.WithPayloadEncoding gives INDEXED_ZSTD (the engine
+// default: parallel decode at open, frame splicing at save).
+func TestPebbleRegisteredStoreDefaultsToIndexedZstd(t *testing.T) {
 	ctx := context.Background()
 	tmp := t.TempDir()
 	out := filepath.Join(tmp, "default.c1z")
@@ -205,7 +208,67 @@ func TestPebbleStoreDefaultsToTarZstd(t *testing.T) {
 		t.Fatalf("ReadEnvelope: %v", err)
 	}
 	defer env.Close()
-	if env.Manifest.GetPayloadEncoding() != c1zv3.PayloadEncoding_PAYLOAD_ENCODING_TAR_ZSTD {
-		t.Fatalf("manifest payload_encoding: got %v, want TAR_ZSTD", env.Manifest.GetPayloadEncoding())
+	if env.Manifest.GetPayloadEncoding() != c1zv3.PayloadEncoding_PAYLOAD_ENCODING_INDEXED_ZSTD {
+		t.Fatalf("manifest payload_encoding: got %v, want INDEXED_ZSTD", env.Manifest.GetPayloadEncoding())
+	}
+}
+
+func TestPebbleStoreOpenHonorsDecoderMaxDecodedSize(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	out := filepath.Join(tmp, "indexed-limit.c1z")
+	store, err := NewStore(ctx, out, WithEngine(EnginePebble))
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	if _, err := store.StartNewSync(ctx, connectorstore.SyncTypeFull, ""); err != nil {
+		t.Fatalf("StartNewSync: %v", err)
+	}
+	if err := store.PutGrants(ctx, &v2.Grant{Id: "g1"}); err != nil {
+		t.Fatalf("PutGrants: %v", err)
+	}
+	if err := store.EndSync(ctx); err != nil {
+		t.Fatalf("EndSync: %v", err)
+	}
+	if err := store.Close(ctx); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	_, err = NewStore(ctx, out,
+		WithReadOnly(true),
+		WithDecoderOptions(WithDecoderMaxDecodedSize(1)),
+	)
+	if !errors.Is(err, formatv3.ErrMaxSizeExceeded) {
+		t.Fatalf("NewStore with tiny max decoded size error = %v, want ErrMaxSizeExceeded", err)
+	}
+}
+
+func TestPebbleStoreOpenHonorsDecoderMaxMemory(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	out := filepath.Join(tmp, "indexed-memory.c1z")
+	store, err := NewStore(ctx, out, WithEngine(EnginePebble))
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	if _, err := store.StartNewSync(ctx, connectorstore.SyncTypeFull, ""); err != nil {
+		t.Fatalf("StartNewSync: %v", err)
+	}
+	if err := store.PutAsset(ctx, v2.AssetRef_builder{Id: "asset-1"}.Build(), "application/octet-stream", bytes.Repeat([]byte("0123456789abcdef"), 256<<10)); err != nil {
+		t.Fatalf("PutAsset: %v", err)
+	}
+	if err := store.EndSync(ctx); err != nil {
+		t.Fatalf("EndSync: %v", err)
+	}
+	if err := store.Close(ctx); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	_, err = NewStore(ctx, out,
+		WithReadOnly(true),
+		WithDecoderOptions(WithDecoderMaxMemory(1)),
+	)
+	if !errors.Is(err, zstd.ErrWindowSizeExceeded) {
+		t.Fatalf("NewStore with tiny decoder memory error = %v, want zstd.ErrWindowSizeExceeded", err)
 	}
 }

--- a/pkg/dotc1z/pool_test.go
+++ b/pkg/dotc1z/pool_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"runtime/debug"
 	"sync"
 	"testing"
@@ -200,6 +201,15 @@ func TestDecoderPool(t *testing.T) {
 // assertions (e.g. "did putEncoder put one in the pool?") flaky under CI
 // memory pressure. Restoring the prior GOGC on teardown keeps the rest of
 // the package suite unaffected.
+//
+// Also pins GOMAXPROCS to 1. sync.Pool.Put parks the item in the current
+// P's private slot, and Get can steal only from other Ps' shared queues —
+// another P's private slot is unreachable. If the goroutine migrates Ps
+// between Put and Get (routine after blocking file syscalls — Sync, Close,
+// Rename — especially on slow Windows CI filesystems), the item is parked
+// where Get cannot see it and exact-membership assertions fail. One P means
+// one slot, making Put→Get deterministic; the stdlib's own sync.Pool tests
+// use the same trick.
 func withIsolatedPools(t *testing.T) {
 	t.Helper()
 	origEnc := encoderPool
@@ -207,7 +217,9 @@ func withIsolatedPools(t *testing.T) {
 	encoderPool = &sync.Pool{}
 	decoderPool = &sync.Pool{}
 	origGCPercent := debug.SetGCPercent(-1)
+	origProcs := runtime.GOMAXPROCS(1)
 	t.Cleanup(func() {
+		runtime.GOMAXPROCS(origProcs)
 		debug.SetGCPercent(origGCPercent)
 		encoderPool = origEnc
 		decoderPool = origDec

--- a/pkg/synccompactor/compactor.go
+++ b/pkg/synccompactor/compactor.go
@@ -51,11 +51,15 @@ type Compactor struct {
 	// pebbleMode optionally forces the Pebble merge strategy; the zero
 	// value (Auto) lets the compactor choose. See WithPebbleCompactorMode.
 	pebbleMode PebbleCompactorMode
-	// overlaySeenKeyLimit / overlayRecordChunkSize optionally override
+	// overlaySeenKeyLimit / overlayRecordChunkSize /
+	// overlayBufferFactor / overlayGateFraction optionally override
 	// the overlay merge tunables; zero means the merge defaults. See
-	// WithOverlaySeenKeyLimit / WithOverlayRecordChunkSize.
+	// WithOverlaySeenKeyLimit / WithOverlayRecordChunkSize /
+	// WithOverlayBufferFactor / WithOverlayGateFraction.
 	overlaySeenKeyLimit    int64
 	overlayRecordChunkSize int
+	overlayBufferFactor    float64
+	overlayGateFraction    float64
 	// decoderPool scopes v3 payload-decoder reuse to one Compact run:
 	// every source envelope open draws from it instead of constructing
 	// a fresh zstd decoder, and Compact closes it on the way out so no
@@ -65,12 +69,57 @@ type Compactor struct {
 }
 
 // resolvedEngine returns the configured engine, treating the zero value
-// as EngineSQLite.
+// as EngineSQLite. Compact calls inferEngineFromInputs first so the zero
+// value can follow existing c1z inputs instead of always producing SQLite.
 func (c *Compactor) resolvedEngine() dotc1z.Engine {
 	if c.engine == "" {
 		return dotc1z.EngineSQLite
 	}
 	return c.engine
+}
+
+func (c *Compactor) inferEngineFromInputs() (dotc1z.Engine, error) {
+	if c.engine != "" {
+		return c.engine, nil
+	}
+	var inferred dotc1z.Engine
+	for _, entry := range c.entries {
+		if entry == nil || entry.FilePath == "" {
+			continue
+		}
+		f, err := os.Open(entry.FilePath) // #nosec G304 - compaction inputs are caller-provided c1z paths.
+		if err != nil {
+			return "", fmt.Errorf("infer compactor engine from %s: %w", entry.FilePath, err)
+		}
+		format, readErr := dotc1z.ReadHeaderFormat(f)
+		closeErr := f.Close()
+		if readErr != nil {
+			return "", fmt.Errorf("infer compactor engine from %s: %w", entry.FilePath, readErr)
+		}
+		if closeErr != nil {
+			return "", fmt.Errorf("infer compactor engine from %s: %w", entry.FilePath, closeErr)
+		}
+		var engine dotc1z.Engine
+		switch format {
+		case dotc1z.C1ZFormatV1:
+			engine = dotc1z.EngineSQLite
+		case dotc1z.C1ZFormatV3:
+			engine = dotc1z.EnginePebble
+		default:
+			return "", fmt.Errorf("infer compactor engine from %s: unsupported c1z format %s", entry.FilePath, format)
+		}
+		if inferred == "" {
+			inferred = engine
+			continue
+		}
+		if inferred != engine {
+			return "", fmt.Errorf("infer compactor engine: mixed input formats are not supported (%s is %s, previously inferred %s)", entry.FilePath, engine, inferred)
+		}
+	}
+	if inferred == "" {
+		return dotc1z.EngineSQLite, nil
+	}
+	return inferred, nil
 }
 
 type CompactableSync struct {
@@ -214,9 +263,35 @@ func (c *Compactor) Compact(ctx context.Context) (*CompactableSync, error) {
 	if c.syncLimit > 0 {
 		opts = append(opts, dotc1z.WithSyncLimit(c.syncLimit))
 	}
+	engine, err := c.inferEngineFromInputs()
+	if err != nil {
+		return nil, err
+	}
+	c.engine = engine
 
 	fileName := fmt.Sprintf("compacted-%s.c1z", c.entries[0].SyncID)
 	destFilePath := path.Join(c.tmpDir, fileName)
+
+	// Resolve the Pebble strategy up front: an explicit
+	// BATON_EXPERIMENTAL_PEBBLE_COMPACTOR value forces a mode;
+	// otherwise overlay is selected (the in-place fold cutover is
+	// disabled until C1 handles a reused sync id; see
+	// resolvePebbleMode).
+	//
+	// In-place fold (explicit only): the dest store starts as a copy
+	// of the base input and the output adopts the base sync's id;
+	// partials are merged into the base keyspace via keep-newer
+	// writes. The original base file is never mutated. See
+	// compactPebbleFold.
+	if c.resolvedEngine() == dotc1z.EnginePebble {
+		c.pebbleMode = c.resolvePebbleMode(ctx)
+	}
+	foldMode := c.pebbleMode == PebbleCompactorModeFold
+	if foldMode {
+		if err = copyFileForFold(c.entries[0].FilePath, destFilePath); err != nil {
+			return nil, fmt.Errorf("fold: copy base input: %w", err)
+		}
+	}
 
 	if c.resolvedEngine() == dotc1z.EnginePebble {
 		// One payload-decoder pool for the whole compaction: the merge
@@ -249,29 +324,38 @@ func (c *Compactor) Compact(ctx context.Context) (*CompactableSync, error) {
 			l.Error("compactor: error closing compacted c1z", zap.Error(err), zap.String("compacted_c1z_file", destFilePath))
 		}
 	}()
-	// Start new sync of type partial. If we compact syncs of other types, this sync type will be updated by attached.UpdateSync which is called by doOneCompaction().
-	newSyncId, err := c.compactedC1z.StartNewSync(ctx, connectorstore.SyncTypePartial, "")
-	if err != nil {
-		return nil, fmt.Errorf("failed to start new sync: %w", err)
-	}
-	err = c.compactedC1z.EndSync(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to end sync: %w", err)
-	}
-	l.Debug("new empty partial sync created", zap.String("sync_id", newSyncId))
-
-	if c.resolvedEngine() == dotc1z.EnginePebble {
-		// Native Pebble path: one multi-source record merge into the
-		// empty newSyncId (the sqlite ATTACH per-input loop does not
-		// apply — Pebble merges all inputs in a single pass).
-		if err = c.compactPebble(runCtx, newSyncId); err != nil {
+	var newSyncId string
+	switch {
+	case foldMode:
+		// In-place fold: no fresh sync — the output adopts the base
+		// sync's id and partials merge into its keyspace.
+		newSyncId, err = c.compactPebbleFold(runCtx)
+		if err != nil {
+			if cause := context.Cause(runCtx); errors.Is(cause, context.DeadlineExceeded) && c.runDuration > 0 && ctx.Err() == nil {
+				l.Info("compaction run duration has expired, exiting compaction early")
+				return nil, fmt.Errorf("compaction run duration has expired: %w", cause)
+			}
+			return nil, fmt.Errorf("failed to compact (pebble fold): %w", err)
+		}
+	case c.resolvedEngine() == dotc1z.EnginePebble:
+		newSyncId, err = c.runPebbleRebuild(ctx, runCtx)
+		if err != nil {
 			if cause := context.Cause(runCtx); errors.Is(cause, context.DeadlineExceeded) && c.runDuration > 0 && ctx.Err() == nil {
 				l.Info("compaction run duration has expired, exiting compaction early")
 				return nil, fmt.Errorf("compaction run duration has expired: %w", cause)
 			}
 			return nil, fmt.Errorf("failed to compact (pebble): %w", err)
 		}
-	} else {
+	default:
+		// Start new sync of type partial. If we compact syncs of other types, this sync type will be updated by attached.UpdateSync which is called by doOneCompaction().
+		newSyncId, err = c.compactedC1z.StartNewSync(ctx, connectorstore.SyncTypePartial, "")
+		if err != nil {
+			return nil, fmt.Errorf("failed to start new sync: %w", err)
+		}
+		if err = c.compactedC1z.EndSync(ctx); err != nil {
+			return nil, fmt.Errorf("failed to end sync: %w", err)
+		}
+		l.Debug("new empty partial sync created", zap.String("sync_id", newSyncId))
 		// Base sync is c.entries[0], so compact in reverse order. That way we compact the biggest sync last.
 		// Pass runCtx (not the outer ctx) so c.runDuration actually bounds the loop. Without this, the
 		// deadline set on runCtx only gates the pre-flight check above and individual doOneCompaction

--- a/pkg/synccompactor/compactor_compare_bench_test.go
+++ b/pkg/synccompactor/compactor_compare_bench_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
@@ -41,6 +42,31 @@ func BenchmarkCompactorSQLiteVsPebbleSkewed(b *testing.B) {
 	}
 }
 
+func BenchmarkCompactorSQLiteVsPebbleLargeBase(b *testing.B) {
+	ctx := context.Background()
+
+	sourceCount := compareEnvInt("BATON_COMPACTION_LARGE_BASE_SYNCS", 50)
+	base := compactorCompareSize{
+		resources:    compareEnvInt("BATON_COMPACTION_LARGE_BASE_RESOURCES", 25000),
+		entitlements: compareEnvInt("BATON_COMPACTION_LARGE_BASE_ENTITLEMENTS", 50000),
+		grants:       compareEnvInt("BATON_COMPACTION_LARGE_BASE_GRANTS", 250000),
+	}
+	incremental := compactorCompareSize{
+		resources:    compareEnvInt("BATON_COMPACTION_LARGE_INCREMENTAL_RESOURCES", 1),
+		entitlements: compareEnvInt("BATON_COMPACTION_LARGE_INCREMENTAL_ENTITLEMENTS", 2),
+		grants:       compareEnvInt("BATON_COMPACTION_LARGE_INCREMENTAL_GRANTS", 5),
+	}
+	if inputs, ok := loadCompareFixtureManifest(b, sourceCount, "large-base"); ok {
+		benchmarkCompactorInputs(b, ctx, sourceCount, base, inputs.SQLite, inputs.Pebble)
+		return
+	}
+	fixtureDir := compareFixtureBuildDir(b, sourceCount, "large-base")
+	sqliteInputs := buildCompareSkewedSQLiteInputsWithSizes(b, ctx, filepath.Join(fixtureDir, "sqlite"), sourceCount, base, incremental)
+	pebbleInputs := convertCompareInputsToPebble(b, ctx, filepath.Join(fixtureDir, "pebble"), sqliteInputs)
+	writeCompareFixtureManifestIfRequested(b, sourceCount, "large-base", sqliteInputs, pebbleInputs)
+	benchmarkCompactorInputs(b, ctx, sourceCount, base, sqliteInputs, pebbleInputs)
+}
+
 type compactorCompareSize struct {
 	resources    int
 	entitlements int
@@ -50,6 +76,18 @@ type compactorCompareSize struct {
 type compactorCompareFixtureManifest struct {
 	SQLite []*CompactableSync `json:"sqlite"`
 	Pebble []*CompactableSync `json:"pebble"`
+}
+
+func compareEnvInt(name string, fallback int) int {
+	raw := os.Getenv(name)
+	if raw == "" {
+		return fallback
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return fallback
+	}
+	return n
 }
 
 func benchmarkCompactorSQLiteVsPebbleKWayCase(b *testing.B, ctx context.Context, sourceCount int, size compactorCompareSize) {
@@ -147,6 +185,7 @@ func benchmarkCompactorInputs(
 		{name: "sqlite", inputs: sqliteInputs},
 		{name: "pebble_kway", inputs: pebbleInputs, engine: dotc1z.EnginePebble, pebbleMode: PebbleCompactorModeKWay},
 		{name: "pebble_overlay", inputs: pebbleInputs, engine: dotc1z.EnginePebble, pebbleMode: PebbleCompactorModeOverlay},
+		{name: "pebble_fold", inputs: pebbleInputs, engine: dotc1z.EnginePebble, pebbleMode: PebbleCompactorModeFold},
 	} {
 		tc := tc
 		b.Run(tc.name, func(b *testing.B) {
@@ -177,23 +216,34 @@ func benchmarkCompactorInputs(
 }
 
 func buildCompareSkewedSQLiteInputs(b *testing.B, ctx context.Context, dir string, sourceCount int) []*CompactableSync {
+	return buildCompareSkewedSQLiteInputsWithSizes(b, ctx, dir, sourceCount, compactorCompareSize{
+		resources:    250,
+		entitlements: 500,
+		grants:       2500,
+	}, compactorCompareSize{
+		resources:    1,
+		entitlements: 2,
+		grants:       5,
+	})
+}
+
+func buildCompareSkewedSQLiteInputsWithSizes(
+	b *testing.B,
+	ctx context.Context,
+	dir string,
+	sourceCount int,
+	base compactorCompareSize,
+	incremental compactorCompareSize,
+) []*CompactableSync {
 	b.Helper()
 	require.NoError(b, os.MkdirAll(dir, 0o755))
 	out := make([]*CompactableSync, 0, sourceCount)
 	for sourceIdx := 0; sourceIdx < sourceCount; sourceIdx++ {
 		syncType := connectorstore.SyncTypePartial
-		size := compactorCompareSize{
-			resources:    1,
-			entitlements: 2,
-			grants:       5,
-		}
+		size := incremental
 		if sourceIdx == 0 {
 			syncType = connectorstore.SyncTypeFull
-			size = compactorCompareSize{
-				resources:    250,
-				entitlements: 500,
-				grants:       2500,
-			}
+			size = base
 		}
 		path := filepath.Join(dir, fmt.Sprintf("source-%03d.c1z", sourceIdx))
 		syncID := writeCompareSQLiteSource(b, ctx, path, sourceIdx, syncType, size)

--- a/pkg/synccompactor/compactor_fold_test.go
+++ b/pkg/synccompactor/compactor_fold_test.go
@@ -1,0 +1,97 @@
+package synccompactor
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	enginepkg "github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble"
+)
+
+// grantDiscoveredAt reads one grant's discovered_at from the Pebble c1z
+// at path, under syncID.
+func grantDiscoveredAt(t *testing.T, ctx context.Context, path, syncID, grantID string) time.Time {
+	t.Helper()
+	w, err := dotc1z.NewStore(ctx, path, dotc1z.WithReadOnly(true), dotc1z.WithTmpDir(t.TempDir()))
+	require.NoError(t, err)
+	defer w.Close(ctx)
+	eng, ok := enginepkg.AsEngine(w)
+	require.True(t, ok, "store at %s is not a pebble engine", path)
+	rec, err := eng.GetGrantRecord(ctx, syncID, grantID)
+	require.NoError(t, err)
+	return rec.GetDiscoveredAt().AsTime()
+}
+
+// TestCompactPebbleFoldAdoptsBaseSync covers the in-place fold strategy
+// (BATON_EXPERIMENTAL_PEBBLE_COMPACTOR=fold): the compacted output is a
+// copy of the base input whose base sync ADOPTS the partials' winners,
+// keeping the base sync id. Base keys are never rewritten; partial
+// records land via the keep-newer path.
+func TestCompactPebbleFoldAdoptsBaseSync(t *testing.T) {
+	ctx := context.Background()
+	inDir := t.TempDir()
+
+	basePath := filepath.Join(inDir, "base.c1z")
+	partialPath := filepath.Join(inDir, "partial.c1z")
+	// The partial is built after the base, so its "g-shared" carries a
+	// strictly newer discovered_at and must win the fold.
+	baseSyncID := buildPebbleInput(t, ctx, basePath, connectorstore.SyncTypeFull, "g-shared", "g-base-only")
+	partialSyncID := buildPebbleInput(t, ctx, partialPath, connectorstore.SyncTypePartial, "g-shared", "g-partial-only")
+
+	t.Setenv("BATON_EXPERIMENTAL_PEBBLE_COMPACTOR", "fold")
+	c, cleanup, err := NewCompactor(ctx, t.TempDir(), []*CompactableSync{
+		{FilePath: basePath, SyncID: baseSyncID},
+		{FilePath: partialPath, SyncID: partialSyncID},
+	}, WithTmpDir(t.TempDir()), WithEngine(dotc1z.EnginePebble), WithSkipGrantExpansion())
+	require.NoError(t, err)
+	defer func() { require.NoError(t, cleanup()) }()
+
+	out, err := c.Compact(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+
+	// Sync-id adoption: the output's sync IS the base sync.
+	require.Equal(t, baseSyncID, out.SyncID, "fold output must adopt the base sync id")
+
+	// Union of grants, union sync type (full beats partial).
+	count, syncType := verifyCompacted(t, ctx, out.FilePath, out.SyncID)
+	require.Equal(t, 3, count)
+	require.Equal(t, string(connectorstore.SyncTypeFull), syncType)
+
+	// The overlapping grant's winner is the partial's record (strictly
+	// newer discovered_at); the base-only grant keeps the base's stamp.
+	require.Equal(t,
+		grantDiscoveredAt(t, ctx, partialPath, partialSyncID, "g-shared"),
+		grantDiscoveredAt(t, ctx, out.FilePath, baseSyncID, "g-shared"),
+		"fold winner for overlapping grant must be the partial's (newer) record")
+	require.Equal(t,
+		grantDiscoveredAt(t, ctx, basePath, baseSyncID, "g-base-only"),
+		grantDiscoveredAt(t, ctx, out.FilePath, baseSyncID, "g-base-only"),
+		"base-only grant must be preserved untouched")
+
+	// ended_at advances to the max across inputs (the partial's).
+	require.Equal(t,
+		latestEndedAt(t, ctx, partialPath).UTC(),
+		latestEndedAt(t, ctx, out.FilePath).UTC())
+
+	// Fold semantics: the base sync is preserved wholesale, so the
+	// base's asset survives (unlike the rebuild strategies, which drop
+	// assets). Partial assets are not copied.
+	require.Equal(t, 1, countPebbleAssets(t, ctx, out.FilePath, baseSyncID))
+
+	// Stats sidecar was recomputed for the folded sync.
+	statsW, err := dotc1z.NewStore(ctx, out.FilePath, dotc1z.WithReadOnly(true), dotc1z.WithTmpDir(t.TempDir()))
+	require.NoError(t, err)
+	defer statsW.Close(ctx)
+	statsEng, ok := enginepkg.AsEngine(statsW)
+	require.True(t, ok)
+	stats, err := enginepkg.ReadSyncStatsRecord(ctx, statsEng, baseSyncID)
+	require.NoError(t, err)
+	require.NotNil(t, stats)
+	require.Equal(t, int64(3), stats.GetGrants())
+}

--- a/pkg/synccompactor/compactor_mode_test.go
+++ b/pkg/synccompactor/compactor_mode_test.go
@@ -1,0 +1,120 @@
+package synccompactor
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolvePebbleModeCutover exercises the auto-selection gate:
+// overlay is always auto-selected — the fold cutover is disabled until
+// C1 handles fold's reused sync id, even for the large-base +
+// small-partial shape where fold wins — and an explicit
+// BATON_EXPERIMENTAL_PEBBLE_COMPACTOR value forces the mode regardless
+// of sizes. The gate reads only file sizes, so plain files stand in
+// for c1z inputs.
+func TestResolvePebbleModeCutover(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	mk := func(name string, size int) string {
+		path := filepath.Join(dir, name)
+		require.NoError(t, os.WriteFile(path, make([]byte, size), 0o600))
+		return path
+	}
+	newC := func(paths ...string) *Compactor {
+		entries := make([]*CompactableSync, 0, len(paths))
+		for i, p := range paths {
+			entries = append(entries, &CompactableSync{FilePath: p, SyncID: fmt.Sprintf("s%d", i)})
+		}
+		return &Compactor{entries: entries}
+	}
+
+	// Lower the base-size floor so the test doesn't need a 256MiB file.
+	t.Setenv("BATON_PEBBLE_FOLD_MIN_BASE_BYTES", "1000")
+
+	bigBase := mk("base.c1z", 4000)
+	smallPartial := mk("p-small.c1z", 100)
+	bigPartial := mk("p-big.c1z", 2000)
+	tinyBase := mk("tiny.c1z", 100)
+
+	t.Setenv("BATON_EXPERIMENTAL_PEBBLE_COMPACTOR", "")
+	// Large base + partials within the ratio is fold's winning shape,
+	// but auto-fold is disabled (reused sync id) → overlay.
+	require.Equal(t, PebbleCompactorModeOverlay, newC(bigBase, smallPartial).resolvePebbleMode(ctx))
+	require.Equal(t, PebbleCompactorModeOverlay,
+		newC(bigBase, smallPartial, smallPartial, smallPartial, smallPartial).resolvePebbleMode(ctx))
+	// Shapes outside the gate were always overlay.
+	require.Equal(t, PebbleCompactorModeOverlay,
+		newC(bigBase, smallPartial, smallPartial, smallPartial, smallPartial, smallPartial).resolvePebbleMode(ctx))
+	require.Equal(t, PebbleCompactorModeOverlay, newC(bigBase, bigPartial).resolvePebbleMode(ctx))
+	require.Equal(t, PebbleCompactorModeOverlay, newC(tinyBase, smallPartial).resolvePebbleMode(ctx))
+	// Unstat-able base counts as zero → overlay; the open fails later
+	// with the real error.
+	require.Equal(t, PebbleCompactorModeOverlay,
+		newC(filepath.Join(dir, "missing.c1z"), smallPartial).resolvePebbleMode(ctx))
+
+	// Explicit env values force the mode regardless of sizes — fold
+	// stays reachable when requested manually.
+	for _, mode := range []PebbleCompactorMode{PebbleCompactorModeKWay, PebbleCompactorModeOverlay, PebbleCompactorModeFold} {
+		t.Setenv("BATON_EXPERIMENTAL_PEBBLE_COMPACTOR", string(mode))
+		require.Equal(t, mode, newC(tinyBase, smallPartial).resolvePebbleMode(ctx))
+	}
+
+	// An explicit compactor option also forces fold.
+	t.Setenv("BATON_EXPERIMENTAL_PEBBLE_COMPACTOR", "")
+	explicit := newC(tinyBase, smallPartial)
+	WithPebbleCompactorMode(PebbleCompactorModeFold)(explicit)
+	require.Equal(t, PebbleCompactorModeFold, explicit.resolvePebbleMode(ctx))
+
+	// Unrecognized values fall back to auto selection (overlay).
+	t.Setenv("BATON_EXPERIMENTAL_PEBBLE_COMPACTOR", "bogus")
+	require.Equal(t, PebbleCompactorModeOverlay, newC(bigBase, smallPartial).resolvePebbleMode(ctx))
+}
+
+func TestInferEngineFromInputFormats(t *testing.T) {
+	dir := t.TempDir()
+	writeHeader := func(name string, header []byte) string {
+		t.Helper()
+		path := filepath.Join(dir, name)
+		require.NoError(t, os.WriteFile(path, header, 0o600))
+		return path
+	}
+
+	v1 := writeHeader("sqlite.c1z", dotc1z.C1ZFileHeader)
+	v3 := writeHeader("pebble.c1z", dotc1z.C1Z3FileHeader)
+
+	engine, err := (&Compactor{entries: []*CompactableSync{
+		{FilePath: v1, SyncID: "s1"},
+		{FilePath: v1, SyncID: "s2"},
+	}}).inferEngineFromInputs()
+	require.NoError(t, err)
+	require.Equal(t, dotc1z.EngineSQLite, engine)
+
+	engine, err = (&Compactor{entries: []*CompactableSync{
+		{FilePath: v3, SyncID: "s1"},
+		{FilePath: v3, SyncID: "s2"},
+	}}).inferEngineFromInputs()
+	require.NoError(t, err)
+	require.Equal(t, dotc1z.EnginePebble, engine)
+
+	_, err = (&Compactor{entries: []*CompactableSync{
+		{FilePath: v1, SyncID: "s1"},
+		{FilePath: v3, SyncID: "s2"},
+	}}).inferEngineFromInputs()
+	require.Error(t, err)
+
+	engine, err = (&Compactor{
+		engine: dotc1z.EngineSQLite,
+		entries: []*CompactableSync{
+			{FilePath: v3, SyncID: "s1"},
+			{FilePath: v3, SyncID: "s2"},
+		},
+	}).inferEngineFromInputs()
+	require.NoError(t, err)
+	require.Equal(t, dotc1z.EngineSQLite, engine)
+}

--- a/pkg/synccompactor/compactor_pebble.go
+++ b/pkg/synccompactor/compactor_pebble.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
@@ -14,6 +16,7 @@ import (
 	c1zv3 "github.com/conductorone/baton-sdk/pb/c1/c1z/v3"
 	reader_v2 "github.com/conductorone/baton-sdk/pb/c1/reader/v2"
 	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z"
 	enginepkg "github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble"
 	formatv3 "github.com/conductorone/baton-sdk/pkg/dotc1z/format/v3"
@@ -23,7 +26,8 @@ import (
 // WithEngine selects the storage engine for the compacted output.
 // The default (unset) is sqlite, which is byte-identical to the
 // historical compactor. EnginePebble produces a v3 Pebble c1z via a
-// native record merge.
+// native record merge whose strategy (overlay / fold / kway) is
+// resolved per run by resolvePebbleMode.
 //
 // This is the only supported way to choose the engine; an engine
 // passed through WithC1ZOptions does not select the compaction
@@ -54,6 +58,13 @@ const (
 
 	// PebbleCompactorModeOverlay forces the seen-set overlay merge.
 	PebbleCompactorModeOverlay PebbleCompactorMode = "overlay"
+
+	// PebbleCompactorModeFold forces in-place fold into the base sync.
+	// Note: the output ADOPTS the base sync's id (no fresh sync id),
+	// which C1's compaction bookkeeping currently mishandles — auto
+	// mode never selects fold for that reason; forcing it is on the
+	// caller to know their consumer tolerates a reused sync id.
+	PebbleCompactorModeFold PebbleCompactorMode = "fold"
 )
 
 // WithPebbleCompactorMode overrides the Pebble merge strategy. The
@@ -86,16 +97,155 @@ func WithOverlayRecordChunkSize(n int) Option {
 	}
 }
 
-// resolvedPebbleMode returns the effective merge strategy: an explicit
-// WithPebbleCompactorMode wins, and Auto resolves to overlay (see
-// PebbleCompactorModeAuto for why).
-func (c *Compactor) resolvedPebbleMode() PebbleCompactorMode {
-	switch c.pebbleMode {
-	case PebbleCompactorModeKWay, PebbleCompactorModeOverlay:
-		return c.pebbleMode
-	default:
-		return PebbleCompactorModeOverlay
+// WithOverlayBufferFactor overrides the overlay merge's soft→hard
+// seen-set limit multiplier (default 1.25). A source that crosses the
+// soft limit mid-scan may finish inside the buffer and resume via the
+// K-way path at the source boundary; crossing the hard limit
+// mid-source restarts the bucket through the blind K-way path. Zero
+// (the default) uses the merge's built-in production value.
+func WithOverlayBufferFactor(f float64) Option {
+	return func(c *Compactor) {
+		c.overlayBufferFactor = f
 	}
+}
+
+// WithOverlayGateFraction overrides the overlay merge's statless
+// pre-source gate, expressed as a fraction of the soft seen-set limit
+// (default 0.9): when a source has no cached stats and the seen set is
+// already past the gate, the bucket degrades to the K-way path before
+// scanning the source. Zero (the default) uses the merge's built-in
+// production value.
+func WithOverlayGateFraction(f float64) Option {
+	return func(c *Compactor) {
+		c.overlayGateFraction = f
+	}
+}
+
+// Fold cutover thresholds. The auto cutover is currently DISABLED
+// (see resolvePebbleMode) — the gate only logs when fold would have
+// been picked. Fold's win is conditional on
+// the base dominating total input volume: it pays a fixed per-source
+// cost (envelope + pebble open, ~10ms each) plus per-record point
+// writes for every partial record, but does ZERO work for base records
+// and splices the base's unchanged frames at save. Measured at a 1.1GB
+// base + 50 small partials, fold is ~3x faster than overlay (~20s vs
+// ~60s); at fixture scale (MB bases) overlay wins every shape.
+//
+// The ratio comes from the crossover sweep
+// (TestProdScaleFoldOverlayCrossover): overlay's cost is nearly flat
+// in partial volume (it streams the base regardless) while fold's is
+// linear (~0.2s per MB of partials), so they cross where fold's
+// partial-write cost eats its base savings — ~9% partial volume at a
+// 117MB base, extrapolating to ~16% at 1.1GB. 10% keeps fold ahead of
+// overlay across the whole gated range; past it the win shrinks
+// toward a loss, and overlay is never badly wrong.
+const (
+	defaultFoldMinBaseBytes      int64 = 256 << 20 // 256 MiB
+	defaultFoldMaxPartialPercent int64 = 10        // partials ≤ 10% of base size
+)
+
+// foldMinBaseBytes is the smallest base input (envelope file size) for
+// which the (currently disabled) auto cutover would pick fold.
+// Tunable via BATON_PEBBLE_FOLD_MIN_BASE_BYTES.
+func foldMinBaseBytes() int64 {
+	if raw := os.Getenv("BATON_PEBBLE_FOLD_MIN_BASE_BYTES"); raw != "" {
+		n, err := strconv.ParseInt(raw, 10, 64)
+		if err == nil && n > 0 {
+			return n
+		}
+	}
+	return defaultFoldMinBaseBytes
+}
+
+// foldMaxPartialPercent caps the summed partial file sizes, as a
+// percent of the base file size, for which the (currently disabled)
+// auto cutover would pick fold.
+// Tunable via BATON_PEBBLE_FOLD_MAX_PARTIAL_PCT.
+func foldMaxPartialPercent() int64 {
+	if raw := os.Getenv("BATON_PEBBLE_FOLD_MAX_PARTIAL_PCT"); raw != "" {
+		n, err := strconv.ParseInt(raw, 10, 64)
+		if err == nil && n > 0 {
+			return n
+		}
+	}
+	return defaultFoldMaxPartialPercent
+}
+
+// resolvePebbleMode picks the Pebble compaction strategy. An explicit
+// mode (WithPebbleCompactorMode or BATON_EXPERIMENTAL_PEBBLE_COMPACTOR
+// = "overlay" / "kway" / "fold") is honored as-is. Otherwise overlay
+// is always selected.
+//
+// Auto-selection of fold is DISABLED: fold adopts the base sync's id
+// instead of minting a fresh one, and C1's compaction bookkeeping
+// treats an unchanged LatestCompactedSyncId as "no new compaction",
+// silently skipping follow-up work like uplift. Until that is resolved
+// on the C1 side, fold runs only when requested explicitly. The size
+// gate still evaluates and logs when fold would have won (large base,
+// partials a small fraction of it — measured ~3x faster there) so the
+// cutover can be re-enabled with confidence. The gate reads only file
+// sizes (os.Stat); nothing is unpacked.
+func (c *Compactor) resolvePebbleMode(ctx context.Context) PebbleCompactorMode {
+	l := ctxzap.Extract(ctx)
+	switch c.pebbleMode {
+	case PebbleCompactorModeKWay, PebbleCompactorModeOverlay, PebbleCompactorModeFold:
+		return c.pebbleMode
+	case PebbleCompactorModeAuto:
+	}
+	switch mode := PebbleCompactorMode(os.Getenv("BATON_EXPERIMENTAL_PEBBLE_COMPACTOR")); mode {
+	case PebbleCompactorModeOverlay, PebbleCompactorModeKWay, PebbleCompactorModeFold:
+		l.Info("pebble compactor: mode forced by env", zap.String("mode", string(mode)))
+		return mode
+	case PebbleCompactorModeAuto:
+	default:
+		l.Warn("pebble compactor: unrecognized BATON_EXPERIMENTAL_PEBBLE_COMPACTOR value, auto-selecting",
+			zap.String("value", string(mode)))
+	}
+
+	baseBytes := fileSizeOrZero(c.entries[0].FilePath)
+	var partialBytes int64
+	for _, e := range c.entries[1:] {
+		partialBytes += fileSizeOrZero(e.FilePath)
+	}
+	minBase := foldMinBaseBytes()
+	maxPct := foldMaxPartialPercent()
+	mode := PebbleCompactorModeOverlay
+	if baseBytes >= minBase && partialBytes*100 <= baseBytes*maxPct {
+		l.Info("pebble compactor: fold gate matched but auto-fold is disabled (duplicate sync id breaks C1 compaction bookkeeping); using overlay",
+			zap.Int64("base_bytes", baseBytes),
+			zap.Int64("partial_bytes", partialBytes),
+			zap.Int64("fold_min_base_bytes", minBase),
+			zap.Int64("fold_max_partial_pct", maxPct),
+		)
+	}
+	l.Info("pebble compactor: auto-selected mode",
+		zap.String("mode", string(mode)),
+		zap.Int64("base_bytes", baseBytes),
+		zap.Int64("partial_bytes", partialBytes),
+		zap.Int("partials", len(c.entries)-1),
+	)
+	return mode
+}
+
+// fileSizeOrZero returns the file's size, or 0 when it can't be
+// stat'ed; a missing/unreadable input fails later with a real error,
+// the gate just declines the fold cutover.
+func fileSizeOrZero(path string) int64 {
+	fi, err := os.Stat(path) // #nosec G703 - path is a caller-provided compaction input, not untrusted user input.
+	if err != nil {
+		return 0
+	}
+	return fi.Size()
+}
+
+// ensurePebbleRegistered is kept for tests and setup paths from the
+// pre-static-registration era. Pebble is now registered by dotc1z init, so this
+// is a cheap sanity check.
+func ensurePebbleRegistered() error {
+	if _, ok := dotc1z.EngineDriverFor(dotc1z.EnginePebble); ok {
+		return nil
+	}
+	return dotc1z.ErrEngineNotAvailable
 }
 
 // compactableV3SyncType reports whether a v3 sync type is a compactable
@@ -146,7 +296,7 @@ type manifestSourceSelection struct {
 // compactable sync — callers fall back to the unpack path, which
 // produces the canonical errors.
 func selectSourceSyncFromManifest(path string) (manifestSourceSelection, bool) {
-	f, err := os.Open(path)
+	f, err := os.Open(path) // #nosec G703 - path is a caller-provided compaction input, not untrusted user input.
 	if err != nil {
 		return manifestSourceSelection{}, false
 	}
@@ -186,6 +336,158 @@ func selectSourceSyncFromManifest(path string) (manifestSourceSelection, bool) {
 	return sel, true
 }
 
+// compactPebbleFold is the in-place fold strategy (auto-selected for
+// large-base + small-partial inputs, or forced via
+// BATON_EXPERIMENTAL_PEBBLE_COMPACTOR=fold): the dest store is a copy
+// of the base input (c.entries[0]), and the compacted output ADOPTS the
+// base sync's id instead of re-keying everything under a fresh sync.
+//
+//   - Base primary and index keys: zero writes — already correct under
+//     their own sync id. Work is O(partials), not O(base).
+//   - Partial winners are merged into the base keyspace via the
+//     engine's keep-newer path (Put*RecordsIfNewer), which compares
+//     discovered_at against the incumbent and maintains indexes with
+//     point tombstones proportional to overridden records only.
+//   - Tie semantics: a partial record with discovered_at EQUAL to the
+//     base's keeps the base record (strictly-newer required). Among
+//     partials, newest-first application means the newest partial wins
+//     ties — matching the K-way/sqlite fold. The base-vs-partial tie
+//     differs from K-way (which would prefer the partial); cross-sync
+//     equal timestamps do not occur with SDK-stamped discovered_at.
+//
+// Returns the adopted sync id. Sync-id continuity is deliberate: diff
+// chains and parent_sync_id links into the base stay valid.
+func (c *Compactor) compactPebbleFold(ctx context.Context) (string, error) {
+	l := ctxzap.Extract(ctx)
+	foldStart := time.Now()
+	destEng, ok := enginepkg.AsEngine(c.compactedC1z)
+	if !ok {
+		return "", errors.New("compactPebbleFold: compacted store is not a pebble engine")
+	}
+	baseRec, err := destEng.LatestFinishedSyncRecord(ctx, compactableV3SyncType)
+	if err != nil {
+		return "", fmt.Errorf("compactPebbleFold: select base sync: %w", err)
+	}
+	if baseRec == nil {
+		return "", fmt.Errorf("compactPebbleFold: base input %s has no finished compactable sync", c.entries[0].FilePath)
+	}
+	baseSyncID := baseRec.GetSyncId()
+	l.Info("compactPebbleFold: folding partials into base sync",
+		zap.String("base_sync_id", baseSyncID),
+		zap.Int("partials", len(c.entries)-1),
+	)
+	unionType := baseRec.GetType()
+	maxEnded := baseRec.GetEndedAt().AsTime()
+
+	// Apply partials newest-first (reverse entry order, excluding the
+	// base at entries[0]); strictly-newer-wins makes earlier
+	// applications take precedence on ties.
+	for i := len(c.entries) - 1; i >= 1; i-- {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		cs := c.entries[i]
+		srcSyncID := ""
+		if sel, ok := selectSourceSyncFromManifest(cs.FilePath); ok {
+			srcSyncID = sel.syncID
+			unionType = unionV3SyncType(unionType, sel.syncType)
+			if sel.endedAt.After(maxEnded) {
+				maxEnded = sel.endedAt
+			}
+		}
+		w, err := dotc1z.NewStore(ctx, cs.FilePath, dotc1z.WithReadOnly(true), dotc1z.WithTmpDir(c.tmpDir))
+		if err != nil {
+			return "", fmt.Errorf("compactPebbleFold: open input %s: %w", cs.FilePath, err)
+		}
+		srcEng, ok := enginepkg.AsEngine(w)
+		if !ok {
+			_ = w.Close(ctx)
+			return "", fmt.Errorf("compactPebbleFold: input %s is not a pebble c1z", cs.FilePath)
+		}
+		if srcSyncID == "" {
+			rec, err := srcEng.LatestFinishedSyncRecord(ctx, compactableV3SyncType)
+			if err != nil || rec == nil {
+				_ = w.Close(ctx)
+				return "", fmt.Errorf("compactPebbleFold: input %s has no finished compactable sync: %w", cs.FilePath, err)
+			}
+			srcSyncID = rec.GetSyncId()
+			unionType = unionV3SyncType(unionType, rec.GetType())
+			if ts := rec.GetEndedAt(); ts != nil && ts.AsTime().After(maxEnded) {
+				maxEnded = ts.AsTime()
+			}
+		}
+		mergeErr := mergepkg.MergeInto(ctx, destEng, []mergepkg.SourceSync{{Engine: srcEng, SyncID: srcSyncID}}, baseSyncID)
+		if cerr := w.Close(ctx); cerr != nil {
+			l.Error("compactPebbleFold: error closing source store", zap.Error(cerr), zap.String("file", cs.FilePath))
+		}
+		if mergeErr != nil {
+			return "", fmt.Errorf("compactPebbleFold: merge %s: %w", cs.FilePath, mergeErr)
+		}
+	}
+
+	baseRec.SetType(unionType)
+	if !maxEnded.IsZero() {
+		baseRec.SetEndedAt(timestamppb.New(maxEnded))
+	}
+	if err := destEng.PutSyncRunRecord(ctx, baseRec); err != nil {
+		return "", fmt.Errorf("compactPebbleFold: persist base sync_run: %w", err)
+	}
+	// The fold mutates an existing sync in place, so the cached stats
+	// sidecar is stale. Recompute (key-range counts, not full
+	// unmarshals); a future delta-accumulating IfNewer path could make
+	// this O(partials) too.
+	if err := destEng.PersistSyncStats(ctx, baseSyncID); err != nil {
+		return "", fmt.Errorf("compactPebbleFold: persist stats: %w", err)
+	}
+	// All writes above went through the engine directly; flip the
+	// store's dirty bit so Close saves the envelope.
+	if !enginepkg.MarkStoreDirty(c.compactedC1z) {
+		return "", errors.New("compactPebbleFold: could not mark store dirty")
+	}
+	l.Info("compactPebbleFold: done",
+		zap.String("base_sync_id", baseSyncID),
+		zap.Duration("elapsed", time.Since(foldStart)),
+	)
+	return baseSyncID, nil
+}
+
+// runPebbleRebuild is the standard (non-fold) Pebble compaction: start
+// an empty partial sync on the dest and merge every input into it.
+// compactPebble updates the sync's type to the union of the input
+// types after the merge.
+func (c *Compactor) runPebbleRebuild(ctx context.Context, runCtx context.Context) (string, error) {
+	newSyncId, err := c.compactedC1z.StartNewSync(ctx, connectorstore.SyncTypePartial, "")
+	if err != nil {
+		return "", fmt.Errorf("failed to start new sync: %w", err)
+	}
+	if err := c.compactedC1z.EndSync(ctx); err != nil {
+		return "", fmt.Errorf("failed to end sync: %w", err)
+	}
+	if err := c.compactPebble(runCtx, newSyncId); err != nil {
+		return "", err
+	}
+	return newSyncId, nil
+}
+
+// copyFileForFold copies the base input to the dest path so the fold
+// mutates a private working copy; the original input is never touched.
+func copyFileForFold(src, dst string) error {
+	in, err := os.Open(src) // #nosec G703 - src is a caller-provided compaction input path, not untrusted user input.
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return err
+	}
+	return out.Close()
+}
+
 // compactPebble folds every input into the empty newSyncId on the
 // Pebble output via a native record merge: each input is opened, its
 // latest finished compactable sync is selected (diff syncs excluded),
@@ -202,12 +504,16 @@ func (c *Compactor) compactPebble(ctx context.Context, newSyncId string) error {
 		return errors.New("compactPebble: compacted store is not a pebble engine")
 	}
 
-	pebbleCompactorMode := c.resolvedPebbleMode()
+	pebbleCompactorMode := c.pebbleMode
+	if pebbleCompactorMode == PebbleCompactorModeAuto {
+		pebbleCompactorMode = c.resolvePebbleMode(ctx)
+	}
 	useOverlay := pebbleCompactorMode == PebbleCompactorModeOverlay
 	sources := make([]mergepkg.SourceFile, 0, len(c.entries))
 	unionType := v3.SyncType_SYNC_TYPE_PARTIAL
 	var maxEnded time.Time
 
+	manifestSelected := 0
 	for i := len(c.entries) - 1; i >= 0; i-- {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -219,6 +525,7 @@ func (c *Compactor) compactPebble(ctx context.Context, newSyncId string) error {
 		// — a header read, no payload unpack. Files written before the
 		// projection existed fall back to the unpack path below.
 		if sel, ok := selectSourceSyncFromManifest(cs.FilePath); ok {
+			manifestSelected++
 			sources = append(sources, mergepkg.SourceFile{Path: cs.FilePath, SyncID: sel.syncID, Stats: sel.stats, DecoderPool: c.decoderPool})
 			unionType = unionV3SyncType(unionType, sel.syncType)
 			if sel.endedAt.After(maxEnded) {
@@ -283,6 +590,15 @@ func (c *Compactor) compactPebble(ctx context.Context, newSyncId string) error {
 			maxEnded = endedAt
 		}
 	}
+	// unpack_selected > 0 means inputs predate the manifest sync-run
+	// projection and pay a full unpack just to pick a sync — a fleet
+	// signal that those files should be regenerated by a current SDK.
+	l.Info("compactPebble: source selection",
+		zap.Int("sources", len(sources)),
+		zap.Int("manifest_selected", manifestSelected),
+		zap.Int("unpack_selected", len(sources)-manifestSelected),
+		zap.String("mode", string(pebbleCompactorMode)),
+	)
 
 	var statsRec *v3.SyncStatsRecord
 	var err error
@@ -297,6 +613,12 @@ func (c *Compactor) compactPebble(ctx context.Context, newSyncId string) error {
 		}
 		if c.overlayRecordChunkSize > 0 {
 			overlayOpts = append(overlayOpts, mergepkg.WithOverlayRecordChunkSize(c.overlayRecordChunkSize))
+		}
+		if c.overlayBufferFactor > 0 {
+			overlayOpts = append(overlayOpts, mergepkg.WithOverlayBufferFactor(c.overlayBufferFactor))
+		}
+		if c.overlayGateFraction > 0 {
+			overlayOpts = append(overlayOpts, mergepkg.WithOverlayGateFraction(c.overlayGateFraction))
 		}
 		statsRec, err = mergepkg.MergeFilesIntoOverlay(ctx, destEng, sources, newSyncId, c.tmpDir, overlayOpts...)
 	default:

--- a/pkg/synccompactor/pebble/compactor.go
+++ b/pkg/synccompactor/pebble/compactor.go
@@ -1,26 +1,3 @@
-// Package pebble implements the cross-engine compaction primitive for
-// the v3 Pebble-backed storage engine.
-//
-// The compactor takes a `base` engine and one or more `applied`
-// engines (each representing a sync_run worth of records) and atomically
-// merges `applied`'s data into `base` using pebble.DB.IngestAndExcise:
-//
-//  1. For each applied engine, iterate its records in the source
-//     engine's key order and accumulate them into an SST file on disk.
-//  2. Call base.DB.IngestAndExcise(paths, exciseSpan) with the new
-//     SST and the key range covering the applied sync_id. Pebble
-//     atomically:
-//     (a) excises every key in [exciseSpan.Start, exciseSpan.End)
-//     from base — old sync_id rows go away in one shot.
-//     (b) ingests the SST as a new L6 file (or flushable, depending
-//     on Pebble's choice) under that range.
-//
-// The net effect is a byte-level merge: zero proto encode/decode per
-// record, zero LSM compaction churn from a record-by-record Put loop.
-//
-// Bound: each Compact call replaces exactly one sync_id range in the
-// destination. Multi-sync rollup is a higher-level loop that Compact
-// in sequence.
 package pebble
 
 import (
@@ -42,8 +19,25 @@ import (
 var ErrEmptySync = errors.New("synccompactor/pebble: source has no records under the given sync_id")
 
 // Compactor merges sync_run data between two Pebble engines using
-// IngestAndExcise. Reusable across many Compact calls; safe for
-// sequential use only (not concurrent).
+// pebble.DB.IngestAndExcise:
+//
+//  1. For each bucket of the applied sync, iterate its records in the
+//     source engine's key order and accumulate them into an SST file
+//     on disk.
+//  2. Call base.DB.IngestAndExcise with the new SST and the key range
+//     covering the applied sync_id. Pebble atomically (a) excises
+//     every key in the span from base — old sync_id rows go away in
+//     one shot — and (b) ingests the SST as a new L6 file (or
+//     flushable, depending on Pebble's choice) under that range.
+//
+// The net effect is a byte-level merge: zero proto encode/decode per
+// record, zero LSM compaction churn from a record-by-record Put loop.
+// Each Compact call replaces exactly one sync_id range in the
+// destination; multi-sync rollup is a higher-level loop calling
+// Compact in sequence.
+//
+// Reusable across many Compact calls; safe for sequential use only
+// (not concurrent).
 type Compactor struct {
 	base   *enginepkg.Engine
 	tmpDir string

--- a/pkg/synccompactor/pebble/doc.go
+++ b/pkg/synccompactor/pebble/doc.go
@@ -1,0 +1,67 @@
+// Package pebble implements the record-merge strategies behind v3
+// (Pebble-engine) c1z compaction.
+//
+// Three strategies live here. Which one runs is decided per compaction
+// by synccompactor.resolvePebbleMode: overlay is the default (and
+// currently the only auto-selected mode), fold runs only when
+// requested explicitly — its sync-id adoption is not yet handled by
+// downstream compaction bookkeeping — and kway is never auto-selected
+// on its own: it is overlay's internal fallback and an operational
+// escape hatch (BATON_EXPERIMENTAL_PEBBLE_COMPACTOR=kway). The
+// dormant fold cutover thresholds and the measured crossover data
+// live next to that gate.
+//
+// # Overlay merge (MergeFilesIntoOverlay) — the default rebuild
+//
+// A sqlite-shaped "newest wins" merge into a fresh dest sync. Sources
+// are scanned newest-to-oldest with a bounded in-memory seen set per
+// bucket (128-bit suffix hash → discovered_at; see seenSuffixSet), and
+// only winners are written, through raw Pebble batches that
+// materialize each record and its derived index keys exactly once.
+// The last source scanned (the oldest — in the production skewed
+// shape, the large base) can skip the record write path entirely: its
+// bucket is materialized as SST files filtered against the seen set
+// (every base key not overridden by a newer source) and ingested
+// wholesale (overlayWholeSourceWorthIt gates this on bucket size).
+// Buckets whose estimated key count exceeds the seen-set memory bound
+// (overlaySeenKeyLimit) are routed to the kway run-file path by
+// overlayPlanBuckets, so overlay's worst case is kway plus a planning
+// pass. Cost: O(total input volume), with the cheapest per-record
+// path of the rebuild strategies; wins or ties every measured shape.
+//
+// # K-way merge (MergeFilesInto) — overlay's fallback
+//
+// A bounded-fan-in external merge sort into a fresh dest sync. Sources
+// are processed in fan-in-sized chunks: each chunk's buckets are
+// streamed into a sorted run file (≤ fanIn sources merge directly into
+// Pebble with no run files at all); run files are then merged fanIn at
+// a time per round until one generation remains, and the final
+// generation is deduped (newest discovered_at wins; runRecordIsNewer)
+// and materialized into SSTs that are ingested into dest. Memory stays
+// bounded regardless of input count or size and there is no reliance
+// on in-memory dedup state — the price is writing and re-reading every
+// record through run files, strictly more I/O than overlay. Kept
+// because overlay's oversized buckets need it, and as a forced-mode
+// backup if overlay misbehaves in production.
+//
+// # In-place fold (MergeInto) — explicit-only, fastest for large bases
+//
+// Not a rebuild. The dest store starts as a byte copy of the base
+// input, the output adopts the base sync's id, and each partial's
+// records are streamed into the base keyspace through the engine's
+// keep-newer puts (Put*RecordsIfNewer), which resolve conflicts
+// against incumbents by discovered_at and maintain indexes with point
+// tombstones for overridden records only. Base records are never
+// read, decoded, or rewritten, and the envelope save splices the
+// base's unchanged zstd frames instead of re-encoding them — total
+// cost is O(partial volume) plus a fixed per-source open, versus
+// O(total input) for the rebuilds (measured ~3x faster at a 1.1GB
+// base with small partials). It loses when partial volume grows:
+// every partial record pays a point read-modify-write (~0.2s/MB), so
+// the (dormant) auto gate caps partials at a small fraction of the
+// base.
+//
+// The package also hosts an IngestAndExcise-based Compactor, a
+// byte-level primitive that atomically replaces one sync_id range in a
+// destination engine with a source's view of it (see Compactor).
+package pebble

--- a/pkg/synccompactor/pebble/kway.go
+++ b/pkg/synccompactor/pebble/kway.go
@@ -16,6 +16,8 @@ import (
 	"time"
 
 	cpebble "github.com/cockroachdb/pebble/v2"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
 	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -57,6 +59,29 @@ type SourceFile struct {
 // resources, entitlements, and grants plus all derived indexes. Assets are not
 // copied, matching SQLite compaction behavior.
 //
+// Algorithm (external merge sort with fan-in cfg.fanIn, default 50):
+//
+//   - ≤ fanIn sources merge DIRECTLY into the dest Pebble — one pass,
+//     no run files (mergeSourceChunkToPebble).
+//   - Otherwise sources are processed in fanIn-sized chunks, each
+//     chunk's buckets streamed into one sorted run file
+//     (buildChunkRunFileFromSources); run files are then merged fanIn
+//     at a time per round (mergeRunFileGroup) until ≤ fanIn remain,
+//     and the final generation is materialized into SSTs and ingested
+//     (materializeRunFilesToPebble). Each extra round re-reads and
+//     re-writes the full dataset, so fan-in should comfortably exceed
+//     the expected source count.
+//   - Winner rule: newest discovered_at per primary key, ties keep the
+//     newer source (runRecordIsNewer) — same rule as the overlay and
+//     sqlite compactors. Sources are unpacked per chunk and their
+//     directories removed asynchronously when the chunk closes, so
+//     peak disk is O(fanIn) unpacked sources, not O(len(sources)).
+//
+// Memory stays bounded regardless of input count or size — there is no
+// in-memory dedup state — at the cost of writing and re-reading every
+// record through run files. The overlay merge routes its oversized
+// buckets here; see the package doc for how the strategies divide up.
+//
 // On success it returns the dest sync's stats record, accumulated at the
 // final winner-dedupe sites (never at run-file build time — run files keep
 // duplicate keys across chunks until the last merge round), so the caller
@@ -83,13 +108,26 @@ func mergeBucketsInto(ctx context.Context, dest *enginepkg.Engine, sources []Sou
 	if err != nil {
 		return nil, err
 	}
+	l := ctxzap.Extract(ctx)
+	mergeStart := time.Now()
+	direct := len(sources) <= cfg.fanIn
+	l.Info("pebble kway merge: start",
+		zap.Int("sources", len(sources)),
+		zap.Int("fan_in", cfg.fanIn),
+		zap.Bool("direct", direct),
+		zap.Strings("buckets", bucketNames(buckets)),
+	)
 	stats := newMergeStatsAccumulator()
 	rm := &asyncRemover{}
 	defer rm.wait()
-	if len(sources) <= cfg.fanIn {
+	if direct {
 		if err := mergeSourceChunkToPebble(ctx, dest, tmpDir, sources, 0, destSyncID, destSyncBytes, buckets, stats, rm); err != nil {
 			return nil, err
 		}
+		l.Info("pebble kway merge: done",
+			zap.Duration("elapsed", time.Since(mergeStart)),
+			zap.Int("merge_rounds", 0),
+		)
 		return stats.record(), nil
 	}
 	roundFiles := make([]runFile, 0, (len(sources)+cfg.fanIn-1)/cfg.fanIn)
@@ -129,6 +167,14 @@ func mergeBucketsInto(ctx context.Context, dest *enginepkg.Engine, sources []Sou
 	if err := materializeRunFilesToPebble(ctx, dest, tmpDir, roundFiles, destSyncBytes, buckets, stats); err != nil {
 		return nil, err
 	}
+	// merge_rounds counts intermediate run-file generations beyond the
+	// initial chunk round — nonzero values mean fan_in is small relative
+	// to the source count and each extra round re-reads + re-writes the
+	// full dataset through run files.
+	l.Info("pebble kway merge: done",
+		zap.Duration("elapsed", time.Since(mergeStart)),
+		zap.Int("merge_rounds", round-1),
+	)
 	return stats.record(), nil
 }
 
@@ -165,6 +211,10 @@ type sourceHandle struct {
 	syncID string
 	engine *enginepkg.Engine
 	close  func() error
+	// stats carries the SourceFile's cached per-bucket counts (from the
+	// envelope manifest / stats sidecar) when available. Consulted by
+	// the overlay's whole-source size gate.
+	stats *reader_v2.SyncStats
 }
 
 // sourceChunk owns one fan-in window of open sources. Path-based
@@ -231,6 +281,7 @@ func openSourceChunk(ctx context.Context, tmpDir string, sources []SourceFile, b
 				rank:   baseRank + i,
 				syncID: source.SyncID,
 				engine: source.Engine,
+				stats:  source.Stats,
 			})
 			continue
 		}
@@ -245,6 +296,7 @@ func openSourceChunk(ctx context.Context, tmpDir string, sources []SourceFile, b
 				syncID: source.SyncID,
 				engine: eng,
 				close:  eng.Close,
+				stats:  source.Stats,
 			})
 			continue
 		}
@@ -272,6 +324,7 @@ func openSourceChunk(ctx context.Context, tmpDir string, sources []SourceFile, b
 			// CloseEngineOnly: the unpacked directory lives under
 			// chunk.dir and is removed wholesale by sourceChunk.close().
 			close: func() error { return enginepkg.CloseEngineOnly(store) },
+			stats: source.Stats,
 		})
 	}
 	return chunk, nil

--- a/pkg/synccompactor/pebble/merge.go
+++ b/pkg/synccompactor/pebble/merge.go
@@ -21,18 +21,17 @@ type SourceSync struct {
 }
 
 // MergeInto folds every source's primary records into dest under
-// destSyncID, producing a single merged sync. It is the native-Pebble
-// equivalent of the SQLite ATTACH union: across all inputs, the newest
-// record per logical key (by discovered_at, ties keep the incumbent)
-// survives, and dest's derived indexes are rebuilt from the survivors.
+// destSyncID. Across all inputs (and any records already present under
+// destSyncID), the newest record per logical key (by discovered_at,
+// ties keep the incumbent) survives, and dest's derived indexes are
+// maintained by the keep-newer write path.
 //
-// destSyncID must already exist in dest (created by StartNewSync) and
-// be empty — MergeInto only adds records, it never excises, so no
-// pre-existing data under destSyncID is assumed. MergeInto binds the
-// dest engine's current sync to destSyncID before writing: v3 record
-// values do not carry sync_id, so the engine's keep-newer write path
-// keys every record off the current sync. The binding is left in
-// place when MergeInto returns.
+// destSyncID must already exist in dest. It may be non-empty: the
+// in-place fold compaction merges partial syncs directly into the base
+// sync's keyspace, relying on the Put*RecordsIfNewer semantics to
+// resolve conflicts against pre-existing records. MergeInto binds the
+// dest engine's current sync to destSyncID — the engine's write
+// methods key off the current sync, not any per-record field.
 //
 // Only the four primary record buckets are copied: resource_types,
 // resources, entitlements, grants. Assets are intentionally NOT copied
@@ -40,13 +39,13 @@ type SourceSync struct {
 // four tables and drops assets from the compacted sync; copying assets
 // here would give Pebble compacted syncs asset access the SQLite path
 // does not have. Index keyspaces are not copied verbatim either; the
-// per-record write path rebuilds them from the surviving primaries.
+// per-record write path maintains them.
 //
 // Sources are applied in the given order. The dedup keeps the record
 // with the strictly-greater discovered_at; on an equal discovered_at
-// the already-written (earlier source) record is kept. Callers pass
-// sources in the same order the SQLite fold applies them so the tie
-// winner is identical across engines.
+// the already-written (earlier source, or pre-existing dest) record is
+// kept. Callers pass sources newest-first so the tie winner matches the
+// SQLite fold.
 func MergeInto(ctx context.Context, dest *enginepkg.Engine, sources []SourceSync, destSyncID string) error {
 	if dest == nil {
 		return errors.New("synccompactor/pebble.MergeInto: dest engine is nil")

--- a/pkg/synccompactor/pebble/merge_stats.go
+++ b/pkg/synccompactor/pebble/merge_stats.go
@@ -83,6 +83,26 @@ func (a *mergeStatsAccumulator) regroupGrant(oldRT, newRT []byte) {
 	incrGroup(a.grantsByEntRT, newRT)
 }
 
+// resetBucket zeroes one bucket's accumulated counts. Used by the
+// overlay merge's restart path: the bucket's dest keyspace is
+// range-deleted and re-materialized through the blind K-way path, so
+// every overlay-era count for it is stale. The per-RT group maps are
+// per-record-type (resourcesByRT only ever holds resources-bucket
+// counts, grantsByEntRT only grants), so clearing the matching map
+// cannot disturb another bucket's grouping.
+func (a *mergeStatsAccumulator) resetBucket(bucketID int) {
+	if a == nil {
+		return
+	}
+	a.totals[bucketID] = 0
+	switch bucketID {
+	case runBucketResources:
+		clear(a.resourcesByRT)
+	case runBucketGrants:
+		clear(a.grantsByEntRT)
+	}
+}
+
 // countWinner is the K-way variant: total plus grouping derived from
 // the winner's key (resources) or value (grants).
 func (a *mergeStatsAccumulator) countWinner(bucket bucketSpec, destKey []byte, destLower []byte, value []byte) error {

--- a/pkg/synccompactor/pebble/overlay.go
+++ b/pkg/synccompactor/pebble/overlay.go
@@ -1,26 +1,62 @@
 package pebble
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
 	"hash/maphash"
+	"io"
 	"os"
 	"path/filepath"
+	"sort"
+	"time"
 
 	cpebble "github.com/cockroachdb/pebble/v2"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
 	"google.golang.org/protobuf/encoding/protowire"
 
 	reader_v2 "github.com/conductorone/baton-sdk/pb/c1/reader/v2"
 	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
-	"github.com/conductorone/baton-sdk/pkg/dotc1z"
 	enginepkg "github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/codec"
 )
 
+// defaultOverlayRecordChunkSize is how many records are buffered per
+// raw write batch while streaming winners into the dest. Tunable via
+// BATON_EXPERIMENTAL_OVERLAY_CHUNK_SIZE.
 const defaultOverlayRecordChunkSize = 32768
+
+// defaultOverlaySeenKeyLimit caps the per-bucket seen-set size (the
+// soft limit) for the overlay path; buckets that would exceed it
+// degrade to the kway run-file path mid-merge (see the bucket state
+// machine in MergeFilesIntoOverlay). Each seen-set entry is a
+// 16-byte hash key + 8-byte timestamp (~40B with map overhead), so
+// this bounds seen-set memory to ~15MB per bucket. Raised from 250k
+// when the hashed set replaced the retained-string set (~3-4x smaller
+// per key). Tunable via BATON_EXPERIMENTAL_OVERLAY_SEEN_LIMIT.
 const defaultOverlaySeenKeyLimit = 375000
+
+// defaultOverlayBufferFactor scales the soft seen-key limit into the
+// hard limit (hard = soft × factor). A source that crosses the soft
+// limit mid-scan is allowed to finish inside this buffer (then the
+// bucket resumes via kway at the source boundary); crossing the HARD
+// limit mid-source restarts the bucket through the blind kway path.
+// Overridable via WithOverlayBufferFactor (synccompactor callers:
+// WithOverlayBufferFactor on the Compactor).
+const defaultOverlayBufferFactor = 1.25
+
+// defaultOverlayGateFraction sets the statless pre-source gate as a
+// fraction of the soft limit: when a source has no cached stats and
+// the seen set is already at gateFraction × soft, the bucket resumes
+// via kway before scanning the source (avoiding a mid-source restart).
+// Sources WITH stats use the exact prediction seen+count > hard
+// instead. Overridable via WithOverlayGateFraction (synccompactor
+// callers: WithOverlayGateFraction on the Compactor).
+const defaultOverlayGateFraction = 0.9
 
 // overlayConfig carries the overlay merge tunables. The defaults are
 // the production values; explicit options exist for benchmarks and
@@ -28,6 +64,41 @@ const defaultOverlaySeenKeyLimit = 375000
 type overlayConfig struct {
 	seenKeyLimit    int64
 	recordChunkSize int
+	bufferFactor    float64
+	gateFraction    float64
+	fanIn           int
+}
+
+func defaultOverlayConfig() overlayConfig {
+	return overlayConfig{
+		seenKeyLimit:    defaultOverlaySeenKeyLimit,
+		recordChunkSize: defaultOverlayRecordChunkSize,
+		bufferFactor:    defaultOverlayBufferFactor,
+		gateFraction:    defaultOverlayGateFraction,
+		fanIn:           defaultKWayFanIn,
+	}
+}
+
+// hardLimit is the seen-set size that triggers a mid-source restart.
+// Clamped to at least the soft limit so a buffer factor below 1 cannot
+// invert the two thresholds.
+func (c overlayConfig) hardLimit() int64 {
+	hl := int64(float64(c.seenKeyLimit) * c.bufferFactor)
+	if hl < c.seenKeyLimit {
+		return c.seenKeyLimit
+	}
+	return hl
+}
+
+// gateThreshold is the statless pre-source gate. Clamped to at least 1
+// so a tiny soft limit cannot make the gate fire on an empty seen set
+// (the first source must always get a chance to scan).
+func (c overlayConfig) gateThreshold() int64 {
+	g := int64(c.gateFraction * float64(c.seenKeyLimit))
+	if g < 1 {
+		return 1
+	}
+	return g
 }
 
 // OverlayOption tunes the overlay merge.
@@ -57,6 +128,38 @@ func WithOverlayRecordChunkSize(n int) OverlayOption {
 	}
 }
 
+// WithOverlayBufferFactor overrides the soft→hard limit multiplier
+// (default 1.25). Non-positive values are ignored.
+func WithOverlayBufferFactor(f float64) OverlayOption {
+	return func(c *overlayConfig) {
+		if f > 0 {
+			c.bufferFactor = f
+		}
+	}
+}
+
+// WithOverlayGateFraction overrides the statless pre-source gate
+// fraction (default 0.9). Non-positive values are ignored.
+func WithOverlayGateFraction(f float64) OverlayOption {
+	return func(c *overlayConfig) {
+		if f > 0 {
+			c.gateFraction = f
+		}
+	}
+}
+
+// WithOverlayFanIn overrides how many sources are opened per chunk
+// (default matches the kway fan-in). Intended for tests that need
+// multi-chunk behavior without dozens of sources. Values below 1 are
+// ignored.
+func WithOverlayFanIn(n int) OverlayOption {
+	return func(c *overlayConfig) {
+		if n >= 1 {
+			c.fanIn = n
+		}
+	}
+}
+
 // seenSuffixSet tracks, per admitted primary-key suffix, the
 // discovered_at (UnixNano) of the record currently admitted for that
 // key. Keys are 128-bit hashes of the suffix instead of the suffix
@@ -69,8 +172,8 @@ func WithOverlayRecordChunkSize(n int) OverlayOption {
 // Trade-off: a hash collision makes a never-seen key look seen, so a
 // record that should have won is dropped (or wrongly compared) in the
 // dest sync. The 128-bit key is built from two independently-seeded
-// 64-bit maphash values; at the 250k-key seen limit the collision
-// probability per merge is ~(n^2/2)/2^128 ≈ 1e-28 — negligible against
+// 64-bit maphash values; at the 375k-key seen limit the collision
+// probability per merge is ~(n^2/2)/2^128 ≈ 2e-28 — negligible against
 // the hardware error floor. Seeds are per-process random, which is
 // fine: the set never persists and never crosses processes.
 type seenSuffixSet struct {
@@ -108,6 +211,117 @@ func (s *seenSuffixSet) put(k [16]byte, ts int64) {
 
 func (s *seenSuffixSet) size() int { return len(s.m) }
 
+// errOverlayHardLimit is the sentinel overlaySinglePassBucket returns
+// when admitting one more key would push the seen set past the hard
+// limit. The caller restarts the bucket through the blind kway path.
+var errOverlayHardLimit = errors.New("overlay merge: seen-set hard limit exceeded")
+
+// overlayBucketMode is the per-bucket degradation state. Transitions
+// are one-way: active → resumed (seen map frozen, remaining sources
+// flow to run files and a map-aware materialization) or active →
+// restarted (dest keyspace range-deleted, ALL sources flow to run
+// files and the blind kway materialization).
+type overlayBucketMode int
+
+const (
+	overlayBucketActive overlayBucketMode = iota
+	overlayBucketResumed
+	overlayBucketRestarted
+)
+
+func (m overlayBucketMode) String() string {
+	switch m {
+	case overlayBucketResumed:
+		return "resumed"
+	case overlayBucketRestarted:
+		return "restarted"
+	default:
+		return "active"
+	}
+}
+
+type overlayBucketState struct {
+	mode overlayBucketMode
+	// cutRank is the global source rank where kway coverage begins for
+	// a resumed bucket: sources[cutRank:] were never overlay-scanned.
+	cutRank int
+	// restartChunk is the chunk index where a restart fired. Chunks
+	// before it closed without building run files for this bucket and
+	// are re-opened by the backfill pass.
+	restartChunk int
+}
+
+// overlayPreGateFires reports whether the bucket should resume via
+// kway BEFORE scanning this source. With per-source stats the gate is
+// the exact overshoot prediction (current seen size plus the source's
+// bucket count exceeding the hard limit); without stats it is the
+// conservative gateThreshold on the current seen size.
+func overlayPreGateFires(seen *seenSuffixSet, srcStats *reader_v2.SyncStats, bucket bucketSpec, hardLimit, gateThreshold int64) bool {
+	if srcStats != nil {
+		if n, ok := syncStatsBucketKeys(srcStats, bucket); ok {
+			return int64(seen.size())+n > hardLimit
+		}
+	}
+	return int64(seen.size()) >= gateThreshold
+}
+
+// bucketIndexRanges enumerates the bucket's sync-scoped secondary
+// index keyspaces under syncBytes — everything the overlay writer's
+// forEachIndexKeyFromRaw can have emitted for this bucket. Paired with
+// bucket.syncRange (the primary range) these are exactly the ranges a
+// restart must delete.
+func bucketIndexRanges(bucket bucketSpec, syncBytes []byte) [][2][]byte {
+	switch bucket.id {
+	case runBucketResources:
+		return [][2][]byte{
+			{enginepkg.ResourceByParentSyncLowerBound(syncBytes), enginepkg.ResourceByParentSyncUpperBound(syncBytes)},
+		}
+	case runBucketEntitlements:
+		return [][2][]byte{
+			{enginepkg.EntitlementByResourceSyncLowerBound(syncBytes), enginepkg.EntitlementByResourceSyncUpperBound(syncBytes)},
+		}
+	case runBucketGrants:
+		return [][2][]byte{
+			{enginepkg.GrantByEntitlementSyncLowerBound(syncBytes), enginepkg.GrantByEntitlementSyncUpperBound(syncBytes)},
+			{enginepkg.GrantByEntitlementResourceSyncLowerBound(syncBytes), enginepkg.GrantByEntitlementResourceSyncUpperBound(syncBytes)},
+			{enginepkg.GrantByPrincipalSyncLowerBound(syncBytes), enginepkg.GrantByPrincipalSyncUpperBound(syncBytes)},
+			{enginepkg.GrantByPrincipalResourceTypeSyncLowerBound(syncBytes), enginepkg.GrantByPrincipalResourceTypeSyncUpperBound(syncBytes)},
+			{enginepkg.GrantByNeedsExpansionSyncLowerBound(syncBytes), enginepkg.GrantByNeedsExpansionSyncUpperBound(syncBytes)},
+		}
+	default:
+		return nil
+	}
+}
+
+// overlayRestartBucket undoes every overlay-era write for one bucket:
+// pending (uncommitted) batch writes are discarded — the writer is
+// bucket-scoped, so nothing else is in them — and the committed
+// primary + index keyspaces are range-deleted, including anything the
+// whole-source SST path ingested. Stats for the bucket are zeroed; the
+// blind kway materialization recounts from scratch.
+func overlayRestartBucket(ctx context.Context, dest *enginepkg.Engine, bucket bucketSpec, destSyncBytes []byte, writer *overlayBucketRawWriter, stats *mergeStatsAccumulator) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	writer.discard()
+	b := dest.DB().NewBatch()
+	defer func() { _ = b.Close() }()
+	lo, hi := bucket.syncRange(destSyncBytes)
+	if err := b.DeleteRange(lo, hi, nil); err != nil {
+		return err
+	}
+	for _, r := range bucketIndexRanges(bucket, destSyncBytes) {
+		if err := b.DeleteRange(r[0], r[1], nil); err != nil {
+			return err
+		}
+	}
+	if err := b.Commit(cpebble.NoSync); err != nil {
+		return err
+	}
+	stats.resetBucket(bucket.id)
+	return nil
+}
+
 // MergeFilesIntoOverlay is a sqlite-shaped compactor:
 //
 //   - keep a bounded in-memory seen map (suffix hash → discovered_at)
@@ -118,9 +332,24 @@ func (s *seenSuffixSet) size() int { return len(s.m) }
 //     sqlite attached compactor (`a.discovered_at > m.discovered_at`),
 //     enforced via a shallow discovered_at scan of each candidate value;
 //   - write winners through raw Pebble batches so secondary indexes are
-//     materialized once; and
-//   - route buckets whose estimated key count exceeds the in-memory
-//     limit through the K-way run-file path instead (overlayPlanBuckets).
+//     materialized once;
+//   - let the last source scanned (the oldest — in the production
+//     skewed shape, the large base) skip the record write path when
+//     its bucket is big enough (overlayWholeSourceWorthIt): the bucket
+//     is materialized as SST files filtered against the seen set and
+//     ingested wholesale, making the base's cost proportional to bytes
+//     copied rather than records decoded; and
+//   - degrade buckets whose seen set would outgrow memory to the K-way
+//     run-file path ADAPTIVELY (per-bucket state machine):
+//     a pre-source gate cuts at a source boundary and RESUMES via kway
+//     with the seen map frozen as the conflict oracle; a source that
+//     crosses the soft limit mid-scan may finish inside the buffer
+//     (hard limit = soft × bufferFactor) and resume at the boundary;
+//     crossing the hard limit mid-source RESTARTS the bucket — its
+//     dest keyspace is range-deleted and the whole bucket flows
+//     through the blind kway path (keeping SST ingest, total work ≤2×).
+//     Planning routes only the provably-safe (stats sum ≤ soft) and
+//     provably-doomed (single-source count > hard) buckets up front.
 //
 // On success it returns the dest sync's stats record, accumulated as
 // winners were written, so the caller can persist the stats sidecar
@@ -132,10 +361,7 @@ func MergeFilesIntoOverlay(ctx context.Context, dest *enginepkg.Engine, sources 
 	if destSyncID == "" {
 		return nil, fmt.Errorf("overlay merge: destSyncID is required")
 	}
-	cfg := overlayConfig{
-		seenKeyLimit:    defaultOverlaySeenKeyLimit,
-		recordChunkSize: defaultOverlayRecordChunkSize,
-	}
+	cfg := defaultOverlayConfig()
 	for _, opt := range opts {
 		opt(&cfg)
 	}
@@ -143,11 +369,21 @@ func MergeFilesIntoOverlay(ctx context.Context, dest *enginepkg.Engine, sources 
 	if err != nil {
 		return nil, err
 	}
+	hardLimit := cfg.hardLimit()
+	gateThreshold := cfg.gateThreshold()
 	buckets := allBuckets()
-	overlayBuckets, kwayBuckets, err := overlayPlanBuckets(ctx, sources, buckets, tmpDir, cfg.seenKeyLimit)
-	if err != nil {
-		return nil, err
-	}
+	overlayBuckets, kwayBuckets := overlayPlanBuckets(ctx, sources, buckets, cfg.seenKeyLimit, hardLimit)
+
+	l := ctxzap.Extract(ctx)
+	mergeStart := time.Now()
+	l.Info("pebble overlay merge: bucket plan",
+		zap.Int("sources", len(sources)),
+		zap.Strings("overlay_buckets", bucketNames(overlayBuckets)),
+		zap.Strings("kway_upfront_buckets", bucketNames(kwayBuckets)),
+		zap.Int64("seen_key_limit", cfg.seenKeyLimit),
+		zap.Int64("seen_key_hard_limit", hardLimit),
+		zap.Int64("pre_gate_threshold", gateThreshold),
+	)
 
 	stats := newMergeStatsAccumulator()
 	rm := &asyncRemover{}
@@ -158,6 +394,7 @@ func MergeFilesIntoOverlay(ctx context.Context, dest *enginepkg.Engine, sources 
 	}()
 	writers := make([]*overlayBucketRawWriter, len(overlayBuckets))
 	seenByBucket := make([]*seenSuffixSet, len(overlayBuckets))
+	states := make([]overlayBucketState, len(overlayBuckets))
 	for i, bucket := range overlayBuckets {
 		writers[i] = newOverlayBucketRawWriter(dest, bucket, stats, cfg.recordChunkSize)
 		seenByBucket[i] = newSeenSuffixSet()
@@ -172,8 +409,9 @@ func MergeFilesIntoOverlay(ctx context.Context, dest *enginepkg.Engine, sources 
 	// closing it. This preserves the K-way FD bound while avoiding the old
 	// bucket-major reopen pattern; same-size syncs=50 overlay dropped from
 	// ~5.4s to ~2.9s when source opens stopped multiplying by bucket count.
-	for start := 0; start < len(sources); start += defaultKWayFanIn {
-		end := min(start+defaultKWayFanIn, len(sources))
+	chunkIdx := 0
+	for start := 0; start < len(sources); start += cfg.fanIn {
+		end := min(start+cfg.fanIn, len(sources))
 		chunk, err := openSourceChunk(ctx, tmpDir, sources[start:end], start)
 		if err != nil {
 			return nil, err
@@ -186,27 +424,151 @@ func MergeFilesIntoOverlay(ctx context.Context, dest *enginepkg.Engine, sources 
 					return err
 				}
 				for bucketIdx, bucket := range overlayBuckets {
-					seen := seenByBucket[bucketIdx]
-					if source.rank == len(sources)-1 && seen.size() == 0 {
-						if err := overlayMaterializeWholeSourceBucketSST(ctx, dest, source.engine, bucket, sourceSyncBytes, destSyncBytes, tmpDir, stats); err != nil {
-							return err
-						}
+					st := &states[bucketIdx]
+					if st.mode != overlayBucketActive {
+						// Degraded buckets are covered by run files
+						// (built per chunk below); nothing to scan.
 						continue
 					}
-					if err := overlaySinglePassBucket(ctx, source.engine, bucket, writers[bucketIdx], seen, sourceSyncBytes, destSyncBytes); err != nil {
+					seen := seenByBucket[bucketIdx]
+					if source.rank == len(sources)-1 {
+						useSST, err := overlayWholeSourceWorthIt(ctx, source, bucket, sourceSyncBytes, seen)
+						if err != nil {
+							return err
+						}
+						// The gate decision is the main prod tunable
+						// (overlayWholeSourceMinKeys): sst_path=false
+						// on a huge base means the threshold is too
+						// high; sst_path=true on small merges means
+						// it's too low.
+						l.Debug("pebble overlay merge: whole-source gate",
+							zap.String("bucket", bucket.name),
+							zap.Bool("sst_path", useSST),
+							zap.Int("seen_keys", seen.size()),
+						)
+						if useSST {
+							// Last source (the base sync in the
+							// skewed/prod shape): filtered SST-ingest.
+							// Unseen keys — the vast majority for a
+							// large base — stream straight into an
+							// ingested SST instead of through the
+							// memtable; seen keys get the same
+							// discovered_at comparison as the
+							// single-pass path. Filtering keeps the
+							// ingested SST key-disjoint from earlier
+							// admissions, so ingest seqnum ordering
+							// can't shadow them. The SST path never
+							// grows the seen set, so no degradation
+							// checks apply here.
+							if err := overlayMaterializeWholeSourceBucketSST(ctx, dest, source.engine, bucket, writers[bucketIdx], seen, sourceSyncBytes, destSyncBytes, tmpDir, stats); err != nil {
+								return err
+							}
+							continue
+						}
+					}
+					if overlayPreGateFires(seen, source.stats, bucket, hardLimit, gateThreshold) {
+						if seen.size() == 0 {
+							// Nothing admitted yet: restarting is free
+							// (discard/range-delete/reset are all
+							// no-ops) and routes the whole bucket
+							// through the blind kway path, keeping
+							// SST ingest instead of paying the
+							// map-aware batch path with an empty map.
+							if err := overlayRestartBucket(ctx, dest, bucket, destSyncBytes, writers[bucketIdx], stats); err != nil {
+								return err
+							}
+							st.mode = overlayBucketRestarted
+							st.restartChunk = chunkIdx
+						} else {
+							st.mode = overlayBucketResumed
+							st.cutRank = source.rank
+						}
+						l.Info("pebble overlay merge: bucket degraded at pre-source gate",
+							zap.String("bucket", bucket.name),
+							zap.String("mode", st.mode.String()),
+							zap.Int("source_rank", source.rank),
+							zap.Int("seen_keys", seen.size()),
+						)
+						continue
+					}
+					err = overlaySinglePassBucket(ctx, source.engine, bucket, writers[bucketIdx], seen, sourceSyncBytes, destSyncBytes, hardLimit)
+					switch {
+					case errors.Is(err, errOverlayHardLimit):
+						if err := overlayRestartBucket(ctx, dest, bucket, destSyncBytes, writers[bucketIdx], stats); err != nil {
+							return err
+						}
+						// Release the (large) seen map; the blind kway
+						// materialization needs no conflict oracle.
+						seenByBucket[bucketIdx] = newSeenSuffixSet()
+						st.mode = overlayBucketRestarted
+						st.restartChunk = chunkIdx
+						l.Info("pebble overlay merge: bucket restarted at hard limit",
+							zap.String("bucket", bucket.name),
+							zap.Int("source_rank", source.rank),
+							zap.Int64("hard_limit", hardLimit),
+						)
+					case err != nil:
 						return err
+					default:
+						if int64(seen.size()) > cfg.seenKeyLimit {
+							// The source finished inside the buffer;
+							// cut at the boundary. The frozen map is
+							// the conflict oracle for the resumed
+							// materialization.
+							st.mode = overlayBucketResumed
+							st.cutRank = source.rank + 1
+							l.Info("pebble overlay merge: bucket resumed at source boundary",
+								zap.String("bucket", bucket.name),
+								zap.Int("source_rank", source.rank),
+								zap.Int("seen_keys", seen.size()),
+								zap.Int64("soft_limit", cfg.seenKeyLimit),
+							)
+						}
 					}
 				}
 			}
+			// Build this chunk's run files. Buckets need different
+			// handle ranges: up-front kway and restarted buckets need
+			// the full chunk; a bucket resumed mid-chunk needs only the
+			// handles from its cut boundary onward. Group by start
+			// index so the common case (everything from 0) stays one
+			// run file per chunk.
+			needs := map[int][]bucketSpec{}
 			if len(kwayBuckets) > 0 {
+				needs[0] = append(needs[0], kwayBuckets...)
+			}
+			for bucketIdx, bucket := range overlayBuckets {
+				switch states[bucketIdx].mode {
+				case overlayBucketResumed:
+					from := states[bucketIdx].cutRank - start
+					if from < 0 {
+						from = 0
+					}
+					if from < len(chunk.handles) {
+						needs[from] = append(needs[from], bucket)
+					}
+				case overlayBucketRestarted:
+					// Chunks before restartChunk are re-opened by the
+					// backfill pass; this chunk and later ones are
+					// covered here in full.
+					needs[0] = append(needs[0], bucket)
+				case overlayBucketActive:
+				}
+			}
+			froms := make([]int, 0, len(needs))
+			for from := range needs {
+				froms = append(froms, from)
+			}
+			sort.Ints(froms)
+			for _, from := range froms {
 				run, err := buildChunkRunFileFromHandles(
 					ctx,
 					tmpDir,
-					chunk.handles,
+					chunk.handles[from:],
 					fmt.Sprintf("overlay-fallback-%04d", len(kwayRunFiles)),
 					destSyncID,
 					destSyncBytes,
-					kwayBuckets,
+					needs[from],
 				)
 				if err != nil {
 					return err
@@ -217,6 +579,16 @@ func MergeFilesIntoOverlay(ctx context.Context, dest *enginepkg.Engine, sources 
 		}(); err != nil {
 			return nil, err
 		}
+		chunkIdx++
+	}
+
+	// Backfill: a restarted bucket needs run files for the chunks that
+	// closed BEFORE its restart point (their overlay writes were
+	// range-deleted). Re-open only those chunks, only for the buckets
+	// that need them. Records carry global source ranks, so backfill
+	// run files merge correctly regardless of build order.
+	if err := overlayBackfillRestartedChunks(ctx, tmpDir, sources, cfg.fanIn, overlayBuckets, states, destSyncID, destSyncBytes, &kwayRunFiles, rm); err != nil {
+		return nil, err
 	}
 
 	for _, writer := range writers {
@@ -227,89 +599,285 @@ func MergeFilesIntoOverlay(ctx context.Context, dest *enginepkg.Engine, sources 
 			return nil, err
 		}
 	}
-	if len(kwayBuckets) > 0 {
+
+	// Materialize the kway-routed data. Up-front kway buckets and
+	// restarted buckets take the blind path (SST ingest, no conflict
+	// checks — their dest keyspace holds nothing from overlay). Resumed
+	// buckets take the map-aware path: the frozen seen map arbitrates
+	// against overlay-admitted winners via addRaw/replaceRaw.
+	blindBuckets := append([]bucketSpec{}, kwayBuckets...)
+	resumedIdx := make([]int, 0, len(overlayBuckets))
+	for i, bucket := range overlayBuckets {
+		switch states[i].mode {
+		case overlayBucketRestarted:
+			blindBuckets = append(blindBuckets, bucket)
+		case overlayBucketResumed:
+			resumedIdx = append(resumedIdx, i)
+		case overlayBucketActive:
+		}
+	}
+	if len(blindBuckets) > 0 && len(kwayRunFiles) > 0 {
 		kwayStats := newMergeStatsAccumulator()
-		if err := materializeRunFilesToPebble(ctx, dest, tmpDir, kwayRunFiles, destSyncBytes, kwayBuckets, kwayStats); err != nil {
+		if err := materializeRunFilesToPebble(ctx, dest, tmpDir, kwayRunFiles, destSyncBytes, blindBuckets, kwayStats); err != nil {
 			return nil, err
 		}
 		stats.addRecord(kwayStats.record())
 	}
+	for _, i := range resumedIdx {
+		if err := materializeResumedRunFilesToPebble(ctx, tmpDir, kwayRunFiles, destSyncBytes, overlayBuckets[i], seenByBucket[i], writers[i]); err != nil {
+			return nil, err
+		}
+	}
+
+	// Per-bucket seen sizes calibrate the seen-key limit (memory);
+	// per-bucket modes report how often degradation fires in prod.
+	doneFields := []zap.Field{
+		zap.Duration("elapsed", time.Since(mergeStart)),
+		zap.Int("kway_fallback_run_files", len(kwayRunFiles)),
+	}
+	for i, bucket := range overlayBuckets {
+		doneFields = append(doneFields,
+			zap.Int("seen_keys_"+bucket.name, seenByBucket[i].size()),
+			zap.String("mode_"+bucket.name, states[i].mode.String()),
+		)
+	}
+	l.Info("pebble overlay merge: done", doneFields...)
 	return stats.record(), nil
 }
 
-func overlayPlanBuckets(ctx context.Context, sources []SourceFile, buckets []bucketSpec, tmpDir string, limit int64) ([]bucketSpec, []bucketSpec, error) {
-	overlayBuckets := make([]bucketSpec, 0, len(buckets))
-	kwayBuckets := make([]bucketSpec, 0, len(buckets))
-	for _, bucket := range buckets {
-		if total, ok := overlayEstimatedBucketKeys(sources, bucket); ok {
-			if total > limit {
-				kwayBuckets = append(kwayBuckets, bucket)
-			} else {
-				overlayBuckets = append(overlayBuckets, bucket)
+// overlayBackfillRestartedChunks re-opens the chunks that closed
+// before each restarted bucket's restart point and builds run files
+// covering those buckets. Chunks at or after a bucket's restartChunk
+// were already covered in the main loop.
+func overlayBackfillRestartedChunks(
+	ctx context.Context,
+	tmpDir string,
+	sources []SourceFile,
+	fanIn int,
+	overlayBuckets []bucketSpec,
+	states []overlayBucketState,
+	destSyncID string,
+	destSyncBytes []byte,
+	kwayRunFiles *[]runFile,
+	rm *asyncRemover,
+) error {
+	chunkIdx := 0
+	for start := 0; start < len(sources); start += fanIn {
+		var needed []bucketSpec
+		for i, bucket := range overlayBuckets {
+			if states[i].mode == overlayBucketRestarted && states[i].restartChunk > chunkIdx {
+				needed = append(needed, bucket)
+			}
+		}
+		if len(needed) == 0 {
+			chunkIdx++
+			continue
+		}
+		end := min(start+fanIn, len(sources))
+		chunk, err := openSourceChunk(ctx, tmpDir, sources[start:end], start)
+		if err != nil {
+			return err
+		}
+		run, err := func() (runFile, error) {
+			defer chunk.closeAsync(rm)
+			return buildChunkRunFileFromHandles(
+				ctx,
+				tmpDir,
+				chunk.handles,
+				fmt.Sprintf("overlay-backfill-%04d", len(*kwayRunFiles)),
+				destSyncID,
+				destSyncBytes,
+				needed,
+			)
+		}()
+		if err != nil {
+			return err
+		}
+		*kwayRunFiles = append(*kwayRunFiles, run)
+		chunkIdx++
+	}
+	return nil
+}
+
+// materializeResumedRunFilesToPebble is the map-aware counterpart to
+// materializeRunFilesToPebble for one resumed bucket. The merged run
+// stream holds the kway winner per key among the remaining (older)
+// sources — duplicates are adjacent and deduped positionally, so the
+// frozen seen map needs no insertions and memory stays exactly capped.
+// Each stream winner is arbitrated against the overlay-admitted record
+// via the map: a miss is a fresh admission (addRaw), a hit replaces
+// only on a strictly newer discovered_at (replaceRaw — ties keep the
+// overlay record, which came from a newer source, matching
+// runRecordIsNewer's ordering), otherwise it is dropped.
+//
+// Writes go through the bucket's overlayBucketRawWriter (batch path)
+// rather than SST ingest: replacements must delete the superseded
+// value's index keys, and fresh admissions must not shadow batch
+// writes via ingest seqnums. addRaw counts winners and replaceRaw
+// regroups; the blind path's countWinner is deliberately not used, so
+// nothing double-counts.
+func materializeResumedRunFilesToPebble(
+	ctx context.Context,
+	tmpDir string,
+	inputs []runFile,
+	destSyncBytes []byte,
+	bucket bucketSpec,
+	seen *seenSuffixSet,
+	writer *overlayBucketRawWriter,
+) error {
+	if len(inputs) == 0 {
+		return nil
+	}
+	merged, err := mergeRunFileGroup(ctx, tmpDir, inputs, "overlay-resumed-"+bucket.name, []bucketSpec{bucket})
+	if err != nil {
+		return err
+	}
+	defer removeRunFiles([]runFile{merged})
+	f, err := os.Open(merged.path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	section := merged.sections[bucket.id]
+	if _, err := f.Seek(section.offset, io.SeekStart); err != nil {
+		return err
+	}
+	br := bufio.NewReaderSize(io.LimitReader(f, section.length), runFileBufferSize)
+	destLower, _ := bucket.syncRange(destSyncBytes)
+	var rec runRecord
+	var hdr [runHeaderSize]byte
+	var lastPrimaryKey []byte
+	for {
+		ok, err := readRunRecordInto(br, &rec, &hdr)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			break
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if bytes.Equal(rec.key, lastPrimaryKey) {
+			continue
+		}
+		lastPrimaryKey = append(lastPrimaryKey[:0], rec.key...)
+		if len(rec.key) <= len(destLower) {
+			return fmt.Errorf("overlay resumed merge: run key shorter than dest prefix: key=%d prefix=%d", len(rec.key), len(destLower))
+		}
+		suffix := rec.key[len(destLower):]
+		if prevTs, hit := seen.get(seen.keyOf(suffix)); hit {
+			if rec.tsNanos <= prevTs {
+				continue
+			}
+			if err := writer.replaceRaw(ctx, bucket, destSyncBytes, rec.key, destLower, rec.value); err != nil {
+				return err
 			}
 			continue
 		}
-		total, err := overlayCountBucketKeysUpTo(ctx, sources, bucket, tmpDir, limit)
-		if err != nil {
-			return nil, nil, err
+		if err := writer.addRaw(ctx, bucket, destSyncBytes, rec.key, destLower, rec.value); err != nil {
+			return err
 		}
-		if total > limit {
+	}
+	return writer.flush(ctx)
+}
+
+// overlayPlanBuckets routes each bucket up front using only cached
+// stats — no counting pre-scan. The stats give two bounds on the
+// distinct-key count the seen set will hold:
+//
+//   - sum of per-source counts is an UPPER bound (duplicates counted
+//     once per source) → sum ≤ softLimit guarantees overlay is safe;
+//   - max single-source count is a LOWER bound (one source's keys are
+//     all distinct within it) → max > hardLimit guarantees overlay
+//     would restart, so route straight to kway and keep blind ingest.
+//
+// Everything in between — and every bucket where any source lacks
+// stats — starts in overlay and relies on the adaptive degradation
+// state machine in MergeFilesIntoOverlay. Sources whose keys never
+// feed the seen set (the last source when it will take the
+// whole-source SST path) are excluded from both bounds.
+func overlayPlanBuckets(ctx context.Context, sources []SourceFile, buckets []bucketSpec, softLimit, hardLimit int64) ([]bucketSpec, []bucketSpec) {
+	l := ctxzap.Extract(ctx)
+	overlayBuckets := make([]bucketSpec, 0, len(buckets))
+	kwayBuckets := make([]bucketSpec, 0, len(buckets))
+	for _, bucket := range buckets {
+		sum, maxSingle, ok := overlayEstimatedBucketBounds(sources, bucket)
+		if !ok {
+			// At least one source lacks a stats projection
+			// (pre-projection file or missing sidecar) — a
+			// fleet-health signal that inputs should be regenerated
+			// by a current SDK. Start in overlay; degradation covers
+			// the misprediction.
+			l.Debug("pebble overlay merge: bucket routing",
+				zap.String("bucket", bucket.name),
+				zap.Bool("from_cached_stats", false),
+				zap.Bool("routed_to_kway", false),
+			)
+			overlayBuckets = append(overlayBuckets, bucket)
+			continue
+		}
+		routeToKway := sum > softLimit && maxSingle > hardLimit
+		l.Debug("pebble overlay merge: bucket routing",
+			zap.String("bucket", bucket.name),
+			zap.Int64("estimated_seen_load", sum),
+			zap.Int64("max_single_source", maxSingle),
+			zap.Bool("from_cached_stats", true),
+			zap.Bool("routed_to_kway", routeToKway),
+		)
+		if routeToKway {
 			kwayBuckets = append(kwayBuckets, bucket)
 		} else {
 			overlayBuckets = append(overlayBuckets, bucket)
 		}
 	}
-	return overlayBuckets, kwayBuckets, nil
+	return overlayBuckets, kwayBuckets
 }
 
-func overlayCountBucketKeysUpTo(ctx context.Context, sources []SourceFile, bucket bucketSpec, tmpDir string, limit int64) (int64, error) {
-	var total int64
-	for _, source := range sources {
-		if err := ctx.Err(); err != nil {
-			return 0, err
-		}
-		err := withSourceEngine(ctx, tmpDir, source, func(eng *enginepkg.Engine) error {
-			sourceSyncBytes, err := codec.EncodeSyncID(source.SyncID)
-			if err != nil {
-				return err
-			}
-			sourceLower, sourceUpper := bucket.syncRange(sourceSyncBytes)
-			iter, err := eng.DB().NewIter(&cpebble.IterOptions{LowerBound: sourceLower, UpperBound: sourceUpper})
-			if err != nil {
-				return err
-			}
-			defer iter.Close()
-			for iter.First(); iter.Valid(); iter.Next() {
-				total++
-				if total > limit {
-					return nil
-				}
-			}
-			return iter.Error()
-		})
-		if err != nil {
-			return 0, err
-		}
-		if total > limit {
-			return total, nil
-		}
+// bucketNames renders a bucket list for log fields.
+func bucketNames(buckets []bucketSpec) []string {
+	out := make([]string, 0, len(buckets))
+	for _, b := range buckets {
+		out = append(out, b.name)
 	}
-	return total, nil
+	return out
 }
 
-func overlayEstimatedBucketKeys(sources []SourceFile, bucket bucketSpec) (int64, bool) {
-	var total int64
+// overlayEstimatedBucketBounds returns the sum (upper bound on
+// distinct keys) and max single-source count (lower bound) over the
+// sources whose keys feed the seen set. ok is false when any source
+// lacks cached stats.
+//
+// The last source's keys never enter the seen set when it takes the
+// whole-source SST path (they're filtered against the set, not added
+// to it). Exclude that contribution from both bounds — otherwise a
+// large base sync (the production skewed shape) routes its bucket to
+// the kway fallback and the SST path never runs for exactly the data
+// it exists for.
+func overlayEstimatedBucketBounds(sources []SourceFile, bucket bucketSpec) (int64, int64, bool) {
+	counts := make([]int64, 0, len(sources))
 	for _, source := range sources {
 		if source.Stats == nil {
-			return 0, false
+			return 0, 0, false
 		}
 		n, ok := syncStatsBucketKeys(source.Stats, bucket)
 		if !ok {
-			return 0, false
+			return 0, 0, false
 		}
-		total += n
+		counts = append(counts, n)
 	}
-	return total, true
+	var sum, maxSingle int64
+	for i, n := range counts {
+		if i == len(counts)-1 && n >= overlayWholeSourceMinKeys {
+			// Will take the whole-source SST path; never feeds the map.
+			continue
+		}
+		sum += n
+		if n > maxSingle {
+			maxSingle = n
+		}
+	}
+	return sum, maxSingle, true
 }
 
 func syncStatsBucketKeys(stats *reader_v2.SyncStats, bucket bucketSpec) (int64, bool) {
@@ -335,6 +903,7 @@ func overlaySinglePassBucket(
 	seen *seenSuffixSet,
 	sourceSyncBytes []byte,
 	destSyncBytes []byte,
+	hardLimit int64,
 ) error {
 	destLower, _ := bucket.syncRange(destSyncBytes)
 	sourceLower, sourceUpper := bucket.syncRange(sourceSyncBytes)
@@ -362,7 +931,8 @@ func overlaySinglePassBucket(
 			// Key already admitted by an earlier (newer) source. Replace
 			// only on a strictly newer discovered_at; ties keep the
 			// earlier admission — matching runRecordIsNewer's
-			// (ts, then source rank) ordering.
+			// (ts, then source rank) ordering. Updates never grow the
+			// map, so no hard-limit check applies.
 			if ts <= prevTs {
 				continue
 			}
@@ -373,6 +943,13 @@ func overlaySinglePassBucket(
 			seen.put(k, ts)
 			continue
 		}
+		// New key: admitting it grows the seen set. Crossing the soft
+		// limit mid-source is allowed (the buffer); crossing the HARD
+		// limit aborts the scan and the caller restarts the bucket
+		// through the blind kway path.
+		if int64(seen.size()) >= hardLimit {
+			return errOverlayHardLimit
+		}
 		seen.put(k, ts)
 		destKey = rewritePrimaryKeyForDestInto(destKey[:0], sourceSuffix, destLower)
 		if err := writer.addRaw(ctx, bucket, destSyncBytes, destKey, destLower, iter.Value()); err != nil {
@@ -382,11 +959,71 @@ func overlaySinglePassBucket(
 	return iter.Error()
 }
 
+// overlayWholeSourceMinKeys gates the filtered whole-source SST path
+// by bucket size. The SST route carries fixed overhead — an index
+// writer set (7 run files), chunk sorts, and one ingest per family,
+// each ingest potentially forcing a memtable flush where it overlaps
+// earlier batch writes — which only pays off when the bucket is large
+// enough that memtable insertion would dominate. Benchmarks showed the
+// unconditional SST route doubling small-merge time. Var (not const)
+// so tests can force the path.
+var overlayWholeSourceMinKeys int64 = 100_000
+
+// overlayWholeSourceWorthIt decides whether the last source's bucket
+// takes the filtered SST-ingest path. An empty seen set always
+// qualifies (pure whole-source adoption, the original fast path);
+// otherwise the bucket must be large enough to amortize the SST
+// machinery. Bucket size comes from the source's cached stats (free,
+// via the manifest projection) or a bounded key count capped at the
+// threshold.
+func overlayWholeSourceWorthIt(ctx context.Context, source sourceHandle, bucket bucketSpec, sourceSyncBytes []byte, seen *seenSuffixSet) (bool, error) {
+	if seen.size() == 0 {
+		return true, nil
+	}
+	if source.stats != nil {
+		if n, ok := syncStatsBucketKeys(source.stats, bucket); ok {
+			return n >= overlayWholeSourceMinKeys, nil
+		}
+	}
+	lower, upper := bucket.syncRange(sourceSyncBytes)
+	iter, err := source.engine.DB().NewIter(&cpebble.IterOptions{LowerBound: lower, UpperBound: upper})
+	if err != nil {
+		return false, err
+	}
+	defer iter.Close()
+	var n int64
+	for iter.First(); iter.Valid(); iter.Next() {
+		if err := ctx.Err(); err != nil {
+			return false, err
+		}
+		n++
+		if n >= overlayWholeSourceMinKeys {
+			return true, nil
+		}
+	}
+	return false, iter.Error()
+}
+
+// overlayMaterializeWholeSourceBucketSST streams the last source's
+// bucket into a pre-sorted SST and ingests it, bypassing the memtable
+// entirely. Keys already admitted by earlier (newer) sources are
+// filtered out via the seen set — that keeps the ingested file
+// key-disjoint from every batch write, so ingest sequence numbers
+// cannot shadow earlier winners. A filtered-out key whose value is
+// strictly newer (by discovered_at) is replaced through the writer's
+// batch path instead, preserving the merge-wide winner rule.
+//
+// This is the bulk path for the production skewed shape: a large base
+// sync with a small partial-derived seen set streams through here at
+// SST-build speed instead of paying memtable insertion, flush, and
+// background compaction per record.
 func overlayMaterializeWholeSourceBucketSST(
 	ctx context.Context,
 	dest *enginepkg.Engine,
 	source *enginepkg.Engine,
 	bucket bucketSpec,
+	writer *overlayBucketRawWriter,
+	seen *seenSuffixSet,
 	sourceSyncBytes []byte,
 	destSyncBytes []byte,
 	tmpDir string,
@@ -419,6 +1056,7 @@ func overlayMaterializeWholeSourceBucketSST(
 	defer indexWriters.cleanup()
 
 	wrotePrimary := false
+	checkSeen := seen.size() > 0
 	var destKey []byte
 	var scratch rawIndexScratch
 	emitIndexKey := indexWriters.writeKey
@@ -430,13 +1068,33 @@ func overlayMaterializeWholeSourceBucketSST(
 		if len(sourceKey) < len(sourceLower) {
 			return fmt.Errorf("overlay merge: source key shorter than lower bound prefix: key=%d prefix=%d", len(sourceKey), len(sourceLower))
 		}
-		destKey = rewritePrimaryKeyForDestInto(destKey[:0], sourceKey[len(sourceLower):], destLower)
+		sourceSuffix := sourceKey[len(sourceLower):]
+		if checkSeen {
+			if prevTs, ok := seen.get(seen.keyOf(sourceSuffix)); ok {
+				// Admitted by an earlier (newer) source. Same rule as
+				// overlaySinglePassBucket: replace only on a strictly
+				// newer discovered_at, through the batch path (rare).
+				// No seen.put: this is the last source, nothing follows.
+				ts, err := discoveredAtNanosFromRaw(bucket, iter.Value())
+				if err != nil {
+					return err
+				}
+				if ts <= prevTs {
+					continue
+				}
+				destKey = rewritePrimaryKeyForDestInto(destKey[:0], sourceSuffix, destLower)
+				if err := writer.replaceRaw(ctx, bucket, destSyncBytes, destKey, destLower, iter.Value()); err != nil {
+					return err
+				}
+				continue
+			}
+		}
+		destKey = rewritePrimaryKeyForDestInto(destKey[:0], sourceSuffix, destLower)
 		if err := primaryWriter.Set(destKey, iter.Value()); err != nil {
 			return err
 		}
 		wrotePrimary = true
-		// Every key in this path is a winner: this fast path only runs
-		// for the last source when nothing was admitted before it.
+		// Every unseen key in this path is a winner.
 		stats.countWinnerTotal(bucket.id)
 		if bucket.forEachIndexKey != nil {
 			if err := forEachIndexKeyFromRaw(bucket, destSyncBytes, destKey, destLower, iter.Value(), &scratch, stats, emitIndexKey); err != nil {
@@ -834,33 +1492,6 @@ func scanPrincipalRefBytes(value []byte) ([]byte, []byte, error) {
 	return rt, id, nil
 }
 
-func withSourceEngine(ctx context.Context, tmpDir string, source SourceFile, fn func(*enginepkg.Engine) error) error {
-	if source.Engine != nil {
-		return fn(source.Engine)
-	}
-	if source.DBDir != "" {
-		eng, err := enginepkg.Open(ctx, source.DBDir, enginepkg.WithReadOnly(true))
-		if err != nil {
-			return err
-		}
-		defer eng.Close()
-		return fn(eng)
-	}
-	w, err := dotc1z.NewStore(ctx, source.Path, dotc1z.WithReadOnly(true), dotc1z.WithTmpDir(tmpDir), dotc1z.WithDecoderPool(source.DecoderPool))
-	if err != nil {
-		return err
-	}
-	// Full Close removes the read-only store's unpacked temp directory;
-	// callers iterate sources one at a time, so planning never holds
-	// more than one unpacked source on disk.
-	defer func() { _ = w.Close(ctx) }()
-	eng, ok := enginepkg.AsEngine(w)
-	if !ok {
-		return fmt.Errorf("overlay merge: input is not pebble: %s", source.Path)
-	}
-	return fn(eng)
-}
-
 type overlayBucketRawWriter struct {
 	dest      *enginepkg.Engine
 	bucket    bucketSpec
@@ -870,6 +1501,11 @@ type overlayBucketRawWriter struct {
 	count     int
 	scratch   rawIndexScratch
 	stats     *mergeStatsAccumulator
+	// replacements counts replaceRaw invocations (an older source
+	// carrying a strictly newer discovered_at). Logged at merge end —
+	// the replace slow path assumes this is rare; a high count in prod
+	// invalidates that assumption.
+	replacements int64
 }
 
 // The normal overlay path writes raw primary values and raw secondary index
@@ -926,6 +1562,7 @@ func (w *overlayBucketRawWriter) addRaw(ctx context.Context, bucket bucketSpec, 
 // admission); only the grant per-RT grouping can move, because the
 // entitlement resource type lives in the value.
 func (w *overlayBucketRawWriter) replaceRaw(ctx context.Context, bucket bucketSpec, syncBytes []byte, destKey []byte, destLower []byte, value []byte) error {
+	w.replacements++
 	if err := w.flush(ctx); err != nil {
 		return err
 	}
@@ -1012,4 +1649,24 @@ func (w *overlayBucketRawWriter) cleanup() {
 	if w.index != nil {
 		_ = w.index.Close()
 	}
+}
+
+// discard drops the writer's uncommitted batches and starts fresh
+// ones. Used by the restart path: the writer is bucket-scoped, so the
+// pending writes are exactly the data the restart's range-delete would
+// tombstone — dropping them before they commit is strictly cheaper and
+// prevents a later flush from resurrecting deleted keys.
+func (w *overlayBucketRawWriter) discard() {
+	if w == nil {
+		return
+	}
+	if w.primary != nil {
+		_ = w.primary.Close()
+	}
+	if w.index != nil {
+		_ = w.index.Close()
+	}
+	w.primary = w.dest.DB().NewBatch()
+	w.index = w.dest.DB().NewBatch()
+	w.count = 0
 }

--- a/pkg/synccompactor/pebble/overlay_degradation_test.go
+++ b/pkg/synccompactor/pebble/overlay_degradation_test.go
@@ -1,0 +1,415 @@
+package pebble
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"github.com/segmentio/ksuid"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"google.golang.org/protobuf/proto"
+
+	cpebble "github.com/cockroachdb/pebble/v2"
+	reader_v2 "github.com/conductorone/baton-sdk/pb/c1/reader/v2"
+	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
+	enginepkg "github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/codec"
+)
+
+// capturingCore is a minimal zapcore.Core that records log messages so
+// tests can assert which degradation transitions fired (the bucket
+// state machine is function-local; logs are its only external trace).
+type capturingCore struct {
+	zapcore.LevelEnabler
+	mu       *sync.Mutex
+	messages *[]string
+}
+
+func newCapturingLogger() (*zap.Logger, func() []string) {
+	mu := &sync.Mutex{}
+	messages := &[]string{}
+	core := capturingCore{LevelEnabler: zapcore.DebugLevel, mu: mu, messages: messages}
+	return zap.New(core), func() []string {
+		mu.Lock()
+		defer mu.Unlock()
+		out := make([]string, len(*messages))
+		copy(out, *messages)
+		return out
+	}
+}
+
+func (c capturingCore) With([]zapcore.Field) zapcore.Core { return c }
+func (c capturingCore) Check(e zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	if c.Enabled(e.Level) {
+		return ce.AddCore(e, c)
+	}
+	return ce
+}
+func (c capturingCore) Write(e zapcore.Entry, _ []zapcore.Field) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	*c.messages = append(*c.messages, e.Message)
+	return nil
+}
+func (c capturingCore) Sync() error { return nil }
+
+func containsMessage(messages []string, want string) bool {
+	for _, m := range messages {
+		if m == want {
+			return true
+		}
+	}
+	return false
+}
+
+// degGrants builds n grant specs named prefix-0..prefix-(n-1), all at ts.
+func degGrants(prefix string, n int, ts time.Time) []kwayGrantSpec {
+	out := make([]kwayGrantSpec, 0, n)
+	for i := 0; i < n; i++ {
+		out = append(out, kwayGrantSpec{
+			id:          fmt.Sprintf("%s-%d", prefix, i),
+			principalID: "alice",
+			entitlement: "member",
+			discovered:  ts,
+		})
+	}
+	return out
+}
+
+// dumpDestSyncContents snapshots every primary and secondary-index key
+// under the dest sync across all buckets. Both engines under
+// comparison use the SAME dest sync id, so byte-equal maps mean
+// byte-equal merge output (records and derived indexes).
+func dumpDestSyncContents(t *testing.T, e *enginepkg.Engine, syncID string) map[string]string {
+	t.Helper()
+	syncBytes, err := codec.EncodeSyncID(syncID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := map[string]string{}
+	for _, bucket := range allBuckets() {
+		lo, hi := bucket.syncRange(syncBytes)
+		ranges := append([][2][]byte{{lo, hi}}, bucketIndexRanges(bucket, syncBytes)...)
+		for _, r := range ranges {
+			iter, err := e.DB().NewIter(&cpebble.IterOptions{LowerBound: r[0], UpperBound: r[1]})
+			if err != nil {
+				t.Fatal(err)
+			}
+			for iter.First(); iter.Valid(); iter.Next() {
+				out[string(iter.Key())] = string(iter.Value())
+			}
+			if err := iter.Error(); err != nil {
+				_ = iter.Close()
+				t.Fatal(err)
+			}
+			_ = iter.Close()
+		}
+	}
+	return out
+}
+
+// assertOverlayMatchesKWay merges sources twice — degraded overlay
+// (with opts) and pure kway — into the same dest sync id, then
+// requires byte-identical dest contents and equal stats records.
+// Returns the captured overlay log messages so callers can assert
+// which degradation transition fired.
+func assertOverlayMatchesKWay(t *testing.T, ctx context.Context, sources []SourceFile, opts ...OverlayOption) []string {
+	t.Helper()
+	destSyncID := ksuid.New().String()
+
+	logger, capture := newCapturingLogger()
+	overlayCtx := ctxzap.ToContext(ctx, logger)
+	overlayDest, _ := newEngine(t, "deg-overlay-dest")
+	overlayStats, err := MergeFilesIntoOverlay(overlayCtx, overlayDest, sources, destSyncID, t.TempDir(), opts...)
+	if err != nil {
+		t.Fatalf("MergeFilesIntoOverlay: %v", err)
+	}
+
+	kwayDest, _ := newEngine(t, "deg-kway-dest")
+	kwayStats, err := MergeFilesInto(ctx, kwayDest, sources, destSyncID, t.TempDir())
+	if err != nil {
+		t.Fatalf("MergeFilesInto: %v", err)
+	}
+
+	got := dumpDestSyncContents(t, overlayDest, destSyncID)
+	want := dumpDestSyncContents(t, kwayDest, destSyncID)
+	if len(got) != len(want) {
+		t.Fatalf("overlay dest has %d keys, kway dest has %d", len(got), len(want))
+	}
+	for k, v := range want {
+		gv, ok := got[k]
+		if !ok {
+			t.Fatalf("overlay dest missing key %q", k)
+		}
+		if gv != v {
+			t.Fatalf("overlay dest value mismatch for key %q", k)
+		}
+	}
+	if !proto.Equal(overlayStats, kwayStats) {
+		t.Fatalf("stats mismatch:\noverlay: %v\nkway:    %v", overlayStats, kwayStats)
+	}
+	return capture()
+}
+
+// TestOverlayDegradationParity drives every degradation transition
+// with tiny limits and requires byte-parity (records, indexes, stats)
+// with the pure kway merge of the same sources.
+func TestOverlayDegradationParity(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("boundary resume within buffer", func(t *testing.T) {
+		dir := t.TempDir()
+		// Source 0 carries 11 distinct grants: soft=10 is crossed
+		// mid-scan, hard=12 is not, so the source finishes inside the
+		// buffer and the bucket resumes at the boundary. Sources 1-2
+		// flow through the resumed (map-aware) path: g-0 with a newer
+		// ts (replace), g-1 with an older ts (drop), and new keys
+		// (fresh admissions).
+		src0 := writeKWaySource(t, ctx, filepath.Join(dir, "src0.c1z"), degGrants("g", 11, time.Unix(2000, 0).UTC()), false)
+		src1 := writeKWaySource(t, ctx, filepath.Join(dir, "src1.c1z"), []kwayGrantSpec{
+			{id: "g-0", principalID: "bob", entitlement: "member", discovered: time.Unix(3000, 0).UTC()},
+			{id: "g-1", principalID: "bob", entitlement: "member", discovered: time.Unix(1000, 0).UTC()},
+			{id: "n-0", principalID: "carol", entitlement: "admin", discovered: time.Unix(1500, 0).UTC()},
+		}, false)
+		src2 := writeKWaySource(t, ctx, filepath.Join(dir, "src2.c1z"), []kwayGrantSpec{
+			{id: "n-1", principalID: "bob", entitlement: "member", discovered: time.Unix(1200, 0).UTC(), needsExpand: true},
+			{id: "g-2", principalID: "carol", entitlement: "member", discovered: time.Unix(900, 0).UTC()},
+		}, false)
+		sources := []SourceFile{
+			{Path: src0.path, SyncID: src0.syncID},
+			{Path: src1.path, SyncID: src1.syncID},
+			{Path: src2.path, SyncID: src2.syncID},
+		}
+		messages := assertOverlayMatchesKWay(t, ctx, sources, WithOverlaySeenKeyLimit(10))
+		if !containsMessage(messages, "pebble overlay merge: bucket resumed at source boundary") {
+			t.Fatalf("expected boundary resume, got logs: %v", messages)
+		}
+	})
+
+	t.Run("statless pre-gate resume", func(t *testing.T) {
+		dir := t.TempDir()
+		// Source 0 lands exactly on the gate threshold (0.9 x 10 = 9
+		// keys, not over the soft limit), so the boundary check does
+		// not fire — the pre-source gate resumes the bucket before
+		// source 1 is scanned.
+		src0 := writeKWaySource(t, ctx, filepath.Join(dir, "src0.c1z"), degGrants("g", 9, time.Unix(2000, 0).UTC()), false)
+		src1 := writeKWaySource(t, ctx, filepath.Join(dir, "src1.c1z"), append(
+			degGrants("h", 4, time.Unix(1500, 0).UTC()),
+			kwayGrantSpec{id: "g-3", principalID: "bob", entitlement: "member", discovered: time.Unix(3000, 0).UTC()},
+		), false)
+		src2 := writeKWaySource(t, ctx, filepath.Join(dir, "src2.c1z"), degGrants("k", 3, time.Unix(1000, 0).UTC()), false)
+		sources := []SourceFile{
+			{Path: src0.path, SyncID: src0.syncID},
+			{Path: src1.path, SyncID: src1.syncID},
+			{Path: src2.path, SyncID: src2.syncID},
+		}
+		messages := assertOverlayMatchesKWay(t, ctx, sources, WithOverlaySeenKeyLimit(10))
+		if !containsMessage(messages, "pebble overlay merge: bucket degraded at pre-source gate") {
+			t.Fatalf("expected pre-gate resume, got logs: %v", messages)
+		}
+	})
+
+	t.Run("hard limit restart", func(t *testing.T) {
+		dir := t.TempDir()
+		// Source 0 alone blows past hard=12 mid-scan: the bucket
+		// restarts and the whole merge flows through the blind kway
+		// path. Stats must be reset and recounted (parity asserts it).
+		src0 := writeKWaySource(t, ctx, filepath.Join(dir, "src0.c1z"), degGrants("g", 30, time.Unix(2000, 0).UTC()), false)
+		src1 := writeKWaySource(t, ctx, filepath.Join(dir, "src1.c1z"), []kwayGrantSpec{
+			{id: "g-0", principalID: "bob", entitlement: "member", discovered: time.Unix(3000, 0).UTC()},
+			{id: "x-0", principalID: "carol", entitlement: "admin", discovered: time.Unix(1500, 0).UTC()},
+		}, false)
+		sources := []SourceFile{
+			{Path: src0.path, SyncID: src0.syncID},
+			{Path: src1.path, SyncID: src1.syncID},
+		}
+		messages := assertOverlayMatchesKWay(t, ctx, sources, WithOverlaySeenKeyLimit(10))
+		if !containsMessage(messages, "pebble overlay merge: bucket restarted at hard limit") {
+			t.Fatalf("expected hard-limit restart, got logs: %v", messages)
+		}
+	})
+
+	t.Run("stats pre-gate predicts overshoot", func(t *testing.T) {
+		dir := t.TempDir()
+		// All sources carry stats, so the pre-gate uses the exact
+		// prediction: after source 0 admits 8 keys, source 1's count
+		// of 6 predicts 14 > hard=12 and the bucket resumes without
+		// scanning source 1.
+		src0 := writeKWaySource(t, ctx, filepath.Join(dir, "src0.c1z"), degGrants("g", 8, time.Unix(2000, 0).UTC()), false)
+		src1 := writeKWaySource(t, ctx, filepath.Join(dir, "src1.c1z"), append(
+			degGrants("h", 5, time.Unix(1500, 0).UTC()),
+			kwayGrantSpec{id: "g-1", principalID: "bob", entitlement: "member", discovered: time.Unix(3000, 0).UTC()},
+		), false)
+		src2 := writeKWaySource(t, ctx, filepath.Join(dir, "src2.c1z"), degGrants("k", 3, time.Unix(1000, 0).UTC()), false)
+		statsFor := func(grants int64) *reader_v2.SyncStats {
+			return reader_v2.SyncStats_builder{
+				ResourceTypes: 2,
+				Resources:     4,
+				Entitlements:  2,
+				Grants:        grants,
+			}.Build()
+		}
+		sources := []SourceFile{
+			{Path: src0.path, SyncID: src0.syncID, Stats: statsFor(8)},
+			{Path: src1.path, SyncID: src1.syncID, Stats: statsFor(6)},
+			{Path: src2.path, SyncID: src2.syncID, Stats: statsFor(3)},
+		}
+		messages := assertOverlayMatchesKWay(t, ctx, sources, WithOverlaySeenKeyLimit(10))
+		if !containsMessage(messages, "pebble overlay merge: bucket degraded at pre-source gate") {
+			t.Fatalf("expected stats pre-gate resume, got logs: %v", messages)
+		}
+	})
+
+	t.Run("stats lower bound routes to kway up front", func(t *testing.T) {
+		dir := t.TempDir()
+		// Source 0's single-source count of 30 exceeds hard=12 — a
+		// lower bound on distinct keys — so planning routes the grants
+		// bucket straight to kway; no degradation events fire.
+		src0 := writeKWaySource(t, ctx, filepath.Join(dir, "src0.c1z"), degGrants("g", 30, time.Unix(2000, 0).UTC()), false)
+		src1 := writeKWaySource(t, ctx, filepath.Join(dir, "src1.c1z"), degGrants("h", 2, time.Unix(1500, 0).UTC()), false)
+		statsFor := func(grants int64) *reader_v2.SyncStats {
+			return reader_v2.SyncStats_builder{
+				ResourceTypes: 2,
+				Resources:     4,
+				Entitlements:  1,
+				Grants:        grants,
+			}.Build()
+		}
+		sources := []SourceFile{
+			{Path: src0.path, SyncID: src0.syncID, Stats: statsFor(30)},
+			{Path: src1.path, SyncID: src1.syncID, Stats: statsFor(2)},
+		}
+		messages := assertOverlayMatchesKWay(t, ctx, sources, WithOverlaySeenKeyLimit(10))
+		for _, m := range messages {
+			switch m {
+			case "pebble overlay merge: bucket resumed at source boundary",
+				"pebble overlay merge: bucket degraded at pre-source gate",
+				"pebble overlay merge: bucket restarted at hard limit":
+				t.Fatalf("unexpected degradation event %q for up-front kway routing", m)
+			}
+		}
+	})
+
+	t.Run("multi-chunk restart with backfill", func(t *testing.T) {
+		dir := t.TempDir()
+		// Five sources at fan-in 2 span three chunks. Sources 0-3
+		// share the same 5 keys (the seen set plateaus at 5, below
+		// the gate of 9); source 4 carries 20 new keys and blows
+		// hard=12 mid-scan in chunk 2. The restart must backfill run
+		// files for chunks 0 and 1, which closed before the restart.
+		var sources []SourceFile
+		for i := 0; i < 4; i++ {
+			src := writeKWaySource(t, ctx, filepath.Join(dir, fmt.Sprintf("src%d.c1z", i)),
+				degGrants("s", 5, time.Unix(int64(2000-i), 0).UTC()), false)
+			sources = append(sources, SourceFile{Path: src.path, SyncID: src.syncID})
+		}
+		last := writeKWaySource(t, ctx, filepath.Join(dir, "src4.c1z"),
+			degGrants("base", 20, time.Unix(500, 0).UTC()), false)
+		sources = append(sources, SourceFile{Path: last.path, SyncID: last.syncID})
+
+		messages := assertOverlayMatchesKWay(t, ctx, sources,
+			WithOverlaySeenKeyLimit(10), WithOverlayFanIn(2))
+		if !containsMessage(messages, "pebble overlay merge: bucket restarted at hard limit") {
+			t.Fatalf("expected hard-limit restart, got logs: %v", messages)
+		}
+	})
+}
+
+// TestOverlayResumedReplaceRawEdge pins the winner rule through the
+// resumed (map-aware) materialization: an older source carrying a
+// strictly newer discovered_at must replace the overlay-admitted
+// record (and swap its index entries), while an equal-or-older
+// discovered_at must keep it.
+func TestOverlayResumedReplaceRawEdge(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	// Source 0 (newest) admits 11 grants at ts=2000 and crosses
+	// soft=10 → boundary resume. Source 1 (older) is materialized
+	// through the frozen map: g-0 has ts=3000 (strictly newer →
+	// replace, with a different principal so the index swap is
+	// observable) and g-1 has ts=2000 (tie → overlay record kept).
+	src0 := writeKWaySource(t, ctx, filepath.Join(dir, "src0.c1z"), degGrants("g", 11, time.Unix(2000, 0).UTC()), false)
+	src1 := writeKWaySource(t, ctx, filepath.Join(dir, "src1.c1z"), []kwayGrantSpec{
+		{id: "g-0", principalID: "bob", entitlement: "member", discovered: time.Unix(3000, 0).UTC()},
+		{id: "g-1", principalID: "bob", entitlement: "member", discovered: time.Unix(2000, 0).UTC()},
+	}, false)
+	sources := []SourceFile{
+		{Path: src0.path, SyncID: src0.syncID},
+		{Path: src1.path, SyncID: src1.syncID},
+	}
+
+	dest, _ := newEngine(t, "resumed-replace-dest")
+	destSyncID := ksuid.New().String()
+	logger, capture := newCapturingLogger()
+	if _, err := MergeFilesIntoOverlay(ctxzap.ToContext(ctx, logger), dest, sources, destSyncID, t.TempDir(), WithOverlaySeenKeyLimit(10)); err != nil {
+		t.Fatalf("MergeFilesIntoOverlay: %v", err)
+	}
+	if !containsMessage(capture(), "pebble overlay merge: bucket resumed at source boundary") {
+		t.Fatalf("expected boundary resume, got logs: %v", capture())
+	}
+
+	grants := grantPrincipalMap(t, ctx, dest, destSyncID)
+	if got := grants["g-0"]; got != "bob" {
+		t.Fatalf("g-0 principal = %q, want bob (strictly newer discovered_at must replace)", got)
+	}
+	if got := grants["g-1"]; got != "alice" {
+		t.Fatalf("g-1 principal = %q, want alice (discovered_at tie keeps the newer source's record)", got)
+	}
+	// The replaced record's index entries must follow the new value.
+	var bobGrants []string
+	if err := dest.IterateGrantsByPrincipal(ctx, destSyncID, "user", "bob", func(g *v3.GrantRecord) bool {
+		bobGrants = append(bobGrants, g.GetExternalId())
+		return true
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(bobGrants) != 1 || bobGrants[0] != "g-0" {
+		t.Fatalf("by_principal(bob) = %v, want [g-0]", bobGrants)
+	}
+	var aliceForG0 bool
+	if err := dest.IterateGrantsByPrincipal(ctx, destSyncID, "user", "alice", func(g *v3.GrantRecord) bool {
+		if g.GetExternalId() == "g-0" {
+			aliceForG0 = true
+		}
+		return true
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if aliceForG0 {
+		t.Fatal("stale by_principal(alice) index entry for replaced grant g-0")
+	}
+}
+
+// TestMergeStatsResetBucket pins the restart path's stats contract:
+// zero the restarted bucket's total and its per-RT grouping without
+// touching other buckets.
+func TestMergeStatsResetBucket(t *testing.T) {
+	a := newMergeStatsAccumulator()
+	a.countWinnerTotal(runBucketGrants)
+	a.countWinnerTotal(runBucketGrants)
+	a.groupGrant([]byte("group"))
+	a.groupGrant([]byte("group"))
+	a.countWinnerTotal(runBucketResources)
+	a.groupResource([]byte("user"))
+	a.countWinnerTotal(runBucketEntitlements)
+
+	a.resetBucket(runBucketGrants)
+	rec := a.record()
+	if rec.GetGrants() != 0 {
+		t.Fatalf("grants total after reset = %d, want 0", rec.GetGrants())
+	}
+	if len(rec.GetGrantsByEntitlementResourceType()) != 0 {
+		t.Fatalf("grants grouping after reset = %v, want empty", rec.GetGrantsByEntitlementResourceType())
+	}
+	if rec.GetResources() != 1 || rec.GetResourcesByResourceType()["user"] != 1 {
+		t.Fatalf("resources counts disturbed by grants reset: %v", rec)
+	}
+	if rec.GetEntitlements() != 1 {
+		t.Fatalf("entitlements total disturbed by grants reset: %d", rec.GetEntitlements())
+	}
+}

--- a/pkg/synccompactor/pebble/overlay_winner_test.go
+++ b/pkg/synccompactor/pebble/overlay_winner_test.go
@@ -31,12 +31,24 @@ func TestMergeFilesIntoOverlayNewerDiscoveredAtWins(t *testing.T) {
 		{id: "shared", principalID: "alice", entitlement: "member", discovered: older},
 		{id: "tie", principalID: "alice", entitlement: "member", discovered: tie},
 	}, false)
-	// sources[1]: older source with a strictly newer discovered_at for
-	// "shared" and an equal one for "tie".
+	// sources[1]: older source (the LAST source, so it takes the
+	// filtered whole-source SST path) with all three branches:
+	// "shared" is seen with a strictly newer discovered_at (replace),
+	// "tie" is seen with an equal one (filtered out), and "only-src2"
+	// is unseen (streams into the ingested SST).
 	src2 := writeKWaySource(t, ctx, filepath.Join(dir, "src2.c1z"), []kwayGrantSpec{
 		{id: "shared", principalID: "bob", entitlement: "member", discovered: newer},
 		{id: "tie", principalID: "bob", entitlement: "member", discovered: tie},
+		{id: "only-src2", principalID: "carol", entitlement: "member", discovered: older},
 	}, false)
+
+	// Force the filtered whole-source SST path despite the tiny fixture
+	// so all three last-source branches (replace, filter, SST stream)
+	// stay covered; the size gate would otherwise route this through
+	// the batch path.
+	oldMin := overlayWholeSourceMinKeys
+	overlayWholeSourceMinKeys = 1
+	defer func() { overlayWholeSourceMinKeys = oldMin }()
 
 	dest, _ := newEngine(t, "overlay-winner-dest")
 	destSyncID := ksuid.New().String()
@@ -55,8 +67,8 @@ func TestMergeFilesIntoOverlayNewerDiscoveredAtWins(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if len(grants) != 2 {
-		t.Fatalf("merged grant count = %d, want 2", len(grants))
+	if len(grants) != 3 {
+		t.Fatalf("merged grant count = %d, want 3", len(grants))
 	}
 	if got := grants["shared"].GetPrincipal().GetResourceId(); got != "bob" {
 		t.Fatalf("shared grant principal = %q, want bob (older source, newer discovered_at)", got)
@@ -64,14 +76,18 @@ func TestMergeFilesIntoOverlayNewerDiscoveredAtWins(t *testing.T) {
 	if got := grants["tie"].GetPrincipal().GetResourceId(); got != "alice" {
 		t.Fatalf("tie grant principal = %q, want alice (first admission keeps ties)", got)
 	}
-	if got := stats.GetGrants(); got != 2 {
-		t.Fatalf("stats grants = %d, want 2 (replacement must not double count)", got)
+	if got := grants["only-src2"].GetPrincipal().GetResourceId(); got != "carol" {
+		t.Fatalf("only-src2 grant principal = %q, want carol (unseen key via ingested SST)", got)
+	}
+	if got := stats.GetGrants(); got != 3 {
+		t.Fatalf("stats grants = %d, want 3 (replacement must not double count)", got)
 	}
 
 	// Index correctness after replacement: the stale by_principal entry
-	// for alice/"shared" must be gone, and bob's must exist.
+	// for alice/"shared" must be gone, and bob's must exist; carol's
+	// SST-ingested index entry must be present.
 	byPrincipal := map[string][]string{}
-	for _, principal := range []string{"alice", "bob"} {
+	for _, principal := range []string{"alice", "bob", "carol"} {
 		if err := dest.IterateGrantsByPrincipal(ctx, destSyncID, "user", principal, func(g *v3.GrantRecord) bool {
 			byPrincipal[principal] = append(byPrincipal[principal], g.GetExternalId())
 			return true
@@ -85,5 +101,8 @@ func TestMergeFilesIntoOverlayNewerDiscoveredAtWins(t *testing.T) {
 	}
 	if got, want := byPrincipal["bob"], []string{"shared"}; fmtSprint(got) != fmtSprint(want) {
 		t.Fatalf("by_principal[bob] = %v, want %v", got, want)
+	}
+	if got, want := byPrincipal["carol"], []string{"only-src2"}; fmtSprint(got) != fmtSprint(want) {
+		t.Fatalf("by_principal[carol] = %v, want %v", got, want)
 	}
 }

--- a/pkg/synccompactor/prodscale_crossover_test.go
+++ b/pkg/synccompactor/prodscale_crossover_test.go
@@ -1,0 +1,193 @@
+package synccompactor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	enginepkg "github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble"
+)
+
+// TestProdScaleFoldOverlayCrossover sweeps the partial-volume ratio at
+// a mid-scale base (~256MB, the auto-cutover floor) to locate where
+// the fold and overlay curves cross. The fold gate's 25% ratio was
+// derived from two points (1.1GB prod shape, MB-scale fixtures); this
+// fills in the middle: a fixed 10 partials whose total grant volume is
+// 5/10/25/50% of the base, each compacted with overlay and fold.
+//
+// Gated and cached like the other prod-scale experiments:
+//
+//	BATON_PROD_SCALE_CROSSOVER=1 go test ./pkg/synccompactor -run TestProdScaleFoldOverlayCrossover -v -timeout 60m
+func TestProdScaleFoldOverlayCrossover(t *testing.T) {
+	if os.Getenv("BATON_PROD_SCALE_CROSSOVER") == "" {
+		t.Skip("set BATON_PROD_SCALE_CROSSOVER=1 to run the crossover experiment")
+	}
+	ctx := context.Background()
+	require.NoError(t, ensurePebbleRegistered())
+
+	fixDir := os.Getenv("BATON_PROD_SCALE_DIR")
+	if fixDir == "" {
+		fixDir = filepath.Join("..", "..", ".profiles", "prodscale-crossover")
+	} else {
+		fixDir = filepath.Join(fixDir, "crossover")
+	}
+	require.NoError(t, os.MkdirAll(fixDir, 0o755)) // #nosec G703 - developer-provided fixture dir env var.
+
+	baseGrants := envInt("BATON_CROSSOVER_GRANTS", 1_200_000)
+	baseUsers := envInt("BATON_CROSSOVER_USERS", 50_000)
+	baseEnts := envInt("BATON_CROSSOVER_ENTS", 10_000)
+	const partialCount = 10
+
+	basePath := filepath.Join(fixDir, "base.c1z")
+	// #nosec G703 - fixture paths derive from a developer-provided env var.
+	if _, err := os.Stat(basePath); errors.Is(err, os.ErrNotExist) {
+		t.Logf("building base c1z: grants=%d users=%d ents=%d", baseGrants, baseUsers, baseEnts)
+		start := time.Now()
+		buildProdScaleBase(t, ctx, basePath, baseGrants, baseUsers, baseEnts)
+		t.Logf("base built in %s", time.Since(start).Round(time.Second))
+	}
+	logFileSize(t, "base", basePath)
+	baseBytes := fileSizeOrZero(basePath)
+	baseSyncID := manifestSyncID(t, basePath)
+
+	for _, ratioPct := range []int{5, 10, 25, 50} {
+		ratioPct := ratioPct
+		t.Run(fmt.Sprintf("ratio=%d", ratioPct), func(t *testing.T) {
+			perPartial := baseGrants * ratioPct / 100 / partialCount
+			require.LessOrEqual(t, perPartial*partialCount, baseGrants,
+				"override windows must fit in the base grant id space")
+
+			entries := []*CompactableSync{{FilePath: basePath, SyncID: baseSyncID}}
+			var partialBytes int64
+			for p := 0; p < partialCount; p++ {
+				path := filepath.Join(fixDir, fmt.Sprintf("partial-r%02d-%03d.c1z", ratioPct, p))
+				// #nosec G703 - fixture paths derive from a developer-provided env var.
+				if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+					buildCrossoverPartial(t, ctx, path, p, perPartial)
+				}
+				partialBytes += fileSizeOrZero(path)
+				entries = append(entries, &CompactableSync{FilePath: path, SyncID: manifestSyncID(t, path)})
+			}
+			t.Logf("ratio=%d%%: grants/partial=%d partial_bytes=%.1fMB base_bytes=%.1fMB byte_ratio=%.1f%%",
+				ratioPct, perPartial,
+				float64(partialBytes)/(1<<20), float64(baseBytes)/(1<<20),
+				100*float64(partialBytes)/float64(baseBytes))
+
+			expectedGrants := int64(baseGrants + partialCount*200)
+			for _, mode := range []string{"overlay", "fold"} {
+				t.Run(mode, func(t *testing.T) {
+					t.Setenv("BATON_EXPERIMENTAL_PEBBLE_COMPACTOR", mode)
+					c, cleanup, err := NewCompactor(ctx, t.TempDir(), entries,
+						WithTmpDir(t.TempDir()), WithEngine(dotc1z.EnginePebble), WithSkipGrantExpansion())
+					require.NoError(t, err)
+					defer func() { require.NoError(t, cleanup()) }()
+
+					start := time.Now()
+					out, err := c.Compact(ctx)
+					elapsed := time.Since(start)
+					require.NoError(t, err)
+					require.NotNil(t, out)
+					t.Logf("ratio=%d%% mode=%s elapsed=%s", ratioPct, mode, elapsed.Round(time.Millisecond))
+					logFileSize(t, "output", out.FilePath)
+
+					// Both modes must converge on the same union: base
+					// grants plus the partial-only additions (overrides
+					// replace, they don't add).
+					w, err := dotc1z.NewStore(ctx, out.FilePath, dotc1z.WithReadOnly(true), dotc1z.WithTmpDir(t.TempDir()))
+					require.NoError(t, err)
+					defer w.Close(ctx)
+					eng, ok := enginepkg.AsEngine(w)
+					require.True(t, ok)
+					stats, err := enginepkg.ReadSyncStatsRecord(ctx, eng, out.SyncID)
+					require.NoError(t, err)
+					require.NotNil(t, stats)
+					require.Equal(t, expectedGrants, stats.GetGrants())
+				})
+			}
+		})
+	}
+}
+
+// buildCrossoverPartial writes one partial sync sized for the
+// crossover sweep: overrideGrants grant overrides into a disjoint
+// window of the base's id space (window idx*overrideGrants) plus 200
+// partial-only grants, with a small supporting catalog.
+func buildCrossoverPartial(t *testing.T, ctx context.Context, path string, idx, overrideGrants int) {
+	t.Helper()
+	w, err := dotc1z.NewStore(ctx, path,
+		dotc1z.WithEngine(dotc1z.EnginePebble),
+		dotc1z.WithPayloadEncoding(dotc1z.PayloadEncodingIndexedZstd),
+		dotc1z.WithTmpDir(t.TempDir()))
+	require.NoError(t, err)
+	_, err = w.StartNewSync(ctx, connectorstore.SyncTypePartial, "")
+	require.NoError(t, err)
+
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	require.NoError(t, w.PutResourceTypes(ctx, userRT, groupRT))
+
+	resources := make([]*v2.Resource, 0, 1001)
+	for i := 0; i < 1000; i++ {
+		resources = append(resources, v2.Resource_builder{
+			Id: v2.ResourceId_builder{ResourceType: "user", Resource: scaleID("u", i)}.Build(),
+		}.Build())
+	}
+	group := v2.Resource_builder{
+		Id: v2.ResourceId_builder{ResourceType: "group", Resource: scaleID("grp", 0)}.Build(),
+	}.Build()
+	resources = append(resources, group)
+	require.NoError(t, w.PutResources(ctx, resources...))
+
+	entObjs := make([]*v2.Entitlement, 0, 100)
+	for i := 0; i < 100; i++ {
+		entObjs = append(entObjs, v2.Entitlement_builder{
+			Id:       scaleID("e", i),
+			Resource: group,
+			Purpose:  v2.Entitlement_PURPOSE_VALUE_ASSIGNMENT,
+		}.Build())
+	}
+	require.NoError(t, w.PutEntitlements(ctx, entObjs...))
+
+	mkGrant := func(id string, userIdx, entIdx int) *v2.Grant {
+		user := v2.Resource_builder{
+			Id: v2.ResourceId_builder{ResourceType: "user", Resource: scaleID("u", userIdx)}.Build(),
+		}.Build()
+		ent := v2.Entitlement_builder{
+			Id:       scaleID("e", entIdx),
+			Resource: group,
+		}.Build()
+		return v2.Grant_builder{Id: id, Principal: user, Entitlement: ent}.Build()
+	}
+	const batchSize = 10_000
+	grantObjs := make([]*v2.Grant, 0, batchSize)
+	flush := func() {
+		if len(grantObjs) > 0 {
+			require.NoError(t, w.PutGrants(ctx, grantObjs...))
+			grantObjs = grantObjs[:0]
+		}
+	}
+	// Overrides into a disjoint window of the base's grant id space.
+	for i := 0; i < overrideGrants; i++ {
+		grantObjs = append(grantObjs, mkGrant(scaleID("g", idx*overrideGrants+i), i%1000, i%100))
+		if len(grantObjs) == batchSize {
+			flush()
+		}
+	}
+	// Partial-only additions.
+	for i := 0; i < 200; i++ {
+		grantObjs = append(grantObjs, mkGrant(scaleID(fmt.Sprintf("x%03d-g", idx), i), i%1000, i%100))
+	}
+	flush()
+
+	require.NoError(t, w.EndSync(ctx))
+	require.NoError(t, w.Close(ctx))
+}

--- a/pkg/synccompactor/prodscale_phases_test.go
+++ b/pkg/synccompactor/prodscale_phases_test.go
@@ -1,0 +1,57 @@
+package synccompactor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	enginepkg "github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble"
+)
+
+// TestProdScaleFoldPhases isolates the fold's phase costs against the
+// cached prod-scale base fixture: file copy, store open (payload
+// unpack), and dirty save (checkpoint + envelope write, where frame
+// splicing should fire). Run after TestProdScaleSkewedCompaction has
+// built the fixture. The development logger surfaces the engine's
+// spliced/encoded frame counts.
+func TestProdScaleFoldPhases(t *testing.T) {
+	if os.Getenv("BATON_PROD_SCALE_TEST") == "" {
+		t.Skip("set BATON_PROD_SCALE_TEST=1 to run")
+	}
+	logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
+	ctx := ctxzap.ToContext(context.Background(), logger)
+	require.NoError(t, ensurePebbleRegistered())
+
+	fixDir := os.Getenv("BATON_PROD_SCALE_DIR")
+	if fixDir == "" {
+		fixDir = filepath.Join("..", "..", ".profiles", "prodscale")
+	}
+	basePath := filepath.Join(fixDir, "base.c1z")
+	// #nosec G703 - developer-provided fixture path.
+	if _, err := os.Stat(basePath); err != nil {
+		t.Skipf("base fixture missing (%v); run TestProdScaleSkewedCompaction first", err)
+	}
+
+	workPath := filepath.Join(t.TempDir(), "fold-base.c1z")
+	start := time.Now()
+	require.NoError(t, copyFileForFold(basePath, workPath))
+	t.Logf("phase copy: %s", time.Since(start).Round(time.Millisecond))
+
+	start = time.Now()
+	w, err := dotc1z.NewStore(ctx, workPath, dotc1z.WithTmpDir(t.TempDir()))
+	require.NoError(t, err)
+	t.Logf("phase open(unpack): %s", time.Since(start).Round(time.Millisecond))
+
+	require.True(t, enginepkg.MarkStoreDirty(w))
+	start = time.Now()
+	require.NoError(t, w.Close(ctx))
+	t.Logf("phase save(close): %s", time.Since(start).Round(time.Millisecond))
+}

--- a/pkg/synccompactor/prodscale_scan_test.go
+++ b/pkg/synccompactor/prodscale_scan_test.go
@@ -1,0 +1,156 @@
+package synccompactor
+
+import (
+	"context"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	enginepkg "github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble"
+)
+
+// TestProdScaleScanVsFoldDebt measures what artifact shape costs the
+// READER: it chains real fold compactions and measures consumer-side
+// operations at several points, against a kway-rebuilt reference:
+//
+//   - a full sequential grant scan (the ingestion/uplift pattern), and
+//   - 10k point lookups (diff-style consumers).
+//
+// Historical findings (12M grants, 1.1GB): the sync-produced base
+// already carries ~240 L0 files (bulk-load flushes; the L0 tuning
+// lets them persist), fold sessions add a handful more, and scans are
+// noise-identical across all of them. The kway rebuild's flat LSM is
+// ~21% smaller and ~3.7x faster on point lookups — a property of
+// rebuilding generally, not of avoiding fold. Folds now run with
+// normal compactions, so L0 self-manages and converges downward over
+// successive folds.
+//
+// Requires the prod-scale base fixture (run
+// TestProdScaleSkewedCompaction first). Gated, like its siblings,
+// behind BATON_PROD_SCALE_TEST=1.
+func TestProdScaleScanVsFoldDebt(t *testing.T) {
+	if os.Getenv("BATON_PROD_SCALE_TEST") == "" {
+		t.Skip("set BATON_PROD_SCALE_TEST=1 to run")
+	}
+	ctx := context.Background()
+	require.NoError(t, ensurePebbleRegistered())
+
+	fixDir := os.Getenv("BATON_PROD_SCALE_DIR")
+	if fixDir == "" {
+		fixDir = filepath.Join("..", "..", ".profiles", "prodscale")
+	}
+	basePath := filepath.Join(fixDir, "base.c1z")
+	// #nosec G703 - developer-provided fixture path.
+	if _, err := os.Stat(basePath); err != nil {
+		t.Skipf("base fixture missing (%v); run TestProdScaleSkewedCompaction first", err)
+	}
+	grants := envInt("BATON_PROD_SCALE_GRANTS", 5_000_000)
+
+	t.Setenv("BATON_EXPERIMENTAL_PEBBLE_COMPACTOR", "fold")
+
+	keepDir := t.TempDir()
+	curPath := filepath.Join(keepDir, "chain.c1z")
+	require.NoError(t, copyFileForFold(basePath, curPath))
+
+	measure := func(label string, path string) {
+		t.Helper()
+		w, err := dotc1z.NewStore(ctx, path, dotc1z.WithReadOnly(true), dotc1z.WithTmpDir(t.TempDir()))
+		require.NoError(t, err)
+		defer w.Close(ctx)
+		eng, ok := enginepkg.AsEngine(w)
+		require.True(t, ok)
+		syncID := manifestSyncID(t, path)
+		// NOTE: read-only pebble opens report Sublevels=0 even with L0
+		// files present; TablesCount is accurate in both modes. (The
+		// fold's production debt gate reads metrics from a writable
+		// open, where Sublevels is correct.)
+		l0Files := eng.DB().Metrics().Levels[0].TablesCount
+
+		start := time.Now()
+		count := 0
+		require.NoError(t, eng.IterateGrantsBySync(ctx, syncID, func(*v3.GrantRecord) bool {
+			count++
+			return true
+		}))
+		scanDur := time.Since(start)
+
+		rng := rand.New(rand.NewSource(42)) //nolint:gosec // deterministic benchmark sampling, not crypto.
+		const lookups = 10_000
+		start = time.Now()
+		for i := 0; i < lookups; i++ {
+			id := scaleID("g", rng.Intn(grants))
+			if _, err := eng.GetGrantRecord(ctx, syncID, id); err != nil {
+				t.Fatalf("lookup %s: %v", id, err)
+			}
+		}
+		lookupDur := time.Since(start)
+
+		info, err := os.Stat(path) // #nosec G703 - test fixture path.
+		require.NoError(t, err)
+		t.Logf("RESULT %-10s l0files=%-3d scan=%-12s (%d grants)  lookups10k=%-12s  size=%.1fMB",
+			label, l0Files, scanDur.Round(time.Millisecond), count, lookupDur.Round(time.Millisecond),
+			float64(info.Size())/(1<<20))
+	}
+
+	measure("flat", curPath)
+
+	round := 0
+	foldOnce := func() {
+		t.Helper()
+		round++
+		partialPath := filepath.Join(t.TempDir(), "round-partial.c1z")
+		// Distinct override window + fresh timestamps per round so the
+		// keep-newer merge actually writes (equal timestamps would be
+		// skipped and nothing would flush).
+		buildProdScalePartial(t, ctx, partialPath, 1000+round)
+		c, cleanup, err := NewCompactor(ctx, t.TempDir(),
+			[]*CompactableSync{
+				{FilePath: curPath, SyncID: manifestSyncID(t, curPath)},
+				{FilePath: partialPath, SyncID: manifestSyncID(t, partialPath)},
+			},
+			WithTmpDir(t.TempDir()), WithEngine(dotc1z.EnginePebble), WithSkipGrantExpansion())
+		require.NoError(t, err)
+		out, err := c.Compact(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, out)
+		require.NoError(t, copyFileForFold(out.FilePath, curPath))
+		require.NoError(t, cleanup())
+	}
+
+	for round < 4 {
+		foldOnce()
+	}
+	measure("debt-4", curPath)
+
+	for round < 10 {
+		foldOnce()
+	}
+	measure("debt-10", curPath)
+
+	// Reference point: a kway REBUILD of the same data. Ingested SSTs
+	// land in deep levels, so this is what a genuinely flat artifact
+	// looks like — the sync-produced base itself carries hundreds of
+	// L0 files from bulk-load flushes (L0CompactionFileThreshold is
+	// 500, so they persist).
+	t.Setenv("BATON_EXPERIMENTAL_PEBBLE_COMPACTOR", "kway")
+	partialPath := filepath.Join(t.TempDir(), "rebuild-partial.c1z")
+	buildProdScalePartial(t, ctx, partialPath, 2000)
+	c, cleanup, err := NewCompactor(ctx, t.TempDir(),
+		[]*CompactableSync{
+			{FilePath: basePath, SyncID: manifestSyncID(t, basePath)},
+			{FilePath: partialPath, SyncID: manifestSyncID(t, partialPath)},
+		},
+		WithTmpDir(t.TempDir()), WithEngine(dotc1z.EnginePebble), WithSkipGrantExpansion())
+	require.NoError(t, err)
+	defer func() { require.NoError(t, cleanup()) }()
+	out, err := c.Compact(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	measure("rebuilt", out.FilePath)
+}

--- a/pkg/synccompactor/prodscale_test.go
+++ b/pkg/synccompactor/prodscale_test.go
@@ -1,0 +1,316 @@
+package synccompactor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	enginepkg "github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble"
+)
+
+// TestProdScaleSkewedCompaction is the GB-scale experiment for the
+// production skewed shape: one large base full sync plus many small
+// partials, compacted with each strategy (kway, overlay, fold). It is
+// gated behind BATON_PROD_SCALE_TEST=1 and caches its fixtures under
+// BATON_PROD_SCALE_DIR (default .profiles/prodscale) because building
+// the base takes minutes.
+//
+// Run with:
+//
+//	BATON_PROD_SCALE_TEST=1 go test ./pkg/synccompactor -run TestProdScaleSkewedCompaction -v -timeout 60m
+func TestProdScaleSkewedCompaction(t *testing.T) {
+	if os.Getenv("BATON_PROD_SCALE_TEST") == "" {
+		t.Skip("set BATON_PROD_SCALE_TEST=1 to run the prod-scale experiment")
+	}
+	ctx := context.Background()
+	require.NoError(t, ensurePebbleRegistered())
+
+	fixDir := os.Getenv("BATON_PROD_SCALE_DIR")
+	if fixDir == "" {
+		fixDir = filepath.Join("..", "..", ".profiles", "prodscale")
+	}
+	require.NoError(t, os.MkdirAll(fixDir, 0o755)) // #nosec G703 - developer-provided fixture dir env var.
+
+	grants := envInt("BATON_PROD_SCALE_GRANTS", 5_000_000)
+	users := envInt("BATON_PROD_SCALE_USERS", 200_000)
+	ents := envInt("BATON_PROD_SCALE_ENTS", 40_000)
+	partialCount := envInt("BATON_PROD_SCALE_PARTIALS", 50)
+
+	basePath := filepath.Join(fixDir, "base.c1z")
+	// #nosec G703 - fixture paths derive from a developer-provided env var.
+	if _, err := os.Stat(basePath); errors.Is(err, os.ErrNotExist) {
+		t.Logf("building base c1z: grants=%d users=%d ents=%d", grants, users, ents)
+		start := time.Now()
+		buildProdScaleBase(t, ctx, basePath, grants, users, ents)
+		t.Logf("base built in %s", time.Since(start).Round(time.Second))
+	}
+	logFileSize(t, "base", basePath)
+
+	partialPaths := make([]string, 0, partialCount)
+	for p := 0; p < partialCount; p++ {
+		path := filepath.Join(fixDir, fmt.Sprintf("partial-%03d.c1z", p))
+		// #nosec G703 - fixture paths derive from a developer-provided env var.
+		if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+			buildProdScalePartial(t, ctx, path, p)
+		}
+		partialPaths = append(partialPaths, path)
+	}
+
+	baseSyncID := manifestSyncID(t, basePath)
+	entries := []*CompactableSync{{FilePath: basePath, SyncID: baseSyncID}}
+	for _, p := range partialPaths {
+		entries = append(entries, &CompactableSync{FilePath: p, SyncID: manifestSyncID(t, p)})
+	}
+
+	baseTs := grantDiscoveredAt(t, ctx, basePath, baseSyncID, scaleID("g", 0))
+	expectedGrants := int64(grants + partialCount*200)
+
+	for _, mode := range []string{"kway", "overlay", "fold"} {
+		name := mode
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("BATON_EXPERIMENTAL_PEBBLE_COMPACTOR", mode)
+			c, cleanup, err := NewCompactor(ctx, t.TempDir(), entries,
+				WithTmpDir(t.TempDir()), WithEngine(dotc1z.EnginePebble), WithSkipGrantExpansion())
+			require.NoError(t, err)
+			defer func() { require.NoError(t, cleanup()) }()
+
+			start := time.Now()
+			out, err := c.Compact(ctx)
+			elapsed := time.Since(start)
+			require.NoError(t, err)
+			require.NotNil(t, out)
+			t.Logf("mode=%s elapsed=%s", name, elapsed.Round(time.Millisecond))
+			logFileSize(t, "output", out.FilePath)
+
+			if mode == "fold" {
+				require.Equal(t, baseSyncID, out.SyncID, "fold must adopt the base sync id")
+			}
+
+			// Sentinel correctness: a partial-only grant exists, an
+			// overridden grant carries the partial's (newer) stamp,
+			// and the stats sidecar shows the expected union.
+			w, err := dotc1z.NewStore(ctx, out.FilePath, dotc1z.WithReadOnly(true), dotc1z.WithTmpDir(t.TempDir()))
+			require.NoError(t, err)
+			defer w.Close(ctx)
+			eng, ok := enginepkg.AsEngine(w)
+			require.True(t, ok)
+			_, err = eng.GetGrantRecord(ctx, out.SyncID, scaleID("p000-g", 0))
+			require.NoError(t, err, "partial-only grant missing from output")
+			overridden, err := eng.GetGrantRecord(ctx, out.SyncID, scaleID("g", 0))
+			require.NoError(t, err)
+			require.True(t, overridden.GetDiscoveredAt().AsTime().After(baseTs),
+				"overridden grant must carry the partial's newer discovered_at")
+			stats, err := enginepkg.ReadSyncStatsRecord(ctx, eng, out.SyncID)
+			require.NoError(t, err)
+			require.NotNil(t, stats)
+			require.Equal(t, expectedGrants, stats.GetGrants(),
+				"output grants must be base + partial-only additions")
+		})
+	}
+}
+
+// scaleID builds a deterministic high-entropy id. Real-world ids
+// (UUIDs, ARNs, KSUIDs) don't compress 30:1 the way sequential
+// patterned test ids do; the fnv-derived hex suffix keeps the
+// fixture's zstd ratio realistic while staying reproducible so cached
+// fixtures and override windows line up across runs.
+func scaleID(kind string, i int) string {
+	h := fnv.New64a()
+	fmt.Fprintf(h, "%s|%d", kind, i)
+	return fmt.Sprintf("%s-%08d-%016x", kind, i, h.Sum64())
+}
+
+func envInt(name string, def int) int {
+	if raw := os.Getenv(name); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n > 0 {
+			return n
+		}
+	}
+	return def
+}
+
+func logFileSize(t *testing.T, label, path string) {
+	t.Helper()
+	info, err := os.Stat(path) // #nosec G703 - test fixture path.
+	require.NoError(t, err)
+	t.Logf("%s: %s (%.1f MB)", label, path, float64(info.Size())/(1<<20))
+}
+
+// manifestSyncID reads the latest finished compactable sync id from a
+// v3 envelope's manifest projection.
+func manifestSyncID(t *testing.T, path string) string {
+	t.Helper()
+	sel, ok := selectSourceSyncFromManifest(path)
+	require.True(t, ok, "no manifest sync projection in %s", path)
+	return sel.syncID
+}
+
+// buildProdScaleBase writes one large full sync: a fixed user/group
+// catalog, `ents` entitlements spread across groups, and `grants`
+// grants spread across users × entitlements.
+func buildProdScaleBase(t *testing.T, ctx context.Context, path string, grants, users, ents int) {
+	t.Helper()
+	w, err := dotc1z.NewStore(ctx, path,
+		dotc1z.WithEngine(dotc1z.EnginePebble),
+		dotc1z.WithPayloadEncoding(dotc1z.PayloadEncodingIndexedZstd),
+		dotc1z.WithTmpDir(t.TempDir()))
+	require.NoError(t, err)
+	_, err = w.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	require.NoError(t, w.PutResourceTypes(ctx, userRT, groupRT))
+
+	groups := users / 10
+	if groups < 1 {
+		groups = 1
+	}
+	const batchSize = 10_000
+	batch := make([]*v2.Resource, 0, batchSize)
+	flushResources := func() {
+		if len(batch) > 0 {
+			require.NoError(t, w.PutResources(ctx, batch...))
+			batch = batch[:0]
+		}
+	}
+	for i := 0; i < users; i++ {
+		batch = append(batch, v2.Resource_builder{
+			Id: v2.ResourceId_builder{ResourceType: "user", Resource: scaleID("u", i)}.Build(),
+		}.Build())
+		if len(batch) == batchSize {
+			flushResources()
+		}
+	}
+	for i := 0; i < groups; i++ {
+		batch = append(batch, v2.Resource_builder{
+			Id: v2.ResourceId_builder{ResourceType: "group", Resource: scaleID("grp", i)}.Build(),
+		}.Build())
+		if len(batch) == batchSize {
+			flushResources()
+		}
+	}
+	flushResources()
+
+	entBatch := make([]*v2.Entitlement, 0, batchSize)
+	for i := 0; i < ents; i++ {
+		group := v2.Resource_builder{
+			Id: v2.ResourceId_builder{ResourceType: "group", Resource: scaleID("grp", i%groups)}.Build(),
+		}.Build()
+		entBatch = append(entBatch, v2.Entitlement_builder{
+			Id:       scaleID("e", i),
+			Resource: group,
+			Purpose:  v2.Entitlement_PURPOSE_VALUE_ASSIGNMENT,
+		}.Build())
+		if len(entBatch) == batchSize {
+			require.NoError(t, w.PutEntitlements(ctx, entBatch...))
+			entBatch = entBatch[:0]
+		}
+	}
+	if len(entBatch) > 0 {
+		require.NoError(t, w.PutEntitlements(ctx, entBatch...))
+	}
+
+	grantBatch := make([]*v2.Grant, 0, batchSize)
+	for i := 0; i < grants; i++ {
+		user := v2.Resource_builder{
+			Id: v2.ResourceId_builder{ResourceType: "user", Resource: scaleID("u", i%users)}.Build(),
+		}.Build()
+		ent := v2.Entitlement_builder{
+			Id: scaleID("e", i%ents),
+			Resource: v2.Resource_builder{
+				Id: v2.ResourceId_builder{ResourceType: "group", Resource: scaleID("grp", (i%ents)%groups)}.Build(),
+			}.Build(),
+		}.Build()
+		grantBatch = append(grantBatch, v2.Grant_builder{
+			Id:          scaleID("g", i),
+			Principal:   user,
+			Entitlement: ent,
+		}.Build())
+		if len(grantBatch) == batchSize {
+			require.NoError(t, w.PutGrants(ctx, grantBatch...))
+			grantBatch = grantBatch[:0]
+		}
+	}
+	if len(grantBatch) > 0 {
+		require.NoError(t, w.PutGrants(ctx, grantBatch...))
+	}
+
+	require.NoError(t, w.EndSync(ctx))
+	require.NoError(t, w.Close(ctx))
+}
+
+// buildProdScalePartial writes one small partial sync: 1000 grant
+// overrides into the base's id space (g-<window>) plus 200 new
+// partial-only grants, with the supporting principals/entitlements.
+func buildProdScalePartial(t *testing.T, ctx context.Context, path string, idx int) {
+	t.Helper()
+	w, err := dotc1z.NewStore(ctx, path,
+		dotc1z.WithEngine(dotc1z.EnginePebble),
+		dotc1z.WithPayloadEncoding(dotc1z.PayloadEncodingIndexedZstd),
+		dotc1z.WithTmpDir(t.TempDir()))
+	require.NoError(t, err)
+	_, err = w.StartNewSync(ctx, connectorstore.SyncTypePartial, "")
+	require.NoError(t, err)
+
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	require.NoError(t, w.PutResourceTypes(ctx, userRT, groupRT))
+
+	resources := make([]*v2.Resource, 0, 1001)
+	for i := 0; i < 1000; i++ {
+		resources = append(resources, v2.Resource_builder{
+			Id: v2.ResourceId_builder{ResourceType: "user", Resource: scaleID("u", i)}.Build(),
+		}.Build())
+	}
+	group := v2.Resource_builder{
+		Id: v2.ResourceId_builder{ResourceType: "group", Resource: scaleID("grp", 0)}.Build(),
+	}.Build()
+	resources = append(resources, group)
+	require.NoError(t, w.PutResources(ctx, resources...))
+
+	entObjs := make([]*v2.Entitlement, 0, 100)
+	for i := 0; i < 100; i++ {
+		entObjs = append(entObjs, v2.Entitlement_builder{
+			Id:       scaleID("e", i),
+			Resource: group,
+			Purpose:  v2.Entitlement_PURPOSE_VALUE_ASSIGNMENT,
+		}.Build())
+	}
+	require.NoError(t, w.PutEntitlements(ctx, entObjs...))
+
+	grantObjs := make([]*v2.Grant, 0, 1200)
+	mkGrant := func(id string, userIdx, entIdx int) *v2.Grant {
+		user := v2.Resource_builder{
+			Id: v2.ResourceId_builder{ResourceType: "user", Resource: scaleID("u", userIdx)}.Build(),
+		}.Build()
+		ent := v2.Entitlement_builder{
+			Id:       scaleID("e", entIdx),
+			Resource: group,
+		}.Build()
+		return v2.Grant_builder{Id: id, Principal: user, Entitlement: ent}.Build()
+	}
+	// Overrides into the base's grant id space.
+	for i := 0; i < 1000; i++ {
+		grantObjs = append(grantObjs, mkGrant(scaleID("g", idx*1000+i), i, i%100))
+	}
+	// Partial-only additions.
+	for i := 0; i < 200; i++ {
+		grantObjs = append(grantObjs, mkGrant(scaleID(fmt.Sprintf("p%03d-g", idx), i), i%1000, i%100))
+	}
+	require.NoError(t, w.PutGrants(ctx, grantObjs...))
+
+	require.NoError(t, w.EndSync(ctx))
+	require.NoError(t, w.Close(ctx))
+}

--- a/proto/c1/c1z/v3/manifest.proto
+++ b/proto/c1/c1z/v3/manifest.proto
@@ -76,18 +76,87 @@ enum PayloadEncoding {
   // with conflicting meanings. Don't reuse.
   reserved 3, 4;
 
-  // Per-file zstd frames, each preceded by a self-describing binary
-  // header (name, raw size, compressed size, xxh64 of raw bytes),
-  // terminated by a zero-length-name sentinel. No tar layer.
+  // Per-file zstd frames written back-to-back, indexed by a trailing
+  // IndexedFrameIndex and fixed-size footer (see that message for
+  // the layout). No tar layer, no per-frame inline headers.
   //
   // Enables (a) parallel frame decode at open — the single-stream
-  // encodings decode sequentially on one core — and (b) frame
-  // splicing at save: a writer that knows a payload file is
-  // byte-identical to one in the source envelope copies its
-  // compressed frame verbatim instead of re-encoding (Pebble SSTs
-  // are immutable and checkpoints hard-link them, so incremental
-  // folds reuse almost every frame).
+  // encodings decode sequentially on one core; (b) frame splicing at
+  // save: a writer that knows a payload file is byte-identical to one
+  // in the source envelope copies its compressed frame verbatim
+  // instead of re-encoding (Pebble SSTs are immutable and checkpoints
+  // hard-link them, so incremental folds reuse almost every frame);
+  // and (c) chunked object storage: the index carries every frame's
+  // byte range and SHA-256 content identity, so a store can upload
+  // only the frames a parent sync doesn't already hold.
   PAYLOAD_ENCODING_INDEXED_ZSTD = 5;
+}
+
+// IndexedFrameIndex is the sole frame table for
+// PAYLOAD_ENCODING_INDEXED_ZSTD payloads. It is serialized (binary
+// proto) immediately after the last frame, followed by a fixed-size
+// footer carrying the index's absolute file offset, length, xxh64,
+// and a trailing magic:
+//
+//	payload := frame* | index | footer
+//	footer  := u64 indexOffset | u32 indexLen | u64 xxh64(index) | "C1ZIDX1\0"
+//
+// Frames carry no framing of their own — each is the bare zstd
+// stream of one payload file, with Frame_Content_Size advertised —
+// so the writer is single-pass (streamable to a non-seekable sink)
+// and a frame's byte range is directly usable as a standalone
+// object. The whole table is fetchable in O(1) reads — footer, then
+// index — which is what makes ranged reads over object storage
+// practical: fetch exactly the frames you want, no per-frame round
+// trips. A payload without a valid footer is corruption-class, the
+// same policy as a torn tar payload.
+//
+// Being a proto message, the index is the extension point for future
+// per-frame metadata (compression algorithm, dictionary IDs,
+// encryption) without a layout revision.
+message IndexedFrameIndex {
+  repeated IndexedFrameEntry entries = 1;
+  // Sum of raw_size over entries. Lets a reader budget extraction
+  // without summing.
+  int64 total_raw_size = 2;
+  // Sum of compressed_size over entries.
+  int64 total_compressed_size = 3;
+  // xxh64 of the marshaled manifest bytes (the region between the
+  // length prefix and the first frame). The manifest is otherwise
+  // the only unprotected byte region — frames carry zstd CRCs and
+  // raw-byte hashes, the index is covered by the footer's xxh64 —
+  // and the header-only manifest decode skips the descriptor
+  // closure, so a flipped bit there would otherwise go unnoticed.
+  // Also lets a chunked store verify reassembly of the envelope
+  // head. Zero means "not recorded".
+  fixed64 manifest_xxh64 = 4;
+}
+
+message IndexedFrameEntry {
+  // Slash-separated relative path of the payload file, identical to
+  // the name in the frame's inline header.
+  string name = 1;
+  // Absolute offset of the frame's compressed zstd bytes from the
+  // start of the envelope file (NOT from the payload start), so a
+  // ranged read needs no other context.
+  int64 frame_offset = 2;
+  int64 compressed_size = 3;
+  int64 raw_size = 4;
+  // xxh64 of the raw (decompressed) bytes. Matches the inline
+  // header; used for corruption detection and splice matching.
+  fixed64 raw_xxh64 = 5;
+  // SHA-256 of the raw bytes. Content-address identity for chunked
+  // object storage: compressed bytes are not stable across encoder
+  // versions, and xxh64 is too weak to key a fleet-wide chunk store.
+  //
+  // REQUIRED: readers reject entries whose value is not exactly 32
+  // bytes. Writers must always compute it, even when content
+  // addressing is not in play — a partially-identified index can't
+  // serve chunk dedupe later, and allowing absence would let
+  // truncated identities propagate through frame splicing. A future
+  // writer that genuinely cannot afford SHA-256 should introduce a
+  // new payload encoding (or footer version) rather than omit this.
+  bytes raw_sha256 = 6;
 }
 
 message RecordTypeInfo {

--- a/proto/c1/c1z/v3/manifest.proto
+++ b/proto/c1/c1z/v3/manifest.proto
@@ -63,7 +63,7 @@ enum PayloadEncoding {
   PAYLOAD_ENCODING_UNSPECIFIED = 0;
 
   // Tar of a Pebble directory, compressed with zstd. The
-  // production default.
+  // production default in older v3 writers.
   PAYLOAD_ENCODING_TAR_ZSTD = 1;
 
   // Tar of a Pebble directory, uncompressed. For tenants whose
@@ -71,6 +71,23 @@ enum PayloadEncoding {
   // layer and want to avoid double-compression CPU at envelope
   // time, or for object-storage targets that compress in-transit.
   PAYLOAD_ENCODING_TAR = 2;
+
+  // 3 and 4 are skipped: pre-release dev builds briefly used them
+  // with conflicting meanings. Don't reuse.
+  reserved 3, 4;
+
+  // Per-file zstd frames, each preceded by a self-describing binary
+  // header (name, raw size, compressed size, xxh64 of raw bytes),
+  // terminated by a zero-length-name sentinel. No tar layer.
+  //
+  // Enables (a) parallel frame decode at open — the single-stream
+  // encodings decode sequentially on one core — and (b) frame
+  // splicing at save: a writer that knows a payload file is
+  // byte-identical to one in the source envelope copies its
+  // compressed frame verbatim instead of re-encoding (Pebble SSTs
+  // are immutable and checkpoints hard-link them, so incremental
+  // folds reuse almost every frame).
+  PAYLOAD_ENCODING_INDEXED_ZSTD = 5;
 }
 
 message RecordTypeInfo {


### PR DESCRIPTION
## Details

- Adds `PAYLOAD_ENCODING_INDEXED_ZSTD`, which stores each Pebble payload file as an independent zstd frame.
- Indexed payloads support parallel extraction and frame splicing on rewrite, so unchanged Pebble files can be copied from the source envelope without recompression.
- Pebble stores now adopt an existing file’s payload encoding on reopen unless the caller explicitly requests one.
- Compactor engine selection now infers SQLite vs Pebble from input `.c1z` formats when `WithEngine` is not specified.
- Overlay compaction no longer uses a counting pre-scan when stats are missing.
- Overlay planning now uses cached stats only:
  - `sum <= softLimit` stays overlay.
  - `max(sourceCount) > hardLimit` routes directly to k-way.
  - missing stats or uncertain ranges start in overlay and degrade adaptively.
- Adds configurable overlay options for seen limit, record chunk size, buffer factor, and gate fraction.
- Keeps local compatibility with tar and tar+zstd v3 payloads.

TODO: reframe the header to sanity.
