### PR TITLE
Windows: Add config option to log to event log.

### DIFF
--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -46,6 +46,11 @@ const (
 	otelShutdownTimeout = 5 * time.Second
 )
 
+// eventLogEnabledKey marks the context when the user passed --log-event-log.
+// The flag is only registered on Windows; the Windows initLogger reads this
+// value to redirect logging to the Windows event log.
+type eventLogEnabledKey struct{}
+
 type ContrainstSetter func(*cobra.Command, field.Configuration) error
 
 // In one shot & service mode, the child process uses this client to connect to the session store server...
@@ -117,11 +122,22 @@ func MakeMainCommand[T field.Configurable](
 			return err
 		}
 
-		runCtx, err := initLogger(
-			ctx,
-			name,
+		logOpts := []logging.Option{
 			logging.WithLogFormat(v.GetString("log-format")),
 			logging.WithLogLevel(v.GetString("log-level")),
+		}
+		logPaths := v.GetStringSlice("log-path")
+		if len(logPaths) > 0 {
+			logOpts = append(logOpts, logging.WithOutputPaths(logPaths))
+		}
+		loggerCtx := ctx
+		if v.GetBool(field.LogEventLogFieldName) {
+			loggerCtx = context.WithValue(loggerCtx, eventLogEnabledKey{}, true)
+		}
+		runCtx, err := initLogger(
+			loggerCtx,
+			name,
+			logOpts...,
 		)
 		if err != nil {
 			return err

--- a/pkg/cli/service_windows.go
+++ b/pkg/cli/service_windows.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/debug"
 	"golang.org/x/sys/windows/svc/eventlog"
@@ -91,14 +92,116 @@ func getExePath() (string, error) {
 	return p, err
 }
 
+const defaultEventLogID uint32 = 1
+const windowsEventIDKey = "event_id"
+
+// eventLogCore writes zap log entries to the Windows Event Log with level-appropriate event types.
+type eventLogCore struct {
+	zapcore.LevelEnabler
+	enc  zapcore.Encoder
+	elog *eventlog.Log
+}
+
+var _ zapcore.Core = (*eventLogCore)(nil)
+
+func newEventLogCore(elog *eventlog.Log, cfg zap.Config) zapcore.Core {
+	return &eventLogCore{
+		LevelEnabler: cfg.Level,
+		enc:          zapcore.NewConsoleEncoder(cfg.EncoderConfig),
+		elog:         elog,
+	}
+}
+
+func (c *eventLogCore) With(fields []zapcore.Field) zapcore.Core {
+	clone := c.clone()
+	for i := range fields {
+		fields[i].AddTo(clone.enc)
+	}
+	return clone
+}
+
+func (c *eventLogCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	if c.Enabled(ent.Level) {
+		return ce.AddCore(ent, c)
+	}
+	return ce
+}
+
+func (c *eventLogCore) Write(ent zapcore.Entry, fields []zapcore.Field) error {
+	buf, err := c.enc.EncodeEntry(ent, fields)
+	if err != nil {
+		return err
+	}
+	msg := buf.String()
+	buf.Free()
+
+	// If a log message has an event ID, use it. Otherwise, use the default.
+	eventID := defaultEventLogID
+	for _, field := range fields {
+		if field.Key == windowsEventIDKey && field.Integer != 0 {
+			eventID = uint32(field.Integer)
+			break
+		}
+	}
+
+	switch {
+	case ent.Level >= zapcore.ErrorLevel:
+		err = c.elog.Error(eventID, msg)
+	case ent.Level >= zapcore.WarnLevel:
+		err = c.elog.Warning(eventID, msg)
+	default:
+		err = c.elog.Info(eventID, msg)
+	}
+	if err != nil {
+		return err
+	}
+	if ent.Level > zapcore.ErrorLevel {
+		// Sync the event log to ensure the message is written.
+		err = c.Sync()
+	}
+	return err
+}
+
+func (c *eventLogCore) Sync() error {
+	return nil
+}
+
+func (c *eventLogCore) clone() *eventLogCore {
+	return &eventLogCore{
+		LevelEnabler: c.LevelEnabler,
+		enc:          c.enc.Clone(),
+		elog:         c.elog,
+	}
+}
+
+type eventLogKey struct{}
+
 func initLogger(ctx context.Context, name string, loggingOpts ...logging.Option) (context.Context, error) {
+	logToEventLog, _ := ctx.Value(eventLogEnabledKey{}).(bool)
+
 	if isService() {
 		defaultLoggingOpts := []logging.Option{
 			logging.WithLogFormat(logging.LogFormatJSON),
 			logging.WithLogLevel("info"),
-			logging.WithOutputPaths([]string{filepath.Join(getConfigDir(name), "baton.log")}),
+		}
+		if !logToEventLog {
+			// On Windows, stdout/stderr on services goes nowhere. Log to a file by default.
+			defaultLoggingOpts = append(defaultLoggingOpts, logging.WithOutputPaths([]string{filepath.Join(getConfigDir(name), "baton.log")}))
 		}
 		loggingOpts = append(defaultLoggingOpts, loggingOpts...)
+	}
+
+	if logToEventLog {
+		elog, err := eventlog.Open(name)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open event log: %w", err)
+		}
+
+		// Put the event log on the context so we can reuse it in runService.
+		ctx = context.WithValue(ctx, eventLogKey{}, elog)
+		return logging.InitWithCore(ctx, func(cfg zap.Config) zapcore.Core {
+			return newEventLogCore(elog, cfg)
+		}, loggingOpts...)
 	}
 
 	return logging.Init(ctx, loggingOpts...)
@@ -528,19 +631,23 @@ func runService(ctx context.Context, name string) (context.Context, error) {
 	l := ctxzap.Extract(ctx)
 	l.Info("Running service.")
 
-	ctx, cancel := context.WithCancelCause(ctx)
-	var elog debug.Log
-	go func() {
-		defer cancel(nil)
-
+	// The event log is only on the context when logging to it was requested
+	// via --log-event-log. Otherwise open it here for service state messages.
+	elog, ok := ctx.Value(eventLogKey{}).(debug.Log)
+	if !ok {
 		var err error
 		elog, err = eventlog.Open(name)
 		if err != nil {
 			l.Error("Failed to open event log.", zap.Error(err))
+			return ctx, err
 		}
-		defer elog.Close()
+	}
 
-		err = svc.Run(name, &batonService{
+	ctx, cancel := context.WithCancelCause(ctx)
+	go func() {
+		defer cancel(nil)
+
+		err := svc.Run(name, &batonService{
 			name: name,
 			ctx:  ctx,
 			elog: elog,

--- a/pkg/field/defaults.go
+++ b/pkg/field/defaults.go
@@ -16,6 +16,11 @@ const (
 	OtelTracingDisabledFieldName              = "otel-tracing-disabled"
 	OtelLoggingDisabledFieldName              = "otel-logging-disabled"
 
+	// LogEventLogFieldName is the name of the flag that redirects logging to
+	// the Windows event log. The field is only registered on Windows builds
+	// (see defaults_windows.go), so the flag does not exist on other platforms.
+	LogEventLogFieldName = "log-event-log"
+
 	// TaskConcurrencySchemaDefault is the configured default for [TaskConcurrencyField].
 	TaskConcurrencySchemaDefault = 3
 )
@@ -84,6 +89,7 @@ var (
 		WithPersistent(true), WithExportTarget(ExportTargetNone))
 	logFormatField = StringField("log-format", WithDefaultValueFunc(defaultLogFormat), WithDescription("The output format for logs: json, console"),
 		WithPersistent(true), WithExportTarget(ExportTargetNone))
+	logOutputPathField     = StringSliceField("log-path", WithDescription("The file path to write logs to"), WithPersistent(true), WithExportTarget(ExportTargetNone))
 	revokeGrantField       = StringField("revoke-grant", WithHidden(true), WithDescription("The grant to revoke"), WithPersistent(true), WithExportTarget(ExportTargetNone))
 	rotateCredentialsField = StringField("rotate-credentials", WithHidden(true), WithDescription("The id of the resource to rotate credentials on"),
 		WithPersistent(true), WithExportTarget(ExportTargetNone))
@@ -383,7 +389,9 @@ func LambdaServerFields() []SchemaField {
 var LambdaServerRelationships = make([]SchemaFieldRelationship, 0)
 
 // DefaultFields list the default fields expected in every single connector.
-var DefaultFields = []SchemaField{
+// platformDefaultFields (defined per-platform) holds additional fields that
+// only exist on some platforms, e.g. the Windows event log flag.
+var DefaultFields = append([]SchemaField{
 	createTicketField,
 	bulkCreateTicketField,
 	bulkTicketTemplatePathField,
@@ -409,6 +417,7 @@ var DefaultFields = []SchemaField{
 	grantPrincipalField,
 	grantPrincipalTypeField,
 	logFormatField,
+	logOutputPathField,
 	revokeGrantField,
 	rotateCredentialsField,
 	rotateCredentialsTypeField,
@@ -460,7 +469,7 @@ var DefaultFields = []SchemaField{
 	HttpTimeoutField,
 	StorageEngineField,
 	TaskConcurrencyField,
-}
+}, platformDefaultFields...)
 
 func IsFieldAmongDefaultList(f SchemaField) bool {
 	for _, v := range DefaultFields {

--- a/pkg/field/defaults_other.go
+++ b/pkg/field/defaults_other.go
@@ -1,0 +1,5 @@
+//go:build !windows
+
+package field
+
+var platformDefaultFields []SchemaField

--- a/pkg/field/defaults_windows.go
+++ b/pkg/field/defaults_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package field
+
+var logEventLogField = BoolField(LogEventLogFieldName,
+	WithDescription("Log to the Windows event log instead of a file"),
+	WithPersistent(true),
+	WithExportTarget(ExportTargetNone))
+
+var platformDefaultFields = []SchemaField{
+	logEventLogField,
+}

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -53,6 +53,8 @@ func NormalizeLogLevel(level string) (string, error) {
 	return parsed.String(), nil
 }
 
+// SetLogLevel sets the log level for the active logger.
+// Currently only used by lambda connectors.
 func SetLogLevel(level string) error {
 	parsed, err := ParseLogLevel(level)
 	if err != nil {
@@ -97,8 +99,8 @@ func WithInitialFields(fields map[string]interface{}) Option {
 	}
 }
 
-// Init creates a new zap logger and attaches it to the provided context.
-func Init(ctx context.Context, opts ...Option) (context.Context, error) {
+// buildConfig returns the zap configuration used by Init and InitWithCore.
+func buildConfig(opts ...Option) zap.Config {
 	zc := zap.NewProductionConfig()
 	zc.Sampling = nil
 	zc.DisableStacktrace = true
@@ -107,9 +109,13 @@ func Init(ctx context.Context, opts ...Option) (context.Context, error) {
 		opt(&zc)
 	}
 
+	return zc
+}
+
+func initFromConfig(ctx context.Context, zc zap.Config) (context.Context, *zap.Logger, error) {
 	l, err := zc.Build()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	activeLevelMu.Lock()
 	activeLevel = &zc.Level
@@ -117,6 +123,32 @@ func Init(ctx context.Context, opts ...Option) (context.Context, error) {
 	zap.ReplaceGlobals(l)
 
 	l.Debug("Logger created!", zap.String("log_level", zc.Level.String()))
+
+	return ctxzap.ToContext(ctx, l), l, nil
+}
+
+// Init creates a new zap logger and attaches it to the provided context.
+func Init(ctx context.Context, opts ...Option) (context.Context, error) {
+	ctx, _, err := initFromConfig(ctx, buildConfig(opts...))
+	return ctx, err
+}
+
+// InitWithCore creates a new zap logger and tees an additional core onto it.
+// buildCore receives the logger config so the extra core uses the same level
+// filtering and encoder settings as Init.
+func InitWithCore(ctx context.Context, buildCore func(zap.Config) zapcore.Core, opts ...Option) (context.Context, error) {
+	zc := buildConfig(opts...)
+
+	ctx, l, err := initFromConfig(ctx, zc)
+	if err != nil {
+		return nil, err
+	}
+
+	extraCore := buildCore(zc)
+	l = l.WithOptions(zap.WrapCore(func(core zapcore.Core) zapcore.Core {
+		return zapcore.NewTee(core, extraCore)
+	}))
+	zap.ReplaceGlobals(l)
 
 	return ctxzap.ToContext(ctx, l), nil
 }


### PR DESCRIPTION
Add option to output logs to the windows event log. Default behavior (logging to a file) is unchanged.