### PR TITLE
Fix resume bug in pebble storage engine

### DIFF
--- a/pkg/c1zsanitize/sanitize.go
+++ b/pkg/c1zsanitize/sanitize.go
@@ -109,10 +109,10 @@ type Options struct {
 	//
 	// Resumable requires the sqlite-backed destination (*dotc1z.C1File). A
 	// pebble destination is rejected with a clear error rather than silently
-	// restarting: its single-sync, replace-in-place storage and its
-	// SetCurrentSync (which does not rehydrate the persisted step) cannot
-	// resume a checkpoint. The rejection is an explicit destination-engine
-	// check, so it holds even though pebble implements ListSyncRuns.
+	// restarting: its single-sync, replace-in-place storage cannot resume a
+	// checkpoint — StartNewSync wipes any prior sync's data before writing.
+	// The rejection is an explicit destination-engine check, so it holds even
+	// though pebble implements ListSyncRuns.
 	Resumable bool
 }
 
@@ -374,9 +374,9 @@ type dstSyncLister interface {
 // ListSyncRuns (for source-side sync-graph-metadata reads), so a capability
 // assertion would SUCCEED for a pebble destination and silently re-admit it.
 // Resume on pebble is unsafe — its single-sync, replace-in-place StartNewSync
-// and its SetCurrentSync/CurrentSyncStep (which do not round-trip the persisted
-// step) cannot rehydrate a checkpoint, so a "resume" would silently restart and
-// corrupt. Keying on the reported engine cannot be defeated by a future engine
+// wipes any prior sync's data before writing, so a "resume" through the
+// sanitize copy path would silently restart and corrupt the destination.
+// Keying on the reported engine cannot be defeated by a future engine
 // adding capability methods. The capability assertion is kept below it as a
 // backstop for any engine that cannot enumerate checkpoints at all.
 func isResumableDestination(dst connectorstore.Writer) error {

--- a/pkg/dotc1z/engine/pebble/adapter.go
+++ b/pkg/dotc1z/engine/pebble/adapter.go
@@ -166,22 +166,50 @@ func (a *Adapter) ResumeSync(ctx context.Context, syncType connectorstore.SyncTy
 		return "", err
 	}
 	a.current = syncRunState{
-		syncID:    syncID,
-		syncType:  existing.GetType(),
-		parentID:  existing.GetParentSyncId(),
+		syncID:   syncID,
+		syncType: existing.GetType(),
+		parentID: existing.GetParentSyncId(),
+		// Load the persisted checkpoint token back into the in-memory
+		// cache. CurrentSyncStep reads a.current.step directly, so
+		// omitting this makes a resumed sync report step "" and the
+		// syncer's state.Unmarshal("") restarts the FSM from InitOp —
+		// i.e. a full sync every activity window. CheckpointSync/EndSync
+		// round-trip SyncToken via the SyncRunRecord; resume must too.
+		step:      existing.GetSyncToken(),
 		startedAt: existing.GetStartedAt().AsTime(),
 	}
 	return syncID, nil
 }
 
-// StartOrResumeSync resumes if syncID-like state exists for the given
-// type, else starts a new sync. Returns (id, started_new, err).
+// StartOrResumeSync resumes an existing sync if one is resumable, else
+// starts a new sync. Returns (id, started_new, err).
+//
+// Resume precedence mirrors SQLite's StartOrResumeSync→ResumeSync
+// cascade (pkg/dotc1z/sync_runs.go):
+//
+//  1. A caller-supplied syncID that names an existing sync_run.
+//  2. With an empty syncID, the latest in-progress (not-yet-ended)
+//     sync of the requested type started within the last week — the
+//     same predicate as Engine.LatestUnfinishedSyncRecord. This is the
+//     path the syncer drives across activity windows: it calls
+//     StartOrResumeSync(ctx, syncType, "") with no id, expecting an
+//     interrupted sync to resume where it checkpointed. Without this,
+//     every window started a brand-new sync (wiping prior data via
+//     ResetForNewSync and resetting the FSM to InitOp), so any sync
+//     exceeding one window never finished.
+//
+// Only when nothing is resumable do we start a new sync.
 func (a *Adapter) StartOrResumeSync(ctx context.Context, syncType connectorstore.SyncType, syncID string) (string, bool, error) {
 	if syncID != "" {
 		if _, err := a.engine.GetSyncRunRecord(ctx, syncID); err == nil {
 			id, err := a.ResumeSync(ctx, syncType, syncID)
 			return id, false, err
 		}
+	} else if rec, err := a.engine.LatestUnfinishedSyncRecord(ctx, syncTypeFilterFromConnectorstore(syncType)); err != nil {
+		return "", false, err
+	} else if rec != nil {
+		id, err := a.ResumeSync(ctx, syncType, rec.GetSyncId())
+		return id, false, err
 	}
 	id, err := a.StartNewSync(ctx, syncType, "")
 	return id, true, err
@@ -196,7 +224,24 @@ func (a *Adapter) SetCurrentSync(ctx context.Context, syncID string) error {
 	if err := a.engine.SetCurrentSync(syncID); err != nil {
 		return err
 	}
-	a.current.syncID = syncID
+	// Rehydrate the in-memory cache from the persisted record so
+	// CurrentSyncStep reflects the on-disk SyncToken after a rebind —
+	// the same reason ResumeSync loads step. SQLite's CurrentSyncStep
+	// re-reads the sync_runs row on every call and so is immune; Pebble
+	// caches a.current.step, so a rebind that doesn't refresh it would
+	// report a stale (or empty) step and reset the FSM. Best-effort: a
+	// missing/unreadable record clears the cached step rather than
+	// leaving a value from a previously-bound sync.
+	a.current = syncRunState{syncID: syncID}
+	if rec, err := a.engine.GetSyncRunRecord(ctx, syncID); err == nil && rec != nil {
+		a.current = syncRunState{
+			syncID:    syncID,
+			syncType:  rec.GetType(),
+			parentID:  rec.GetParentSyncId(),
+			step:      rec.GetSyncToken(),
+			startedAt: rec.GetStartedAt().AsTime(),
+		}
+	}
 	return nil
 }
 

--- a/pkg/dotc1z/engine/pebble/resume_checkpoint_test.go
+++ b/pkg/dotc1z/engine/pebble/resume_checkpoint_test.go
@@ -1,0 +1,90 @@
+package pebble
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+)
+
+// reopenEngine closes the engine and reopens a fresh one against the
+// same on-disk directory, returning the new engine. It models a new
+// activity window / process: the in-memory adapter cache (a.current) is
+// gone, but the persisted sync_run record survives a graceful Close
+// (which flushes + fsyncs).
+func reopenEngine(t testing.TB, e *Engine, dir string) *Engine {
+	t.Helper()
+	require.NoError(t, e.Close(), "close before reopen")
+	reopened, err := Open(context.Background(), filepath.Join(dir, "db"))
+	require.NoError(t, err, "reopen")
+	t.Cleanup(func() { _ = reopened.Close() })
+	return reopened
+}
+
+// TestResumeSyncRestoresCheckpointStep is the core regression for the
+// Pebble resume bug: ResumeSync must rehydrate the in-memory step from
+// the persisted SyncToken so CurrentSyncStep returns the checkpointed
+// token (not "") after a new-process resume. A lost step makes the
+// syncer's state.Unmarshal("") restart the FSM from InitOp — i.e. a
+// full sync on every activity window.
+func TestResumeSyncRestoresCheckpointStep(t *testing.T) {
+	ctx := context.Background()
+	e, dir := newTestEngine(t)
+	a := NewAdapter(e)
+
+	const fsmCursor = "page-cursor-abc123"
+
+	syncID, err := a.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, a.PutResourceTypes(ctx, v2.ResourceType_builder{Id: "group"}.Build()))
+	require.NoError(t, a.CheckpointSync(ctx, fsmCursor))
+	// No EndSync: the sync is still in progress when the window expires.
+
+	// New activity window / process: reopen from disk, fresh adapter.
+	e2 := reopenEngine(t, e, dir)
+	a2 := NewAdapter(e2)
+
+	resumedID, err := a2.ResumeSync(ctx, connectorstore.SyncTypeFull, syncID)
+	require.NoError(t, err)
+	require.Equal(t, syncID, resumedID)
+
+	step, err := a2.CurrentSyncStep(ctx)
+	require.NoError(t, err)
+	require.Equal(t, fsmCursor, step, "ResumeSync must restore the checkpointed step from the persisted SyncToken")
+}
+
+// TestStartOrResumeSyncRestoresCheckpointStep exercises the production
+// resume path the syncer actually drives: startOrResumeSync calls
+// store.StartOrResumeSync(ctx, syncType, "") with an EMPTY syncID. It
+// must resume the existing in-progress sync (started==false) and keep
+// its checkpoint — NOT start a fresh sync that wipes prior data and
+// resets the FSM to InitOp.
+func TestStartOrResumeSyncRestoresCheckpointStep(t *testing.T) {
+	ctx := context.Background()
+	e, dir := newTestEngine(t)
+	a := NewAdapter(e)
+
+	const fsmCursor = "page-cursor-xyz789"
+
+	syncID, err := a.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, a.PutResourceTypes(ctx, v2.ResourceType_builder{Id: "group"}.Build()))
+	require.NoError(t, a.CheckpointSync(ctx, fsmCursor))
+
+	// New activity window / process.
+	e2 := reopenEngine(t, e, dir)
+	a2 := NewAdapter(e2)
+
+	resumedID, startedNew, err := a2.StartOrResumeSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.False(t, startedNew, "StartOrResumeSync with empty syncID must resume the in-progress sync, not start a new one")
+	require.Equal(t, syncID, resumedID, "must resume the same sync_id")
+
+	step, err := a2.CurrentSyncStep(ctx)
+	require.NoError(t, err)
+	require.Equal(t, fsmCursor, step, "resumed sync must retain its checkpointed step")
+}

--- a/pkg/dotc1z/resume_checkpoint_parity_test.go
+++ b/pkg/dotc1z/resume_checkpoint_parity_test.go
@@ -1,0 +1,70 @@
+package dotc1z_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+)
+
+// TestResumeCheckpointParity locks in that both storage engines resume
+// an interrupted sync across a process restart instead of restarting it
+// from scratch. This is the contract the syncer depends on for
+// time-boxed (activity-window) syncs: when a window expires mid-sync,
+// the next window must pick up at the persisted checkpoint.
+//
+// It exercises the exact call the syncer makes on resume —
+// StartOrResumeSync(ctx, syncType, "") with an EMPTY syncID
+// (pkg/sync/syncer.go startOrResumeSync) — and asserts:
+//   - the interrupted sync is resumed (started_new == false), not
+//     replaced by a fresh sync, and
+//   - CurrentSyncStep returns the checkpointed token, so the syncer's
+//     state.Unmarshal sees a real FSM cursor rather than "" (which
+//     would reset the FSM to InitOp and re-run the whole sync).
+//
+// Pebble previously failed both: StartOrResumeSync("") always started a
+// new sync (wiping prior data), and even on the direct ResumeSync path
+// it dropped the in-memory step. SQLite has always satisfied this via
+// getLatestUnfinishedSync + reading sync_token from the row.
+func TestResumeCheckpointParity(t *testing.T) {
+	ctx := context.Background()
+	const fsmCursor = "fsm-page-cursor-42"
+
+	for _, engine := range []dotc1z.Engine{dotc1z.EngineSQLite, dotc1z.EnginePebble} {
+		t.Run(string(engine), func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "sync.c1z")
+
+			// Activity window 1: start a sync, write a record, checkpoint
+			// a non-empty FSM token mid-sync, then close WITHOUT EndSync
+			// (the window expired before the sync finished).
+			store, err := dotc1z.NewStore(ctx, path, dotc1z.WithTmpDir(dir), dotc1z.WithEngine(engine))
+			require.NoError(t, err)
+			syncID, err := store.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+			require.NoError(t, err)
+			require.NoError(t, store.PutResourceTypes(ctx, v2.ResourceType_builder{Id: "group"}.Build()))
+			require.NoError(t, store.CheckpointSync(ctx, fsmCursor))
+			require.NoError(t, store.Close(ctx))
+
+			// Activity window 2: a fresh process reopens the same c1z and
+			// resumes via the empty-syncID path the syncer drives.
+			store2, err := dotc1z.NewStore(ctx, path, dotc1z.WithTmpDir(dir), dotc1z.WithEngine(engine))
+			require.NoError(t, err)
+			defer func() { _ = store2.Close(ctx) }()
+
+			resumedID, startedNew, err := store2.StartOrResumeSync(ctx, connectorstore.SyncTypeFull, "")
+			require.NoError(t, err)
+			require.False(t, startedNew, "must resume the interrupted sync, not start a new one")
+			require.Equal(t, syncID, resumedID, "must resume the same sync_id")
+
+			step, err := store2.CurrentSyncStep(ctx)
+			require.NoError(t, err)
+			require.Equal(t, fsmCursor, step, "resumed sync must retain its checkpoint token")
+		})
+	}
+}


### PR DESCRIPTION
I have looked this over, but it could really use a baton-sdk expert review to make sure this makes sense.
it does explain the behavior we've been seeing during syncs though.