### PR TITLE
fix(lambda/grpc): code function-returned errors as FailedPrecondition

### DIFF
--- a/pkg/lambda/grpc/client.go
+++ b/pkg/lambda/grpc/client.go
@@ -18,8 +18,14 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+// lambdaInvoker is the subset of *lambda.Client that the transport needs. It
+// exists so RoundTrip can be unit-tested against a fake invoker.
+type lambdaInvoker interface {
+	Invoke(ctx context.Context, params *lambda.InvokeInput, optFns ...func(*lambda.Options)) (*lambda.InvokeOutput, error)
+}
+
 type lambdaTransport struct {
-	lambdaClient *lambda.Client
+	lambdaClient lambdaInvoker
 	functionName string
 }
 
@@ -68,11 +74,16 @@ func (l *lambdaTransport) RoundTrip(ctx context.Context, req *Request) (*Respons
 		}
 		// If a third case is ever added to this, put the logic in its own function and add some test cases.
 
+		// The function was invoked but its own code returned an error (vs. an
+		// infra/invoke failure above). That's a caller/function-state fault, not a
+		// server fault: code it FailedPrecondition so it doesn't surface as a
+		// gRPC Unknown (which otel counts as a 5xx).
 		if filteredLogs != "" {
-			return nil, fmt.Errorf("%s", filteredLogs)
+			return nil, status.Errorf(codes.FailedPrecondition, "%s", filteredLogs)
 		}
 
-		return nil, fmt.Errorf(
+		return nil, status.Errorf(
+			codes.FailedPrecondition,
 			"lambda_transport: function returned error: %s; status code: %d",
 			*invokeResp.FunctionError,
 			invokeResp.StatusCode,

--- a/pkg/lambda/grpc/client_test.go
+++ b/pkg/lambda/grpc/client_test.go
@@ -1,10 +1,65 @@
 package grpc
 
 import (
+	"context"
+	"encoding/base64"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/lambda"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
+
+type fakeInvoker struct {
+	resp *lambda.InvokeOutput
+	err  error
+}
+
+func (f *fakeInvoker) Invoke(_ context.Context, _ *lambda.InvokeInput, _ ...func(*lambda.Options)) (*lambda.InvokeOutput, error) {
+	return f.resp, f.err
+}
+
+// A function that runs but returns an error (FunctionError set) is a
+// caller/function-state fault, not a server fault — RoundTrip must surface it
+// as FailedPrecondition so it never shows up as a gRPC Unknown (counted 5xx).
+func TestRoundTrip_FunctionErrorIsFailedPrecondition(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload string
+		logs    string
+	}{
+		{
+			name:    "no meaningful logs",
+			payload: "{}",
+			logs:    "START RequestId: abc\nEND RequestId: abc\n",
+		},
+		{
+			name:    "meaningful logs present",
+			payload: "{}",
+			logs:    "Unhandled: connector failed to initialize\n",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			tr := &lambdaTransport{
+				functionName: "fn",
+				lambdaClient: &fakeInvoker{resp: &lambda.InvokeOutput{
+					FunctionError: aws.String("Unhandled"),
+					StatusCode:    200,
+					Payload:       []byte(c.payload),
+					LogResult:     aws.String(base64.StdEncoding.EncodeToString([]byte(c.logs))),
+				}},
+			}
+
+			_, err := tr.RoundTrip(context.Background(), &Request{})
+			require.Error(t, err)
+			require.Equal(t, codes.FailedPrecondition, status.Code(err), "function-returned error must be FailedPrecondition, got: %v", err)
+		})
+	}
+}
 
 func TestExtractMeaningfulLogLines(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
## Problem

When the lambda gRPC transport invokes a function successfully but the **function's own code** returns an error (`invokeResp.FunctionError` set), `RoundTrip` returned a bare `fmt.Errorf`. That surfaces as gRPC `codes.Unknown`, and our otel pipeline counts `Unknown` as a span error / HTTP 5xx.

At low call volume this trips the 99.99% failure-rate monitor on **be-temporal-lambda-manager** — a handful of function-application faults (e.g. a connector that exits `Unhandled` during init, or a function whose startup config fetch is rejected) pages even though nothing on the server is broken.

## Fix

Recode both return paths inside the `if invokeResp.FunctionError != nil` block from bare error → `status.Errorf(codes.FailedPrecondition, ...)`. A function-returned error is a caller/function-state fault, not a server fault, so `FailedPrecondition` (4xx, uncounted) is the correct code. The message text is preserved.

**Unchanged on purpose:**
- The retryable paths above — transient-network → `Unavailable`, function timeout → `DeadlineExceeded`.
- The invoke-failure (`failed to invoke lambda function`) and marshal/unmarshal paths — genuine infra/our-bug faults that stay counted.

**No retry-behavior change:** `pkg/retry` only retries `Unavailable`/`DeadlineExceeded`. `Unknown` was never retried, and neither is `FailedPrecondition` — so recoding is behavior-preserving for retries. (The connector-side Hello retry classifier, `isRetryableHelloError`, is the opposite direction — connector→c1api over a normal dial — and never sees these errors.)

## Test

Adds a `lambdaInvoker` interface seam (subset of `*lambda.Client`; the concrete client still satisfies it, no caller changes) so `RoundTrip` is unit-testable, plus a regression test asserting `FailedPrecondition` on both function-error paths (meaningful-logs and no-meaningful-logs).

`go vet` clean; `go test ./pkg/lambda/grpc/` passes.

## Downstream

c1 picks this up on the next baton-sdk release + re-vendor; `be-temporal-lambda-manager`'s existing `classifyLambdaError` pass-through then carries the `FailedPrecondition` code through unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)