### PR TITLE
[Draft] ~50% faster grant expansion

### DIFF
--- a/pkg/dotc1z/engine/pebble/adapter.go
+++ b/pkg/dotc1z/engine/pebble/adapter.go
@@ -322,6 +322,15 @@ func (a *Adapter) EndSync(ctx context.Context) error {
 			zap.Error(err),
 		)
 	}
+	// If the expansion write path deferred the principal/resource index
+	// families (BATON_PEBBLE_DEFER_EXPANSION_INDEXES), rebuild them now in one
+	// sorted ingest, before the durability flush so EndFreshSync hardens them.
+	if a.engine.deferGrantIndexes && a.engine.deferredIdxPending.Load() {
+		if err := a.engine.BuildDeferredGrantIndexes(ctx); err != nil {
+			return fmt.Errorf("EndSync: build deferred grant indexes: %w", err)
+		}
+		a.engine.deferredIdxPending.Store(false)
+	}
 	// Single flush + WAL fsync at sync end. This is the durability
 	// boundary — counterpart to MarkFreshSync at StartNewSync. After
 	// this returns, all writes from the sync are on disk.

--- a/pkg/dotc1z/engine/pebble/adapter_grants_store.go
+++ b/pkg/dotc1z/engine/pebble/adapter_grants_store.go
@@ -72,6 +72,41 @@ func (g pebbleGrantStore) StoreExpandedGrants(ctx context.Context, grants ...*v2
 	// equivalent to V2GrantToV3 and (like it) leaves discovered_at unset:
 	// PutExpandedGrantRecords stamps/preserves it. The returned pointers alias
 	// the arena, which outlives this call's use of `merged`.
+	merged := g.translateExpanded(syncID, grants)
+	return g.a.engine.PutExpandedGrantRecords(ctx, merged)
+}
+
+// StoreNewExpandedGrants is the fast path for expanded grants the caller
+// guarantees are brand-new (no existing record shares their external_id in this
+// sync) — the expander's SYNTHESIZED grants. It performs the same v2→v3
+// translation as StoreExpandedGrants but routes to PutSynthesizedGrantRecords,
+// which skips the per-record read-before-write Get (and stale-index cleanup)
+// that only exists to handle a prior record. See PutSynthesizedGrantRecords for
+// the contract and the fail-safe if the uniqueness guarantee is violated.
+//
+// Optional ExpanderStore fast path: the expander detects this method by
+// interface assertion and falls back to StoreExpandedGrants when it is absent
+// (SQLite, in-memory doubles), so behavior is identical everywhere — only the
+// redundant Get is elided on Pebble.
+func (g pebbleGrantStore) StoreNewExpandedGrants(ctx context.Context, grants ...*v2.Grant) error {
+	syncID := g.a.currentSyncID()
+	if syncID == "" {
+		return ErrNoCurrentSync
+	}
+	if len(grants) == 0 {
+		return nil
+	}
+	merged := g.translateExpanded(syncID, grants)
+	return g.a.engine.PutSynthesizedGrantRecords(ctx, merged)
+}
+
+// translateExpanded translates expander output v2 grants into v3 records,
+// stripping any residual expansion side-state: StoreExpandedGrants restores the
+// prior record's Expansion/NeedsExpansion in PutExpandedGrantRecords, and new
+// (synthesized) records must not become expandable just because the caller left
+// a residual GrantExpandable annotation. The returned pointers alias the arena,
+// which outlives the caller's use of the slice.
+func (g pebbleGrantStore) translateExpanded(syncID string, grants []*v2.Grant) []*v3.GrantRecord {
 	merged := make([]*v3.GrantRecord, 0, len(grants))
 	arena := newGrantTranslateArena(len(grants))
 	for _, gr := range grants {
@@ -82,15 +117,11 @@ func (g pebbleGrantStore) StoreExpandedGrants(ctx context.Context, grants ...*v2
 		if newRec == nil {
 			continue
 		}
-		// StoreExpandedGrants consumes expansion metadata before persisting.
-		// Existing records get their prior Expansion/NeedsExpansion restored in
-		// PutExpandedGrantRecords; new records must not become expandable just
-		// because the caller left a residual GrantExpandable annotation.
 		newRec.SetExpansion(nil)
 		newRec.SetNeedsExpansion(false)
 		merged = append(merged, newRec)
 	}
-	return g.a.engine.PutExpandedGrantRecords(ctx, merged)
+	return merged
 }
 
 // PendingExpansionPage returns the next page of grants whose

--- a/pkg/dotc1z/engine/pebble/bulk_import.go
+++ b/pkg/dotc1z/engine/pebble/bulk_import.go
@@ -656,6 +656,40 @@ func newSpillSorter(dir, name string, sem chan struct{}, chunkBytes int) *spillS
 	return &spillSorter{name: name, dir: dir, sem: sem, chunkBytes: chunkBytes}
 }
 
+// spillArenaPool / spillViewsPool recycle the per-chunk key/value arena and its
+// kvView slice across chunks. Without recycling, every cut allocates a fresh
+// arena that grows from zero by append-doubling (≈2× the chunk's bytes) and is
+// then GC'd — on the deferred index build (≈162M key-only entries) the arena
+// was the single largest allocator (~131GB churn). A background sort goroutine
+// owns a detached arena until its chunk is written, then returns it here.
+var spillArenaPool = sync.Pool{New: func() any { b := make([]byte, 0, bulkSpillKeyChunkBytes); return &b }}
+var spillViewsPool = sync.Pool{New: func() any { v := make([]kvView, 0, 1<<16); return &v }}
+
+func getSpillArena() []byte {
+	bp := spillArenaPool.Get().(*[]byte)
+	return (*bp)[:0]
+}
+
+func putSpillArena(b []byte) {
+	// Only recycle full-size arenas; a short tail chunk's buffer would shrink
+	// the pool's effective capacity, forcing later chunks to re-grow.
+	if cap(b) < bulkSpillKeyChunkBytes {
+		return
+	}
+	b = b[:0]
+	spillArenaPool.Put(&b)
+}
+
+func getSpillViews() []kvView {
+	vp := spillViewsPool.Get().(*[]kvView)
+	return (*vp)[:0]
+}
+
+func putSpillViews(v []kvView) {
+	v = v[:0]
+	spillViewsPool.Put(&v)
+}
+
 // add appends one entry. val may be nil (key-only spills). NOT
 // goroutine-safe — each sorter has exactly one producer. May block on
 // the sort semaphore when the arena fills (backpressure on this
@@ -666,6 +700,12 @@ func (s *spillSorter) add(key, val []byte) error {
 	}
 	if err := s.takeErr(); err != nil {
 		return err
+	}
+	if s.arena == nil {
+		// Start of a new chunk: take a recycled arena/views from the pool
+		// instead of growing fresh ones from zero.
+		s.arena = getSpillArena()
+		s.views = getSpillViews()
 	}
 	keyOff := len(s.arena)
 	s.arena = append(s.arena, key...)
@@ -708,6 +748,9 @@ func (s *spillSorter) sortAndWriteChunk(arena []byte, views []kvView) {
 	if err := writeSortedSpillChunk(chunkPath, arena, views); err != nil {
 		s.setErr(err)
 	}
+	// The chunk is on disk; recycle the buffers for the next chunk.
+	putSpillArena(arena)
+	putSpillViews(views)
 }
 
 func (s *spillSorter) setErr(err error) {

--- a/pkg/dotc1z/engine/pebble/deferred_index.go
+++ b/pkg/dotc1z/engine/pebble/deferred_index.go
@@ -1,0 +1,262 @@
+package pebble
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
+
+	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/codec"
+)
+
+// BuildDeferredGrantIndexes rebuilds the three grant index families that the
+// expansion write path skips when deferGrantIndexes is enabled —
+// by_entitlement_resource, by_principal, by_principal_resource_type — by
+// scanning the by_entitlement index keys once and ingesting one sorted SST per
+// family. It is the "build" half of the defer-then-sort strategy: it converts
+// the out-of-order, compaction-churning inline writes of the scattered families
+// into a single external sort + ingest each.
+//
+// Correctness notes:
+//   - These families are NOT read during expansion (the merge reads only
+//     by_entitlement), so deferring them to EndSync changes no expansion read.
+//   - They are derived from the by_entitlement index (which carries
+//     (entitlement_id, principal_rt, principal_id, external_id) in its key) plus
+//     a one-time entitlement->resource map for by_entitlement_resource — so no
+//     grant primary is decoded, and the rebuild is a pure function of durable,
+//     checkpoint-captured state (resumable: re-run from by_entitlement).
+//   - Each key carries the grant's external_id as its tail, and every primary
+//     has a unique external_id, so the emitted keys are unique within a family —
+//     no duplicate-key conflict in the spill merge.
+//   - Ingesting into a keyspace that already holds base-grant entries (written
+//     inline by the connector sync) is fine: identical keys are shadowed by the
+//     higher-seqnum ingest, and the family SSTs have disjoint key ranges so a
+//     single Ingest is legal.
+//
+// EndSync gates the call on deferredIdxPending so a non-expansion sync skips it.
+func (e *Engine) BuildDeferredGrantIndexes(ctx context.Context) error {
+	l := ctxzap.Extract(ctx)
+	start := time.Now()
+
+	dir, err := os.MkdirTemp("", "pebble-deferred-idx-")
+	if err != nil {
+		return fmt.Errorf("BuildDeferredGrantIndexes: mkdir temp: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+
+	sorters := min(4, max(2, runtime.GOMAXPROCS(0)/2))
+	sem := make(chan struct{}, sorters)
+
+	entRes := newSpillSorter(dir, fmt.Sprintf("index-%02x", idxGrantByEntitlementResource), sem, bulkSpillKeyChunkBytes)
+	prin := newSpillSorter(dir, fmt.Sprintf("index-%02x", idxGrantByPrincipal), sem, bulkSpillKeyChunkBytes)
+	prinRT := newSpillSorter(dir, fmt.Sprintf("index-%02x", idxGrantByPrincipalResourceType), sem, bulkSpillKeyChunkBytes)
+
+	// All three deferred families are derived from the by_entitlement index —
+	// written inline and therefore checkpoint-captured — with no grant primary
+	// decode. The key's (principal_rt, principal_id, external_id) tail directly
+	// yields by_principal and by_principal_resource_type. by_entitlement_resource
+	// needs the entitlement's split (resource_type, resource_id); the
+	// entitlement_id in the key is the lossy ":"-join, so we resolve it from a
+	// one-time scan of the (small) entitlement keyspace — any handy index — rather
+	// than parsing it.
+	entResByID, err := e.entitlementResourceMap(ctx)
+	if err != nil {
+		return err
+	}
+	mapDone := time.Now()
+
+	prefix := []byte{versionV3, typeIndex, idxGrantByEntitlement}
+	iter, err := e.db.NewIter(&pebble.IterOptions{LowerBound: prefix, UpperBound: upperBoundOf(prefix)})
+	if err != nil {
+		return fmt.Errorf("BuildDeferredGrantIndexes: iter: %w", err)
+	}
+	defer iter.Close()
+
+	var scratch []byte
+	var scanned int64
+	for iter.First(); iter.Valid(); iter.Next() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		entID, pRT, pID, ext, ok := decodeGrantByEntitlementIndexKey(iter.Key())
+		if !ok {
+			continue
+		}
+		// Byte-slice appenders + a string()-keyed map lookup (compiler-elided
+		// alloc) keep this loop allocation-free over 162M keys.
+		scratch = AppendGrantByPrincipalIndexKeyRawBytes(scratch[:0], pRT, pID, ext)
+		if err := prin.add(scratch, nil); err != nil {
+			return err
+		}
+		scratch = AppendGrantByPrincipalResourceTypeIndexKeyRawBytes(scratch[:0], pRT, ext)
+		if err := prinRT.add(scratch, nil); err != nil {
+			return err
+		}
+		if er, found := entResByID[string(entID)]; found && len(er.resourceID) > 0 {
+			scratch = AppendGrantByEntitlementResourceIndexKeyRawBytes(scratch[:0], er.resourceTypeID, er.resourceID, ext)
+			if err := entRes.add(scratch, nil); err != nil {
+				return err
+			}
+		}
+		scanned++
+	}
+	if err := iter.Error(); err != nil {
+		return fmt.Errorf("BuildDeferredGrantIndexes: iter error: %w", err)
+	}
+	scanDone := time.Now()
+
+	units := []struct {
+		name string
+		s    *spillSorter
+	}{
+		{fmt.Sprintf("index-%02x", idxGrantByEntitlementResource), entRes},
+		{fmt.Sprintf("index-%02x", idxGrantByPrincipal), prin},
+		{fmt.Sprintf("index-%02x", idxGrantByPrincipalResourceType), prinRT},
+	}
+	// The families are independent, so finalize + k-way merge each into its SST
+	// in parallel (mirrors BulkSyncImport.Finish).
+	results := make([]struct {
+		path string
+		err  error
+	}, len(units))
+	var wg sync.WaitGroup
+	for i, u := range units {
+		wg.Add(1)
+		go func(i int, name string, s *spillSorter) {
+			defer wg.Done()
+			chunks, err := s.finalize()
+			if err != nil {
+				results[i].err = err
+				return
+			}
+			if len(chunks) == 0 {
+				return
+			}
+			sstPath := filepath.Join(dir, name+".sst")
+			if err := mergeSortedSpillChunksToSST(ctx, sstPath, name, chunks); err != nil {
+				results[i].err = err
+				return
+			}
+			results[i].path = sstPath
+		}(i, u.name, u.s)
+	}
+	wg.Wait()
+	paths := make([]string, 0, len(units))
+	for _, r := range results {
+		if r.err != nil {
+			return r.err
+		}
+		if r.path != "" {
+			paths = append(paths, r.path)
+		}
+	}
+	mergeDone := time.Now()
+
+	if len(paths) == 0 {
+		return nil
+	}
+	if err := e.withWrite(func() error {
+		return e.db.Ingest(ctx, paths)
+	}); err != nil {
+		return fmt.Errorf("BuildDeferredGrantIndexes: ingest: %w", err)
+	}
+
+	l.Info("deferred grant index build complete",
+		zap.Int64("index_keys_scanned", scanned),
+		zap.Int("entitlements_mapped", len(entResByID)),
+		zap.Int("families", len(paths)),
+		zap.Duration("ent_map", mapDone.Sub(start)),
+		zap.Duration("scan", scanDone.Sub(mapDone)),
+		zap.Duration("merge", mergeDone.Sub(scanDone)),
+		zap.Duration("ingest", time.Since(mergeDone)),
+		zap.Duration("total", time.Since(start)),
+	)
+	return nil
+}
+
+// entResource is the entitlement's split resource identity as raw bytes, so the
+// by_entitlement_resource build can use the byte-slice key appenders and skip a
+// per-grant string conversion. Allocated once per entitlement (reused across
+// every grant on it), not per grant.
+type entResource struct {
+	resourceTypeID []byte
+	resourceID     []byte
+}
+
+// entitlementResourceMap scans the entitlement keyspace once and maps each
+// entitlement_id (external id) to its resource's (type, id). The entitlement
+// set is small relative to grants, so this is cheap and avoids decoding any
+// grant primary.
+func (e *Engine) entitlementResourceMap(ctx context.Context) (map[string]entResource, error) {
+	lo := []byte{versionV3, typeEntitlement}
+	iter, err := e.db.NewIter(&pebble.IterOptions{LowerBound: lo, UpperBound: upperBoundOf(lo)})
+	if err != nil {
+		return nil, fmt.Errorf("entitlementResourceMap: iter: %w", err)
+	}
+	defer iter.Close()
+	out := make(map[string]entResource)
+	var rec v3.EntitlementRecord
+	for iter.First(); iter.Valid(); iter.Next() {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		rec.Reset()
+		if err := unmarshalRecord(iter.Value(), &rec); err != nil {
+			return nil, fmt.Errorf("entitlementResourceMap: unmarshal: %w", err)
+		}
+		res := rec.GetResource()
+		if res == nil {
+			continue
+		}
+		out[rec.GetExternalId()] = entResource{
+			resourceTypeID: []byte(res.GetResourceTypeId()),
+			resourceID:     []byte(res.GetResourceId()),
+		}
+	}
+	if err := iter.Error(); err != nil {
+		return nil, fmt.Errorf("entitlementResourceMap: iter error: %w", err)
+	}
+	return out, nil
+}
+
+// decodeGrantByEntitlementIndexKey decodes a by_entitlement grant index key into
+// its (entitlement_id, principal_rt, principal_id, external_id) components. The
+// key layout is the 3-byte family header, a leading tuple separator, then the
+// four escaped tuple components. Returns ok=false for any key that does not
+// match that shape.
+// Returned slices alias key (no allocation) and are only valid until the
+// iterator that produced key advances; callers must copy/encode before Next.
+func decodeGrantByEntitlementIndexKey(key []byte) (entID, prinRT, prinID, ext []byte, ok bool) {
+	const headerLen = 3 // versionV3 | typeIndex | idxGrantByEntitlement
+	if len(key) <= headerLen {
+		return nil, nil, nil, nil, false
+	}
+	tail := key[headerLen:]
+	// tail[0] is the leading tuple separator written by AppendTupleSeparator;
+	// the first component begins at offset 1.
+	a, n1, ok1 := codec.DecodeTupleStringAlias(tail, 1)
+	if !ok1 || n1 >= len(tail) {
+		return nil, nil, nil, nil, false
+	}
+	b, n2, ok2 := codec.DecodeTupleStringAlias(tail, n1+1)
+	if !ok2 || n2 >= len(tail) {
+		return nil, nil, nil, nil, false
+	}
+	c, n3, ok3 := codec.DecodeTupleStringAlias(tail, n2+1)
+	if !ok3 || n3 >= len(tail) {
+		return nil, nil, nil, nil, false
+	}
+	d, _, ok4 := codec.DecodeTupleStringAlias(tail, n3+1)
+	if !ok4 {
+		return nil, nil, nil, nil, false
+	}
+	return a, b, c, d, true
+}

--- a/pkg/dotc1z/engine/pebble/deferred_index_test.go
+++ b/pkg/dotc1z/engine/pebble/deferred_index_test.go
@@ -1,0 +1,102 @@
+package pebble
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/segmentio/ksuid"
+	"github.com/stretchr/testify/require"
+
+	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
+)
+
+// grantWith builds a GrantRecord with explicit entitlement/principal/resource
+// components so the test can exercise colon-bearing ids and varied families.
+func grantWith(externalID, entRT, entRID, entID, prinRT, prinID string) *v3.GrantRecord {
+	return v3.GrantRecord_builder{
+		ExternalId: externalID,
+		Entitlement: v3.EntitlementRef_builder{
+			ResourceTypeId: entRT,
+			ResourceId:     entRID,
+			EntitlementId:  entID,
+		}.Build(),
+		Principal: v3.PrincipalRef_builder{
+			ResourceTypeId: prinRT,
+			ResourceId:     prinID,
+		}.Build(),
+	}.Build()
+}
+
+func dumpIndexKeys(t *testing.T, e *Engine, lo, hi []byte) []string {
+	t.Helper()
+	iter, err := e.db.NewIter(&pebble.IterOptions{LowerBound: lo, UpperBound: hi})
+	require.NoError(t, err)
+	defer iter.Close()
+	var keys []string
+	for iter.First(); iter.Valid(); iter.Next() {
+		keys = append(keys, string(append([]byte(nil), iter.Key()...)))
+	}
+	require.NoError(t, iter.Error())
+	return keys
+}
+
+// TestDeferredGrantIndexesMatchInline proves that the deferred index build
+// (BATON_PEBBLE_DEFER_EXPANSION_INDEXES) produces byte-identical index keyspaces
+// to the normal inline write path, across all grant index families — including
+// colon-bearing entitlement/principal ids that stress the tuple codec.
+func TestDeferredGrantIndexesMatchInline(t *testing.T) {
+	ctx := context.Background()
+	syncID := ksuid.New().String()
+
+	// A varied set: distinct entitlements/resources/principals, several with
+	// colons inside resource ids and principal ids.
+	mk := func() []*v3.GrantRecord {
+		return []*v3.GrantRecord{
+			grantWith("github:repo:123:write:user:alice", "repo", "123", "github:repo:123:write", "user", "alice"),
+			grantWith("github:repo:123:write:user:bob", "repo", "123", "github:repo:123:write", "user", "bob"),
+			grantWith("g2", "group", "eng", "group:eng:member", "user", "carol:contractor"),
+			grantWith("g3", "group", "eng:platform", "group:eng:platform:admin", "group", "oncall"),
+			grantWith("g4", "app", "github", "app:github:read", "user", "dave"),
+		}
+	}
+
+	// Entitlement records backing the grants' entitlements, so the deferred
+	// build's entitlement->resource map can resolve by_entitlement_resource.
+	// Their resource (type, id) must match each grant's entitlement ref.
+	ents := []*v3.EntitlementRecord{
+		v3.EntitlementRecord_builder{ExternalId: "github:repo:123:write", Resource: v3.ResourceRef_builder{ResourceTypeId: "repo", ResourceId: "123"}.Build()}.Build(),
+		v3.EntitlementRecord_builder{ExternalId: "group:eng:member", Resource: v3.ResourceRef_builder{ResourceTypeId: "group", ResourceId: "eng"}.Build()}.Build(),
+		v3.EntitlementRecord_builder{ExternalId: "group:eng:platform:admin", Resource: v3.ResourceRef_builder{ResourceTypeId: "group", ResourceId: "eng:platform"}.Build()}.Build(),
+		v3.EntitlementRecord_builder{ExternalId: "app:github:read", Resource: v3.ResourceRef_builder{ResourceTypeId: "app", ResourceId: "github"}.Build()}.Build(),
+	}
+
+	control, _ := newTestEngine(t)
+	require.NoError(t, control.SetCurrentSync(syncID))
+	require.NoError(t, control.PutEntitlementRecords(ctx, ents...))
+	require.NoError(t, control.PutExpandedGrantRecords(ctx, mk()))
+
+	deferred, _ := newTestEngine(t)
+	deferred.deferGrantIndexes = true
+	require.NoError(t, deferred.SetCurrentSync(syncID))
+	require.NoError(t, deferred.PutEntitlementRecords(ctx, ents...))
+	require.NoError(t, deferred.PutExpandedGrantRecords(ctx, mk()))
+	require.True(t, deferred.deferredIdxPending.Load(), "expansion write should mark a deferred rebuild pending")
+	require.NoError(t, deferred.BuildDeferredGrantIndexes(ctx))
+
+	families := []struct {
+		name   string
+		lo, hi []byte
+	}{
+		{"by_entitlement", GrantByEntitlementLowerBound(), GrantByEntitlementUpperBound()},
+		{"by_entitlement_resource", GrantByEntitlementResourceLowerBound(), GrantByEntitlementResourceUpperBound()},
+		{"by_principal", GrantByPrincipalLowerBound(), GrantByPrincipalUpperBound()},
+		{"by_principal_resource_type", GrantByPrincipalResourceTypeLowerBound(), GrantByPrincipalResourceTypeUpperBound()},
+	}
+	for _, f := range families {
+		want := dumpIndexKeys(t, control, f.lo, f.hi)
+		got := dumpIndexKeys(t, deferred, f.lo, f.hi)
+		require.Equal(t, want, got, "family %s: deferred build must match inline writes", f.name)
+		require.NotEmpty(t, got, "family %s should have entries", f.name)
+	}
+}

--- a/pkg/dotc1z/engine/pebble/engine.go
+++ b/pkg/dotc1z/engine/pebble/engine.go
@@ -71,6 +71,14 @@ type Engine struct {
 	// record they wrote.
 	computedStatsMu sync.Mutex
 	computedStats   map[string]*v3.SyncStatsRecord
+
+	// expandStats, when non-nil, accumulates a timing/volume breakdown of
+	// the PutExpandedGrantRecords write path (read-before-write Gets, marshal,
+	// index-delete, primary/index commit time, and per-index-family key/byte
+	// counts). Diagnostic only: enabled via EnableExpandWriteStats before an
+	// expansion run and read back via ExpandWriteStats. nil in production, so
+	// the hot path pays one nil check per record.
+	expandStats *expandWriteStats
 }
 
 // Open creates or opens a Pebble engine rooted at dir. If dir does

--- a/pkg/dotc1z/engine/pebble/engine.go
+++ b/pkg/dotc1z/engine/pebble/engine.go
@@ -79,6 +79,20 @@ type Engine struct {
 	// expansion run and read back via ExpandWriteStats. nil in production, so
 	// the hot path pays one nil check per record.
 	expandStats *expandWriteStats
+
+	// deferGrantIndexes, when true (env BATON_PEBBLE_DEFER_EXPANSION_INDEXES),
+	// makes the expansion write path (writeGrantIndexesScratch) skip the three
+	// index families that are NOT read during expansion — by_entitlement_resource,
+	// by_principal, by_principal_resource_type — writing only by_entitlement
+	// inline. The skipped families are rebuilt in one sorted-SST ingest at
+	// EndSync (BuildDeferredGrantIndexes), trading out-of-order LSM churn for a
+	// single external sort. Experimental perf knob; off by default.
+	deferGrantIndexes bool
+	// deferredIdxPending is set the first time the expansion path skips a
+	// deferred family, so EndSync knows to run the rebuild. Connector-sync
+	// writes (writeGrantIndexes) never set it, so a non-expansion sync skips
+	// the rebuild entirely.
+	deferredIdxPending atomic.Bool
 }
 
 // Open creates or opens a Pebble engine rooted at dir. If dir does
@@ -106,10 +120,11 @@ func Open(ctx context.Context, dir string, opts ...Option) (*Engine, error) {
 	}
 
 	e := &Engine{
-		db:         db,
-		dbDir:      dir,
-		opts:       o,
-		pebbleOpts: pebbleOpts,
+		db:                db,
+		dbDir:             dir,
+		opts:              o,
+		pebbleOpts:        pebbleOpts,
+		deferGrantIndexes: os.Getenv("BATON_PEBBLE_DEFER_EXPANSION_INDEXES") != "",
 	}
 	// Enforce the single-sync key-layout contract before touching any
 	// keys: reject an old multi-sync-layout file (which the current

--- a/pkg/dotc1z/engine/pebble/expand_write_stats.go
+++ b/pkg/dotc1z/engine/pebble/expand_write_stats.go
@@ -1,0 +1,164 @@
+package pebble
+
+import (
+	"errors"
+	"io"
+	"sync/atomic"
+	"time"
+
+	"github.com/cockroachdb/pebble/v2"
+)
+
+// expandWriteStats accumulates a breakdown of the PutExpandedGrantRecords
+// write path so a diagnostic run can attribute the expansion write cost to
+// its parts: the per-record read-before-write Get, the proto marshal, the
+// stale-index delete, the primary-batch commit, the index-batch commit, and
+// the per-index-family key/byte volume.
+//
+// All fields are atomic so accumulation is safe regardless of how the engine
+// serializes writes. It is allocated only when EnableExpandWriteStats is
+// called; the hot path guards on a nil pointer, so a production run pays one
+// nil check per record and nothing else.
+type expandWriteStats struct {
+	calls   atomic.Int64
+	records atomic.Int64
+
+	getNs       atomic.Int64
+	getCount    atomic.Int64
+	getNotFound atomic.Int64
+	marshalNs   atomic.Int64
+	deleteNs    atomic.Int64
+	priCommitNs atomic.Int64
+	idxCommitNs atomic.Int64
+
+	// readGet* track the primary Get issued per by_entitlement index row when
+	// the read path (projection-source scan + destination base stream) hydrates
+	// full grant records from the index. This is the "materialization Get" the
+	// streaming-merge design flags as the main remaining read cost — distinct
+	// from the read-before-write get* fields above, which live on the write path.
+	readGetNs       atomic.Int64
+	readGetCount    atomic.Int64
+	readGetNotFound atomic.Int64
+
+	priKeyBytes atomic.Int64
+	priValBytes atomic.Int64
+
+	entKeys  atomic.Int64
+	entBytes atomic.Int64
+
+	entResKeys  atomic.Int64
+	entResBytes atomic.Int64
+
+	prinKeys  atomic.Int64
+	prinBytes atomic.Int64
+
+	prinRTKeys  atomic.Int64
+	prinRTBytes atomic.Int64
+
+	needsExpKeys  atomic.Int64
+	needsExpBytes atomic.Int64
+}
+
+// ExpandWriteStats is a snapshot of the expansion write-path breakdown.
+// Durations are wall time summed across every PutExpandedGrantRecords call;
+// because commits run NoSync, the commit durations also absorb any write-stall
+// back-pressure the LSM applies when L0/compaction falls behind — i.e. a large
+// IdxCommit relative to PriCommit is the signature of out-of-order index
+// writes overwhelming compaction.
+type ExpandWriteStats struct {
+	Calls   int64
+	Records int64
+
+	GetDur       time.Duration
+	GetCount     int64
+	GetNotFound  int64
+	MarshalDur   time.Duration
+	DeleteIdxDur time.Duration
+	PriCommitDur time.Duration
+	IdxCommitDur time.Duration
+
+	// Read-path primary materialization Get (by_entitlement scans).
+	ReadGetDur      time.Duration
+	ReadGetCount    int64
+	ReadGetNotFound int64
+
+	PriKeyBytes int64
+	PriValBytes int64
+
+	ByEntitlementKeys  int64
+	ByEntitlementBytes int64
+
+	ByEntitlementResourceKeys  int64
+	ByEntitlementResourceBytes int64
+
+	ByPrincipalKeys  int64
+	ByPrincipalBytes int64
+
+	ByPrincipalResourceTypeKeys  int64
+	ByPrincipalResourceTypeBytes int64
+
+	NeedsExpansionKeys  int64
+	NeedsExpansionBytes int64
+}
+
+// getGrantPrimaryTimed wraps the per-index-row primary Get used by the grant
+// pagination read paths (PaginateGrantsBy*). When expansion write stats are
+// enabled it records read-materialization Get timing/count; otherwise it is a
+// straight pass-through to e.db.Get with identical (value, closer, error)
+// semantics. Diagnostic only.
+func (e *Engine) getGrantPrimaryTimed(key []byte) ([]byte, io.Closer, error) {
+	stats := e.expandStats
+	if stats == nil {
+		return e.db.Get(key)
+	}
+	t0 := time.Now()
+	val, closer, err := e.db.Get(key)
+	stats.readGetNs.Add(int64(time.Since(t0)))
+	stats.readGetCount.Add(1)
+	if errors.Is(err, pebble.ErrNotFound) {
+		stats.readGetNotFound.Add(1)
+	}
+	return val, closer, err
+}
+
+// EnableExpandWriteStats turns on PutExpandedGrantRecords instrumentation.
+// Call before an expansion run; read the result with ExpandWriteStats.
+// Diagnostic only — not used by production code paths.
+func (e *Engine) EnableExpandWriteStats() {
+	e.expandStats = &expandWriteStats{}
+}
+
+// ExpandWriteStats returns a snapshot of accumulated expansion write-path
+// stats and whether instrumentation was enabled.
+func (e *Engine) ExpandWriteStats() (ExpandWriteStats, bool) {
+	s := e.expandStats
+	if s == nil {
+		return ExpandWriteStats{}, false
+	}
+	return ExpandWriteStats{
+		Calls:                        s.calls.Load(),
+		Records:                      s.records.Load(),
+		GetDur:                       time.Duration(s.getNs.Load()),
+		GetCount:                     s.getCount.Load(),
+		GetNotFound:                  s.getNotFound.Load(),
+		MarshalDur:                   time.Duration(s.marshalNs.Load()),
+		DeleteIdxDur:                 time.Duration(s.deleteNs.Load()),
+		PriCommitDur:                 time.Duration(s.priCommitNs.Load()),
+		IdxCommitDur:                 time.Duration(s.idxCommitNs.Load()),
+		ReadGetDur:                   time.Duration(s.readGetNs.Load()),
+		ReadGetCount:                 s.readGetCount.Load(),
+		ReadGetNotFound:              s.readGetNotFound.Load(),
+		PriKeyBytes:                  s.priKeyBytes.Load(),
+		PriValBytes:                  s.priValBytes.Load(),
+		ByEntitlementKeys:            s.entKeys.Load(),
+		ByEntitlementBytes:           s.entBytes.Load(),
+		ByEntitlementResourceKeys:    s.entResKeys.Load(),
+		ByEntitlementResourceBytes:   s.entResBytes.Load(),
+		ByPrincipalKeys:              s.prinKeys.Load(),
+		ByPrincipalBytes:             s.prinBytes.Load(),
+		ByPrincipalResourceTypeKeys:  s.prinRTKeys.Load(),
+		ByPrincipalResourceTypeBytes: s.prinRTBytes.Load(),
+		NeedsExpansionKeys:           s.needsExpKeys.Load(),
+		NeedsExpansionBytes:          s.needsExpBytes.Load(),
+	}, true
+}

--- a/pkg/dotc1z/engine/pebble/grants.go
+++ b/pkg/dotc1z/engine/pebble/grants.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/cockroachdb/pebble/v2"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -189,6 +190,16 @@ func (e *Engine) PutExpandedGrantRecords(ctx context.Context, records []*v3.Gran
 
 		now := timestamppb.Now()
 
+		// stats is nil unless EnableExpandWriteStats was called (diagnostic
+		// runs only). When set, the per-record Get/marshal/delete and the two
+		// commits below are wall-timed into it; writeGrantIndexesScratch tallies
+		// per-index-family key/byte volume.
+		stats := e.expandStats
+		if stats != nil {
+			stats.calls.Add(1)
+		}
+		var tStat time.Time
+
 		// Dedup pre-pass: keep only the LAST occurrence of each
 		// external_id. The expander appends the same deterministic
 		// grant id more than once when it merges sources for a
@@ -223,7 +234,17 @@ func (e *Engine) PutExpandedGrantRecords(ctx context.Context, records []*v3.Gran
 			ext := r.GetExternalId()
 			keyScratch = appendGrantKey(keyScratch[:0], ext)
 
+			if stats != nil {
+				tStat = time.Now()
+			}
 			oldVal, closer, getErr := e.db.Get(keyScratch)
+			if stats != nil {
+				stats.getNs.Add(int64(time.Since(tStat)))
+				stats.getCount.Add(1)
+				if errors.Is(getErr, pebble.ErrNotFound) {
+					stats.getNotFound.Add(1)
+				}
+			}
 			switch {
 			case getErr == nil:
 				// Preserve the prior record's expansion side-state +
@@ -238,7 +259,13 @@ func (e *Engine) PutExpandedGrantRecords(ctx context.Context, records []*v3.Gran
 				r.SetNeedsExpansion(prior.GetNeedsExpansion())
 				r.SetDiscoveredAt(prior.GetDiscoveredAt())
 				var err error
+				if stats != nil {
+					tStat = time.Now()
+				}
 				idxScratch, err = e.deleteGrantIndexesScratch(idxBatch, ext, oldVal, idxScratch)
+				if stats != nil {
+					stats.deleteNs.Add(int64(time.Since(tStat)))
+				}
 				if err != nil {
 					closer.Close()
 					return err
@@ -254,7 +281,13 @@ func (e *Engine) PutExpandedGrantRecords(ctx context.Context, records []*v3.Gran
 				r.SetDiscoveredAt(now)
 			}
 
+			if stats != nil {
+				tStat = time.Now()
+			}
 			val, err := marshalRecordAppend(valScratch[:0], r)
+			if stats != nil {
+				stats.marshalNs.Add(int64(time.Since(tStat)))
+			}
 			if err != nil {
 				return err
 			}
@@ -262,16 +295,34 @@ func (e *Engine) PutExpandedGrantRecords(ctx context.Context, records []*v3.Gran
 			if err := priBatch.Set(keyScratch, val, nil); err != nil {
 				return err
 			}
+			if stats != nil {
+				stats.records.Add(1)
+				stats.priKeyBytes.Add(int64(len(keyScratch)))
+				stats.priValBytes.Add(int64(len(val)))
+			}
 			idxScratch, err = e.writeGrantIndexesScratch(idxBatch, r, idxScratch)
 			if err != nil {
 				return err
 			}
 		}
 
+		if stats != nil {
+			tStat = time.Now()
+		}
 		if err := priBatch.Commit(pebble.NoSync); err != nil {
 			return err
 		}
-		return idxBatch.Commit(pebble.NoSync)
+		if stats != nil {
+			stats.priCommitNs.Add(int64(time.Since(tStat)))
+			tStat = time.Now()
+		}
+		if err := idxBatch.Commit(pebble.NoSync); err != nil {
+			return err
+		}
+		if stats != nil {
+			stats.idxCommitNs.Add(int64(time.Since(tStat)))
+		}
+		return nil
 	})
 }
 
@@ -484,11 +535,16 @@ func (e *Engine) writeGrantIndexesScratch(batch *pebble.Batch, r *v3.GrantRecord
 	ent := r.GetEntitlement()
 	princ := r.GetPrincipal()
 	ext := r.GetExternalId()
+	stats := e.expandStats
 
 	if ent != nil && princ != nil {
 		scratch = appendGrantByEntitlementIndexKey(scratch[:0], ent.GetEntitlementId(), princ.GetResourceTypeId(), princ.GetResourceId(), ext)
 		if err := batch.Set(scratch, nil, nil); err != nil {
 			return scratch, err
+		}
+		if stats != nil {
+			stats.entKeys.Add(1)
+			stats.entBytes.Add(int64(len(scratch)))
 		}
 	}
 	if ent != nil && ent.GetResourceId() != "" {
@@ -496,21 +552,37 @@ func (e *Engine) writeGrantIndexesScratch(batch *pebble.Batch, r *v3.GrantRecord
 		if err := batch.Set(scratch, nil, nil); err != nil {
 			return scratch, err
 		}
+		if stats != nil {
+			stats.entResKeys.Add(1)
+			stats.entResBytes.Add(int64(len(scratch)))
+		}
 	}
 	if princ != nil {
 		scratch = appendGrantByPrincipalIndexKey(scratch[:0], princ.GetResourceTypeId(), princ.GetResourceId(), ext)
 		if err := batch.Set(scratch, nil, nil); err != nil {
 			return scratch, err
 		}
+		if stats != nil {
+			stats.prinKeys.Add(1)
+			stats.prinBytes.Add(int64(len(scratch)))
+		}
 		scratch = appendGrantByPrincipalResourceTypeIndexKey(scratch[:0], princ.GetResourceTypeId(), ext)
 		if err := batch.Set(scratch, nil, nil); err != nil {
 			return scratch, err
+		}
+		if stats != nil {
+			stats.prinRTKeys.Add(1)
+			stats.prinRTBytes.Add(int64(len(scratch)))
 		}
 	}
 	if r.GetNeedsExpansion() {
 		scratch = appendGrantByNeedsExpansionIndexKey(scratch[:0], ext)
 		if err := batch.Set(scratch, nil, nil); err != nil {
 			return scratch, err
+		}
+		if stats != nil {
+			stats.needsExpKeys.Add(1)
+			stats.needsExpBytes.Add(int64(len(scratch)))
 		}
 	}
 	return scratch, nil

--- a/pkg/dotc1z/engine/pebble/grants.go
+++ b/pkg/dotc1z/engine/pebble/grants.go
@@ -326,6 +326,105 @@ func (e *Engine) PutExpandedGrantRecords(ctx context.Context, records []*v3.Gran
 	})
 }
 
+// PutSynthesizedGrantRecords is the expander fast path for grants the caller
+// guarantees are brand-new for this sync: no record with the same external_id
+// exists yet. The topological merge knows this for every SYNTHESIZED grant — it
+// only synthesizes when the destination's base stream reported no existing
+// grant for the principal, so the deterministic external_id (D:rt:res) is
+// absent. That guarantee lets this path skip the per-record read-before-write
+// Get that PutExpandedGrantRecords issues to preserve side-state and clean
+// stale index entries. On the whale that Get was ~30% of expansion wall time
+// and >99.99% NotFound (synthesized keys never had a prior), so dropping it for
+// the synthesized majority is the single cheapest expansion win.
+//
+// Contract (mirrors UnsafePutUniqueGrantRecords minus the fresh-sync
+// requirement, since expansion runs on a resumed sync):
+//   - Each record's external_id must be absent in the current sync. The merge's
+//     "base stream empty ⇒ synthesize" decision is that guarantee.
+//   - Records carry no expansion side-state to preserve (Expansion nil,
+//     NeedsExpansion false); StoreExpandedGrants strips it before calling here.
+//   - discovered_at is stamped if unset.
+//
+// If the guarantee is ever violated the result is an overwritten primary whose
+// prior index entries may be orphaned — the same fail-safe every index path
+// already tolerates (iterators skip orphans; fsck reconciles). Commits NoSync
+// like PutExpandedGrantRecords; the sync-end flush hardens the data.
+func (e *Engine) PutSynthesizedGrantRecords(ctx context.Context, records []*v3.GrantRecord) error {
+	if len(records) == 0 {
+		return nil
+	}
+	return e.withWrite(func() error {
+		if err := e.requireCurrentSync(); err != nil {
+			return err
+		}
+		priBatch := e.db.NewBatch()
+		defer priBatch.Close()
+		idxBatch := e.db.NewBatch()
+		defer idxBatch.Close()
+
+		now := timestamppb.Now()
+		stats := e.expandStats
+		if stats != nil {
+			stats.calls.Add(1)
+		}
+		var tStat time.Time
+
+		// Scratch buffers reused across records, same as
+		// PutExpandedGrantRecords — pebble.Batch copies key/value on Set.
+		var keyScratch, valScratch, idxScratch []byte
+		for _, r := range records {
+			if r == nil {
+				continue
+			}
+			keyScratch = appendGrantKey(keyScratch[:0], r.GetExternalId())
+			if r.GetDiscoveredAt() == nil {
+				r.SetDiscoveredAt(now)
+			}
+			if stats != nil {
+				tStat = time.Now()
+			}
+			val, err := marshalRecordAppend(valScratch[:0], r)
+			if stats != nil {
+				stats.marshalNs.Add(int64(time.Since(tStat)))
+			}
+			if err != nil {
+				return err
+			}
+			valScratch = val
+			if err := priBatch.Set(keyScratch, val, nil); err != nil {
+				return err
+			}
+			if stats != nil {
+				stats.records.Add(1)
+				stats.priKeyBytes.Add(int64(len(keyScratch)))
+				stats.priValBytes.Add(int64(len(val)))
+			}
+			idxScratch, err = e.writeGrantIndexesScratch(idxBatch, r, idxScratch)
+			if err != nil {
+				return err
+			}
+		}
+
+		if stats != nil {
+			tStat = time.Now()
+		}
+		if err := priBatch.Commit(pebble.NoSync); err != nil {
+			return err
+		}
+		if stats != nil {
+			stats.priCommitNs.Add(int64(time.Since(tStat)))
+			tStat = time.Now()
+		}
+		if err := idxBatch.Commit(pebble.NoSync); err != nil {
+			return err
+		}
+		if stats != nil {
+			stats.idxCommitNs.Add(int64(time.Since(tStat)))
+		}
+		return nil
+	})
+}
+
 // UnsafePutUniqueGrantRecords is the trusted-import write path: it writes
 // records unconditionally, with NO read-before-write and NO dedup pass. Do not
 // use it for live connector output. The engine must currently be in fresh-sync
@@ -536,6 +635,15 @@ func (e *Engine) writeGrantIndexesScratch(batch *pebble.Batch, r *v3.GrantRecord
 	princ := r.GetPrincipal()
 	ext := r.GetExternalId()
 	stats := e.expandStats
+	// deferIdx: in defer mode, the three families that are NOT read during
+	// expansion (by_entitlement_resource, by_principal, by_principal_resource_type)
+	// are skipped inline and rebuilt in one sorted ingest at EndSync
+	// (BuildDeferredGrantIndexes). They're the scattered families that cause the
+	// worst out-of-order compaction churn. by_entitlement stays inline (the merge
+	// reads it) along with needs_expansion. The rebuild derives the principal
+	// families from by_entitlement keys and by_entitlement_resource from the
+	// entitlement->resource map.
+	deferIdx := e.deferGrantIndexes
 
 	if ent != nil && princ != nil {
 		scratch = appendGrantByEntitlementIndexKey(scratch[:0], ent.GetEntitlementId(), princ.GetResourceTypeId(), princ.GetResourceId(), ext)
@@ -547,7 +655,7 @@ func (e *Engine) writeGrantIndexesScratch(batch *pebble.Batch, r *v3.GrantRecord
 			stats.entBytes.Add(int64(len(scratch)))
 		}
 	}
-	if ent != nil && ent.GetResourceId() != "" {
+	if !deferIdx && ent != nil && ent.GetResourceId() != "" {
 		scratch = appendGrantByEntitlementResourceIndexKey(scratch[:0], ent.GetResourceTypeId(), ent.GetResourceId(), ext)
 		if err := batch.Set(scratch, nil, nil); err != nil {
 			return scratch, err
@@ -557,7 +665,7 @@ func (e *Engine) writeGrantIndexesScratch(batch *pebble.Batch, r *v3.GrantRecord
 			stats.entResBytes.Add(int64(len(scratch)))
 		}
 	}
-	if princ != nil {
+	if !deferIdx && princ != nil {
 		scratch = appendGrantByPrincipalIndexKey(scratch[:0], princ.GetResourceTypeId(), princ.GetResourceId(), ext)
 		if err := batch.Set(scratch, nil, nil); err != nil {
 			return scratch, err
@@ -574,6 +682,10 @@ func (e *Engine) writeGrantIndexesScratch(batch *pebble.Batch, r *v3.GrantRecord
 			stats.prinRTKeys.Add(1)
 			stats.prinRTBytes.Add(int64(len(scratch)))
 		}
+	}
+	if deferIdx {
+		// A deferred family was skipped; EndSync owes a rebuild.
+		e.deferredIdxPending.Store(true)
 	}
 	if r.GetNeedsExpansion() {
 		scratch = appendGrantByNeedsExpansionIndexKey(scratch[:0], ext)
@@ -599,19 +711,24 @@ func (e *Engine) deleteGrantIndexesScratch(batch *pebble.Batch, externalID strin
 	if err != nil {
 		return scratch, err
 	}
+	// In defer mode the three deferred families are rebuilt wholesale at EndSync,
+	// so deleting their prior entries here would just create tombstones the
+	// rebuild has to shadow. Skip them; by_entitlement (written inline) and
+	// needs_expansion are cleaned here as usual.
+	deferIdx := e.deferGrantIndexes
 	if entID != "" && principalRT != "" && principalID != "" {
 		scratch = appendGrantByEntitlementIndexKey(scratch[:0], entID, principalRT, principalID, externalID)
 		if err := batch.Delete(scratch, nil); err != nil {
 			return scratch, err
 		}
 	}
-	if entRID != "" {
+	if !deferIdx && entRID != "" {
 		scratch = appendGrantByEntitlementResourceIndexKey(scratch[:0], entRT, entRID, externalID)
 		if err := batch.Delete(scratch, nil); err != nil {
 			return scratch, err
 		}
 	}
-	if principalRT != "" && principalID != "" {
+	if !deferIdx && principalRT != "" && principalID != "" {
 		scratch = appendGrantByPrincipalIndexKey(scratch[:0], principalRT, principalID, externalID)
 		if err := batch.Delete(scratch, nil); err != nil {
 			return scratch, err

--- a/pkg/dotc1z/engine/pebble/paginate.go
+++ b/pkg/dotc1z/engine/pebble/paginate.go
@@ -213,7 +213,7 @@ func (e *Engine) PaginateGrantsByEntitlement(
 		if externalID == "" {
 			continue
 		}
-		val, closer, getErr := e.db.Get(encodeGrantKey(externalID))
+		val, closer, getErr := e.getGrantPrimaryTimed(encodeGrantKey(externalID))
 		if getErr != nil {
 			if errors.Is(getErr, pebble.ErrNotFound) {
 				// Orphan index entry — primary deleted before the
@@ -336,7 +336,7 @@ func (e *Engine) PaginateGrantsByEntitlementPrincipal(
 		if externalID == "" {
 			continue
 		}
-		val, closer, getErr := e.db.Get(encodeGrantKey(externalID))
+		val, closer, getErr := e.getGrantPrimaryTimed(encodeGrantKey(externalID))
 		if getErr != nil {
 			if errors.Is(getErr, pebble.ErrNotFound) {
 				continue
@@ -399,7 +399,7 @@ func (e *Engine) PaginateGrantsByPrincipal(
 		if externalID == "" {
 			continue
 		}
-		val, closer, getErr := e.db.Get(encodeGrantKey(externalID))
+		val, closer, getErr := e.getGrantPrimaryTimed(encodeGrantKey(externalID))
 		if getErr != nil {
 			if errors.Is(getErr, pebble.ErrNotFound) {
 				// Orphan index entry — primary deleted before the
@@ -472,7 +472,7 @@ func (e *Engine) PaginateGrantsByEntitlementResource(
 		if externalID == "" {
 			continue
 		}
-		val, closer, getErr := e.db.Get(encodeGrantKey(externalID))
+		val, closer, getErr := e.getGrantPrimaryTimed(encodeGrantKey(externalID))
 		if getErr != nil {
 			if errors.Is(getErr, pebble.ErrNotFound) {
 				continue
@@ -536,7 +536,7 @@ func (e *Engine) PaginateGrantsByPrincipalResourceType(
 		if externalID == "" {
 			continue
 		}
-		val, closer, getErr := e.db.Get(encodeGrantKey(externalID))
+		val, closer, getErr := e.getGrantPrimaryTimed(encodeGrantKey(externalID))
 		if getErr != nil {
 			if errors.Is(getErr, pebble.ErrNotFound) {
 				continue
@@ -603,7 +603,7 @@ func (e *Engine) PaginateGrantsByNeedsExpansion(
 		if externalID == "" {
 			continue
 		}
-		val, closer, getErr := e.db.Get(encodeGrantKey(externalID))
+		val, closer, getErr := e.getGrantPrimaryTimed(encodeGrantKey(externalID))
 		if getErr != nil {
 			if errors.Is(getErr, pebble.ErrNotFound) {
 				// Orphan index entry; skip.

--- a/pkg/dotc1z/pebble_store.go
+++ b/pkg/dotc1z/pebble_store.go
@@ -478,6 +478,23 @@ func (g pebbleStoreGrants) StoreExpandedGrants(ctx context.Context, grants ...*v
 	return g.store.markDirty(g.inner.StoreExpandedGrants(ctx, grants...))
 }
 
+// StoreNewExpandedGrants forwards the expander's synthesized-grant fast path
+// (no read-before-write Get) to the engine-level grant store when it supports
+// it, flipping the dirty bit like StoreExpandedGrants. Falls back to the
+// read-merge path otherwise. This wrapper must expose the method explicitly:
+// the optional fast-path interface is satisfied by the engine's grant store
+// (g.inner), but callers see this wrapper, so without this passthrough the
+// expander's interface assertion fails and every synthesized grant takes the
+// redundant Get path.
+func (g pebbleStoreGrants) StoreNewExpandedGrants(ctx context.Context, grants ...*v2.Grant) error {
+	if fast, ok := g.inner.(interface {
+		StoreNewExpandedGrants(context.Context, ...*v2.Grant) error
+	}); ok {
+		return g.store.markDirty(fast.StoreNewExpandedGrants(ctx, grants...))
+	}
+	return g.store.markDirty(g.inner.StoreExpandedGrants(ctx, grants...))
+}
+
 func (g pebbleStoreGrants) PendingExpansionPage(ctx context.Context, pageToken string) ([]PendingExpansion, string, error) {
 	return g.inner.PendingExpansionPage(ctx, pageToken)
 }

--- a/pkg/sync/expand/expand_benchmark_test.go
+++ b/pkg/sync/expand/expand_benchmark_test.go
@@ -221,6 +221,16 @@ func (s benchmarkExpanderStore) StoreExpandedGrants(ctx context.Context, grants 
 	return s.store.Grants().StoreExpandedGrants(ctx, grants...)
 }
 
+func (s benchmarkExpanderStore) StoreNewExpandedGrants(ctx context.Context, grants ...*v2.Grant) error {
+	gs := s.store.Grants()
+	if fast, ok := gs.(interface {
+		StoreNewExpandedGrants(context.Context, ...*v2.Grant) error
+	}); ok {
+		return fast.StoreNewExpandedGrants(ctx, grants...)
+	}
+	return gs.StoreExpandedGrants(ctx, grants...)
+}
+
 func (s benchmarkExpanderStore) GrantsForEntitlementPrincipalSorted() bool {
 	store, ok := s.store.(interface {
 		GrantsForEntitlementPrincipalSorted() bool

--- a/pkg/sync/expand/expander.go
+++ b/pkg/sync/expand/expander.go
@@ -80,6 +80,17 @@ type ExpanderStore interface {
 	GrantsForEntitlementPrincipalSorted() bool
 }
 
+// newExpandedGrantStorer is an optional ExpanderStore fast path for grants the
+// merge knows are brand-new (synthesized): no prior record exists for their
+// external_id, so the store can skip the read-before-write Get and stale-index
+// cleanup that StoreExpandedGrants performs. Stores that do not implement it
+// fall back to StoreExpandedGrants, which is always correct. The topological
+// merge proves the "no prior" precondition via its base-stream-empty decision;
+// see PutSynthesizedGrantRecords for the engine-side contract.
+type newExpandedGrantStorer interface {
+	StoreNewExpandedGrants(ctx context.Context, grants ...*v2.Grant) error
+}
+
 // entitlementGrantPrincipalKeyLister is an optional fast path for stores that
 // can list only descendant principal identities without materializing full
 // grants. Returned keys must use descendantGrantKey(resourceType, resource).

--- a/pkg/sync/expand/graph.go
+++ b/pkg/sync/expand/graph.go
@@ -96,6 +96,15 @@ type EntitlementGraphMetrics struct {
 	NodesReduced            int64  `json:"nodes_reduced"`
 	DestinationEntitlements int64  `json:"destination_entitlements"`
 	DirtyGrantsWritten      int64  `json:"dirty_grants_written"`
+	// SynthesizedGrants and BaseUpdateGrants partition DirtyGrantsWritten by
+	// the merge's two output arms: a synthesized grant is a brand-new expanded
+	// grant (deterministic external_id D:rt:res, index keys derivable), while a
+	// base-update grant is an existing connector grant whose Sources gained a
+	// contribution (arbitrary external_id, requires a proto rewrite). Their
+	// ratio sizes the irreducible proto-rewrite floor for any deferred/sorted
+	// index-build fast path. They must sum to DirtyGrantsWritten.
+	SynthesizedGrants int64 `json:"synthesized_grants"`
+	BaseUpdateGrants  int64 `json:"base_update_grants"`
 }
 
 func NewEntitlementGraph(_ context.Context) *EntitlementGraph {

--- a/pkg/sync/expand/skipget_diag_test.go
+++ b/pkg/sync/expand/skipget_diag_test.go
@@ -1,0 +1,38 @@
+package expand
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSynthesizedGrantFastPathWired guards the synthesized-grant fast path
+// (skip the read-before-write Get for brand-new expanded grants) against silent
+// breakage. The optimization only engages if every store layer between the
+// merge and the engine exposes StoreNewExpandedGrants; if any wrapper hides it,
+// the expander's interface assertion fails and synthesized grants silently fall
+// back to the Get path — correct, but 0% faster, with no test failure. This
+// asserts the assertions succeed at both layers the expander uses.
+func TestSynthesizedGrantFastPathWired(t *testing.T) {
+	ctx := context.Background()
+
+	// Sink-level: the ExpanderStore the merge holds must route synthesized
+	// batches to the fast path.
+	var s ExpanderStore = benchmarkExpanderStore{}
+	_, ok := s.(newExpandedGrantStorer)
+	require.True(t, ok, "benchmarkExpanderStore must satisfy newExpandedGrantStorer")
+
+	// Store-level: the dotc1z grant store wrapper returned by store.Grants()
+	// must expose the fast path too (the layer the first whale run tripped on:
+	// pebbleStoreGrants wraps the engine store and previously hid the method).
+	path := filepath.Join(t.TempDir(), "fastpath.pebble.c1z")
+	store, err := dotc1z.NewStore(ctx, path, dotc1z.WithEngine(dotc1z.EnginePebble))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, store.Close(ctx)) }()
+
+	_, ok = store.Grants().(newExpandedGrantStorer)
+	require.True(t, ok, "pebble store.Grants() must expose StoreNewExpandedGrants")
+}

--- a/pkg/sync/expand/topological_merge.go
+++ b/pkg/sync/expand/topological_merge.go
@@ -3,6 +3,7 @@ package expand
 import (
 	"context"
 	"fmt"
+	"os"
 	"sort"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
@@ -30,41 +31,87 @@ import (
 // multi-flush path on small fixtures; production never mutates it.
 var expansionDirtyFlushChunk = 10000
 
+// synthesizedSkipGetEnabled gates the synthesized-grant write fast path that
+// skips the per-record read-before-write Get. Enabled via env
+// BATON_EXPAND_SKIP_GET so it can be measured in combination with the deferred
+// index build (BATON_PEBBLE_DEFER_EXPANSION_INDEXES).
+//
+// UNSOUND in production until grant keys are injective: the lossy ":"-joined
+// deterministic id lets two distinct (entitlement, principal) pairs fold to one
+// primary key, and the Get is what keeps that case from orphaning index entries
+// (and silently dropping a grant). Use only for perf measurement until the
+// escaped-tuple identity change lands.
+var synthesizedSkipGetEnabled = os.Getenv("BATON_EXPAND_SKIP_GET") != ""
+
 // destinationSink persists a batch of dirty grants for the destination currently
 // being reduced. Reduce implementations call it repeatedly (via dirtyFlusher) so
 // the write buffer stays bounded regardless of how many grants a destination
-// produces.
-type destinationSink func(ctx context.Context, dirty []*v2.Grant) error
+// produces. allNew is true when every grant in the batch is freshly SYNTHESIZED
+// (no prior record exists for its external_id), which lets the sink route to a
+// store fast path that skips the read-before-write Get; false for base-update
+// batches, which mutate an existing grant and must take the read-merge path.
+type destinationSink func(ctx context.Context, dirty []*v2.Grant, allNew bool) error
 
 // dirtyFlusher buffers dirty grants and flushes them through a destinationSink
-// once the buffer reaches its limit. The buffer is reused across flushes; the
-// sink consumes each batch synchronously before the buffer is truncated.
+// once a buffer reaches its limit. Synthesized and base-update grants are
+// buffered separately so each flushes as a homogeneous batch (all-new vs
+// update), letting the all-new batches take the Get-skipping store path. Buffers
+// are reused across flushes; the sink consumes each batch synchronously before
+// the buffer is truncated.
 type dirtyFlusher struct {
-	sink  destinationSink
-	limit int
-	buf   []*v2.Grant
+	sink   destinationSink
+	limit  int
+	synth  []*v2.Grant
+	update []*v2.Grant
 }
 
 func newDirtyFlusher(sink destinationSink) *dirtyFlusher {
 	return &dirtyFlusher{sink: sink, limit: expansionDirtyFlushChunk}
 }
 
-func (f *dirtyFlusher) add(ctx context.Context, grant *v2.Grant) error {
-	f.buf = append(f.buf, grant)
-	if len(f.buf) >= f.limit {
-		return f.flush(ctx)
+// add buffers one dirty grant. isNew marks a freshly synthesized grant (no
+// prior record); false marks a base-update of an existing grant.
+func (f *dirtyFlusher) add(ctx context.Context, grant *v2.Grant, isNew bool) error {
+	if isNew {
+		f.synth = append(f.synth, grant)
+		if len(f.synth) >= f.limit {
+			return f.flushSynth(ctx)
+		}
+		return nil
+	}
+	f.update = append(f.update, grant)
+	if len(f.update) >= f.limit {
+		return f.flushUpdate(ctx)
 	}
 	return nil
 }
 
 func (f *dirtyFlusher) flush(ctx context.Context) error {
-	if len(f.buf) == 0 {
-		return nil
-	}
-	if err := f.sink(ctx, f.buf); err != nil {
+	if err := f.flushSynth(ctx); err != nil {
 		return err
 	}
-	f.buf = f.buf[:0]
+	return f.flushUpdate(ctx)
+}
+
+func (f *dirtyFlusher) flushSynth(ctx context.Context) error {
+	if len(f.synth) == 0 {
+		return nil
+	}
+	if err := f.sink(ctx, f.synth, true); err != nil {
+		return err
+	}
+	f.synth = f.synth[:0]
+	return nil
+}
+
+func (f *dirtyFlusher) flushUpdate(ctx context.Context) error {
+	if len(f.update) == 0 {
+		return nil
+	}
+	if err := f.sink(ctx, f.update, false); err != nil {
+		return err
+	}
+	f.update = f.update[:0]
 	return nil
 }
 
@@ -135,11 +182,29 @@ func (e *Expander) driveTopological(
 ) error {
 	logFanInWidth(ctx, e.graph, order)
 
-	sink := func(ctx context.Context, dirty []*v2.Grant) error {
+	sink := func(ctx context.Context, dirty []*v2.Grant, allNew bool) error {
 		if len(dirty) == 0 {
 			return nil
 		}
-		if err := e.store.StoreExpandedGrants(ctx, dirty...); err != nil {
+		// All-new (synthesized) batches have no prior record on the same
+		// (entitlement, principal), so in principle they can skip the
+		// read-before-write Get via the store's fast path. That is GATED OFF
+		// for now (synthesizedSkipGetEnabled): the deterministic grant id is a
+		// lossy ":"-join, so two distinct (entitlement, principal) tuples can
+		// fold to the same primary key. The Get is what keeps that case sound
+		// (it cleans the shadowed record's index entries); skipping it orphans
+		// them. Re-enable only once grant keys are injective (escaped-tuple
+		// identity) so the fold cannot occur — then we want to measure the
+		// combination. Until then every batch takes the read-merge path.
+		if allNew && synthesizedSkipGetEnabled {
+			if fast, ok := e.store.(newExpandedGrantStorer); ok {
+				if err := fast.StoreNewExpandedGrants(ctx, dirty...); err != nil {
+					return fmt.Errorf("topological merge: store new expanded grants: %w", err)
+				}
+			} else if err := e.store.StoreExpandedGrants(ctx, dirty...); err != nil {
+				return fmt.Errorf("topological merge: store expanded grants: %w", err)
+			}
+		} else if err := e.store.StoreExpandedGrants(ctx, dirty...); err != nil {
 			return fmt.Errorf("topological merge: store expanded grants: %w", err)
 		}
 		if run.onStored != nil {

--- a/pkg/sync/expand/topological_merge_projection.go
+++ b/pkg/sync/expand/topological_merge_projection.go
@@ -74,7 +74,7 @@ func (e *Expander) RunTopologicalMergeProjection(ctx context.Context) error {
 	lastLog := expandStart
 	err = e.driveTopological(ctx, entitlements, order, topologicalRun{
 		reduce: func(ctx context.Context, dest *v2.Entitlement, incoming []topoIncomingEdge, ents map[string]*v2.Entitlement, sink destinationSink) error {
-			return e.mergeDestinationStreams(ctx, dest, incoming, ents, projDB, projectionSources, sink)
+			return e.mergeDestinationStreams(ctx, dest, incoming, ents, projDB, projectionSources, sink, metrics)
 		},
 		onStored: func(_ context.Context, dirty []*v2.Grant) error {
 			addedRows, err := addProjectionRows(projDB, dirty, projectionSources)
@@ -112,6 +112,8 @@ func (e *Expander) RunTopologicalMergeProjection(ctx context.Context) error {
 	l.Info("topological projection: expansion complete",
 		zap.Int("nodes_total", len(order)),
 		zap.Int64("dirty_grants_written", metrics.DirtyGrantsWritten),
+		zap.Int64("synthesized_grants", metrics.SynthesizedGrants),
+		zap.Int64("base_update_grants", metrics.BaseUpdateGrants),
 		zap.Int64("projection_rows", metrics.ProjectionRowsBuilt),
 		zap.Int64("nodes_reduced", metrics.NodesReduced),
 		zap.Duration("elapsed", time.Since(expandStart)),
@@ -134,6 +136,7 @@ func (e *Expander) mergeDestinationStreams(
 	projDB *pebble.DB,
 	projectionSources map[string]struct{},
 	sink destinationSink,
+	metrics *EntitlementGraphMetrics,
 ) error {
 	streams := make([]contributionGroupStream, 0, 1+len(incoming))
 	streams = append(streams, &baseContributionStream{
@@ -162,7 +165,7 @@ func (e *Expander) mergeDestinationStreams(
 			})
 		}
 	}
-	return mergeContributionGroupStreams(ctx, destEntitlement, streams, sink)
+	return mergeContributionGroupStreams(ctx, destEntitlement, streams, sink, metrics)
 }
 
 // buildProjectionDB scans the projection-source entitlements once and ingests a

--- a/pkg/sync/expand/topological_merge_projection.go
+++ b/pkg/sync/expand/topological_merge_projection.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/cockroachdb/pebble/v2"
@@ -45,7 +46,22 @@ func (e *Expander) RunTopologicalMergeProjection(ctx context.Context) error {
 	}
 	defer os.RemoveAll(tempDir)
 
-	projDB, err := pebble.Open(filepath.Join(tempDir, "db"), &pebble.Options{})
+	// The projection DB is the merge's read path (each destination pulls its
+	// projected source streams from here). Pebble's default cache is only 8MB,
+	// which is too small for a hot read DB; give it a modest 64MB (env-tunable).
+	// Note: a larger cache did NOT speed up the whale measurably — projection
+	// fan-out is mostly 1, so sources are scanned once and there is little to
+	// re-cache — but 8MB is still poor hygiene for higher-fan-out tenants. The
+	// cache is owned here and Unref'd after the DB closes.
+	projCacheMB := 64
+	if v := os.Getenv("BATON_EXPAND_PROJECTION_CACHE_MB"); v != "" {
+		if n, perr := strconv.Atoi(v); perr == nil && n > 0 {
+			projCacheMB = n
+		}
+	}
+	projCache := pebble.NewCache(int64(projCacheMB) << 20)
+	defer projCache.Unref()
+	projDB, err := pebble.Open(filepath.Join(tempDir, "db"), &pebble.Options{Cache: projCache})
 	if err != nil {
 		return fmt.Errorf("topological projection: open temp db: %w", err)
 	}

--- a/pkg/sync/expand/topological_merge_streaming.go
+++ b/pkg/sync/expand/topological_merge_streaming.go
@@ -373,7 +373,10 @@ func mergeContributionGroupStreams(
 			if err != nil {
 				return err
 			}
-			if err := flusher.add(ctx, grant); err != nil {
+			// Synthesized: base stream reported no grant for this principal on
+			// the destination, so the deterministic external_id is brand-new and
+			// the store can skip its read-before-write Get.
+			if err := flusher.add(ctx, grant, true); err != nil {
 				return err
 			}
 			if metrics != nil {
@@ -384,7 +387,9 @@ func mergeContributionGroupStreams(
 		for _, baseGrant := range base {
 			updated := mergeContributionIntoExistingGrant(baseGrant, destEntitlement.GetId(), contrib.sources)
 			if updated != nil {
-				if err := flusher.add(ctx, updated); err != nil {
+				// Base update: rewrites an existing grant's Sources, so a prior
+				// record exists and the store must take the read-merge path.
+				if err := flusher.add(ctx, updated, false); err != nil {
 					return err
 				}
 				if metrics != nil {

--- a/pkg/sync/expand/topological_merge_streaming.go
+++ b/pkg/sync/expand/topological_merge_streaming.go
@@ -20,7 +20,7 @@ func (e *Expander) RunTopologicalMergeStreaming(ctx context.Context) error {
 	}
 	if err := e.driveTopological(ctx, entitlements, order, topologicalRun{
 		reduce: func(ctx context.Context, dest *v2.Entitlement, incoming []topoIncomingEdge, ents map[string]*v2.Entitlement, sink destinationSink) error {
-			return e.mergeDestinationStreams(ctx, dest, incoming, ents, nil, nil, sink)
+			return e.mergeDestinationStreams(ctx, dest, incoming, ents, nil, nil, sink, nil)
 		},
 	}); err != nil {
 		return err
@@ -306,6 +306,7 @@ func mergeContributionGroupStreams(
 	destEntitlement *v2.Entitlement,
 	streams []contributionGroupStream,
 	sink destinationSink,
+	metrics *EntitlementGraphMetrics,
 ) error {
 	for _, stream := range streams {
 		defer stream.close()
@@ -375,6 +376,9 @@ func mergeContributionGroupStreams(
 			if err := flusher.add(ctx, grant); err != nil {
 				return err
 			}
+			if metrics != nil {
+				metrics.SynthesizedGrants++
+			}
 			continue
 		}
 		for _, baseGrant := range base {
@@ -382,6 +386,9 @@ func mergeContributionGroupStreams(
 			if updated != nil {
 				if err := flusher.add(ctx, updated); err != nil {
 					return err
+				}
+				if metrics != nil {
+					metrics.BaseUpdateGrants++
 				}
 			}
 		}

--- a/pkg/sync/expand/topological_merge_streaming.go
+++ b/pkg/sync/expand/topological_merge_streaming.go
@@ -324,22 +324,36 @@ func mergeContributionGroupStreams(
 	}
 
 	flusher := newDirtyFlusher(sink)
+
+	// Reuse the per-principal accumulator (struct + sources map) and the base
+	// slice across iterations rather than allocating fresh ones per output
+	// group — there are tens of millions of groups on a large expansion, and
+	// that churn was a measurable share of GC time. Safe because
+	// newExpandedGrantWithSources and mergeContributionIntoExistingGrant copy
+	// out of contrib.sources, and the output grant holds its own reference to
+	// the principal, so clearing contrib after each group keeps nothing alive.
+	contrib := &topoContribution{}
+	var base []*v2.Grant
+	consume := func(group contributionGroup) {
+		if group.isBase {
+			base = append(base, group.base...)
+			return
+		}
+		contrib.merge(group.contrib)
+	}
 	for h.Len() > 0 {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
 		item := heap.Pop(&h).(mergeHeapItem)
 		key := item.group.key
-		var base []*v2.Grant
-		contrib := &topoContribution{}
-
-		consume := func(group contributionGroup) {
-			if group.isBase {
-				base = append(base, group.base...)
-				return
-			}
-			contrib.merge(group.contrib)
+		base = base[:0]
+		if contrib.sources != nil {
+			clear(contrib.sources)
 		}
+		contrib.principal = nil
+		contrib.principalBytes = nil
+
 		consume(item.group)
 
 		if next, ok, err := streams[item.streamID].next(ctx); err != nil {

--- a/pkg/sync/expand/topological_merge_test.go
+++ b/pkg/sync/expand/topological_merge_test.go
@@ -43,7 +43,7 @@ func TestMergeContributionGroupStreamsChecksContextDuringMergeLoop(t *testing.T)
 	err := mergeContributionGroupStreams(ctx, makeEntitlement("ent:dest", makeResource("group", "dest")), []contributionGroupStream{stream}, func(context.Context, []*v2.Grant) error {
 		sinkCalled = true
 		return nil
-	})
+	}, nil)
 
 	require.Error(t, err)
 	require.True(t, errors.Is(err, context.Canceled))

--- a/pkg/sync/expand/topological_merge_test.go
+++ b/pkg/sync/expand/topological_merge_test.go
@@ -40,7 +40,7 @@ func TestMergeContributionGroupStreamsChecksContextDuringMergeLoop(t *testing.T)
 	stream := &cancelingBaseGroupStream{cancel: cancel, remaining: 3}
 	sinkCalled := false
 
-	err := mergeContributionGroupStreams(ctx, makeEntitlement("ent:dest", makeResource("group", "dest")), []contributionGroupStream{stream}, func(context.Context, []*v2.Grant) error {
+	err := mergeContributionGroupStreams(ctx, makeEntitlement("ent:dest", makeResource("group", "dest")), []contributionGroupStream{stream}, func(context.Context, []*v2.Grant, bool) error {
 		sinkCalled = true
 		return nil
 	}, nil)

--- a/pkg/sync/expand/whale_pebble_expansion_test.go
+++ b/pkg/sync/expand/whale_pebble_expansion_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	enginepkg "github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -59,14 +60,64 @@ func TestRunWhalePebbleProjectionExpansion(t *testing.T) {
 	require.NoError(t, graph.FixCycles(ctx))
 	t.Logf("graph: %d nodes, %d edges (cycles fixed, has_no_cycles=%t)", len(graph.Nodes), len(graph.Edges), graph.HasNoCycles)
 
+	// Engine-level write-path instrumentation (diagnostic): attributes the
+	// expansion write cost to Get / marshal / index-delete / primary-commit /
+	// index-commit and breaks index volume out per family. Reachable because
+	// the Pebble store satisfies connectorstore.Writer.
+	var eng *enginepkg.Engine
+	var metricsBefore string
+	if w, ok := store.(connectorstore.Writer); ok {
+		if e, ok := enginepkg.AsEngine(w); ok {
+			eng = e
+			eng.EnableExpandWriteStats()
+			metricsBefore = eng.DB().Metrics().String()
+		}
+	}
+
 	expandStart := time.Now()
 	expander := NewExpander(benchmarkExpanderStore{store: store}, graph)
 	require.NoError(t, expander.RunTopologicalMergeProjection(ctx))
-	t.Logf("projection expansion finished in %s", time.Since(expandStart))
+	elapsed := time.Since(expandStart)
+	t.Logf("projection expansion finished in %s", elapsed)
+
+	if eng != nil {
+		if s, ok := eng.ExpandWriteStats(); ok {
+			writeDur := s.GetDur + s.MarshalDur + s.DeleteIdxDur + s.PriCommitDur + s.IdxCommitDur
+			t.Logf("write-path time split (sum across %d calls, %d records):", s.Calls, s.Records)
+			t.Logf("  rbw-get      = %-12s (read-before-write; count=%d notfound=%d)", s.GetDur, s.GetCount, s.GetNotFound)
+			t.Logf("  marshal      = %s", s.MarshalDur)
+			t.Logf("  delete-index = %s", s.DeleteIdxDur)
+			t.Logf("  pri-commit   = %-12s (main blob: %d keys, %d val bytes)", s.PriCommitDur, s.Records, s.PriValBytes)
+			t.Logf("  idx-commit   = %s", s.IdxCommitDur)
+			t.Logf("  write total  = %-12s (%.1f%% of %s expansion)",
+				writeDur, 100*float64(writeDur)/float64(elapsed), elapsed)
+			t.Logf("read-path materialization get (by_entitlement primary Get per index row):")
+			t.Logf("  read-get     = %-12s (count=%d notfound=%d, %.1f%% of %s expansion)",
+				s.ReadGetDur, s.ReadGetCount, s.ReadGetNotFound, 100*float64(s.ReadGetDur)/float64(elapsed), elapsed)
+			t.Logf("  write+read get accounted = %.1f%% of expansion (remainder is merge compute, iteration, projection build/ingest)",
+				100*float64(writeDur+s.ReadGetDur)/float64(elapsed))
+			t.Logf("index family volume (keys / bytes):")
+			t.Logf("  by_entitlement          = %d / %d", s.ByEntitlementKeys, s.ByEntitlementBytes)
+			t.Logf("  by_entitlement_resource = %d / %d", s.ByEntitlementResourceKeys, s.ByEntitlementResourceBytes)
+			t.Logf("  by_principal            = %d / %d", s.ByPrincipalKeys, s.ByPrincipalBytes)
+			t.Logf("  by_principal_rtype      = %d / %d", s.ByPrincipalResourceTypeKeys, s.ByPrincipalResourceTypeBytes)
+			t.Logf("  needs_expansion         = %d / %d", s.NeedsExpansionKeys, s.NeedsExpansionBytes)
+			totalIdxKeys := s.ByEntitlementKeys + s.ByEntitlementResourceKeys + s.ByPrincipalKeys + s.ByPrincipalResourceTypeKeys + s.NeedsExpansionKeys
+			totalIdxBytes := s.ByEntitlementBytes + s.ByEntitlementResourceBytes + s.ByPrincipalBytes + s.ByPrincipalResourceTypeBytes + s.NeedsExpansionBytes
+			t.Logf("  TOTAL index             = %d keys / %d bytes (vs %d primary keys / %d primary bytes)",
+				totalIdxKeys, totalIdxBytes, s.Records, s.PriValBytes)
+		}
+		t.Logf("pebble metrics BEFORE expansion:\n%s", metricsBefore)
+		t.Logf("pebble metrics AFTER expansion (compaction/flush/WAL cumulative since open):\n%s", eng.DB().Metrics().String())
+	}
 
 	if m := graph.ExpansionMetrics; m != nil {
-		t.Logf("metrics: algorithm=%s dirty_grants_written=%d projection_rows=%d nodes_reduced=%d dest_entitlements=%d",
-			m.Algorithm, m.DirtyGrantsWritten, m.ProjectionRowsBuilt, m.NodesReduced, m.DestinationEntitlements)
+		t.Logf("metrics: algorithm=%s dirty_grants_written=%d synthesized=%d base_update=%d projection_rows=%d nodes_reduced=%d dest_entitlements=%d",
+			m.Algorithm, m.DirtyGrantsWritten, m.SynthesizedGrants, m.BaseUpdateGrants, m.ProjectionRowsBuilt, m.NodesReduced, m.DestinationEntitlements)
+		if total := m.SynthesizedGrants + m.BaseUpdateGrants; total > 0 {
+			t.Logf("base-update fraction: %.4f (%d / %d) — sizes the proto-rewrite floor for a sorted index-build fast path",
+				float64(m.BaseUpdateGrants)/float64(total), m.BaseUpdateGrants, total)
+		}
 	}
 
 	require.NoError(t, store.EndSync(ctx))

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -201,6 +201,21 @@ func (a expanderStoreAdapter) StoreExpandedGrants(ctx context.Context, grants ..
 	return a.store.Grants().StoreExpandedGrants(ctx, grants...)
 }
 
+// StoreNewExpandedGrants forwards the expander's brand-new (synthesized) grant
+// batches to the engine's Get-skipping fast path when the grant store supports
+// it (Pebble), and falls back to the normal read-merge path otherwise (SQLite),
+// so behavior is identical across engines — only the redundant read-before-write
+// Get is elided. Detected by the expander via interface assertion.
+func (a expanderStoreAdapter) StoreNewExpandedGrants(ctx context.Context, grants ...*v2.Grant) error {
+	gs := a.store.Grants()
+	if fast, ok := gs.(interface {
+		StoreNewExpandedGrants(context.Context, ...*v2.Grant) error
+	}); ok {
+		return fast.StoreNewExpandedGrants(ctx, grants...)
+	}
+	return gs.StoreExpandedGrants(ctx, grants...)
+}
+
 // GrantsForEntitlementPrincipalSorted forwards the underlying engine's
 // principal-sort guarantee (Pebble) so the topological merge can stream grant
 // groups instead of buffering and sorting each entitlement. Engines that do not


### PR DESCRIPTION
## Summary

Speeds up Pebble grant expansion on large tenants by attacking the two biggest
write-path costs, both behind off-by-default env flags so merging changes no
behavior until explicitly enabled (remove those)

1. **Deferred index build** (`BATON_PEBBLE_DEFER_EXPANSION_INDEXES`) — during
   expansion, skip the three grant index families that are *not* read by the
   merge (`by_entitlement_resource`, `by_principal`, `by_principal_resource_type`)
   and rebuild them once at `EndSync` from a single `by_entitlement` scan →
   spill-sort → one sorted SST ingest per family. Trades millions of
   out-of-order inline index writes (the dominant compaction-churn source) for
   one external sort. `by_entitlement` + `needs_expansion` stay inline (the merge
   reads `by_entitlement`).

2. **Synthesized-grant skip-Get** (`BATON_EXPAND_SKIP_GET`) — expanded grants the
   merge knows are brand-new skip the per-record read-before-write `Get` (and
   stale-index cleanup) that only exists to merge a prior record. Routed via a
   new `StoreNewExpandedGrants` fast path (`PutSynthesizedGrantRecords`).

3. **Write-path instrumentation** — `expandWriteStats` attributes expansion
   write time across `rbw-get` / marshal / index-delete / primary-commit /
   index-commit and breaks index volume out per family, plus a persisted whale
   harness test for end-to-end measurement.

TODO: 

- [ ] Fix soundness issue with colon delimited indexes.
- [ ] Remove the stats thing (probably)

## Performance (whale: ~3.68M base → 54M expanded grants)

| config | expansion wall | `rbw-get` | `idx-commit` |
|---|---|---|---|
| baseline (inline) | 9m14s | 3m12s (54M no-op Gets) | 2m08s |
| defer + skip-Get | **3m39s** | **8ms** (1.5K real Gets) | **11.6s** |

~2.5× faster expansion; compaction write dropped ~100GB → ~53GB, estimated debt
17GB → ~6GB. The deferred build itself is ~1m17s for all three families
(single amortized scan + parallel merge).

## Safety

- Both paths are **off by default** (env-gated); no behavior change on merge.
- `skip-Get` depends on the deterministic grant-id assumption and is **not yet
  safe to enable in production** — it must wait on the injective grant-id fix
  (a non-injective id could let two distinct `(entitlement, principal)` tuples
  collide). Shipped here gated-off for measurement only.
- The deferred build is a pure function of durable, checkpoint-captured
  `by_entitlement` state (resumable) and produces **byte-identical** index
  keyspaces to inline writes (`TestDeferredGrantIndexesMatchInline`).