### PR TITLE
even betterer compaction

### DIFF
--- a/pb/c1/c1z/v3/manifest.pb.go
+++ b/pb/c1/c1z/v3/manifest.pb.go
@@ -134,7 +134,18 @@ type C1ZManifestV3 struct {
 	RecordTypes []*RecordTypeInfo `protobuf:"bytes,11,rep,name=record_types,json=recordTypes,proto3" json:"record_types,omitempty"`
 	// Cheap projection of sync runs inside the payload — lets tooling
 	// enumerate without opening the engine.
-	SyncRuns      []*SyncRunSummary `protobuf:"bytes,40,rep,name=sync_runs,json=syncRuns,proto3" json:"sync_runs,omitempty"`
+	SyncRuns []*SyncRunSummary `protobuf:"bytes,40,rep,name=sync_runs,json=syncRuns,proto3" json:"sync_runs,omitempty"`
+	// Cumulative raw bytes of records (and their derived index keys)
+	// shadowed by in-place fold compactions since the last rebuild.
+	// Fold splices the base's compressed frames verbatim at save, so an
+	// overridden record's bytes stay inside the output as dead weight;
+	// this counter is the exact accounting of that waste, carried
+	// forward across consecutive folds (the dest store inherits it from
+	// the file it was opened from, and each fold adds its own delta).
+	// A rebuild (overlay / kway) writes a fresh store and resets it to
+	// zero. The compactor's auto mode reads this from the envelope
+	// header to force a rebuild once waste crosses its threshold.
+	FoldDeadBytes int64 `protobuf:"varint,41,opt,name=fold_dead_bytes,json=foldDeadBytes,proto3" json:"fold_dead_bytes,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -213,6 +224,13 @@ func (x *C1ZManifestV3) GetSyncRuns() []*SyncRunSummary {
 	return nil
 }
 
+func (x *C1ZManifestV3) GetFoldDeadBytes() int64 {
+	if x != nil {
+		return x.FoldDeadBytes
+	}
+	return 0
+}
+
 func (x *C1ZManifestV3) SetEngine(v string) {
 	x.Engine = v
 }
@@ -239,6 +257,10 @@ func (x *C1ZManifestV3) SetRecordTypes(v []*RecordTypeInfo) {
 
 func (x *C1ZManifestV3) SetSyncRuns(v []*SyncRunSummary) {
 	x.SyncRuns = v
+}
+
+func (x *C1ZManifestV3) SetFoldDeadBytes(v int64) {
+	x.FoldDeadBytes = v
 }
 
 func (x *C1ZManifestV3) HasEngineConfig() bool {
@@ -296,6 +318,17 @@ type C1ZManifestV3_builder struct {
 	// Cheap projection of sync runs inside the payload — lets tooling
 	// enumerate without opening the engine.
 	SyncRuns []*SyncRunSummary
+	// Cumulative raw bytes of records (and their derived index keys)
+	// shadowed by in-place fold compactions since the last rebuild.
+	// Fold splices the base's compressed frames verbatim at save, so an
+	// overridden record's bytes stay inside the output as dead weight;
+	// this counter is the exact accounting of that waste, carried
+	// forward across consecutive folds (the dest store inherits it from
+	// the file it was opened from, and each fold adds its own delta).
+	// A rebuild (overlay / kway) writes a fresh store and resets it to
+	// zero. The compactor's auto mode reads this from the envelope
+	// header to force a rebuild once waste crosses its threshold.
+	FoldDeadBytes int64
 }
 
 func (b0 C1ZManifestV3_builder) Build() *C1ZManifestV3 {
@@ -309,6 +342,7 @@ func (b0 C1ZManifestV3_builder) Build() *C1ZManifestV3 {
 	x.Descriptors = b.Descriptors
 	x.RecordTypes = b.RecordTypes
 	x.SyncRuns = b.SyncRuns
+	x.FoldDeadBytes = b.FoldDeadBytes
 	return m0
 }
 
@@ -969,7 +1003,7 @@ var File_c1_c1z_v3_manifest_proto protoreflect.FileDescriptor
 
 const file_c1_c1z_v3_manifest_proto_rawDesc = "" +
 	"\n" +
-	"\x18c1/c1z/v3/manifest.proto\x12\tc1.c1z.v3\x1a\x1bc1/storage/v3/records.proto\x1a\x19google/protobuf/any.proto\x1a google/protobuf/descriptor.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\x99\x03\n" +
+	"\x18c1/c1z/v3/manifest.proto\x12\tc1.c1z.v3\x1a\x1bc1/storage/v3/records.proto\x1a\x19google/protobuf/any.proto\x1a google/protobuf/descriptor.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xc1\x03\n" +
 	"\rC1ZManifestV3\x12\x16\n" +
 	"\x06engine\x18\x01 \x01(\tR\x06engine\x122\n" +
 	"\x15engine_schema_version\x18\x02 \x01(\rR\x13engineSchemaVersion\x129\n" +
@@ -978,7 +1012,8 @@ const file_c1_c1z_v3_manifest_proto_rawDesc = "" +
 	"\vdescriptors\x18\n" +
 	" \x01(\v2\".google.protobuf.FileDescriptorSetR\vdescriptors\x12<\n" +
 	"\frecord_types\x18\v \x03(\v2\x19.c1.c1z.v3.RecordTypeInfoR\vrecordTypes\x126\n" +
-	"\tsync_runs\x18( \x03(\v2\x19.c1.c1z.v3.SyncRunSummaryR\bsyncRuns\"\xcc\x01\n" +
+	"\tsync_runs\x18( \x03(\v2\x19.c1.c1z.v3.SyncRunSummaryR\bsyncRuns\x12&\n" +
+	"\x0ffold_dead_bytes\x18) \x01(\x03R\rfoldDeadBytes\"\xcc\x01\n" +
 	"\x11IndexedFrameIndex\x126\n" +
 	"\aentries\x18\x01 \x03(\v2\x1c.c1.c1z.v3.IndexedFrameEntryR\aentries\x12$\n" +
 	"\x0etotal_raw_size\x18\x02 \x01(\x03R\ftotalRawSize\x122\n" +

--- a/pb/c1/c1z/v3/manifest.pb.validate.go
+++ b/pb/c1/c1z/v3/manifest.pb.validate.go
@@ -193,6 +193,8 @@ func (m *C1ZManifestV3) validate(all bool) error {
 
 	}
 
+	// no validation rules for FoldDeadBytes
+
 	if len(errors) > 0 {
 		return C1ZManifestV3MultiError(errors)
 	}

--- a/pb/c1/c1z/v3/manifest_protoopaque.pb.go
+++ b/pb/c1/c1z/v3/manifest_protoopaque.pb.go
@@ -112,6 +112,7 @@ type C1ZManifestV3 struct {
 	xxx_hidden_Descriptors         *descriptorpb.FileDescriptorSet `protobuf:"bytes,10,opt,name=descriptors,proto3"`
 	xxx_hidden_RecordTypes         *[]*RecordTypeInfo              `protobuf:"bytes,11,rep,name=record_types,json=recordTypes,proto3"`
 	xxx_hidden_SyncRuns            *[]*SyncRunSummary              `protobuf:"bytes,40,rep,name=sync_runs,json=syncRuns,proto3"`
+	xxx_hidden_FoldDeadBytes       int64                           `protobuf:"varint,41,opt,name=fold_dead_bytes,json=foldDeadBytes,proto3"`
 	unknownFields                  protoimpl.UnknownFields
 	sizeCache                      protoimpl.SizeCache
 }
@@ -194,6 +195,13 @@ func (x *C1ZManifestV3) GetSyncRuns() []*SyncRunSummary {
 	return nil
 }
 
+func (x *C1ZManifestV3) GetFoldDeadBytes() int64 {
+	if x != nil {
+		return x.xxx_hidden_FoldDeadBytes
+	}
+	return 0
+}
+
 func (x *C1ZManifestV3) SetEngine(v string) {
 	x.xxx_hidden_Engine = v
 }
@@ -220,6 +228,10 @@ func (x *C1ZManifestV3) SetRecordTypes(v []*RecordTypeInfo) {
 
 func (x *C1ZManifestV3) SetSyncRuns(v []*SyncRunSummary) {
 	x.xxx_hidden_SyncRuns = &v
+}
+
+func (x *C1ZManifestV3) SetFoldDeadBytes(v int64) {
+	x.xxx_hidden_FoldDeadBytes = v
 }
 
 func (x *C1ZManifestV3) HasEngineConfig() bool {
@@ -277,6 +289,17 @@ type C1ZManifestV3_builder struct {
 	// Cheap projection of sync runs inside the payload — lets tooling
 	// enumerate without opening the engine.
 	SyncRuns []*SyncRunSummary
+	// Cumulative raw bytes of records (and their derived index keys)
+	// shadowed by in-place fold compactions since the last rebuild.
+	// Fold splices the base's compressed frames verbatim at save, so an
+	// overridden record's bytes stay inside the output as dead weight;
+	// this counter is the exact accounting of that waste, carried
+	// forward across consecutive folds (the dest store inherits it from
+	// the file it was opened from, and each fold adds its own delta).
+	// A rebuild (overlay / kway) writes a fresh store and resets it to
+	// zero. The compactor's auto mode reads this from the envelope
+	// header to force a rebuild once waste crosses its threshold.
+	FoldDeadBytes int64
 }
 
 func (b0 C1ZManifestV3_builder) Build() *C1ZManifestV3 {
@@ -290,6 +313,7 @@ func (b0 C1ZManifestV3_builder) Build() *C1ZManifestV3 {
 	x.xxx_hidden_Descriptors = b.Descriptors
 	x.xxx_hidden_RecordTypes = &b.RecordTypes
 	x.xxx_hidden_SyncRuns = &b.SyncRuns
+	x.xxx_hidden_FoldDeadBytes = b.FoldDeadBytes
 	return m0
 }
 
@@ -910,7 +934,7 @@ var File_c1_c1z_v3_manifest_proto protoreflect.FileDescriptor
 
 const file_c1_c1z_v3_manifest_proto_rawDesc = "" +
 	"\n" +
-	"\x18c1/c1z/v3/manifest.proto\x12\tc1.c1z.v3\x1a\x1bc1/storage/v3/records.proto\x1a\x19google/protobuf/any.proto\x1a google/protobuf/descriptor.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\x99\x03\n" +
+	"\x18c1/c1z/v3/manifest.proto\x12\tc1.c1z.v3\x1a\x1bc1/storage/v3/records.proto\x1a\x19google/protobuf/any.proto\x1a google/protobuf/descriptor.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xc1\x03\n" +
 	"\rC1ZManifestV3\x12\x16\n" +
 	"\x06engine\x18\x01 \x01(\tR\x06engine\x122\n" +
 	"\x15engine_schema_version\x18\x02 \x01(\rR\x13engineSchemaVersion\x129\n" +
@@ -919,7 +943,8 @@ const file_c1_c1z_v3_manifest_proto_rawDesc = "" +
 	"\vdescriptors\x18\n" +
 	" \x01(\v2\".google.protobuf.FileDescriptorSetR\vdescriptors\x12<\n" +
 	"\frecord_types\x18\v \x03(\v2\x19.c1.c1z.v3.RecordTypeInfoR\vrecordTypes\x126\n" +
-	"\tsync_runs\x18( \x03(\v2\x19.c1.c1z.v3.SyncRunSummaryR\bsyncRuns\"\xcc\x01\n" +
+	"\tsync_runs\x18( \x03(\v2\x19.c1.c1z.v3.SyncRunSummaryR\bsyncRuns\x12&\n" +
+	"\x0ffold_dead_bytes\x18) \x01(\x03R\rfoldDeadBytes\"\xcc\x01\n" +
 	"\x11IndexedFrameIndex\x126\n" +
 	"\aentries\x18\x01 \x03(\v2\x1c.c1.c1z.v3.IndexedFrameEntryR\aentries\x12$\n" +
 	"\x0etotal_raw_size\x18\x02 \x01(\x03R\ftotalRawSize\x122\n" +

--- a/pkg/dotc1z/engine/pebble/adapter_clone_sync.go
+++ b/pkg/dotc1z/engine/pebble/adapter_clone_sync.go
@@ -23,12 +23,23 @@ import (
 // pebbleFileOps.CloneSync. Materializes the named sync's data into
 // a freshly-created Pebble-backed c1z at outPath.
 //
-// Strategy: open a fresh Pebble engine under a temp dir, range-copy
-// every key prefix that's scoped to (sync_id) — both primary
-// records and index entries — from the source engine into the
-// destination. Then Checkpoint the destination and emit a c1z v3
-// envelope at outPath. The copy is byte-level (proto values aren't
-// re-encoded; the schema_version is preserved).
+// Strategy: the file holds exactly one sync and keys carry no
+// sync_id, so cloning "the sync" is cloning the database. Stage a
+// pebble Checkpoint of the source (hard links on the same
+// filesystem — O(live files), not O(records)), open it, excise the
+// engine-local keyspaces the clone contract excludes (sessions,
+// counters — everything outside scopedRanges except the engine-meta
+// stamp, which the clone keeps), then Checkpoint again and emit a
+// c1z v3 envelope at outPath. No record is ever decoded, copied, or
+// re-encoded. The excised keyspaces are usually empty; when they are
+// not, their bytes may survive physically inside linked SSTs but are
+// excised from the cloned LSM and unreachable.
+//
+// The raw db.Checkpoint (no flush) is used for the staging copy so
+// read-only source engines work: any unflushed source writes ride
+// along in the checkpointed WAL and replay when the stage opens. The
+// stage engine is always writable, so the final CheckpointTo gets
+// the usual flush + WAL-truncate envelope shape.
 //
 // Defaults syncID to the latest finished SyncTypeFull when empty.
 // Errors if the sync isn't ended (mirrors the SQLite contract in
@@ -81,22 +92,38 @@ func cloneSync(
 	}()
 	destDBDir := filepath.Join(cloneTmp, "db")
 
+	// Stage: checkpoint the whole source DB. Raw db.Checkpoint, not
+	// Engine.CheckpointTo — the source may be opened read-only, where
+	// the flush inside CheckpointTo is refused; the checkpoint carries
+	// the live WALs instead, which replay on open below.
+	if err := a.engine.DB().Checkpoint(destDBDir); err != nil {
+		return fmt.Errorf("clone-sync: checkpoint source: %w", err)
+	}
+
 	dest, err := Open(ctx, destDBDir)
 	if err != nil {
-		return fmt.Errorf("clone-sync: open dest engine: %w", err)
+		return fmt.Errorf("clone-sync: open staged clone: %w", err)
 	}
 	defer func() { _ = dest.Close() }()
 
-	// The file holds one sync and keys carry no sync_id, so cloning
-	// is a copy of every record/index/sync-run/stats keyspace —
-	// identical to the ranges ResetForNewSync wipes.
-	for _, r := range scopedRanges() {
-		if err := copyRange(ctx, a.engine.DB(), dest.DB(), r[0], r[1]); err != nil {
-			return fmt.Errorf("clone-sync: copy range: %w", err)
+	// Drop the engine-local keyspaces a clone must not carry: counters
+	// and sessions (adjacent type bytes, one span). Everything else in
+	// the checkpoint is either sync-scoped data (scopedRanges) or the
+	// engine-meta stamp, both of which the clone keeps.
+	if err := dest.withWrite(func() error {
+		span := pebble.KeyRange{
+			Start: []byte{versionV3, typeCounter},
+			End:   upperBoundOf([]byte{versionV3, typeSession}),
 		}
+		if err := dest.db.Excise(ctx, span); err != nil {
+			return fmt.Errorf("excise [%x, %x): %w", span.Start, span.End, err)
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("clone-sync: drop engine-local keyspaces: %w", err)
 	}
 
-	// Checkpoint the destination and emit the envelope at outPath.
+	// Checkpoint the staged clone and emit the envelope at outPath.
 	checkpointDir := filepath.Join(cloneTmp, "checkpoint")
 	if err := dest.CheckpointTo(ctx, checkpointDir); err != nil {
 		return fmt.Errorf("clone-sync: checkpoint: %w", err)
@@ -137,50 +164,3 @@ func cloneSync(
 	success = true
 	return nil
 }
-
-// copyRange iterates [lower, upper) on src and Sets each key/value
-// onto dst in fixed-size batches, committing each batch with
-// pebble.Sync. Chunking caps the per-batch memory at
-// copyRangeBatchKeys keys regardless of total range size, so a
-// clone of a 1M-grant sync uses ~80 batches instead of one
-// gigabyte-scale batch.
-func copyRange(ctx context.Context, src, dst *pebble.DB, lower, upper []byte) error {
-	iter, err := src.NewIter(&pebble.IterOptions{LowerBound: lower, UpperBound: upper})
-	if err != nil {
-		return err
-	}
-	defer iter.Close()
-	batch := dst.NewBatch()
-	defer func() { _ = batch.Close() }()
-	count := 0
-	for iter.First(); iter.Valid(); iter.Next() {
-		if err := ctx.Err(); err != nil {
-			return err
-		}
-		if err := batch.Set(iter.Key(), iter.Value(), nil); err != nil {
-			return err
-		}
-		count++
-		if count >= copyRangeBatchKeys {
-			if err := batch.Commit(pebble.Sync); err != nil {
-				return err
-			}
-			_ = batch.Close()
-			batch = dst.NewBatch()
-			count = 0
-		}
-	}
-	if err := iter.Error(); err != nil {
-		return err
-	}
-	if batch.Empty() {
-		return nil
-	}
-	return batch.Commit(pebble.Sync)
-}
-
-// copyRangeBatchKeys caps copyRange's per-batch memory footprint.
-// Chosen at 10k keys to roughly match the engine's DefaultPageSize;
-// larger batches don't improve commit throughput once Pebble's
-// memtable already absorbs the writes.
-const copyRangeBatchKeys = 10_000

--- a/pkg/dotc1z/engine/pebble/if_newer_test.go
+++ b/pkg/dotc1z/engine/pebble/if_newer_test.go
@@ -1,10 +1,15 @@
 package pebble
 
 import (
+	"context"
 	"testing"
 	"time"
 
+	"github.com/segmentio/ksuid"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
 )
 
 // TestDiscoveredAtIsNewer locks in the SQLite-parity contract for
@@ -45,9 +50,9 @@ func TestDiscoveredAtIsNewer(t *testing.T) {
 		{"real incoming, nil existing — write", t1, nil, true},
 
 		// Strict After: equal timestamps are NOT newer (matches
-		// SQLite's > operator, exercised by TestIfNewerSkipsStaleGrants
-		// in adapter_reader_test.go via the full PutXxxRecordsIfNewer
-		// path).
+		// SQLite's > operator, exercised end-to-end through the full
+		// PutXxxRecordsIfNewer path by TestPutGrantRecordsIfNewerSkipsStale
+		// and TestPutRecordsIfNewerRejectsOlderAllTypes below).
 		{"strictly newer incoming — write", t2, t1, true},
 		{"equal timestamps — do not write", t1, t1, false},
 		{"older incoming — do not write", t1, t2, false},
@@ -61,4 +66,137 @@ func TestDiscoveredAtIsNewer(t *testing.T) {
 			}
 		})
 	}
+}
+
+func ifNewerGrant(principal string, at time.Time) *v3.GrantRecord {
+	return v3.GrantRecord_builder{
+		ExternalId: "g-1",
+		Entitlement: v3.EntitlementRef_builder{
+			ResourceTypeId: "app", ResourceId: "github", EntitlementId: "ent-A",
+		}.Build(),
+		Principal:    v3.PrincipalRef_builder{ResourceTypeId: "user", ResourceId: principal}.Build(),
+		DiscoveredAt: timestamppb.New(at),
+	}.Build()
+}
+
+func grantsByPrincipal(t *testing.T, ctx context.Context, e *Engine, principal string) []string {
+	t.Helper()
+	var ids []string
+	require.NoError(t, e.IterateGrantsByPrincipal(ctx, "user", principal, func(g *v3.GrantRecord) bool {
+		ids = append(ids, g.GetExternalId())
+		return true
+	}))
+	return ids
+}
+
+// TestPutGrantRecordsIfNewerSkipsStale is the end-to-end guard the
+// TestDiscoveredAtIsNewer predicate test points at: it drives the full
+// PutGrantRecordsIfNewer path (read incumbent, compare discovered_at,
+// conditionally write + swap derived index keys) rather than the bare
+// predicate. It pins that a stale (older or equal) replay never
+// regresses the stored grant OR its by_principal index, and that a
+// strictly-newer record both replaces the value and moves the index
+// entry off the old principal — the index-swap step a value-only check
+// would miss.
+func TestPutGrantRecordsIfNewerSkipsStale(t *testing.T) {
+	ctx := context.Background()
+	e, _ := newTestEngine(t)
+	require.NoError(t, e.SetCurrentSync(ksuid.New().String()))
+
+	older := time.Unix(1000, 0).UTC()
+	newer := time.Unix(2000, 0).UTC()
+	newest := time.Unix(3000, 0).UTC()
+
+	// Seed the incumbent at `newer`.
+	require.NoError(t, e.PutGrantRecordsIfNewer(ctx, ifNewerGrant("winner", newer)))
+	got, err := e.GetGrantRecord(ctx, "g-1")
+	require.NoError(t, err)
+	require.Equal(t, "winner", got.GetPrincipal().GetResourceId())
+
+	// Older replay: dropped — value and index unchanged.
+	require.NoError(t, e.PutGrantRecordsIfNewer(ctx, ifNewerGrant("stale-older", older)))
+	got, err = e.GetGrantRecord(ctx, "g-1")
+	require.NoError(t, err)
+	require.Equal(t, "winner", got.GetPrincipal().GetResourceId(), "older replay must not regress the grant")
+
+	// Equal replay: dropped — strict `>` keeps the incumbent.
+	require.NoError(t, e.PutGrantRecordsIfNewer(ctx, ifNewerGrant("stale-tie", newer)))
+	got, err = e.GetGrantRecord(ctx, "g-1")
+	require.NoError(t, err)
+	require.Equal(t, "winner", got.GetPrincipal().GetResourceId(), "equal discovered_at must keep the incumbent")
+
+	// No stale index keys leaked from the dropped writes.
+	require.Equal(t, []string{"g-1"}, grantsByPrincipal(t, ctx, e, "winner"))
+	require.Empty(t, grantsByPrincipal(t, ctx, e, "stale-older"))
+	require.Empty(t, grantsByPrincipal(t, ctx, e, "stale-tie"))
+
+	// Strictly newer: replaces value AND swaps the by_principal index.
+	require.NoError(t, e.PutGrantRecordsIfNewer(ctx, ifNewerGrant("new-winner", newest)))
+	got, err = e.GetGrantRecord(ctx, "g-1")
+	require.NoError(t, err)
+	require.Equal(t, "new-winner", got.GetPrincipal().GetResourceId(), "strictly newer must replace")
+	require.Empty(t, grantsByPrincipal(t, ctx, e, "winner"), "stale index entry must be removed on replace")
+	require.Equal(t, []string{"g-1"}, grantsByPrincipal(t, ctx, e, "new-winner"))
+}
+
+// TestPutRecordsIfNewerRejectsOlderAllTypes guards the per-type
+// discovered_at field constants in the *IfNewer path
+// (grant/resource/entitlement/resource_type each scan a different proto
+// field): for every primary type, seeding a newer record then replaying
+// an older one must keep the newer incumbent. A transposed field
+// constant would read the wrong bytes and silently let the older replay
+// win for that one type.
+func TestPutRecordsIfNewerRejectsOlderAllTypes(t *testing.T) {
+	ctx := context.Background()
+	e, _ := newTestEngine(t)
+	require.NoError(t, e.SetCurrentSync(ksuid.New().String()))
+
+	older := time.Unix(1000, 0).UTC()
+	newer := time.Unix(2000, 0).UTC()
+
+	t.Run("resource_type", func(t *testing.T) {
+		newRec := func(dn string, at time.Time) *v3.ResourceTypeRecord {
+			return v3.ResourceTypeRecord_builder{ExternalId: "rt-1", DisplayName: dn, DiscoveredAt: timestamppb.New(at)}.Build()
+		}
+		require.NoError(t, e.PutResourceTypeRecordsIfNewer(ctx, newRec("kept", newer)))
+		require.NoError(t, e.PutResourceTypeRecordsIfNewer(ctx, newRec("stale", older)))
+		got, err := e.GetResourceTypeRecord(ctx, "rt-1")
+		require.NoError(t, err)
+		require.Equal(t, "kept", got.GetDisplayName())
+	})
+
+	t.Run("resource", func(t *testing.T) {
+		newRec := func(dn string, at time.Time) *v3.ResourceRecord {
+			return v3.ResourceRecord_builder{ResourceTypeId: "user", ResourceId: "u1", DisplayName: dn, DiscoveredAt: timestamppb.New(at)}.Build()
+		}
+		require.NoError(t, e.PutResourceRecordsIfNewer(ctx, newRec("kept", newer)))
+		require.NoError(t, e.PutResourceRecordsIfNewer(ctx, newRec("stale", older)))
+		got, err := e.GetResourceRecord(ctx, "user", "u1")
+		require.NoError(t, err)
+		require.Equal(t, "kept", got.GetDisplayName())
+	})
+
+	t.Run("entitlement", func(t *testing.T) {
+		newRec := func(dn string, at time.Time) *v3.EntitlementRecord {
+			return v3.EntitlementRecord_builder{
+				ExternalId:   "e-1",
+				Resource:     v3.ResourceRef_builder{ResourceTypeId: "user", ResourceId: "u1"}.Build(),
+				DisplayName:  dn,
+				DiscoveredAt: timestamppb.New(at),
+			}.Build()
+		}
+		require.NoError(t, e.PutEntitlementRecordsIfNewer(ctx, newRec("kept", newer)))
+		require.NoError(t, e.PutEntitlementRecordsIfNewer(ctx, newRec("stale", older)))
+		got, err := e.GetEntitlementRecord(ctx, "e-1")
+		require.NoError(t, err)
+		require.Equal(t, "kept", got.GetDisplayName())
+	})
+
+	t.Run("grant", func(t *testing.T) {
+		require.NoError(t, e.PutGrantRecordsIfNewer(ctx, ifNewerGrant("kept", newer)))
+		require.NoError(t, e.PutGrantRecordsIfNewer(ctx, ifNewerGrant("stale", older)))
+		got, err := e.GetGrantRecord(ctx, "g-1")
+		require.NoError(t, err)
+		require.Equal(t, "kept", got.GetPrincipal().GetResourceId())
+	})
 }

--- a/pkg/dotc1z/engine/pebble/merge_accessor.go
+++ b/pkg/dotc1z/engine/pebble/merge_accessor.go
@@ -99,6 +99,26 @@ type storeDirtyMarker interface {
 	MarkDirty()
 }
 
+type foldDeadBytesAdder interface {
+	AddFoldDeadBytes(n int64)
+}
+
+// AddFoldDeadBytes bumps a registered store's cumulative fold-waste
+// counter (persisted as the envelope manifest's fold_dead_bytes at
+// save). Called by the fold compactor with the exact raw bytes its
+// merge shadowed in the base keyspace; the compactor's auto cutover
+// later reads the counter from the envelope header to force a rebuild
+// once waste crosses its threshold. Returns false when w is not a
+// registered Pebble store.
+func AddFoldDeadBytes(w connectorstore.Writer, n int64) bool {
+	s, ok := w.(foldDeadBytesAdder)
+	if !ok || s == nil {
+		return false
+	}
+	s.AddFoldDeadBytes(n)
+	return true
+}
+
 // MarkStoreDirty flips a registered store's dirty bit so Close drives
 // the save → checkpoint → envelope path. Engine-level writes (raw
 // batches, SST ingest, direct Put*Records) bypass the registered

--- a/pkg/dotc1z/format/v3/envelope.go
+++ b/pkg/dotc1z/format/v3/envelope.go
@@ -516,8 +516,9 @@ func readEnvelope(r io.Reader, headerOnly bool, pool *DecoderPool) (*Envelope, e
 }
 
 // unmarshalManifestHeader decodes the cheap manifest fields by hand:
-// engine (1), engine_schema_version (2), payload_encoding (4), and the
-// sync_runs projection (40). The descriptor closure (field 10) — by far
+// engine (1), engine_schema_version (2), payload_encoding (4), the
+// sync_runs projection (40), and fold_dead_bytes (41). The descriptor
+// closure (field 10) — by far
 // the largest field — is skipped, which is what makes header reads
 // cheap enough for engine dispatch on every open. Sync run summaries
 // are small and few (bounded by the sync retention limit), so decoding
@@ -580,6 +581,16 @@ func unmarshalManifestHeader(b []byte) (*c1zv3.C1ZManifestV3, error) {
 				return nil, fmt.Errorf("%w: sync_runs entry: %w", ErrManifestInvalid, err)
 			}
 			out.SetSyncRuns(append(out.GetSyncRuns(), summary))
+			b = b[n:]
+		case 41:
+			if typ != protowire.VarintType {
+				return nil, fmt.Errorf("c1z v3: manifest fold_dead_bytes has wire type %v", typ)
+			}
+			v, n := protowire.ConsumeVarint(b)
+			if n < 0 {
+				return nil, protowire.ParseError(n)
+			}
+			out.SetFoldDeadBytes(int64(v)) //nolint:gosec // proto int64 varint round-trips through uint64 by definition.
 			b = b[n:]
 		default:
 			n := protowire.ConsumeFieldValue(num, typ, b)

--- a/pkg/dotc1z/pebble_store.go
+++ b/pkg/dotc1z/pebble_store.go
@@ -42,7 +42,7 @@ func (pebbleDriver) OpenStore(ctx context.Context, outputFilePath string, opts S
 	}
 
 	dbDir := filepath.Join(tmpDir, "db")
-	reuse, fileEncoding, err := unpackExistingPebbleC1Z(outputFilePath, dbDir, opts.MaxDecodedPayloadBytes, opts.MaxDecoderMemoryBytes, opts.DecoderPool)
+	reuse, fileEncoding, foldDeadBytes, err := unpackExistingPebbleC1Z(outputFilePath, dbDir, opts.MaxDecodedPayloadBytes, opts.MaxDecoderMemoryBytes, opts.DecoderPool)
 	if err != nil {
 		return nil, cleanupOnError(err)
 	}
@@ -70,6 +70,7 @@ func (pebbleDriver) OpenStore(ctx context.Context, outputFilePath string, opts S
 		readOnly:        opts.ReadOnly,
 		payloadEncoding: encoding,
 		payloadReuse:    reuse,
+		foldDeadBytes:   foldDeadBytes,
 		syncLimit:       opts.SyncLimit,
 		skipCleanup:     opts.SkipCleanup,
 	}, nil
@@ -81,32 +82,32 @@ func unpackExistingPebbleC1Z(
 	maxDecodedPayloadBytes uint64,
 	maxDecoderMemoryBytes uint64,
 	pool *EnvelopeDecoderPool,
-) (*formatv3.PayloadReuse, PayloadEncoding, error) {
+) (*formatv3.PayloadReuse, PayloadEncoding, int64, error) {
 	stat, err := os.Stat(outputFilePath)
 	switch {
 	case errors.Is(err, os.ErrNotExist):
-		return nil, PayloadEncodingUnspecified, nil
+		return nil, PayloadEncodingUnspecified, 0, nil
 	case err != nil:
-		return nil, PayloadEncodingUnspecified, err
+		return nil, PayloadEncodingUnspecified, 0, err
 	case stat.Size() == 0:
-		return nil, PayloadEncodingUnspecified, nil
+		return nil, PayloadEncodingUnspecified, 0, nil
 	}
 
 	f, err := os.Open(outputFilePath)
 	if err != nil {
-		return nil, PayloadEncodingUnspecified, err
+		return nil, PayloadEncodingUnspecified, 0, err
 	}
 	defer f.Close()
 
 	header, err := formatv3.ReadManifestHeader(f)
 	if err != nil {
-		return nil, PayloadEncodingUnspecified, err
+		return nil, PayloadEncodingUnspecified, 0, err
 	}
 	if e := Engine(header.GetEngine()); e != EnginePebble && e != PebbleManifestEngine {
-		return nil, PayloadEncodingUnspecified, fmt.Errorf("%w: %s", pebble.ErrUnknownEngine, header.GetEngine())
+		return nil, PayloadEncodingUnspecified, 0, fmt.Errorf("%w: %s", pebble.ErrUnknownEngine, header.GetEngine())
 	}
 	if err := os.MkdirAll(dbDir, 0o755); err != nil {
-		return nil, PayloadEncodingUnspecified, err
+		return nil, PayloadEncodingUnspecified, 0, err
 	}
 	manifest, reuse, err := formatv3.ExtractEnvelopePayload(f, dbDir,
 		formatv3.WithMaxDecodedPayloadBytes(maxDecodedPayloadBytes),
@@ -114,9 +115,12 @@ func unpackExistingPebbleC1Z(
 		formatv3.WithPayloadDecoderPool(pool),
 	)
 	if err != nil {
-		return nil, PayloadEncodingUnspecified, err
+		return nil, PayloadEncodingUnspecified, 0, err
 	}
-	return reuse, payloadEncodingFromProto(manifest.GetPayloadEncoding()), nil
+	// fold_dead_bytes is inherited from the source file so the waste
+	// accounting survives arbitrary open/save cycles, not just fold
+	// compactions; a fresh file starts at zero.
+	return reuse, payloadEncodingFromProto(manifest.GetPayloadEncoding()), header.GetFoldDeadBytes(), nil
 }
 
 func payloadEncodingFromProto(enc c1zv3.PayloadEncoding) PayloadEncoding {
@@ -142,6 +146,13 @@ type pebbleStore struct {
 	readOnly        bool
 	payloadEncoding PayloadEncoding
 	payloadReuse    *formatv3.PayloadReuse
+	// foldDeadBytes is the cumulative fold-waste counter carried in
+	// the envelope manifest (C1ZManifestV3.fold_dead_bytes): seeded
+	// from the file this store was opened from, optionally bumped by
+	// AddFoldDeadBytes during a fold compaction, and written back at
+	// save. Guarded by closeMu (writes happen on the compactor's
+	// single merge goroutine; the lock just pairs it with save/Close).
+	foldDeadBytes int64
 
 	// syncLimit and skipCleanup mirror StoreOptions and feed into
 	// Cleanup. The Adapter intentionally has no awareness of these
@@ -287,6 +298,21 @@ func (s *pebbleStore) MarkDirty() {
 	s.closeMu.Lock()
 	if !s.closed {
 		s.dirty = true
+	}
+	s.closeMu.Unlock()
+}
+
+// AddFoldDeadBytes bumps the cumulative fold-waste counter persisted
+// in the envelope manifest at save. Called by the fold compactor with
+// the raw bytes its merge shadowed in the base keyspace (see
+// pebble.AddFoldDeadBytes for the Writer-level accessor).
+func (s *pebbleStore) AddFoldDeadBytes(n int64) {
+	if s == nil || n <= 0 {
+		return
+	}
+	s.closeMu.Lock()
+	if !s.closed {
+		s.foldDeadBytes += n
 	}
 	s.closeMu.Unlock()
 }
@@ -465,6 +491,9 @@ func (s *pebbleStore) save(ctx context.Context) error {
 	manifest, err := pebble.BuildManifestWithSyncRuns(ctx, s.engine, s.payloadEncoding)
 	if err != nil {
 		return err
+	}
+	if s.foldDeadBytes > 0 {
+		manifest.SetFoldDeadBytes(s.foldDeadBytes)
 	}
 	encodeStart := time.Now()
 	if _, err := formatv3.WriteEnvelopeWithReuse(out, manifest, checkpointDir, s.payloadReuse); err != nil {

--- a/pkg/synccompactor/compactor.go
+++ b/pkg/synccompactor/compactor.go
@@ -60,6 +60,11 @@ type Compactor struct {
 	overlayRecordChunkSize int
 	overlayBufferFactor    float64
 	overlayGateFraction    float64
+	// foldMaxWastePct optionally overrides the fold waste cutover
+	// (accumulated fold dead bytes as a percent of the base's live
+	// payload bytes, above which auto mode forces an overlay rebuild).
+	// Zero means the default; see WithFoldMaxWastePercent.
+	foldMaxWastePct int64
 	// decoderPool scopes v3 payload-decoder reuse to one Compact run:
 	// every source envelope open draws from it instead of constructing
 	// a fresh zstd decoder, and Compact closes it on the way out so no

--- a/pkg/synccompactor/compactor_fold_test.go
+++ b/pkg/synccompactor/compactor_fold_test.go
@@ -121,4 +121,139 @@ func TestCompactPebbleFoldMintsFreshSync(t *testing.T) {
 	require.NotEqual(t, baseSyncID, runs[0].GetSyncId(), "the overwritten base sync id must not appear in the manifest")
 	require.NotNil(t, runs[0].GetStats(), "manifest projection must carry the recomputed stats sidecar")
 	require.Equal(t, int64(3), runs[0].GetStats().GetGrants())
+
+	// The fold overrode g-shared, so its incumbent's bytes are dead
+	// weight inside the spliced base frames — the manifest's waste
+	// counter must record them.
+	require.Positive(t, m.GetFoldDeadBytes(), "fold must record the overridden incumbent's bytes in fold_dead_bytes")
+}
+
+// TestCompactPebbleFoldWasteAccumulates covers the fold-waste
+// accounting lifecycle: each fold adds the raw bytes it shadowed to
+// the manifest's fold_dead_bytes (carried forward from the base it
+// folded into), and a rebuild resets the counter to zero.
+func TestCompactPebbleFoldWasteAccumulates(t *testing.T) {
+	ctx := context.Background()
+	inDir := t.TempDir()
+
+	basePath := filepath.Join(inDir, "base.c1z")
+	p1Path := filepath.Join(inDir, "p1.c1z")
+	p2Path := filepath.Join(inDir, "p2.c1z")
+	// Built in order, so each partial's g-shared is strictly newer than
+	// everything before it and overrides the incumbent at fold time.
+	baseSyncID := buildPebbleInput(t, ctx, basePath, connectorstore.SyncTypeFull, "g-shared", "g-base-only")
+	p1SyncID := buildPebbleInput(t, ctx, p1Path, connectorstore.SyncTypePartial, "g-shared")
+	p2SyncID := buildPebbleInput(t, ctx, p2Path, connectorstore.SyncTypePartial, "g-shared")
+
+	t.Setenv("BATON_EXPERIMENTAL_PEBBLE_COMPACTOR", "fold")
+
+	// Fold #1: p1 overrides the base's g-shared.
+	out1 := compactPairOnce(t, ctx,
+		&CompactableSync{FilePath: basePath, SyncID: baseSyncID},
+		&CompactableSync{FilePath: p1Path, SyncID: p1SyncID})
+	dead1 := readFoldDeadBytes(t, out1.FilePath)
+	require.Positive(t, dead1, "first fold must record dead bytes for the overridden grant")
+
+	// Fold #2 into the folded output: p2 overrides g-shared again. The
+	// counter is cumulative — inherited from out1's manifest, plus this
+	// fold's own dead bytes.
+	out2 := compactPairOnce(t, ctx, out1, &CompactableSync{FilePath: p2Path, SyncID: p2SyncID})
+	dead2 := readFoldDeadBytes(t, out2.FilePath)
+	require.Greater(t, dead2, dead1, "second fold must accumulate on top of the inherited counter")
+
+	// A rebuild garbage-collects every shadowed record, so its output
+	// resets the counter.
+	t.Setenv("BATON_EXPERIMENTAL_PEBBLE_COMPACTOR", "overlay")
+	out3 := compactPairOnce(t, ctx, out2, &CompactableSync{FilePath: p2Path, SyncID: p2SyncID})
+	require.Zero(t, readFoldDeadBytes(t, out3.FilePath), "a rebuild must reset fold_dead_bytes")
+}
+
+// TestFoldWasteCarryForwardAndAutoCutover covers the two waste-debt
+// behaviors the synthetic-envelope gate test can't: the counter
+// surviving a plain (non-fold) open/save cycle of a real Pebble c1z,
+// and the AUTO mode gate reading a real folded file's manifest +
+// indexed trailer to decide fold vs overlay — including the full
+// Compact run that rebuilds and resets the debt once it's injected
+// past the cutover. (Organic fixture-scale waste is far below 15% of
+// the payload, so the over-threshold leg injects debt through the
+// same AddFoldDeadBytes accessor the fold compactor uses.)
+func TestFoldWasteCarryForwardAndAutoCutover(t *testing.T) {
+	ctx := context.Background()
+	inDir := t.TempDir()
+
+	basePath := filepath.Join(inDir, "base.c1z")
+	pPath := filepath.Join(inDir, "p.c1z")
+	baseSyncID := buildPebbleInput(t, ctx, basePath, connectorstore.SyncTypeFull, "g-shared", "g-base-only")
+	pSyncID := buildPebbleInput(t, ctx, pPath, connectorstore.SyncTypePartial, "g-shared")
+	partial := &CompactableSync{FilePath: pPath, SyncID: pSyncID}
+
+	// Produce a real folded c1z carrying organic dead bytes.
+	t.Setenv("BATON_EXPERIMENTAL_PEBBLE_COMPACTOR", "fold")
+	out := compactPairOnce(t, ctx, &CompactableSync{FilePath: basePath, SyncID: baseSyncID}, partial)
+	dead := readFoldDeadBytes(t, out.FilePath)
+	require.Positive(t, dead)
+
+	// Carry-forward: a writable open + dirty save that folds nothing
+	// must preserve the inherited counter verbatim (the store seeds it
+	// from the source manifest at open and writes it back at save).
+	w, err := dotc1z.NewStore(ctx, out.FilePath, dotc1z.WithTmpDir(t.TempDir()))
+	require.NoError(t, err)
+	require.True(t, enginepkg.MarkStoreDirty(w))
+	require.NoError(t, w.Close(ctx))
+	require.Equal(t, dead, readFoldDeadBytes(t, out.FilePath),
+		"a non-fold save must carry the inherited fold_dead_bytes forward unchanged")
+
+	// AUTO mode against the real file: organic waste is far below the
+	// cutover, so the gate stays on fold. The fixture partial is not
+	// small relative to the fixture base, so widen the size leg to
+	// isolate the waste leg.
+	t.Setenv("BATON_EXPERIMENTAL_PEBBLE_COMPACTOR", "")
+	t.Setenv("BATON_PEBBLE_FOLD_MAX_PARTIAL_PCT", "10000")
+	autoC := &Compactor{entries: []*CompactableSync{{FilePath: out.FilePath, SyncID: out.SyncID}, partial}}
+	require.Equal(t, PebbleCompactorModeFold, autoC.resolvePebbleMode(ctx),
+		"real folded file below the waste cutover must stay on fold")
+
+	// Inject debt past the cutover through the production accessor,
+	// persisted by the same dirty-save path.
+	w, err = dotc1z.NewStore(ctx, out.FilePath, dotc1z.WithTmpDir(t.TempDir()))
+	require.NoError(t, err)
+	require.True(t, enginepkg.AddFoldDeadBytes(w, 1<<30))
+	require.True(t, enginepkg.MarkStoreDirty(w))
+	require.NoError(t, w.Close(ctx))
+	require.Equal(t, dead+1<<30, readFoldDeadBytes(t, out.FilePath))
+
+	require.Equal(t, PebbleCompactorModeOverlay, autoC.resolvePebbleMode(ctx),
+		"debt past the cutover must force the rebuild")
+
+	// Full AUTO compaction: the run must route to the rebuild and the
+	// rebuilt output must reset the counter.
+	rebuilt := compactPairOnce(t, ctx, &CompactableSync{FilePath: out.FilePath, SyncID: out.SyncID}, partial)
+	require.Zero(t, readFoldDeadBytes(t, rebuilt.FilePath),
+		"the auto-selected rebuild must reset fold_dead_bytes")
+}
+
+// compactPairOnce compacts base + partial with the pebble engine and
+// returns the output.
+func compactPairOnce(t *testing.T, ctx context.Context, base, partial *CompactableSync, opts ...Option) *CompactableSync {
+	t.Helper()
+	opts = append([]Option{WithTmpDir(t.TempDir()), WithEngine(dotc1z.EnginePebble), WithSkipGrantExpansion()}, opts...)
+	c, cleanup, err := NewCompactor(ctx, t.TempDir(), []*CompactableSync{base, partial}, opts...)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, cleanup()) }()
+	out, err := c.Compact(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	return out
+}
+
+// readFoldDeadBytes returns the envelope manifest's fold_dead_bytes
+// counter via a header-only read.
+func readFoldDeadBytes(t *testing.T, path string) int64 {
+	t.Helper()
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer f.Close()
+	m, err := formatv3.ReadManifestHeader(f)
+	require.NoError(t, err)
+	return m.GetFoldDeadBytes()
 }

--- a/pkg/synccompactor/compactor_mode_test.go
+++ b/pkg/synccompactor/compactor_mode_test.go
@@ -7,7 +7,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	c1zv3 "github.com/conductorone/baton-sdk/pb/c1/c1z/v3"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	formatv3 "github.com/conductorone/baton-sdk/pkg/dotc1z/format/v3"
 	"github.com/stretchr/testify/require"
 )
 
@@ -80,6 +82,75 @@ func TestResolvePebbleModeCutover(t *testing.T) {
 	// (partials too large for the gate) auto-selects overlay.
 	t.Setenv("BATON_EXPERIMENTAL_PEBBLE_COMPACTOR", "bogus")
 	require.Equal(t, PebbleCompactorModeOverlay, newC(bigBase, bigPartial, smallPartial).resolvePebbleMode(ctx))
+}
+
+// TestResolvePebbleModeFoldWasteCutover exercises the waste leg of the
+// auto gate: a base whose manifest carries accumulated fold dead bytes
+// past the cutover (default 15% of live payload bytes) forces an
+// overlay rebuild even when the size gate would pick fold. The base
+// envelopes are written with exactly controlled raw payload size and
+// fold_dead_bytes, so the ratio arithmetic is deterministic.
+func TestResolvePebbleModeFoldWasteCutover(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	mkEnv := func(name string, payloadBytes int, dead int64, enc c1zv3.PayloadEncoding) string {
+		t.Helper()
+		payloadDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(payloadDir, "payload.bin"), make([]byte, payloadBytes), 0o600))
+		m := c1zv3.C1ZManifestV3_builder{
+			Engine:          "pebble",
+			PayloadEncoding: enc,
+			FoldDeadBytes:   dead,
+		}.Build()
+		path := filepath.Join(dir, name)
+		f, err := os.Create(path)
+		require.NoError(t, err)
+		defer f.Close()
+		_, err = formatv3.WriteEnvelopeWithReuse(f, m, payloadDir, nil)
+		require.NoError(t, err)
+		return path
+	}
+	newC := func(base string, opts ...Option) *Compactor {
+		// A 1-byte partial keeps the size gate firmly inside fold's
+		// shape, so any overlay result comes from the waste leg.
+		partial := filepath.Join(dir, "partial.c1z")
+		require.NoError(t, os.WriteFile(partial, []byte{0}, 0o600))
+		c := &Compactor{entries: []*CompactableSync{
+			{FilePath: base, SyncID: "base"},
+			{FilePath: partial, SyncID: "p"},
+		}}
+		for _, opt := range opts {
+			opt(c)
+		}
+		return c
+	}
+	t.Setenv("BATON_EXPERIMENTAL_PEBBLE_COMPACTOR", "")
+
+	const indexed = c1zv3.PayloadEncoding_PAYLOAD_ENCODING_INDEXED_ZSTD
+	noWaste := mkEnv("nowaste.c1z", 10000, 0, indexed)
+	lowWaste := mkEnv("low.c1z", 10000, 1000, indexed)   // 1000/9000 ≈ 11% ≤ 15% → fold
+	highWaste := mkEnv("high.c1z", 10000, 2000, indexed) // 2000/8000 = 25% > 15% → overlay
+
+	require.Equal(t, PebbleCompactorModeFold, newC(noWaste).resolvePebbleMode(ctx))
+	require.Equal(t, PebbleCompactorModeFold, newC(lowWaste).resolvePebbleMode(ctx))
+	require.Equal(t, PebbleCompactorModeOverlay, newC(highWaste).resolvePebbleMode(ctx))
+
+	// The option moves the cutover in both directions, and a negative
+	// value disables the waste leg entirely.
+	require.Equal(t, PebbleCompactorModeFold, newC(highWaste, WithFoldMaxWastePercent(30)).resolvePebbleMode(ctx))
+	require.Equal(t, PebbleCompactorModeOverlay, newC(lowWaste, WithFoldMaxWastePercent(10)).resolvePebbleMode(ctx))
+	require.Equal(t, PebbleCompactorModeFold, newC(highWaste, WithFoldMaxWastePercent(-1)).resolvePebbleMode(ctx))
+
+	// Recorded waste but no indexed trailer (tar payload): live bytes
+	// can't be computed cheaply, so the gate errs toward the rebuild.
+	tarWaste := mkEnv("tar.c1z", 10000, 100, c1zv3.PayloadEncoding_PAYLOAD_ENCODING_TAR)
+	require.Equal(t, PebbleCompactorModeOverlay, newC(tarWaste).resolvePebbleMode(ctx))
+
+	// An explicit fold mode bypasses the waste leg like every other
+	// auto-gate check.
+	require.Equal(t, PebbleCompactorModeFold,
+		newC(highWaste, WithPebbleCompactorMode(PebbleCompactorModeFold)).resolvePebbleMode(ctx))
 }
 
 func TestInferEngineFromInputFormats(t *testing.T) {

--- a/pkg/synccompactor/compactor_mode_test.go
+++ b/pkg/synccompactor/compactor_mode_test.go
@@ -33,20 +33,20 @@ func TestResolvePebbleModeCutover(t *testing.T) {
 		return &Compactor{entries: entries}
 	}
 
-	// Lower the base-size floor so the test doesn't need a 256MiB file.
-	t.Setenv("BATON_PEBBLE_FOLD_MIN_BASE_BYTES", "1000")
-
 	bigBase := mk("base.c1z", 4000)
 	smallPartial := mk("p-small.c1z", 100)
 	bigPartial := mk("p-big.c1z", 2000)
 	tinyBase := mk("tiny.c1z", 100)
+	tinyPartial := mk("p-tiny.c1z", 10)
 
 	t.Setenv("BATON_EXPERIMENTAL_PEBBLE_COMPACTOR", "")
-	// Large base + partials within the ratio is fold's winning shape →
-	// auto-selects fold.
+	// Base + partials within the 10% ratio is fold's winning shape →
+	// auto-selects fold. No base-size floor by default.
 	require.Equal(t, PebbleCompactorModeFold, newC(bigBase, smallPartial).resolvePebbleMode(ctx))
+	// Exactly at the 10% boundary → still fold.
 	require.Equal(t, PebbleCompactorModeFold,
 		newC(bigBase, smallPartial, smallPartial, smallPartial, smallPartial).resolvePebbleMode(ctx))
+	require.Equal(t, PebbleCompactorModeFold, newC(tinyBase, tinyPartial).resolvePebbleMode(ctx))
 	// Partials past the ratio fall outside the gate → overlay.
 	require.Equal(t, PebbleCompactorModeOverlay,
 		newC(bigBase, smallPartial, smallPartial, smallPartial, smallPartial, smallPartial).resolvePebbleMode(ctx))
@@ -56,6 +56,12 @@ func TestResolvePebbleModeCutover(t *testing.T) {
 	// with the real error.
 	require.Equal(t, PebbleCompactorModeOverlay,
 		newC(filepath.Join(dir, "missing.c1z"), smallPartial).resolvePebbleMode(ctx))
+	// An explicit base-size floor (ops escape hatch) still declines
+	// fold for bases below it.
+	t.Setenv("BATON_PEBBLE_FOLD_MIN_BASE_BYTES", "1000")
+	require.Equal(t, PebbleCompactorModeOverlay, newC(tinyBase, tinyPartial).resolvePebbleMode(ctx))
+	require.Equal(t, PebbleCompactorModeFold, newC(bigBase, smallPartial).resolvePebbleMode(ctx))
+	t.Setenv("BATON_PEBBLE_FOLD_MIN_BASE_BYTES", "")
 
 	// Explicit env values force the mode regardless of sizes — fold
 	// stays reachable when requested manually.
@@ -73,7 +79,7 @@ func TestResolvePebbleModeCutover(t *testing.T) {
 	// Unrecognized values fall back to auto selection: a non-fold shape
 	// (partials too large for the gate) auto-selects overlay.
 	t.Setenv("BATON_EXPERIMENTAL_PEBBLE_COMPACTOR", "bogus")
-	require.Equal(t, PebbleCompactorModeOverlay, newC(bigBase, bigPartial).resolvePebbleMode(ctx))
+	require.Equal(t, PebbleCompactorModeOverlay, newC(bigBase, bigPartial, smallPartial).resolvePebbleMode(ctx))
 }
 
 func TestInferEngineFromInputFormats(t *testing.T) {

--- a/pkg/synccompactor/compactor_pebble.go
+++ b/pkg/synccompactor/compactor_pebble.go
@@ -125,23 +125,32 @@ func WithOverlayGateFraction(f float64) Option {
 // Fold cutover thresholds gate the auto fold/overlay choice in
 // resolvePebbleMode. Fold's win is conditional on the base dominating
 // total input volume: it pays a fixed per-source cost (envelope +
-// pebble open, ~10ms each) plus per-record point writes for every
-// partial record, but does ZERO work for base records and splices the
-// base's unchanged frames at save. Measured at a 1.1GB base + 50 small
-// partials, fold is ~3x faster than overlay (~20s vs ~60s); at fixture
-// scale (MB bases) overlay wins every shape.
+// pebble open, ~10ms each) plus per-record raw keep-newer writes for
+// every partial record, but does ZERO work for base records and
+// splices the base's unchanged frames at save.
 //
-// The ratio comes from the crossover sweep
-// (TestProdScaleFoldOverlayCrossover): overlay's cost is nearly flat
-// in partial volume (it streams the base regardless) while fold's is
-// linear (~0.2s per MB of partials), so they cross where fold's
-// partial-write cost eats its base savings — ~9% partial volume at a
-// 117MB base, extrapolating to ~16% at 1.1GB. 10% keeps fold ahead of
-// overlay across the whole gated range; past it the win shrinks
-// toward a loss, and overlay is never badly wrong.
+// The thresholds were re-derived after the fold merge went raw
+// (byte-level keep-newer, no proto round-trip — mergeBucketRawIfNewer)
+// and the overlay's whole-source path switched to verbatim index
+// copies — both strategies got faster, and the crossover sweep
+// (TestProdScaleFoldOverlayCrossover, 117MB base) puts the crossing
+// at ~7% partial byte volume: fold wins at 4.9% (4.8s vs 6.1s) and
+// loses mildly from 8.9% up (6.2s vs 5.5s), with overlay's lead
+// roughly flat (~15%) through 41%. Fold's output also grows with the
+// override ratio — replaced records leave dead bytes inside the
+// spliced base frames (+18% at 8.9%, +58% at 41%) — so past the
+// crossing overlay is better on both axes.
+//
+// At the production shape the gate exists for (partials ≲ 5% of a
+// large base) fold wins at every measured scale: GB-scale skewed
+// (~1% ratio) 11.3s vs overlay's 20.8s, and fixture-scale bases all
+// the way down to KBs. The old 256MiB min-base requirement is
+// therefore gone — fold's win comes from splicing the base's
+// unchanged compressed frames at save instead of re-encoding the
+// whole output envelope, which holds at any base size.
 const (
-	defaultFoldMinBaseBytes      int64 = 256 << 20 // 256 MiB
-	defaultFoldMaxPartialPercent int64 = 10        // partials ≤ 10% of base size
+	defaultFoldMinBaseBytes      int64 = 0  // no minimum — fold wins at every measured base size
+	defaultFoldMaxPartialPercent int64 = 10 // partials ≤ 10% of base size
 )
 
 // foldMinBaseBytes is the smallest base input (envelope file size) for
@@ -207,7 +216,9 @@ func (c *Compactor) resolvePebbleMode(ctx context.Context) PebbleCompactorMode {
 	minBase := foldMinBaseBytes()
 	maxPct := foldMaxPartialPercent()
 	mode := PebbleCompactorModeOverlay
-	if baseBytes >= minBase && partialBytes*100 <= baseBytes*maxPct {
+	// baseBytes > 0 keeps an unstat-able base (size 0) out of the fold
+	// path so the open fails later with the canonical error.
+	if baseBytes > 0 && baseBytes >= minBase && partialBytes*100 <= baseBytes*maxPct {
 		mode = PebbleCompactorModeFold
 	}
 	l.Info("pebble compactor: auto-selected mode",

--- a/pkg/synccompactor/compactor_pebble.go
+++ b/pkg/synccompactor/compactor_pebble.go
@@ -122,6 +122,27 @@ func WithOverlayGateFraction(f float64) Option {
 	}
 }
 
+// WithFoldMaxWastePercent overrides the fold waste cutover: when the
+// base input's accumulated fold dead bytes (the envelope manifest's
+// fold_dead_bytes counter) exceed this percent of its live payload
+// bytes, auto mode forces an overlay rebuild instead of another fold,
+// reclaiming the waste. Zero (the default) uses
+// defaultFoldMaxWastePercent; negative disables the waste cutover.
+func WithFoldMaxWastePercent(pct int64) Option {
+	return func(c *Compactor) {
+		c.foldMaxWastePct = pct
+	}
+}
+
+// foldMaxWastePercent resolves the configured waste cutover, treating
+// zero as the default.
+func (c *Compactor) foldMaxWastePercent() int64 {
+	if c.foldMaxWastePct != 0 {
+		return c.foldMaxWastePct
+	}
+	return defaultFoldMaxWastePercent
+}
+
 // Fold cutover thresholds gate the auto fold/overlay choice in
 // resolvePebbleMode. Fold's win is conditional on the base dominating
 // total input volume: it pays a fixed per-source cost (envelope +
@@ -148,9 +169,24 @@ func WithOverlayGateFraction(f float64) Option {
 // therefore gone — fold's win comes from splicing the base's
 // unchanged compressed frames at save instead of re-encoding the
 // whole output envelope, which holds at any base size.
+//
+// The waste cutover bounds how much dead weight consecutive folds may
+// accumulate before auto mode forces a rebuild. Every record a fold
+// overrides leaves its raw bytes shadowed inside the spliced base
+// frames (the crossover sweep measured +18% output at an 8.9%
+// override ratio, +58% at 41%), and that waste taxes every subsequent
+// download, open, and save until a rebuild reclaims it. The fold
+// merge counts the shadowed bytes exactly (FoldStats.DeadBytes — the
+// incumbent is already in hand at override time), the counter is
+// carried in the envelope manifest (fold_dead_bytes) across
+// consecutive folds, and a rebuild resets it to zero. 15% sits below
+// the band where the sweep showed overlay winning on both axes
+// (~18% bloat) while still amortizing one rebuild over several folds
+// at production override ratios. Override via WithFoldMaxWastePercent.
 const (
 	defaultFoldMinBaseBytes      int64 = 0  // no minimum — fold wins at every measured base size
 	defaultFoldMaxPartialPercent int64 = 10 // partials ≤ 10% of base size
+	defaultFoldMaxWastePercent   int64 = 15 // accumulated dead bytes ≤ 15% of live payload bytes
 )
 
 // foldMinBaseBytes is the smallest base input (envelope file size) for
@@ -221,15 +257,71 @@ func (c *Compactor) resolvePebbleMode(ctx context.Context) PebbleCompactorMode {
 	if baseBytes > 0 && baseBytes >= minBase && partialBytes*100 <= baseBytes*maxPct {
 		mode = PebbleCompactorModeFold
 	}
+	var deadBytes, liveBytes int64
+	wastePct := c.foldMaxWastePercent()
+	if mode == PebbleCompactorModeFold && wastePct > 0 {
+		var exceeded bool
+		deadBytes, liveBytes, exceeded = foldWaste(c.entries[0].FilePath)
+		// Division form of deadBytes*100 > liveBytes*wastePct: the
+		// cross-multiplied version overflows int64 around 92 PB
+		// (deadBytes*100) / 615 PB (liveBytes*wastePct), so divide
+		// instead. wastePct > 0 is guaranteed by the enclosing
+		// condition; integer truncation is immaterial at byte scale.
+		if exceeded || (liveBytes > 0 && deadBytes/wastePct > liveBytes/100) {
+			// Accumulated fold waste has crossed the cutover: rebuild
+			// to reclaim it instead of folding more dead weight in.
+			mode = PebbleCompactorModeOverlay
+		}
+	}
 	l.Info("pebble compactor: auto-selected mode",
 		zap.String("mode", string(mode)),
 		zap.Int64("base_bytes", baseBytes),
 		zap.Int64("partial_bytes", partialBytes),
 		zap.Int64("fold_min_base_bytes", minBase),
 		zap.Int64("fold_max_partial_pct", maxPct),
+		zap.Int64("fold_dead_bytes", deadBytes),
+		zap.Int64("fold_live_bytes", liveBytes),
+		zap.Int64("fold_max_waste_pct", wastePct),
 		zap.Int("partials", len(c.entries)-1),
 	)
 	return mode
+}
+
+// foldWaste reads the base envelope's accumulated fold waste. The
+// first return is the manifest's fold_dead_bytes counter; the second
+// is the live payload bytes — the indexed trailer's total_raw_size
+// minus the dead bytes (three small preads, no payload unpack). The
+// bool short-circuits the degenerate cases: when dead bytes are
+// recorded but live bytes can't be computed (non-indexed payload — no
+// cheap raw-size source — or a corrupt trailer) it returns true,
+// erring toward the rebuild, which is the safe direction (a rebuild
+// is always correct, just slower). A base with no recorded waste, or
+// one that isn't a readable v3 envelope, returns all zeros — the gate
+// stays on fold and a genuinely bad file fails later with the
+// canonical open error.
+func foldWaste(path string) (int64, int64, bool) {
+	f, err := os.Open(path) // #nosec G703 - path is a caller-provided compaction input, not untrusted user input.
+	if err != nil {
+		return 0, 0, false
+	}
+	defer f.Close()
+	m, err := formatv3.ReadManifestHeader(f)
+	if err != nil {
+		return 0, 0, false
+	}
+	dead := m.GetFoldDeadBytes()
+	if dead <= 0 {
+		return dead, 0, false
+	}
+	idx, err := formatv3.ReadIndexedFrameIndex(f)
+	if err != nil {
+		return dead, 0, true
+	}
+	live := idx.GetTotalRawSize() - dead
+	if live <= 0 {
+		return dead, live, true
+	}
+	return dead, live, false
 }
 
 // fileSizeOrZero returns the file's size, or 0 when it can't be
@@ -390,6 +482,7 @@ func (c *Compactor) compactPebbleFold(ctx context.Context) (string, error) {
 	// Apply partials newest-first (reverse entry order, excluding the
 	// base at entries[0]); strictly-newer-wins makes earlier
 	// applications take precedence on ties.
+	var foldStats mergepkg.FoldStats
 	for i := len(c.entries) - 1; i >= 1; i-- {
 		if err := ctx.Err(); err != nil {
 			return "", err
@@ -428,13 +521,46 @@ func (c *Compactor) compactPebbleFold(ctx context.Context) (string, error) {
 				maxEnded = ts.AsTime()
 			}
 		}
-		mergeErr := mergepkg.MergeInto(ctx, destEng, []mergepkg.SourceSync{{Engine: srcEng, SyncID: srcSyncID}}, baseSyncID)
+		mergeStats, mergeErr := mergepkg.MergeInto(ctx, destEng, []mergepkg.SourceSync{{Engine: srcEng, SyncID: srcSyncID}}, baseSyncID)
+		foldStats.Add(mergeStats)
 		if cerr := w.Close(ctx); cerr != nil {
 			l.Error("compactPebbleFold: error closing source store", zap.Error(cerr), zap.String("file", cs.FilePath))
 		}
 		if mergeErr != nil {
 			return "", fmt.Errorf("compactPebbleFold: merge %s: %w", cs.FilePath, mergeErr)
 		}
+	}
+
+	// Record the bytes this fold shadowed in the base keyspace. The
+	// store inherited the base manifest's running fold_dead_bytes at
+	// open (the dest is a byte copy of the base), so adding the delta
+	// keeps the manifest counter cumulative across consecutive folds;
+	// resolvePebbleMode's waste cutover reads it to force the eventual
+	// rebuild that reclaims the dead weight.
+	if foldStats.DeadBytes > 0 {
+		if !enginepkg.AddFoldDeadBytes(c.compactedC1z, foldStats.DeadBytes) {
+			return "", errors.New("compactPebbleFold: could not record fold dead bytes")
+		}
+	}
+
+	// Optionally compact the folded LSM before save. Off by default:
+	// a compaction rewrites the SSTs that overlap the partials' writes
+	// — for scattered overrides that is most of the base — which both
+	// costs O(base) on the critical path and makes those files no
+	// longer byte-identical to the source envelope's frames, so the
+	// splice-at-save degrades to a full re-encode. The payoff is an
+	// output with zero shadowed records (overrides otherwise leave
+	// dead bytes inside the spliced base frames). Experimental knob
+	// for measuring that trade-off; the long-term plan for reclaiming
+	// accumulated fold bloat is routing the occasional compaction to
+	// the rebuild path instead.
+	if os.Getenv("BATON_EXPERIMENTAL_FOLD_COMPACT") == "1" {
+		compactStart := time.Now()
+		if err := destEng.CompactAllRanges(ctx); err != nil {
+			return "", fmt.Errorf("compactPebbleFold: compact ranges: %w", err)
+		}
+		l.Info("compactPebbleFold: compacted LSM before save",
+			zap.Duration("elapsed", time.Since(compactStart)))
 	}
 
 	// Mint a fresh sync id for the folded output. Renaming a v3 c1z's
@@ -475,6 +601,8 @@ func (c *Compactor) compactPebbleFold(ctx context.Context) (string, error) {
 	l.Info("compactPebbleFold: done",
 		zap.String("base_sync_id", baseSyncID),
 		zap.String("folded_sync_id", newSyncID),
+		zap.Int64("overridden_records", foldStats.OverriddenRecords),
+		zap.Int64("dead_bytes", foldStats.DeadBytes),
 		zap.Duration("elapsed", time.Since(foldStart)),
 	)
 	return newSyncID, nil

--- a/pkg/synccompactor/pebble/doc.go
+++ b/pkg/synccompactor/pebble/doc.go
@@ -2,14 +2,21 @@
 // (Pebble-engine) c1z compaction.
 //
 // Three strategies live here. Which one runs is decided per compaction
-// by synccompactor.resolvePebbleMode: overlay is the default (and
-// currently the only auto-selected mode), fold runs only when
-// requested explicitly — its sync-id adoption is not yet handled by
-// downstream compaction bookkeeping — and kway is never auto-selected
-// on its own: it is overlay's internal fallback and an operational
-// escape hatch (BATON_EXPERIMENTAL_PEBBLE_COMPACTOR=kway). The
-// dormant fold cutover thresholds and the measured crossover data
-// live next to that gate.
+// by synccompactor.resolvePebbleMode. Fold is auto-selected for the
+// large-base/small-partials shape (summed partials ≤ 10% of the base
+// file, no minimum base size) now that a folded c1z gets a fresh sync
+// id — compactPebbleFold renames the single sync-run record, a
+// metadata-only write since keys carry no sync_id, so C1's compaction
+// bookkeeping sees a new LatestCompactedSyncId instead of mistaking the
+// fold for "no new compaction". Overlay is the default for every other
+// shape, and it also reclaims accumulated fold bloat: once a base's
+// recorded fold_dead_bytes crosses the waste cutover
+// (synccompactor.WithFoldMaxWastePercent, default 15% of live payload),
+// the gate flips a fold-shaped input back to overlay to rebuild it.
+// Kway is never auto-selected on its own: it is overlay's internal
+// fallback and an operational escape hatch
+// (BATON_EXPERIMENTAL_PEBBLE_COMPACTOR=kway). The fold cutover
+// thresholds and the measured crossover data live next to that gate.
 //
 // # Overlay merge (MergeFilesIntoOverlay) — the default rebuild
 //
@@ -59,7 +66,12 @@
 // base with small partials). It loses when partial volume grows:
 // every partial record pays a point read-modify-write (~0.2s/MB), so
 // the (dormant) auto gate caps partials at a small fraction of the
-// base.
+// base. Overridden incumbents leave their bytes shadowed inside the
+// spliced base frames; the merge counts them exactly (FoldStats) and
+// the compactor accumulates the total in the envelope manifest's
+// fold_dead_bytes, forcing an overlay rebuild once waste crosses the
+// cutover (synccompactor.WithFoldMaxWastePercent, default 15% of
+// live payload bytes).
 //
 // The package also hosts an IngestAndExcise-based Compactor, a
 // byte-level primitive that atomically replaces one sync_id range in a

--- a/pkg/synccompactor/pebble/kway.go
+++ b/pkg/synccompactor/pebble/kway.go
@@ -524,8 +524,6 @@ type directStream struct {
 	sourceRank int
 	iter       *cpebble.Iterator
 	bucket     bucketSpec
-	sourceLo   []byte
-	destLo     []byte
 
 	// keyBuf/valBuf back the runRecord returned by next(). The merge
 	// loops hold at most one live record per stream (in the heap or
@@ -551,15 +549,12 @@ func (s *directStream) next() (runRecord, bool, error) {
 		}
 		return runRecord{}, false, nil
 	}
-	// K-way's source stream is raw by default: copy the stored value, rewrite
-	// the primary key, and shallow-scan only discovered_at. Indexes are
-	// generated once for final winners instead of being carried through every
-	// run-file round; on non-skewed syncs=500, carrying index blobs accounted
-	// for tens of millions of allocations.
-	sourceKey := s.iter.Key()
-	if len(sourceKey) < len(s.sourceLo) {
-		return runRecord{}, false, fmt.Errorf("source key shorter than lower bound prefix: key=%d prefix=%d", len(sourceKey), len(s.sourceLo))
-	}
+	// K-way's source stream is raw: source keys and values are already
+	// in final dest form (v3 keys and values carry no sync_id), so the
+	// stream copies both verbatim and shallow-scans only discovered_at.
+	// Indexes are generated once for final winners instead of being
+	// carried through every run-file round; on non-skewed syncs=500,
+	// carrying index blobs accounted for tens of millions of allocations.
 	rank, err := checkedUint32(s.sourceRank, "source rank")
 	if err != nil {
 		return runRecord{}, false, err
@@ -568,7 +563,7 @@ func (s *directStream) next() (runRecord, bool, error) {
 	if err != nil {
 		return runRecord{}, false, err
 	}
-	s.keyBuf = rewritePrimaryKeyForDestInto(s.keyBuf[:0], sourceKey[len(s.sourceLo):], s.destLo)
+	s.keyBuf = append(s.keyBuf[:0], s.iter.Key()...)
 	s.valBuf = append(s.valBuf[:0], s.iter.Value()...)
 	item := runRecord{
 		key:        s.keyBuf,
@@ -595,7 +590,6 @@ func mergeSourceBucketToRunSection(
 		}
 	}()
 	lower, upper := bucket.syncRange()
-	destLower, _ := bucket.syncRange()
 	h := &directHeap{}
 	for i, source := range sources {
 		iter, err := source.engine.DB().NewIter(&cpebble.IterOptions{LowerBound: lower, UpperBound: upper})
@@ -607,8 +601,6 @@ func mergeSourceBucketToRunSection(
 			sourceRank: source.rank,
 			iter:       iter,
 			bucket:     bucket,
-			sourceLo:   lower,
-			destLo:     destLower,
 		}
 		streams = append(streams, stream)
 		rec, ok, err := stream.next()
@@ -684,7 +676,6 @@ func materializeSourceBucketToPebble(
 		}
 	}()
 	lower, upper := bucket.syncRange()
-	destLower, _ := bucket.syncRange()
 	h := &directHeap{}
 	for i, source := range sources {
 		iter, err := source.engine.DB().NewIter(&cpebble.IterOptions{LowerBound: lower, UpperBound: upper})
@@ -696,8 +687,6 @@ func materializeSourceBucketToPebble(
 			sourceRank: source.rank,
 			iter:       iter,
 			bucket:     bucket,
-			sourceLo:   lower,
-			destLo:     destLower,
 		}
 		streams = append(streams, stream)
 		rec, ok, err := stream.next()
@@ -733,7 +722,7 @@ func materializeSourceBucketToPebble(
 			if err := primaryWriter.Set(winner.key, winner.value); err != nil {
 				return err
 			}
-			if err := stats.countWinner(bucket, winner.key, destLower, winner.value); err != nil {
+			if err := stats.countWinner(bucket, winner.key, lower, winner.value); err != nil {
 				return err
 			}
 			lastPrimaryKey = append(lastPrimaryKey[:0], winner.key...)
@@ -741,7 +730,7 @@ func materializeSourceBucketToPebble(
 			// above (the winner-only contract on forEachIndexKeyFromRaw's
 			// stats parameter is satisfied either way, but counting twice
 			// would double the totals).
-			if err := forEachIndexKeyFromRaw(bucket, winner.key, destLower, winner.value, &scratch, nil, emitIndexKey); err != nil {
+			if err := forEachIndexKeyFromRaw(bucket, winner.key, lower, winner.value, &scratch, nil, emitIndexKey); err != nil {
 				return err
 			}
 		}
@@ -1018,11 +1007,6 @@ func timestampBytesNanosFromRaw(value []byte) (int64, error) {
 		return 0, fmt.Errorf("timestamp seconds overflow: %d", seconds)
 	}
 	return seconds*int64(time.Second) + int64(nanos), nil
-}
-
-func rewritePrimaryKeyForDestInto(dst []byte, sourceTail []byte, destLower []byte) []byte {
-	dst = append(dst, destLower...)
-	return append(dst, sourceTail...)
 }
 
 func indexID(key []byte) (byte, bool) {

--- a/pkg/synccompactor/pebble/merge.go
+++ b/pkg/synccompactor/pebble/merge.go
@@ -18,6 +18,28 @@ type SourceSync struct {
 	SyncID string
 }
 
+// FoldStats reports what a MergeInto call overrode in the destination
+// keyspace. DeadBytes is the exact raw size (keys + values) of the
+// incumbent records — and their derived index keys — that the fold
+// shadowed: because the envelope save splices the base's compressed
+// frames verbatim, those bytes stay in the output as dead weight.
+// Callers accumulate this into the manifest's fold_dead_bytes so the
+// auto cutover can force a rebuild once waste crosses its threshold.
+type FoldStats struct {
+	// OverriddenRecords counts incumbents replaced by a strictly-newer
+	// source record. Byte-identical resubmissions are no-ops and do
+	// not count.
+	OverriddenRecords int64
+	// DeadBytes sums len(key)+len(value) of each overridden incumbent
+	// plus len(key) of each of its stale derived index keys.
+	DeadBytes int64
+}
+
+func (s *FoldStats) Add(o FoldStats) {
+	s.OverriddenRecords += o.OverriddenRecords
+	s.DeadBytes += o.DeadBytes
+}
+
 // MergeInto folds every source's primary records into dest under
 // destSyncID. Across all inputs (and any records already present under
 // destSyncID), the newest record per logical key (by discovered_at,
@@ -48,29 +70,32 @@ type SourceSync struct {
 // the already-written (earlier source, or pre-existing dest) record is
 // kept. Callers pass sources newest-first so the tie winner matches the
 // SQLite fold.
-func MergeInto(ctx context.Context, dest *enginepkg.Engine, sources []SourceSync, destSyncID string) error {
+func MergeInto(ctx context.Context, dest *enginepkg.Engine, sources []SourceSync, destSyncID string) (FoldStats, error) {
+	var stats FoldStats
 	if dest == nil {
-		return errors.New("synccompactor/pebble.MergeInto: dest engine is nil")
+		return stats, errors.New("synccompactor/pebble.MergeInto: dest engine is nil")
 	}
 	if destSyncID == "" {
-		return errors.New("synccompactor/pebble.MergeInto: destSyncID is required")
+		return stats, errors.New("synccompactor/pebble.MergeInto: destSyncID is required")
 	}
 	if err := dest.SetCurrentSync(destSyncID); err != nil {
-		return fmt.Errorf("synccompactor/pebble.MergeInto: bind dest sync: %w", err)
+		return stats, fmt.Errorf("synccompactor/pebble.MergeInto: bind dest sync: %w", err)
 	}
 	for i := range sources {
 		if err := ctx.Err(); err != nil {
-			return err
+			return stats, err
 		}
 		s := sources[i]
 		if s.Engine == nil || s.SyncID == "" {
 			continue
 		}
-		if err := mergeOneSource(ctx, dest, s, destSyncID); err != nil {
-			return fmt.Errorf("merge source %s: %w", s.SyncID, err)
+		srcStats, err := mergeOneSource(ctx, dest, s, destSyncID)
+		stats.Add(srcStats)
+		if err != nil {
+			return stats, fmt.Errorf("merge source %s: %w", s.SyncID, err)
 		}
 	}
-	return nil
+	return stats, nil
 }
 
 // mergeRawFlushRecords bounds how many records accumulate in one raw
@@ -95,24 +120,28 @@ const mergeRawFlushRecords = 32768
 //     incumbent, mirroring the engine's Put*RecordsIfNewer rule —
 //     missing discovered_at scans as 0, reproducing its nil-timestamp
 //     ordering ("never overwrite an incumbent, always fill a hole").
-func mergeOneSource(ctx context.Context, dest *enginepkg.Engine, s SourceSync, destSyncID string) error {
+func mergeOneSource(ctx context.Context, dest *enginepkg.Engine, s SourceSync, destSyncID string) (FoldStats, error) {
+	var stats FoldStats
 	srcDB := s.Engine.DB()
 	if srcDB == nil {
-		return errors.New("source engine has no DB (closed?)")
+		return stats, errors.New("source engine has no DB (closed?)")
 	}
 	for _, bucket := range allBuckets() {
-		if err := mergeBucketRawIfNewer(ctx, dest, srcDB, bucket); err != nil {
-			return fmt.Errorf("merge %s: %w", bucket.name, err)
+		bucketStats, err := mergeBucketRawIfNewer(ctx, dest, srcDB, bucket)
+		stats.Add(bucketStats)
+		if err != nil {
+			return stats, fmt.Errorf("merge %s: %w", bucket.name, err)
 		}
 	}
-	return nil
+	return stats, nil
 }
 
-func mergeBucketRawIfNewer(ctx context.Context, dest *enginepkg.Engine, src *pebble.DB, bucket bucketSpec) error {
+func mergeBucketRawIfNewer(ctx context.Context, dest *enginepkg.Engine, src *pebble.DB, bucket bucketSpec) (FoldStats, error) {
+	var stats FoldStats
 	lower, upper := bucket.syncRange()
 	iter, err := src.NewIter(&pebble.IterOptions{LowerBound: lower, UpperBound: upper})
 	if err != nil {
-		return err
+		return stats, err
 	}
 	defer func() { _ = iter.Close() }()
 
@@ -124,7 +153,12 @@ func mergeBucketRawIfNewer(ctx context.Context, dest *enginepkg.Engine, src *peb
 	// The closures see batch by reference, so flush's reassignment
 	// routes subsequent index writes to the fresh batch.
 	setIndexKey := func(key []byte) error { return batch.Set(key, nil, nil) }
-	delIndexKey := func(key []byte) error { return batch.Delete(key, nil) }
+	// Each deleted index key is an incumbent's stale index entry: dead
+	// weight in the spliced base frames, counted toward FoldStats.
+	delIndexKey := func(key []byte) error {
+		stats.DeadBytes += int64(len(key))
+		return batch.Delete(key, nil)
+	}
 	flush := func() error {
 		if batch.Empty() {
 			return nil
@@ -142,7 +176,7 @@ func mergeBucketRawIfNewer(ctx context.Context, dest *enginepkg.Engine, src *peb
 
 	for iter.First(); iter.Valid(); iter.Next() {
 		if err := ctx.Err(); err != nil {
-			return err
+			return stats, err
 		}
 		key, value := iter.Key(), iter.Value()
 		// Point-read the committed incumbent. Safe against the pending
@@ -158,41 +192,46 @@ func mergeBucketRawIfNewer(ctx context.Context, dest *enginepkg.Engine, src *peb
 			newTs, err := discoveredAtNanosFromRaw(bucket, value)
 			if err != nil {
 				closer.Close()
-				return err
+				return stats, err
 			}
 			oldTs, err := discoveredAtNanosFromRaw(bucket, oldVal)
 			if err != nil {
 				closer.Close()
-				return err
+				return stats, err
 			}
 			if newTs <= oldTs {
 				closer.Close()
 				continue
 			}
+			// The incumbent loses: its key and value go dead inside the
+			// spliced base frames. Its stale index keys are counted by
+			// delIndexKey as forEachIndexKeyFromRaw enumerates them.
+			stats.OverriddenRecords++
+			stats.DeadBytes += int64(len(key)) + int64(len(oldVal))
 			if err := forEachIndexKeyFromRaw(bucket, key, lower, oldVal, &scratch, nil, delIndexKey); err != nil {
 				closer.Close()
-				return err
+				return stats, err
 			}
 			closer.Close()
 		case errors.Is(getErr, pebble.ErrNotFound):
 		default:
-			return fmt.Errorf("get incumbent: %w", getErr)
+			return stats, fmt.Errorf("get incumbent: %w", getErr)
 		}
 		if err := batch.Set(key, value, nil); err != nil {
-			return err
+			return stats, err
 		}
 		if err := forEachIndexKeyFromRaw(bucket, key, lower, value, &scratch, nil, setIndexKey); err != nil {
-			return err
+			return stats, err
 		}
 		pending++
 		if pending >= mergeRawFlushRecords {
 			if err := flush(); err != nil {
-				return err
+				return stats, err
 			}
 		}
 	}
 	if err := iter.Error(); err != nil {
-		return err
+		return stats, err
 	}
-	return flush()
+	return stats, flush()
 }

--- a/pkg/synccompactor/pebble/merge.go
+++ b/pkg/synccompactor/pebble/merge.go
@@ -1,14 +1,13 @@
 package pebble
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 
 	"github.com/cockroachdb/pebble/v2"
-	"google.golang.org/protobuf/proto"
 
-	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
 	enginepkg "github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble"
 )
 
@@ -23,22 +22,26 @@ type SourceSync struct {
 // destSyncID. Across all inputs (and any records already present under
 // destSyncID), the newest record per logical key (by discovered_at,
 // ties keep the incumbent) survives, and dest's derived indexes are
-// maintained by the keep-newer write path.
+// maintained by the raw keep-newer merge (mergeBucketRawIfNewer).
+//
+// The merge is byte-level end to end: v3 keys and values carry no
+// sync_id, so a source record is copied into dest verbatim — no proto
+// decode/re-encode — and a source record byte-identical to the
+// incumbent is a pure no-op.
 //
 // destSyncID must already exist in dest. It may be non-empty: the
 // in-place fold compaction merges partial syncs directly into the base
-// sync's keyspace, relying on the Put*RecordsIfNewer semantics to
-// resolve conflicts against pre-existing records. MergeInto binds the
-// dest engine's current sync to destSyncID — the engine's write
-// methods key off the current sync, not any per-record field.
+// sync's keyspace, resolving conflicts against pre-existing records
+// via the keep-newer rule. MergeInto binds the dest engine's current
+// sync to destSyncID for engine bookkeeping.
 //
 // Only the four primary record buckets are copied: resource_types,
 // resources, entitlements, grants. Assets are intentionally NOT copied
 // — this matches the SQLite compaction path, which folds only those
 // four tables and drops assets from the compacted sync; copying assets
 // here would give Pebble compacted syncs asset access the SQLite path
-// does not have. Index keyspaces are not copied verbatim either; the
-// per-record write path maintains them.
+// does not have. Index keyspaces are maintained per record (replaced
+// records get point deletes for their stale index keys).
 //
 // Sources are applied in the given order. The dedup keeps the record
 // with the strictly-greater discovered_at; on an equal discovered_at
@@ -70,86 +73,70 @@ func MergeInto(ctx context.Context, dest *enginepkg.Engine, sources []SourceSync
 	return nil
 }
 
-// mergeBatchSize bounds how many decoded records are held in memory
-// before a flush into the keep-newer put path. A whole bucket can hold
-// millions of records at the large-connector scale compaction targets,
-// so the merge streams in fixed-size batches rather than materializing
-// the bucket — peak heap stays O(mergeBatchSize), not O(bucket).
-const mergeBatchSize = 1000
+// mergeRawFlushRecords bounds how many records accumulate in one raw
+// write batch before it commits. Matches the overlay writer's chunk
+// size; peak batch memory stays O(chunk), not O(bucket).
+const mergeRawFlushRecords = 32768
 
-// mergeOneSource streams every primary record under s.SyncID, re-keys
-// it to destSyncID, and writes it into dest via the engine's keep-newer
-// put path (which dedups by discovered_at and rebuilds indexes). Each
-// bucket is drained in fixed-size batches to bound peak memory.
+// mergeOneSource streams every primary record of the source and folds
+// it into dest with keep-newer semantics, entirely at the byte level:
+// source keys and values are already in final dest form (v3 keys and
+// values carry no sync_id), so nothing is proto-decoded or re-encoded.
+// Per record:
+//
+//   - no incumbent at the key → raw copy + derived index keys;
+//   - incumbent byte-identical → pure no-op (no tombstones, no index
+//     churn — the common case when overlapping partials resubmit
+//     unchanged records);
+//   - otherwise a shallow discovered_at comparison decides: strictly
+//     newer wins, replacing the value and swapping the incumbent's
+//     derived index keys for the new value's (point deletes
+//     proportional to overridden records only). Ties keep the
+//     incumbent, mirroring the engine's Put*RecordsIfNewer rule —
+//     missing discovered_at scans as 0, reproducing its nil-timestamp
+//     ordering ("never overwrite an incumbent, always fill a hole").
 func mergeOneSource(ctx context.Context, dest *enginepkg.Engine, s SourceSync, destSyncID string) error {
 	srcDB := s.Engine.DB()
 	if srcDB == nil {
 		return errors.New("source engine has no DB (closed?)")
 	}
-
-	if err := streamBucket(ctx, srcDB,
-		enginepkg.ResourceTypeLowerBound(), enginepkg.ResourceTypeUpperBound(),
-		func() *v3.ResourceTypeRecord { return &v3.ResourceTypeRecord{} },
-		dest.PutResourceTypeRecordsIfNewer,
-	); err != nil {
-		return fmt.Errorf("merge resource_types: %w", err)
+	for _, bucket := range allBuckets() {
+		if err := mergeBucketRawIfNewer(ctx, dest, srcDB, bucket); err != nil {
+			return fmt.Errorf("merge %s: %w", bucket.name, err)
+		}
 	}
-
-	if err := streamBucket(ctx, srcDB,
-		enginepkg.ResourceLowerBound(), enginepkg.ResourceUpperBound(),
-		func() *v3.ResourceRecord { return &v3.ResourceRecord{} },
-		dest.PutResourceRecordsIfNewer,
-	); err != nil {
-		return fmt.Errorf("merge resources: %w", err)
-	}
-
-	if err := streamBucket(ctx, srcDB,
-		enginepkg.EntitlementLowerBound(), enginepkg.EntitlementUpperBound(),
-		func() *v3.EntitlementRecord { return &v3.EntitlementRecord{} },
-		dest.PutEntitlementRecordsIfNewer,
-	); err != nil {
-		return fmt.Errorf("merge entitlements: %w", err)
-	}
-
-	if err := streamBucket(ctx, srcDB,
-		enginepkg.GrantLowerBound(), enginepkg.GrantUpperBound(),
-		func() *v3.GrantRecord { return &v3.GrantRecord{} },
-		dest.PutGrantRecordsIfNewer,
-	); err != nil {
-		return fmt.Errorf("merge grants: %w", err)
-	}
-
 	return nil
 }
 
-// streamBucket drains a primary bucket's [lower, upper) key range,
-// unmarshalling each value into a fresh T (the stored value is a
-// deterministic proto marshal of the v3 record) and flushing fixed-size
-// batches into put. The destination sync id is supplied by the engine's
-// current-sync key context; data record values do not carry sync_id.
-// Peak memory is bounded by mergeBatchSize rather than the bucket size.
-func streamBucket[T proto.Message](
-	ctx context.Context,
-	db *pebble.DB,
-	lower, upper []byte,
-	mk func() T,
-	put func(context.Context, ...T) error,
-) error {
-	iter, err := db.NewIter(&pebble.IterOptions{LowerBound: lower, UpperBound: upper})
+func mergeBucketRawIfNewer(ctx context.Context, dest *enginepkg.Engine, src *pebble.DB, bucket bucketSpec) error {
+	lower, upper := bucket.syncRange()
+	iter, err := src.NewIter(&pebble.IterOptions{LowerBound: lower, UpperBound: upper})
 	if err != nil {
 		return err
 	}
 	defer func() { _ = iter.Close() }()
 
-	batch := make([]T, 0, mergeBatchSize)
+	destDB := dest.DB()
+	batch := destDB.NewBatch()
+	defer func() { _ = batch.Close() }()
+	pending := 0
+	var scratch rawIndexScratch
+	// The closures see batch by reference, so flush's reassignment
+	// routes subsequent index writes to the fresh batch.
+	setIndexKey := func(key []byte) error { return batch.Set(key, nil, nil) }
+	delIndexKey := func(key []byte) error { return batch.Delete(key, nil) }
 	flush := func() error {
-		if len(batch) == 0 {
+		if batch.Empty() {
 			return nil
 		}
-		if err := put(ctx, batch...); err != nil {
+		// NoSync: the fold's envelope save checkpoints (which flushes
+		// and fsyncs) before anything depends on these writes.
+		if err := batch.Commit(pebble.NoSync); err != nil {
 			return err
 		}
-		batch = batch[:0]
+		_ = batch.Close()
+		batch = destDB.NewBatch()
+		pending = 0
 		return nil
 	}
 
@@ -157,12 +144,48 @@ func streamBucket[T proto.Message](
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		rec := mk()
-		if err := proto.Unmarshal(iter.Value(), rec); err != nil {
-			return fmt.Errorf("unmarshal record: %w", err)
+		key, value := iter.Key(), iter.Value()
+		// Point-read the committed incumbent. Safe against the pending
+		// batch: a sync holds one record per key, so no key repeats
+		// within this loop, and earlier sources were fully flushed.
+		oldVal, closer, getErr := destDB.Get(key)
+		switch {
+		case getErr == nil:
+			if bytes.Equal(oldVal, value) {
+				closer.Close()
+				continue
+			}
+			newTs, err := discoveredAtNanosFromRaw(bucket, value)
+			if err != nil {
+				closer.Close()
+				return err
+			}
+			oldTs, err := discoveredAtNanosFromRaw(bucket, oldVal)
+			if err != nil {
+				closer.Close()
+				return err
+			}
+			if newTs <= oldTs {
+				closer.Close()
+				continue
+			}
+			if err := forEachIndexKeyFromRaw(bucket, key, lower, oldVal, &scratch, nil, delIndexKey); err != nil {
+				closer.Close()
+				return err
+			}
+			closer.Close()
+		case errors.Is(getErr, pebble.ErrNotFound):
+		default:
+			return fmt.Errorf("get incumbent: %w", getErr)
 		}
-		batch = append(batch, rec)
-		if len(batch) >= mergeBatchSize {
+		if err := batch.Set(key, value, nil); err != nil {
+			return err
+		}
+		if err := forEachIndexKeyFromRaw(bucket, key, lower, value, &scratch, nil, setIndexKey); err != nil {
+			return err
+		}
+		pending++
+		if pending >= mergeRawFlushRecords {
 			if err := flush(); err != nil {
 				return err
 			}

--- a/pkg/synccompactor/pebble/merge_test.go
+++ b/pkg/synccompactor/pebble/merge_test.go
@@ -5,10 +5,13 @@ import (
 	"testing"
 	"time"
 
+	cpebble "github.com/cockroachdb/pebble/v2"
 	"github.com/segmentio/ksuid"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
+	enginepkg "github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble"
 )
 
 func grantAt(syncID, externalID string, at time.Time) *v3.GrantRecord {
@@ -60,8 +63,18 @@ func TestMergeIntoUnionNewerWins(t *testing.T) {
 	// No SetCurrentSync here: MergeInto must bind the dest engine to
 	// destSyncID itself (record values carry no sync_id, so a stale
 	// binding would silently write into the wrong sync's keyspace).
-	if err := MergeInto(ctx, dst, []SourceSync{{Engine: src1, SyncID: syncA}, {Engine: src2, SyncID: syncB}}, destSync); err != nil {
+	stats, err := MergeInto(ctx, dst, []SourceSync{{Engine: src1, SyncID: syncA}, {Engine: src2, SyncID: syncB}}, destSync)
+	if err != nil {
 		t.Fatalf("MergeInto: %v", err)
+	}
+	// src2's g-shared@newer overrode src1's incumbent — exactly one
+	// override, and its dead bytes must cover at least the incumbent's
+	// key+value.
+	if stats.OverriddenRecords != 1 {
+		t.Fatalf("FoldStats.OverriddenRecords = %d, want 1", stats.OverriddenRecords)
+	}
+	if stats.DeadBytes <= 0 {
+		t.Fatalf("FoldStats.DeadBytes = %d, want > 0 (overridden incumbent's key+value+index keys)", stats.DeadBytes)
 	}
 
 	// Union of distinct external_ids: g-shared, g-only1, g-only2 = 3.
@@ -127,8 +140,13 @@ func TestMergeIntoTieKeepsIncumbent(t *testing.T) {
 	}
 	// src1 applied first → incumbent wins the tie. MergeInto binds the
 	// dest sync itself.
-	if err := MergeInto(ctx, dst, []SourceSync{{Engine: src1, SyncID: syncA}, {Engine: src2, SyncID: syncB}}, destSync); err != nil {
+	stats, err := MergeInto(ctx, dst, []SourceSync{{Engine: src1, SyncID: syncA}, {Engine: src2, SyncID: syncB}}, destSync)
+	if err != nil {
 		t.Fatal(err)
+	}
+	// A tie keeps the incumbent — nothing is overridden, no dead bytes.
+	if stats.OverriddenRecords != 0 || stats.DeadBytes != 0 {
+		t.Fatalf("FoldStats = %+v, want zero (tie keeps incumbent)", stats)
 	}
 
 	var winner string
@@ -142,4 +160,167 @@ func TestMergeIntoTieKeepsIncumbent(t *testing.T) {
 		t.Fatalf("tie winner = %q, want from-src1 (earliest-applied incumbent, strict-> parity)", winner)
 	}
 	assertIndexesMatchDerived(t, ctx, dst)
+}
+
+// baseNewerSets returns a base record set (one record per primary type)
+// stamped at `base` and an overriding source set with the SAME keys but
+// distinct display/principal tags stamped at `other`. The two stamps
+// let a test fold an older source into a newer base, or vice versa, and
+// assert per-type winner + FoldStats without rebuilding fixtures.
+func baseNewerSets(base, other time.Time) (recordSet, recordSet) {
+	baseSet := recordSet{
+		rts: []*v3.ResourceTypeRecord{winRT("rt-1", "rt-base", base)},
+		rs:  []*v3.ResourceRecord{winRes("user", "u1", "res-base", base)},
+		es:  []*v3.EntitlementRecord{winEnt("e-1", "ent-base", base)},
+		gs:  []*v3.GrantRecord{winGrant("g-1", "base", base)},
+	}
+	otherSet := recordSet{
+		rts: []*v3.ResourceTypeRecord{winRT("rt-1", "rt-other", other)},
+		rs:  []*v3.ResourceRecord{winRes("user", "u1", "res-other", other)},
+		es:  []*v3.EntitlementRecord{winEnt("e-1", "ent-other", other)},
+		gs:  []*v3.GrantRecord{winGrant("g-1", "other", other)},
+	}
+	return baseSet, otherSet
+}
+
+func seedBase(t *testing.T, ctx context.Context, name string, rs recordSet) (*enginepkg.Engine, string) {
+	t.Helper()
+	dest, _ := newEngine(t, name)
+	destSync := ksuid.New().String()
+	require.NoError(t, dest.SetCurrentSync(destSync))
+	populateEngine(t, ctx, dest, rs)
+	return dest, destSync
+}
+
+func assertFoldWinners(t *testing.T, ctx context.Context, eng *enginepkg.Engine, rtDN, resDN, entDN, grantPrincipal string) {
+	t.Helper()
+	rt, err := eng.GetResourceTypeRecord(ctx, "rt-1")
+	require.NoError(t, err)
+	require.Equal(t, rtDN, rt.GetDisplayName(), "resource_type winner")
+	res, err := eng.GetResourceRecord(ctx, "user", "u1")
+	require.NoError(t, err)
+	require.Equal(t, resDN, res.GetDisplayName(), "resource winner")
+	ent, err := eng.GetEntitlementRecord(ctx, "e-1")
+	require.NoError(t, err)
+	require.Equal(t, entDN, ent.GetDisplayName(), "entitlement winner")
+	g, err := eng.GetGrantRecord(ctx, "g-1")
+	require.NoError(t, err)
+	require.Equal(t, grantPrincipal, g.GetPrincipal().GetResourceId(), "grant winner")
+}
+
+// TestMergeIntoBaseNewerKeepsBaseAllTypes is the symmetric counterpart
+// to TestMergeIntoUnionNewerWins for the real fold shape: an OLDER
+// partial folded into a newer pre-seeded base must NOT regress any of
+// the four primary record types. This is the "newer data already lives
+// in the base sync" case — the fold must keep every incumbent, record
+// nothing as overridden, and leave the derived indexes untouched. It
+// guards the strict-newer comparison (`newTs <= oldTs` keeps the
+// incumbent) for every per-type discovered_at field, not just grants.
+func TestMergeIntoBaseNewerKeepsBaseAllTypes(t *testing.T) {
+	ctx := context.Background()
+	older := time.Unix(1000, 0).UTC()
+	newer := time.Unix(2000, 0).UTC()
+
+	baseSet, olderSet := baseNewerSets(newer, older)
+	dest, destSync := seedBase(t, ctx, "base-newer-dest", baseSet)
+	src := buildEngineSource(t, ctx, "older-src", olderSet)
+
+	stats, err := MergeInto(ctx, dest, []SourceSync{src}, destSync)
+	require.NoError(t, err)
+
+	// Nothing regressed: the base (newer) version survives for every type.
+	assertFoldWinners(t, ctx, dest, "rt-base", "res-base", "ent-base", "base")
+	// An older source overrides nothing, so no dead weight accrues.
+	require.Zero(t, stats.OverriddenRecords, "older partial must override nothing")
+	require.Zero(t, stats.DeadBytes, "no overrides means no dead bytes")
+	assertIndexesMatchDerived(t, ctx, dest)
+}
+
+// TestMergeIntoNewerPartialOverridesBaseAllTypes is the override
+// direction into a pre-seeded base: a NEWER partial replaces the base's
+// record for every primary type, FoldStats counts one override per type
+// with positive dead bytes, and the stale index keys are swapped for
+// the winners'. Together with the base-newer test this pins newest-wins
+// in BOTH directions across all four discovered_at fields.
+func TestMergeIntoNewerPartialOverridesBaseAllTypes(t *testing.T) {
+	ctx := context.Background()
+	older := time.Unix(1000, 0).UTC()
+	newer := time.Unix(2000, 0).UTC()
+
+	baseSet, newerSet := baseNewerSets(older, newer)
+	dest, destSync := seedBase(t, ctx, "base-older-dest", baseSet)
+	src := buildEngineSource(t, ctx, "newer-src", newerSet)
+
+	stats, err := MergeInto(ctx, dest, []SourceSync{src}, destSync)
+	require.NoError(t, err)
+
+	// The newer partial wins for every type.
+	assertFoldWinners(t, ctx, dest, "rt-other", "res-other", "ent-other", "other")
+	// One override per primary record type (rt, resource, entitlement, grant).
+	require.Equal(t, int64(4), stats.OverriddenRecords, "one override per primary type")
+	require.Positive(t, stats.DeadBytes, "overrides must record the shadowed incumbents' bytes")
+	assertIndexesMatchDerived(t, ctx, dest)
+}
+
+// sumBucketRawBytes sums len(key)+len(value) over a bucket's primary
+// range and every one of its derived index ranges — the exact byte
+// total the fold merge must charge as dead when every record in the
+// bucket is overridden (index values are empty, so an index entry
+// contributes only its key length, matching the merge's accounting).
+func sumBucketRawBytes(t *testing.T, eng *enginepkg.Engine, bucket bucketSpec) int64 {
+	t.Helper()
+	lo, hi := bucket.syncRange()
+	ranges := append([][2][]byte{{lo, hi}}, bucketIndexRanges(bucket)...)
+	var total int64
+	for _, r := range ranges {
+		iter, err := eng.DB().NewIter(&cpebble.IterOptions{LowerBound: r[0], UpperBound: r[1]})
+		require.NoError(t, err)
+		for iter.First(); iter.Valid(); iter.Next() {
+			total += int64(len(iter.Key())) + int64(len(iter.Value()))
+		}
+		require.NoError(t, iter.Error())
+		require.NoError(t, iter.Close())
+	}
+	return total
+}
+
+// TestMergeIntoDeadBytesExactCount pins FoldStats.DeadBytes to the exact
+// footprint of the shadowed incumbent — primary key+value plus every
+// derived index key — instead of just "> 0". It seeds one grant,
+// measures its on-disk byte total straight from the dest LSM, then folds
+// a strictly-newer override and asserts the reported dead bytes equal
+// that measured footprint. The override is a deliberately different size
+// (longer principal) and carries an extra index key (needs_expansion),
+// so a wrong-record miscount — charging the winner's bytes, or dropping
+// the index-key bytes — can't coincidentally match. This is the guard
+// the qualitative >0 / grows / resets assertions can't provide.
+func TestMergeIntoDeadBytesExactCount(t *testing.T) {
+	ctx := context.Background()
+	older := time.Unix(1000, 0).UTC()
+	newer := time.Unix(2000, 0).UTC()
+
+	dest, destSync := seedBase(t, ctx, "deadbytes-dest", recordSet{
+		gs: []*v3.GrantRecord{winGrant("g-1", "p", older)},
+	})
+	// Exact footprint of the incumbent the override will shadow,
+	// measured before the merge touches it.
+	wantDead := sumBucketRawBytes(t, dest, grantBucket())
+
+	override := v3.GrantRecord_builder{
+		ExternalId: "g-1",
+		Entitlement: v3.EntitlementRef_builder{
+			ResourceTypeId: "app", ResourceId: "github", EntitlementId: "ent-A",
+		}.Build(),
+		Principal:      v3.PrincipalRef_builder{ResourceTypeId: "user", ResourceId: "a-deliberately-longer-principal-id"}.Build(),
+		NeedsExpansion: true,
+		DiscoveredAt:   timestamppb.New(newer),
+	}.Build()
+	src := buildEngineSource(t, ctx, "deadbytes-src", recordSet{gs: []*v3.GrantRecord{override}})
+
+	stats, err := MergeInto(ctx, dest, []SourceSync{src}, destSync)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), stats.OverriddenRecords)
+	require.Equal(t, wantDead, stats.DeadBytes,
+		"dead bytes must equal the incumbent's primary key+value plus its index keys")
+	assertIndexesMatchDerived(t, ctx, dest)
 }

--- a/pkg/synccompactor/pebble/merge_test.go
+++ b/pkg/synccompactor/pebble/merge_test.go
@@ -90,6 +90,11 @@ func TestMergeIntoUnionNewerWins(t *testing.T) {
 			t.Errorf("%q missing from merged union", id)
 		}
 	}
+
+	// The raw merge derives index keys itself (no engine put path):
+	// every index keyspace must match a recompute from the surviving
+	// primary records, including the replaced incumbent's swapped keys.
+	assertIndexesMatchDerived(t, ctx, dst)
 }
 
 // TestMergeIntoTieKeepsIncumbent pins the equal-discovered_at tie rule
@@ -136,4 +141,5 @@ func TestMergeIntoTieKeepsIncumbent(t *testing.T) {
 	if winner != "from-src1" {
 		t.Fatalf("tie winner = %q, want from-src1 (earliest-applied incumbent, strict-> parity)", winner)
 	}
+	assertIndexesMatchDerived(t, ctx, dst)
 }

--- a/pkg/synccompactor/pebble/overlay.go
+++ b/pkg/synccompactor/pebble/overlay.go
@@ -889,24 +889,24 @@ func overlaySinglePassBucket(
 	seen *seenSuffixSet,
 	hardLimit int64,
 ) error {
-	destLower, _ := bucket.syncRange()
-	sourceLower, sourceUpper := bucket.syncRange()
-	iter, err := source.DB().NewIter(&cpebble.IterOptions{LowerBound: sourceLower, UpperBound: sourceUpper})
+	lower, upper := bucket.syncRange()
+	iter, err := source.DB().NewIter(&cpebble.IterOptions{LowerBound: lower, UpperBound: upper})
 	if err != nil {
 		return err
 	}
 	defer iter.Close()
-	var destKey []byte
 	for iter.First(); iter.Valid(); iter.Next() {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		// Dedupe on the primary-key suffix before constructing the
-		// destination key. Admission is hash-based and allocation-free
-		// (see seenSuffixSet); the shallow discovered_at scan keeps the
-		// winner rule identical to K-way / sqlite.
-		sourceSuffix := iter.Key()[len(sourceLower):]
-		k := seen.keyOf(sourceSuffix)
+		// Dedupe on the primary-key suffix. Source keys are already in
+		// final dest form (no sync_id), so admitted records are written
+		// under iter.Key() verbatim. Admission is hash-based and
+		// allocation-free (see seenSuffixSet); the shallow
+		// discovered_at scan keeps the winner rule identical to
+		// K-way / sqlite.
+		suffix := iter.Key()[len(lower):]
+		k := seen.keyOf(suffix)
 		ts, err := discoveredAtNanosFromRaw(bucket, iter.Value())
 		if err != nil {
 			return err
@@ -920,8 +920,7 @@ func overlaySinglePassBucket(
 			if ts <= prevTs {
 				continue
 			}
-			destKey = rewritePrimaryKeyForDestInto(destKey[:0], sourceSuffix, destLower)
-			if err := writer.replaceRaw(ctx, bucket, destKey, destLower, iter.Value()); err != nil {
+			if err := writer.replaceRaw(ctx, bucket, iter.Key(), lower, iter.Value()); err != nil {
 				return err
 			}
 			seen.put(k, ts)
@@ -935,8 +934,7 @@ func overlaySinglePassBucket(
 			return errOverlayHardLimit
 		}
 		seen.put(k, ts)
-		destKey = rewritePrimaryKeyForDestInto(destKey[:0], sourceSuffix, destLower)
-		if err := writer.addRaw(ctx, bucket, destKey, destLower, iter.Value()); err != nil {
+		if err := writer.addRaw(ctx, bucket, iter.Key(), lower, iter.Value()); err != nil {
 			return err
 		}
 	}
@@ -997,6 +995,12 @@ func overlayWholeSourceWorthIt(ctx context.Context, source sourceHandle, bucket 
 // strictly newer (by discovered_at) is replaced through the writer's
 // batch path instead, preserving the merge-wide winner rule.
 //
+// Secondary indexes are NOT derived here: the source's index
+// keyspaces are copied verbatim by overlayCopySourceIndexesSST, which
+// applies the same seen-set filter at byte level. Re-deriving and
+// re-sorting index keys per record was the whole-source path's
+// dominant allocation and CPU cost.
+//
 // This is the bulk path for the production skewed shape: a large base
 // sync with a small partial-derived seen set streams through here at
 // SST-build speed instead of paying memtable insertion, flush, and
@@ -1011,9 +1015,8 @@ func overlayMaterializeWholeSourceBucketSST(
 	tmpDir string,
 	stats *mergeStatsAccumulator,
 ) error {
-	sourceLower, sourceUpper := bucket.syncRange()
-	destLower, _ := bucket.syncRange()
-	iter, err := source.DB().NewIter(&cpebble.IterOptions{LowerBound: sourceLower, UpperBound: sourceUpper})
+	lower, upper := bucket.syncRange()
+	iter, err := source.DB().NewIter(&cpebble.IterOptions{LowerBound: lower, UpperBound: upper})
 	if err != nil {
 		return err
 	}
@@ -1031,28 +1034,22 @@ func overlayMaterializeWholeSourceBucketSST(
 			_ = os.Remove(primaryPath)
 		}
 	}()
-	indexWriters, err := newIndexWriterSet(tmpDir, bucket.name+"-overlay-whole-index")
-	if err != nil {
-		return err
-	}
-	defer indexWriters.cleanup()
 
 	wrotePrimary := false
 	checkSeen := seen.size() > 0
-	var destKey []byte
-	var scratch rawIndexScratch
-	emitIndexKey := indexWriters.writeKey
 	for iter.First(); iter.Valid(); iter.Next() {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
+		// Source keys are already in final dest form (no sync_id):
+		// winners are written under iter.Key() verbatim.
 		sourceKey := iter.Key()
-		if len(sourceKey) < len(sourceLower) {
-			return fmt.Errorf("overlay merge: source key shorter than lower bound prefix: key=%d prefix=%d", len(sourceKey), len(sourceLower))
+		if len(sourceKey) < len(lower) {
+			return fmt.Errorf("overlay merge: source key shorter than lower bound prefix: key=%d prefix=%d", len(sourceKey), len(lower))
 		}
-		sourceSuffix := sourceKey[len(sourceLower):]
+		suffix := sourceKey[len(lower):]
 		if checkSeen {
-			if prevTs, ok := seen.get(seen.keyOf(sourceSuffix)); ok {
+			if prevTs, ok := seen.get(seen.keyOf(suffix)); ok {
 				// Admitted by an earlier (newer) source. Same rule as
 				// overlaySinglePassBucket: replace only on a strictly
 				// newer discovered_at, through the batch path (rare).
@@ -1064,24 +1061,22 @@ func overlayMaterializeWholeSourceBucketSST(
 				if ts <= prevTs {
 					continue
 				}
-				destKey = rewritePrimaryKeyForDestInto(destKey[:0], sourceSuffix, destLower)
-				if err := writer.replaceRaw(ctx, bucket, destKey, destLower, iter.Value()); err != nil {
+				if err := writer.replaceRaw(ctx, bucket, sourceKey, lower, iter.Value()); err != nil {
 					return err
 				}
 				continue
 			}
 		}
-		destKey = rewritePrimaryKeyForDestInto(destKey[:0], sourceSuffix, destLower)
-		if err := primaryWriter.Set(destKey, iter.Value()); err != nil {
+		if err := primaryWriter.Set(sourceKey, iter.Value()); err != nil {
 			return err
 		}
 		wrotePrimary = true
-		// Every unseen key in this path is a winner.
-		stats.countWinnerTotal(bucket.id)
-		if bucket.forEachIndexKey != nil {
-			if err := forEachIndexKeyFromRaw(bucket, destKey, destLower, iter.Value(), &scratch, stats, emitIndexKey); err != nil {
-				return err
-			}
+		// Every unseen key in this path is a winner. countWinner does
+		// total + grouping (resources: from the key tail; grants: a
+		// shallow value scan) — the grouping the removed index-key
+		// derivation used to piggyback.
+		if err := stats.countWinner(bucket, sourceKey, lower, iter.Value()); err != nil {
+			return err
 		}
 	}
 	if err := iter.Error(); err != nil {
@@ -1097,7 +1092,139 @@ func overlayMaterializeWholeSourceBucketSST(
 			return fmt.Errorf("overlay merge: ingest whole primary %s: %w", bucket.name, err)
 		}
 	}
-	return indexWriters.closeSortAndIngest(ctx, dest)
+	return overlayCopySourceIndexesSST(ctx, dest, source, bucket, seen, tmpDir)
+}
+
+// indexKeyPrimarySuffix extracts the trailing tuple elements of an
+// index key that form the corresponding record's primary-key suffix —
+// the exact bytes the seen set hashed when the record was admitted:
+//
+//   - grants / entitlements: every index family's last element is the
+//     record's external_id, and the grant/entitlement primary suffix
+//     is sep | esc(external_id) → elems = 1;
+//   - resources (by_parent): the tail is (parent_rt, parent_id,
+//     child_rt, child_id) and the resource primary suffix is
+//     sep | esc(rt) | sep | esc(id) → elems = 2.
+//
+// The returned slice INCLUDES the leading separator, matching
+// key[len(lower):] of the primary key byte-for-byte: tuple escaping
+// guarantees element bytes never contain a bare separator (0x00), so
+// the separators found by LastIndexByte are exactly the element
+// boundaries, and the escaped element bytes are identical in primary
+// and index keys.
+func indexKeyPrimarySuffix(key []byte, elems int) ([]byte, error) {
+	i := len(key)
+	for n := 0; n < elems; n++ {
+		i = bytes.LastIndexByte(key[:i], 0x00)
+		if i < 3 {
+			// Position 3 is the first separator (after the 3-byte
+			// v3|typeIndex|idx header); anything earlier means the key
+			// has fewer tuple elements than the family guarantees.
+			return nil, fmt.Errorf("overlay merge: index key too short for %d-element suffix: %x", elems, key)
+		}
+	}
+	return key[i:], nil
+}
+
+// overlayCopySourceIndexesSST streams one bucket's secondary-index
+// keyspaces from the source verbatim into a single SST and ingests it.
+// Source index keys are already in final dest byte form (v3 keys carry
+// no sync_id) and each family range is already sorted, so no per-record
+// derivation, run files, or external sort are needed.
+//
+// Index entries belonging to records the primary copy filtered out
+// (admitted earlier by a newer source) are dropped by probing the seen
+// set with the index key's primary suffix (indexKeyPrimarySuffix).
+// Replacements that went through the batch path re-emit their own
+// index keys there, so dropping every seen entry here is exact.
+func overlayCopySourceIndexesSST(
+	ctx context.Context,
+	dest *enginepkg.Engine,
+	source *enginepkg.Engine,
+	bucket bucketSpec,
+	seen *seenSuffixSet,
+	tmpDir string,
+) error {
+	ranges := bucketIndexRanges(bucket)
+	if len(ranges) == 0 {
+		return nil
+	}
+	// SST keys must be appended in ascending order; the family ranges
+	// are disjoint, so ordering them by lower bound suffices.
+	sort.Slice(ranges, func(i, j int) bool {
+		return bytes.Compare(ranges[i][0], ranges[j][0]) < 0
+	})
+	suffixElems := 1
+	if bucket.id == runBucketResources {
+		suffixElems = 2
+	}
+	sstPath := filepath.Join(tmpDir, fmt.Sprintf("overlay-whole-%s-index.sst", bucket.name))
+	w, err := newSSTBuilder(sstPath)
+	if err != nil {
+		return err
+	}
+	success := false
+	defer func() {
+		if !success {
+			_ = w.Close()
+		}
+		_ = os.Remove(sstPath)
+	}()
+	checkSeen := seen.size() > 0
+	wrote := false
+	for _, r := range ranges {
+		if err := copyIndexRangeFiltered(ctx, source, r[0], r[1], checkSeen, seen, suffixElems, w, &wrote); err != nil {
+			return err
+		}
+	}
+	if err := w.Close(); err != nil {
+		return err
+	}
+	success = true
+	if !wrote {
+		return nil
+	}
+	if err := dest.DB().Ingest(ctx, []string{sstPath}); err != nil {
+		return fmt.Errorf("overlay merge: ingest whole index %s: %w", bucket.name, err)
+	}
+	return nil
+}
+
+func copyIndexRangeFiltered(
+	ctx context.Context,
+	source *enginepkg.Engine,
+	lower, upper []byte,
+	checkSeen bool,
+	seen *seenSuffixSet,
+	suffixElems int,
+	w *sstBuilder,
+	wrote *bool,
+) error {
+	iter, err := source.DB().NewIter(&cpebble.IterOptions{LowerBound: lower, UpperBound: upper})
+	if err != nil {
+		return err
+	}
+	defer iter.Close()
+	for iter.First(); iter.Valid(); iter.Next() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		key := iter.Key()
+		if checkSeen {
+			suffix, err := indexKeyPrimarySuffix(key, suffixElems)
+			if err != nil {
+				return err
+			}
+			if _, ok := seen.get(seen.keyOf(suffix)); ok {
+				continue
+			}
+		}
+		if err := w.Set(key, nil); err != nil {
+			return err
+		}
+		*wrote = true
+	}
+	return iter.Error()
 }
 
 type rawIndexScratch struct {

--- a/pkg/synccompactor/pebble/overlay_index_copy_test.go
+++ b/pkg/synccompactor/pebble/overlay_index_copy_test.go
@@ -1,0 +1,291 @@
+package pebble
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	cpebble "github.com/cockroachdb/pebble/v2"
+	"github.com/segmentio/ksuid"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	enginepkg "github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble"
+)
+
+// TestIndexKeyPrimarySuffix pins the byte-level contract behind the
+// whole-source verbatim index copy: the trailing tuple elements of an
+// index key are byte-identical to the corresponding primary key's
+// suffix (key[len(prefix):]), including for IDs containing the tuple
+// separator (0x00) and escape (0x01) bytes.
+func TestIndexKeyPrimarySuffix(t *testing.T) {
+	nasty := []string{
+		"plain",
+		"",
+		"with\x00nul",
+		"with\x01esc",
+		"\x00",
+		"\x01\x01",
+		"tail\x00",
+	}
+	for _, ext := range nasty {
+		primarySuffix := enginepkg.GrantRecordKey(ext)[2:]
+		grantIndexKeys := [][]byte{
+			enginepkg.AppendGrantByEntitlementIndexKeyRawBytes(nil, []byte("ent\x00id"), []byte("user"), []byte("alice"), []byte(ext)),
+			enginepkg.AppendGrantByEntitlementResourceIndexKeyRawBytes(nil, []byte("group"), []byte("eng\x01"), []byte(ext)),
+			enginepkg.AppendGrantByPrincipalIndexKeyRawBytes(nil, []byte("user"), []byte("ali\x00ce"), []byte(ext)),
+			enginepkg.AppendGrantByPrincipalResourceTypeIndexKeyRawBytes(nil, []byte("user"), []byte(ext)),
+			enginepkg.AppendGrantByNeedsExpansionIndexKeyRawBytes(nil, []byte(ext)),
+		}
+		for i, key := range grantIndexKeys {
+			got, err := indexKeyPrimarySuffix(key, 1)
+			if err != nil {
+				t.Fatalf("ext=%q family=%d: %v", ext, i, err)
+			}
+			if !bytes.Equal(got, primarySuffix) {
+				t.Fatalf("ext=%q family=%d: suffix = %x, want %x", ext, i, got, primarySuffix)
+			}
+		}
+	}
+	for _, rt := range nasty {
+		for _, id := range nasty {
+			primarySuffix := enginepkg.ResourceRecordKey(rt, id)[2:]
+			key := enginepkg.AppendResourceIndexKeyRawBytes(nil, []byte("par\x00ent"), []byte("p\x01id"), []byte(rt), []byte(id))
+			got, err := indexKeyPrimarySuffix(key, 2)
+			if err != nil {
+				t.Fatalf("rt=%q id=%q: %v", rt, id, err)
+			}
+			if !bytes.Equal(got, primarySuffix) {
+				t.Fatalf("rt=%q id=%q: suffix = %x, want %x", rt, id, got, primarySuffix)
+			}
+		}
+	}
+	if _, err := indexKeyPrimarySuffix([]byte{0x03, 0x07, 0x01}, 1); err == nil {
+		t.Fatal("separator-free index key: expected error, got nil")
+	}
+	if _, err := indexKeyPrimarySuffix(enginepkg.AppendGrantByNeedsExpansionIndexKeyRawBytes(nil, []byte("x")), 2); err == nil {
+		t.Fatal("2-element suffix on 1-element tail: expected error, got nil")
+	}
+}
+
+// TestOverlayWholeSourceIndexCopyParityWithDerived locks in the
+// verbatim index copy: after an overlay merge whose last source took
+// the filtered whole-source SST path, every secondary index keyspace
+// in the dest must be byte-identical to what re-deriving the indexes
+// from the dest's primary records produces. This catches both stale
+// entries (a filtered-out loser's indexes leaking through the copy)
+// and missing entries (a winner's indexes dropped by the filter).
+func TestOverlayWholeSourceIndexCopyParityWithDerived(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	older := time.Unix(1000, 0).UTC()
+	newer := time.Unix(2000, 0).UTC()
+
+	// Newer partial: overlaps base keys with different index-relevant
+	// fields (principal, entitlement, needs_expansion) so the base's
+	// index entries for those keys are stale and must be filtered.
+	partial := writeIndexCopySource(t, ctx, filepath.Join(dir, "partial.c1z"), indexCopySpec{
+		resources: []resourceSpec{
+			{rt: "user", id: "alice", parentRT: "group", parentID: "platform"},
+			{rt: "user", id: "evil\x00nul", parentRT: "group", parentID: "eng\x01neering"},
+		},
+		grants: []kwayGrantSpec{
+			{id: "shared", principalID: "alice", entitlement: "admin", discovered: newer, needsExpand: true},
+			{id: "gr\x00nul", principalID: "evil\x00nul", entitlement: "admin", discovered: newer},
+		},
+		discovered: newer,
+	})
+	// Older base: superset of keys, including ones the partial
+	// overrides and ones only it has.
+	base := writeIndexCopySource(t, ctx, filepath.Join(dir, "base.c1z"), indexCopySpec{
+		resources: []resourceSpec{
+			{rt: "user", id: "alice", parentRT: "group", parentID: "engineering"},
+			{rt: "user", id: "bob", parentRT: "group", parentID: "engineering"},
+			{rt: "user", id: "evil\x00nul", parentRT: "group", parentID: "engineering"},
+			{rt: "user", id: "orphan"},
+		},
+		grants: []kwayGrantSpec{
+			{id: "shared", principalID: "bob", entitlement: "member", discovered: older},
+			{id: "base-only", principalID: "bob", entitlement: "member", discovered: older, needsExpand: true},
+			{id: "gr\x00nul", principalID: "bob", entitlement: "member", discovered: older},
+		},
+		discovered: older,
+	})
+
+	oldMin := overlayWholeSourceMinKeys
+	overlayWholeSourceMinKeys = 1
+	defer func() { overlayWholeSourceMinKeys = oldMin }()
+
+	dest, _ := newEngine(t, "index-copy-dest")
+	destSyncID := ksuid.New().String()
+	if _, err := MergeFilesIntoOverlay(ctx, dest, []SourceFile{
+		{Path: partial.path, SyncID: partial.syncID},
+		{Path: base.path, SyncID: base.syncID},
+	}, destSyncID, t.TempDir()); err != nil {
+		t.Fatalf("MergeFilesIntoOverlay: %v", err)
+	}
+
+	assertIndexesMatchDerived(t, ctx, dest)
+}
+
+type resourceSpec struct {
+	rt, id, parentRT, parentID string
+}
+
+type indexCopySpec struct {
+	resources  []resourceSpec
+	grants     []kwayGrantSpec
+	discovered time.Time
+}
+
+func writeIndexCopySource(t *testing.T, ctx context.Context, path string, spec indexCopySpec) kwaySourceFixture {
+	t.Helper()
+	w, err := dotc1z.NewStore(ctx, path, dotc1z.WithEngine(dotc1z.EnginePebble), dotc1z.WithTmpDir(t.TempDir()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	eng, ok := enginepkg.AsEngine(w)
+	if !ok {
+		t.Fatalf("store is not pebble: %T", w)
+	}
+	syncID, err := w.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ts := timestamppb.New(spec.discovered)
+	if err := eng.PutResourceTypeRecords(ctx,
+		v3.ResourceTypeRecord_builder{ExternalId: "user", DisplayName: "User", DiscoveredAt: ts}.Build(),
+		v3.ResourceTypeRecord_builder{ExternalId: "group", DisplayName: "Group", DiscoveredAt: ts}.Build(),
+	); err != nil {
+		t.Fatal(err)
+	}
+	resources := make([]*v3.ResourceRecord, 0, len(spec.resources))
+	for _, r := range spec.resources {
+		b := v3.ResourceRecord_builder{ResourceTypeId: r.rt, ResourceId: r.id, DiscoveredAt: ts}
+		if r.parentID != "" {
+			b.Parent = v3.ResourceRef_builder{ResourceTypeId: r.parentRT, ResourceId: r.parentID}.Build()
+		}
+		resources = append(resources, b.Build())
+	}
+	if err := eng.PutResourceRecords(ctx, resources...); err != nil {
+		t.Fatal(err)
+	}
+	seenEnt := map[string]bool{}
+	for _, g := range spec.grants {
+		if seenEnt[g.entitlement] {
+			continue
+		}
+		seenEnt[g.entitlement] = true
+		if err := eng.PutEntitlementRecords(ctx, v3.EntitlementRecord_builder{
+			ExternalId:   g.entitlement,
+			Resource:     v3.ResourceRef_builder{ResourceTypeId: "group", ResourceId: "engineering"}.Build(),
+			DiscoveredAt: ts,
+		}.Build()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, g := range spec.grants {
+		if err := eng.PutGrantRecords(ctx, v3.GrantRecord_builder{
+			ExternalId: g.id,
+			Entitlement: v3.EntitlementRef_builder{
+				ResourceTypeId: "group",
+				ResourceId:     "engineering",
+				EntitlementId:  g.entitlement,
+			}.Build(),
+			Principal:      v3.PrincipalRef_builder{ResourceTypeId: "user", ResourceId: g.principalID}.Build(),
+			NeedsExpansion: g.needsExpand,
+			DiscoveredAt:   timestamppb.New(g.discovered),
+		}.Build()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := w.EndSync(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(ctx); err != nil {
+		t.Fatal(err)
+	}
+	return kwaySourceFixture{path: path, syncID: syncID}
+}
+
+// assertIndexesMatchDerived reads every secondary-index keyspace from
+// the dest and compares it, byte for byte, against the index keys
+// re-derived from the dest's primary records.
+func assertIndexesMatchDerived(t *testing.T, ctx context.Context, dest *enginepkg.Engine) {
+	t.Helper()
+	var derived [][]byte
+	collect := func(key []byte) error {
+		derived = append(derived, append([]byte(nil), key...))
+		return nil
+	}
+	if err := dest.IterateResources(ctx, func(r *v3.ResourceRecord) bool {
+		if err := enginepkg.ForEachResourceIndexKey(r, collect); err != nil {
+			t.Fatal(err)
+		}
+		return true
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := dest.IterateEntitlements(ctx, func(e *v3.EntitlementRecord) bool {
+		if err := enginepkg.ForEachEntitlementIndexKey(e, collect); err != nil {
+			t.Fatal(err)
+		}
+		return true
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := dest.IterateGrants(ctx, func(g *v3.GrantRecord) bool {
+		if err := enginepkg.ForEachGrantIndexKey(g, collect); err != nil {
+			t.Fatal(err)
+		}
+		return true
+	}); err != nil {
+		t.Fatal(err)
+	}
+	sort.Slice(derived, func(i, j int) bool { return bytes.Compare(derived[i], derived[j]) < 0 })
+
+	var stored [][]byte
+	for _, bucket := range allBuckets() {
+		for _, r := range bucketIndexRanges(bucket) {
+			iter, err := dest.DB().NewIter(&cpebble.IterOptions{LowerBound: r[0], UpperBound: r[1]})
+			if err != nil {
+				t.Fatal(err)
+			}
+			for iter.First(); iter.Valid(); iter.Next() {
+				stored = append(stored, append([]byte(nil), iter.Key()...))
+			}
+			if err := iter.Error(); err != nil {
+				_ = iter.Close()
+				t.Fatal(err)
+			}
+			if err := iter.Close(); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	sort.Slice(stored, func(i, j int) bool { return bytes.Compare(stored[i], stored[j]) < 0 })
+
+	if len(stored) != len(derived) {
+		t.Fatalf("stored index keys = %d, derived = %d\nstored: %s\nderived: %s",
+			len(stored), len(derived), fmtKeys(stored), fmtKeys(derived))
+	}
+	for i := range stored {
+		if !bytes.Equal(stored[i], derived[i]) {
+			t.Fatalf("index key %d mismatch:\nstored:  %x\nderived: %x", i, stored[i], derived[i])
+		}
+	}
+}
+
+func fmtKeys(keys [][]byte) string {
+	var b bytes.Buffer
+	for _, k := range keys {
+		fmt.Fprintf(&b, "\n  %x", k)
+	}
+	return b.String()
+}

--- a/pkg/synccompactor/pebble/winner_equivalence_test.go
+++ b/pkg/synccompactor/pebble/winner_equivalence_test.go
@@ -1,0 +1,270 @@
+package pebble
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/segmentio/ksuid"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	enginepkg "github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble"
+)
+
+// recordSet is one sync's worth of primary records, used to build a
+// merge source either as an on-disk c1z (kway/overlay take SourceFiles)
+// or as a live engine (fold's MergeInto takes SourceSyncs).
+type recordSet struct {
+	rts []*v3.ResourceTypeRecord
+	rs  []*v3.ResourceRecord
+	es  []*v3.EntitlementRecord
+	gs  []*v3.GrantRecord
+}
+
+func winRT(externalID, displayName string, at time.Time) *v3.ResourceTypeRecord {
+	return v3.ResourceTypeRecord_builder{
+		ExternalId:   externalID,
+		DisplayName:  displayName,
+		DiscoveredAt: timestamppb.New(at),
+	}.Build()
+}
+
+func winRes(rtID, rID, displayName string, at time.Time) *v3.ResourceRecord {
+	return v3.ResourceRecord_builder{
+		ResourceTypeId: rtID,
+		ResourceId:     rID,
+		DisplayName:    displayName,
+		DiscoveredAt:   timestamppb.New(at),
+	}.Build()
+}
+
+func winEnt(externalID, displayName string, at time.Time) *v3.EntitlementRecord {
+	return v3.EntitlementRecord_builder{
+		ExternalId:   externalID,
+		Resource:     v3.ResourceRef_builder{ResourceTypeId: "user", ResourceId: "u1"}.Build(),
+		DisplayName:  displayName,
+		DiscoveredAt: timestamppb.New(at),
+	}.Build()
+}
+
+// winGrant tags the winning source in Principal.ResourceId so the merge
+// result names which version survived.
+func winGrant(externalID, principal string, at time.Time) *v3.GrantRecord {
+	return v3.GrantRecord_builder{
+		ExternalId: externalID,
+		Entitlement: v3.EntitlementRef_builder{
+			ResourceTypeId: "app", ResourceId: "github", EntitlementId: "ent-A",
+		}.Build(),
+		Principal:    v3.PrincipalRef_builder{ResourceTypeId: "user", ResourceId: principal}.Build(),
+		DiscoveredAt: timestamppb.New(at),
+	}.Build()
+}
+
+func populateEngine(t *testing.T, ctx context.Context, eng *enginepkg.Engine, rs recordSet) {
+	t.Helper()
+	if len(rs.rts) > 0 {
+		require.NoError(t, eng.PutResourceTypeRecords(ctx, rs.rts...))
+	}
+	if len(rs.rs) > 0 {
+		require.NoError(t, eng.PutResourceRecords(ctx, rs.rs...))
+	}
+	if len(rs.es) > 0 {
+		require.NoError(t, eng.PutEntitlementRecords(ctx, rs.es...))
+	}
+	if len(rs.gs) > 0 {
+		require.NoError(t, eng.PutGrantRecords(ctx, rs.gs...))
+	}
+}
+
+// buildC1ZSource writes rs to a fresh Pebble c1z and returns its path +
+// sync id, for the file-based strategies (kway, overlay).
+func buildC1ZSource(t *testing.T, ctx context.Context, path string, rs recordSet) SourceFile {
+	t.Helper()
+	w, err := dotc1z.NewStore(ctx, path, dotc1z.WithEngine(dotc1z.EnginePebble), dotc1z.WithTmpDir(t.TempDir()))
+	require.NoError(t, err)
+	eng, ok := enginepkg.AsEngine(w)
+	require.True(t, ok)
+	syncID, err := w.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	populateEngine(t, ctx, eng, rs)
+	require.NoError(t, w.EndSync(ctx))
+	require.NoError(t, w.Close(ctx))
+	return SourceFile{Path: path, SyncID: syncID}
+}
+
+// buildEngineSource builds a standalone engine holding rs under a fresh
+// sync id, for fold's MergeInto (which takes live engines).
+func buildEngineSource(t *testing.T, ctx context.Context, name string, rs recordSet) SourceSync {
+	t.Helper()
+	eng, _ := newEngine(t, name)
+	syncID := ksuid.New().String()
+	require.NoError(t, eng.SetCurrentSync(syncID))
+	populateEngine(t, ctx, eng, rs)
+	return SourceSync{Engine: eng, SyncID: syncID}
+}
+
+// winners is the observed survivor identity for every probed key, keyed
+// so the three strategies can be compared field-for-field.
+type winners struct {
+	resourceTypes map[string]string // externalID -> display name
+	resources     map[string]string // resourceID -> display name
+	entitlements  map[string]string // externalID -> display name
+	grants        map[string]string // externalID -> principal id
+}
+
+func collectWinners(t *testing.T, ctx context.Context, eng *enginepkg.Engine) winners {
+	t.Helper()
+	w := winners{
+		resourceTypes: map[string]string{},
+		resources:     map[string]string{},
+		entitlements:  map[string]string{},
+		grants:        map[string]string{},
+	}
+	require.NoError(t, eng.IterateResourceTypes(ctx, func(r *v3.ResourceTypeRecord) bool {
+		w.resourceTypes[r.GetExternalId()] = r.GetDisplayName()
+		return true
+	}))
+	require.NoError(t, eng.IterateResources(ctx, func(r *v3.ResourceRecord) bool {
+		w.resources[r.GetResourceId()] = r.GetDisplayName()
+		return true
+	}))
+	require.NoError(t, eng.IterateEntitlements(ctx, func(e *v3.EntitlementRecord) bool {
+		w.entitlements[e.GetExternalId()] = e.GetDisplayName()
+		return true
+	}))
+	require.NoError(t, eng.IterateGrants(ctx, func(g *v3.GrantRecord) bool {
+		w.grants[g.GetExternalId()] = g.GetPrincipal().GetResourceId()
+		return true
+	}))
+	return w
+}
+
+// TestPebbleStrategiesAgreeOnWinners is the cross-strategy correctness
+// pin: the same overlapping inputs, fed through all three Pebble merge
+// strategies (k-way, overlay, in-place fold), must converge on the
+// identical winner set — the record with the strictly-newest
+// discovered_at per logical key — for EVERY primary record type, and
+// must leave byte-identical derived index keyspaces.
+//
+// The scenario is deliberately adversarial on two axes the per-strategy
+// tests don't jointly cover:
+//
+//   - Winner position: the survivor lives in the newest-applied source
+//     (g-A), a middle source (g-B), AND the OLDEST-applied source
+//     (g-C) — a newer discovered_at carried by an older sync must win
+//     regardless of scan/application order. A strategy that shortcuts
+//     to "first writer wins" or "last writer wins" diverges here.
+//   - Record type: resource_types, resources, entitlements, and grants
+//     each carry discovered_at in a different proto field
+//     (discoveredAtFieldNumber: 6 / 8 / 8 / 5). A transposed field
+//     number silently breaks newest-wins for one type while the others
+//     pass — caught only by probing every type.
+//
+// Distinct timestamps everywhere means there are no ties, so all three
+// strategies must agree unconditionally; the tie-break conventions
+// (which legitimately differ) are pinned by the per-strategy tests.
+func TestPebbleStrategiesAgreeOnWinners(t *testing.T) {
+	ctx := context.Background()
+
+	t1 := time.Unix(1000, 0).UTC()
+	t2 := time.Unix(2000, 0).UTC()
+	t3 := time.Unix(3000, 0).UTC()
+	t4 := time.Unix(4000, 0).UTC()
+
+	// Three sources, passed newest-first (s0, s1, s2) — the convention
+	// the compactor uses so ties resolve to the newest sync. The
+	// discovered_at values deliberately do NOT track that order.
+	srcSets := []recordSet{
+		{ // s0 (newest-applied)
+			rts: []*v3.ResourceTypeRecord{winRT("rt-1", "rt-from-s0", t1)},
+			rs:  []*v3.ResourceRecord{winRes("user", "u1", "res-from-s0", t3)},
+			gs: []*v3.GrantRecord{
+				winGrant("g-A", "s0", t4), // wins: newest, in newest source
+				winGrant("g-B", "s0", t1),
+				winGrant("g-C", "s0", t1),
+			},
+		},
+		{ // s1 (middle)
+			rs: []*v3.ResourceRecord{winRes("user", "u1", "res-from-s1", t1)},
+			es: []*v3.EntitlementRecord{winEnt("e-1", "ent-from-s1", t1)},
+			gs: []*v3.GrantRecord{
+				winGrant("g-A", "s1", t2),
+				winGrant("g-B", "s1", t4), // wins: newest, in middle source
+				winGrant("g-C", "s1", t2),
+			},
+		},
+		{ // s2 (oldest-applied) — carries the newest data for several keys
+			rts: []*v3.ResourceTypeRecord{winRT("rt-1", "rt-from-s2", t3)},
+			es:  []*v3.EntitlementRecord{winEnt("e-1", "ent-from-s2", t3)},
+			gs: []*v3.GrantRecord{
+				winGrant("g-A", "s2", t3),
+				winGrant("g-B", "s2", t2),
+				winGrant("g-C", "s2", t4), // wins: newest, in OLDEST source
+			},
+		},
+	}
+
+	want := winners{
+		resourceTypes: map[string]string{"rt-1": "rt-from-s2"}, // t3 (s2) > t1 (s0)
+		resources:     map[string]string{"u1": "res-from-s0"},  // t3 (s0) > t1 (s1)
+		entitlements:  map[string]string{"e-1": "ent-from-s2"}, // t3 (s2) > t1 (s1)
+		grants: map[string]string{
+			"g-A": "s0", // t4 in newest source
+			"g-B": "s1", // t4 in middle source
+			"g-C": "s2", // t4 in oldest source
+		},
+	}
+
+	// Build the file-backed sources once; kway and overlay both read
+	// them, fold gets independent live engines from the same sets.
+	dir := t.TempDir()
+	files := make([]SourceFile, len(srcSets))
+	for i, rs := range srcSets {
+		files[i] = buildC1ZSource(t, ctx, fmt.Sprintf("%s/src%d.c1z", dir, i), rs)
+	}
+
+	runStrategy := func(t *testing.T, merge func(dest *enginepkg.Engine, destSyncID string) error) winners {
+		t.Helper()
+		dest, _ := newEngine(t, "dest")
+		destSyncID := ksuid.New().String()
+		require.NoError(t, merge(dest, destSyncID))
+		assertIndexesMatchDerived(t, ctx, dest)
+		return collectWinners(t, ctx, dest)
+	}
+
+	t.Run("kway", func(t *testing.T) {
+		got := runStrategy(t, func(dest *enginepkg.Engine, destSyncID string) error {
+			// fanIn=2 forces a multi-round recursive merge over the 3
+			// sources, exercising run-file round-tripping rather than a
+			// single direct pass.
+			_, err := MergeFilesInto(ctx, dest, files, destSyncID, t.TempDir(), WithFanIn(2))
+			return err
+		})
+		require.Equal(t, want, got)
+	})
+
+	t.Run("overlay", func(t *testing.T) {
+		got := runStrategy(t, func(dest *enginepkg.Engine, destSyncID string) error {
+			_, err := MergeFilesIntoOverlay(ctx, dest, files, destSyncID, t.TempDir())
+			return err
+		})
+		require.Equal(t, want, got)
+	})
+
+	t.Run("fold", func(t *testing.T) {
+		got := runStrategy(t, func(dest *enginepkg.Engine, destSyncID string) error {
+			sources := make([]SourceSync, len(srcSets))
+			for i, rs := range srcSets {
+				sources[i] = buildEngineSource(t, ctx, fmt.Sprintf("fold-src%d", i), rs)
+			}
+			_, err := MergeInto(ctx, dest, sources, destSyncID)
+			return err
+		})
+		require.Equal(t, want, got)
+	})
+}

--- a/pkg/synccompactor/prodscale_crossover_test.go
+++ b/pkg/synccompactor/prodscale_crossover_test.go
@@ -45,6 +45,7 @@ func TestProdScaleFoldOverlayCrossover(t *testing.T) {
 	baseGrants := envInt("BATON_CROSSOVER_GRANTS", 1_200_000)
 	baseUsers := envInt("BATON_CROSSOVER_USERS", 50_000)
 	baseEnts := envInt("BATON_CROSSOVER_ENTS", 10_000)
+	ratios := envInts("BATON_CROSSOVER_RATIOS", []int{5, 10, 25, 50})
 	const partialCount = 10
 
 	basePath := filepath.Join(fixDir, "base.c1z")
@@ -59,7 +60,7 @@ func TestProdScaleFoldOverlayCrossover(t *testing.T) {
 	baseBytes := fileSizeOrZero(basePath)
 	baseSyncID := manifestSyncID(t, basePath)
 
-	for _, ratioPct := range []int{5, 10, 25, 50} {
+	for _, ratioPct := range ratios {
 		ratioPct := ratioPct
 		t.Run(fmt.Sprintf("ratio=%d", ratioPct), func(t *testing.T) {
 			perPartial := baseGrants * ratioPct / 100 / partialCount

--- a/pkg/synccompactor/prodscale_test.go
+++ b/pkg/synccompactor/prodscale_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -138,6 +139,26 @@ func envInt(name string, def int) int {
 		}
 	}
 	return def
+}
+
+// envInts parses a comma-separated list of positive ints from an env
+// var (e.g. BATON_CROSSOVER_RATIOS=5,6,7,8). Any malformed element
+// falls back to def wholesale.
+func envInts(name string, def []int) []int {
+	raw := os.Getenv(name)
+	if raw == "" {
+		return def
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]int, 0, len(parts))
+	for _, p := range parts {
+		n, err := strconv.Atoi(strings.TrimSpace(p))
+		if err != nil || n <= 0 {
+			return def
+		}
+		out = append(out, n)
+	}
+	return out
 }
 
 func logFileSize(t *testing.T, label, path string) {

--- a/pkg/synccompactor/prodscale_test.go
+++ b/pkg/synccompactor/prodscale_test.go
@@ -94,7 +94,7 @@ func TestProdScaleSkewedCompaction(t *testing.T) {
 			logFileSize(t, "output", out.FilePath)
 
 			if mode == "fold" {
-				require.Equal(t, baseSyncID, out.SyncID, "fold must adopt the base sync id")
+				require.NotEqual(t, baseSyncID, out.SyncID, "fold must mint a fresh sync id")
 			}
 
 			// Sentinel correctness: a partial-only grant exists, an

--- a/proto/c1/c1z/v3/manifest.proto
+++ b/proto/c1/c1z/v3/manifest.proto
@@ -57,6 +57,18 @@ message C1ZManifestV3 {
   // Cheap projection of sync runs inside the payload — lets tooling
   // enumerate without opening the engine.
   repeated SyncRunSummary sync_runs = 40;
+
+  // Cumulative raw bytes of records (and their derived index keys)
+  // shadowed by in-place fold compactions since the last rebuild.
+  // Fold splices the base's compressed frames verbatim at save, so an
+  // overridden record's bytes stay inside the output as dead weight;
+  // this counter is the exact accounting of that waste, carried
+  // forward across consecutive folds (the dest store inherits it from
+  // the file it was opened from, and each fold adds its own delta).
+  // A rebuild (overlay / kway) writes a fresh store and resets it to
+  // zero. The compactor's auto mode reads this from the envelope
+  // header to force a rebuild once waste crosses its threshold.
+  int64 fold_dead_bytes = 41;
 }
 
 enum PayloadEncoding {


### PR DESCRIPTION
# Faster Pebble compaction: auto-fold + verbatim-index SST ingestion

## Summary

Now that v3 Pebble keys no longer carry a `sync_id` (#950), compaction can be
much cheaper. This PR makes two changes that exploit that:

1. **Overlay rebuilds ingest the base's derived index keys verbatim** as SSTs
   instead of re-deriving them per record. Sync-id-free keys are valid as-is in
   the destination store, so the largest source's whole bucket — records *and*
   indexes — is materialized and ingested wholesale.
2. **In-place fold is now an auto-selected mode**, not explicit-only. It's
   chosen for the large-base / small-partials shape, with a dead-byte waste
   accountant that forces a rebuild before bloat accumulates.

## Background

Fold (copy the base, stream partials in via keep-newer puts, splice the base's
compressed frames verbatim at save) was previously explicit-only and dormant:
its sync-id adoption wasn't handled by downstream compaction bookkeeping, so C1
would mistake a fold for "no new compaction". With keys no longer carrying a
sync_id, `compactPebbleFold` can mint a fresh sync id by renaming the single
sync-run record — a metadata-only write — so bookkeeping sees a new
`LatestCompactedSyncId`. That unblocks auto-fold.

## What changed

- **Auto mode selection** (`resolvePebbleMode`):
  - Fold when `base > 0` and summed partials ≤ 10% of the base file
    (`defaultFoldMaxPartialPercent`, no minimum base size).
  - Overlay otherwise, and overlay also reclaims accumulated fold bloat: when a
    base's recorded `fold_dead_bytes` exceeds the waste cutover
    (`WithFoldMaxWastePercent`, default 15% of live payload), a fold-shaped
    input is flipped back to overlay to rebuild.
  - Kway remains overlay's internal fallback / escape hatch
    (`BATON_EXPERIMENTAL_PEBBLE_COMPACTOR=kway`).
- **Fold waste accounting**: the fold merge went raw-bytes and now counts
  shadowed (overridden) record + stale index-key bytes exactly
  (`FoldStats.DeadBytes`). The total is persisted in the envelope manifest as
  `fold_dead_bytes` (new field 41), carried forward across consecutive folds and
  reset to zero on any rebuild. Plumbed through the envelope header read/write so
  the cutover can be evaluated without unpacking the payload.
- **Overlay whole-source path**: switched to verbatim index-key copy (ingested
  as SSTs) rather than re-derivation.
- **New config knob**: `WithFoldMaxWastePercent(pct)` — 0 = default (15%),
  negative = disable the waste cutover.
- Overflow-proofed the waste comparison (division form instead of
  cross-multiplication).

## Why

- Verbatim index ingestion removes per-record index re-derivation from the
  dominant (largest-source) leg of every overlay rebuild.
- Auto-fold lets the common production shape (big base + small incrementals)
  skip a full rebuild entirely, splicing the base's frames instead of
  re-encoding them.
- The waste cutover bounds how much dead weight consecutive folds may accumulate
  (which taxes every subsequent download/open/save) before one rebuild reclaims
  it — set below the band where the sweep showed overlay winning on both time
  and size (~18% bloat) while still amortizing a rebuild over several folds.

## Performance

Measured on Apple M1 (darwin/arm64), `BenchmarkCompactorSQLiteVsPebble`:

- Large-base shape (250k-grant base, 50 syncs, tiny incrementals): fold
  ~489 ms vs SQLite ~3.62 s (~7.4×); overlay ~3.6×, kway ~2.5×.
- Skewed sweep, 500 syncs: fold ~2.49 s vs SQLite ~4.53 s (~1.8×).
- Uniform "same" shape, 500 syncs (adversarial for fold): kway ~6.7 s /
  overlay ~7.6 s vs SQLite ~26.6 s; fold ~11.8 s — exactly the large-partial
  crossover the waste/partial gate is designed to avoid.
- Crossover fixture (`TestProdScaleFoldOverlayCrossover`, 117 MB base): fold
  wins at ~4.9% partial ratio (4.8s vs 6.1s) and loses mildly from ~8.9% up,
  which is why the partial cap sits at 10%.

Tradeoff: Pebble compaction holds far more peak heap than SQLite (~1.4–1.6 GB vs
56 MB on the large-base shape).