### PR TITLE
Cleanup.

### DIFF
--- a/pkg/dotc1z/engine/pebble/cleanup.go
+++ b/pkg/dotc1z/engine/pebble/cleanup.go
@@ -123,7 +123,7 @@ func (e *Engine) CompactAllRanges(ctx context.Context) error {
 	e.writeWG.Add(1)
 	defer e.writeWG.Done()
 	if e.closing.Load() {
-		return ErrEngineQuiesced
+		return ErrEngineClosing
 	}
 
 	var firstErr error
@@ -173,7 +173,7 @@ func (e *Engine) Flush(ctx context.Context) error {
 	e.writeWG.Add(1)
 	defer e.writeWG.Done()
 	if e.closing.Load() {
-		return ErrEngineQuiesced
+		return ErrEngineClosing
 	}
 	if err := e.db.Flush(); err != nil {
 		return fmt.Errorf("engine: flush: %w", err)

--- a/pkg/dotc1z/engine/pebble/engine.go
+++ b/pkg/dotc1z/engine/pebble/engine.go
@@ -23,8 +23,6 @@ import (
 //
 //   - Open the engine once with Open(...).
 //   - Concurrent Reader/Writer calls are safe.
-//   - Quiesce() flips the engine into a terminal state; subsequent
-//     Writer calls return ErrEngineQuiesced.
 //   - Close() releases all resources. After Close, all methods return
 //     ErrEngineClosing.
 type Engine struct {
@@ -59,10 +57,8 @@ type Engine struct {
 	freshResourcesEmpty    bool
 	freshEntitlementsEmpty bool
 
-	// writeWG tracks in-flight writes for the strict quiesce
-	// protocol. Incremented at the start of every Writer method,
-	// decremented in defer. Quiesce flips closing=true then waits
-	// for writeWG to drain.
+	// writeWG tracks in-flight writes. Incremented at the start of
+	// every Writer method, decremented in defer.
 	writeWG sync.WaitGroup
 	writeMu sync.Mutex
 	closing atomic.Bool // strict write-barrier flag, read on every Writer call
@@ -127,9 +123,7 @@ func Open(ctx context.Context, dir string, opts ...Option) (*Engine, error) {
 }
 
 // Close shuts down the engine. After Close, all methods return
-// ErrEngineClosing. If the engine was Quiesce'd first, the
-// in-flight writes have already drained; otherwise Close blocks
-// until they complete.
+// ErrEngineClosing. Close blocks until all in-flight writes complete.
 func (e *Engine) Close() error {
 	e.closeMu.Lock()
 	defer e.closeMu.Unlock()
@@ -318,10 +312,10 @@ func (e *Engine) requireCurrentSync() error {
 }
 
 // checkWritable returns ErrEngineClosing if the engine has been
-// Quiesce'd or closed. Called at the start of every Writer method.
+// closed. Called at the start of every Writer method.
 func (e *Engine) checkWritable() error {
 	if e.closing.Load() {
-		return ErrEngineQuiesced
+		return ErrEngineClosing
 	}
 	if e.db == nil {
 		return ErrEngineClosing
@@ -333,18 +327,17 @@ func (e *Engine) checkWritable() error {
 }
 
 // withWrite wraps a writer function with WaitGroup tracking + the
-// closing check. The closure runs only if the engine is open and
-// not quiesced.
+// closing check. The closure runs only if the engine is open.
 func (e *Engine) withWrite(fn func() error) error {
 	if err := e.checkWritable(); err != nil {
 		return err
 	}
 	e.writeWG.Add(1)
 	defer e.writeWG.Done()
-	// Re-check after Add because Quiesce could have flipped between
+	// Re-check after Add because closing could have flipped between
 	// our first check and our Add.
 	if e.closing.Load() {
-		return ErrEngineQuiesced
+		return ErrEngineClosing
 	}
 	e.writeMu.Lock()
 	defer e.writeMu.Unlock()
@@ -428,7 +421,7 @@ func (e *Engine) CheckpointTo(ctx context.Context, destDir string) error {
 	e.writeWG.Wait()
 
 	if e.closing.Load() {
-		return ErrEngineQuiesced
+		return ErrEngineClosing
 	}
 	e.writeMu.Lock()
 	defer e.writeMu.Unlock()

--- a/pkg/dotc1z/engine/pebble/engine_stub.go
+++ b/pkg/dotc1z/engine/pebble/engine_stub.go
@@ -27,12 +27,8 @@ func (e *sentinelError) GRPCStatus() *status.Status { return status.New(e.code, 
 
 func sentinel(code codes.Code, msg string) error { return &sentinelError{code: code, msg: msg} }
 
-// Sentinel errors from Appendix E. Centralized here so the codec
-// package + engine package + envelope package all reference one
-// source of truth.
 var (
 	ErrEngineClosing                 = sentinel(codes.Unavailable, "pebble engine: closing")
-	ErrEngineQuiesced                = sentinel(codes.Unavailable, "pebble engine: quiesced; writes refused")
 	ErrEngineNotAvailable            = sentinel(codes.Unavailable, "pebble engine: not available")
 	ErrEngineMismatch                = sentinel(codes.InvalidArgument, "pebble engine: source/dest engine mismatch")
 	ErrManifestInvalid               = sentinel(codes.DataLoss, "pebble engine: manifest unmarshal failed")

--- a/pkg/dotc1z/engine/pebble/engine_test.go
+++ b/pkg/dotc1z/engine/pebble/engine_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cockroachdb/pebble/v2"
 	"github.com/segmentio/ksuid"
+	"github.com/stretchr/testify/require"
 
 	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
 )
@@ -373,22 +374,19 @@ func TestCheckpointTo(t *testing.T) {
 	}
 }
 
-func TestSaveDoesNotQuiesceOnError(t *testing.T) {
+func TestSaveDoesNotCloseOnError(t *testing.T) {
 	ctx := context.Background()
 	e, dir := newTestEngine(t)
 	syncID := ksuid.New().String()
-	if err := e.SetCurrentSync(syncID); err != nil {
-		t.Fatal(err)
-	}
+	err := e.SetCurrentSync(syncID)
+	require.NoError(t, err)
 
-	if err := e.Save(ctx, filepath.Join(dir, "out.c1z3")); err == nil {
-		t.Fatal("expected Save error")
-	}
+	err = e.Save(ctx, filepath.Join(dir, "out.c1z3"))
+	require.Error(t, err, "expected Save error")
 
 	r := makeGrant(syncID, "after-save", "e1", "p1")
-	if err := e.PutGrantRecord(ctx, r); err != nil {
-		t.Fatalf("Put after failed Save: %v", err)
-	}
+	err = e.PutGrantRecord(ctx, r)
+	require.NoError(t, err, "expected Put after failed Save to succeed")
 }
 
 func TestConcurrentGrantOverwriteIndexes(t *testing.T) {

--- a/pkg/dotc1z/engine/pebble/grants.go
+++ b/pkg/dotc1z/engine/pebble/grants.go
@@ -167,7 +167,7 @@ func (e *Engine) PutGrantRecords(ctx context.Context, records ...*v3.GrantRecord
 //     sync (the expander recomputes them from the entitlement graph),
 //     so a per-batch fsync buys nothing. Writes commit with
 //     pebble.NoSync and are hardened by the single Flush at sync end
-//     (EndFreshSync) or Close (Quiesce) — the same bargain the
+//     (EndFreshSync) or Close — the same bargain the
 //     fresh-sync fast path strikes, extended to resumed syncs where
 //     IsFreshSync() is false.
 //

--- a/pkg/dotc1z/engine/pebble/options.go
+++ b/pkg/dotc1z/engine/pebble/options.go
@@ -16,29 +16,6 @@ import (
 // newer than what the binary supports.
 const SDKPebbleFormat = pebble.FormatNewest
 
-// Preset selects per-deployment defaults for engine tuning. Set once
-// at engine-open via WithPreset; never changes for the engine's
-// lifetime.
-type Preset int
-
-const (
-	// PresetBackendInfra is the production default: 256 MiB block cache,
-	// per-level compression presets tuned for write-once-read-many sync
-	// payloads, MaxConcurrentCompactions ≤ 4.
-	PresetBackendInfra Preset = iota
-
-	// PresetBackendInfraHot is for hosts that run many engines in the
-	// same process (e.g. C1's per-app ReaderCache). 4 GiB block cache;
-	// otherwise identical to PresetBackendInfra. Use WithSharedCache to
-	// share one cache across engines.
-	PresetBackendInfraHot
-
-	// PresetCLI is for one-shot tooling. 32 MiB cache, low compaction
-	// concurrency. Optimized for fast open/close rather than steady-
-	// state throughput.
-	PresetCLI
-)
-
 // Durability controls how aggressively the engine fsyncs writes. The
 // default for production is DurabilitySync; the fresh-sync fast path
 // (which uses pebble.NoSync for in-flight grant batches) falls under
@@ -55,7 +32,6 @@ const (
 // Options configures an Engine. Construct via the WithXxx functional
 // options passed to Open.
 type Options struct {
-	preset      Preset
 	sharedCache *pebble.Cache
 	durability  Durability
 
@@ -70,10 +46,6 @@ type Options struct {
 
 // Option is a functional option passed to Open.
 type Option func(*Options)
-
-// WithPreset picks one of PresetBackendInfra (default),
-// PresetBackendInfraHot, or PresetCLI.
-func WithPreset(p Preset) Option { return func(o *Options) { o.preset = p } }
 
 // WithSharedCache reuses a single *pebble.Cache across multiple
 // engine instances. Mandatory for any caller that opens >1 engine in
@@ -141,18 +113,10 @@ func newPebbleOptions(o *Options) *pebble.Options {
 	// be added after benchmark data justifies it.
 	opts.Levels[0].BlockSize = 32 << 10
 
-	// Cache: shared or minted per preset.
-	if o.sharedCache != nil {
-		opts.Cache = o.sharedCache
+	if o.sharedCache == nil {
+		opts.Cache = pebble.NewCache(256 << 20)
 	} else {
-		switch o.preset {
-		case PresetBackendInfraHot:
-			opts.Cache = pebble.NewCache(4 << 30)
-		case PresetCLI:
-			opts.Cache = pebble.NewCache(32 << 20)
-		default:
-			opts.Cache = pebble.NewCache(256 << 20)
-		}
+		opts.Cache = o.sharedCache
 	}
 
 	return opts
@@ -169,7 +133,6 @@ func writeOpts(d Durability) *pebble.WriteOptions {
 
 func defaultOptions() *Options {
 	return &Options{
-		preset:             PresetBackendInfra,
 		durability:         DurabilitySync,
 		slowQueryThreshold: 5 * time.Second,
 	}

--- a/pkg/synccompactor/pebble/compactor.go
+++ b/pkg/synccompactor/pebble/compactor.go
@@ -78,7 +78,7 @@ func NewCompactor(base *enginepkg.Engine, tmpDir string) (*Compactor, error) {
 // step is idempotent (excise + ingest the same SSTs again converges
 // to the source's view).
 //
-// Caller is responsible for quiescing writes to `source` for the
+// Caller is responsible for not writing to `source` for the
 // duration of the call (an active syncer would invalidate the SST as
 // it's being built).
 func (c *Compactor) Compact(ctx context.Context, source *enginepkg.Engine, syncID string) error {


### PR DESCRIPTION
- Remove ErrEngineQuiesced. It's the same as ErrEngineClosing.
- Remove WithPreset. It's not used by anything, and it does the wrong thing for backend/backendhot presets. Those should be using a shared cache.

Same as https://github.com/ConductorOne/baton-sdk/pull/973 but without the more controversial trait filter removal.