### PR TITLE
cmd/baton: remove Hidden flag from rollback-expansion command

### DIFF
--- a/cmd/baton/rollback_expansion.go
+++ b/cmd/baton/rollback_expansion.go
@@ -25,10 +25,9 @@ type rollbackExpansionStore interface {
 
 func rollbackExpansionCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:    "rollback-expansion",
-		Short:  "Roll back grant expansion in a c1z so it can be replayed",
-		Hidden: true,
-		RunE:   runRollbackExpansion,
+		Use:   "rollback-expansion",
+		Short: "Roll back grant expansion in a c1z so it can be replayed",
+		RunE:  runRollbackExpansion,
 	}
 	cmd.Flags().String("sync-id", "", "Sync to roll back. Defaults to the latest finished sync.")
 	cmd.Flags().String("out", "", "Path to write the rolled-back c1z to (required for a write; the input file is never modified).")


### PR DESCRIPTION
The `rollback-expansion` subcommand was registered with `Hidden: true` in
`cmd/baton/rollback_expansion.go`, which suppressed it from appearing in
`baton --help` output. The command is compiled in and fully functional;
hiding it makes it undiscoverable to users.

This change removes the `Hidden: true` field so the command appears in
the standard help listing alongside other subcommands.

---

Built with stargate.