### PR TITLE
Increase event feed max page size to 1000

### DIFF
--- a/pb/c1/connector/v2/event_feed.pb.go
+++ b/pb/c1/connector/v2/event_feed.pb.go
@@ -1501,7 +1501,7 @@ const file_c1_connector_v2_event_feed_proto_rawDesc = "" +
 	"r\b \x01(\x80 \xd0\x01\x01R\x06cursor\x125\n" +
 	"\bstart_at\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\astartAt\x12'\n" +
 	"\tpage_size\x18\x03 \x01(\rB\n" +
-	"\xfaB\a*\x05\x18\xfa\x01@\x01R\bpageSize\x126\n" +
+	"\xfaB\a*\x05\x18\xe8\a@\x01R\bpageSize\x126\n" +
 	"\vannotations\x18\x04 \x03(\v2\x14.google.protobuf.AnyR\vannotations\x121\n" +
 	"\revent_feed_id\x18\x05 \x01(\tB\r\xfaB\n" +
 	"r\b \x01(\x80\b\xd0\x01\x01R\veventFeedId\"\xbe\x01\n" +

--- a/pb/c1/connector/v2/event_feed.pb.validate.go
+++ b/pb/c1/connector/v2/event_feed.pb.validate.go
@@ -103,10 +103,10 @@ func (m *ListEventsRequest) validate(all bool) error {
 
 	if m.GetPageSize() != 0 {
 
-		if m.GetPageSize() > 250 {
+		if m.GetPageSize() > 1000 {
 			err := ListEventsRequestValidationError{
 				field:  "PageSize",
-				reason: "value must be less than or equal to 250",
+				reason: "value must be less than or equal to 1000",
 			}
 			if !all {
 				return err

--- a/pb/c1/connector/v2/event_feed_protoopaque.pb.go
+++ b/pb/c1/connector/v2/event_feed_protoopaque.pb.go
@@ -1496,7 +1496,7 @@ const file_c1_connector_v2_event_feed_proto_rawDesc = "" +
 	"r\b \x01(\x80 \xd0\x01\x01R\x06cursor\x125\n" +
 	"\bstart_at\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\astartAt\x12'\n" +
 	"\tpage_size\x18\x03 \x01(\rB\n" +
-	"\xfaB\a*\x05\x18\xfa\x01@\x01R\bpageSize\x126\n" +
+	"\xfaB\a*\x05\x18\xe8\a@\x01R\bpageSize\x126\n" +
 	"\vannotations\x18\x04 \x03(\v2\x14.google.protobuf.AnyR\vannotations\x121\n" +
 	"\revent_feed_id\x18\x05 \x01(\tB\r\xfaB\n" +
 	"r\b \x01(\x80\b\xd0\x01\x01R\veventFeedId\"\xbe\x01\n" +

--- a/proto/c1/connector/v2/event_feed.proto
+++ b/proto/c1/connector/v2/event_feed.proto
@@ -26,7 +26,7 @@ message ListEventsRequest {
   google.protobuf.Timestamp start_at = 2;
   uint32 page_size = 3 [(validate.rules).uint32 = {
     ignore_empty: true
-    lte: 250
+    lte: 1000
   }];
   repeated google.protobuf.Any annotations = 4;
   // Used to specify a specific event feed to list events from.


### PR DESCRIPTION
## Summary
- Raise the `ListEventsRequest.page_size` validation limit from 250 to 1000 for connector event feeds
- Regenerate protobuf and validate artifacts

## Test plan
- [x] `make protogen`
- [ ] Verify `ListEventsRequest` with `page_size=1000` passes validation
- [ ] Verify `ListEventsRequest` with `page_size=1001` fails validation


Made with [Cursor](https://cursor.com)