### PR TITLE
perf(expand): group grant expansion by source to cut per-edge source re-reads

### DIFF
--- a/pkg/sync/expand/expand_benchmark_test.go
+++ b/pkg/sync/expand/expand_benchmark_test.go
@@ -111,6 +111,7 @@ func copyGraph(g *EntitlementGraph) *EntitlementGraph {
 	for i, action := range g.Actions {
 		newGraph.Actions[i] = &EntitlementGraphAction{
 			SourceEntitlementID:     action.SourceEntitlementID,
+			Descendants:             slices.Clone(action.Descendants),
 			DescendantEntitlementID: action.DescendantEntitlementID,
 			Shallow:                 action.Shallow,
 			ResourceTypeIDs:         slices.Clone(action.ResourceTypeIDs),

--- a/pkg/sync/expand/expander.go
+++ b/pkg/sync/expand/expander.go
@@ -27,6 +27,21 @@ const defaultMaxDepth int64 = 20
 
 var maxDepth, _ = strconv.ParseInt(os.Getenv("BATON_GRAPH_EXPAND_MAX_DEPTH"), 10, 64)
 
+// defaultDestBatchSize bounds how many destination entitlements a single action
+// fans one source read out to. Larger batches read the source fewer times but
+// hold more oracles. K=1 reproduces the pre-grouping per-edge behavior.
+const defaultDestBatchSize = 4
+
+// destBatchSize returns the configured destination fan-out width, or the
+// default when unset/invalid. Read at call time (not package init) so the env
+// can be overridden per test.
+func destBatchSize() int {
+	if v, err := strconv.Atoi(os.Getenv("BATON_GRAPH_EXPAND_DEST_BATCH_SIZE")); err == nil && v > 0 {
+		return v
+	}
+	return defaultDestBatchSize
+}
+
 // ErrMaxDepthExceeded is returned when the expansion graph exceeds the maximum allowed depth.
 var ErrMaxDepthExceeded = errors.New("max depth exceeded")
 
@@ -104,9 +119,11 @@ func (e *Expander) RunSingleStep(ctx context.Context) error {
 		nextPageToken, err := e.runAction(ctx, action)
 		if err != nil {
 			l.Error("expander: error running graph action", zap.Error(err), zap.Any("action", action))
-			_ = e.graph.DeleteEdge(ctx, action.SourceEntitlementID, action.DescendantEntitlementID)
+			for _, d := range action.descendants() {
+				_ = e.graph.DeleteEdge(ctx, action.SourceEntitlementID, d.EntitlementID)
+			}
 			if status.Code(err) == codes.NotFound {
-				// Skip action and delete the edge that caused the error.
+				// Skip action and delete the edges that caused the error.
 				e.graph.Actions = e.graph.Actions[1:]
 				return nil
 			}
@@ -117,8 +134,10 @@ func (e *Expander) RunSingleStep(ctx context.Context) error {
 			// More pages to process
 			action.PageToken = nextPageToken
 		} else {
-			// Action is complete - mark edge expanded and remove from queue
-			e.graph.MarkEdgeExpanded(action.SourceEntitlementID, action.DescendantEntitlementID)
+			// Action is complete - mark every edge in the batch expanded and remove from queue.
+			for _, d := range action.descendants() {
+				e.graph.MarkEdgeExpanded(action.SourceEntitlementID, d.EntitlementID)
+			}
 			e.graph.Actions = e.graph.Actions[1:]
 		}
 	}
@@ -139,16 +158,28 @@ func (e *Expander) RunSingleStep(ctx context.Context) error {
 		return fmt.Errorf("expander: %w (%d)", ErrMaxDepthExceeded, depth)
 	}
 
-	// Generate new actions from expandable entitlements
+	// Generate new actions from expandable entitlements. One action per
+	// (source, filter, destination-batch): the source's grants are read once
+	// per filter group and fanned out to every destination in the batch,
+	// instead of re-read once per outgoing edge.
+	batchSize := destBatchSize()
 	for sourceEntitlementID := range e.graph.GetExpandableEntitlements(ctx) {
-		for descendantEntitlementID, grantInfo := range e.graph.GetExpandableDescendantEntitlements(ctx, sourceEntitlementID) {
-			e.graph.Actions = append(e.graph.Actions, &EntitlementGraphAction{
-				SourceEntitlementID:     sourceEntitlementID,
-				DescendantEntitlementID: descendantEntitlementID,
-				PageToken:               "",
-				Shallow:                 grantInfo.IsShallow,
-				ResourceTypeIDs:         grantInfo.ResourceTypeIDs,
-			})
+		for _, group := range groupExpandableDescendants(ctx, e.graph, sourceEntitlementID) {
+			for start := 0; start < len(group.dests); start += batchSize {
+				end := start + batchSize
+				if end > len(group.dests) {
+					end = len(group.dests)
+				}
+				// Copy the batch slice so it does not alias the group's backing
+				// array once serialized into graph state.
+				batch := append([]ActionDescendant(nil), group.dests[start:end]...)
+				e.graph.Actions = append(e.graph.Actions, &EntitlementGraphAction{
+					SourceEntitlementID: sourceEntitlementID,
+					Descendants:         batch,
+					ResourceTypeIDs:     group.resourceTypeIDs,
+					PageToken:           "",
+				})
+			}
 		}
 	}
 
@@ -287,12 +318,13 @@ func listDescendantGrantsForPrincipal(
 //
 //nolint:nonamedreturns // see doc comment above.
 func (e *Expander) runAction(ctx context.Context, action *EntitlementGraphAction) (nextPage string, err error) {
+	dests := action.descendants()
+
 	ctx, span := uotel.StartWithLink(ctx, tracer, "expand.runAction",
 		trace.WithAttributes(
 			attribute.String("source_entitlement_id", action.SourceEntitlementID),
-			attribute.String("descendant_entitlement_id", action.DescendantEntitlementID),
+			attribute.Int("descendant_count", len(dests)),
 			attribute.Int("depth", e.graph.Depth),
-			attribute.Bool("shallow", action.Shallow),
 		),
 	)
 	defer func() { uotel.EndSpanWithError(span, err) }()
@@ -301,10 +333,15 @@ func (e *Expander) runAction(ctx context.Context, action *EntitlementGraphAction
 	l = l.With(
 		zap.Int("depth", e.graph.Depth),
 		zap.String("source_entitlement_id", action.SourceEntitlementID),
-		zap.String("descendant_entitlement_id", action.DescendantEntitlementID),
+		zap.Int("descendant_count", len(dests)),
 	)
 
-	// Fetch source and descendant entitlement
+	if len(dests) == 0 {
+		// Defensive: an action with no destinations has nothing to expand.
+		return "", nil
+	}
+
+	// Fetch the source entitlement once for the whole batch.
 	sourceEntitlement, err := e.store.GetEntitlement(ctx, reader_v2.EntitlementsReaderServiceGetEntitlementRequest_builder{
 		EntitlementId: action.SourceEntitlementID,
 	}.Build())
@@ -312,16 +349,6 @@ func (e *Expander) runAction(ctx context.Context, action *EntitlementGraphAction
 		l.Error("runAction: error fetching source entitlement", zap.Error(err))
 		return "", fmt.Errorf("runAction: error fetching source entitlement: %w", err)
 	}
-
-	descendantEntitlement, err := e.store.GetEntitlement(ctx, reader_v2.EntitlementsReaderServiceGetEntitlementRequest_builder{
-		EntitlementId: action.DescendantEntitlementID,
-	}.Build())
-	if err != nil {
-		l.Error("runAction: error fetching descendant entitlement", zap.Error(err))
-		return "", fmt.Errorf("runAction: error fetching descendant entitlement: %w", err)
-	}
-
-	// Fetch a page of source grants
 	sourceGrants, err := e.store.ListGrantsForEntitlement(ctx, reader_v2.GrantsReaderServiceListGrantsForEntitlementRequest_builder{
 		Entitlement:              sourceEntitlement.GetEntitlement(),
 		PageToken:                action.PageToken,
@@ -332,33 +359,77 @@ func (e *Expander) runAction(ctx context.Context, action *EntitlementGraphAction
 		return "", fmt.Errorf("runAction: error fetching source grants: %w", err)
 	}
 
-	existingPrincipals, complete, err := prefetchDescendantPrincipals(ctx, e.store, descendantEntitlement.GetEntitlement())
-	if err != nil {
-		l.Error("runAction: error prefetching descendant principals", zap.Error(err))
-		return "", fmt.Errorf("runAction: error prefetching descendant principals: %w", err)
+	// Build per-destination state (entitlement + "who already has it" oracle +
+	// per-page cache). One oracle per destination is held at once, so peak
+	// memory grows with batch size K. Span carries batch totals
+	// (oracle overflows, max oracle size) since one span now covers many dests.
+	destStates := make([]*destExpandState, 0, len(dests))
+	prefetchIncompleteCount := 0
+	prefetchSetSizeMax := 0
+	for _, d := range dests {
+		descendantEntitlement, err := e.store.GetEntitlement(ctx, reader_v2.EntitlementsReaderServiceGetEntitlementRequest_builder{
+			EntitlementId: d.EntitlementID,
+		}.Build())
+		if err != nil {
+			if status.Code(err) == codes.NotFound {
+				// A single missing descendant drops only its own edge; the rest
+				// of the batch still expands.
+				l.Warn("runAction: descendant entitlement not found, dropping edge",
+					zap.String("descendant_entitlement_id", d.EntitlementID))
+				_ = e.graph.DeleteEdge(ctx, action.SourceEntitlementID, d.EntitlementID)
+				continue
+			}
+			l.Error("runAction: error fetching descendant entitlement", zap.Error(err))
+			return "", fmt.Errorf("runAction: error fetching descendant entitlement: %w", err)
+		}
+
+		existingPrincipals, complete, err := prefetchDescendantPrincipals(ctx, e.store, descendantEntitlement.GetEntitlement())
+		if err != nil {
+			l.Error("runAction: error prefetching descendant principals", zap.Error(err))
+			return "", fmt.Errorf("runAction: error prefetching descendant principals: %w", err)
+		}
+		if !complete {
+			// Partial set is unsafe as a negative oracle; drop it and pay the
+			// per-principal cost for every source grant. Slow but bounded.
+			prefetchIncompleteCount++
+			l.Warn("runAction: descendant-grant prefetch cap exceeded; falling back to per-principal queries",
+				zap.String("descendant_entitlement_id", d.EntitlementID),
+				zap.Int("prefetch_page_cap", maxPrefetchPages))
+			existingPrincipals = nil
+		} else if n := len(existingPrincipals); n > prefetchSetSizeMax {
+			prefetchSetSizeMax = n
+		}
+		destStates = append(destStates, &destExpandState{
+			entitlementID: d.EntitlementID,
+			shallow:       d.Shallow,
+			// Per-destination cache of descendant grants by principal key.
+			// Populated lazily from the store on the first hit for a key, and
+			// seeded with newly created grants so a second source grant for the
+			// same principal in the same page merges into the in-memory grant
+			// instead of producing a duplicate (same deterministic grant ID
+			// would otherwise upsert and lose the first iteration's source
+			// attribution).
+			entitlement: descendantEntitlement.GetEntitlement(),
+			existing:    existingPrincipals,
+			byKey:       make(map[string][]*v2.Grant),
+		})
 	}
-	if !complete {
-		// Partial set is unsafe as a negative oracle; drop it and pay the
-		// per-principal cost for every source grant. Slow but bounded.
-		l.Warn("runAction: descendant-grant prefetch cap exceeded; falling back to per-principal queries",
-			zap.String("descendant_entitlement_id", action.DescendantEntitlementID),
-			zap.Int("prefetch_page_cap", maxPrefetchPages))
-		existingPrincipals = nil
-	}
+
 	span.SetAttributes(
-		attribute.Int("descendant_prefetch_set_size", len(existingPrincipals)),
-		attribute.Bool("descendant_prefetch_complete", complete),
+		attribute.Int("active_descendant_count", len(destStates)),
+		attribute.Int("descendant_prefetch_incomplete_count", prefetchIncompleteCount),
+		attribute.Bool("descendant_prefetch_any_incomplete", prefetchIncompleteCount > 0),
+		attribute.Int("descendant_prefetch_set_size_max", prefetchSetSizeMax),
 	)
 
-	// Per-page cache of descendant grants by principal key. Populated lazily
-	// from the store on the first hit for a key, and seeded with newly
-	// created grants so a second source grant for the same principal in the
-	// same page merges into the in-memory grant instead of producing a
-	// duplicate (same deterministic grant ID would otherwise upsert and lose
-	// the first iteration's source attribution).
-	descendantsByKey := make(map[string][]*v2.Grant)
+	if len(destStates) == 0 {
+		// Every destination in the batch was missing (edges already deleted),
+		// so there is nothing to write for any source page. Return "" to finish
+		// the action now instead of paginating the source pointlessly.
+		return "", nil
+	}
 
-	var newGrants = make([]*v2.Grant, 0)
+	newGrants := make([]*v2.Grant, 0)
 	for _, sourceGrant := range sourceGrants.GetList() {
 		if sourceGrant.GetPrincipal() == nil {
 			// Malformed grant with no principal. main passed this through to
@@ -371,16 +442,6 @@ func (e *Expander) runAction(ctx context.Context, action *EntitlementGraphAction
 				zap.String("source_grant_id", sourceGrant.GetId()))
 			continue
 		}
-		if action.Shallow {
-			sourcesMap := sourceGrant.GetSources().GetSources()
-			foundDirectGrant := len(sourcesMap) == 0
-			if sourcesMap[action.SourceEntitlementID] != nil {
-				foundDirectGrant = true
-			}
-			if !foundDirectGrant {
-				continue
-			}
-		}
 
 		sgSources := sourceGrant.GetSources().GetSources()
 		isSourceDirect := len(sgSources) == 0 || sgSources[action.SourceEntitlementID] != nil
@@ -388,75 +449,32 @@ func (e *Expander) runAction(ctx context.Context, action *EntitlementGraphAction
 		principal := sourceGrant.GetPrincipal().GetId()
 		key := descendantGrantKey(principal.GetResourceType(), principal.GetResource())
 
-		descendantGrants, cached := descendantsByKey[key]
-		if !cached {
-			// Fast path: if the key-set is complete and this principal is
-			// not in it, we know there is no existing descendant grant
-			// without issuing a SQL query.
-			needQuery := true
-			if existingPrincipals != nil {
-				if _, ok := existingPrincipals[key]; !ok {
-					needQuery = false
+		for _, ds := range destStates {
+			// Shallow is per-edge and only gates which source grants qualify
+			// for this destination; the shared source read is unaffected.
+			if ds.shallow {
+				foundDirectGrant := len(sgSources) == 0
+				if sgSources[action.SourceEntitlementID] != nil {
+					foundDirectGrant = true
+				}
+				if !foundDirectGrant {
+					continue
 				}
 			}
-			if needQuery {
-				descendantGrants, err = listDescendantGrantsForPrincipal(ctx, e.store, descendantEntitlement.GetEntitlement(), principal)
-				if err != nil {
-					l.Error("runAction: error fetching descendant grants", zap.Error(err))
-					return "", fmt.Errorf("runAction: error fetching descendant grants: %w", err)
-				}
-			}
-			descendantsByKey[key] = descendantGrants
-		}
 
-		if len(descendantGrants) == 0 {
-			descendantGrant, err := newExpandedGrant(descendantEntitlement.GetEntitlement(), sourceGrant.GetPrincipal(), action.SourceEntitlementID, isSourceDirect)
+			newGrants, err = e.applyDestGrant(ctx, action.SourceEntitlementID, ds, sourceGrant, principal, key, isSourceDirect, newGrants)
 			if err != nil {
-				l.Error("runAction: error creating new grant", zap.Error(err))
-				return "", fmt.Errorf("runAction: error creating new grant: %w", err)
+				return "", err
 			}
-			newGrants = append(newGrants, descendantGrant)
-			// Seed the cache so a later source grant for the same principal
-			// in this page merges into this grant rather than re-creating it.
-			descendantsByKey[key] = []*v2.Grant{descendantGrant}
-		} else {
-			for _, descendantGrant := range descendantGrants {
-				sourcesMap := descendantGrant.GetSources().GetSources()
-				if sourcesMap == nil {
-					sourcesMap = make(map[string]*v2.GrantSources_GrantSource)
-				}
 
-				updated := false
-				if len(sourcesMap) == 0 {
-					sourcesMap[action.DescendantEntitlementID] = &v2.GrantSources_GrantSource{IsDirect: true}
-					updated = true
-				}
-				if existingSource := sourcesMap[action.SourceEntitlementID]; existingSource == nil {
-					sourcesMap[action.SourceEntitlementID] = &v2.GrantSources_GrantSource{IsDirect: isSourceDirect}
-					updated = true
-				} else if isSourceDirect && !existingSource.GetIsDirect() {
-					// A later source grant for the same principal is direct;
-					// upgrade the recorded source from indirect to direct.
-					// Direct wins over indirect. main got this via re-querying
-					// the store each iteration + last-write-wins on the
-					// re-created grant; the in-page cache merge path must do it
-					// explicitly or the upgrade is silently dropped.
-					existingSource.SetIsDirect(true)
-					updated = true
-				}
-
-				if updated {
-					sources := v2.GrantSources_builder{Sources: sourcesMap}.Build()
-					descendantGrant.SetSources(sources)
-					newGrants = append(newGrants, descendantGrant)
-				}
+			// check the flush threshold inside the per-destination loop so
+			// the write buffer can't balloon to pageSize × batchSize before a
+			// single flush. The write path itself is unchanged.
+			newGrants, err = PutGrantsInChunks(ctx, e.store, newGrants, 10000)
+			if err != nil {
+				l.Error("runAction: error updating descendant grants", zap.Error(err))
+				return "", fmt.Errorf("runAction: error updating descendant grants: %w", err)
 			}
-		}
-
-		newGrants, err = PutGrantsInChunks(ctx, e.store, newGrants, 10000)
-		if err != nil {
-			l.Error("runAction: error updating descendant grants", zap.Error(err))
-			return "", fmt.Errorf("runAction: error updating descendant grants: %w", err)
 		}
 	}
 
@@ -467,6 +485,102 @@ func (e *Expander) runAction(ctx context.Context, action *EntitlementGraphAction
 	}
 
 	return sourceGrants.GetNextPageToken(), nil
+}
+
+// destExpandState is the per-destination working set held while fanning one
+// source read out across a batch of destinations.
+type destExpandState struct {
+	entitlementID string
+	shallow       bool
+	entitlement   *v2.Entitlement
+	// existing is the descendant's "already has a grant" key set, or nil when
+	// the prefetch cap was exceeded (forcing per-principal fallback queries).
+	existing map[string]struct{}
+	byKey    map[string][]*v2.Grant
+}
+
+// applyDestGrant resolves a single source grant against one destination,
+// appending any created/updated grant to newGrants and returning the new
+// buffer. It is the per-(source grant, destination) body of the original
+// runAction loop, lifted out so one source read can drive many destinations.
+func (e *Expander) applyDestGrant(
+	ctx context.Context,
+	sourceEntitlementID string,
+	ds *destExpandState,
+	sourceGrant *v2.Grant,
+	principal *v2.ResourceId,
+	key string,
+	isSourceDirect bool,
+	newGrants []*v2.Grant,
+) ([]*v2.Grant, error) {
+	l := ctxzap.Extract(ctx)
+
+	descendantGrants, cached := ds.byKey[key]
+	if !cached {
+		// Fast path: if the key-set is complete and this principal is not in
+		// it, we know there is no existing descendant grant without issuing a
+		// SQL query.
+		needQuery := true
+		if ds.existing != nil {
+			if _, ok := ds.existing[key]; !ok {
+				needQuery = false
+			}
+		}
+		if needQuery {
+			var err error
+			descendantGrants, err = listDescendantGrantsForPrincipal(ctx, e.store, ds.entitlement, principal)
+			if err != nil {
+				l.Error("runAction: error fetching descendant grants", zap.Error(err))
+				return nil, fmt.Errorf("runAction: error fetching descendant grants: %w", err)
+			}
+		}
+		ds.byKey[key] = descendantGrants
+	}
+
+	if len(descendantGrants) == 0 {
+		descendantGrant, err := newExpandedGrant(ds.entitlement, sourceGrant.GetPrincipal(), sourceEntitlementID, isSourceDirect)
+		if err != nil {
+			l.Error("runAction: error creating new grant", zap.Error(err))
+			return nil, fmt.Errorf("runAction: error creating new grant: %w", err)
+		}
+		newGrants = append(newGrants, descendantGrant)
+		// Seed the cache so a later source grant for the same principal in this
+		// page merges into this grant rather than re-creating it.
+		ds.byKey[key] = []*v2.Grant{descendantGrant}
+		return newGrants, nil
+	}
+
+	for _, descendantGrant := range descendantGrants {
+		sourcesMap := descendantGrant.GetSources().GetSources()
+		if sourcesMap == nil {
+			sourcesMap = make(map[string]*v2.GrantSources_GrantSource)
+		}
+
+		updated := false
+		if len(sourcesMap) == 0 {
+			sourcesMap[ds.entitlementID] = &v2.GrantSources_GrantSource{IsDirect: true}
+			updated = true
+		}
+		if existingSource := sourcesMap[sourceEntitlementID]; existingSource == nil {
+			sourcesMap[sourceEntitlementID] = &v2.GrantSources_GrantSource{IsDirect: isSourceDirect}
+			updated = true
+		} else if isSourceDirect && !existingSource.GetIsDirect() {
+			// A later source grant for the same principal is direct; upgrade the
+			// recorded source from indirect to direct. Direct wins over indirect.
+			// main got this via re-querying the store each iteration +
+			// last-write-wins on the re-created grant; the in-page cache merge
+			// path must do it explicitly or the upgrade is silently dropped.
+			existingSource.SetIsDirect(true)
+			updated = true
+		}
+
+		if updated {
+			sources := v2.GrantSources_builder{Sources: sourcesMap}.Build()
+			descendantGrant.SetSources(sources)
+			newGrants = append(newGrants, descendantGrant)
+		}
+	}
+	return newGrants, nil
 }
 
 // PutGrantsInChunks accumulates grants until the buffer exceeds minChunkSize,

--- a/pkg/sync/expand/expander.go
+++ b/pkg/sync/expand/expander.go
@@ -118,15 +118,11 @@ func (e *Expander) RunSingleStep(ctx context.Context) error {
 		action := e.graph.Actions[0]
 		nextPageToken, err := e.runAction(ctx, action)
 		if err != nil {
+			// Mutate nothing on error: leave the action queued and its edges
+			// intact so a retried run re-processes them. Missing source/dest
+			// entitlements are handled inline in runAction, so any error here is
+			// a real failure to propagate.
 			l.Error("expander: error running graph action", zap.Error(err), zap.Any("action", action))
-			for _, d := range action.descendants() {
-				_ = e.graph.DeleteEdge(ctx, action.SourceEntitlementID, d.EntitlementID)
-			}
-			if status.Code(err) == codes.NotFound {
-				// Skip action and delete the edges that caused the error.
-				e.graph.Actions = e.graph.Actions[1:]
-				return nil
-			}
 			return err
 		}
 
@@ -346,6 +342,18 @@ func (e *Expander) runAction(ctx context.Context, action *EntitlementGraphAction
 		EntitlementId: action.SourceEntitlementID,
 	}.Build())
 	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			// Source entitlement is gone; every edge in the batch shares it, so
+			// drop them all and complete the action. Mirrors the inline handling
+			// of missing destinations below. (MarkEdgeExpanded no-ops on deleted
+			// edges, so returning "" here completes the action cleanly.)
+			l.Warn("runAction: source entitlement not found, dropping batch edges",
+				zap.String("source_entitlement_id", action.SourceEntitlementID))
+			for _, d := range dests {
+				_ = e.graph.DeleteEdge(ctx, action.SourceEntitlementID, d.EntitlementID)
+			}
+			return "", nil
+		}
 		l.Error("runAction: error fetching source entitlement", zap.Error(err))
 		return "", fmt.Errorf("runAction: error fetching source entitlement: %w", err)
 	}

--- a/pkg/sync/expand/expander_test.go
+++ b/pkg/sync/expand/expander_test.go
@@ -2,12 +2,15 @@ package expand
 
 import (
 	"context"
+	"errors"
 	"strconv"
 	"testing"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	reader_v2 "github.com/conductorone/baton-sdk/pb/c1/reader/v2"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // MockExpanderStore implements ExpanderStore for testing purposes.
@@ -15,6 +18,10 @@ type MockExpanderStore struct {
 	entitlements map[string]*v2.Entitlement
 	grants       map[string][]*v2.Grant // keyed by entitlement ID
 	putGrants    []*v2.Grant            // grants that were written
+	// pageSize > 0 paginates ListGrantsForEntitlement: PageToken is an integer
+	// offset into the (filtered) grant slice. 0 (default) returns everything in
+	// one page, leaving existing tests unaffected.
+	pageSize int
 }
 
 // NewMockExpanderStore creates a new mock store for testing.
@@ -90,8 +97,27 @@ func (m *MockExpanderStore) ListGrantsForEntitlement(
 		grants = filtered
 	}
 
+	nextPageToken := ""
+	if m.pageSize > 0 {
+		offset := 0
+		if tok := req.GetPageToken(); tok != "" {
+			offset, _ = strconv.Atoi(tok)
+		}
+		if offset > len(grants) {
+			offset = len(grants)
+		}
+		end := offset + m.pageSize
+		if end >= len(grants) {
+			end = len(grants)
+		} else {
+			nextPageToken = strconv.Itoa(end)
+		}
+		grants = grants[offset:end]
+	}
+
 	return reader_v2.GrantsReaderServiceListGrantsForEntitlementResponse_builder{
-		List: grants,
+		List:          grants,
+		NextPageToken: nextPageToken,
 	}.Build(), nil
 }
 
@@ -694,6 +720,169 @@ func TestExpanderPerDestinationShallow(t *testing.T) {
 		"shallow edge must drop a transitively-held source grant")
 	require.True(t, granted[destDeep.GetId()],
 		"non-shallow edge must keep the transitively-held source grant")
+}
+
+// errInjectStore wraps MockExpanderStore and returns a chosen error from
+// GetEntitlement for specific entitlement IDs, so tests can drive runAction's
+// error paths (a missing source vs a transient source-read failure).
+type errInjectStore struct {
+	*MockExpanderStore
+	getEntErr map[string]error
+}
+
+func newErrInjectStore() *errInjectStore {
+	return &errInjectStore{
+		MockExpanderStore: NewMockExpanderStore(),
+		getEntErr:         make(map[string]error),
+	}
+}
+
+func (s *errInjectStore) GetEntitlement(
+	ctx context.Context,
+	req *reader_v2.EntitlementsReaderServiceGetEntitlementRequest,
+) (*reader_v2.EntitlementsReaderServiceGetEntitlementResponse, error) {
+	if err := s.getEntErr[req.GetEntitlementId()]; err != nil {
+		return nil, err
+	}
+	return s.MockExpanderStore.GetEntitlement(ctx, req)
+}
+
+// TestExpanderSourceNotFoundCompletes: when the source entitlement is missing
+// (GetEntitlement → codes.NotFound) during the walk, the batch's edges are
+// dropped and expansion completes without error.
+func TestExpanderSourceNotFoundCompletes(t *testing.T) {
+	ctx := context.Background()
+	store := newErrInjectStore()
+
+	group := makeResource("group", "org")
+	source := makeEntitlement("ent:source", group)
+	dest := makeEntitlement("ent:dest", group)
+	store.AddEntitlement(source)
+	store.AddEntitlement(dest)
+
+	graph := NewEntitlementGraph(ctx)
+	graph.AddEntitlementID(source.GetId())
+	graph.AddEntitlementID(dest.GetId())
+	require.NoError(t, graph.AddEdge(ctx, source.GetId(), dest.GetId(), false, nil))
+
+	store.getEntErr[source.GetId()] = status.Error(codes.NotFound, "entitlement not found")
+
+	expander := NewExpander(store, graph)
+	require.NoError(t, expander.Run(ctx), "missing source must complete, not error")
+	require.True(t, graph.IsExpanded(), "the batch's edge must be dropped")
+	require.Empty(t, graph.Edges, "no edges should remain")
+}
+
+// TestExpanderTransientErrorPreservesEdges: a transient (non-ErrNoRows) failure
+// must propagate AND leave the graph's edges intact, so a retry can re-run the
+// action instead of silently dropping its edges.
+func TestExpanderTransientErrorPreservesEdges(t *testing.T) {
+	ctx := context.Background()
+	store := newErrInjectStore()
+
+	group := makeResource("group", "org")
+	source := makeEntitlement("ent:source", group)
+	dest := makeEntitlement("ent:dest", group)
+	store.AddEntitlement(source)
+	store.AddEntitlement(dest)
+
+	graph := NewEntitlementGraph(ctx)
+	graph.AddEntitlementID(source.GetId())
+	graph.AddEntitlementID(dest.GetId())
+	require.NoError(t, graph.AddEdge(ctx, source.GetId(), dest.GetId(), false, nil))
+
+	store.getEntErr[source.GetId()] = errors.New("transient boom")
+
+	expander := NewExpander(store, graph)
+	err := expander.Run(ctx)
+	require.Error(t, err, "transient failure must propagate")
+	require.False(t, graph.IsExpanded(), "edges must survive a transient failure")
+	require.Len(t, graph.Edges, 1, "the edge must remain for retry")
+}
+
+// TestExpanderMultiPageSourceCrossPageDedup exercises the multi-page action
+// lifecycle the batching rewrite touches: a source whose grants span several
+// pages, with the SAME principal appearing on two different pages. The per-page
+// destStates/byKey are rebuilt each page, so the second appearance must be
+// rediscovered via the rebuilt oracle and take applyDestGrant's merge path —
+// not create a duplicate grant. Also asserts the action stays queued with a
+// page token mid-source, and that source reads == pages × batches.
+func TestExpanderMultiPageSourceCrossPageDedup(t *testing.T) {
+	t.Setenv("BATON_GRAPH_EXPAND_DEST_BATCH_SIZE", "2")
+
+	ctx := context.Background()
+	store := newCountingMockStore()
+	store.pageSize = 2 // 5 source grants → 3 pages (2,2,1)
+
+	group := makeResource("group", "org")
+	alice := makeResource("user", "alice")
+	bob := makeResource("user", "bob")
+	carol := makeResource("user", "carol")
+	dave := makeResource("user", "dave")
+
+	source := makeEntitlement("ent:source", group)
+	d1 := makeEntitlement("ent:d1", group)
+	d2 := makeEntitlement("ent:d2", group)
+	store.AddEntitlement(source)
+	store.AddEntitlement(d1)
+	store.AddEntitlement(d2)
+
+	// alice holds TWO source grants (distinct records), landing on page 0 and
+	// page 1 once paginated at size 2.
+	store.AddGrant(makeGrant("g:alice:1", source, alice)) // page 0
+	store.AddGrant(makeGrant("g:bob", source, bob))       // page 0
+	store.AddGrant(makeGrant("g:alice:2", source, alice)) // page 1
+	store.AddGrant(makeGrant("g:carol", source, carol))   // page 1
+	store.AddGrant(makeGrant("g:dave", source, dave))     // page 2
+
+	graph := NewEntitlementGraph(ctx)
+	graph.AddEntitlementID(source.GetId())
+	graph.AddEntitlementID(d1.GetId())
+	graph.AddEntitlementID(d2.GetId())
+	require.NoError(t, graph.AddEdge(ctx, source.GetId(), d1.GetId(), false, nil))
+	require.NoError(t, graph.AddEdge(ctx, source.GetId(), d2.GetId(), false, nil))
+
+	expander := NewExpander(store, graph)
+
+	// Step 1: generate the action (no work yet, no page token).
+	require.NoError(t, expander.RunSingleStep(ctx))
+	require.Len(t, graph.Actions, 1)
+	require.Empty(t, graph.Actions[0].PageToken)
+
+	// Step 2: process page 0 — the action must stay queued with a page token.
+	require.NoError(t, expander.RunSingleStep(ctx))
+	require.Len(t, graph.Actions, 1, "action must remain queued while the source has more pages")
+	require.NotEmpty(t, graph.Actions[0].PageToken, "page token must advance mid-source")
+
+	// Finish.
+	for !expander.IsDone(ctx) {
+		require.NoError(t, expander.RunSingleStep(ctx))
+	}
+
+	// Source read once per page per batch. K=2 ≥ 2 dests → 1 batch; 3 pages → 3.
+	require.Equal(t, 3, store.sourceReads[source.GetId()],
+		"source read == pages × batches")
+
+	// Exactly one expanded grant per (destination, principal) — no duplicate for
+	// alice despite her appearing on two source pages.
+	counts := make(map[string]int)
+	for _, g := range store.GetPutGrants() {
+		counts[g.GetEntitlement().GetId()+"|"+g.GetPrincipal().GetId().GetResource()]++
+	}
+	for _, d := range []*v2.Entitlement{d1, d2} {
+		for _, p := range []string{"alice", "bob", "carol", "dave"} {
+			require.Equal(t, 1, counts[d.GetId()+"|"+p],
+				"exactly one grant for (%s, %s)", d.GetId(), p)
+		}
+	}
+
+	// alice's grant records the source entitlement.
+	for _, g := range store.GetPutGrants() {
+		if g.GetEntitlement().GetId() == d1.GetId() && g.GetPrincipal().GetId().GetResource() == "alice" {
+			require.Contains(t, g.GetSources().GetSources(), source.GetId(),
+				"alice's expanded grant must record the source")
+		}
+	}
 }
 
 // pageCapStubStore always returns a non-empty NextPageToken so the prefetch

--- a/pkg/sync/expand/expander_test.go
+++ b/pkg/sync/expand/expander_test.go
@@ -2,6 +2,7 @@ package expand
 
 import (
 	"context"
+	"strconv"
 	"testing"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
@@ -223,10 +224,12 @@ func TestExpanderStepByStep(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, expander.IsDone(ctx))
 
-	// Actions should be generated
+	// Actions should be generated: one action per (source, filter, batch),
+	// fanning the single A→B edge out to one destination.
 	require.Len(t, graph.Actions, 1)
 	require.Equal(t, entA.GetId(), graph.Actions[0].SourceEntitlementID)
-	require.Equal(t, entB.GetId(), graph.Actions[0].DescendantEntitlementID)
+	require.Len(t, graph.Actions[0].Descendants, 1)
+	require.Equal(t, entB.GetId(), graph.Actions[0].Descendants[0].EntitlementID)
 
 	// Second step: should process the action and complete (action completes and graph is expanded in same step)
 	err = expander.RunSingleStep(ctx)
@@ -453,6 +456,244 @@ func TestExpanderMixedDirectness(t *testing.T) {
 	// Source B: Alice has B only through expansion from A → IsDirect=false
 	require.Contains(t, sourcesC, entB.GetId())
 	require.False(t, sourcesC[entB.GetId()].GetIsDirect(), "source B should be transitive")
+}
+
+// countingMockStore wraps MockExpanderStore and records, per entitlement ID,
+// how many times its grants were read via an unfiltered (no PrincipalId)
+// ListGrantsForEntitlement call. That is the "source read" the grouping change
+// is meant to deduplicate: one read per (source, filter) instead of one per
+// outgoing edge.
+type countingMockStore struct {
+	*MockExpanderStore
+	sourceReads map[string]int
+}
+
+func newCountingMockStore() *countingMockStore {
+	return &countingMockStore{
+		MockExpanderStore: NewMockExpanderStore(),
+		sourceReads:       make(map[string]int),
+	}
+}
+
+func (s *countingMockStore) ListGrantsForEntitlement(
+	ctx context.Context,
+	req *reader_v2.GrantsReaderServiceListGrantsForEntitlementRequest,
+) (*reader_v2.GrantsReaderServiceListGrantsForEntitlementResponse, error) {
+	// Only count full-entitlement reads (the source read and descendant
+	// prefetch). Per-principal reads carry a PrincipalId filter.
+	if req.GetPrincipalId() == nil { //nolint:staticcheck // ignore deprecated field
+		s.sourceReads[req.GetEntitlement().GetId()]++
+	}
+	return s.MockExpanderStore.ListGrantsForEntitlement(ctx, req)
+}
+
+// TestExpanderHighOutDegreeSourceSingleRead is the core read-amplification
+// guard: one source feeding N destinations (all sharing the empty
+// ResourceTypeIDs filter) must read the source's grants once per destination
+// batch — ceil(N/K) reads — not once per edge. Every destination must still
+// receive the expanded grant.
+func TestExpanderHighOutDegreeSourceSingleRead(t *testing.T) {
+	t.Setenv("BATON_GRAPH_EXPAND_DEST_BATCH_SIZE", "4")
+
+	ctx := context.Background()
+	store := newCountingMockStore()
+
+	groupResource := makeResource("group", "org")
+	userResource := makeResource("user", "alice")
+
+	source := makeEntitlement("ent:source", groupResource)
+	store.AddEntitlement(source)
+	store.AddGrant(makeGrant("grant:alice:source", source, userResource))
+
+	const numDests = 10
+	graph := NewEntitlementGraph(ctx)
+	graph.AddEntitlementID(source.GetId())
+	dests := make([]*v2.Entitlement, 0, numDests)
+	for i := 0; i < numDests; i++ {
+		d := makeEntitlement("ent:dest:"+strconv.Itoa(i), groupResource)
+		store.AddEntitlement(d)
+		dests = append(dests, d)
+		graph.AddEntitlementID(d.GetId())
+		require.NoError(t, graph.AddEdge(ctx, source.GetId(), d.GetId(), false, nil))
+	}
+
+	expander := NewExpander(store, graph)
+	require.NoError(t, expander.Run(ctx))
+
+	// Source read once per batch of 4 destinations: ceil(10/4) = 3.
+	require.Equal(t, 3, store.sourceReads[source.GetId()],
+		"source must be read once per destination batch, not once per edge")
+
+	// Every destination must have received alice's expanded grant.
+	granted := make(map[string]bool)
+	for _, g := range store.GetPutGrants() {
+		if g.GetPrincipal().GetId().GetResource() == "alice" {
+			granted[g.GetEntitlement().GetId()] = true
+		}
+	}
+	for _, d := range dests {
+		require.True(t, granted[d.GetId()], "destination %s must receive the expanded grant", d.GetId())
+	}
+}
+
+// TestExpanderMixedResourceTypeIDsReadPerFilter verifies constraint C2: edges
+// from one source with *different* ResourceTypeIDs filters cannot share a read.
+// Each distinct filter gets its own source read, and the filter is honored
+// (only matching principals are fanned out).
+func TestExpanderMixedResourceTypeIDsReadPerFilter(t *testing.T) {
+	t.Setenv("BATON_GRAPH_EXPAND_DEST_BATCH_SIZE", "16")
+
+	ctx := context.Background()
+	store := newCountingMockStore()
+
+	groupResource := makeResource("group", "org")
+	userPrincipal := makeResource("user", "alice")
+	servicePrincipal := makeResource("service", "robot")
+
+	source := makeEntitlement("ent:source", groupResource)
+	destUser := makeEntitlement("ent:dest:user", groupResource)
+	destService := makeEntitlement("ent:dest:service", groupResource)
+	store.AddEntitlement(source)
+	store.AddEntitlement(destUser)
+	store.AddEntitlement(destService)
+
+	// Source has both a user principal and a service principal.
+	store.AddGrant(makeGrant("grant:alice:source", source, userPrincipal))
+	store.AddGrant(makeGrant("grant:robot:source", source, servicePrincipal))
+
+	graph := NewEntitlementGraph(ctx)
+	graph.AddEntitlementID(source.GetId())
+	graph.AddEntitlementID(destUser.GetId())
+	graph.AddEntitlementID(destService.GetId())
+	// Two edges, two different filters → two distinct source reads.
+	require.NoError(t, graph.AddEdge(ctx, source.GetId(), destUser.GetId(), false, []string{"user"}))
+	require.NoError(t, graph.AddEdge(ctx, source.GetId(), destService.GetId(), false, []string{"service"}))
+
+	expander := NewExpander(store, graph)
+	require.NoError(t, expander.Run(ctx))
+
+	// One read per distinct filter, even though both edges share the source.
+	require.Equal(t, 2, store.sourceReads[source.GetId()],
+		"distinct ResourceTypeIDs filters must each get their own source read")
+
+	// The user-filtered edge must only grant the user principal; the
+	// service-filtered edge only the service principal.
+	byEnt := make(map[string]map[string]bool)
+	for _, g := range store.GetPutGrants() {
+		ent := g.GetEntitlement().GetId()
+		if byEnt[ent] == nil {
+			byEnt[ent] = make(map[string]bool)
+		}
+		byEnt[ent][g.GetPrincipal().GetId().GetResource()] = true
+	}
+	require.True(t, byEnt[destUser.GetId()]["alice"], "user-filtered dest must grant alice")
+	require.False(t, byEnt[destUser.GetId()]["robot"], "user-filtered dest must not grant the service principal")
+	require.True(t, byEnt[destService.GetId()]["robot"], "service-filtered dest must grant the service principal")
+	require.False(t, byEnt[destService.GetId()]["alice"], "service-filtered dest must not grant the user principal")
+}
+
+// TestExpanderMultiParentDestination verifies constraint C5: a destination fed
+// by two different sources must wait until both parents are expanded and must
+// record both as sources. The grouping change must not let a destination act
+// before all incoming edges are processed.
+func TestExpanderMultiParentDestination(t *testing.T) {
+	ctx := context.Background()
+	store := NewMockExpanderStore()
+
+	groupResource := makeResource("group", "org")
+	alice := makeResource("user", "alice")
+
+	parentA := makeEntitlement("ent:parentA", groupResource)
+	parentB := makeEntitlement("ent:parentB", groupResource)
+	child := makeEntitlement("ent:child", groupResource)
+	store.AddEntitlement(parentA)
+	store.AddEntitlement(parentB)
+	store.AddEntitlement(child)
+
+	// Alice holds both parents directly.
+	store.AddGrant(makeGrant("grant:alice:parentA", parentA, alice))
+	store.AddGrant(makeGrant("grant:alice:parentB", parentB, alice))
+
+	graph := NewEntitlementGraph(ctx)
+	graph.AddEntitlementID(parentA.GetId())
+	graph.AddEntitlementID(parentB.GetId())
+	graph.AddEntitlementID(child.GetId())
+	require.NoError(t, graph.AddEdge(ctx, parentA.GetId(), child.GetId(), false, nil))
+	require.NoError(t, graph.AddEdge(ctx, parentB.GetId(), child.GetId(), false, nil))
+
+	expander := NewExpander(store, graph)
+	require.NoError(t, expander.Run(ctx))
+	require.True(t, graph.IsExpanded())
+
+	var childGrant *v2.Grant
+	for _, g := range store.GetPutGrants() {
+		if g.GetEntitlement().GetId() == child.GetId() && g.GetPrincipal().GetId().GetResource() == "alice" {
+			childGrant = g
+		}
+	}
+	require.NotNil(t, childGrant)
+	sources := childGrant.GetSources().GetSources()
+	require.Contains(t, sources, parentA.GetId(), "both parents must be recorded as sources")
+	require.Contains(t, sources, parentB.GetId(), "both parents must be recorded as sources")
+}
+
+// TestExpanderPerDestinationShallow verifies constraint C1: a single source
+// read fans out to two destinations with different Shallow settings, and each
+// destination's own Shallow gate is applied independently. The shallow edge
+// must drop the transitively-held source grant while the non-shallow edge keeps
+// it.
+func TestExpanderPerDestinationShallow(t *testing.T) {
+	t.Setenv("BATON_GRAPH_EXPAND_DEST_BATCH_SIZE", "16")
+
+	ctx := context.Background()
+	store := newCountingMockStore()
+
+	groupResource := makeResource("group", "org")
+	alice := makeResource("user", "alice")
+
+	source := makeEntitlement("ent:source", groupResource)
+	other := makeEntitlement("ent:other", groupResource)
+	destShallow := makeEntitlement("ent:dest:shallow", groupResource)
+	destDeep := makeEntitlement("ent:dest:deep", groupResource)
+	store.AddEntitlement(source)
+	store.AddEntitlement(destShallow)
+	store.AddEntitlement(destDeep)
+
+	// Alice's grant on the source is transitive (its only source is some other
+	// entitlement, not the source itself) → it does NOT qualify for a shallow
+	// edge, but does for a non-shallow edge.
+	transitive := makeGrant("grant:alice:source", source, alice)
+	transitive.SetSources(v2.GrantSources_builder{Sources: map[string]*v2.GrantSources_GrantSource{
+		other.GetId(): {IsDirect: false},
+	}}.Build())
+	store.AddGrant(transitive)
+
+	graph := NewEntitlementGraph(ctx)
+	graph.AddEntitlementID(source.GetId())
+	graph.AddEntitlementID(destShallow.GetId())
+	graph.AddEntitlementID(destDeep.GetId())
+	// Same (empty) filter → one shared source read; different Shallow per edge.
+	require.NoError(t, graph.AddEdge(ctx, source.GetId(), destShallow.GetId(), true, nil))
+	require.NoError(t, graph.AddEdge(ctx, source.GetId(), destDeep.GetId(), false, nil))
+
+	expander := NewExpander(store, graph)
+	require.NoError(t, expander.Run(ctx))
+
+	// Both shallow and deep edges share the same empty filter and the same
+	// batch, so the source is read once.
+	require.Equal(t, 1, store.sourceReads[source.GetId()],
+		"two edges sharing a filter must share one source read despite differing Shallow")
+
+	granted := make(map[string]bool)
+	for _, g := range store.GetPutGrants() {
+		if g.GetPrincipal().GetId().GetResource() == "alice" {
+			granted[g.GetEntitlement().GetId()] = true
+		}
+	}
+	require.False(t, granted[destShallow.GetId()],
+		"shallow edge must drop a transitively-held source grant")
+	require.True(t, granted[destDeep.GetId()],
+		"non-shallow edge must keep the transitively-held source grant")
 }
 
 // pageCapStubStore always returns a non-empty NextPageToken so the prefetch

--- a/pkg/sync/expand/expander_tracing_test.go
+++ b/pkg/sync/expand/expander_tracing_test.go
@@ -92,12 +92,13 @@ func TestRunActionEmitsLinkedRootSpan(t *testing.T) {
 	require.Len(t, links, 1, "runAction span must carry one link to the originating expansion span")
 	require.Equal(t, parentTraceID, links[0].SpanContext.TraceID(), "link must point to the parent trace ID")
 
-	// All four documented attributes are present.
+	// The documented attributes are present. After grouping, one runAction span
+	// covers a batch of destinations, so the span carries descendant_count
+	// instead of a single descendant_entitlement_id.
 	want := map[string]bool{
-		"source_entitlement_id":     true,
-		"descendant_entitlement_id": true,
-		"depth":                     true,
-		"shallow":                   true,
+		"source_entitlement_id": true,
+		"descendant_count":      true,
+		"depth":                 true,
 	}
 	got := map[string]bool{}
 	for _, a := range first.Attributes() {
@@ -105,10 +106,8 @@ func TestRunActionEmitsLinkedRootSpan(t *testing.T) {
 		switch string(a.Key) {
 		case "source_entitlement_id":
 			require.Equal(t, entA.GetId(), a.Value.AsString())
-		case "descendant_entitlement_id":
-			require.Equal(t, entB.GetId(), a.Value.AsString())
-		case "shallow":
-			require.False(t, a.Value.AsBool(), "edge in this fixture is non-shallow")
+		case "descendant_count":
+			require.Equal(t, int64(1), a.Value.AsInt64(), "fixture has one A→B edge")
 		case "depth":
 			// Depth starts at 0 on the first runAction call.
 			require.GreaterOrEqual(t, a.Value.AsInt64(), int64(0))

--- a/pkg/sync/expand/fanout_benchmark_test.go
+++ b/pkg/sync/expand/fanout_benchmark_test.go
@@ -1,0 +1,119 @@
+package expand
+
+import (
+	"context"
+	"strconv"
+	"sync/atomic"
+	"testing"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	reader_v2 "github.com/conductorone/baton-sdk/pb/c1/reader/v2"
+)
+
+// fanoutStore is a self-contained in-memory ExpanderStore for the
+// high-out-degree (read-amplification) scenario: one hot source entitlement
+// with `members` grants, fanned out to `dests` destination entitlements.
+//
+// It deliberately holds only the source's grants (built once) and DISCARDS
+// written grants (counting them) so memory stays bounded even at 10M expanded
+// grants. Destinations report no existing grants, so every source grant
+// expands to every destination (full fan-out, identical write volume for both
+// the old and new expander — the only difference is how many times the source
+// is read).
+type fanoutStore struct {
+	sourceEntID  string
+	sourceGrants []*v2.Grant
+	srcReads     atomic.Int64 // ListGrantsForEntitlement calls against the hot source
+	written      atomic.Int64 // expanded grants handed to StoreExpandedGrants
+}
+
+func newFanoutStore(sourceEntID string, members int) *fanoutStore {
+	grants := make([]*v2.Grant, members)
+	srcEnt := v2.Entitlement_builder{Id: sourceEntID}.Build()
+	for i := 0; i < members; i++ {
+		principal := v2.Resource_builder{
+			Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u" + strconv.Itoa(i)}.Build(),
+		}.Build()
+		grants[i] = v2.Grant_builder{
+			Id:          "g-src-" + strconv.Itoa(i),
+			Entitlement: srcEnt,
+			Principal:   principal,
+		}.Build()
+	}
+	return &fanoutStore{sourceEntID: sourceEntID, sourceGrants: grants}
+}
+
+func (s *fanoutStore) GetEntitlement(
+	_ context.Context,
+	req *reader_v2.EntitlementsReaderServiceGetEntitlementRequest,
+) (*reader_v2.EntitlementsReaderServiceGetEntitlementResponse, error) {
+	id := req.GetEntitlementId()
+	ent := v2.Entitlement_builder{
+		Id: id,
+		Resource: v2.Resource_builder{
+			Id: v2.ResourceId_builder{ResourceType: "group", Resource: id}.Build(),
+		}.Build(),
+	}.Build()
+	return reader_v2.EntitlementsReaderServiceGetEntitlementResponse_builder{Entitlement: ent}.Build(), nil
+}
+
+func (s *fanoutStore) ListGrantsForEntitlement(
+	_ context.Context,
+	req *reader_v2.GrantsReaderServiceListGrantsForEntitlementRequest,
+) (*reader_v2.GrantsReaderServiceListGrantsForEntitlementResponse, error) {
+	if req.GetEntitlement().GetId() != s.sourceEntID {
+		// Destination entitlements have no existing grants yet.
+		return reader_v2.GrantsReaderServiceListGrantsForEntitlementResponse_builder{}.Build(), nil
+	}
+	// The hot source: single page of all member grants. Every call here is a
+	// re-read of the source — the cost the "group by source" change removes.
+	s.srcReads.Add(1)
+	return reader_v2.GrantsReaderServiceListGrantsForEntitlementResponse_builder{
+		List: s.sourceGrants,
+	}.Build(), nil
+}
+
+func (s *fanoutStore) StoreExpandedGrants(_ context.Context, grants ...*v2.Grant) error {
+	s.written.Add(int64(len(grants)))
+	return nil // discard: keeps memory bounded at 10M scale
+}
+
+// benchmarkFanout builds a 1-source -> N-dest graph and expands it once per op.
+func benchmarkFanout(b *testing.B, members, dests int) {
+	ctx := context.Background()
+	const sourceEntID = "group:everyone:member"
+
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		store := newFanoutStore(sourceEntID, members)
+		graph := NewEntitlementGraph(ctx)
+		graph.AddEntitlementID(sourceEntID)
+		for d := 0; d < dests; d++ {
+			dst := "role:" + strconv.Itoa(d) + ":assigned"
+			graph.AddEntitlementID(dst)
+			if err := graph.AddEdge(ctx, sourceEntID, dst, false, nil); err != nil {
+				b.Fatalf("AddEdge: %v", err)
+			}
+		}
+		graph.Loaded = true
+		b.StartTimer()
+
+		expander := NewExpander(store, graph)
+		if err := expander.Run(ctx); err != nil {
+			b.Fatalf("expand: %v", err)
+		}
+
+		b.StopTimer()
+		// Report the two metrics the design doc cares about:
+		//   src_reads/op  -> read amplification (should be ~dests for old, ~1 for new)
+		//   written/op    -> expanded grant volume (should be identical: members*dests)
+		b.ReportMetric(float64(store.srcReads.Load()), "src_reads/op")
+		b.ReportMetric(float64(store.written.Load()), "written/op")
+		b.StartTimer()
+	}
+}
+
+// 10k members x 1000 dests = 10,000,000 expanded grants.
+func BenchmarkExpandFanout10M(b *testing.B) {
+	benchmarkFanout(b, 10000, 1000)
+}

--- a/pkg/sync/expand/fanout_disk_benchmark_test.go
+++ b/pkg/sync/expand/fanout_disk_benchmark_test.go
@@ -1,0 +1,188 @@
+package expand
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"strconv"
+	"testing"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	reader_v2 "github.com/conductorone/baton-sdk/pb/c1/reader/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+)
+
+// buildFanoutC1Z writes a REAL disk-backed c1z for the high-out-degree scenario:
+// one hot source entitlement (group:everyone:member) with `members` grants, and
+// `dests` destination entitlements each assigned to group-everyone (expandable
+// from the source). Expanding it produces members*dests grants on disk.
+// Returns the base file path and its syncID.
+func buildFanoutC1Z(b *testing.B, ctx context.Context, members, dests int) (string, string) {
+	b.Helper()
+	tmp, err := os.CreateTemp("", "fanout-base-*.c1z")
+	if err != nil {
+		b.Fatal(err)
+	}
+	_ = tmp.Close()
+	path := tmp.Name()
+
+	c1f, err := dotc1z.NewC1ZFile(ctx, path)
+	if err != nil {
+		b.Fatal(err)
+	}
+	syncID, err := c1f.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	res := func(rt, id string) *v2.Resource {
+		return v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: rt, Resource: id}.Build()}.Build()
+	}
+
+	must := func(err error) {
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	must(c1f.PutResourceTypes(ctx,
+		v2.ResourceType_builder{Id: "group"}.Build(),
+		v2.ResourceType_builder{Id: "user"}.Build(),
+		v2.ResourceType_builder{Id: "role"}.Build(),
+	))
+
+	const srcEntID = "group:everyone:member"
+	groupRes := res("group", "everyone")
+	srcEnt := v2.Entitlement_builder{Id: srcEntID, Resource: groupRes}.Build()
+	must(c1f.PutResources(ctx, groupRes))
+
+	// Destination role resources + entitlements.
+	roleResources := make([]*v2.Resource, dests)
+	destEnts := make([]*v2.Entitlement, dests)
+	for d := 0; d < dests; d++ {
+		rr := res("role", "r"+strconv.Itoa(d))
+		roleResources[d] = rr
+		destEnts[d] = v2.Entitlement_builder{Id: "role:r" + strconv.Itoa(d) + ":assigned", Resource: rr}.Build()
+	}
+	putInChunks(b, dests, 500, func(lo, hi int) { must(c1f.PutResources(ctx, roleResources[lo:hi]...)) })
+	must(c1f.PutEntitlements(ctx, srcEnt))
+	putInChunks(b, dests, 500, func(lo, hi int) { must(c1f.PutEntitlements(ctx, destEnts[lo:hi]...)) })
+
+	// Source member grants (plain): `members` distinct users hold group:everyone:member.
+	userResources := make([]*v2.Resource, members)
+	sourceGrants := make([]*v2.Grant, members)
+	for i := 0; i < members; i++ {
+		ur := res("user", "u"+strconv.Itoa(i))
+		userResources[i] = ur
+		sourceGrants[i] = v2.Grant_builder{Id: "g-src-" + strconv.Itoa(i), Entitlement: srcEnt, Principal: ur}.Build()
+	}
+	putInChunks(b, members, 1000, func(lo, hi int) { must(c1f.PutResources(ctx, userResources[lo:hi]...)) })
+	putInChunks(b, members, 1000, func(lo, hi int) { must(c1f.PutGrants(ctx, sourceGrants[lo:hi]...)) })
+
+	// Expandable grants: each role assigned to group-everyone, expandable from the source entitlement.
+	expGrants := make([]*v2.Grant, dests)
+	for d := 0; d < dests; d++ {
+		g := v2.Grant_builder{Id: "g-exp-" + strconv.Itoa(d), Entitlement: destEnts[d], Principal: groupRes}.Build()
+		annos := annotations.Annotations(g.GetAnnotations())
+		annos.Update(v2.GrantExpandable_builder{EntitlementIds: []string{srcEntID}}.Build())
+		g.SetAnnotations(annos)
+		expGrants[d] = g
+	}
+	putInChunks(b, dests, 500, func(lo, hi int) { must(c1f.PutGrants(ctx, expGrants[lo:hi]...)) })
+
+	must(c1f.EndSync(ctx))
+	must(c1f.Close(ctx))
+	return path, syncID
+}
+
+func putInChunks(b *testing.B, n, chunk int, fn func(lo, hi int)) {
+	b.Helper()
+	for lo := 0; lo < n; lo += chunk {
+		hi := lo + chunk
+		if hi > n {
+			hi = n
+		}
+		fn(lo, hi)
+	}
+}
+
+// loadFanoutGraph builds the entitlement graph from the store's pending-expansion
+// metadata (self-contained copy of the loader so it does not depend on stashed test files).
+func loadFanoutGraph(b *testing.B, ctx context.Context, store *dotc1z.C1File) *EntitlementGraph {
+	b.Helper()
+	graph := NewEntitlementGraph(ctx)
+	for def, err := range store.Grants().PendingExpansion(ctx) {
+		if errors.Is(err, sql.ErrNoRows) {
+			graph.Loaded = true
+			return graph
+		}
+		if err != nil {
+			b.Fatal(err)
+		}
+		for _, srcID := range def.Annotation.GetEntitlementIds() {
+			srcEnt, err := store.GetEntitlement(ctx, reader_v2.EntitlementsReaderServiceGetEntitlementRequest_builder{
+				EntitlementId: srcID,
+			}.Build())
+			if err != nil {
+				continue
+			}
+			graph.AddEntitlementID(def.TargetEntitlementID)
+			graph.AddEntitlementID(srcEnt.GetEntitlement().GetId())
+			_ = graph.AddEdge(ctx, srcEnt.GetEntitlement().GetId(), def.TargetEntitlementID,
+				def.Annotation.GetShallow(), def.Annotation.GetResourceTypeIds())
+		}
+	}
+	graph.Loaded = true
+	return graph
+}
+
+// 10k members x 1000 dests = 10,000,000 expanded grants, written to a real c1z on disk.
+func BenchmarkExpandFanout10MDisk(b *testing.B) {
+	ctx := context.Background()
+	const members, dests = 10000, 1000
+
+	basePath, syncID := buildFanoutC1Z(b, ctx, members, dests)
+	defer os.Remove(basePath)
+	baseData, err := os.ReadFile(basePath)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		tmp, err := os.CreateTemp("", "fanout-run-*.c1z")
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = tmp.Close()
+		runPath := tmp.Name()
+		// runPath is from os.CreateTemp().Name(), not external input — benchmark-only.
+		if err := os.WriteFile(runPath, baseData, 0600); err != nil { //nolint:gosec // G703: path is a test-created temp file, not tainted
+			b.Fatal(err)
+		}
+		c1f, err := dotc1z.NewC1ZFile(ctx, runPath)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if err := c1f.SetSyncID(ctx, syncID); err != nil {
+			b.Fatal(err)
+		}
+		graph := loadFanoutGraph(b, ctx, c1f)
+		b.StartTimer()
+
+		expander := NewExpander(c1f, graph)
+		err = expander.Run(ctx)
+
+		b.StopTimer()
+		if err != nil {
+			b.Fatalf("expand: %v", err)
+		}
+		_ = c1f.Close(ctx)
+		_ = os.Remove(runPath)
+		b.StartTimer()
+	}
+}

--- a/pkg/sync/expand/graph.go
+++ b/pkg/sync/expand/graph.go
@@ -3,6 +3,8 @@ package expand
 import (
 	"context"
 	"iter"
+	"sort"
+	"strings"
 
 	"github.com/conductorone/baton-sdk/pkg/sync/expand/scc"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
@@ -11,12 +13,45 @@ import (
 
 // JSON tags for actions, edges, and nodes are short to minimize size of serialized data when checkpointing
 
+// ActionDescendant is one destination an action fans out to. Shallow is per
+// destination because destinations sharing a source read can differ on it
+// (Shallow only gates which grants qualify when writing, not the source read).
+type ActionDescendant struct {
+	EntitlementID string `json:"did"`
+	Shallow       bool   `json:"s"`
+}
+
+// EntitlementGraphAction is one unit of expansion work: read the source's
+// grants once (filtered by ResourceTypeIDs) and fan them out to every
+// destination in Descendants. Reading the source once per batch instead of
+// once per outgoing edge is what cuts the read-amplification.
+//
+// DescendantEntitlementID/Shallow are the old per-edge fields, kept only so
+// checkpoints written by an older baton-sdk still load: descendants() folds
+// such an action into a one-element batch. New actions leave them empty and
+// use Descendants. JSON names are unchanged, so old and new checkpoints
+// round-trip without a version bump.
 type EntitlementGraphAction struct {
-	SourceEntitlementID     string   `json:"sid"`
-	DescendantEntitlementID string   `json:"did"`
-	Shallow                 bool     `json:"s"`
-	ResourceTypeIDs         []string `json:"rtids"`
-	PageToken               string   `json:"pt"`
+	SourceEntitlementID string             `json:"sid"`
+	Descendants         []ActionDescendant `json:"dsts,omitempty"`
+	ResourceTypeIDs     []string           `json:"rtids"`
+	PageToken           string             `json:"pt"`
+
+	// Legacy per-edge fields, retained for resuming pre-grouping checkpoints.
+	DescendantEntitlementID string `json:"did,omitempty"`
+	Shallow                 bool   `json:"s,omitempty"`
+}
+
+// descendants returns the destination batch for this action, folding a legacy
+// per-edge action (DescendantEntitlementID/Shallow) into a one-element batch.
+func (a *EntitlementGraphAction) descendants() []ActionDescendant {
+	if len(a.Descendants) > 0 {
+		return a.Descendants
+	}
+	if a.DescendantEntitlementID != "" {
+		return []ActionDescendant{{EntitlementID: a.DescendantEntitlementID, Shallow: a.Shallow}}
+	}
+	return nil
 }
 
 type Edge struct {
@@ -172,6 +207,49 @@ func (g *EntitlementGraph) GetExpandableDescendantEntitlements(ctx context.Conte
 			}
 		}
 	}
+}
+
+// filterGroup is a set of destination entitlements reachable from one source
+// that share the same ResourceTypeIDs source-read filter, so they can be served
+// by a single read of the source's grants.
+type filterGroup struct {
+	resourceTypeIDs []string
+	dests           []ActionDescendant
+}
+
+// groupExpandableDescendants buckets a source's unexpanded outgoing edges by
+// their ResourceTypeIDs filter (the filter changes the source read, so only
+// edges with the same filter can share one read). Output is
+// deterministic — groups ordered by their filter key, destinations sorted by
+// entitlement ID — so action generation and checkpoint resume are stable across
+// runs despite the underlying map iteration order.
+func groupExpandableDescendants(ctx context.Context, g *EntitlementGraph, sourceEntitlementID string) []filterGroup {
+	byKey := make(map[string]*filterGroup)
+	order := make([]string, 0)
+	for entID, edge := range g.GetExpandableDescendantEntitlements(ctx, sourceEntitlementID) {
+		// Canonicalize the filter so ["user","group"] and ["group","user"]
+		// share a read. ListGrantsForEntitlement filters by set membership, so
+		// reordering the slice does not change the read.
+		rtids := append([]string(nil), edge.ResourceTypeIDs...)
+		sort.Strings(rtids)
+		key := strings.Join(rtids, "\x00")
+		grp, ok := byKey[key]
+		if !ok {
+			grp = &filterGroup{resourceTypeIDs: rtids}
+			byKey[key] = grp
+			order = append(order, key)
+		}
+		grp.dests = append(grp.dests, ActionDescendant{EntitlementID: entID, Shallow: edge.IsShallow})
+	}
+
+	sort.Strings(order)
+	groups := make([]filterGroup, 0, len(order))
+	for _, key := range order {
+		grp := byKey[key]
+		sort.Slice(grp.dests, func(i, j int) bool { return grp.dests[i].EntitlementID < grp.dests[j].EntitlementID })
+		groups = append(groups, *grp)
+	}
+	return groups
 }
 
 func (g *EntitlementGraph) HasEntitlement(entitlementID string) bool {


### PR DESCRIPTION
# perf(expand): group grant expansion by source to cut per-edge source re-reads

## What?

Grant expansion used to do one job per edge — so a source feeding N destinations got its grants read N times, once per outgoing edge. This PR restructures it to one job per (source, filter): read the source's grants once and fan them out to all its destinations.

Reads-only change. Writes, ordering (all-parents-first), and cycle handling are untouched, and existing expansion tests pass unchanged.

## Why?

High-fan-out sources are common in prod i.e., a single role granted across many resources. Re-reading that source once per edge is wasted work, and each read decompresses + serDe the source's full membership from the c1z. Cutting that is the whole point.

## Results

| scenario | time (OLD vs NEW) | results |
|---|---|---|
| synthetic 10M, real disk store | 491.6 → 358.0s | −27% (−133s)|

PS: Read reduction is bounded by the destination batch size K (default 4), so on the 1000-dest source it's ~4× fewer reads (1000→250), not the full out-degree. "read once per source" is the K=∞ ceiling, not the default.

Ticket: [DAT-652](https://linear.app/ductone/issue/DAT-652/grantexpansion-improvements)