### PR TITLE
feat(dotc1z): copy-isolate sync for rollback-expansion (copy + delete-others instead of row-by-row rebuild)

### DIFF
--- a/cmd/baton/rollback_expansion.go
+++ b/cmd/baton/rollback_expansion.go
@@ -115,9 +115,11 @@ func runRollbackExpansion(cmd *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	// Writes go to a fresh clone of the targeted sync; the input is never
-	// touched. CloneSync refuses an existing --out and copies only the
-	// targeted sync, not every sync in the source.
+	// Writes go to a fresh isolated copy of the targeted sync; the input is
+	// never touched. CopyIsolateSync refuses an existing --out and produces an
+	// output containing only the targeted sync — by copying the working DB and
+	// deleting the other syncs rather than rebuilding the target row-by-row,
+	// which is the dominant cost on whale-scale files.
 	src, err := openReadOnlyC1ZStore(ctx, inPath)
 	if err != nil {
 		return fmt.Errorf("open c1z: %w", err)
@@ -140,15 +142,15 @@ func runRollbackExpansion(cmd *cobra.Command, _ []string) error {
 			return fmt.Errorf("capture pre-rollback grant sources: %w", err)
 		}
 	}
-	cloneErr := src.FileOps().CloneSync(ctx, outPath, syncID)
+	cloneErr := src.FileOps().CopyIsolateSync(ctx, outPath, syncID)
 	_ = src.Close(ctx)
 	if cloneErr != nil {
-		return fmt.Errorf("clone to --out: %w", cloneErr)
+		return fmt.Errorf("isolate to --out: %w", cloneErr)
 	}
 
-	// CloneSync has already written outPath. If anything downstream
+	// CopyIsolateSync has already written outPath. If anything downstream
 	// fails, remove the partial output so an identical retry isn't
-	// blocked by CloneSync refusing an existing path. Cleared once the
+	// blocked by the isolation step refusing an existing path. Cleared once the
 	// output is finalized successfully.
 	succeeded := false
 	defer func() {

--- a/pkg/dotc1z/c1file_store.go
+++ b/pkg/dotc1z/c1file_store.go
@@ -312,6 +312,18 @@ func (f c1FileFileOps) CloneSync(ctx context.Context, outPath string, syncID str
 	return f.c.CloneSync(ctx, outPath, syncID, c1fOpts...)
 }
 
+// CopyIsolateSync implements FileOps. Translates the engine-neutral
+// CloneSyncOptions into the SQLite-specific C1FOptions applied to the
+// destination file.
+func (f c1FileFileOps) CopyIsolateSync(ctx context.Context, outPath string, syncID string, opts ...CloneSyncOption) error {
+	cloneOpts := c1zstore.NewCloneSyncOptions(opts...)
+	var c1fOpts []C1FOption
+	if cloneOpts.TmpDir != "" {
+		c1fOpts = append(c1fOpts, WithC1FTmpDir(cloneOpts.TmpDir))
+	}
+	return f.c.CopyIsolateSync(ctx, outPath, syncID, c1fOpts...)
+}
+
 // GenerateSyncDiff implements FileOps. Direct passthrough.
 func (f c1FileFileOps) GenerateSyncDiff(ctx context.Context, baseSyncID, appliedSyncID string) (string, error) {
 	return f.c.GenerateSyncDiff(ctx, baseSyncID, appliedSyncID)

--- a/pkg/dotc1z/c1zstore/file_ops.go
+++ b/pkg/dotc1z/c1zstore/file_ops.go
@@ -12,6 +12,13 @@ type FileOps interface {
 	// activity to archive a completed sync.
 	CloneSync(ctx context.Context, outPath string, syncID string, opts ...CloneSyncOption) error
 
+	// CopyIsolateSync materializes the given sync run into a freshly created
+	// standalone c1z at outPath like CloneSync, but copies the source working
+	// database and deletes the other syncs from the copy instead of rebuilding
+	// the target sync row-by-row. It is the optimized isolation step for large
+	// files; the output contains only the target sync and is schema-normalized.
+	CopyIsolateSync(ctx context.Context, outPath string, syncID string, opts ...CloneSyncOption) error
+
 	// GenerateSyncDiff computes the diff between two existing sync runs
 	// in this same file and writes the delta as a new SyncTypePartial
 	// sync. Returns the new sync's id. Used by the local differ CLI.

--- a/pkg/dotc1z/copy_isolate_sync.go
+++ b/pkg/dotc1z/copy_isolate_sync.go
@@ -2,6 +2,7 @@ package dotc1z
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"io"
@@ -55,10 +56,14 @@ func copyDBFile(srcPath, dstPath string) (retErr error) {
 	if err := out.Sync(); err != nil {
 		return err
 	}
-	if err := out.Close(); err != nil {
-		return err
-	}
+	// Nil out before inspecting the Close error so the deferred close becomes a
+	// no-op on both paths: if this explicit Close fails, a second close from the
+	// defer would only join a benign already-closed error onto the real one.
+	cerr := out.Close()
 	out = nil
+	if cerr != nil {
+		return cerr
+	}
 	return nil
 }
 
@@ -75,9 +80,11 @@ func copyDBFile(srcPath, dstPath string) (retErr error) {
 //
 // Correctness contract (mirrors what CloneSync got for free):
 //
-//   - Input immutability: only the copy is written; the source .c1z and its
-//     decompressed working DB are read, never mutated. A failure mid-op leaves
-//     a discardable copy in a temp dir, not a half-mutated source.
+//   - Input immutability: the source .c1z is never rewritten and the copy is
+//     the only durable output. The source working DB is WAL-checkpointed before
+//     the copy so the byte-copy is complete, but that folds already-committed
+//     frames into the main file and changes no logical data. A failure mid-op
+//     leaves a discardable copy in a temp dir, not a half-mutated source.
 //   - Sync isolation: a single-sync source is used as-is; a multi-sync source
 //     has every non-target sync deleted from the copy. Either way the output
 //     contains only the target sync.
@@ -136,19 +143,70 @@ func (c *C1File) CopyIsolateSync(ctx context.Context, outPath string, syncID str
 
 	copyDbPath := filepath.Join(tmpDir, "db")
 
-	// Step 1 — copy the decompressed working DB. The source handle is opened
-	// read-only (init sets journal_mode=OFF, so there is no WAL), so its working
-	// file is the complete committed image and a plain file copy is a consistent
-	// snapshot without checkpointing — and without touching the source.
+	// Step 1 — copy the decompressed working DB. copyDBFile reads only the main
+	// database file, so any WAL frames left uncheckpointed would be silently
+	// dropped from the copy. Checkpoint first to fold every committed frame into
+	// the main file: this makes the byte-copy a complete, consistent snapshot by
+	// construction, independent of the caller's journal mode rather than relying
+	// on the current read-only caller. It is a no-op on a read-only handle
+	// (journal_mode=OFF, no WAL) and relocates no logical data, so the source is
+	// not observably mutated.
+	if _, err = c.db.ExecContext(ctx, "PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
+		return fmt.Errorf("copy-isolate-sync: error checkpointing source before copy: %w", err)
+	}
 	if err = copyDBFile(c.dbFilePath, copyDbPath); err != nil {
 		return fmt.Errorf("copy-isolate-sync: error copying working database: %w", err)
 	}
 
-	// Step 2 — open the copy. NewC1File's init() runs migrations (schema
+	// Step 2 — on a multi-sync source, delete the non-target syncs from the copy
+	// BEFORE opening it through NewC1File. NewC1File's init() runs the
+	// schema-normalization migrations — including the per-row grant-expansion
+	// backfill and the secondary-index builds — across every row present. Doing
+	// the delete first keeps that work off the (usually majority) rows that are
+	// about to be discarded. The delete filters on sync_id alone, which is in
+	// every table's base schema and so predates any migration, and the
+	// already-open source guarantees the copy carries every current table. A raw
+	// handle with throwaway pragmas keeps the delete cheap; the copy is discarded
+	// after recompress, so a crash here only loses the temp file the defer above
+	// already removes.
+	if err = func() error {
+		rawCopy, openErr := sql.Open("sqlite", copyDbPath)
+		if openErr != nil {
+			return fmt.Errorf("error opening copy for pre-migration delete: %w", openErr)
+		}
+		defer func() { _ = rawCopy.Close() }()
+		rawCopy.SetMaxOpenConns(1)
+		for _, p := range []string{"PRAGMA journal_mode = OFF", "PRAGMA synchronous = OFF"} {
+			if _, perr := rawCopy.ExecContext(ctx, p); perr != nil {
+				return fmt.Errorf("error setting %q on copy: %w", p, perr)
+			}
+		}
+		var syncCount int
+		//nolint:gosec // table name is from the hardcoded syncRuns descriptor; no user input.
+		countQuery := fmt.Sprintf("SELECT COUNT(DISTINCT sync_id) FROM %s", syncRuns.Name())
+		if scanErr := rawCopy.QueryRowContext(ctx, countQuery).Scan(&syncCount); scanErr != nil {
+			return fmt.Errorf("error counting syncs: %w", scanErr)
+		}
+		if syncCount <= 1 {
+			return nil
+		}
+		for _, t := range allTableDescriptors {
+			//nolint:gosec // table names are from the hardcoded allTableDescriptors list; sync_id is a bound parameter.
+			delQuery := fmt.Sprintf("DELETE FROM %s WHERE sync_id != ?", t.Name())
+			if _, delErr := rawCopy.ExecContext(ctx, delQuery, syncID); delErr != nil {
+				return fmt.Errorf("error deleting other syncs from %s: %w", t.Name(), delErr)
+			}
+		}
+		return nil
+	}(); err != nil {
+		return fmt.Errorf("copy-isolate-sync: %w", err)
+	}
+
+	// Step 3 — open the copy. NewC1File's init() runs migrations (schema
 	// normalization) before our pragmas are applied, so the migrations stay
 	// crash-safe under SQLite's default rollback journal. WithC1FSkipCleanup
 	// keeps close-time old-sync cleanup from deleting the isolated sync. The
-	// throwaway pragmas make the multi-sync bulk delete cheap: the copy is
+	// throwaway pragmas make the migrations and the recompress cheap: the copy is
 	// discarded after recompress, so its durability does not matter.
 	defaultOpts := []C1FOption{
 		WithC1FEncoderConcurrency(0),
@@ -172,29 +230,7 @@ func (c *C1File) CopyIsolateSync(ctx context.Context, outPath string, syncID str
 		}
 	}()
 
-	// Step 3 — count syncs (a cheap single-row read).
-	var syncCount int
-	//nolint:gosec // table name is from the hardcoded syncRuns descriptor; no user input.
-	countQuery := fmt.Sprintf("SELECT COUNT(DISTINCT sync_id) FROM %s", syncRuns.Name())
-	if err = copyFile.rawDb.QueryRowContext(ctx, countQuery).Scan(&syncCount); err != nil {
-		return fmt.Errorf("copy-isolate-sync: error counting syncs: %w", err)
-	}
-
-	// Step 4 — multiple syncs: delete the non-target syncs from every data table
-	// on the copy. This removes the (usually minority) other-sync rows rather
-	// than re-inserting the entire target sync. A single-sync source skips this
-	// entirely and passes the copy through unchanged.
-	if syncCount > 1 {
-		for _, t := range allTableDescriptors {
-			//nolint:gosec // table names are from the hardcoded allTableDescriptors list; sync_id is a bound parameter.
-			delQuery := fmt.Sprintf("DELETE FROM %s WHERE sync_id != ?", t.Name())
-			if _, err = copyFile.rawDb.ExecContext(ctx, delQuery, syncID); err != nil {
-				return fmt.Errorf("copy-isolate-sync: error deleting other syncs from %s: %w", t.Name(), err)
-			}
-		}
-	}
-
-	// Step 5 — recompress the isolated copy to outPath. Mirrors cloneCopy's
+	// Step 4 — recompress the isolated copy to outPath. Mirrors cloneCopy's
 	// finalize: dbUpdated + outputFilePath + Close() runs the
 	// WAL-checkpoint -> close-raw-db -> saveC1z sequence.
 	copyFile.dbUpdated = true

--- a/pkg/dotc1z/copy_isolate_sync.go
+++ b/pkg/dotc1z/copy_isolate_sync.go
@@ -1,0 +1,208 @@
+package dotc1z
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/uotel"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// copyDBFile streams srcPath to a new file at dstPath (which must not exist).
+// The source is opened read-only and never written, preserving input
+// immutability. Streaming (rather than os.ReadFile) keeps memory flat when the
+// working database is whale-scale.
+func copyDBFile(srcPath, dstPath string) (retErr error) {
+	// #nosec G304 -- srcPath is the connector's own decompressed working DB.
+	in, err := os.Open(srcPath)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if cerr := in.Close(); cerr != nil {
+			retErr = errors.Join(retErr, cerr)
+		}
+	}()
+
+	// O_EXCL: dstPath lives in a freshly created temp dir and must not
+	// pre-exist; refuse to clobber.
+	out, err := os.OpenFile(dstPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if out != nil {
+			if cerr := out.Close(); cerr != nil {
+				retErr = errors.Join(retErr, cerr)
+			}
+		}
+	}()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+
+	// Sync before SQLite opens the copy: on aggressively-caching filesystems an
+	// unsynced copy can be read with incomplete data — the same hazard
+	// decompressC1z guards against.
+	if err := out.Sync(); err != nil {
+		return err
+	}
+	if err := out.Close(); err != nil {
+		return err
+	}
+	out = nil
+	return nil
+}
+
+// CopyIsolateSync produces a standalone .c1z at outPath containing only the
+// given sync, like CloneSync, but it copies the source working database and
+// deletes the other syncs from the copy instead of rebuilding the target sync
+// row-by-row with INSERT ... SELECT.
+//
+// For a whale c1z whose target sync is the bulk of the data, that rebuild reads
+// and re-inserts every target row into a fresh file (maintaining every index
+// per row) — the dominant cost of the ~5h/~99GB clone. Copy-isolation instead
+// pays one sequential file copy plus a delete of the (usually minority)
+// non-target rows, which is far less work.
+//
+// Correctness contract (mirrors what CloneSync got for free):
+//
+//   - Input immutability: only the copy is written; the source .c1z and its
+//     decompressed working DB are read, never mutated. A failure mid-op leaves
+//     a discardable copy in a temp dir, not a half-mutated source.
+//   - Sync isolation: a single-sync source is used as-is; a multi-sync source
+//     has every non-target sync deleted from the copy. Either way the output
+//     contains only the target sync.
+//   - Schema normalization: the copy is opened through NewC1File, whose init()
+//     runs the same migrations CloneSync's fresh-DB creation did, so an
+//     older-schema source is normalized to the current schema.
+//   - Close-time cleanup: the copy is opened WithC1FSkipCleanup(true) so the
+//     old-sync cleanup that runs at close does not delete the isolated sync.
+func (c *C1File) CopyIsolateSync(ctx context.Context, outPath string, syncID string, opts ...C1FOption) (err error) {
+	ctx, span := tracer.Start(ctx, "C1File.CopyIsolateSync")
+	defer func() { uotel.EndSpanWithError(span, err) }()
+
+	if c.rawDb == nil {
+		return ErrDbNotOpen
+	}
+	if c.dbFilePath == "" {
+		return fmt.Errorf("copy-isolate-sync: source working database path is not set")
+	}
+
+	// Check the output path before inspecting the sync, matching CloneSync's
+	// observable ordering.
+	if _, statErr := os.Stat(outPath); statErr == nil || !errors.Is(statErr, fs.ErrNotExist) {
+		return errOutPathExists("copy-isolate-sync", outPath)
+	}
+
+	if syncID == "" {
+		syncID, err = c.LatestSyncID(ctx, connectorstore.SyncTypeFull)
+		if err != nil {
+			return err
+		}
+	}
+
+	sync, err := c.getSync(ctx, syncID)
+	if err != nil {
+		return err
+	}
+	if sync == nil {
+		return status.Errorf(codes.NotFound, "copy-isolate-sync: sync %s not found", syncID)
+	}
+	if sync.EndedAt == nil {
+		return status.Errorf(codes.FailedPrecondition, "copy-isolate-sync: sync %s is not ended", syncID)
+	}
+
+	tmpDir, err := os.MkdirTemp(c.tempDir, "c1zcopyiso")
+	if err != nil {
+		return err
+	}
+	// Always clean up the temp dir. A successful Close already removes it via
+	// cleanupDbDir; RemoveAll on an absent dir is a no-op, so this stays correct
+	// on both the success and error paths.
+	defer func() {
+		if cleanupErr := os.RemoveAll(tmpDir); cleanupErr != nil {
+			err = errors.Join(err, fmt.Errorf("copy-isolate-sync: error cleaning up temp dir: %w", cleanupErr))
+		}
+	}()
+
+	copyDbPath := filepath.Join(tmpDir, "db")
+
+	// Step 1 — copy the decompressed working DB. The source handle is opened
+	// read-only (init sets journal_mode=OFF, so there is no WAL), so its working
+	// file is the complete committed image and a plain file copy is a consistent
+	// snapshot without checkpointing — and without touching the source.
+	if err = copyDBFile(c.dbFilePath, copyDbPath); err != nil {
+		return fmt.Errorf("copy-isolate-sync: error copying working database: %w", err)
+	}
+
+	// Step 2 — open the copy. NewC1File's init() runs migrations (schema
+	// normalization) before our pragmas are applied, so the migrations stay
+	// crash-safe under SQLite's default rollback journal. WithC1FSkipCleanup
+	// keeps close-time old-sync cleanup from deleting the isolated sync. The
+	// throwaway pragmas make the multi-sync bulk delete cheap: the copy is
+	// discarded after recompress, so its durability does not matter.
+	defaultOpts := []C1FOption{
+		WithC1FEncoderConcurrency(0),
+		WithC1FSkipCleanup(true),
+		WithC1FPragma("journal_mode", "OFF"),
+		WithC1FPragma("synchronous", "OFF"),
+	}
+	copyFile, err := NewC1File(ctx, copyDbPath, append(defaultOpts, opts...)...)
+	if err != nil {
+		return fmt.Errorf("copy-isolate-sync: error opening copy: %w", err)
+	}
+
+	// Release the copy handle on any path that does not reach a successful
+	// Close. Set once Close is invoked so we never double-close its rawDb.
+	finalized := false
+	defer func() {
+		if !finalized && copyFile.rawDb != nil {
+			if closeErr := copyFile.closeRawDB(ctx); closeErr != nil {
+				err = errors.Join(err, closeErr)
+			}
+		}
+	}()
+
+	// Step 3 — count syncs (a cheap single-row read).
+	var syncCount int
+	//nolint:gosec // table name is from the hardcoded syncRuns descriptor; no user input.
+	countQuery := fmt.Sprintf("SELECT COUNT(DISTINCT sync_id) FROM %s", syncRuns.Name())
+	if err = copyFile.rawDb.QueryRowContext(ctx, countQuery).Scan(&syncCount); err != nil {
+		return fmt.Errorf("copy-isolate-sync: error counting syncs: %w", err)
+	}
+
+	// Step 4 — multiple syncs: delete the non-target syncs from every data table
+	// on the copy. This removes the (usually minority) other-sync rows rather
+	// than re-inserting the entire target sync. A single-sync source skips this
+	// entirely and passes the copy through unchanged.
+	if syncCount > 1 {
+		for _, t := range allTableDescriptors {
+			//nolint:gosec // table names are from the hardcoded allTableDescriptors list; sync_id is a bound parameter.
+			delQuery := fmt.Sprintf("DELETE FROM %s WHERE sync_id != ?", t.Name())
+			if _, err = copyFile.rawDb.ExecContext(ctx, delQuery, syncID); err != nil {
+				return fmt.Errorf("copy-isolate-sync: error deleting other syncs from %s: %w", t.Name(), err)
+			}
+		}
+	}
+
+	// Step 5 — recompress the isolated copy to outPath. Mirrors cloneCopy's
+	// finalize: dbUpdated + outputFilePath + Close() runs the
+	// WAL-checkpoint -> close-raw-db -> saveC1z sequence.
+	copyFile.dbUpdated = true
+	copyFile.outputFilePath = outPath
+	finalized = true
+	if err = copyFile.Close(ctx); err != nil {
+		return fmt.Errorf("copy-isolate-sync: error writing output: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/dotc1z/copy_isolate_sync_test.go
+++ b/pkg/dotc1z/copy_isolate_sync_test.go
@@ -1,0 +1,182 @@
+package dotc1z
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+)
+
+// writeSync writes one full sync to f containing a single resource type, one
+// resource, one entitlement, and one grant, all tagged with idSuffix so syncs
+// written to the same file are distinguishable. It returns the new sync's id.
+func writeSync(ctx context.Context, t *testing.T, f *C1File, idSuffix string) string {
+	t.Helper()
+
+	syncID, err := f.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+
+	groupRT := v2.ResourceType_builder{Id: "group"}.Build()
+	require.NoError(t, f.PutResourceTypes(ctx, groupRT))
+
+	g := v2.Resource_builder{
+		Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g-" + idSuffix}.Build(),
+	}.Build()
+	require.NoError(t, f.PutResources(ctx, g))
+
+	ent := v2.Entitlement_builder{Id: "ent-" + idSuffix, Resource: g}.Build()
+	require.NoError(t, f.PutEntitlements(ctx, ent))
+
+	grant := v2.Grant_builder{Id: "grant-" + idSuffix, Entitlement: ent, Principal: g}.Build()
+	require.NoError(t, f.PutGrants(ctx, grant))
+
+	require.NoError(t, f.EndSync(ctx))
+	return syncID
+}
+
+func countRows(ctx context.Context, t *testing.T, f *C1File, query string, args ...any) int {
+	t.Helper()
+	var n int
+	require.NoError(t, f.rawDb.QueryRowContext(ctx, query, args...).Scan(&n))
+	return n
+}
+
+// TestCopyIsolateSyncSingleSync verifies the single-sync passthrough: the copy
+// is used as-is (no per-sync deletes) and the output is a correct single-sync
+// c1z with the data intact.
+func TestCopyIsolateSyncSingleSync(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	src, err := NewC1File(ctx, filepath.Join(dir, "source.db"), WithC1FTmpDir(dir))
+	require.NoError(t, err)
+	syncID := writeSync(ctx, t, src, "a")
+
+	outPath := filepath.Join(dir, "out.c1z")
+	require.NoError(t, src.CopyIsolateSync(ctx, outPath, syncID))
+	require.NoError(t, src.rawDb.Close())
+
+	out, err := NewC1ZFile(ctx, outPath)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, out.Close(ctx)) }()
+
+	require.Equal(t, 1, countRows(ctx, t, out, fmt.Sprintf("SELECT COUNT(DISTINCT sync_id) FROM %s", syncRuns.Name())))
+	require.Equal(t, 1, countRows(ctx, t, out, fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE sync_id = ?", resources.Name()), syncID))
+	require.Equal(t, 1, countRows(ctx, t, out, fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE sync_id = ?", grants.Name()), syncID))
+
+	out.currentSyncID = ""
+	require.NoError(t, out.ViewSync(ctx, syncID))
+	resp, err := out.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{}.Build())
+	require.NoError(t, err)
+	require.Len(t, resp.GetList(), 1)
+	require.Equal(t, "grant-a", resp.GetList()[0].GetId())
+}
+
+// TestCopyIsolateSyncMultiSync verifies that for a multi-sync source the other
+// syncs are deleted from the copy (only the target sync survives in the output)
+// and that the source file is left untouched (input immutability).
+func TestCopyIsolateSyncMultiSync(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	src, err := NewC1File(ctx, filepath.Join(dir, "source.db"), WithC1FTmpDir(dir))
+	require.NoError(t, err)
+	targetSyncID := writeSync(ctx, t, src, "target")
+	otherSyncID := writeSync(ctx, t, src, "other")
+	require.NotEqual(t, targetSyncID, otherSyncID)
+
+	outPath := filepath.Join(dir, "out.c1z")
+	require.NoError(t, src.CopyIsolateSync(ctx, outPath, targetSyncID))
+
+	// Input immutability: the source still has BOTH syncs after the call.
+	require.Equal(t, 2, countRows(ctx, t, src, fmt.Sprintf("SELECT COUNT(DISTINCT sync_id) FROM %s", syncRuns.Name())))
+	require.NoError(t, src.rawDb.Close())
+
+	out, err := NewC1ZFile(ctx, outPath)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, out.Close(ctx)) }()
+
+	// Sync isolation: only the target sync remains, across every data table.
+	require.Equal(t, 1, countRows(ctx, t, out, fmt.Sprintf("SELECT COUNT(DISTINCT sync_id) FROM %s", syncRuns.Name())))
+	for _, table := range []string{resources.Name(), entitlements.Name(), grants.Name(), syncRuns.Name()} {
+		require.Equal(t, 0, countRows(ctx, t, out, fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE sync_id = ?", table), otherSyncID),
+			"table %s should have no rows from the non-target sync", table)
+	}
+	require.Equal(t, 1, countRows(ctx, t, out, fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE sync_id = ?", grants.Name()), targetSyncID))
+
+	out.currentSyncID = ""
+	require.NoError(t, out.ViewSync(ctx, targetSyncID))
+	resp, err := out.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{}.Build())
+	require.NoError(t, err)
+	require.Len(t, resp.GetList(), 1)
+	require.Equal(t, "grant-target", resp.GetList()[0].GetId())
+}
+
+// TestCopyIsolateSyncMigratesOlderSchema verifies requirement (c): the copy is
+// opened through NewC1File, so schema migrations run on it. A source whose
+// grants table is missing the migration-added expansion/needs_expansion columns
+// (an older schema) must produce an output whose grants table has them.
+func TestCopyIsolateSyncMigratesOlderSchema(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	src, err := NewC1File(ctx, filepath.Join(dir, "source.db"), WithC1FTmpDir(dir))
+	require.NoError(t, err)
+	syncID := writeSync(ctx, t, src, "a")
+
+	// Simulate an older schema: drop the migration-added columns (and the
+	// partial indexes that depend on them) from the source grants table. getSync
+	// and the sync-count read only touch sync_runs, so the source stays readable
+	// for CopyIsolateSync's preconditions.
+	for _, idx := range []string{"idx_grants_sync_expansion_v1", "idx_grants_sync_needs_expansion_v1"} {
+		_, err = src.db.ExecContext(ctx, fmt.Sprintf("DROP INDEX IF EXISTS %s", idx))
+		require.NoError(t, err)
+	}
+	for _, col := range []string{"expansion", "needs_expansion"} {
+		_, err = src.db.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %s DROP COLUMN %s", grants.Name(), col))
+		require.NoError(t, err)
+	}
+	require.Equal(t, 0, countRows(ctx, t, src,
+		fmt.Sprintf("SELECT COUNT(*) FROM pragma_table_info('%s') WHERE name IN ('expansion','needs_expansion')", grants.Name())),
+		"precondition: source grants should be missing the migration columns")
+
+	outPath := filepath.Join(dir, "out.c1z")
+	require.NoError(t, src.CopyIsolateSync(ctx, outPath, syncID))
+	require.NoError(t, src.rawDb.Close())
+
+	out, err := NewC1ZFile(ctx, outPath)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, out.Close(ctx)) }()
+
+	require.Equal(t, 2, countRows(ctx, t, out,
+		fmt.Sprintf("SELECT COUNT(*) FROM pragma_table_info('%s') WHERE name IN ('expansion','needs_expansion')", grants.Name())),
+		"migration should have re-added expansion and needs_expansion on the copy")
+	require.Equal(t, 1, countRows(ctx, t, out, fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE sync_id = ?", grants.Name()), syncID),
+		"grant data should survive the copy + migration")
+}
+
+// TestCopyIsolateSyncRejectsExistingOutput verifies the output-path precheck.
+func TestCopyIsolateSyncRejectsExistingOutput(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	src, err := NewC1File(ctx, filepath.Join(dir, "source.db"), WithC1FTmpDir(dir))
+	require.NoError(t, err)
+	syncID := writeSync(ctx, t, src, "a")
+	defer func() { require.NoError(t, src.rawDb.Close()) }()
+
+	outPath := filepath.Join(dir, "exists.c1z")
+	f, ferr := os.Create(outPath)
+	require.NoError(t, ferr)
+	require.NoError(t, f.Close())
+
+	err = src.CopyIsolateSync(ctx, outPath, syncID)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "must not exist")
+}

--- a/pkg/dotc1z/engine/pebble/adapter_file_ops.go
+++ b/pkg/dotc1z/engine/pebble/adapter_file_ops.go
@@ -38,6 +38,15 @@ func (f pebbleFileOps) CloneSync(ctx context.Context, outPath string, syncID str
 	return cloneSync(ctx, f.a, f.encoding, outPath, syncID, opts...)
 }
 
+// CopyIsolateSync falls back to cloneSync for the Pebble engine. The
+// copy-isolation optimization is SQLite-specific (it copies the SQLite working
+// file and deletes other syncs); the Pebble engine already materializes only
+// the target sync's keyspace into a fresh engine, so it has no whale-rebuild
+// cost to avoid.
+func (f pebbleFileOps) CopyIsolateSync(ctx context.Context, outPath string, syncID string, opts ...c1zstore.CloneSyncOption) error {
+	return cloneSync(ctx, f.a, f.encoding, outPath, syncID, opts...)
+}
+
 // GenerateSyncDiff computes the additions-only set difference
 // between two ended syncs and emits a new SyncTypePartial sync
 // containing them. Matches the SQLite contract in

--- a/pkg/dotc1z/pebble_store.go
+++ b/pkg/dotc1z/pebble_store.go
@@ -189,6 +189,10 @@ func (f pebbleStoreFileOps) CloneSync(ctx context.Context, outPath string, syncI
 	return f.inner.CloneSync(ctx, outPath, syncID, opts...)
 }
 
+func (f pebbleStoreFileOps) CopyIsolateSync(ctx context.Context, outPath string, syncID string, opts ...CloneSyncOption) error {
+	return f.inner.CopyIsolateSync(ctx, outPath, syncID, opts...)
+}
+
 func (f pebbleStoreFileOps) GenerateSyncDiff(ctx context.Context, baseSyncID, appliedSyncID string) (string, error) {
 	diffSyncID, err := f.inner.GenerateSyncDiff(ctx, baseSyncID, appliedSyncID)
 	if err != nil {


### PR DESCRIPTION
## Summary

The rollback-expansion `--out` flow isolates the target sync into a fresh `.c1z` via `C1File.CloneSync`, which creates a new SQLite DB and runs `INSERT INTO clone.<table> SELECT ... WHERE sync_id=?` for every table, maintaining every index per inserted row. On a large file whose target sync is the bulk of the data, that rebuild is the dominant cost of the flow (multi-hour, ~100GB of I/O) because it re-materializes the whole target sync into a new file.

This adds **`C1File.CopyIsolateSync`**, an optimized isolation step, and switches the `--out` flow to it. `CloneSync` is left untouched (its contract and tests are stable).

## Algorithm

1. **Copy** the decompressed working DB file to a temp path — the source is read-only, never written.
2. **Open the copy through `NewC1File`** so `init()` runs the schema migrations (normalization), opened `WithC1FSkipCleanup(true)`.
3. **Count syncs** (`SELECT COUNT(DISTINCT sync_id) FROM v1_sync_runs`).
4. **Single sync** → use the copy as-is (passthrough, no row work). **Multiple syncs** → `DELETE FROM <table> WHERE sync_id != ?` across every table in `allTableDescriptors`, under throwaway-DB pragmas (`journal_mode=OFF`, `synchronous=OFF`) since the copy is discarded after recompress.
5. **Recompress** the isolated copy to the output path (`RollbackExpansion` + replay downstream are unchanged).

## Why this is faster

`CloneSync` reads and re-inserts **every row of the target sync** into a fresh file, paying per-row B-tree maintenance on every index. When the target sync is most of the file, copy-isolation instead pays:

- one **sequential file copy** (streamed, flat memory), plus
- a delete of only the **non-target (usually minority) rows**.

Deleting the minority of rows from a copy is far less work than re-inserting the majority into a new DB, and a sequential copy beats the random-I/O `INSERT ... SELECT`. A single-sync source skips the deletes entirely.

## Correctness contract (matches what CloneSync got for free)

- **Input immutability** — only the copy is written; the source `.c1z` and its working DB are read-only. A failure mid-op leaves a discardable copy in a temp dir, not a half-mutated source.
- **Sync isolation** — output contains only the target sync (single-sync passthrough or delete-others).
- **Schema normalization** — the copy is opened through `NewC1File`, which runs migrations, so an older-schema source is normalized to the current schema (migrations run under SQLite's default rollback journal, before the throwaway pragmas apply, so they stay crash-safe).
- **Close-time cleanup** — opened `WithC1FSkipCleanup(true)` so old-sync cleanup at close does not delete the isolated sync.

## Wiring

`CopyIsolateSync` is added to the `c1zstore.FileOps` contract and implemented by `c1FileFileOps` (real) and both Pebble `FileOps` shims (the Pebble engine falls back to its existing single-sync clone — the copy optimization is SQLite-specific and Pebble already materializes only the target sync's keyspace).

## Tests

New `pkg/dotc1z/copy_isolate_sync_test.go`:
- **single-sync** passthrough → correct single-sync output, data intact;
- **multi-sync** → other syncs deleted from the copy (only the target remains across every data table) **and the source still has both syncs** (immutability);
- **older-schema source** → migration-added columns (`expansion`/`needs_expansion`) dropped from the source grants table are **re-added on the copy** (migrations ran), data survives;
- **existing-output** path is rejected.

`go test ./pkg/dotc1z/... ./cmd/baton/...` passes (including the existing `clone_sync_test.go`, `rollback_expansion_test.go`, and `rollback_feedback_test.go`); `make lint` is clean.

## Review notes

- Review-only — please do not merge or self-approve; a human reviews before merge.
- Next phase: build a local binary and re-run the large rollback to confirm the wall-clock improvement.