### PR TITLE
feat(dotc1z): add SnapshotTo to materialize a partial .c1z from a live handle

### DIFF
--- a/pkg/c1zsanitize/resume_phase.go
+++ b/pkg/c1zsanitize/resume_phase.go
@@ -1,0 +1,30 @@
+package c1zsanitize
+
+import "encoding/json"
+
+// ResumePhase reads the sanitize resume phase encoded in a destination sync's
+// raw sync_token. It returns the phase name (one of "resources",
+// "entitlements", "grants", "assets"), the grant page token (meaningful only at
+// the grants phase), the source sync id the token correlates to, and ok=false
+// when the token is empty or not a c1zsanitize checkpoint. It does NOT validate
+// the secret fingerprint and performs no I/O — it is a pure decoder over the
+// token string a caller already holds (e.g. from dotc1z.SyncRun.SyncToken or
+// CurrentSyncStep), so a consumer does not have to couple to the unexported
+// token JSON shape.
+//
+//nolint:nonamedreturns // the named results document the decoded token fields.
+func ResumePhase(syncToken string) (phase, grantPage, srcSyncID string, ok bool) {
+	if syncToken == "" {
+		return "", "", "", false
+	}
+	var ct checkpointToken
+	if json.Unmarshal([]byte(syncToken), &ct) != nil {
+		return "", "", "", false
+	}
+	// An empty fingerprint means this is not one of our checkpoints; match the
+	// loadResumeStates tolerance, which skips such tokens rather than failing.
+	if ct.Fingerprint == "" {
+		return "", "", "", false
+	}
+	return ct.Phase, ct.GrantPage, ct.SrcSyncID, true
+}

--- a/pkg/c1zsanitize/resume_phase.go
+++ b/pkg/c1zsanitize/resume_phase.go
@@ -21,8 +21,9 @@ func ResumePhase(syncToken string) (phase, grantPage, srcSyncID string, ok bool)
 	if json.Unmarshal([]byte(syncToken), &ct) != nil {
 		return "", "", "", false
 	}
-	// An empty fingerprint means this is not one of our checkpoints; match the
-	// loadResumeStates tolerance, which skips such tokens rather than failing.
+	// An empty fingerprint marks a token that is not one of our checkpoints, so
+	// skip it — ResumePhase does not otherwise validate the fingerprint; matching
+	// it against the secret is loadResumeStates' concern.
 	if ct.Fingerprint == "" {
 		return "", "", "", false
 	}

--- a/pkg/c1zsanitize/resume_phase.go
+++ b/pkg/c1zsanitize/resume_phase.go
@@ -26,5 +26,12 @@ func ResumePhase(syncToken string) (phase, grantPage, srcSyncID string, ok bool)
 	if ct.Fingerprint == "" {
 		return "", "", "", false
 	}
+	// A foreign token can carry an "fp" field yet name no phase we recognize;
+	// such a token is not a resumable checkpoint, so report ok=false.
+	switch ct.Phase {
+	case phaseResources, phaseEntitlements, phaseGrants, phaseAssets:
+	default:
+		return "", "", "", false
+	}
 	return ct.Phase, ct.GrantPage, ct.SrcSyncID, true
 }

--- a/pkg/c1zsanitize/snapshot_resume_test.go
+++ b/pkg/c1zsanitize/snapshot_resume_test.go
@@ -1,0 +1,240 @@
+package c1zsanitize
+
+import (
+	"context"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+)
+
+// buildManyGrantsFixture writes a single sync with nGrants grants on one
+// entitlement, drawing principals from a tiny pool so the fixture stays cheap
+// while still exceeding listPageSize. With nGrants > listPageSize the sanitizer
+// reads grants in multiple pages, so an interruption on the second page leaves a
+// NON-empty grant page token in the destination checkpoint.
+func buildManyGrantsFixture(t *testing.T, ctx context.Context, path string, nGrants int) {
+	t.Helper()
+	f, err := dotc1z.NewC1ZFile(ctx, path)
+	require.NoError(t, err)
+
+	_, err = f.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+
+	require.NoError(t, f.PutResourceTypes(ctx,
+		v2.ResourceType_builder{Id: "user", DisplayName: "User", Traits: []v2.ResourceType_Trait{v2.ResourceType_TRAIT_USER}}.Build(),
+		v2.ResourceType_builder{Id: "role", DisplayName: "Role", Traits: []v2.ResourceType_Trait{v2.ResourceType_TRAIT_ROLE}}.Build(),
+	))
+
+	role := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "role", Resource: "admin"}.Build(), DisplayName: "Admin"}.Build()
+	users := make([]*v2.Resource, 4)
+	for i := range users {
+		users[i] = v2.Resource_builder{
+			Id:          v2.ResourceId_builder{ResourceType: "user", Resource: "u" + strconv.Itoa(i)}.Build(),
+			DisplayName: "User " + strconv.Itoa(i),
+		}.Build()
+	}
+	require.NoError(t, f.PutResources(ctx, append([]*v2.Resource{role}, users...)...))
+
+	ent := v2.Entitlement_builder{Id: "ent-admin", Resource: role, DisplayName: "admin", Slug: "admin"}.Build()
+	require.NoError(t, f.PutEntitlements(ctx, ent))
+
+	grants := make([]*v2.Grant, nGrants)
+	for i := 0; i < nGrants; i++ {
+		grants[i] = v2.Grant_builder{
+			Id:          "grant-" + strconv.Itoa(i),
+			Entitlement: ent,
+			Principal:   users[i%len(users)],
+		}.Build()
+	}
+	require.NoError(t, f.PutGrants(ctx, grants...))
+	require.NoError(t, f.EndSync(ctx))
+	require.NoError(t, f.Close(ctx))
+}
+
+func listAllRuns(t *testing.T, ctx context.Context, f *dotc1z.C1File) []*dotc1z.SyncRun {
+	t.Helper()
+	var out []*dotc1z.SyncRun
+	pageToken := ""
+	for {
+		runs, next, err := f.ListSyncRuns(ctx, pageToken, 1000)
+		require.NoError(t, err)
+		out = append(out, runs...)
+		if next == "" {
+			return out
+		}
+		pageToken = next
+	}
+}
+
+// TestSnapshotResumeRecordIdentical is the headline test: a mid-sanitize
+// destination is materialized with SnapshotTo (no Close, no re-decompress),
+// reopened, and a resumable Sanitize is run against the snapshot. The
+// reopened-and-resumed output must be record-identical to a single uninterrupted
+// run with the same secret and anchor. Two interrupt points are covered: the
+// resources/entitlements boundary (empty grant page token) and mid-grants (a
+// non-empty grant page token in the snapshot's sync_token).
+func TestSnapshotResumeRecordIdentical(t *testing.T) {
+	t.Run("boundary", func(t *testing.T) {
+		ctx := context.Background()
+		tmp := t.TempDir()
+		srcPath := filepath.Join(tmp, "src.c1z")
+		cleanDst := filepath.Join(tmp, "clean.c1z")
+		workDst := filepath.Join(tmp, "work.c1z")
+		snapPath := filepath.Join(tmp, "snap.c1z")
+		secret := bytes32("snapshot-resume-boundary")
+		buildSyncFixture(t, ctx, srcPath, 1, 40)
+
+		// Reference: one uninterrupted resumable run.
+		sanitizeToFile(t, ctx, srcPath, cleanDst, secret, Options{Resumable: true})
+
+		// Interrupt at the first PutGrants — resources + entitlements written and
+		// checkpointed at phaseGrants with an empty page token. Snapshot the LIVE
+		// destination at that checkpoint, then resume from the snapshot.
+		func() {
+			src := mustOpen(t, ctx, srcPath, true)
+			defer src.Close(ctx)
+			w := &interruptingWriter{C1File: mustOpen(t, ctx, workDst, false), failOnPutGrantsCall: 1}
+			err := Sanitize(ctx, src, w, Options{Secret: secret, TimestampAnchor: fixedAnchor, Resumable: true})
+			require.Error(t, err, "run must be interrupted at the grant phase")
+			require.NoError(t, w.SnapshotTo(ctx, snapPath, dotc1z.WithC1FBulkLoad(true), dotc1z.WithC1FSkipVacuum(true)))
+			require.NoError(t, w.Close(ctx))
+		}()
+
+		// Resume into the snapshot.
+		func() {
+			src := mustOpen(t, ctx, srcPath, true)
+			defer src.Close(ctx)
+			dst := mustOpen(t, ctx, snapPath, false)
+			require.NoError(t, Sanitize(ctx, src, dst, Options{Secret: secret, TimestampAnchor: fixedAnchor, Resumable: true}))
+			require.NoError(t, dst.Close(ctx))
+		}()
+
+		cleanRO := mustOpen(t, ctx, cleanDst, true)
+		defer cleanRO.Close(ctx)
+		snapRO := mustOpen(t, ctx, snapPath, true)
+		defer snapRO.Close(ctx)
+		clean := collectRecords(t, ctx, cleanRO)
+		resumed := collectRecords(t, ctx, snapRO)
+		require.NotZero(t, len(clean.grants))
+		require.Equal(t, clean.idOccurrences, resumed.idOccurrences,
+			"resume-from-snapshot output must be record-identical to the uninterrupted run")
+	})
+
+	t.Run("mid-grants", func(t *testing.T) {
+		ctx := context.Background()
+		tmp := t.TempDir()
+		srcPath := filepath.Join(tmp, "src.c1z")
+		cleanDst := filepath.Join(tmp, "clean.c1z")
+		workDst := filepath.Join(tmp, "work.c1z")
+		snapPath := filepath.Join(tmp, "snap.c1z")
+		secret := bytes32("snapshot-resume-mid-grants")
+		// One sync with more than listPageSize (10000) grants → multiple grant
+		// pages, so a second-page interruption produces a non-empty page token.
+		buildManyGrantsFixture(t, ctx, srcPath, 10001)
+
+		sanitizeToFile(t, ctx, srcPath, cleanDst, secret, Options{Resumable: true})
+
+		func() {
+			src := mustOpen(t, ctx, srcPath, true)
+			defer src.Close(ctx)
+			// Fail the SECOND grant page: page one (10000 grants) is written and a
+			// non-empty grant page token is checkpointed before page two fails.
+			w := &interruptingWriter{C1File: mustOpen(t, ctx, workDst, false), failOnPutGrantsCall: 2}
+			err := Sanitize(ctx, src, w, Options{Secret: secret, TimestampAnchor: fixedAnchor, Resumable: true})
+			require.Error(t, err, "run must be interrupted on the second grant page")
+
+			// The live checkpoint must carry a non-empty grant page token.
+			runs := listAllRuns(t, ctx, w.C1File)
+			require.Len(t, runs, 1)
+			phase, gpt, _, ok := ResumePhase(runs[0].SyncToken)
+			require.True(t, ok)
+			require.Equal(t, "grants", phase)
+			require.NotEmpty(t, gpt, "mid-grants interruption must checkpoint a non-empty grant page token")
+
+			require.NoError(t, w.SnapshotTo(ctx, snapPath, dotc1z.WithC1FBulkLoad(true), dotc1z.WithC1FSkipVacuum(true)))
+			require.NoError(t, w.Close(ctx))
+		}()
+
+		func() {
+			src := mustOpen(t, ctx, srcPath, true)
+			defer src.Close(ctx)
+			dst := mustOpen(t, ctx, snapPath, false)
+			require.NoError(t, Sanitize(ctx, src, dst, Options{Secret: secret, TimestampAnchor: fixedAnchor, Resumable: true}))
+			require.NoError(t, dst.Close(ctx))
+		}()
+
+		cleanRO := mustOpen(t, ctx, cleanDst, true)
+		defer cleanRO.Close(ctx)
+		snapRO := mustOpen(t, ctx, snapPath, true)
+		defer snapRO.Close(ctx)
+		clean := collectRecords(t, ctx, cleanRO)
+		resumed := collectRecords(t, ctx, snapRO)
+		require.Equal(t, len(clean.grants), len(resumed.grants))
+		require.Equal(t, clean.idOccurrences, resumed.idOccurrences,
+			"resume-from-mid-grants-snapshot output must be record-identical to the uninterrupted run")
+	})
+}
+
+// TestSnapshotPreservesSyncTokenByteForByte covers Test 3: the snapshot
+// reproduces each sync's sync_token bytes exactly, and ResumePhase decodes the
+// same phase/grant-page from the snapshot as from the live source.
+func TestSnapshotPreservesSyncTokenByteForByte(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	srcPath := filepath.Join(tmp, "src.c1z")
+	workDst := filepath.Join(tmp, "work.c1z")
+	snapPath := filepath.Join(tmp, "snap.c1z")
+	secret := bytes32("snapshot-token-bytes")
+	buildManyGrantsFixture(t, ctx, srcPath, 10001)
+
+	var liveTokens map[string]string
+	var livePhase, liveGPT, liveSrc string
+	var liveOK bool
+
+	func() {
+		src := mustOpen(t, ctx, srcPath, true)
+		defer src.Close(ctx)
+		w := &interruptingWriter{C1File: mustOpen(t, ctx, workDst, false), failOnPutGrantsCall: 2}
+		err := Sanitize(ctx, src, w, Options{Secret: secret, TimestampAnchor: fixedAnchor, Resumable: true})
+		require.Error(t, err)
+
+		liveTokens = map[string]string{}
+		for _, r := range listAllRuns(t, ctx, w.C1File) {
+			liveTokens[r.ID] = r.SyncToken
+		}
+		require.NotEmpty(t, liveTokens)
+		// Capture the decoded phase of the (single) destination sync for the
+		// cross-check below.
+		for _, tok := range liveTokens {
+			livePhase, liveGPT, liveSrc, liveOK = ResumePhase(tok)
+		}
+		require.True(t, liveOK)
+
+		require.NoError(t, w.SnapshotTo(ctx, snapPath))
+		require.NoError(t, w.Close(ctx))
+	}()
+
+	snap := mustOpen(t, ctx, snapPath, true)
+	defer snap.Close(ctx)
+	snapTokens := map[string]string{}
+	for _, r := range listAllRuns(t, ctx, snap) {
+		snapTokens[r.ID] = r.SyncToken
+	}
+
+	require.Equal(t, liveTokens, snapTokens, "snapshot sync_token bytes must match the source exactly")
+
+	// ResumePhase decodes identically from the snapshot.
+	for _, tok := range snapTokens {
+		phase, gpt, src, ok := ResumePhase(tok)
+		require.True(t, ok)
+		require.Equal(t, livePhase, phase)
+		require.Equal(t, liveGPT, gpt)
+		require.Equal(t, liveSrc, src)
+	}
+}

--- a/pkg/dotc1z/clone_sync.go
+++ b/pkg/dotc1z/clone_sync.go
@@ -99,6 +99,13 @@ func cloneTableQueryAll(tableName string, columns []string) string {
 	)
 }
 
+// errOutPathExists builds the single canonical error returned when a clone or
+// snapshot output path is already occupied. errPrefix namespaces it to the
+// caller ("clone-sync" / "snapshot-to") while keeping one message shape.
+func errOutPathExists(errPrefix, outPath string) error {
+	return fmt.Errorf("%s: output path (%s) must not exist", errPrefix, outPath)
+}
+
 // CloneSync uses sqlite hackery to directly copy the pertinent rows into a new database.
 // 1. Create a new empty sqlite database in a temp file
 // 2. Open the c1z that we are cloning to get a db handle
@@ -116,11 +123,11 @@ func (c *C1File) CloneSync(ctx context.Context, outPath string, syncID string, o
 	}
 	opts = append(defaultOpts, opts...)
 
-	// Be sure that the output path is empty else return an error. Checked here,
-	// ahead of the sync preconditions, so an occupied output path is reported
-	// before the target sync is inspected — the order callers have always seen.
+	// Check the output path ahead of the sync preconditions so an occupied
+	// output path is reported before the target sync is inspected — the order
+	// callers have always seen. cloneCopy re-checks it as the shared chokepoint.
 	if _, statErr := os.Stat(outPath); statErr == nil || !errors.Is(statErr, fs.ErrNotExist) {
-		return fmt.Errorf("clone-sync: output path (%s) must not exist for cloning to proceed", outPath)
+		return errOutPathExists("clone-sync", outPath)
 	}
 
 	if syncID == "" {
@@ -224,15 +231,20 @@ func (c *C1File) SnapshotTo(ctx context.Context, outPath string, opts ...C1FOpti
 // The compress runs on the separate temp db and does not hold the live
 // connection. cloneCopy reads c.rawDb to take that one connection but never
 // mutates c.rawDb/c.db/c.currentSyncID/c.closed, so the live handle is left
-// exactly as it was found (plus the row-copy stall). Callers guard a closed
-// handle before reaching here, so c.rawDb is non-nil.
+// exactly as it was found (plus the row-copy stall). Both entry points already
+// reject a closed handle; the nil-rawDb guard below is defensive against a
+// future caller that does not.
 // errPrefix is the caller's error-message namespace ("clone-sync" /
 // "snapshot-to") so each entry point keeps its own observable error strings.
 func (c *C1File) cloneCopy(ctx context.Context, outPath string, syncID string, selectAll bool, errPrefix string, opts ...C1FOption) error {
+	if c.rawDb == nil {
+		return ErrDbNotOpen
+	}
+
 	// Be sure that the output path is empty else return an error
 	_, err := os.Stat(outPath)
 	if err == nil || !errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf("%s: output path (%s) must not exist", errPrefix, outPath)
+		return errOutPathExists(errPrefix, outPath)
 	}
 
 	tmpDir, err := os.MkdirTemp(c.tempDir, "c1zclone")
@@ -288,7 +300,10 @@ func (c *C1File) cloneCopy(ctx context.Context, outPath string, syncID string, s
 		}
 		defer conn.Close()
 
-		if _, err := conn.ExecContext(qCtx, fmt.Sprintf(`ATTACH '%s' AS clone`, dbPath)); err != nil {
+		// dbPath sits under the operator-controlled temp dir; escape single
+		// quotes so a quote in the path can't break out of the SQL string literal.
+		escapedDBPath := strings.ReplaceAll(dbPath, "'", "''")
+		if _, err := conn.ExecContext(qCtx, fmt.Sprintf(`ATTACH '%s' AS clone`, escapedDBPath)); err != nil {
 			return err
 		}
 		defer func() {
@@ -318,11 +333,26 @@ func (c *C1File) cloneCopy(ctx context.Context, outPath string, syncID string, s
 	}(); copyErr != nil {
 		return copyErr
 	}
-	canc()
 
 	// Open a fresh C1File to compress the populated db into a c1z.
 	// No other connections are open on dbPath at this point.
-	outFile, err := NewC1File(ctx, dbPath, opts...)
+	//
+	// Reopening the populated clone re-runs each table's Schema() in InitTables,
+	// whose CREATE INDEX statements rebuild the secondary indexes that were
+	// deferred (dropped) for the row copy. On a whale-scale snapshot that
+	// rebuild is the dominant cost, so InitTables runs on a context detached
+	// from caller cancellation and bounded by BulkLoadIndexTimeout — the same
+	// protection buildDeferredIndexes gives the normal Close path — so a
+	// deadlined caller ctx cannot abort the half-built indexes. The compress
+	// itself still runs under the caller's ctx and stays cancellable.
+	//
+	// WithC1FBulkLoad is forced off for this open: the clone tables are now
+	// populated, so the per-table bulk-load emptiness check would only log a
+	// spurious "degrading to normal mode" warning while the rebuild happens via
+	// Schema() anyway.
+	idxCtx, cancelIdx := context.WithTimeout(context.WithoutCancel(ctx), BulkLoadIndexTimeout())
+	defer cancelIdx()
+	outFile, err := NewC1File(idxCtx, dbPath, append(opts, WithC1FBulkLoad(false))...)
 	if err != nil {
 		return err
 	}

--- a/pkg/dotc1z/clone_sync.go
+++ b/pkg/dotc1z/clone_sync.go
@@ -83,6 +83,22 @@ func cloneTableQuery(tableName string, columns []string) string {
 	)
 }
 
+// cloneTableQueryAll is the all-rows sibling of cloneTableQuery: it omits the
+// WHERE sync_id=? filter so every row of the table is copied verbatim. It is
+// used by SnapshotTo, which reproduces the whole file — including un-ended
+// syncs and the full sync_runs table (with each row's sync_token bytes intact).
+func cloneTableQueryAll(tableName string, columns []string) string {
+	quoted := make([]string, len(columns))
+	for i, c := range columns {
+		quoted[i] = quoteIdentifier(c)
+	}
+	colList := strings.Join(quoted, ", ")
+	return fmt.Sprintf(
+		"INSERT INTO clone.%s (%s) SELECT %s FROM %s",
+		tableName, colList, colList, tableName,
+	)
+}
+
 // CloneSync uses sqlite hackery to directly copy the pertinent rows into a new database.
 // 1. Create a new empty sqlite database in a temp file
 // 2. Open the c1z that we are cloning to get a db handle
@@ -99,42 +115,6 @@ func (c *C1File) CloneSync(ctx context.Context, outPath string, syncID string, o
 		WithC1FSkipCleanup(true), // No need to clean up old syncs, as we only copied one sync into the new file.
 	}
 	opts = append(defaultOpts, opts...)
-
-	// Be sure that the output path is empty else return an error
-	_, err = os.Stat(outPath)
-	if err == nil || !errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf("clone-sync: output path (%s) must not exist for cloning to proceed", outPath)
-	}
-
-	tmpDir, err := os.MkdirTemp(c.tempDir, "c1zclone")
-	if err != nil {
-		return err
-	}
-
-	// Always clean up the temp dir and return an error if that fails
-	defer func() {
-		cleanupErr := os.RemoveAll(tmpDir)
-		if cleanupErr != nil {
-			err = errors.Join(err, fmt.Errorf("clone-sync: error cleaning up temp dir: %w", cleanupErr))
-		}
-	}()
-
-	dbPath := filepath.Join(tmpDir, "db")
-
-	// Create a temporary C1File to initialize the schema in the new db.
-	// NewC1File calls init() internally, creating all required tables.
-	// We close only the rawDb to release the connection and file locks
-	// without triggering C1File.Close()'s cleanupDbDir which would
-	// remove the tmpDir we still need.
-	initFile, err := NewC1File(ctx, dbPath)
-	if err != nil {
-		return err
-	}
-	if err = initFile.rawDb.Close(); err != nil {
-		return err
-	}
-	initFile.rawDb = nil
-	initFile.db = nil
 
 	if syncID == "" {
 		syncID, err = c.LatestSyncID(ctx, connectorstore.SyncTypeFull)
@@ -156,6 +136,119 @@ func (c *C1File) CloneSync(ctx context.Context, outPath string, syncID string, o
 		return status.Errorf(codes.FailedPrecondition, "clone-sync: sync %s is not ended", syncID)
 	}
 
+	err = c.cloneCopy(ctx, outPath, syncID, false, opts...)
+	return err
+}
+
+// SnapshotTo writes a valid, openable .c1z of this file's CURRENT committed
+// state to outPath, without closing the live handle and without
+// re-decompressing the source. The live handle remains fully usable for reads
+// and writes after SnapshotTo returns.
+//
+// Unlike CloneSync, which copies exactly one ended sync, SnapshotTo copies
+// EVERY sync_runs row — ended and un-ended alike — and preserves each row's
+// sync_token bytes exactly. A consumer that checkpoints resume progress into
+// sync_token (e.g. c1zsanitize with Options.Resumable) can therefore reopen the
+// snapshot with NewC1ZFile and resume from the checkpoint that was current when
+// the snapshot was taken. All object tables (resources, entitlements, grants,
+// assets, ...) are copied wholesale.
+//
+// outPath must not already exist. The write is atomic: a .tmp file is built and
+// renamed into place only on full success, so a failure leaves no partial file
+// at outPath (same guarantee as Close/saveC1z).
+//
+// Concurrency: the copy runs over the file's single SQLite connection
+// (SetMaxOpenConns(1)), so it serializes against the live writer — writes block
+// for the snapshot's row-copy window, then resume. The snapshot is a
+// point-in-time view of committed rows; in-flight uncommitted work is excluded.
+// There is no cancellation of the live sync and no phase redo. The compress
+// half runs on a separate temp db and does not hold the live connection, so
+// only the row copy stalls the writer, not the compress.
+//
+// For whale files, callers should also pass WithC1FBulkLoad(true) and
+// WithC1FSkipVacuum(true) so the snapshot-side write defers secondary-index
+// maintenance to a single rebuild pass at Close.
+//
+// SnapshotTo is a SQLite-engine (*C1File) method. It returns an error for the
+// Pebble engine, which manages its own storage, and for a read-only handle.
+func (c *C1File) SnapshotTo(ctx context.Context, outPath string, opts ...C1FOption) error {
+	ctx, span := tracer.Start(ctx, "C1File.SnapshotTo")
+	var err error
+	defer func() { uotel.EndSpanWithError(span, err) }()
+
+	if c.engine == EnginePebble {
+		err = fmt.Errorf("snapshot-to: unsupported for the %q engine; it manages its own storage", EnginePebble)
+		return err
+	}
+	if c.readOnly {
+		err = fmt.Errorf("snapshot-to: cannot snapshot a read-only handle")
+		return err
+	}
+
+	// Mirror CloneSync's defaults: no old-sync cleanup (we are copying all syncs
+	// deliberately) and GOMAXPROCS encoder concurrency for the compress.
+	defaultOpts := []C1FOption{
+		WithC1FEncoderConcurrency(0),
+		WithC1FSkipCleanup(true),
+	}
+	opts = append(defaultOpts, opts...)
+
+	err = c.cloneCopy(ctx, outPath, "", true, opts...)
+	return err
+}
+
+// cloneCopy copies tables from the live connection into a fresh schema db in a
+// temp dir, then compresses that db to outPath via a fresh C1File. It is the
+// shared machinery behind CloneSync and SnapshotTo.
+//
+// When selectAll is false it copies only rows WHERE sync_id=syncID (CloneSync's
+// single-sync clone). When selectAll is true it copies every row of every table
+// verbatim — including the full sync_runs table with its sync_token bytes — and
+// syncID is ignored (SnapshotTo's whole-file snapshot).
+//
+// The row copy runs over a single connection taken from the live pool
+// (SetMaxOpenConns(1)), so it serializes against the live writer rather than
+// racing it; the SELECTs read committed rows on the writer's own connection.
+// The compress runs on the separate temp db and does not hold the live
+// connection. cloneCopy never touches c.rawDb/c.db/c.currentSyncID/c.closed, so
+// the live handle is left exactly as it was found (plus the row-copy stall).
+func (c *C1File) cloneCopy(ctx context.Context, outPath string, syncID string, selectAll bool, opts ...C1FOption) error {
+	// Be sure that the output path is empty else return an error
+	_, err := os.Stat(outPath)
+	if err == nil || !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("clone-copy: output path (%s) must not exist", outPath)
+	}
+
+	tmpDir, err := os.MkdirTemp(c.tempDir, "c1zclone")
+	if err != nil {
+		return err
+	}
+
+	// Always clean up the temp dir and return an error if that fails
+	defer func() {
+		cleanupErr := os.RemoveAll(tmpDir)
+		if cleanupErr != nil {
+			err = errors.Join(err, fmt.Errorf("clone-copy: error cleaning up temp dir: %w", cleanupErr))
+		}
+	}()
+
+	dbPath := filepath.Join(tmpDir, "db")
+
+	// Create a temporary C1File to initialize the schema in the new db.
+	// NewC1File calls init() internally, creating all required tables.
+	// We close only the rawDb to release the connection and file locks
+	// without triggering C1File.Close()'s cleanupDbDir which would
+	// remove the tmpDir we still need.
+	initFile, err := NewC1File(ctx, dbPath)
+	if err != nil {
+		return err
+	}
+	if err = initFile.rawDb.Close(); err != nil {
+		return err
+	}
+	initFile.rawDb = nil
+	initFile.db = nil
+
 	qCtx, canc := context.WithCancel(ctx)
 	defer canc()
 
@@ -174,11 +267,17 @@ func (c *C1File) CloneSync(ctx context.Context, outPath string, syncID string, o
 	for _, t := range allTableDescriptors {
 		columns, err := cloneTableColumns(qCtx, conn, t.Name())
 		if err != nil {
-			return fmt.Errorf("clone-sync: error reading columns for %s: %w", t.Name(), err)
+			return fmt.Errorf("clone-copy: error reading columns for %s: %w", t.Name(), err)
 		}
-		q := cloneTableQuery(t.Name(), columns)
-		_, err = conn.ExecContext(qCtx, q, syncID)
-		if err != nil {
+		var q string
+		var args []any
+		if selectAll {
+			q = cloneTableQueryAll(t.Name(), columns)
+		} else {
+			q = cloneTableQuery(t.Name(), columns)
+			args = append(args, syncID)
+		}
+		if _, err = conn.ExecContext(qCtx, q, args...); err != nil {
 			return err
 		}
 	}

--- a/pkg/dotc1z/clone_sync.go
+++ b/pkg/dotc1z/clone_sync.go
@@ -173,8 +173,9 @@ func (c *C1File) CloneSync(ctx context.Context, outPath string, syncID string, o
 // only the row copy stalls the writer, not the compress.
 //
 // For whale files, callers should also pass WithC1FBulkLoad(true) and
-// WithC1FSkipVacuum(true) so the snapshot-side write defers secondary-index
-// maintenance to a single rebuild pass at Close.
+// WithC1FSkipVacuum(true): the row copy then runs against clone tables whose
+// deferrable secondary indexes have been dropped, and those indexes are
+// rebuilt in a single pass when the snapshot is finalized.
 //
 // SnapshotTo is a SQLite-engine (*C1File) method. It returns an error for the
 // Pebble engine, which manages its own storage, and for a read-only handle.
@@ -182,6 +183,10 @@ func (c *C1File) SnapshotTo(ctx context.Context, outPath string, opts ...C1FOpti
 	ctx, span := tracer.Start(ctx, "C1File.SnapshotTo")
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
+
+	if err = c.validateDb(ctx); err != nil {
+		return err
+	}
 
 	if c.engine == EnginePebble {
 		err = fmt.Errorf("snapshot-to: unsupported for the %q engine; it manages its own storage", EnginePebble)
@@ -217,8 +222,10 @@ func (c *C1File) SnapshotTo(ctx context.Context, outPath string, opts ...C1FOpti
 // (SetMaxOpenConns(1)), so it serializes against the live writer rather than
 // racing it; the SELECTs read committed rows on the writer's own connection.
 // The compress runs on the separate temp db and does not hold the live
-// connection. cloneCopy never touches c.rawDb/c.db/c.currentSyncID/c.closed, so
-// the live handle is left exactly as it was found (plus the row-copy stall).
+// connection. cloneCopy reads c.rawDb to take that one connection but never
+// mutates c.rawDb/c.db/c.currentSyncID/c.closed, so the live handle is left
+// exactly as it was found (plus the row-copy stall). Callers guard a closed
+// handle before reaching here, so c.rawDb is non-nil.
 // errPrefix is the caller's error-message namespace ("clone-sync" /
 // "snapshot-to") so each entry point keeps its own observable error strings.
 func (c *C1File) cloneCopy(ctx context.Context, outPath string, syncID string, selectAll bool, errPrefix string, opts ...C1FOption) error {
@@ -245,10 +252,15 @@ func (c *C1File) cloneCopy(ctx context.Context, outPath string, syncID string, s
 
 	// Create a temporary C1File to initialize the schema in the new db.
 	// NewC1File calls init() internally, creating all required tables.
+	// opts are forwarded so WithC1FBulkLoad's index deferral fires here, on
+	// the empty clone tables, dropping the deferrable secondary indexes before
+	// the row copy so the inserts maintain only the rowid PK and the unique
+	// index. The compress-side NewC1File below reopens the populated db and its
+	// Schema() re-run rebuilds the dropped indexes in one pass.
 	// We close only the rawDb to release the connection and file locks
 	// without triggering C1File.Close()'s cleanupDbDir which would
 	// remove the tmpDir we still need.
-	initFile, err := NewC1File(ctx, dbPath)
+	initFile, err := NewC1File(ctx, dbPath, opts...)
 	if err != nil {
 		return err
 	}
@@ -262,11 +274,13 @@ func (c *C1File) cloneCopy(ctx context.Context, outPath string, syncID string, s
 	defer canc()
 
 	// Copy the rows over a single connection. DETACH is deferred so it runs on
-	// every path — including a mid-copy ExecContext failure — before the
-	// connection is released and before the deferred temp-dir cleanup. Without
-	// that, an early return leaves the clone db attached, the source pool keeps a
-	// handle on the temp file, and os.RemoveAll fails (Windows), masking the real
-	// error with a cleanup error.
+	// every path — including a mid-copy ExecContext failure or a context cancel —
+	// before the connection is released and before the deferred temp-dir cleanup.
+	// Without that, an early return leaves the clone db attached, the source pool
+	// keeps a handle on the temp file, and os.RemoveAll fails (Windows), masking
+	// the real error with a cleanup error. On a mid-copy cancel the clone would
+	// also stay ATTACHED to the single pooled connection (SetMaxOpenConns(1)),
+	// bricking the live handle — so the DETACH runs on an uncancelled context.
 	if copyErr := func() error {
 		conn, err := c.rawDb.Conn(qCtx)
 		if err != nil {
@@ -278,7 +292,7 @@ func (c *C1File) cloneCopy(ctx context.Context, outPath string, syncID string, s
 			return err
 		}
 		defer func() {
-			if _, derr := conn.ExecContext(qCtx, "DETACH clone"); derr != nil {
+			if _, derr := conn.ExecContext(context.WithoutCancel(ctx), "DETACH clone"); derr != nil {
 				ctxzap.Extract(ctx).Error("error detaching clone database", zap.Error(derr))
 			}
 		}()

--- a/pkg/dotc1z/clone_sync.go
+++ b/pkg/dotc1z/clone_sync.go
@@ -116,6 +116,13 @@ func (c *C1File) CloneSync(ctx context.Context, outPath string, syncID string, o
 	}
 	opts = append(defaultOpts, opts...)
 
+	// Be sure that the output path is empty else return an error. Checked here,
+	// ahead of the sync preconditions, so an occupied output path is reported
+	// before the target sync is inspected — the order callers have always seen.
+	if _, statErr := os.Stat(outPath); statErr == nil || !errors.Is(statErr, fs.ErrNotExist) {
+		return fmt.Errorf("clone-sync: output path (%s) must not exist for cloning to proceed", outPath)
+	}
+
 	if syncID == "" {
 		syncID, err = c.LatestSyncID(ctx, connectorstore.SyncTypeFull)
 		if err != nil {
@@ -136,7 +143,7 @@ func (c *C1File) CloneSync(ctx context.Context, outPath string, syncID string, o
 		return status.Errorf(codes.FailedPrecondition, "clone-sync: sync %s is not ended", syncID)
 	}
 
-	err = c.cloneCopy(ctx, outPath, syncID, false, opts...)
+	err = c.cloneCopy(ctx, outPath, syncID, false, "clone-sync", opts...)
 	return err
 }
 
@@ -193,7 +200,7 @@ func (c *C1File) SnapshotTo(ctx context.Context, outPath string, opts ...C1FOpti
 	}
 	opts = append(defaultOpts, opts...)
 
-	err = c.cloneCopy(ctx, outPath, "", true, opts...)
+	err = c.cloneCopy(ctx, outPath, "", true, "snapshot-to", opts...)
 	return err
 }
 
@@ -212,11 +219,13 @@ func (c *C1File) SnapshotTo(ctx context.Context, outPath string, opts ...C1FOpti
 // The compress runs on the separate temp db and does not hold the live
 // connection. cloneCopy never touches c.rawDb/c.db/c.currentSyncID/c.closed, so
 // the live handle is left exactly as it was found (plus the row-copy stall).
-func (c *C1File) cloneCopy(ctx context.Context, outPath string, syncID string, selectAll bool, opts ...C1FOption) error {
+// errPrefix is the caller's error-message namespace ("clone-sync" /
+// "snapshot-to") so each entry point keeps its own observable error strings.
+func (c *C1File) cloneCopy(ctx context.Context, outPath string, syncID string, selectAll bool, errPrefix string, opts ...C1FOption) error {
 	// Be sure that the output path is empty else return an error
 	_, err := os.Stat(outPath)
 	if err == nil || !errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf("clone-copy: output path (%s) must not exist", outPath)
+		return fmt.Errorf("%s: output path (%s) must not exist", errPrefix, outPath)
 	}
 
 	tmpDir, err := os.MkdirTemp(c.tempDir, "c1zclone")
@@ -228,7 +237,7 @@ func (c *C1File) cloneCopy(ctx context.Context, outPath string, syncID string, s
 	defer func() {
 		cleanupErr := os.RemoveAll(tmpDir)
 		if cleanupErr != nil {
-			err = errors.Join(err, fmt.Errorf("clone-copy: error cleaning up temp dir: %w", cleanupErr))
+			err = errors.Join(err, fmt.Errorf("%s: error cleaning up temp dir: %w", errPrefix, cleanupErr))
 		}
 	}()
 
@@ -252,45 +261,50 @@ func (c *C1File) cloneCopy(ctx context.Context, outPath string, syncID string, s
 	qCtx, canc := context.WithCancel(ctx)
 	defer canc()
 
-	// Get a single connection to the current db so we can make multiple queries in the same session
-	conn, err := c.rawDb.Conn(qCtx)
-	if err != nil {
-		return err
-	}
-	defer conn.Close()
-
-	_, err = conn.ExecContext(qCtx, fmt.Sprintf(`ATTACH '%s' AS clone`, dbPath))
-	if err != nil {
-		return err
-	}
-
-	for _, t := range allTableDescriptors {
-		columns, err := cloneTableColumns(qCtx, conn, t.Name())
+	// Copy the rows over a single connection. DETACH is deferred so it runs on
+	// every path — including a mid-copy ExecContext failure — before the
+	// connection is released and before the deferred temp-dir cleanup. Without
+	// that, an early return leaves the clone db attached, the source pool keeps a
+	// handle on the temp file, and os.RemoveAll fails (Windows), masking the real
+	// error with a cleanup error.
+	if copyErr := func() error {
+		conn, err := c.rawDb.Conn(qCtx)
 		if err != nil {
-			return fmt.Errorf("clone-copy: error reading columns for %s: %w", t.Name(), err)
-		}
-		var q string
-		var args []any
-		if selectAll {
-			q = cloneTableQueryAll(t.Name(), columns)
-		} else {
-			q = cloneTableQuery(t.Name(), columns)
-			args = append(args, syncID)
-		}
-		if _, err = conn.ExecContext(qCtx, q, args...); err != nil {
 			return err
 		}
-	}
+		defer conn.Close()
 
-	// Detach the clone database before releasing the connection. On Windows,
-	// open file handles prevent deletion; without DETACH the source connection
-	// pool retains a handle on the clone db file, causing os.RemoveAll to fail.
-	_, err = conn.ExecContext(qCtx, "DETACH clone")
-	if err != nil {
-		ctxzap.Extract(ctx).Error("error detaching clone database", zap.Error(err))
+		if _, err := conn.ExecContext(qCtx, fmt.Sprintf(`ATTACH '%s' AS clone`, dbPath)); err != nil {
+			return err
+		}
+		defer func() {
+			if _, derr := conn.ExecContext(qCtx, "DETACH clone"); derr != nil {
+				ctxzap.Extract(ctx).Error("error detaching clone database", zap.Error(derr))
+			}
+		}()
+
+		for _, t := range allTableDescriptors {
+			columns, err := cloneTableColumns(qCtx, conn, t.Name())
+			if err != nil {
+				return fmt.Errorf("%s: error reading columns for %s: %w", errPrefix, t.Name(), err)
+			}
+			var q string
+			var args []any
+			if selectAll {
+				q = cloneTableQueryAll(t.Name(), columns)
+			} else {
+				q = cloneTableQuery(t.Name(), columns)
+				args = append(args, syncID)
+			}
+			if _, err := conn.ExecContext(qCtx, q, args...); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); copyErr != nil {
+		return copyErr
 	}
 	canc()
-	_ = conn.Close()
 
 	// Open a fresh C1File to compress the populated db into a c1z.
 	// No other connections are open on dbPath at this point.

--- a/pkg/dotc1z/clone_sync_test.go
+++ b/pkg/dotc1z/clone_sync_test.go
@@ -177,3 +177,20 @@ func TestCloneSyncMigratedColumnOrder(t *testing.T) {
 	require.NoError(t, srcFile.rawDb.Close())
 	require.NoError(t, cloneFile.Close(ctx))
 }
+
+// TestSnapshotToAfterCloseReturnsErrDbNotOpen verifies that calling SnapshotTo
+// on a closed handle returns ErrDbNotOpen rather than panicking on the now-nil
+// rawDb, matching the guard every other C1File method applies.
+func TestSnapshotToAfterCloseReturnsErrDbNotOpen(t *testing.T) {
+	ctx := context.Background()
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "source.db")
+
+	f, err := NewC1File(ctx, dbPath, WithC1FTmpDir(dir))
+	require.NoError(t, err)
+	require.NoError(t, f.Close(ctx))
+
+	err = f.SnapshotTo(ctx, filepath.Join(dir, "snapshot.c1z"))
+	require.ErrorIs(t, err, ErrDbNotOpen)
+}

--- a/pkg/dotc1z/snapshot_test.go
+++ b/pkg/dotc1z/snapshot_test.go
@@ -192,6 +192,33 @@ func TestCloneSyncRejectsUnendedSync(t *testing.T) {
 	require.True(t, os.IsNotExist(statErr), "no clone file may be written when the precondition fails")
 }
 
+// TestCloneSyncOutPathCheckedBeforeUnendedPrecondition pins the precondition
+// ordering: when CloneSync is given BOTH an already-existing outPath AND an
+// un-ended sync, it must report the output-path error first — not the
+// FailedPrecondition (not-ended) error. The cloneCopy refactor must preserve
+// this original observable order.
+func TestCloneSyncOutPathCheckedBeforeUnendedPrecondition(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "src.db")
+	outPath := filepath.Join(tmp, "clone.c1z")
+	require.NoError(t, os.WriteFile(outPath, []byte("occupied"), 0o600))
+
+	f, err := NewC1File(ctx, dbPath, WithC1FTmpDir(tmp))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, f.rawDb.Close()) }()
+
+	syncID := writeSnapSync(t, ctx, f, "a-", 2, false) // un-ended
+
+	err = f.CloneSync(ctx, outPath, syncID)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "output path")
+	require.Contains(t, err.Error(), "must not exist")
+	st, ok := status.FromError(err)
+	require.False(t, ok && st.Code() == codes.FailedPrecondition,
+		"outPath-exists must be reported before the un-ended precondition")
+}
+
 // TestSnapshotGuards covers Test 7: outPath-must-not-exist, the Pebble-engine
 // guard, and the read-only guard each return an error and write no file.
 func TestSnapshotGuards(t *testing.T) {

--- a/pkg/dotc1z/snapshot_test.go
+++ b/pkg/dotc1z/snapshot_test.go
@@ -1,0 +1,243 @@
+package dotc1z
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+)
+
+// writeSnapSync writes one sync (resource types, resources, an entitlement, and
+// nGrants grants) into f. When end is true the sync is EndSync'd; when false it
+// is left as the current, un-ended sync. Returns the sync id.
+func writeSnapSync(t *testing.T, ctx context.Context, f *C1File, prefix string, nGrants int, end bool) string {
+	t.Helper()
+	syncID, err := f.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+
+	require.NoError(t, f.PutResourceTypes(ctx,
+		v2.ResourceType_builder{Id: "user", DisplayName: "User", Traits: []v2.ResourceType_Trait{v2.ResourceType_TRAIT_USER}}.Build(),
+		v2.ResourceType_builder{Id: "role", DisplayName: "Role", Traits: []v2.ResourceType_Trait{v2.ResourceType_TRAIT_ROLE}}.Build(),
+	))
+
+	role := v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "role", Resource: prefix + "admin"}.Build(), DisplayName: "Admin"}.Build()
+	resources := []*v2.Resource{role}
+	for i := 0; i < nGrants; i++ {
+		resources = append(resources, v2.Resource_builder{
+			Id:          v2.ResourceId_builder{ResourceType: "user", Resource: prefix + "u" + strconv.Itoa(i)}.Build(),
+			DisplayName: "User " + strconv.Itoa(i),
+		}.Build())
+	}
+	require.NoError(t, f.PutResources(ctx, resources...))
+
+	ent := v2.Entitlement_builder{Id: prefix + "ent-admin", Resource: role, DisplayName: "admin", Slug: "admin"}.Build()
+	require.NoError(t, f.PutEntitlements(ctx, ent))
+
+	var grants []*v2.Grant
+	for i := 0; i < nGrants; i++ {
+		grants = append(grants, v2.Grant_builder{
+			Id:          prefix + "grant-" + strconv.Itoa(i),
+			Entitlement: ent,
+			Principal:   resources[i+1],
+		}.Build())
+	}
+	require.NoError(t, f.PutGrants(ctx, grants...))
+
+	if end {
+		require.NoError(t, f.EndSync(ctx))
+	}
+	return syncID
+}
+
+func listAllSyncRuns(t *testing.T, ctx context.Context, f *C1File) []*SyncRun {
+	t.Helper()
+	var out []*SyncRun
+	pageToken := ""
+	for {
+		runs, next, err := f.ListSyncRuns(ctx, pageToken, 1000)
+		require.NoError(t, err)
+		out = append(out, runs...)
+		if next == "" {
+			return out
+		}
+		pageToken = next
+	}
+}
+
+// TestSnapshotIncludesUnendedSyncs covers Test 2: the snapshot copies every
+// sync_runs row, including an in-progress (un-ended) sync, and the un-ended row
+// still has EndedAt == nil after reopen.
+func TestSnapshotIncludesUnendedSyncs(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	dstPath := filepath.Join(tmp, "dst.c1z")
+	snapPath := filepath.Join(tmp, "snap.c1z")
+
+	f, err := NewC1ZFile(ctx, dstPath)
+	require.NoError(t, err)
+	endedID := writeSnapSync(t, ctx, f, "a-", 3, true)    // ended
+	unendedID := writeSnapSync(t, ctx, f, "b-", 2, false) // in-progress
+
+	require.NoError(t, f.SnapshotTo(ctx, snapPath))
+	require.NoError(t, f.Close(ctx))
+
+	snap, err := NewC1ZFile(ctx, snapPath, WithReadOnly(true))
+	require.NoError(t, err)
+	defer snap.Close(ctx)
+
+	runs := listAllSyncRuns(t, ctx, snap)
+	byID := map[string]*SyncRun{}
+	for _, r := range runs {
+		byID[r.ID] = r
+	}
+	require.Len(t, runs, 2, "snapshot must contain both the ended and the un-ended sync")
+	require.Contains(t, byID, endedID)
+	require.Contains(t, byID, unendedID)
+	require.NotNil(t, byID[endedID].EndedAt, "ended sync must keep its EndedAt")
+	require.Nil(t, byID[unendedID].EndedAt, "un-ended sync must remain un-ended in the snapshot")
+}
+
+// TestSnapshotAtomicityOnFailure covers Test 4: a compress-side failure (outPath
+// in a non-existent directory) leaves no file at outPath, and the live handle
+// stays fully usable afterward.
+func TestSnapshotAtomicityOnFailure(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	dstPath := filepath.Join(tmp, "dst.c1z")
+	badOut := filepath.Join(tmp, "missing-dir", "snap.c1z") // parent dir does not exist
+
+	f, err := NewC1ZFile(ctx, dstPath)
+	require.NoError(t, err)
+	writeSnapSync(t, ctx, f, "a-", 2, true)
+
+	err = f.SnapshotTo(ctx, badOut)
+	require.Error(t, err, "snapshot into a non-existent directory must fail")
+
+	_, statErr := os.Stat(badOut)
+	require.True(t, os.IsNotExist(statErr), "no partial file may be left at outPath after a failed snapshot")
+
+	// Live handle is unchanged: keep writing and close cleanly.
+	writeSnapSync(t, ctx, f, "b-", 1, true)
+	require.NoError(t, f.Close(ctx))
+
+	reopened, err := NewC1ZFile(ctx, dstPath, WithReadOnly(true))
+	require.NoError(t, err)
+	defer reopened.Close(ctx)
+	require.Len(t, listAllSyncRuns(t, ctx, reopened), 2, "both syncs written around the failed snapshot must be present")
+}
+
+// TestSnapshotLiveHandleStillWritable covers Test 5: after a snapshot on an
+// active destination, the live handle continues to accept writes and closes to
+// a valid, complete file; the snapshot itself is a valid point-in-time view.
+func TestSnapshotLiveHandleStillWritable(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	dstPath := filepath.Join(tmp, "dst.c1z")
+	snapPath := filepath.Join(tmp, "snap.c1z")
+
+	f, err := NewC1ZFile(ctx, dstPath)
+	require.NoError(t, err)
+	writeSnapSync(t, ctx, f, "a-", 2, true)
+
+	require.NoError(t, f.SnapshotTo(ctx, snapPath))
+
+	// Keep writing on the same live handle after the snapshot.
+	writeSnapSync(t, ctx, f, "b-", 2, true)
+	require.NoError(t, f.Close(ctx))
+
+	// Live file has both syncs.
+	live, err := NewC1ZFile(ctx, dstPath, WithReadOnly(true))
+	require.NoError(t, err)
+	require.Len(t, listAllSyncRuns(t, ctx, live), 2)
+	require.NoError(t, live.Close(ctx))
+
+	// Snapshot is a valid point-in-time view: only the first sync existed when
+	// it was taken.
+	snap, err := NewC1ZFile(ctx, snapPath, WithReadOnly(true))
+	require.NoError(t, err)
+	require.Len(t, listAllSyncRuns(t, ctx, snap), 1)
+	require.NoError(t, snap.Close(ctx))
+}
+
+// TestCloneSyncRejectsUnendedSync covers Test 6: the shared-helper refactor must
+// preserve CloneSync's precondition that the target sync is ended. This pins the
+// codes.FailedPrecondition rejection so the refactor cannot silently drop it.
+func TestCloneSyncRejectsUnendedSync(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "src.db")
+	outPath := filepath.Join(tmp, "clone.c1z")
+
+	f, err := NewC1File(ctx, dbPath, WithC1FTmpDir(tmp))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, f.rawDb.Close()) }()
+
+	syncID := writeSnapSync(t, ctx, f, "a-", 2, false) // un-ended
+
+	err = f.CloneSync(ctx, outPath, syncID)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok, "CloneSync must return a gRPC status error for an un-ended sync")
+	require.Equal(t, codes.FailedPrecondition, st.Code())
+
+	_, statErr := os.Stat(outPath)
+	require.True(t, os.IsNotExist(statErr), "no clone file may be written when the precondition fails")
+}
+
+// TestSnapshotGuards covers Test 7: outPath-must-not-exist, the Pebble-engine
+// guard, and the read-only guard each return an error and write no file.
+func TestSnapshotGuards(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("outPath exists", func(t *testing.T) {
+		tmp := t.TempDir()
+		dstPath := filepath.Join(tmp, "dst.c1z")
+		snapPath := filepath.Join(tmp, "snap.c1z")
+		require.NoError(t, os.WriteFile(snapPath, []byte("occupied"), 0o600))
+
+		f, err := NewC1ZFile(ctx, dstPath)
+		require.NoError(t, err)
+		defer f.Close(ctx)
+		writeSnapSync(t, ctx, f, "a-", 1, true)
+
+		require.Error(t, f.SnapshotTo(ctx, snapPath), "snapshot must refuse an existing outPath")
+	})
+
+	t.Run("pebble engine rejected", func(t *testing.T) {
+		tmp := t.TempDir()
+		dbPath := filepath.Join(tmp, "src.db")
+		snapPath := filepath.Join(tmp, "snap.c1z")
+
+		f, err := NewC1File(ctx, dbPath, WithC1FTmpDir(tmp))
+		require.NoError(t, err)
+		defer func() { require.NoError(t, f.rawDb.Close()) }()
+		f.engine = EnginePebble
+
+		require.Error(t, f.SnapshotTo(ctx, snapPath), "snapshot must reject the pebble engine")
+		_, statErr := os.Stat(snapPath)
+		require.True(t, os.IsNotExist(statErr))
+	})
+
+	t.Run("read-only handle rejected", func(t *testing.T) {
+		tmp := t.TempDir()
+		dbPath := filepath.Join(tmp, "src.db")
+		snapPath := filepath.Join(tmp, "snap.c1z")
+
+		f, err := NewC1File(ctx, dbPath, WithC1FTmpDir(tmp))
+		require.NoError(t, err)
+		defer func() { require.NoError(t, f.rawDb.Close()) }()
+		f.readOnly = true
+
+		require.Error(t, f.SnapshotTo(ctx, snapPath), "snapshot must reject a read-only handle")
+		_, statErr := os.Stat(snapPath)
+		require.True(t, os.IsNotExist(statErr))
+	})
+}


### PR DESCRIPTION
## What

Adds `(*C1File).SnapshotTo(ctx, outPath, opts...)` to `pkg/dotc1z`: a generic dotc1z method that writes a valid, openable `.c1z` of the destination's **current committed on-disk state** to `outPath` **without closing the live handle** and **without re-decompressing** the source. The live handle remains fully usable for reads and writes afterward.

Unlike `CloneSync`, which copies exactly one *ended* sync filtered by `sync_id`, `SnapshotTo`:

- copies **every** `sync_runs` row — ended **and** un-ended alike — and every row of every object table (resources, entitlements, grants, assets, ...) wholesale; and
- preserves each row's `sync_token` bytes **exactly** (a plain table copy, no parse/re-encode).

That byte-for-byte `sync_token` preservation is the load-bearing property: a consumer that checkpoints resume progress into `sync_token` (e.g. `c1zsanitize` with `Options.Resumable`) can reopen the snapshot with `NewC1ZFile` and resume from the checkpoint that was current when the snapshot was taken.

Also adds `c1zsanitize.ResumePhase(syncToken)` — a read-only, no-I/O decoder that returns the resume phase, grant page token, and source sync id from a destination sync's raw `sync_token`, so a consumer can read resume state without coupling to the unexported checkpoint JSON shape.

## Why

A consumer runs `c1zsanitize.Sanitize` over whale-scale `.c1z` files inside a long-running activity. Resumable sanitize already checkpoints progress into each destination sync's `sync_token`, but there was no way to materialize a valid partial `.c1z` from a **live, mid-run** destination handle: `NewC1ZFile` decompresses into a hidden temp sqlite db, and the `.c1z` at the caller's path is only written by `Close`. So a partial destination could not be staged without closing the file, and reopening a whale `.c1z` pays a long single-threaded decompress. `SnapshotTo` closes that gap: stage a resumable partial at checkpoint time, then continue (or resume later) with no full restart.

This is an additive, backward-compatible change — a new method and a new exported function, no signature changes.

## How

- Refactors `CloneSync`'s body into a shared private `cloneCopy(ctx, outPath, syncID, selectAll, opts...)` helper: schema-init → `ATTACH` → per-table `INSERT...SELECT` → `DETACH` → compress. `selectAll=false` copies `WHERE sync_id=?` (CloneSync); `selectAll=true` copies all rows including the full `sync_runs` table (SnapshotTo).
- `CloneSync` becomes a thin wrapper that resolves the sync id, enforces its existing `NotFound` / `FailedPrecondition` (not-ended) preconditions, then calls `cloneCopy(..., selectAll=false)`. Its exported signature, godoc, preconditions, and observable behavior are unchanged.
- `SnapshotTo` is the other wrapper: no sync resolution, no not-ended precondition, prepends the same default opts (`WithC1FEncoderConcurrency(0)`, `WithC1FSkipCleanup(true)`), and calls `cloneCopy(..., selectAll=true)`. It rejects the Pebble engine and read-only handles with a clear error.

### Concurrency and atomicity

The row copy runs over the file's single SQLite connection (`SetMaxOpenConns(1)`), so it serializes against the live writer via that one connection rather than racing it — the SELECTs read committed rows on the writer's own connection. The compress half runs on a separate temp db and does **not** hold the live connection, so only the row-copy window blocks the writer; there is no live-sync cancellation and no phase redo. The write is atomic: a `.tmp` file is built and renamed into place only on full success, so a failed snapshot leaves no partial file at `outPath` (same guarantee as `Close`/`saveC1z`). `cloneCopy` never touches the live `C1File`'s db handle or sync state, so the handle is left exactly as it was found.

For whale files the godoc recommends callers also pass `WithC1FBulkLoad(true)` + `WithC1FSkipVacuum(true)` so the snapshot-side write defers secondary-index maintenance to a single rebuild pass.

## Files changed

- `pkg/dotc1z/clone_sync.go` — `cloneCopy` extraction, `cloneTableQueryAll`, `SnapshotTo`; `CloneSync` reduced to a wrapper (behavior unchanged).
- `pkg/c1zsanitize/resume_phase.go` — new `ResumePhase` decoder.
- `pkg/dotc1z/snapshot_test.go` — un-ended-sync inclusion, atomicity-on-failure, live-handle-still-writable, engine/read-only/outPath guards, and a CloneSync not-ended-rejection regression pin.
- `pkg/c1zsanitize/snapshot_resume_test.go` — headline resume-from-snapshot record-identity (resources/entitlements boundary and mid-grants with a non-empty grant page token) and `sync_token` byte-for-byte preservation.

## Tests

`gofmt` clean; `go build ./...` clean; `golangci-lint` clean for the changed files. `go test ./pkg/dotc1z/... ./pkg/c1zsanitize/...` is green:

```
ok  github.com/conductorone/baton-sdk/pkg/dotc1z                          40.3s
ok  github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore                  0.005s
ok  github.com/conductorone/baton-sdk/pkg/dotc1z/engine/equivalence        0.066s
ok  github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble             0.598s
ok  github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/codec       0.009s
ok  github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/microtests  0.014s
ok  github.com/conductorone/baton-sdk/pkg/dotc1z/format/v3                 0.049s
ok  github.com/conductorone/baton-sdk/pkg/c1zsanitize                      2.746s
```

The existing `clone_sync_test.go` passes unchanged (the shared-helper refactor's regression gate).

---

_(🛰) Built with stargate._
