### PR TITLE
c1 sanitizer: Pebble storage-engine support

### DIFF
--- a/cmd/baton/sanitize.go
+++ b/cmd/baton/sanitize.go
@@ -23,6 +23,7 @@ func sanitizeCmd() *cobra.Command {
 	}
 
 	cmd.Flags().String("out", "", "Path to the sanitized .c1z output file (required)")
+	cmd.Flags().String("out-engine", "", "Storage engine for the output: sqlite or pebble. Defaults to the source c1z's engine.")
 	cmd.Flags().String("secret-file", "", "Path to a per-c1z HMAC secret (>=32 random bytes). If unset, a fresh secret is generated and written next to --out.")
 	cmd.Flags().String("anchor", "", "RFC3339 timestamp the newest source timestamp lands on. Defaults to now.")
 	cmd.Flags().Bool("allow-unknown-annotations", false, "Pass annotations of unknown type through unchanged instead of dropping. Dangerous on real customer data.")
@@ -57,8 +58,17 @@ func runSanitize(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	outEngineRaw, err := cmd.Flags().GetString("out-engine")
+	if err != nil {
+		return err
+	}
 	if outPath == "" {
 		return fmt.Errorf("--out is required")
+	}
+	switch outEngineRaw {
+	case "", string(dotc1z.EngineSQLite), string(dotc1z.EnginePebble):
+	default:
+		return fmt.Errorf("--out-engine must be %q or %q, got %q", dotc1z.EngineSQLite, dotc1z.EnginePebble, outEngineRaw)
 	}
 
 	// All input validation happens BEFORE the secret is loaded or
@@ -93,9 +103,20 @@ func runSanitize(cmd *cobra.Command, args []string) error {
 	}
 	defer src.Close(ctx)
 
+	// Default the output engine to the source's so `sanitize` round-trips
+	// the engine unless the operator asks otherwise. An empty source engine
+	// (virtual/unknown store) falls back to the SQLite default.
+	dstEngine := dotc1z.Engine(outEngineRaw)
+	if outEngineRaw == "" {
+		dstEngine = dotc1z.Engine(src.Metadata().Engine)
+		if dstEngine == "" {
+			dstEngine = dotc1z.EngineSQLite
+		}
+	}
+
 	// The dst is a net-new, single-writer intermediate that is discarded
-	// on any failure, so durability and index-maintenance costs are pure
-	// throughput overhead here:
+	// on any failure. The throughput pragmas below are SQLite-only — Pebble
+	// ignores them — so they are applied only for a SQLite destination:
 	//   - journal_mode=OFF + synchronous=OFF: no rollback journal, no fsync
 	//     (the output is rebuilt from source on any failure, not recovered).
 	//   - cache_size=-1048576 (1 GiB) + mmap_size=8 GiB + temp_store=MEMORY:
@@ -105,19 +126,23 @@ func runSanitize(cmd *cobra.Command, args []string) error {
 	//   - WithBulkLoad: defer secondary-index creation until after the load
 	//     so per-row random-key B-tree maintenance does not dominate.
 	// These pragmas are scoped to THIS writer instance; normal connector
-	// syncs open their own C1File and are unaffected.
-	dst, err := dotc1z.NewStore(ctx, outPath,
-		dotc1z.WithPragma("journal_mode", "OFF"),
-		dotc1z.WithPragma("synchronous", "OFF"),
-		dotc1z.WithPragma("cache_size", "-1048576"),
-		dotc1z.WithPragma("mmap_size", "8589934592"),
-		dotc1z.WithPragma("temp_store", "MEMORY"),
-		dotc1z.WithBulkLoad(true),
-		// bulkLoad already implies skip-cleanup; skip VACUUM too — vacuuming
-		// before the deferred indexes are rebuilt at Close is wasted work on a
-		// throwaway artifact.
-		dotc1z.WithSkipVacuum(true),
-	)
+	// syncs open their own store and are unaffected.
+	dstOpts := []dotc1z.C1ZOption{dotc1z.WithEngine(dstEngine)}
+	if dstEngine == dotc1z.EngineSQLite {
+		dstOpts = append(dstOpts,
+			dotc1z.WithPragma("journal_mode", "OFF"),
+			dotc1z.WithPragma("synchronous", "OFF"),
+			dotc1z.WithPragma("cache_size", "-1048576"),
+			dotc1z.WithPragma("mmap_size", "8589934592"),
+			dotc1z.WithPragma("temp_store", "MEMORY"),
+			dotc1z.WithBulkLoad(true),
+			// bulkLoad already implies skip-cleanup; skip VACUUM too — vacuuming
+			// before the deferred indexes are rebuilt at Close is wasted work on
+			// a throwaway artifact.
+			dotc1z.WithSkipVacuum(true),
+		)
+	}
+	dst, err := dotc1z.NewStore(ctx, outPath, dstOpts...)
 	if err != nil {
 		return fmt.Errorf("open dst c1z: %w", err)
 	}

--- a/cmd/baton/sanitize.go
+++ b/cmd/baton/sanitize.go
@@ -65,10 +65,15 @@ func runSanitize(cmd *cobra.Command, args []string) error {
 	if outPath == "" {
 		return fmt.Errorf("--out is required")
 	}
-	switch outEngineRaw {
-	case "", string(dotc1z.EngineSQLite), string(dotc1z.EnginePebble):
-	default:
-		return fmt.Errorf("--out-engine must be %q or %q, got %q", dotc1z.EngineSQLite, dotc1z.EnginePebble, outEngineRaw)
+	// An omitted --out-engine (default "") means "follow the source engine".
+	// An explicitly-supplied empty value is a mistake, not a request to default,
+	// so reject it rather than silently following the source.
+	if cmd.Flags().Changed("out-engine") {
+		switch outEngineRaw {
+		case string(dotc1z.EngineSQLite), string(dotc1z.EnginePebble):
+		default:
+			return fmt.Errorf("--out-engine must be %q or %q, got %q", dotc1z.EngineSQLite, dotc1z.EnginePebble, outEngineRaw)
+		}
 	}
 
 	// All input validation happens BEFORE the secret is loaded or

--- a/cmd/baton/sanitize_test.go
+++ b/cmd/baton/sanitize_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -10,6 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/c1zsanitize"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z"
 )
@@ -59,6 +62,110 @@ func TestSanitizeCommand(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, resp.GetList(), 1, "grant count must be preserved")
 	require.NotEqual(t, srcGrantID, resp.GetList()[0].GetId(), "grant id must be sanitized, not passed through verbatim")
+}
+
+// TestSanitizeCommandPebbleEngine exercises engine selection end-to-end: a
+// Pebble source defaults the output to Pebble, and the reopened output carries
+// every entity kind plus assets and the needs_expansion index. A second run
+// with --out-engine sqlite forces a SQLite output from the same Pebble source.
+func TestSanitizeCommandPebbleEngine(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	srcPath := filepath.Join(tmp, "src.c1z")
+	outPath := filepath.Join(tmp, "out.c1z")
+	secretPath := filepath.Join(tmp, "secret")
+
+	secret := make([]byte, 32)
+	for i := range secret {
+		secret[i] = byte(i + 1)
+	}
+	require.NoError(t, os.WriteFile(secretPath, secret, 0o600))
+
+	const assetID = "icon-1"
+	srcIcon := []byte{0x11, 0x22, 0x33, 0x44}
+
+	src, err := dotc1z.NewStore(ctx, srcPath, dotc1z.WithEngine(dotc1z.EnginePebble))
+	require.NoError(t, err)
+	_, err = src.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, src.PutResourceTypes(ctx,
+		v2.ResourceType_builder{Id: "user", DisplayName: "User", Traits: []v2.ResourceType_Trait{v2.ResourceType_TRAIT_USER}}.Build(),
+	))
+	require.NoError(t, src.PutAsset(ctx, v2.AssetRef_builder{Id: assetID}.Build(), "image/png", srcIcon))
+	userRes := v2.Resource_builder{
+		Id:          v2.ResourceId_builder{ResourceType: "user", Resource: "alice"}.Build(),
+		DisplayName: "Alice",
+		Annotations: annotations.New(v2.UserTrait_builder{Login: "alice@acme.com", Icon: v2.AssetRef_builder{Id: assetID}.Build()}.Build()),
+	}.Build()
+	require.NoError(t, src.PutResources(ctx, userRes))
+	ent := v2.Entitlement_builder{Id: "user:alice:self", DisplayName: "Self", Resource: userRes, Slug: "self"}.Build()
+	require.NoError(t, src.PutEntitlements(ctx, ent))
+	require.NoError(t, src.PutGrants(ctx,
+		v2.Grant_builder{
+			Id: "g-expand", Entitlement: ent, Principal: userRes,
+			Annotations: annotations.New(v2.GrantExpandable_builder{EntitlementIds: []string{"user:alice:self"}}.Build()),
+		}.Build(),
+	))
+	require.NoError(t, src.EndSync(ctx))
+	require.NoError(t, src.Close(ctx))
+
+	root := &cobra.Command{Use: "baton"}
+	root.PersistentFlags().StringP("file", "f", "sync.c1z", "")
+	root.AddCommand(sanitizeCmd())
+	root.SetArgs([]string{"sanitize", "--file", srcPath, "--out", outPath, "--secret-file", secretPath})
+	require.NoError(t, root.ExecuteContext(ctx))
+	require.FileExists(t, outPath)
+
+	// Default output engine follows the Pebble source.
+	out, err := openReadOnlyC1ZStore(ctx, outPath)
+	require.NoError(t, err)
+	defer out.Close(ctx)
+	require.Equal(t, string(dotc1z.EnginePebble), out.Metadata().Engine, "output engine must default to the source (pebble)")
+
+	rtResp, err := out.ListResourceTypes(ctx, v2.ResourceTypesServiceListResourceTypesRequest_builder{PageSize: 100}.Build())
+	require.NoError(t, err)
+	require.Len(t, rtResp.GetList(), 1)
+	resResp, err := out.ListResources(ctx, v2.ResourcesServiceListResourcesRequest_builder{PageSize: 100}.Build())
+	require.NoError(t, err)
+	require.Len(t, resResp.GetList(), 1)
+	entResp, err := out.ListEntitlements(ctx, v2.EntitlementsServiceListEntitlementsRequest_builder{PageSize: 100}.Build())
+	require.NoError(t, err)
+	require.Len(t, entResp.GetList(), 1)
+	grantResp, err := out.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{PageSize: 100}.Build())
+	require.NoError(t, err)
+	require.Len(t, grantResp.GetList(), 1)
+
+	// needs_expansion index survived.
+	pending := 0
+	for _, err := range out.Grants().PendingExpansion(ctx) {
+		require.NoError(t, err)
+		pending++
+	}
+	require.Equal(t, 1, pending, "the expandable grant must remain in the needs_expansion index")
+
+	// The asset reads back under its transformed id, stripped to a placeholder.
+	dstAssetID := c1zsanitize.SanitizeID(secret, assetID)
+	ct, r, err := out.GetAsset(ctx, v2.AssetServiceGetAssetRequest_builder{Asset: v2.AssetRef_builder{Id: dstAssetID}.Build()}.Build())
+	require.NoError(t, err, "the sanitized asset must be readable under its transformed id")
+	assetBytes, err := io.ReadAll(r)
+	require.NoError(t, err)
+	if c, ok := r.(io.Closer); ok {
+		_ = c.Close()
+	}
+	require.Equal(t, "image/png", ct)
+	require.NotEqual(t, srcIcon, assetBytes, "asset payload must be stripped, not the source bytes")
+
+	// --out-engine sqlite forces a SQLite output from the same Pebble source.
+	outSQLite := filepath.Join(tmp, "out-sqlite.c1z")
+	root2 := &cobra.Command{Use: "baton"}
+	root2.PersistentFlags().StringP("file", "f", "sync.c1z", "")
+	root2.AddCommand(sanitizeCmd())
+	root2.SetArgs([]string{"sanitize", "--file", srcPath, "--out", outSQLite, "--secret-file", secretPath, "--out-engine", "sqlite"})
+	require.NoError(t, root2.ExecuteContext(ctx))
+	outS, err := openReadOnlyC1ZStore(ctx, outSQLite)
+	require.NoError(t, err)
+	defer outS.Close(ctx)
+	require.Equal(t, string(dotc1z.EngineSQLite), outS.Metadata().Engine, "--out-engine sqlite must force a sqlite output")
 }
 
 // newSanitizeRoot builds the cobra root the same way main.go wires it:

--- a/pkg/c1zsanitize/expansion_parity_test.go
+++ b/pkg/c1zsanitize/expansion_parity_test.go
@@ -1,0 +1,438 @@
+package c1zsanitize
+
+import (
+	"context"
+	"io"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+)
+
+// Fixture identifiers. The cross-engine matrix sanitizes the same logical
+// graph through every engine combination under one secret, so the
+// transformed ids are identical across arms and the outputs are directly
+// comparable.
+const (
+	pfRTUser  = "user"  // declared resource type -> token preserved
+	pfRTRole  = "role"  // declared resource type
+	pfRTGroup = "group" // NOT declared -> token HMAC'd; used to exercise multiset
+
+	pfEntAdmin  = "ent-admin"
+	pfEntReader = "ent-reader"
+
+	pfGrantMultiExpand = "grant-multi-expand" // multi-Ent + multi-RT (with a dup RT)
+	pfGrantDivergence  = "grant-divergence"   // GrantExpandable AND populated Sources
+	pfGrantWhitespace  = "grant-whitespace"   // only blank entitlement ids -> not expandable
+	pfGrantSourced     = "grant-sourced"      // multi-edge Sources, no expansion
+	pfGrantPlain       = "grant-plain"        // neither
+
+	pfAssetID = "icon-asset-1"
+)
+
+// pfSourceIconBytes is the original asset payload. The sanitizer must
+// REPLACE it with a content-type placeholder, never copy these bytes
+// through (that would be an identity leak).
+var pfSourceIconBytes = []byte{0xde, 0xad, 0xbe, 0xef, 0x01, 0x02, 0x03, 0x04}
+
+// buildParityFixture writes the same logical graph into store through the
+// engine-agnostic connectorstore.Writer surface, so the GrantExpandable
+// annotations and Sources land in each engine's real side-state exactly as
+// production files store them.
+func buildParityFixture(t *testing.T, ctx context.Context, store dotc1z.C1ZStore) {
+	t.Helper()
+
+	_, err := store.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+
+	require.NoError(t, store.PutResourceTypes(ctx,
+		v2.ResourceType_builder{Id: pfRTUser, DisplayName: "User", Traits: []v2.ResourceType_Trait{v2.ResourceType_TRAIT_USER}}.Build(),
+		v2.ResourceType_builder{Id: pfRTRole, DisplayName: "Role", Traits: []v2.ResourceType_Trait{v2.ResourceType_TRAIT_ROLE}}.Build(),
+	))
+
+	// A resolvable asset: PutAsset writes the bytes; a UserTrait icon ref on
+	// a resource carries the id so the sanitizer's resource walk registers it
+	// and copyAssets fetches it (a dangling ref would be skipped and break the
+	// count assertion).
+	require.NoError(t, store.PutAsset(ctx, v2.AssetRef_builder{Id: pfAssetID}.Build(), "image/png", pfSourceIconBytes))
+
+	parent := v2.Resource_builder{
+		Id:          v2.ResourceId_builder{ResourceType: pfRTRole, Resource: "admins"}.Build(),
+		DisplayName: "Admins",
+	}.Build()
+	// child's parent_resource_id points at parent -> structural-linkage check.
+	child := v2.Resource_builder{
+		Id:               v2.ResourceId_builder{ResourceType: pfRTUser, Resource: "alice"}.Build(),
+		ParentResourceId: v2.ResourceId_builder{ResourceType: pfRTRole, Resource: "admins"}.Build(),
+		DisplayName:      "Alice",
+		Annotations: []*anypb.Any{anyTB(t, v2.UserTrait_builder{
+			Login: "alice@acme.com",
+			Icon:  v2.AssetRef_builder{Id: pfAssetID}.Build(),
+		}.Build())},
+	}.Build()
+	require.NoError(t, store.PutResources(ctx, parent, child))
+
+	entAdmin := v2.Entitlement_builder{Id: pfEntAdmin, Resource: parent, DisplayName: "admin", Slug: "admin"}.Build()
+	entReader := v2.Entitlement_builder{Id: pfEntReader, Resource: parent, DisplayName: "reader", Slug: "reader"}.Build()
+	require.NoError(t, store.PutEntitlements(ctx, entAdmin, entReader))
+
+	sources := v2.GrantSources_builder{Sources: map[string]*v2.GrantSources_GrantSource{
+		pfEntAdmin:  v2.GrantSources_GrantSource_builder{IsDirect: true}.Build(),
+		pfEntReader: v2.GrantSources_GrantSource_builder{IsDirect: false}.Build(),
+	}}.Build()
+
+	grants := []*v2.Grant{
+		// multi-EntitlementId + multi-ResourceTypeId, with pfRTGroup duplicated
+		// so the resource_type_ids multiset (multiplicity 2) is exercised.
+		v2.Grant_builder{
+			Id: pfGrantMultiExpand, Entitlement: entAdmin, Principal: child,
+			Annotations: annotations.New(v2.GrantExpandable_builder{
+				EntitlementIds:  []string{pfEntAdmin, pfEntReader},
+				Shallow:         true,
+				ResourceTypeIds: []string{pfRTUser, pfRTGroup, pfRTGroup},
+			}.Build()),
+		}.Build(),
+		// Divergence trigger: carries a GrantExpandable AND already-populated
+		// Sources (expanded-but-still-annotated). Proves the first-write
+		// needs_expansion projection is identical across engines for this shape.
+		v2.Grant_builder{
+			Id: pfGrantDivergence, Entitlement: entAdmin, Principal: child,
+			Sources: sources,
+			Annotations: annotations.New(v2.GrantExpandable_builder{
+				EntitlementIds: []string{pfEntReader},
+				Shallow:        false,
+			}.Build()),
+		}.Build(),
+		// Blank entitlement ids only -> annotation stripped, needs_expansion=false
+		// on both engines.
+		v2.Grant_builder{
+			Id: pfGrantWhitespace, Entitlement: entReader, Principal: child,
+			Annotations: annotations.New(v2.GrantExpandable_builder{
+				EntitlementIds: []string{"  ", ""},
+			}.Build()),
+		}.Build(),
+		// Multi-edge Sources, no expansion.
+		v2.Grant_builder{Id: pfGrantSourced, Entitlement: entReader, Principal: child, Sources: sources}.Build(),
+		// Neither.
+		v2.Grant_builder{Id: pfGrantPlain, Entitlement: entAdmin, Principal: child}.Build(),
+	}
+	require.NoError(t, store.PutGrants(ctx, grants...))
+	require.NoError(t, store.EndSync(ctx))
+}
+
+// newEngineStore opens a fresh writable store for the given engine.
+func newEngineStore(t *testing.T, ctx context.Context, path string, eng dotc1z.Engine) dotc1z.C1ZStore {
+	t.Helper()
+	s, err := dotc1z.NewStore(ctx, path, dotc1z.WithEngine(eng))
+	require.NoError(t, err)
+	return s
+}
+
+// openEngineStoreRO reopens a store read-only with its latest finished sync
+// selected, so the neutral reader + Grants() surfaces resolve content.
+func openEngineStoreRO(t *testing.T, ctx context.Context, path string) dotc1z.C1ZStore {
+	t.Helper()
+	s, err := dotc1z.NewStore(ctx, path, dotc1z.WithReadOnly(true))
+	require.NoError(t, err)
+	latest, err := s.SyncMeta().LatestFinishedSyncOfAnyType(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, latest, "sanitized output must carry a finished sync")
+	require.NoError(t, s.SetCurrentSync(ctx, latest.ID))
+	return s
+}
+
+type expandBlob struct {
+	ents    []string
+	shallow bool
+	rts     []string // multiset: sorted, multiplicity preserved
+}
+
+// pendingExpansionBlobs returns the full GrantExpandable blob for every
+// expandable grant, keyed by the grant external id, read off the
+// needs_expansion index via the neutral Grants().PendingExpansion surface.
+func pendingExpansionBlobs(t *testing.T, ctx context.Context, store dotc1z.C1ZStore) map[string]expandBlob {
+	t.Helper()
+	out := map[string]expandBlob{}
+	for pe, err := range store.Grants().PendingExpansion(ctx) {
+		require.NoError(t, err)
+		require.NotNil(t, pe.Annotation, "PendingExpansion row must carry its annotation")
+		ents := append([]string(nil), pe.Annotation.GetEntitlementIds()...)
+		sort.Strings(ents)
+		rts := append([]string(nil), pe.Annotation.GetResourceTypeIds()...)
+		sort.Strings(rts) // sorted but NOT deduped -> multiset
+		out[pe.GrantExternalID] = expandBlob{ents: ents, shallow: pe.Annotation.GetShallow(), rts: rts}
+	}
+	return out
+}
+
+// grantSourcesCanonical returns, per grant id, the sorted expansion-source
+// edge set ("<sourceEntitlementID>=<isDirect>"), read through the neutral
+// ListGrants surface. nil and empty Sources both normalize to an empty slice.
+func grantSourcesCanonical(t *testing.T, ctx context.Context, store dotc1z.C1ZStore) map[string][]string {
+	t.Helper()
+	out := map[string][]string{}
+	pageToken := ""
+	for {
+		resp, err := store.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{PageSize: 1000, PageToken: pageToken}.Build())
+		require.NoError(t, err)
+		for _, g := range resp.GetList() {
+			srcMap := g.GetSources().GetSources()
+			edges := make([]string, 0, len(srcMap))
+			for k, v := range srcMap {
+				edges = append(edges, k+"="+boolStr(v.GetIsDirect()))
+			}
+			sort.Strings(edges)
+			out[g.GetId()] = edges
+		}
+		if resp.GetNextPageToken() == "" {
+			break
+		}
+		pageToken = resp.GetNextPageToken()
+	}
+	return out
+}
+
+func boolStr(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
+func grantCount(t *testing.T, ctx context.Context, store dotc1z.C1ZStore) int {
+	t.Helper()
+	n := 0
+	pageToken := ""
+	for {
+		resp, err := store.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{PageSize: 1000, PageToken: pageToken}.Build())
+		require.NoError(t, err)
+		n += len(resp.GetList())
+		if resp.GetNextPageToken() == "" {
+			return n
+		}
+		pageToken = resp.GetNextPageToken()
+	}
+}
+
+func resourceCount(t *testing.T, ctx context.Context, store dotc1z.C1ZStore) int {
+	t.Helper()
+	resp, err := store.ListResources(ctx, v2.ResourcesServiceListResourcesRequest_builder{PageSize: 1000}.Build())
+	require.NoError(t, err)
+	return len(resp.GetList())
+}
+
+func resourceTypeCount(t *testing.T, ctx context.Context, store dotc1z.C1ZStore) int {
+	t.Helper()
+	resp, err := store.ListResourceTypes(ctx, v2.ResourceTypesServiceListResourceTypesRequest_builder{PageSize: 1000}.Build())
+	require.NoError(t, err)
+	return len(resp.GetList())
+}
+
+func entitlementCount(t *testing.T, ctx context.Context, store dotc1z.C1ZStore) int {
+	t.Helper()
+	resp, err := store.ListEntitlements(ctx, v2.EntitlementsServiceListEntitlementsRequest_builder{PageSize: 1000}.Build())
+	require.NoError(t, err)
+	return len(resp.GetList())
+}
+
+// resourceParentChains maps each resource id to its parent resource id.
+func resourceParentChains(t *testing.T, ctx context.Context, store dotc1z.C1ZStore) map[string]string {
+	t.Helper()
+	resp, err := store.ListResources(ctx, v2.ResourcesServiceListResourcesRequest_builder{PageSize: 1000}.Build())
+	require.NoError(t, err)
+	out := map[string]string{}
+	for _, r := range resp.GetList() {
+		out[r.GetId().GetResource()] = r.GetParentResourceId().GetResource()
+	}
+	return out
+}
+
+// entitlementOwnership maps each entitlement id to its owning resource id.
+func entitlementOwnership(t *testing.T, ctx context.Context, store dotc1z.C1ZStore) map[string]string {
+	t.Helper()
+	resp, err := store.ListEntitlements(ctx, v2.EntitlementsServiceListEntitlementsRequest_builder{PageSize: 1000}.Build())
+	require.NoError(t, err)
+	out := map[string]string{}
+	for _, e := range resp.GetList() {
+		out[e.GetId()] = e.GetResource().GetId().GetResource()
+	}
+	return out
+}
+
+// grantRefs maps each grant id to its "<entitlementID>|<principalType>/<principalID>".
+func grantRefs(t *testing.T, ctx context.Context, store dotc1z.C1ZStore) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	pageToken := ""
+	for {
+		resp, err := store.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{PageSize: 1000, PageToken: pageToken}.Build())
+		require.NoError(t, err)
+		for _, g := range resp.GetList() {
+			pid := g.GetPrincipal().GetId()
+			out[g.GetId()] = g.GetEntitlement().GetId() + "|" + pid.GetResourceType() + "/" + pid.GetResource()
+		}
+		if resp.GetNextPageToken() == "" {
+			break
+		}
+		pageToken = resp.GetNextPageToken()
+	}
+	return out
+}
+
+func readAsset(t *testing.T, ctx context.Context, store dotc1z.C1ZStore, assetID string) (string, []byte) {
+	t.Helper()
+	ct, r, err := store.GetAsset(ctx, v2.AssetServiceGetAssetRequest_builder{Asset: v2.AssetRef_builder{Id: assetID}.Build()}.Build())
+	require.NoError(t, err)
+	b, err := io.ReadAll(r)
+	require.NoError(t, err)
+	if c, ok := r.(io.Closer); ok {
+		_ = c.Close()
+	}
+	return ct, b
+}
+
+// TestSanitizeCrossEnginePebbleParity sanitizes the same fixture across all
+// four engine combinations (sqlite/pebble source x sqlite/pebble dest) under a
+// single secret, then asserts every sanitized output is identical on the
+// dimensions the intent names: cardinality, structural linkage, expansion-source
+// edges, the full GrantExpandable blob, the needs_expansion enumeration, and the
+// asset identity-strip.
+//
+// The matrix proves RELATIVE parity-to-SQLite; ABSOLUTE correctness of the
+// transform is anchored by the sqlite->sqlite arm together with
+// TestSanitizeGrantExpansionRoundTrip, so a regression uniform across all
+// engines is not invisible.
+func TestSanitizeCrossEnginePebbleParity(t *testing.T) {
+	ctx := context.Background()
+	secret := bytes32("cross-engine-parity")
+
+	engines := []struct {
+		name string
+		eng  dotc1z.Engine
+	}{
+		{"sqlite", dotc1z.EngineSQLite},
+		{"pebble", dotc1z.EnginePebble},
+	}
+
+	type arm struct {
+		name string
+		path string
+	}
+	var arms []arm
+
+	for _, srcE := range engines {
+		// Build one source per source-engine, reused for both dest engines.
+		srcPath := filepath.Join(t.TempDir(), "src-"+srcE.name+".c1z")
+		func() {
+			src := newEngineStore(t, ctx, srcPath, srcE.eng)
+			buildParityFixture(t, ctx, src)
+			require.NoError(t, src.Close(ctx))
+		}()
+
+		for _, dstE := range engines {
+			dstPath := filepath.Join(t.TempDir(), "dst-"+srcE.name+"-"+dstE.name+".c1z")
+			src := openEngineStoreRO(t, ctx, srcPath)
+			dst := newEngineStore(t, ctx, dstPath, dstE.eng)
+			require.NoError(t, Sanitize(ctx, src, dst, Options{Secret: secret, TimestampAnchor: fixedAnchor}),
+				"sanitize %s->%s", srcE.name, dstE.name)
+			require.NoError(t, dst.Close(ctx))
+			require.NoError(t, src.Close(ctx))
+			arms = append(arms, arm{name: srcE.name + "->" + dstE.name, path: dstPath})
+		}
+	}
+	require.Len(t, arms, 4)
+
+	// Reference transform (secret-only) to compute expected transformed ids.
+	ref := newTestSanitizer(secret)
+	ref.knownResourceTypes[pfRTUser] = struct{}{}
+	ref.knownResourceTypes[pfRTRole] = struct{}{}
+	wantAssetID := SanitizeID(secret, pfAssetID)
+
+	// Collect every comparable projection per arm.
+	type snapshot struct {
+		rtCount, resCount, entCount, grantCount int
+		parents, entOwn, refs                   map[string]string
+		sources                                 map[string][]string
+		blobs                                   map[string]expandBlob
+		assetCT                                 string
+		assetBytes                              []byte
+	}
+	snaps := make([]snapshot, len(arms))
+	for i, a := range arms {
+		ro := openEngineStoreRO(t, ctx, a.path)
+		ct, ab := readAsset(t, ctx, ro, wantAssetID)
+		snaps[i] = snapshot{
+			rtCount:    resourceTypeCount(t, ctx, ro),
+			resCount:   resourceCount(t, ctx, ro),
+			entCount:   entitlementCount(t, ctx, ro),
+			grantCount: grantCount(t, ctx, ro),
+			parents:    resourceParentChains(t, ctx, ro),
+			entOwn:     entitlementOwnership(t, ctx, ro),
+			refs:       grantRefs(t, ctx, ro),
+			sources:    grantSourcesCanonical(t, ctx, ro),
+			blobs:      pendingExpansionBlobs(t, ctx, ro),
+			assetCT:    ct,
+			assetBytes: ab,
+		}
+		require.NoError(t, ro.Close(ctx))
+	}
+
+	// (1) Cardinality parity: equal to the known source cardinality and equal
+	// across all four arms. The fixture has 2 resource types, 2 resources, 2
+	// entitlements, 5 grants.
+	for i, a := range arms {
+		require.Equalf(t, 2, snaps[i].rtCount, "%s resource-type count", a.name)
+		require.Equalf(t, 2, snaps[i].resCount, "%s resource count", a.name)
+		require.Equalf(t, 2, snaps[i].entCount, "%s entitlement count", a.name)
+		require.Equalf(t, 5, snaps[i].grantCount, "%s grant count", a.name)
+	}
+
+	// (2) Everything else: every arm identical to the first arm.
+	base := snaps[0]
+	for i := 1; i < len(snaps); i++ {
+		require.Equalf(t, base.parents, snaps[i].parents, "%s resource parent chains", arms[i].name)
+		require.Equalf(t, base.entOwn, snaps[i].entOwn, "%s entitlement ownership", arms[i].name)
+		require.Equalf(t, base.refs, snaps[i].refs, "%s grant entitlement/principal refs", arms[i].name)
+		require.Equalf(t, base.sources, snaps[i].sources, "%s expansion-source edges", arms[i].name)
+		require.Equalf(t, base.blobs, snaps[i].blobs, "%s GrantExpandable blobs + needs_expansion enumeration", arms[i].name)
+	}
+
+	// (3) needs_expansion membership: the multi-expand and divergence-trigger
+	// grants are present on EVERY arm; the whitespace-only grant is absent on
+	// every arm. Keyed by transformed grant id.
+	wantMulti := ref.transformID(pfGrantMultiExpand)
+	wantDiverge := ref.transformID(pfGrantDivergence)
+	wantWhitespace := ref.transformID(pfGrantWhitespace)
+	for i := range snaps {
+		_, hasMulti := snaps[i].blobs[wantMulti]
+		_, hasDiverge := snaps[i].blobs[wantDiverge]
+		_, hasWhitespace := snaps[i].blobs[wantWhitespace]
+		require.Truef(t, hasMulti, "%s: multi-expand grant must need expansion", arms[i].name)
+		require.Truef(t, hasDiverge, "%s: divergence-trigger grant must need expansion", arms[i].name)
+		require.Falsef(t, hasWhitespace, "%s: blank-entitlement-id grant must NOT need expansion", arms[i].name)
+	}
+
+	// (4) Multiset semantics for resource_type_ids: the multi-expand blob keeps
+	// the duplicated (HMAC'd) group token at multiplicity 2, plus the preserved
+	// "user" token -> 3 entries total.
+	multiBlob := base.blobs[wantMulti]
+	require.Len(t, multiBlob.rts, 3, "resource_type_ids multiset must preserve the duplicate group token")
+	require.Contains(t, multiBlob.rts, pfRTUser, "declared resource-type token preserved verbatim")
+	require.NotContains(t, multiBlob.rts, pfRTGroup, "undeclared resource-type token must be HMAC'd")
+
+	// (5) Asset: identity STRIPPED (placeholder, not source bytes) and identical
+	// across engines. Byte survival would be an identity leak.
+	wantPlaceholder := placeholderForContentType("image/png")
+	for i, a := range arms {
+		require.Equalf(t, "image/png", snaps[i].assetCT, "%s asset content type", a.name)
+		require.Equalf(t, wantPlaceholder, snaps[i].assetBytes, "%s asset payload must be the content-type placeholder", a.name)
+		require.NotEqualf(t, pfSourceIconBytes, snaps[i].assetBytes, "%s asset payload must NOT be the source bytes (identity leak)", a.name)
+	}
+}

--- a/pkg/c1zsanitize/sanitize.go
+++ b/pkg/c1zsanitize/sanitize.go
@@ -365,6 +365,36 @@ type dstSyncLister interface {
 	ListSyncRuns(ctx context.Context, pageToken string, pageSize uint32) ([]*dotc1z.SyncRun, string, error)
 }
 
+// isResumableDestination reports whether dst can safely back a resumable run,
+// returning a descriptive error when it cannot.
+//
+// The pebble engine is rejected by an EXPLICIT engine check
+// (dst.Metadata().Engine == EnginePebble), deliberately NOT by the dstSyncLister
+// capability assertion. That distinction is load-bearing: pebble now implements
+// ListSyncRuns (for source-side sync-graph-metadata reads), so a capability
+// assertion would SUCCEED for a pebble destination and silently re-admit it.
+// Resume on pebble is unsafe — its single-sync, replace-in-place StartNewSync
+// and its SetCurrentSync/CurrentSyncStep (which do not round-trip the persisted
+// step) cannot rehydrate a checkpoint, so a "resume" would silently restart and
+// corrupt. Keying on the reported engine cannot be defeated by a future engine
+// adding capability methods. The capability assertion is kept below it as a
+// backstop for any engine that cannot enumerate checkpoints at all.
+func isResumableDestination(dst connectorstore.Writer) error {
+	if dst.Metadata().Engine == string(dotc1z.EnginePebble) {
+		return fmt.Errorf(
+			"resumable runs are not supported with a pebble destination: its " +
+				"single-sync, replace-in-place storage cannot rehydrate a persisted " +
+				"checkpoint, so resume would silently restart; use a sqlite destination")
+	}
+	if _, ok := dst.(dstSyncLister); !ok {
+		return fmt.Errorf(
+			"resumable runs require a destination that can enumerate checkpoints " +
+				"without mutating sync state (sqlite-backed); this destination cannot, " +
+				"so resume would silently restart")
+	}
+	return nil
+}
+
 // loadResumeStates scans the destination's existing syncs for checkpoint
 // tokens written by a prior resumable run, reading them through ListSyncRuns so
 // the destination's current-sync pointer is never mutated. A token whose
@@ -376,29 +406,15 @@ type dstSyncLister interface {
 // silently mix two transforms. Destinations with no tokens yield an empty map
 // and a clean full run.
 //
-// The pebble engine is rejected up front: its single-sync replace-in-place
-// StartNewSync and its SetCurrentSync/CurrentSyncStep (which do not round-trip
-// the persisted step) make resume unsafe — it would silently restart and
-// corrupt rather than continue. The rejection is an explicit engine check on
-// the live destination, NOT the dstSyncLister type assertion: pebble now
-// implements ListSyncRuns (for source-side metadata reads), so the assertion no
-// longer distinguishes it. The type assertion is kept below as a backstop for
-// any future engine that cannot enumerate checkpoints at all.
+// Destinations that cannot safely resume are rejected up front by
+// isResumableDestination.
 func (s *sanitizer) loadResumeStates(ctx context.Context, dst connectorstore.Writer) (map[string]*resumeState, error) {
-	if dst.Metadata().Engine == string(dotc1z.EnginePebble) {
-		return nil, fmt.Errorf(
-			"resumable runs are not supported with a pebble destination: its " +
-				"single-sync, replace-in-place storage cannot rehydrate a persisted " +
-				"checkpoint, so resume would silently restart; use a sqlite destination")
+	if err := isResumableDestination(dst); err != nil {
+		return nil, err
 	}
-
-	lister, ok := dst.(dstSyncLister)
-	if !ok {
-		return nil, fmt.Errorf(
-			"resumable runs require a destination that can enumerate checkpoints " +
-				"without mutating sync state (sqlite-backed); this destination cannot, " +
-				"so resume would silently restart")
-	}
+	// Guaranteed by isResumableDestination: a non-pebble destination that
+	// reached here implements dstSyncLister.
+	lister := dst.(dstSyncLister)
 
 	out := map[string]*resumeState{}
 	pageToken := ""

--- a/pkg/c1zsanitize/sanitize.go
+++ b/pkg/c1zsanitize/sanitize.go
@@ -108,10 +108,11 @@ type Options struct {
 	// finds progress that a prior run persisted to disk.
 	//
 	// Resumable requires the sqlite-backed destination (*dotc1z.C1File). A
-	// destination engine that cannot enumerate checkpoints without mutating
-	// sync state — currently the pebble engine, whose SetCurrentSync does not
-	// rehydrate the persisted step — is rejected with a clear error rather than
-	// silently restarting from scratch.
+	// pebble destination is rejected with a clear error rather than silently
+	// restarting: its single-sync, replace-in-place storage and its
+	// SetCurrentSync (which does not rehydrate the persisted step) cannot
+	// resume a checkpoint. The rejection is an explicit destination-engine
+	// check, so it holds even though pebble implements ListSyncRuns.
 	Resumable bool
 }
 
@@ -371,11 +372,22 @@ type dstSyncLister interface {
 // silently mix two transforms. Destinations with no tokens yield an empty map
 // and a clean full run.
 //
-// A destination that cannot enumerate sync tokens this way (e.g. the pebble
-// engine, whose SetCurrentSync/CurrentSyncStep do not round-trip the persisted
-// step) is rejected with a clear error rather than silently restarting from
-// scratch; resumable runs require the sqlite-backed destination.
+// The pebble engine is rejected up front: its single-sync replace-in-place
+// StartNewSync and its SetCurrentSync/CurrentSyncStep (which do not round-trip
+// the persisted step) make resume unsafe — it would silently restart and
+// corrupt rather than continue. The rejection is an explicit engine check on
+// the live destination, NOT the dstSyncLister type assertion: pebble now
+// implements ListSyncRuns (for source-side metadata reads), so the assertion no
+// longer distinguishes it. The type assertion is kept below as a backstop for
+// any future engine that cannot enumerate checkpoints at all.
 func (s *sanitizer) loadResumeStates(ctx context.Context, dst connectorstore.Writer) (map[string]*resumeState, error) {
+	if dst.Metadata().Engine == string(dotc1z.EnginePebble) {
+		return nil, fmt.Errorf(
+			"resumable runs are not supported with a pebble destination: its " +
+				"single-sync, replace-in-place storage cannot rehydrate a persisted " +
+				"checkpoint, so resume would silently restart; use a sqlite destination")
+	}
+
 	lister, ok := dst.(dstSyncLister)
 	if !ok {
 		return nil, fmt.Errorf(

--- a/pkg/c1zsanitize/sanitize.go
+++ b/pkg/c1zsanitize/sanitize.go
@@ -9,9 +9,12 @@
 // stay coherent; different across c1zs whose secrets differ so an
 // attacker holding multiple sanitized outputs cannot correlate them.
 //
-// v0.1 reads and writes the v1/v2 sqlite-zstd .c1z format via
-// connectorstore.Reader / Writer. v3 c1z3 output will land in v0.2
-// once the storage-engine-v4 PR stack merges.
+// Sanitize is engine-agnostic: it reads and writes through
+// connectorstore.Reader / Writer, so a source or destination may be
+// either the v1/v2 sqlite-zstd engine or the v3 Pebble engine. A
+// Pebble c1z holds exactly one sync by contract, so a multi-sync
+// source cannot be sanitized into a Pebble destination; that
+// combination is rejected up front (see Sanitize).
 package c1zsanitize
 
 import (
@@ -138,6 +141,17 @@ func Sanitize(ctx context.Context, src connectorstore.Reader, dst connectorstore
 	if err != nil {
 		return fmt.Errorf("c1zsanitize: list source syncs: %w", err)
 	}
+
+	// A v3 Pebble c1z holds exactly one sync; StartNewSync replaces any
+	// prior sync in place. Sanitizing a multi-sync source into a Pebble
+	// destination would silently keep only the last sync's records, which
+	// is data corruption. Reject it up front. The engine is read from the
+	// live destination store, not a caller-supplied option, so the guard
+	// cannot be silenced by omitting a field.
+	if dst.Metadata().Engine == string(dotc1z.EnginePebble) && len(srcSyncs) > 1 {
+		return fmt.Errorf("c1zsanitize: destination engine pebble holds exactly one sync, but the source has %d syncs; sanitize to a sqlite destination or pre-select a single source sync", len(srcSyncs))
+	}
+
 	tMax := findTMax(srcSyncs)
 
 	s := &sanitizer{
@@ -676,9 +690,14 @@ func (s *sanitizer) preserveSyncGraphMetadata(ctx context.Context, src connector
 }
 
 // listAllSyncs paginates the source SyncsReaderService and returns
-// every sync run the source can see. The SQLite-backed C1File emits
-// in id-asc order which matches insertion order, which is parent-
-// before-child for any well-formed sync chain.
+// every sync run the source can see, ordered parent-before-child.
+//
+// The sanitize loop resolves each child's parent through the
+// srcSyncID -> dstSyncID map, so a parent must be processed before its
+// children or the child gets a dangling HMAC'd parent ref. We sort
+// explicitly rather than trust the reader's order: it walks by sync id
+// (KSUID), and KSUIDs only encode time to second resolution, so two
+// syncs created in the same second can come back child-before-parent.
 func listAllSyncs(ctx context.Context, src connectorstore.Reader) ([]*reader_v2.SyncRun, error) {
 	var out []*reader_v2.SyncRun
 	pageToken := ""
@@ -692,10 +711,60 @@ func listAllSyncs(ctx context.Context, src connectorstore.Reader) ([]*reader_v2.
 		}
 		out = append(out, resp.GetSyncs()...)
 		if resp.GetNextPageToken() == "" {
-			return out, nil
+			return sortSyncsParentFirst(out), nil
 		}
 		pageToken = resp.GetNextPageToken()
 	}
+}
+
+// sortSyncsParentFirst stably reorders syncs so every sync follows its
+// parent_sync_id, preserving the reader's order wherever it is already
+// valid. It is a stable topological refinement, not a re-sort: a child
+// that already trails its in-set parent (the well-formed case, and any
+// external-parent sync) keeps its position; only a child that precedes
+// its in-set parent is moved to just after that parent. A cycle or
+// otherwise unresolvable remainder is flushed in input order rather than
+// dropped. Keeping the reader's order as the base means a multi-sync
+// SQLite source whose runs are already id-asc is unchanged, while a
+// same-second KSUID inversion that put a child before its parent is
+// corrected.
+func sortSyncsParentFirst(syncs []*reader_v2.SyncRun) []*reader_v2.SyncRun {
+	if len(syncs) < 2 {
+		return syncs
+	}
+	present := make(map[string]struct{}, len(syncs))
+	for _, s := range syncs {
+		present[s.GetId()] = struct{}{}
+	}
+
+	emitted := make(map[string]struct{}, len(syncs))
+	out := make([]*reader_v2.SyncRun, 0, len(syncs))
+	for len(out) < len(syncs) {
+		progressed := false
+		for _, s := range syncs {
+			id := s.GetId()
+			if _, done := emitted[id]; done {
+				continue
+			}
+			parent := s.GetParentSyncId()
+			_, parentPresent := present[parent]
+			_, parentEmitted := emitted[parent]
+			if parent == "" || !parentPresent || parentEmitted {
+				out = append(out, s)
+				emitted[id] = struct{}{}
+				progressed = true
+			}
+		}
+		if !progressed {
+			for _, s := range syncs {
+				if _, done := emitted[s.GetId()]; !done {
+					out = append(out, s)
+					emitted[s.GetId()] = struct{}{}
+				}
+			}
+		}
+	}
+	return out
 }
 
 func findTMax(syncs []*reader_v2.SyncRun) time.Time {

--- a/pkg/c1zsanitize/sanitize.go
+++ b/pkg/c1zsanitize/sanitize.go
@@ -150,7 +150,11 @@ func Sanitize(ctx context.Context, src connectorstore.Reader, dst connectorstore
 	// live destination store, not a caller-supplied option, so the guard
 	// cannot be silenced by omitting a field.
 	if dst.Metadata().Engine == string(dotc1z.EnginePebble) && len(srcSyncs) > 1 {
-		return fmt.Errorf("c1zsanitize: destination engine pebble holds exactly one sync, but the source has %d syncs; sanitize to a sqlite destination or pre-select a single source sync", len(srcSyncs))
+		return fmt.Errorf(
+			"c1zsanitize: destination engine pebble holds exactly one sync, but the source has %d "+
+				"syncs; sanitize to a sqlite destination or pre-select a single source sync",
+			len(srcSyncs),
+		)
 	}
 
 	tMax := findTMax(srcSyncs)

--- a/pkg/c1zsanitize/sanitize_pebble_test.go
+++ b/pkg/c1zsanitize/sanitize_pebble_test.go
@@ -112,6 +112,41 @@ func TestSanitizeMultiSyncIntoPebbleIsRejected(t *testing.T) {
 	require.NoError(t, src2.Close(ctx))
 }
 
+// TestSanitizeResumableIntoPebbleIsRejected proves the resumable guard is an
+// explicit destination-engine check, not a type assertion. Pebble now
+// implements ListSyncRuns (added for source-side metadata reads), so the prior
+// dst.(dstSyncLister) assertion no longer rejects it; resume into a pebble
+// destination must still fail closed because pebble cannot rehydrate a
+// checkpoint.
+func TestSanitizeResumableIntoPebbleIsRejected(t *testing.T) {
+	ctx := context.Background()
+	secret := bytes32("resumable-pebble-guard")
+	tmp := t.TempDir()
+	srcPath := filepath.Join(tmp, "src.c1z")
+	dstPath := filepath.Join(tmp, "dst.c1z")
+
+	func() {
+		src := newEngineStore(t, ctx, srcPath, dotc1z.EnginePebble)
+		buildParityFixture(t, ctx, src)
+		require.NoError(t, src.Close(ctx))
+	}()
+
+	src := openEngineStoreRO(t, ctx, srcPath)
+	dst := newEngineStore(t, ctx, dstPath, dotc1z.EnginePebble)
+	err := Sanitize(ctx, src, dst, Options{Secret: secret, TimestampAnchor: fixedAnchor, Resumable: true})
+	require.Error(t, err, "resumable sanitize into a pebble destination must be rejected")
+	require.Contains(t, err.Error(), "pebble destination")
+	_ = dst.Close(ctx)
+	require.NoError(t, src.Close(ctx))
+
+	// Control: the same source is accepted into a sqlite destination.
+	src2 := openEngineStoreRO(t, ctx, srcPath)
+	dstSQLite := newEngineStore(t, ctx, filepath.Join(tmp, "dst-sqlite.c1z"), dotc1z.EngineSQLite)
+	require.NoError(t, Sanitize(ctx, src2, dstSQLite, Options{Secret: secret, TimestampAnchor: fixedAnchor, Resumable: true}))
+	require.NoError(t, dstSQLite.Close(ctx))
+	require.NoError(t, src2.Close(ctx))
+}
+
 // TestSanitizeRealExpanderEngineParity hardens the first-write precondition
 // against being subtly incomplete: it sanitizes a c1z whose grants were
 // produced by the REAL expander (not hand-built) into both a SQLite and a

--- a/pkg/c1zsanitize/sanitize_pebble_test.go
+++ b/pkg/c1zsanitize/sanitize_pebble_test.go
@@ -1,0 +1,152 @@
+package c1zsanitize
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+)
+
+// TestSanitizePebbleEndToEnd is the core-invariant check on a
+// Pebble-in -> Pebble-out run: identity is stripped, cardinalities are
+// preserved across all entity kinds and assets, and the supports_diff marker
+// carries over.
+func TestSanitizePebbleEndToEnd(t *testing.T) {
+	ctx := context.Background()
+	secret := bytes32("pebble-e2e")
+	tmp := t.TempDir()
+	srcPath := filepath.Join(tmp, "src.c1z")
+	dstPath := filepath.Join(tmp, "dst.c1z")
+
+	var srcSyncID string
+	func() {
+		src := newEngineStore(t, ctx, srcPath, dotc1z.EnginePebble)
+		// Reuse the shared fixture, then mark the sync diff-capable.
+		buildParityFixture(t, ctx, src)
+		runs, _, err := src.(syncRunMetadataReader).ListSyncRuns(ctx, "", 100)
+		require.NoError(t, err)
+		require.Len(t, runs, 1, "a pebble c1z holds exactly one sync")
+		srcSyncID = runs[0].ID
+		require.NoError(t, src.(supportsDiffWriter).SetSupportsDiff(ctx, srcSyncID))
+		require.NoError(t, src.Close(ctx))
+	}()
+
+	src := openEngineStoreRO(t, ctx, srcPath)
+	dst := newEngineStore(t, ctx, dstPath, dotc1z.EnginePebble)
+	require.NoError(t, Sanitize(ctx, src, dst, Options{Secret: secret, TimestampAnchor: fixedAnchor}))
+	require.NoError(t, dst.Close(ctx))
+	require.NoError(t, src.Close(ctx))
+
+	ro := openEngineStoreRO(t, ctx, dstPath)
+	defer ro.Close(ctx)
+
+	// Cardinality preserved.
+	require.Equal(t, 2, resourceTypeCount(t, ctx, ro))
+	require.Equal(t, 2, resourceCount(t, ctx, ro))
+	require.Equal(t, 2, entitlementCount(t, ctx, ro))
+	require.Equal(t, 5, grantCount(t, ctx, ro))
+
+	// Identity stripped: the source resource id/display must not survive; the
+	// transformed id must be present.
+	resp, err := ro.ListResources(ctx, v2.ResourcesServiceListResourcesRequest_builder{PageSize: 100}.Build())
+	require.NoError(t, err)
+	wantAlice := SanitizeID(secret, "alice")
+	var sawTransformed bool
+	for _, r := range resp.GetList() {
+		require.NotEqual(t, "alice", r.GetId().GetResource(), "raw source resource id must not survive")
+		require.NotEqual(t, "Alice", r.GetDisplayName(), "raw source display name must not survive")
+		if r.GetId().GetResource() == wantAlice {
+			sawTransformed = true
+		}
+	}
+	require.True(t, sawTransformed, "the transformed resource id must be present")
+
+	// supports_diff carried over to the sanitized sync.
+	dstRuns, _, err := ro.(syncRunMetadataReader).ListSyncRuns(ctx, "", 100)
+	require.NoError(t, err)
+	require.Len(t, dstRuns, 1)
+	require.True(t, dstRuns[0].SupportsDiff, "supports_diff marker must carry to the pebble output")
+}
+
+// TestSanitizeMultiSyncIntoPebbleIsRejected proves the live-dst guard: a
+// multi-sync SQLite source cannot be sanitized into a single-sync Pebble
+// destination, while a single-sync source into Pebble succeeds.
+func TestSanitizeMultiSyncIntoPebbleIsRejected(t *testing.T) {
+	ctx := context.Background()
+	secret := bytes32("multisync-guard")
+	tmp := t.TempDir()
+
+	// Multi-sync SQLite source: two independent finished full syncs.
+	multiPath := filepath.Join(tmp, "multi.c1z")
+	func() {
+		f, err := dotc1z.NewC1ZFile(ctx, multiPath)
+		require.NoError(t, err)
+		for i := 0; i < 2; i++ {
+			_, err = f.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+			require.NoError(t, err)
+			require.NoError(t, f.PutResourceTypes(ctx,
+				v2.ResourceType_builder{Id: "user", DisplayName: "User", Traits: []v2.ResourceType_Trait{v2.ResourceType_TRAIT_USER}}.Build()))
+			require.NoError(t, f.EndSync(ctx))
+		}
+		require.NoError(t, f.Close(ctx))
+	}()
+
+	src := openEngineStoreRO(t, ctx, multiPath)
+	dst := newEngineStore(t, ctx, filepath.Join(tmp, "dst-pebble.c1z"), dotc1z.EnginePebble)
+	err := Sanitize(ctx, src, dst, Options{Secret: secret, TimestampAnchor: fixedAnchor})
+	require.Error(t, err, "multi-sync source into a pebble destination must be rejected")
+	require.Contains(t, err.Error(), "pebble holds exactly one sync")
+	_ = dst.Close(ctx)
+	require.NoError(t, src.Close(ctx))
+
+	// Sanity: the same multi-sync source into a SQLite destination is allowed.
+	src2 := openEngineStoreRO(t, ctx, multiPath)
+	dstSQLite := newEngineStore(t, ctx, filepath.Join(tmp, "dst-sqlite.c1z"), dotc1z.EngineSQLite)
+	require.NoError(t, Sanitize(ctx, src2, dstSQLite, Options{Secret: secret, TimestampAnchor: fixedAnchor}))
+	require.NoError(t, dstSQLite.Close(ctx))
+	require.NoError(t, src2.Close(ctx))
+}
+
+// TestSanitizeRealExpanderEngineParity hardens the first-write precondition
+// against being subtly incomplete: it sanitizes a c1z whose grants were
+// produced by the REAL expander (not hand-built) into both a SQLite and a
+// Pebble destination and asserts the needs_expansion enumeration, the full
+// GrantExpandable blobs, and the expansion-source edges are identical across
+// the two engines.
+func TestSanitizeRealExpanderEngineParity(t *testing.T) {
+	ctx := context.Background()
+	secret := bytes32("real-expander-parity")
+	tmp := t.TempDir()
+
+	// Build a nested expandable graph and run the production expander over it.
+	srcPath := filepath.Join(tmp, "expanded.c1z")
+	syncID := buildNestedExpandableC1Z(t, ctx, srcPath)
+	expandViaRealSyncer(t, ctx, srcPath, syncID)
+
+	sanitizeTo := func(eng dotc1z.Engine, name string) (map[string]expandBlob, map[string][]string, int) {
+		dstPath := filepath.Join(tmp, "dst-"+name+".c1z")
+		src := openEngineStoreRO(t, ctx, srcPath)
+		dst := newEngineStore(t, ctx, dstPath, eng)
+		require.NoError(t, Sanitize(ctx, src, dst, Options{Secret: secret, TimestampAnchor: fixedAnchor}))
+		require.NoError(t, dst.Close(ctx))
+		require.NoError(t, src.Close(ctx))
+
+		ro := openEngineStoreRO(t, ctx, dstPath)
+		defer ro.Close(ctx)
+		return pendingExpansionBlobs(t, ctx, ro), grantSourcesCanonical(t, ctx, ro), grantCount(t, ctx, ro)
+	}
+
+	sqlBlobs, sqlSources, sqlGrants := sanitizeTo(dotc1z.EngineSQLite, "sqlite")
+	pebBlobs, pebSources, pebGrants := sanitizeTo(dotc1z.EnginePebble, "pebble")
+
+	require.Equal(t, sqlGrants, pebGrants, "real-expander grant count must match across engines")
+	require.Greater(t, sqlGrants, 4, "the expander must have derived additional grants")
+	require.Equal(t, sqlBlobs, pebBlobs, "needs_expansion enumeration + GrantExpandable blobs must match across engines")
+	require.Equal(t, sqlSources, pebSources, "expansion-source edges must match across engines")
+	require.NotEmpty(t, sqlSources, "real-expander output must carry derived grant sources")
+}

--- a/pkg/c1zsanitize/sort_test.go
+++ b/pkg/c1zsanitize/sort_test.go
@@ -1,0 +1,87 @@
+package c1zsanitize
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	reader_v2 "github.com/conductorone/baton-sdk/pb/c1/reader/v2"
+)
+
+// TestSortSyncsParentFirst exercises the stable topological refinement that
+// orders source syncs parent-before-child. It is a refinement, not a re-sort:
+// an already-valid order is preserved exactly, and only a child that precedes
+// its in-set parent is moved.
+func TestSortSyncsParentFirst(t *testing.T) {
+	mk := func(id, parent string) *reader_v2.SyncRun {
+		return reader_v2.SyncRun_builder{Id: id, ParentSyncId: parent}.Build()
+	}
+	ids := func(runs []*reader_v2.SyncRun) []string {
+		out := make([]string, len(runs))
+		for i, r := range runs {
+			out[i] = r.GetId()
+		}
+		return out
+	}
+
+	tests := []struct {
+		name string
+		in   []*reader_v2.SyncRun
+		want []string
+	}{
+		{
+			name: "empty",
+			in:   nil,
+			want: []string{},
+		},
+		{
+			name: "single",
+			in:   []*reader_v2.SyncRun{mk("a", "")},
+			want: []string{"a"},
+		},
+		{
+			name: "already correct order preserved",
+			in:   []*reader_v2.SyncRun{mk("p", ""), mk("c", "p")},
+			want: []string{"p", "c"},
+		},
+		{
+			name: "inversion is fixed",
+			in:   []*reader_v2.SyncRun{mk("c", "p"), mk("p", "")},
+			want: []string{"p", "c"},
+		},
+		{
+			name: "external parent is a root, order preserved",
+			in:   []*reader_v2.SyncRun{mk("a", "outside"), mk("b", "outside")},
+			want: []string{"a", "b"},
+		},
+		{
+			name: "three-level chain inverted",
+			in:   []*reader_v2.SyncRun{mk("c", "b"), mk("b", "a"), mk("a", "")},
+			want: []string{"a", "b", "c"},
+		},
+		{
+			name: "stable among independent roots",
+			in:   []*reader_v2.SyncRun{mk("r1", ""), mk("r2", ""), mk("c1", "r1")},
+			want: []string{"r1", "r2", "c1"},
+		},
+		{
+			name: "two-node cycle is flushed in input order, not dropped or looping",
+			in:   []*reader_v2.SyncRun{mk("a", "b"), mk("b", "a")},
+			want: []string{"a", "b"},
+		},
+		{
+			name: "self-parent cycle flushed",
+			in:   []*reader_v2.SyncRun{mk("p", ""), mk("x", "x")},
+			want: []string{"p", "x"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sortSyncsParentFirst(tc.in)
+			require.Equal(t, tc.want, ids(got))
+			// Every input sync appears exactly once in the output.
+			require.Len(t, got, len(tc.in))
+		})
+	}
+}

--- a/pkg/dotc1z/engine/pebble/adapter_grants_store.go
+++ b/pkg/dotc1z/engine/pebble/adapter_grants_store.go
@@ -18,13 +18,11 @@ import (
 // adapter. Implements c1zstore.Store.Grants(); used by the
 // expander, the c1-side fileClientWrapper, and the differ.
 //
-// Caveat: the *Page methods that filter on needs_expansion currently
-// return no candidates because grant expansion (Stack 6 per RFC v4)
-// is deferred. The methods are CORRECT (they don't break the syncer's
-// expansion phase — they make it a no-op) but they don't actually
-// find expandable grants. Once Stack 6 lands, the engine will start
-// flagging needs_expansion at PutGrants and the index walk here will
-// return real rows.
+// needs_expansion is populated at PutGrants time: V2GrantToV3 extracts
+// the GrantExpandable annotation and sets NeedsExpansion, which keys the
+// idxGrantByNeedsExpansion index. The *Page methods walk that index and
+// return real expandable rows (see TestExpansionAnnotationRoundtrip and
+// the live PendingExpansion path).
 func (a *Adapter) Grants() c1zstore.GrantStore {
 	return pebbleGrantStore{a: a}
 }

--- a/pkg/dotc1z/engine/pebble/adapter_reader.go
+++ b/pkg/dotc1z/engine/pebble/adapter_reader.go
@@ -496,23 +496,12 @@ func v3SyncRunToV2(rec *v3.SyncRunRecord) *reader_v2.SyncRun {
 }
 
 // v3SyncTypeToString maps the v3.SyncType enum to the
-// connectorstore.SyncType string form used in the gRPC reader API.
+// connectorstore.SyncType string form used in the gRPC reader API. It is the
+// string view of the same enum dispatch syncTypeV3ToConnectorstore performs for
+// the SyncMeta projection; both share one switch so a new SyncType is handled
+// in one place.
 func v3SyncTypeToString(t v3.SyncType) string {
-	switch t {
-	case v3.SyncType_SYNC_TYPE_FULL:
-		return string(connectorstore.SyncTypeFull)
-	case v3.SyncType_SYNC_TYPE_PARTIAL:
-		return string(connectorstore.SyncTypePartial)
-	case v3.SyncType_SYNC_TYPE_RESOURCES_ONLY:
-		return string(connectorstore.SyncTypeResourcesOnly)
-	case v3.SyncType_SYNC_TYPE_PARTIAL_UPSERTS:
-		return string(connectorstore.SyncTypePartialUpserts)
-	case v3.SyncType_SYNC_TYPE_PARTIAL_DELETIONS:
-		return string(connectorstore.SyncTypePartialDeletions)
-	case v3.SyncType_SYNC_TYPE_UNSPECIFIED:
-		return ""
-	}
-	return ""
+	return string(syncTypeV3ToConnectorstore(t))
 }
 
 // resolveActiveSyncForReader resolves the sync_id a read should scope

--- a/pkg/dotc1z/engine/pebble/adapter_sync_meta.go
+++ b/pkg/dotc1z/engine/pebble/adapter_sync_meta.go
@@ -168,6 +168,28 @@ func (a *Adapter) CleanupCandidates(ctx context.Context) ([]c1zstore.SyncRun, er
 	return out, nil
 }
 
+// ListSyncRuns returns every sync-run record projected into the
+// engine-neutral c1zstore.SyncRun shape, oldest-first (parent before
+// child for a well-formed chain), in a single page. A v3 Pebble c1z
+// holds exactly one sync, so pagination is trivial: the whole set is
+// returned on the first call and the next-page token is always empty.
+// pageToken and pageSize are accepted for parity with the SQLite
+// ListSyncRuns and are not used. It backs the c1z sanitizer's
+// source-side sync-graph-metadata read (linked_sync_id, supports_diff),
+// which the gRPC reader surface does not carry.
+func (a *Adapter) ListSyncRuns(ctx context.Context, pageToken string, pageSize uint32) ([]*c1zstore.SyncRun, string, error) {
+	cands, err := a.CleanupCandidates(ctx)
+	if err != nil {
+		return nil, "", fmt.Errorf("pebble ListSyncRuns: %w", err)
+	}
+	out := make([]*c1zstore.SyncRun, 0, len(cands))
+	for i := range cands {
+		sr := cands[i]
+		out = append(out, &sr)
+	}
+	return out, "", nil
+}
+
 // syncTypeV3ToConnectorstore maps the v3-owned mirror SyncType enum
 // back to the connectorstore.SyncType string-typed enum. Unknown
 // values yield the empty (unspecified) string.

--- a/pkg/dotc1z/engine/pebble/adapter_sync_meta.go
+++ b/pkg/dotc1z/engine/pebble/adapter_sync_meta.go
@@ -112,11 +112,10 @@ func syncRunRecordToExported(r *v3.SyncRunRecord) *c1zstore.SyncRun {
 	return out
 }
 
-// CleanupCandidates walks every sync_run record and projects it into
-// the engine-neutral c1zstore.SyncRun shape, sorted oldest-first.
-// c1zstore.SelectSyncsToDelete depends on this ordering so "drop the
-// oldest overflow" trims the right end. Used by pkg/dotc1z's Pebble
-// store to drive the retention policy at Cleanup.
+// sortedSyncRuns reads every sync_run record into the engine-neutral
+// c1zstore.SyncRun shape, sorted oldest-first (started_at, sync_id
+// tiebreaker). Shared by CleanupCandidates and ListSyncRuns so the
+// projection and ordering live in one place.
 //
 // We sort explicitly rather than trust IterateAllSyncRuns' order:
 // the iterator walks by sync_id (KSUID), and KSUIDs only encode the
@@ -125,7 +124,7 @@ func syncRunRecordToExported(r *v3.SyncRunRecord) *c1zstore.SyncRun {
 // which would silently pick the wrong sync to prune. Sorting on
 // started_at (with sync_id tiebreaker) matches the SQLite engine's
 // ListSyncRuns ORDER BY id ASC semantics.
-func (a *Adapter) CleanupCandidates(ctx context.Context) ([]c1zstore.SyncRun, error) {
+func (a *Adapter) sortedSyncRuns(ctx context.Context) ([]c1zstore.SyncRun, error) {
 	var out []c1zstore.SyncRun
 	err := a.engine.IterateAllSyncRuns(ctx, func(r *v3.SyncRunRecord) bool {
 		cand := c1zstore.SyncRun{
@@ -148,7 +147,7 @@ func (a *Adapter) CleanupCandidates(ctx context.Context) ([]c1zstore.SyncRun, er
 		return true
 	})
 	if err != nil {
-		return nil, fmt.Errorf("pebble CleanupCandidates: IterateAllSyncRuns: %w", err)
+		return nil, err
 	}
 	sort.SliceStable(out, func(i, j int) bool {
 		ti, tj := out[i].StartedAt, out[j].StartedAt
@@ -168,6 +167,19 @@ func (a *Adapter) CleanupCandidates(ctx context.Context) ([]c1zstore.SyncRun, er
 	return out, nil
 }
 
+// CleanupCandidates walks every sync_run record and projects it into
+// the engine-neutral c1zstore.SyncRun shape, sorted oldest-first.
+// c1zstore.SelectSyncsToDelete depends on this ordering so "drop the
+// oldest overflow" trims the right end. Used by pkg/dotc1z's Pebble
+// store to drive the retention policy at Cleanup.
+func (a *Adapter) CleanupCandidates(ctx context.Context) ([]c1zstore.SyncRun, error) {
+	out, err := a.sortedSyncRuns(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("pebble CleanupCandidates: IterateAllSyncRuns: %w", err)
+	}
+	return out, nil
+}
+
 // ListSyncRuns returns every sync-run record projected into the
 // engine-neutral c1zstore.SyncRun shape, oldest-first (parent before
 // child for a well-formed chain), in a single page. A v3 Pebble c1z
@@ -178,14 +190,15 @@ func (a *Adapter) CleanupCandidates(ctx context.Context) ([]c1zstore.SyncRun, er
 // source-side sync-graph-metadata read (linked_sync_id, supports_diff),
 // which the gRPC reader surface does not carry.
 func (a *Adapter) ListSyncRuns(ctx context.Context, pageToken string, pageSize uint32) ([]*c1zstore.SyncRun, string, error) {
-	cands, err := a.CleanupCandidates(ctx)
+	runs, err := a.sortedSyncRuns(ctx)
 	if err != nil {
 		return nil, "", fmt.Errorf("pebble ListSyncRuns: %w", err)
 	}
-	out := make([]*c1zstore.SyncRun, 0, len(cands))
-	for i := range cands {
-		sr := cands[i]
-		out = append(out, &sr)
+	// The returned pointers index into runs' backing array, which escapes via
+	// the return value; runs must outlive this call and must not be reused.
+	out := make([]*c1zstore.SyncRun, len(runs))
+	for i := range runs {
+		out[i] = &runs[i]
 	}
 	return out, "", nil
 }

--- a/pkg/dotc1z/pebble_store.go
+++ b/pkg/dotc1z/pebble_store.go
@@ -348,6 +348,13 @@ func (s *pebbleStore) markDirty(err error) error {
 	return err
 }
 
+// StartNewSync begins a sync on the Pebble v3 store. INVARIANT: a v3 Pebble
+// c1z holds exactly ONE sync — StartNewSync replaces any prior sync in place
+// (the engine's ResetForNewSync wipes every sync-scoped keyspace). There is no
+// multi-sync Pebble file. Callers that copy N source syncs into a Pebble
+// destination (e.g. the c1z sanitizer) must reject N>1 up front, since each
+// StartNewSync after the first would discard the previous sync's records.
+// Future engine authors relying on this contract should preserve it here.
 func (s *pebbleStore) StartNewSync(ctx context.Context, syncType connectorstore.SyncType, parentSyncID string) (string, error) {
 	syncID, err := s.Adapter.StartNewSync(ctx, syncType, parentSyncID)
 	if err == nil {
@@ -410,7 +417,7 @@ func (s *pebbleStore) SetSupportsDiff(ctx context.Context, syncID string) error 
 // sanitize mints fresh destination sync ids.
 func (s *pebbleStore) SetSyncLink(ctx context.Context, syncID string, linkedSyncID string) error {
 	if syncID == "" {
-		return errors.New("SetSyncLink: empty syncID")
+		return fmt.Errorf("SetSyncLink: empty syncID")
 	}
 	r, err := s.engine.GetSyncRunRecord(ctx, syncID)
 	if err != nil {

--- a/pkg/dotc1z/pebble_store.go
+++ b/pkg/dotc1z/pebble_store.go
@@ -26,6 +26,30 @@ type pebbleDriver struct{}
 var _ C1ZStore = (*pebbleStore)(nil)
 var _ connectorstore.Writer = (*pebbleStore)(nil)
 
+// Local mirrors of the optional capabilities the c1z sanitizer probes on
+// the source/destination store (pkg/c1zsanitize keeps those interfaces
+// unexported). The assertions below make a refactor that drops one of these
+// methods from either engine break the build here, rather than silently
+// disarming the sanitizer's sync-graph-metadata preservation.
+type sanitizeSyncLinkWriter interface {
+	SetSyncLink(ctx context.Context, syncID string, linkedSyncID string) error
+}
+type sanitizeSupportsDiffWriter interface {
+	SetSupportsDiff(ctx context.Context, syncID string) error
+}
+type sanitizeSyncRunMetadataReader interface {
+	ListSyncRuns(ctx context.Context, pageToken string, pageSize uint32) ([]*SyncRun, string, error)
+}
+
+var (
+	_ sanitizeSyncLinkWriter        = (*pebbleStore)(nil)
+	_ sanitizeSupportsDiffWriter    = (*pebbleStore)(nil)
+	_ sanitizeSyncRunMetadataReader = (*pebbleStore)(nil)
+	_ sanitizeSyncLinkWriter        = (*C1File)(nil)
+	_ sanitizeSupportsDiffWriter    = (*C1File)(nil)
+	_ sanitizeSyncRunMetadataReader = (*C1File)(nil)
+)
+
 func (pebbleDriver) Engine() Engine    { return EnginePebble }
 func (pebbleDriver) Format() C1ZFormat { return C1ZFormatV3 }
 
@@ -365,6 +389,38 @@ func (s *pebbleStore) Cleanup(ctx context.Context) error {
 
 func (s *pebbleStore) PutAsset(ctx context.Context, assetRef *v2.AssetRef, contentType string, data []byte) error {
 	return s.markDirty(s.Adapter.PutAsset(ctx, assetRef, contentType, data))
+}
+
+// SetSupportsDiff marks the given sync as diff-capable, matching the
+// SQLite engine's sync_runs.supports_diff column. The c1z sanitizer
+// carries this marker from a source sync to its sanitized copy so the
+// output remains usable wherever the source was. Delegates to the
+// SyncMeta sub-store's MarkSyncSupportsDiff.
+func (s *pebbleStore) SetSupportsDiff(ctx context.Context, syncID string) error {
+	return s.markDirty(s.SyncMeta().MarkSyncSupportsDiff(ctx, syncID))
+}
+
+// SetSyncLink records linkedSyncID as the diff partner of syncID on the
+// sync-run record (v3 linked_sync_id), matching the SQLite engine.
+//
+// This is implemented for connectorstore.Writer parity but is NOT
+// reached by the c1z sanitizer's Pebble path: a v3 Pebble c1z holds
+// exactly one sync, so there is never a second sync to link to. Cross-
+// file linkage is unpreservable on either engine regardless, because
+// sanitize mints fresh destination sync ids.
+func (s *pebbleStore) SetSyncLink(ctx context.Context, syncID string, linkedSyncID string) error {
+	if syncID == "" {
+		return errors.New("SetSyncLink: empty syncID")
+	}
+	r, err := s.engine.GetSyncRunRecord(ctx, syncID)
+	if err != nil {
+		return fmt.Errorf("SetSyncLink: get: %w", err)
+	}
+	r.SetLinkedSyncId(linkedSyncID)
+	if err := s.engine.PutSyncRunRecord(ctx, r); err != nil {
+		return fmt.Errorf("SetSyncLink: put: %w", err)
+	}
+	return s.markDirty(nil)
 }
 
 func (s *pebbleStore) PutGrants(ctx context.Context, grants ...*v2.Grant) error {


### PR DESCRIPTION
## c1 sanitizer: Pebble storage-engine support

`baton sanitize` previously produced a correct identity-stripped copy only for SQLite-backed c1z files. On a Pebble-engine (v3) c1z the output was always silently downgraded to v1 SQLite, and the sync-graph metadata path skipped Pebble entirely. This makes sanitize work end-to-end on a Pebble c1z, Pebble-in to Pebble-out, preserving the core invariant — identity stripped; topology and cardinalities preserved for resource types, resources, entitlements, grants, and assets — plus grant-expansion information (the `needs_expansion` index, `GrantExpandable` blobs, expansion-source edges, and the derived `needs_expansion` flag) at full parity with the SQLite backend.

### What changed

The sanitize core (`c1zsanitize.Sanitize`) is already interface-typed on `connectorstore.Reader` / `Writer` and needed no structural change. Four ordered commits close the gaps:

1. **`feat(dotc1z): add pebble store SetSyncLink/SetSupportsDiff/ListSyncRuns`** — the sanitizer preserves sync-graph metadata (`linked_sync_id`, `supports_diff`) by reading sync runs from the source and writing them onto the destination. The Pebble store exposed none of the methods that path probes for, so a Pebble source or destination silently skipped preservation. Adds the three methods (with compile-time assertions so dropping any of them from either engine breaks the build) and corrects a stale comment that claimed the `needs_expansion` index is never populated.

2. **`feat(c1zsanitize): parent-before-child ordering + pebble dest guard`** — stably reorders the source sync list parent-first before the sanitize loop consumes it, so a child sync never gets a dangling transformed parent reference when the reader returns same-second syncs out of order. Adds a guard, read from the live destination store, that rejects sanitizing a multi-sync source into a Pebble destination: a Pebble c1z holds exactly one sync, so silently keeping only the last would be data corruption.

3. **`feat(baton): select sanitize output engine (default = source)`** — resolves the destination engine from the source (with an explicit `--out-engine {sqlite,pebble}` override) and applies the SQLite-only throughput pragmas and bulk-load options only for a SQLite destination, so a Pebble output is built with its native v3 framing.

4. **`test(c1zsanitize): cross-engine parity matrix + pebble e2e tests`** — see Testing.

### Testing

A four-combination matrix (sqlite/pebble source × sqlite/pebble destination) sanitizes one fixture under a single secret and asserts every output is identical on: per-entity cardinality; structural linkage (resource parent chains, entitlement ownership, grant entitlement/principal refs); expansion-source edges (`Sources` key set + `is_direct`, with nil-vs-empty normalized); the full `GrantExpandable` blob (entitlement-id set + `shallow` + resource-type-id **multiset**, since `resource_type_ids` is not unique-constrained); the `needs_expansion` enumeration; and assets. The asset assertion checks each output payload equals the content-type placeholder and does **not** equal the source bytes — sanitize deliberately discards asset payloads, so byte survival would be an identity leak. The fixture includes a divergence-trigger grant (expandable with already-populated sources) and a multi-entitlement / multi-resource-type grant. A Pebble end-to-end test covers the core invariant, the multi-sync guard, and `supports_diff` carry-over; a real-expander backstop sanitizes expander-produced grants into both engines and asserts identical expansion state.

The matrix proves relative parity to SQLite; absolute correctness of the transform stays anchored by the SQLite arm and the existing `TestSanitizeGrantExpansionRoundTrip`, so a regression uniform across all engines is not invisible.

`go build ./...`, `go test ./pkg/dotc1z/...`, `go test ./pkg/c1zsanitize/...`, and `go test ./cmd/baton/...` all pass.

### Notes

- A v3 `GrantSourceRecord`'s audit fields (`resource_type_id` / `resource_id` / `entitlement_id`) are not carried through the v2 round-trip — the v2 `GrantSources` message only carries `is_direct` — so they are absent uniformly across engines. The expansion-source edge (the source entitlement-id key + `is_direct`) is preserved.
- Multi-sync SQLite source into a Pebble destination is rejected, not converted. Collapsing N SQLite syncs into a single Pebble output is a separate design and is intentionally out of scope here.

---

_🛰 Built with stargate._
