### PR TITLE
Add squire env manifest for baton-sdk

### DIFF
--- a/.squire/squire.yaml
+++ b/.squire/squire.yaml
@@ -1,0 +1,15 @@
+# Squire env manifest for baton-sdk.
+# Public Go SDK: Go toolchain + vendored deps + a frontend/ built via npm.
+# No databases, no docker, no dev secrets — so no services are declared.
+# Gates `make build` / `make test` / `make lint` run on the shared
+# squire-base image (Go 1.26.x + Node 24 + golangci-lint). `make protogen`
+# needs `buf` (not in base) and is CI-only; see PR body for the follow-up.
+version: "1"
+
+repo:
+  url: "https://github.com/ConductorOne/baton-sdk"
+  branch: "main"
+
+env:
+  name: "baton-sdk"
+  description: "ConductorOne baton-sdk development environment"


### PR DESCRIPTION
## Why

We want to run `baton-sdk` in ephemeral [Squire](https://github.com/ConductorOne) development environments. This repo is a pure Go SDK with a `frontend/` built via npm — no databases, no docker, no dev secrets — so the shared **`squire-base`** image (Go 1.26.x + Node 24 + golangci-lint) is sufficient. No services need to be declared.

## What this changes

Adds `.squire/squire.yaml`, a minimal env manifest:

- `version: "1"`
- `repo` → `https://github.com/ConductorOne/baton-sdk`, branch `main`
- `env` → name `baton-sdk`, one-line description
- **No `services`, no `init`, no `post_start`** — nothing in this repo needs a backing process or a tool beyond what the base image provides.

### Verified in-env on `squire-base`

| Gate | Command | Result |
|------|---------|--------|
| build | `make build` (npm frontend build + `go build`) | ✅ exit 0 |
| test | `make test` (`go test -tags=baton_lambda_support ./...`, no external services) | ✅ exit 0 |
| lint | `make lint` (`golangci-lint run`) | ⚠️ toolchain runs; one **pre-existing** `nolintlint` finding in `pkg/sync/expand/fanout_disk_benchmark_test.go`, unrelated to this change and out of scope here |

The lint finding exists on `main` independent of this PR (this PR touches only `.squire/`). Note: base image ships golangci-lint v2.9.0 while CI pins v2.12.2 — a version-parity follow-up, not a blocker for booting the env.

### Documented follow-up: `make protogen`

`make protogen` (`buf generate`) needs `buf`, which is **not** in `squire-base`, plus network access to remote BSR plugins. It is a CI-only/codegen path and is not required to build, test, or lint. If protogen-in-env is later desired, add an `init` hook pinned to the `buf` version this repo's `buf.gen.yaml` expects; left out here to keep the manifest minimal.

## Image-row proposal (operator action — not a repo file)

To register this repo as a bootable Squire image, an operator should add an image row (admin API / `SQUIRE_SEED_IMAGES`):

| Field | Value |
|-------|-------|
| `slug` | `baton-sdk` |
| `image_ref` | shared `squire-base` |
| `git_url` | `https://github.com/ConductorOne/baton-sdk` |
| `workspace_path` | repo root |
| `default_flavor` | `small` |

---

Draft PR — opening for review of the manifest before the image row is seeded.

<!-- squire-env -->
---
🏰 Squire environment: [tiny-moose-28780](https://us-west-2.squire.ductone.com/env?id=tiny-moose-28780&task=8a4f5c1a-136d-425a-a648-a22f2301f6ce)
Task: 8a4f5c1a-136d-425a-a648-a22f2301f6ce