### PR TITLE
multi-engine-compaction support

### DIFF
--- a/pkg/connectorrunner/runner.go
+++ b/pkg/connectorrunner/runner.go
@@ -1076,7 +1076,7 @@ func NewConnectorRunner(ctx context.Context, c types.ConnectorServer, opts ...Op
 					SyncID:   c.syncIDs[i],
 				})
 			}
-			tm = local.NewLocalCompactor(ctx, cfg.syncCompactorConfig.outputPath, configs, cfg.tempDir)
+			tm = local.NewLocalCompactor(ctx, cfg.syncCompactorConfig.outputPath, configs, cfg.tempDir, local.WithCompactorStorageEngine(cfg.storageEngine))
 		default:
 			tm, err = local.NewSyncer(ctx, cfg.c1zPath,
 				local.WithTmpDir(cfg.tempDir),

--- a/pkg/dotc1z/to_pebble.go
+++ b/pkg/dotc1z/to_pebble.go
@@ -18,6 +18,7 @@ import (
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
@@ -243,6 +244,16 @@ func (c *C1File) ToPebble(ctx context.Context, outPath string, syncID string, op
 	endSyncStart := time.Now()
 	if err = dest.EndSync(ctx); err != nil {
 		return nil, fmt.Errorf("to-pebble: end destination sync: %w", err)
+	}
+	if sync.EndedAt != nil {
+		rec, err := destEng.GetSyncRunRecord(ctx, destSyncID)
+		if err != nil {
+			return nil, fmt.Errorf("to-pebble: load destination sync metadata: %w", err)
+		}
+		rec.SetEndedAt(timestamppb.New(*sync.EndedAt))
+		if err := destEng.PutSyncRunRecord(ctx, rec); err != nil {
+			return nil, fmt.Errorf("to-pebble: preserve source ended_at: %w", err)
+		}
 	}
 	endSyncDur := time.Since(endSyncStart)
 	closeStart := time.Now()

--- a/pkg/synccompactor/attached/attached.go
+++ b/pkg/synccompactor/attached/attached.go
@@ -3,6 +3,7 @@ package attached
 import (
 	"context"
 	"fmt"
+	"time"
 
 	reader_v2 "github.com/conductorone/baton-sdk/pb/c1/reader/v2"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
@@ -61,7 +62,12 @@ func latestFinishedCompactableSync(ctx context.Context, f *dotc1z.C1File) (*read
 			continue
 		}
 
-		if best == nil || s.GetEndedAt().AsTime().After(best.GetEndedAt().AsTime()) {
+		sEndedAt := s.GetEndedAt().AsTime()
+		bestEndedAt := time.Time{}
+		if best != nil {
+			bestEndedAt = best.GetEndedAt().AsTime()
+		}
+		if best == nil || sEndedAt.After(bestEndedAt) || (sEndedAt.Equal(bestEndedAt) && s.GetId() > best.GetId()) {
 			best = s
 		}
 	}

--- a/pkg/synccompactor/attached/attached_test.go
+++ b/pkg/synccompactor/attached/attached_test.go
@@ -2,14 +2,19 @@ package attached
 
 import (
 	"context"
+	"database/sql"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"testing"
+	"time"
+	"unsafe"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	reader_v2 "github.com/conductorone/baton-sdk/pb/c1/reader/v2"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	"github.com/segmentio/ksuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -237,6 +242,62 @@ func TestAttachedCompactorUsesLatestAppliedSyncOfAnyType(t *testing.T) {
 	// Verify that compaction completed without errors
 	// This test verifies that the latest sync (incremental) was used from applied
 	// even though there was an earlier full sync
+}
+
+func TestLatestFinishedCompactableSyncTiebreaksBySyncID(t *testing.T) {
+	ctx := t.Context()
+	tmpDir := t.TempDir()
+	db, err := dotc1z.NewC1ZFile(ctx, filepath.Join(tmpDir, "tied.c1z"), dotc1z.WithTmpDir(tmpDir))
+	require.NoError(t, err)
+	defer db.Close(ctx)
+
+	fullOriginalID, err := db.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, db.EndSync(ctx))
+
+	partialOriginalID, err := db.StartNewSync(ctx, connectorstore.SyncTypePartial, fullOriginalID)
+	require.NoError(t, err)
+	require.NoError(t, db.EndSync(ctx))
+
+	fullSyncID, partialSyncID := orderedAttachedTestSyncIDs()
+	rawDB := rawAttachedSQLiteDBForTest(t, db)
+	retargetAttachedSyncRunID(t, ctx, rawDB, fullOriginalID, fullSyncID)
+	retargetAttachedSyncRunID(t, ctx, rawDB, partialOriginalID, partialSyncID)
+	_, err = rawDB.ExecContext(ctx, "UPDATE v1_sync_runs SET parent_sync_id = ? WHERE sync_id = ?", fullSyncID, partialSyncID)
+	require.NoError(t, err)
+	tiedEndedAt := time.Date(2026, time.June, 29, 12, 0, 0, 0, time.UTC).Format("2006-01-02 15:04:05.999999999")
+	_, err = rawDB.ExecContext(ctx, "UPDATE v1_sync_runs SET ended_at = ? WHERE sync_id IN (?, ?)", tiedEndedAt, fullSyncID, partialSyncID)
+	require.NoError(t, err)
+
+	sync, err := latestFinishedCompactableSync(ctx, db)
+	require.NoError(t, err)
+	require.NotNil(t, sync)
+	require.Equal(t, partialSyncID, sync.GetId(), "greater sync_id must win when compactable sync types tie on ended_at")
+}
+
+func orderedAttachedTestSyncIDs() (string, string) {
+	a := ksuid.New().String()
+	b := ksuid.New().String()
+	if a > b {
+		return b, a
+	}
+	return a, b
+}
+
+func rawAttachedSQLiteDBForTest(t testing.TB, store *dotc1z.C1File) *sql.DB {
+	t.Helper()
+	field := reflect.ValueOf(store).Elem().FieldByName("rawDb")
+	require.True(t, field.IsValid())
+	require.False(t, field.IsNil())
+	return (*sql.DB)(unsafe.Pointer(field.Pointer()))
+}
+
+func retargetAttachedSyncRunID(t testing.TB, ctx context.Context, db *sql.DB, oldID, newID string) {
+	t.Helper()
+	_, err := db.ExecContext(ctx, "UPDATE v1_sync_runs SET sync_id = ? WHERE sync_id = ?", newID, oldID)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, "UPDATE v1_sync_runs SET parent_sync_id = ? WHERE parent_sync_id = ?", newID, oldID)
+	require.NoError(t, err)
 }
 
 func TestAttachedCompactorDoesNotOperateOnDiffSyncTypes(t *testing.T) {

--- a/pkg/synccompactor/compactor.go
+++ b/pkg/synccompactor/compactor.go
@@ -83,11 +83,29 @@ func (c *Compactor) resolvedEngine() dotc1z.Engine {
 	return c.engine
 }
 
+// ErrEnginePolicyConflict is returned when the caller explicitly requests
+// SQLite output but one or more inputs are Pebble/v3 format. Pebble inputs
+// cannot be re-encoded as SQLite without a full data-layer conversion, so
+// the combination is rejected rather than silently downgrading.
+var ErrEnginePolicyConflict = errors.New("compactor: engine policy conflict: cannot compact Pebble input to SQLite output")
+
+// inferEngineFromInputs determines the output engine for a compaction run
+// when no engine was explicitly set by the caller (WithEngine).
+//
+// Policy (evaluated in order):
+//  1. Explicit engine set via WithEngine: honored, subject to the Pebble-input
+//     constraint below.
+//  2. Any input is Pebble/v3: output is Pebble, regardless of whether other
+//     inputs are SQLite/v1 (mixed inputs produce Pebble). SQLite inputs in a
+//     Pebble run are converted to Pebble automatically; callers are not
+//     required to pre-convert.
+//  3. All inputs are SQLite/v1: output is SQLite.
+//
+// Constraint: an explicit SQLite request (WithEngine(EngineSQLite)) when any
+// input is Pebble/v3 returns ErrEnginePolicyConflict.
 func (c *Compactor) inferEngineFromInputs() (dotc1z.Engine, error) {
-	if c.engine != "" {
-		return c.engine, nil
-	}
-	var inferred dotc1z.Engine
+	hasPebble := false
+	hasSQLite := false
 	for _, entry := range c.entries {
 		if entry == nil || entry.FilePath == "" {
 			continue
@@ -104,27 +122,33 @@ func (c *Compactor) inferEngineFromInputs() (dotc1z.Engine, error) {
 		if closeErr != nil {
 			return "", fmt.Errorf("infer compactor engine from %s: %w", entry.FilePath, closeErr)
 		}
-		var engine dotc1z.Engine
 		switch format {
 		case dotc1z.C1ZFormatV1:
-			engine = dotc1z.EngineSQLite
+			hasSQLite = true
 		case dotc1z.C1ZFormatV3:
-			engine = dotc1z.EnginePebble
+			hasPebble = true
 		default:
 			return "", fmt.Errorf("infer compactor engine from %s: unsupported c1z format %s", entry.FilePath, format)
 		}
-		if inferred == "" {
-			inferred = engine
-			continue
-		}
-		if inferred != engine {
-			return "", fmt.Errorf("infer compactor engine: mixed input formats are not supported (%s is %s, previously inferred %s)", entry.FilePath, engine, inferred)
-		}
 	}
-	if inferred == "" {
+
+	// Explicit engine: validate and return.
+	if c.engine != "" {
+		if c.engine == dotc1z.EngineSQLite && hasPebble {
+			return "", fmt.Errorf("%w: caller requested SQLite but at least one input is Pebble/v3", ErrEnginePolicyConflict)
+		}
+		return c.engine, nil
+	}
+
+	// Auto-select: any Pebble input → Pebble output.
+	if hasPebble {
+		return dotc1z.EnginePebble, nil
+	}
+	if hasSQLite {
 		return dotc1z.EngineSQLite, nil
 	}
-	return inferred, nil
+	// No readable inputs: default to SQLite to preserve historical behavior.
+	return dotc1z.EngineSQLite, nil
 }
 
 type CompactableSync struct {
@@ -290,6 +314,22 @@ func (c *Compactor) Compact(ctx context.Context) (*CompactableSync, error) {
 		c.pebbleMode = c.resolvePebbleMode(ctx)
 	}
 	foldMode := c.pebbleMode == PebbleCompactorModeFold
+	if foldMode {
+		// Fold merges partials in place into a private copy of the base, so
+		// only the BASE must already be Pebble: converting the base would
+		// mean rewriting the whole base, which defeats fold's point. SQLite
+		// partials are fine — they are converted to Pebble inside the fold
+		// loop. When the base itself is SQLite/v1, fall back to the overlay
+		// path, which converts every input before merging.
+		baseFormat, ferr := readCompactionInputFormat(c.entries[0].FilePath)
+		if ferr != nil {
+			return nil, ferr
+		}
+		if baseFormat != dotc1z.C1ZFormatV3 {
+			foldMode = false
+			c.pebbleMode = PebbleCompactorModeOverlay
+		}
+	}
 	if foldMode {
 		if err = copyFileForFold(c.entries[0].FilePath, destFilePath); err != nil {
 			return nil, fmt.Errorf("fold: copy base input: %w", err)

--- a/pkg/synccompactor/compactor_mode_test.go
+++ b/pkg/synccompactor/compactor_mode_test.go
@@ -165,6 +165,7 @@ func TestInferEngineFromInputFormats(t *testing.T) {
 	v1 := writeHeader("sqlite.c1z", dotc1z.C1ZFileHeader)
 	v3 := writeHeader("pebble.c1z", dotc1z.C1Z3FileHeader)
 
+	// All-SQLite → SQLite.
 	engine, err := (&Compactor{entries: []*CompactableSync{
 		{FilePath: v1, SyncID: "s1"},
 		{FilePath: v1, SyncID: "s2"},
@@ -172,6 +173,7 @@ func TestInferEngineFromInputFormats(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, dotc1z.EngineSQLite, engine)
 
+	// All-Pebble → Pebble.
 	engine, err = (&Compactor{entries: []*CompactableSync{
 		{FilePath: v3, SyncID: "s1"},
 		{FilePath: v3, SyncID: "s2"},
@@ -179,19 +181,44 @@ func TestInferEngineFromInputFormats(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, dotc1z.EnginePebble, engine)
 
-	_, err = (&Compactor{entries: []*CompactableSync{
+	// Mixed SQLite/Pebble → Pebble (any Pebble wins).
+	engine, err = (&Compactor{entries: []*CompactableSync{
 		{FilePath: v1, SyncID: "s1"},
 		{FilePath: v3, SyncID: "s2"},
 	}}).inferEngineFromInputs()
-	require.Error(t, err)
+	require.NoError(t, err, "mixed inputs must no longer return an error; any Pebble input wins")
+	require.Equal(t, dotc1z.EnginePebble, engine, "mixed input must produce Pebble output")
 
+	// Explicit Pebble + all-Pebble → Pebble.
 	engine, err = (&Compactor{
-		engine: dotc1z.EngineSQLite,
+		engine: dotc1z.EnginePebble,
 		entries: []*CompactableSync{
 			{FilePath: v3, SyncID: "s1"},
 			{FilePath: v3, SyncID: "s2"},
 		},
 	}).inferEngineFromInputs()
 	require.NoError(t, err)
-	require.Equal(t, dotc1z.EngineSQLite, engine)
+	require.Equal(t, dotc1z.EnginePebble, engine)
+
+	// Explicit SQLite + Pebble input → ErrEnginePolicyConflict.
+	_, err = (&Compactor{
+		engine: dotc1z.EngineSQLite,
+		entries: []*CompactableSync{
+			{FilePath: v3, SyncID: "s1"},
+			{FilePath: v3, SyncID: "s2"},
+		},
+	}).inferEngineFromInputs()
+	require.ErrorIs(t, err, ErrEnginePolicyConflict,
+		"explicit SQLite with Pebble input must return ErrEnginePolicyConflict")
+
+	// Explicit Pebble + SQLite inputs → Pebble (SQLite inputs are converted).
+	engine, err = (&Compactor{
+		engine: dotc1z.EnginePebble,
+		entries: []*CompactableSync{
+			{FilePath: v1, SyncID: "s1"},
+			{FilePath: v1, SyncID: "s2"},
+		},
+	}).inferEngineFromInputs()
+	require.NoError(t, err)
+	require.Equal(t, dotc1z.EnginePebble, engine, "explicit Pebble with SQLite inputs is valid")
 }

--- a/pkg/synccompactor/compactor_pebble.go
+++ b/pkg/synccompactor/compactor_pebble.go
@@ -483,37 +483,58 @@ func (c *Compactor) compactPebbleFold(ctx context.Context) (string, error) {
 	// base at entries[0]); strictly-newer-wins makes earlier
 	// applications take precedence on ties.
 	var foldStats mergepkg.FoldStats
+	// SQLite/v1 partials are converted to Pebble in the tmp dir before being
+	// folded in; their converted copies are removed when this run completes.
+	var convertedInputs []string
+	defer func() {
+		for _, path := range convertedInputs {
+			_ = os.Remove(path)
+		}
+	}()
 	for i := len(c.entries) - 1; i >= 1; i-- {
 		if err := ctx.Err(); err != nil {
 			return "", err
 		}
 		cs := c.entries[i]
+		sourcePath := cs.FilePath
+		format, err := readCompactionInputFormat(sourcePath)
+		if err != nil {
+			return "", err
+		}
+		if format == dotc1z.C1ZFormatV1 {
+			convertedPath, err := c.convertSQLiteInputToPebble(ctx, cs)
+			if err != nil {
+				return "", err
+			}
+			convertedInputs = append(convertedInputs, convertedPath)
+			sourcePath = convertedPath
+		}
 		srcSyncID := ""
-		if sel, ok := selectSourceSyncFromManifest(cs.FilePath); ok {
+		if sel, ok := selectSourceSyncFromManifest(sourcePath); ok {
 			srcSyncID = sel.syncID
 			unionType = unionV3SyncType(unionType, sel.syncType)
 			if sel.endedAt.After(maxEnded) {
 				maxEnded = sel.endedAt
 			}
 		}
-		w, err := dotc1z.NewStore(ctx, cs.FilePath, dotc1z.WithReadOnly(true), dotc1z.WithTmpDir(c.tmpDir), dotc1z.WithDecoderPool(c.decoderPool))
+		w, err := dotc1z.NewStore(ctx, sourcePath, dotc1z.WithReadOnly(true), dotc1z.WithTmpDir(c.tmpDir), dotc1z.WithDecoderPool(c.decoderPool))
 		if err != nil {
-			return "", fmt.Errorf("compactPebbleFold: open input %s: %w", cs.FilePath, err)
+			return "", fmt.Errorf("compactPebbleFold: open input %s: %w", sourcePath, err)
 		}
 		srcEng, ok := enginepkg.AsEngine(w)
 		if !ok {
 			_ = w.Close(ctx)
-			return "", fmt.Errorf("compactPebbleFold: input %s is not a pebble c1z", cs.FilePath)
+			return "", fmt.Errorf("compactPebbleFold: input %s is not a pebble c1z", sourcePath)
 		}
 		if srcSyncID == "" {
 			rec, err := srcEng.LatestFinishedSyncRecord(ctx, compactableV3SyncType)
 			if err != nil {
 				_ = w.Close(ctx)
-				return "", fmt.Errorf("compactPebbleFold: input %s: select compactable sync: %w", cs.FilePath, err)
+				return "", fmt.Errorf("compactPebbleFold: input %s: select compactable sync: %w", sourcePath, err)
 			}
 			if rec == nil {
 				_ = w.Close(ctx)
-				return "", fmt.Errorf("compactPebbleFold: input %s has no finished compactable sync", cs.FilePath)
+				return "", fmt.Errorf("compactPebbleFold: input %s has no finished compactable sync", sourcePath)
 			}
 			srcSyncID = rec.GetSyncId()
 			unionType = unionV3SyncType(unionType, rec.GetType())
@@ -524,10 +545,10 @@ func (c *Compactor) compactPebbleFold(ctx context.Context) (string, error) {
 		mergeStats, mergeErr := mergepkg.MergeInto(ctx, destEng, []mergepkg.SourceSync{{Engine: srcEng, SyncID: srcSyncID}}, baseSyncID)
 		foldStats.Add(mergeStats)
 		if cerr := w.Close(ctx); cerr != nil {
-			l.Error("compactPebbleFold: error closing source store", zap.Error(cerr), zap.String("file", cs.FilePath))
+			l.Error("compactPebbleFold: error closing source store", zap.Error(cerr), zap.String("file", sourcePath))
 		}
 		if mergeErr != nil {
-			return "", fmt.Errorf("compactPebbleFold: merge %s: %w", cs.FilePath, mergeErr)
+			return "", fmt.Errorf("compactPebbleFold: merge %s: %w", sourcePath, mergeErr)
 		}
 	}
 
@@ -645,6 +666,116 @@ func copyFileForFold(src, dst string) error {
 	return out.Close()
 }
 
+// readCompactionInputFormat reads the c1z header of path and returns its
+// on-disk format, rejecting anything that is not a supported v1/v3 c1z.
+func readCompactionInputFormat(path string) (dotc1z.C1ZFormat, error) {
+	f, err := os.Open(path) // #nosec G304 - compaction inputs are caller-provided c1z paths.
+	if err != nil {
+		return dotc1z.C1ZFormatUnknown, fmt.Errorf("compactPebble: open input header %s: %w", path, err)
+	}
+	defer f.Close()
+	format, err := dotc1z.ReadHeaderFormat(f)
+	if err != nil {
+		return dotc1z.C1ZFormatUnknown, fmt.Errorf("compactPebble: read input header %s: %w", path, err)
+	}
+	switch format {
+	case dotc1z.C1ZFormatV1, dotc1z.C1ZFormatV3:
+		return format, nil
+	default:
+		return dotc1z.C1ZFormatUnknown, fmt.Errorf("compactPebble: unsupported c1z format %s for %s", format, path)
+	}
+}
+
+func resolveSQLiteCompactionSyncID(ctx context.Context, store *dotc1z.C1File, explicitSyncID string) (string, error) {
+	if explicitSyncID != "" {
+		return explicitSyncID, nil
+	}
+
+	candidates := []connectorstore.SyncType{
+		connectorstore.SyncTypeFull,
+		connectorstore.SyncTypeResourcesOnly,
+		connectorstore.SyncTypePartial,
+	}
+	var best *reader_v2.SyncRun
+	for _, st := range candidates {
+		resp, err := store.GetLatestFinishedSync(ctx, reader_v2.SyncsReaderServiceGetLatestFinishedSyncRequest_builder{
+			SyncType: string(st),
+		}.Build())
+		if err != nil {
+			return "", err
+		}
+		sync := resp.GetSync()
+		if sync == nil {
+			continue
+		}
+		syncEndedAt := sync.GetEndedAt().AsTime()
+		bestEndedAt := time.Time{}
+		if best != nil {
+			bestEndedAt = best.GetEndedAt().AsTime()
+		}
+		if best == nil || syncEndedAt.After(bestEndedAt) || (syncEndedAt.Equal(bestEndedAt) && sync.GetId() > best.GetId()) {
+			best = sync
+		}
+	}
+	if best == nil {
+		return "", fmt.Errorf(
+			"no finished compactable sync found in sqlite input (diff sync types %q/%q are not compactable)",
+			string(connectorstore.SyncTypePartialUpserts),
+			string(connectorstore.SyncTypePartialDeletions),
+		)
+	}
+	return best.GetId(), nil
+}
+
+// convertSQLiteInputToPebble converts a v1/SQLite compaction input into a
+// freshly-written Pebble (v3) c1z in the compactor tmp dir and returns the
+// path to the converted file. The caller owns the returned path and must
+// remove it when the compaction run completes.
+func (c *Compactor) convertSQLiteInputToPebble(ctx context.Context, cs *CompactableSync) (string, error) {
+	if cs == nil {
+		return "", errors.New("compactPebble: nil compactable sync")
+	}
+	tmp, err := os.CreateTemp(c.tmpDir, "sqlite-input-*.pebble.c1z")
+	if err != nil {
+		return "", fmt.Errorf("compactPebble: create conversion temp file: %w", err)
+	}
+	convertedPath := tmp.Name()
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(convertedPath)
+		return "", fmt.Errorf("compactPebble: close conversion temp file: %w", err)
+	}
+	// ToPebble requires the destination path to not exist.
+	if err := os.Remove(convertedPath); err != nil {
+		return "", fmt.Errorf("compactPebble: remove conversion temp placeholder: %w", err)
+	}
+
+	store, err := dotc1z.NewStore(ctx, cs.FilePath, dotc1z.WithReadOnly(true), dotc1z.WithTmpDir(c.tmpDir))
+	if err != nil {
+		return "", fmt.Errorf("compactPebble: open sqlite input for conversion %s: %w", cs.FilePath, err)
+	}
+	sqliteStore, ok := dotc1z.AsSQLiteStore(store)
+	if !ok {
+		_ = store.Close(ctx)
+		return "", fmt.Errorf("compactPebble: expected SQLite input while converting %s, got %T", cs.FilePath, store)
+	}
+	syncID, err := resolveSQLiteCompactionSyncID(ctx, sqliteStore, cs.SyncID)
+	if err != nil {
+		_ = store.Close(ctx)
+		_ = os.Remove(convertedPath)
+		return "", fmt.Errorf("compactPebble: select sqlite input sync %s: %w", cs.FilePath, err)
+	}
+	if _, err := sqliteStore.ToPebble(ctx, convertedPath, syncID, dotc1z.WithConvertTmpDir(c.tmpDir)); err != nil {
+		_ = store.Close(ctx)
+		_ = os.Remove(convertedPath)
+		return "", fmt.Errorf("compactPebble: convert sqlite input %s to pebble: %w", cs.FilePath, err)
+	}
+	if err := store.Close(ctx); err != nil {
+		_ = os.Remove(convertedPath)
+		return "", fmt.Errorf("compactPebble: close sqlite input after conversion %s: %w", cs.FilePath, err)
+	}
+	return convertedPath, nil
+}
+
 // compactPebble folds every input into the empty newSyncId on the
 // Pebble output via a native record merge: each input is opened, its
 // latest finished compactable sync is selected (diff syncs excluded),
@@ -671,19 +802,40 @@ func (c *Compactor) compactPebble(ctx context.Context, newSyncId string) error {
 	var maxEnded time.Time
 
 	manifestSelected := 0
+	// SQLite/v1 inputs are converted to Pebble in the tmp dir before being
+	// merged; their converted copies are removed when this run completes.
+	var convertedInputs []string
+	defer func() {
+		for _, path := range convertedInputs {
+			_ = os.Remove(path)
+		}
+	}()
 	for i := len(c.entries) - 1; i >= 0; i-- {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
 		cs := c.entries[i]
+		sourcePath := cs.FilePath
+		format, err := readCompactionInputFormat(sourcePath)
+		if err != nil {
+			return err
+		}
+		if format == dotc1z.C1ZFormatV1 {
+			convertedPath, err := c.convertSQLiteInputToPebble(ctx, cs)
+			if err != nil {
+				return err
+			}
+			convertedInputs = append(convertedInputs, convertedPath)
+			sourcePath = convertedPath
+		}
 
 		// Fast path: read the latest finished compactable sync (and its
 		// cached stats) from the envelope manifest's sync-run projection
 		// — a header read, no payload unpack. Files written before the
 		// projection existed fall back to the unpack path below.
-		if sel, ok := selectSourceSyncFromManifest(cs.FilePath); ok {
+		if sel, ok := selectSourceSyncFromManifest(sourcePath); ok {
 			manifestSelected++
-			sources = append(sources, mergepkg.SourceFile{Path: cs.FilePath, SyncID: sel.syncID, Stats: sel.stats, DecoderPool: c.decoderPool})
+			sources = append(sources, mergepkg.SourceFile{Path: sourcePath, SyncID: sel.syncID, Stats: sel.stats, DecoderPool: c.decoderPool})
 			unionType = unionV3SyncType(unionType, sel.syncType)
 			if sel.endedAt.After(maxEnded) {
 				maxEnded = sel.endedAt
@@ -693,26 +845,26 @@ func (c *Compactor) compactPebble(ctx context.Context, newSyncId string) error {
 
 		source, syncType, endedAt, err := func() (mergepkg.SourceFile, v3.SyncType, time.Time, error) {
 			var zeroSource mergepkg.SourceFile
-			w, err := dotc1z.NewStore(ctx, cs.FilePath, dotc1z.WithReadOnly(true), dotc1z.WithTmpDir(c.tmpDir), dotc1z.WithDecoderPool(c.decoderPool))
+			w, err := dotc1z.NewStore(ctx, sourcePath, dotc1z.WithReadOnly(true), dotc1z.WithTmpDir(c.tmpDir), dotc1z.WithDecoderPool(c.decoderPool))
 			if err != nil {
-				return zeroSource, v3.SyncType_SYNC_TYPE_UNSPECIFIED, time.Time{}, fmt.Errorf("compactPebble: open input %s: %w", cs.FilePath, err)
+				return zeroSource, v3.SyncType_SYNC_TYPE_UNSPECIFIED, time.Time{}, fmt.Errorf("compactPebble: open input %s: %w", sourcePath, err)
 			}
 			defer func() {
 				if cerr := w.Close(ctx); cerr != nil {
-					l.Error("compactPebble: error closing source store", zap.Error(cerr), zap.String("file", cs.FilePath))
+					l.Error("compactPebble: error closing source store", zap.Error(cerr), zap.String("file", sourcePath))
 				}
 			}()
 
 			srcEng, ok := enginepkg.AsEngine(w)
 			if !ok {
-				return zeroSource, v3.SyncType_SYNC_TYPE_UNSPECIFIED, time.Time{}, fmt.Errorf("compactPebble: input %s is not a pebble c1z", cs.FilePath)
+				return zeroSource, v3.SyncType_SYNC_TYPE_UNSPECIFIED, time.Time{}, fmt.Errorf("compactPebble: input %s is not a pebble c1z", sourcePath)
 			}
 			rec, err := srcEng.LatestFinishedSyncRecord(ctx, compactableV3SyncType)
 			if err != nil {
-				return zeroSource, v3.SyncType_SYNC_TYPE_UNSPECIFIED, time.Time{}, fmt.Errorf("compactPebble: select source sync for %s: %w", cs.FilePath, err)
+				return zeroSource, v3.SyncType_SYNC_TYPE_UNSPECIFIED, time.Time{}, fmt.Errorf("compactPebble: select source sync for %s: %w", sourcePath, err)
 			}
 			if rec == nil {
-				return zeroSource, v3.SyncType_SYNC_TYPE_UNSPECIFIED, time.Time{}, fmt.Errorf("compactPebble: input %s has no finished compactable sync (diff syncs are not compactable)", cs.FilePath)
+				return zeroSource, v3.SyncType_SYNC_TYPE_UNSPECIFIED, time.Time{}, fmt.Errorf("compactPebble: input %s has no finished compactable sync (diff syncs are not compactable)", sourcePath)
 			}
 
 			// Record only (Path, SyncID, Stats) and fully close the store,
@@ -721,11 +873,11 @@ func (c *Compactor) compactPebble(ctx context.Context, newSyncId string) error {
 			// chunk closes, so peak disk is O(fan-in) source directories,
 			// not O(len(entries)). The fallback unpacks one source at a
 			// time and pays one extra unpack per source (selection + merge).
-			source := mergepkg.SourceFile{Path: cs.FilePath, SyncID: rec.GetSyncId(), DecoderPool: c.decoderPool}
+			source := mergepkg.SourceFile{Path: sourcePath, SyncID: rec.GetSyncId(), DecoderPool: c.decoderPool}
 			if useOverlay {
 				stats, ok, err := enginepkg.CachedSyncStats(ctx, srcEng, rec.GetSyncId())
 				if err != nil {
-					return zeroSource, v3.SyncType_SYNC_TYPE_UNSPECIFIED, time.Time{}, fmt.Errorf("compactPebble: cached stats for %s: %w", cs.FilePath, err)
+					return zeroSource, v3.SyncType_SYNC_TYPE_UNSPECIFIED, time.Time{}, fmt.Errorf("compactPebble: cached stats for %s: %w", sourcePath, err)
 				}
 				if ok {
 					source.Stats = stats

--- a/pkg/synccompactor/compactor_pebble_test.go
+++ b/pkg/synccompactor/compactor_pebble_test.go
@@ -2,10 +2,14 @@ package synccompactor
 
 import (
 	"context"
+	"database/sql"
 	"path/filepath"
+	"reflect"
 	"testing"
 	"time"
+	"unsafe"
 
+	"github.com/segmentio/ksuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cockroachdb/pebble/v2"
@@ -173,6 +177,278 @@ func TestCompactPebbleEndToEnd(t *testing.T) {
 	require.Len(t, byResource.GetList(), 3, "compacted pebble output must materialize grant_by_entitlement_resource index")
 }
 
+// requirePebbleOutput asserts the compacted output at path is a Pebble store.
+func requirePebbleOutput(t *testing.T, ctx context.Context, path string) {
+	t.Helper()
+	w, err := dotc1z.NewStore(ctx, path, dotc1z.WithReadOnly(true))
+	require.NoError(t, err)
+	defer w.Close(ctx)
+	_, ok := enginepkg.AsEngine(w)
+	require.True(t, ok, "compacted output at %s must be a pebble engine", path)
+}
+
+// TestCompactMixedInputsAutoSelectsPebble exercises multi-engine compaction:
+// when the incremental chain mixes a SQLite (v1) input and a Pebble (v3)
+// input and no engine is forced, the run auto-selects Pebble, converts the
+// SQLite input, and produces a single Pebble output with the deduped union.
+func TestCompactMixedInputsAutoSelectsPebble(t *testing.T) {
+	ctx := context.Background()
+	inDir := t.TempDir()
+	outDir := t.TempDir()
+
+	sqlitePath := filepath.Join(inDir, "in-sqlite.c1z")
+	pebblePath := filepath.Join(inDir, "in-pebble.c1z")
+	s1 := buildSQLiteInput(t, ctx, sqlitePath, connectorstore.SyncTypeFull, "g-shared", "g-only1")
+	s2 := buildPebbleInput(t, ctx, pebblePath, connectorstore.SyncTypePartial, "g-shared", "g-only2")
+
+	// Base (entries[0]) is the SQLite input, so the conversion path covers
+	// the base, not just a partial.
+	entries := []*CompactableSync{{FilePath: sqlitePath, SyncID: s1}, {FilePath: pebblePath, SyncID: s2}}
+	c, cleanup, err := NewCompactor(ctx, outDir, entries, WithTmpDir(t.TempDir()))
+	require.NoError(t, err)
+	defer func() { _ = cleanup() }()
+
+	out, err := c.Compact(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+
+	requirePebbleOutput(t, ctx, out.FilePath)
+	count, st := verifyCompacted(t, ctx, out.FilePath, out.SyncID)
+	require.Equal(t, 3, count, "union of {g-shared,g-only1} and {g-shared,g-only2} deduped = 3 grants")
+	require.Equal(t, string(connectorstore.SyncTypeFull), st, "union of full + partial = full")
+}
+
+// TestCompactExplicitPebbleConvertsAllSQLiteInputs pins that an explicit
+// WithEngine(EnginePebble) request over all-SQLite inputs converts every
+// input to Pebble and merges them, rather than rejecting the run.
+func TestCompactExplicitPebbleConvertsAllSQLiteInputs(t *testing.T) {
+	ctx := context.Background()
+	inDir := t.TempDir()
+	outDir := t.TempDir()
+
+	p1 := filepath.Join(inDir, "in1.c1z")
+	p2 := filepath.Join(inDir, "in2.c1z")
+	s1 := buildSQLiteInput(t, ctx, p1, connectorstore.SyncTypeFull, "g-shared", "g-only1")
+	s2 := buildSQLiteInput(t, ctx, p2, connectorstore.SyncTypePartial, "g-shared", "g-only2")
+
+	entries := []*CompactableSync{{FilePath: p1, SyncID: s1}, {FilePath: p2, SyncID: s2}}
+	c, cleanup, err := NewCompactor(ctx, outDir, entries, WithTmpDir(t.TempDir()), WithEngine(dotc1z.EnginePebble))
+	require.NoError(t, err)
+	defer func() { _ = cleanup() }()
+
+	out, err := c.Compact(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+
+	requirePebbleOutput(t, ctx, out.FilePath)
+	count, st := verifyCompacted(t, ctx, out.FilePath, out.SyncID)
+	require.Equal(t, 3, count, "union of all-sqlite inputs deduped = 3 grants")
+	require.Equal(t, string(connectorstore.SyncTypeFull), st, "union of full + partial = full")
+}
+
+// TestCompactExplicitPebbleConvertsSQLitePartialWithEmptySyncID preserves the
+// SQLite compactor's empty-SyncID behavior: it selects the latest finished
+// compactable sync, including partial-only inputs. ToPebble's own "" fallback
+// is full-only, so conversion must resolve the compactable sync first.
+func TestCompactExplicitPebbleConvertsSQLitePartialWithEmptySyncID(t *testing.T) {
+	ctx := context.Background()
+	inDir := t.TempDir()
+	outDir := t.TempDir()
+
+	p1 := filepath.Join(inDir, "full.c1z")
+	p2 := filepath.Join(inDir, "partial-only.c1z")
+	s1 := buildSQLiteInput(t, ctx, p1, connectorstore.SyncTypeFull, "g-shared", "g-only1")
+	_ = buildSQLiteInput(t, ctx, p2, connectorstore.SyncTypePartial, "g-shared", "g-only2")
+
+	entries := []*CompactableSync{
+		{FilePath: p1, SyncID: s1},
+		{FilePath: p2, SyncID: ""},
+	}
+	c, cleanup, err := NewCompactor(ctx, outDir, entries, WithTmpDir(t.TempDir()), WithEngine(dotc1z.EnginePebble))
+	require.NoError(t, err)
+	defer func() { _ = cleanup() }()
+
+	out, err := c.Compact(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+
+	requirePebbleOutput(t, ctx, out.FilePath)
+	count, st := verifyCompacted(t, ctx, out.FilePath, out.SyncID)
+	require.Equal(t, 3, count, "empty SyncID partial-only sqlite input must be selected and converted")
+	require.Equal(t, string(connectorstore.SyncTypeFull), st, "union of full + partial = full")
+}
+
+func TestCompactExplicitPebbleConvertsSQLiteEmptySyncIDTiebreaksBySyncID(t *testing.T) {
+	ctx := context.Background()
+	inDir := t.TempDir()
+	outDir := t.TempDir()
+
+	p1 := filepath.Join(inDir, "base.c1z")
+	p2 := filepath.Join(inDir, "tied-source.c1z")
+	s1 := buildSQLiteInput(t, ctx, p1, connectorstore.SyncTypePartial, "g-base")
+	_, partialSyncID := buildSQLiteInputWithTiedCompactableSyncs(t, ctx, p2)
+
+	entries := []*CompactableSync{
+		{FilePath: p1, SyncID: s1},
+		{FilePath: p2, SyncID: ""},
+	}
+	c, cleanup, err := NewCompactor(ctx, outDir, entries, WithTmpDir(t.TempDir()), WithEngine(dotc1z.EnginePebble), WithSkipGrantExpansion())
+	require.NoError(t, err)
+	defer func() { _ = cleanup() }()
+
+	out, err := c.Compact(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+
+	store, err := dotc1z.NewStore(ctx, out.FilePath, dotc1z.WithReadOnly(true), dotc1z.WithTmpDir(t.TempDir()))
+	require.NoError(t, err)
+	defer store.Close(ctx)
+	require.NoError(t, store.SetCurrentSync(ctx, out.SyncID))
+
+	resp, err := store.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{PageSize: 1000}.Build())
+	require.NoError(t, err)
+	grantIDs := make(map[string]bool, len(resp.GetList()))
+	for _, grant := range resp.GetList() {
+		grantIDs[grant.GetId()] = true
+	}
+	require.True(t, grantIDs["g-partial"], "empty SyncID must select tied sync with greater sync_id %s", partialSyncID)
+	require.False(t, grantIDs["g-full"], "lower sync_id full sync must not be selected just because full is checked first")
+}
+
+// TestCompactFoldConvertsSQLitePartial pins that the in-place fold strategy
+// only requires the BASE to be Pebble: with a Pebble base and a SQLite
+// partial (fold forced), the SQLite partial is converted to Pebble and
+// folded into the base copy, yielding the deduped union.
+func TestCompactFoldConvertsSQLitePartial(t *testing.T) {
+	ctx := context.Background()
+	inDir := t.TempDir()
+	outDir := t.TempDir()
+
+	basePath := filepath.Join(inDir, "base-pebble.c1z")
+	partialPath := filepath.Join(inDir, "partial-sqlite.c1z")
+	s1 := buildPebbleInput(t, ctx, basePath, connectorstore.SyncTypeFull, "g-shared", "g-only1")
+	s2 := buildSQLiteInput(t, ctx, partialPath, connectorstore.SyncTypePartial, "g-shared", "g-only2")
+
+	entries := []*CompactableSync{{FilePath: basePath, SyncID: s1}, {FilePath: partialPath, SyncID: s2}}
+	c, cleanup, err := NewCompactor(ctx, outDir, entries,
+		WithTmpDir(t.TempDir()),
+		WithEngine(dotc1z.EnginePebble),
+		WithPebbleCompactorMode(PebbleCompactorModeFold),
+	)
+	require.NoError(t, err)
+	defer func() { _ = cleanup() }()
+
+	out, err := c.Compact(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+
+	requirePebbleOutput(t, ctx, out.FilePath)
+	count, st := verifyCompacted(t, ctx, out.FilePath, out.SyncID)
+	require.Equal(t, 3, count, "fold of pebble base + sqlite partial deduped = 3 grants")
+	require.Equal(t, string(connectorstore.SyncTypeFull), st, "union of full + partial = full")
+}
+
+// TestCompactFoldPebbleBaseMixedPartials covers the canonical multi-engine
+// fold chain: a Pebble base plus two partials, one Pebble and one SQLite.
+// The SQLite partial is converted to Pebble and both partials are folded
+// into the base copy (fold forced), yielding the deduped union across all
+// three inputs.
+func TestCompactFoldPebbleBaseMixedPartials(t *testing.T) {
+	ctx := context.Background()
+	inDir := t.TempDir()
+	outDir := t.TempDir()
+
+	basePath := filepath.Join(inDir, "base-pebble.c1z")
+	partialPebblePath := filepath.Join(inDir, "partial-pebble.c1z")
+	partialSQLitePath := filepath.Join(inDir, "partial-sqlite.c1z")
+
+	// base: {g-shared, g-base1}; pebble partial: {g-shared, g-p1};
+	// sqlite partial: {g-shared, g-p2}. Deduped union = 4 grants.
+	sBase := buildPebbleInput(t, ctx, basePath, connectorstore.SyncTypeFull, "g-shared", "g-base1")
+	sPebble := buildPebbleInput(t, ctx, partialPebblePath, connectorstore.SyncTypePartial, "g-shared", "g-p1")
+	sSQLite := buildSQLiteInput(t, ctx, partialSQLitePath, connectorstore.SyncTypePartial, "g-shared", "g-p2")
+
+	// entries[0] is the base; the two partials follow.
+	entries := []*CompactableSync{
+		{FilePath: basePath, SyncID: sBase},
+		{FilePath: partialPebblePath, SyncID: sPebble},
+		{FilePath: partialSQLitePath, SyncID: sSQLite},
+	}
+	c, cleanup, err := NewCompactor(ctx, outDir, entries,
+		WithTmpDir(t.TempDir()),
+		WithEngine(dotc1z.EnginePebble),
+		WithPebbleCompactorMode(PebbleCompactorModeFold),
+	)
+	require.NoError(t, err)
+	defer func() { _ = cleanup() }()
+
+	out, err := c.Compact(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+
+	requirePebbleOutput(t, ctx, out.FilePath)
+	count, st := verifyCompacted(t, ctx, out.FilePath, out.SyncID)
+	require.Equal(t, 4, count, "deduped union of base + pebble partial + sqlite partial = 4 grants")
+	require.Equal(t, string(connectorstore.SyncTypeFull), st, "union of full + partial + partial = full")
+}
+
+// TestCompactPebbleBaseMixedPartialsAutoMode is the same Pebble-base +
+// mixed-partial chain but with the strategy auto-selected rather than fold
+// forced, ensuring the overlay/kway merge path also handles a SQLite partial.
+func TestCompactPebbleBaseMixedPartialsAutoMode(t *testing.T) {
+	ctx := context.Background()
+	inDir := t.TempDir()
+	outDir := t.TempDir()
+
+	basePath := filepath.Join(inDir, "base-pebble.c1z")
+	partialPebblePath := filepath.Join(inDir, "partial-pebble.c1z")
+	partialSQLitePath := filepath.Join(inDir, "partial-sqlite.c1z")
+
+	sBase := buildPebbleInput(t, ctx, basePath, connectorstore.SyncTypeFull, "g-shared", "g-base1")
+	sPebble := buildPebbleInput(t, ctx, partialPebblePath, connectorstore.SyncTypePartial, "g-shared", "g-p1")
+	sSQLite := buildSQLiteInput(t, ctx, partialSQLitePath, connectorstore.SyncTypePartial, "g-shared", "g-p2")
+
+	entries := []*CompactableSync{
+		{FilePath: basePath, SyncID: sBase},
+		{FilePath: partialPebblePath, SyncID: sPebble},
+		{FilePath: partialSQLitePath, SyncID: sSQLite},
+	}
+	c, cleanup, err := NewCompactor(ctx, outDir, entries, WithTmpDir(t.TempDir()))
+	require.NoError(t, err)
+	defer func() { _ = cleanup() }()
+
+	out, err := c.Compact(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+
+	requirePebbleOutput(t, ctx, out.FilePath)
+	count, st := verifyCompacted(t, ctx, out.FilePath, out.SyncID)
+	require.Equal(t, 4, count, "deduped union of base + pebble partial + sqlite partial = 4 grants")
+	require.Equal(t, string(connectorstore.SyncTypeFull), st, "union of full + partial + partial = full")
+}
+
+// TestCompactExplicitSQLiteRejectsPebbleInput pins the policy conflict: an
+// explicit SQLite request with a Pebble input is rejected rather than
+// silently downgrading the Pebble data.
+func TestCompactExplicitSQLiteRejectsPebbleInput(t *testing.T) {
+	ctx := context.Background()
+	inDir := t.TempDir()
+	outDir := t.TempDir()
+
+	sqlitePath := filepath.Join(inDir, "in-sqlite.c1z")
+	pebblePath := filepath.Join(inDir, "in-pebble.c1z")
+	s1 := buildSQLiteInput(t, ctx, sqlitePath, connectorstore.SyncTypeFull, "g1")
+	s2 := buildPebbleInput(t, ctx, pebblePath, connectorstore.SyncTypePartial, "g2")
+
+	entries := []*CompactableSync{{FilePath: sqlitePath, SyncID: s1}, {FilePath: pebblePath, SyncID: s2}}
+	c, cleanup, err := NewCompactor(ctx, outDir, entries, WithTmpDir(t.TempDir()), WithEngine(dotc1z.EngineSQLite))
+	require.NoError(t, err)
+	defer func() { _ = cleanup() }()
+
+	_, err = c.Compact(ctx)
+	require.ErrorIs(t, err, ErrEnginePolicyConflict)
+}
+
 // buildSQLiteInput writes a minimal SQLite (v1) c1z with one grant per
 // id, for the default-engine regression.
 func buildSQLiteInput(t testing.TB, ctx context.Context, path string, st connectorstore.SyncType, grantIDs ...string) string {
@@ -181,6 +457,44 @@ func buildSQLiteInput(t testing.TB, ctx context.Context, path string, st connect
 	require.NoError(t, err)
 	syncID, err := store.StartNewSync(ctx, st, "")
 	require.NoError(t, err)
+	putSQLiteInputData(t, ctx, store, grantIDs...)
+	require.NoError(t, store.EndSync(ctx))
+	require.NoError(t, store.Close(ctx))
+	return syncID
+}
+
+func buildSQLiteInputWithTiedCompactableSyncs(t testing.TB, ctx context.Context, path string) (string, string) {
+	t.Helper()
+	store, err := dotc1z.NewC1ZFile(ctx, path)
+	require.NoError(t, err)
+
+	fullOriginalID, err := store.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	putSQLiteInputData(t, ctx, store, "g-full")
+	require.NoError(t, store.EndSync(ctx))
+
+	partialOriginalID, err := store.StartNewSync(ctx, connectorstore.SyncTypePartial, fullOriginalID)
+	require.NoError(t, err)
+	putSQLiteInputData(t, ctx, store, "g-partial")
+	require.NoError(t, store.EndSync(ctx))
+
+	fullSyncID, partialSyncID := orderedTestSyncIDs()
+	db := rawSQLiteDBForTest(t, store)
+	retargetSQLiteSyncID(t, ctx, db, fullOriginalID, fullSyncID)
+	retargetSQLiteSyncID(t, ctx, db, partialOriginalID, partialSyncID)
+	_, err = db.ExecContext(ctx, "UPDATE v1_sync_runs SET parent_sync_id = ? WHERE sync_id = ?", fullSyncID, partialSyncID)
+	require.NoError(t, err)
+
+	tiedEndedAt := time.Date(2026, time.June, 29, 12, 0, 0, 0, time.UTC).Format("2006-01-02 15:04:05.999999999")
+	_, err = db.ExecContext(ctx, "UPDATE v1_sync_runs SET ended_at = ? WHERE sync_id IN (?, ?)", tiedEndedAt, fullSyncID, partialSyncID)
+	require.NoError(t, err)
+
+	require.NoError(t, store.Close(ctx))
+	return fullSyncID, partialSyncID
+}
+
+func putSQLiteInputData(t testing.TB, ctx context.Context, store *dotc1z.C1File, grantIDs ...string) {
+	t.Helper()
 	require.NoError(t, store.PutResourceTypes(ctx,
 		v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build(),
 		v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()))
@@ -192,9 +506,33 @@ func buildSQLiteInput(t testing.TB, ctx context.Context, path string, st connect
 	for _, id := range grantIDs {
 		require.NoError(t, store.PutGrants(ctx, v2.Grant_builder{Id: id, Principal: user, Entitlement: member}.Build()))
 	}
-	require.NoError(t, store.EndSync(ctx))
-	require.NoError(t, store.Close(ctx))
-	return syncID
+}
+
+func orderedTestSyncIDs() (string, string) {
+	a := ksuid.New().String()
+	b := ksuid.New().String()
+	if a > b {
+		return b, a
+	}
+	return a, b
+}
+
+func rawSQLiteDBForTest(t testing.TB, store *dotc1z.C1File) *sql.DB {
+	t.Helper()
+	field := reflect.ValueOf(store).Elem().FieldByName("rawDb")
+	require.True(t, field.IsValid())
+	require.False(t, field.IsNil())
+	return (*sql.DB)(unsafe.Pointer(field.Pointer()))
+}
+
+func retargetSQLiteSyncID(t testing.TB, ctx context.Context, db *sql.DB, oldID, newID string) {
+	t.Helper()
+	for _, table := range []string{"v1_sync_runs", "v1_resource_types", "v1_resources", "v1_entitlements", "v1_grants"} {
+		_, err := db.ExecContext(ctx, "UPDATE "+table+" SET sync_id = ? WHERE sync_id = ?", newID, oldID) //nolint:gosec // Table names are fixed test fixtures.
+		require.NoError(t, err)
+	}
+	_, err := db.ExecContext(ctx, "UPDATE v1_sync_runs SET parent_sync_id = ? WHERE parent_sync_id = ?", newID, oldID)
+	require.NoError(t, err)
 }
 
 // TestCompactPebbleDropsAssets pins the asset-drop parity: the SQLite

--- a/pkg/tasks/local/compactor.go
+++ b/pkg/tasks/local/compactor.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	v1 "github.com/conductorone/baton-sdk/pb/c1/connectorapi/baton/v1"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
 	"github.com/conductorone/baton-sdk/pkg/synccompactor"
 	"github.com/conductorone/baton-sdk/pkg/tasks"
 	"github.com/conductorone/baton-sdk/pkg/types"
@@ -22,6 +23,15 @@ type localCompactor struct {
 	compactableSyncs []*synccompactor.CompactableSync
 	outputPath       string
 	tmpDir           string
+	storageEngine    dotc1z.Engine
+}
+
+type CompactorOption func(*localCompactor)
+
+func WithCompactorStorageEngine(engine dotc1z.Engine) CompactorOption {
+	return func(m *localCompactor) {
+		m.storageEngine = engine
+	}
 }
 
 func (m *localCompactor) GetTempDir() string {
@@ -53,6 +63,9 @@ func (m *localCompactor) Process(ctx context.Context, task *v1.Task, cc types.Co
 	if m.tmpDir != "" {
 		compactOpts = append(compactOpts, synccompactor.WithTmpDir(m.tmpDir))
 	}
+	if m.storageEngine != "" {
+		compactOpts = append(compactOpts, synccompactor.WithEngine(m.storageEngine))
+	}
 	compactor, cleanup, err := synccompactor.NewCompactor(ctx, m.outputPath, m.compactableSyncs, compactOpts...)
 	if err != nil {
 		return err
@@ -72,10 +85,14 @@ func (m *localCompactor) Process(ctx context.Context, task *v1.Task, cc types.Co
 }
 
 // NewLocalCompactor returns a task manager that queues a compaction task.
-func NewLocalCompactor(ctx context.Context, outputPath string, compactableSyncs []*synccompactor.CompactableSync, tmpDir string) tasks.Manager {
-	return &localCompactor{
+func NewLocalCompactor(ctx context.Context, outputPath string, compactableSyncs []*synccompactor.CompactableSync, tmpDir string, opts ...CompactorOption) tasks.Manager {
+	m := &localCompactor{
 		compactableSyncs: compactableSyncs,
 		outputPath:       outputPath,
 		tmpDir:           tmpDir,
 	}
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m
 }

--- a/pkg/tasks/local/compactor_test.go
+++ b/pkg/tasks/local/compactor_test.go
@@ -1,0 +1,89 @@
+package local
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	enginepkg "github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble"
+	"github.com/conductorone/baton-sdk/pkg/synccompactor"
+)
+
+func TestLocalCompactorPassesStorageEngine(t *testing.T) {
+	ctx := context.Background()
+	inDir := t.TempDir()
+	outDir := t.TempDir()
+
+	p1 := filepath.Join(inDir, "in1.c1z")
+	p2 := filepath.Join(inDir, "in2.c1z")
+	s1 := buildLocalCompactorSQLiteInput(t, ctx, p1, connectorstore.SyncTypeFull, "g-shared", "g-only1")
+	s2 := buildLocalCompactorSQLiteInput(t, ctx, p2, connectorstore.SyncTypePartial, "g-shared", "g-only2")
+
+	mgr := NewLocalCompactor(ctx, outDir, []*synccompactor.CompactableSync{
+		{FilePath: p1, SyncID: s1},
+		{FilePath: p2, SyncID: s2},
+	}, t.TempDir(), WithCompactorStorageEngine(dotc1z.EnginePebble))
+
+	require.NoError(t, mgr.Process(ctx, nil, nil))
+
+	entries, err := os.ReadDir(outDir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+
+	store, err := dotc1z.NewStore(ctx, filepath.Join(outDir, entries[0].Name()), dotc1z.WithReadOnly(true))
+	require.NoError(t, err)
+	defer func() { _ = store.Close(ctx) }()
+
+	_, ok := enginepkg.AsEngine(store)
+	require.True(t, ok, "local compactor must pass requested pebble engine to synccompactor")
+}
+
+func buildLocalCompactorSQLiteInput(t *testing.T, ctx context.Context, path string, st connectorstore.SyncType, grantIDs ...string) string {
+	t.Helper()
+
+	store, err := dotc1z.NewC1ZFile(ctx, path)
+	require.NoError(t, err)
+
+	syncID, err := store.StartNewSync(ctx, st, "")
+	require.NoError(t, err)
+
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	require.NoError(t, store.PutResourceTypes(ctx, userRT, groupRT))
+
+	group := v2.Resource_builder{
+		Id:          v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(),
+		DisplayName: "Group One",
+	}.Build()
+	user := v2.Resource_builder{
+		Id:          v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(),
+		DisplayName: "User One",
+	}.Build()
+	require.NoError(t, store.PutResources(ctx, group, user))
+
+	member := v2.Entitlement_builder{
+		Id:       "member",
+		Resource: group,
+		Purpose:  v2.Entitlement_PURPOSE_VALUE_ASSIGNMENT,
+	}.Build()
+	require.NoError(t, store.PutEntitlements(ctx, member))
+
+	for _, id := range grantIDs {
+		grant := v2.Grant_builder{
+			Id:          id,
+			Principal:   user,
+			Entitlement: member,
+		}.Build()
+		require.NoError(t, store.PutGrants(ctx, grant))
+	}
+
+	require.NoError(t, store.EndSync(ctx))
+	require.NoError(t, store.Close(ctx))
+	return syncID
+}


### PR DESCRIPTION
The new compaction policy is that if pebble is the target, or if any c1z is pebble, we convert to pebble.  Or, if sqlite is the target and any sync is pebble, we error out.  If the base sync is not pebble, we can not choose Fold.