### PR TITLE
feat(lambda): binary wire frames for annotation-lossless transport

### DIFF
--- a/pkg/lambda/grpc/client.go
+++ b/pkg/lambda/grpc/client.go
@@ -11,6 +11,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
 	"github.com/aws/aws-sdk-go-v2/service/lambda/types"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -24,9 +26,17 @@ type lambdaTransport struct {
 }
 
 func (l *lambdaTransport) RoundTrip(ctx context.Context, req *Request) (*Response, error) {
-	payload, err := req.MarshalJSON()
+	payload, frameOnly, err := req.marshalPayload()
 	if err != nil {
 		return nil, fmt.Errorf("lambda_transport: failed to marshal frame: %w", err)
+	}
+	if frameOnly != nil {
+		ctxzap.Extract(ctx).Warn(
+			"lambda_transport: request has no legacy encoding, sending v2 frame only; a connector on a pre-frame SDK cannot process this call",
+			zap.String("method", req.Method()),
+			zap.String("function_name", l.functionName),
+			zap.NamedError("legacy_encoding_error", frameOnly),
+		)
 	}
 
 	input := &lambda.InvokeInput{

--- a/pkg/lambda/grpc/server.go
+++ b/pkg/lambda/grpc/server.go
@@ -236,7 +236,18 @@ func TimeoutForRequest(req *Request) (time.Duration, bool, error) {
 	return 0, false, nil
 }
 
+// Handler serves one transport request. The response echoes the request's
+// wire version so v2 invokers get lossless frames and legacy invokers get
+// protojson (see Response.MarshalJSON).
 func (s *Server) Handler(ctx context.Context, req *Request) (*Response, error) {
+	resp, err := s.handle(ctx, req)
+	if resp != nil {
+		resp.wireV2 = req.wireV2
+	}
+	return resp, err
+}
+
+func (s *Server) handle(ctx context.Context, req *Request) (*Response, error) {
 	serviceName, methodName, err := parseMethod(req.Method())
 	if err != nil {
 		return ErrorResponse(err), nil

--- a/pkg/lambda/grpc/transport.go
+++ b/pkg/lambda/grpc/transport.go
@@ -20,10 +20,12 @@ import (
 const annotationsFieldName = "annotations"
 
 /*
-unmarshalTransportJSON unmarshals transport JSON into msg, discarding any
-unknown fields.
+unmarshalTransportJSON unmarshals transport JSON into msg. It reports whether
+the payload carried a v2 wire frame (binary proto, see wireFrame), which is
+decoded losslessly with no type resolution.
 
-When the payload fails to unmarshal, it retries after filtering out any
+Legacy payloads are protojson, unmarshaled discarding any unknown fields.
+When a legacy payload fails to unmarshal, it retries after filtering out any
 annotations whose types are not known to the global registry. Annotation type
 skew happens frequently for new features and would otherwise require rolling
 every lambda function (and, in the response direction, would let an old
@@ -39,7 +41,11 @@ payloads that already failed, where the alternative is a hard error. Our
 payloads are small relative to the work of the connector, so the performance
 impact is negligible.
 */
-func unmarshalTransportJSON(b []byte, msg proto.Message) error {
+func unmarshalTransportJSON(b []byte, msg proto.Message) (bool, error) {
+	if ok, err := decodeWireFrame(b, msg); ok {
+		return true, err
+	}
+
 	unmarshalOptions := protojson.UnmarshalOptions{
 		DiscardUnknown: true,
 	}
@@ -47,19 +53,19 @@ func unmarshalTransportJSON(b []byte, msg proto.Message) error {
 	// so any failure falls through to the annotation filter.
 	originalErr := unmarshalOptions.Unmarshal(b, msg)
 	if originalErr == nil {
-		return nil
+		return false, nil
 	}
 
 	filtered, changed := filterUnknownAnnotations(b)
 	if !changed {
-		return originalErr
+		return false, originalErr
 	}
 
 	if err := unmarshalOptions.Unmarshal(filtered, msg); err != nil {
-		return errors.Join(originalErr, err)
+		return false, errors.Join(originalErr, err)
 	}
 
-	return nil
+	return false, nil
 }
 
 // filterUnknownAnnotations recursively walks raw JSON and prunes entries from
@@ -181,18 +187,61 @@ func filterAnnotationsArray(raw json.RawMessage) (json.RawMessage, bool) {
 
 type Request struct {
 	msg *pbtransport.Request
+
+	// wireV2 records that the request arrived as a v2 wire frame, proving
+	// the invoker can read one back. The server stamps it onto the Response.
+	wireV2 bool
 }
 
-// UnmarshalJSON unmarshals the JSON into a Request, discarding unknown fields
-// and filtering annotations with unresolvable types. See
-// unmarshalTransportJSON.
+// UnmarshalJSON unmarshals the JSON into a Request. v2 wire frames decode
+// losslessly; legacy payloads are protojson, discarding unknown fields and
+// filtering annotations with unresolvable types. See unmarshalTransportJSON.
 func (f *Request) UnmarshalJSON(b []byte) error {
 	f.msg = &pbtransport.Request{}
-	return unmarshalTransportJSON(b, f.msg)
+	wireV2, err := unmarshalTransportJSON(b, f.msg)
+	if err != nil {
+		return err
+	}
+	f.wireV2 = wireV2
+	return nil
 }
 
+// MarshalJSON dual-encodes the request: the legacy protojson fields and the
+// v2 wire frame share one JSON object, so legacy connectors keep working
+// (they discard the unknown frame fields) while v2 connectors decode the
+// frame and see annotations whose types this process cannot resolve. When no
+// legacy view can be produced — protojson cannot represent an Any whose type
+// is not linked into this process — the frame is sent alone: a legacy
+// connector would have failed on that payload anyway. Oversized dual
+// payloads fall back to legacy-only to stay under the Lambda invoke limit;
+// v2 connectors accept those too.
 func (f *Request) MarshalJSON() ([]byte, error) {
-	return protojson.Marshal(f.msg)
+	payload, _, err := f.marshalPayload()
+	return payload, err
+}
+
+// marshalPayload builds the invoke payload. The middle return reports the
+// frame-only condition: when non-nil, the payload carries only the v2 frame
+// and the value is the reason the legacy view could not be produced —
+// callers with a context should surface it, since a legacy connector cannot
+// process a frame-only payload.
+func (f *Request) marshalPayload() ([]byte, error, error) {
+	legacy, legacyErr := protojson.Marshal(f.msg)
+	if legacyErr != nil {
+		payload, err := encodeWireFrame(f.msg)
+		if err != nil {
+			return nil, nil, errors.Join(legacyErr, err)
+		}
+		return payload, legacyErr, nil
+	}
+	dual, err := spliceWireFrame(legacy, f.msg)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(dual) > maxDualEncodedPayload {
+		return legacy, nil, nil
+	}
+	return dual, nil, nil
 }
 
 func (f *Request) Method() string {
@@ -236,20 +285,40 @@ func NewRequest(method string, req proto.Message, headers metadata.MD) (*Request
 
 type Response struct {
 	msg *pbtransport.Response
+
+	// wireV2 selects the v2 wire frame encoding. The server sets it from
+	// the request: a frame in the request proves the invoker reads frames.
+	wireV2 bool
 }
 
-// UnmarshalJSON unmarshals the JSON into a Response, discarding unknown
-// fields and filtering annotations with unresolvable types. Responses carry
-// annotations at the response level and nested inside rows (grants embed
-// resources, etc.), so this protects an invoker from annotation types it
-// does not know about — for example an older invoker receiving annotations
-// from a connector built with a newer SDK. See unmarshalTransportJSON.
+// UnmarshalJSON unmarshals the JSON into a Response. v2 wire frames decode
+// losslessly with no type resolution. Legacy payloads are protojson,
+// discarding unknown fields and filtering annotations with unresolvable
+// types: responses carry annotations at the response level and nested inside
+// rows (grants embed resources, etc.), so this protects an invoker from
+// annotation types it does not know about — for example an older invoker
+// receiving annotations from a connector built with a newer SDK. See
+// unmarshalTransportJSON.
 func (f *Response) UnmarshalJSON(b []byte) error {
 	f.msg = &pbtransport.Response{}
-	return unmarshalTransportJSON(b, f.msg)
+	wireV2, err := unmarshalTransportJSON(b, f.msg)
+	if err != nil {
+		return err
+	}
+	f.wireV2 = wireV2
+	return nil
 }
 
+// MarshalJSON encodes a v2 wire frame when the invoker proved it reads them
+// (see wireV2), preserving annotations whose types this process cannot
+// resolve. Legacy invokers get plain protojson, which fails on an Any whose
+// type is not linked into this process — deliberately: the sender's registry
+// is no authority on what the receiver understands or needs, so degrading
+// the payload by silently dropping data is worse than failing loudly.
 func (f *Response) MarshalJSON() ([]byte, error) {
+	if f.wireV2 {
+		return encodeWireFrame(f.msg)
+	}
 	return protojson.Marshal(f.msg)
 }
 

--- a/pkg/lambda/grpc/wire.go
+++ b/pkg/lambda/grpc/wire.go
@@ -1,0 +1,88 @@
+package grpc
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"google.golang.org/protobuf/proto"
+)
+
+const transportWireVersion = 2
+
+// maxDualEncodedPayload caps dual-encoded requests below the 6MiB Lambda
+// invoke payload limit. Past it the frame is dropped and the request goes
+// out legacy-only, which v2 peers also accept.
+var maxDualEncodedPayload = 5 << 20
+
+/*
+wireFrame is the v2 transport encoding: the binary proto bytes of a
+transport Request or Response, carried base64-encoded in the JSON Lambda
+payload. Binary proto copies google.protobuf.Any payloads verbatim instead
+of resolving their type URLs the way protojson must, so annotation types
+that are not linked into a process survive the transport intact — the fix
+for connector-specific annotations (e.g. baton-jira's CustomField) being
+dropped or crashing the marshal in runtimes that don't register them.
+
+Version skew is handled without negotiation state:
+
+  - Requests are dual-encoded: the legacy protojson fields and the frame
+    share one JSON object. Legacy peers unmarshal with DiscardUnknown and
+    never see the frame; v2 peers prefer it.
+  - Responses carry the frame alone, but only when the request carried
+    one — a frame in the request proves the invoker can read it. Legacy
+    requests get legacy responses.
+
+The field names cannot collide with the legacy encoding: protojson emits
+only "method"/"req"/"headers" for Requests and
+"resp"/"status"/"headers"/"trailers" for Responses.
+*/
+type wireFrame struct {
+	V     int    `json:"v"`
+	Frame []byte `json:"frame"`
+}
+
+// decodeWireFrame reports whether raw carries a v2 wire frame and, if so,
+// decodes it into msg. A false return means raw is a legacy payload: either
+// it isn't shaped like a frame, or it doesn't parse as JSON at all — the
+// legacy path owns reporting that error.
+func decodeWireFrame(raw []byte, msg proto.Message) (bool, error) {
+	var wf wireFrame
+	if err := json.Unmarshal(raw, &wf); err != nil || len(wf.Frame) == 0 {
+		return false, nil //nolint:nilerr // not a v2 frame; the legacy path owns error reporting
+	}
+	if wf.V != transportWireVersion {
+		return true, fmt.Errorf("transport: unsupported wire frame version %d", wf.V)
+	}
+	return true, proto.Unmarshal(wf.Frame, msg)
+}
+
+func encodeWireFrame(msg proto.Message) ([]byte, error) {
+	frame, err := proto.Marshal(msg)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(wireFrame{V: transportWireVersion, Frame: frame})
+}
+
+// spliceWireFrame appends the v2 frame fields to a legacy protojson object,
+// producing the dual-encoded request payload.
+func spliceWireFrame(legacy []byte, msg proto.Message) ([]byte, error) {
+	suffix, err := encodeWireFrame(msg)
+	if err != nil {
+		return nil, err
+	}
+	legacy = bytes.TrimSpace(legacy)
+	if len(legacy) < 2 || legacy[0] != '{' || legacy[len(legacy)-1] != '}' {
+		return nil, fmt.Errorf("transport: legacy payload is not a JSON object")
+	}
+	if len(legacy) == 2 {
+		return suffix, nil
+	}
+	var buf bytes.Buffer
+	buf.Grow(len(legacy) + len(suffix))
+	buf.Write(legacy[:len(legacy)-1])
+	buf.WriteByte(',')
+	buf.Write(suffix[1:])
+	return buf.Bytes(), nil
+}

--- a/pkg/lambda/grpc/wire_test.go
+++ b/pkg/lambda/grpc/wire_test.go
@@ -1,0 +1,262 @@
+package grpc
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	batonv1 "github.com/conductorone/baton-sdk/pb/c1/connectorapi/baton/v1"
+	pbtransport "github.com/conductorone/baton-sdk/pb/c1/transport/v1"
+)
+
+// unresolvableAnnotation fabricates an annotation whose type is not linked
+// into this test binary — the shape a connector-specific annotation (e.g.
+// baton-jira's c1.connector.v2.CustomField) has inside a runtime that does
+// not register it. The value bytes encode field 1 (string) = "team".
+func unresolvableAnnotation() *anypb.Any {
+	return &anypb.Any{
+		TypeUrl: "type.googleapis.com/fake.connector.v1.CustomField",
+		Value:   []byte("\n\x04team"),
+	}
+}
+
+func knownAnnotation(t *testing.T) *anypb.Any {
+	t.Helper()
+	profile, err := structpb.NewStruct(map[string]any{"name": "test-group"})
+	require.NoError(t, err)
+	known, err := anypb.New(v2.GroupTrait_builder{Profile: profile}.Build())
+	require.NoError(t, err)
+	return known
+}
+
+// ce918Response builds the CE-918 payload shape: a ticket schema whose
+// custom fields carry annotations of a type this process cannot resolve.
+func ce918Response(t *testing.T) *pbtransport.Response {
+	t.Helper()
+	schemas := v2.TicketsServiceListTicketSchemasResponse_builder{
+		List: []*v2.TicketSchema{
+			v2.TicketSchema_builder{
+				Id:          "DEV:10003",
+				DisplayName: "Task (DEV)",
+				CustomFields: map[string]*v2.TicketCustomField{
+					"customfield_10001": v2.TicketCustomField_builder{
+						Id:          "customfield_10001",
+						DisplayName: "Team",
+						Annotations: []*anypb.Any{unresolvableAnnotation()},
+					}.Build(),
+				},
+				Annotations: []*anypb.Any{knownAnnotation(t), unresolvableAnnotation()},
+			}.Build(),
+		},
+	}.Build()
+
+	respAny, err := anypb.New(schemas)
+	require.NoError(t, err)
+	stAny, err := anypb.New(status.New(codes.OK, "OK").Proto())
+	require.NoError(t, err)
+	return pbtransport.Response_builder{
+		Resp:   respAny,
+		Status: stAny,
+	}.Build()
+}
+
+func unpackSchemas(t *testing.T, f *Response) *v2.TicketsServiceListTicketSchemasResponse {
+	t.Helper()
+	out := &v2.TicketsServiceListTicketSchemasResponse{}
+	require.NoError(t, f.UnmarshalResponse(out))
+	return out
+}
+
+func TestResponse_WireFrame_PreservesUnresolvableAnnotations(t *testing.T) {
+	msg := ce918Response(t)
+
+	// The legacy encoding cannot represent this payload at all: protojson
+	// aborts on the first unresolvable Any. This is the CE-918 sync crash.
+	_, err := protojson.Marshal(msg)
+	require.ErrorContains(t, err, "unable to resolve")
+
+	f := &Response{msg: msg, wireV2: true}
+	payload, err := f.MarshalJSON()
+	require.NoError(t, err)
+
+	var wire map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(payload, &wire))
+	assert.Contains(t, wire, "frame")
+	assert.NotContains(t, wire, "resp", "v2 responses are frame-only")
+
+	rt := &Response{}
+	require.NoError(t, rt.UnmarshalJSON(payload))
+	assert.True(t, rt.wireV2)
+	require.True(t, proto.Equal(msg, rt.msg), "frame round-trip must be lossless")
+
+	schema := unpackSchemas(t, rt).GetList()[0]
+	fieldAnns := schema.GetCustomFields()["customfield_10001"].GetAnnotations()
+	require.Len(t, fieldAnns, 1)
+	assert.Equal(t, unresolvableAnnotation().GetTypeUrl(), fieldAnns[0].GetTypeUrl())
+	assert.Equal(t, unresolvableAnnotation().GetValue(), fieldAnns[0].GetValue(),
+		"annotation wire bytes must arrive byte-identical")
+	assert.Len(t, schema.GetAnnotations(), 2)
+}
+
+func TestResponse_LegacyMarshal_FailsOnUnresolvableAnnotations(t *testing.T) {
+	f := &Response{msg: ce918Response(t)}
+
+	// A response to a legacy invoker cannot silently drop data the sender
+	// happens not to resolve — the sender's registry is no authority on what
+	// the receiver needs. The marshal fails loudly instead (pre-frame
+	// behavior).
+	_, err := f.MarshalJSON()
+	require.ErrorContains(t, err, "unable to resolve")
+}
+
+func TestRequest_DualEncode_SkewMatrix(t *testing.T) {
+	req := batonv1.BatonServiceHelloRequest_builder{
+		HostId:      "test-host",
+		Annotations: []*anypb.Any{knownAnnotation(t)},
+	}.Build()
+	treq, err := NewRequest("/c1.connectorapi.baton.v1.BatonService/Hello", req, metadata.MD{})
+	require.NoError(t, err)
+
+	payload, frameOnly, err := treq.marshalPayload()
+	require.NoError(t, err)
+	assert.Nil(t, frameOnly)
+
+	var wire map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(payload, &wire))
+	assert.Contains(t, wire, "method")
+	assert.Contains(t, wire, "req")
+	assert.Contains(t, wire, "frame")
+	assert.Contains(t, wire, "v")
+
+	// Old connector: plain protojson with DiscardUnknown — the pre-frame
+	// fast path. The unknown frame fields are discarded and the legacy view
+	// carries the full request.
+	legacyMsg := &pbtransport.Request{}
+	require.NoError(t, protojson.UnmarshalOptions{DiscardUnknown: true}.Unmarshal(payload, legacyMsg))
+	legacyReq := &batonv1.BatonServiceHelloRequest{}
+	require.NoError(t, anypb.UnmarshalTo(legacyMsg.GetReq(), legacyReq, proto.UnmarshalOptions{}))
+	require.Len(t, legacyReq.GetAnnotations(), 1)
+	assert.Equal(t, knownAnnotation(t).GetTypeUrl(), legacyReq.GetAnnotations()[0].GetTypeUrl())
+
+	// New connector: reads the frame.
+	rt := &Request{}
+	require.NoError(t, rt.UnmarshalJSON(payload))
+	assert.True(t, rt.wireV2)
+	frameReq := &batonv1.BatonServiceHelloRequest{}
+	require.NoError(t, rt.UnmarshalRequest(frameReq))
+	require.Len(t, frameReq.GetAnnotations(), 1)
+}
+
+func TestRequest_UnresolvableAnnotations_FrameOnly(t *testing.T) {
+	req := batonv1.BatonServiceHelloRequest_builder{
+		HostId:      "test-host",
+		Annotations: []*anypb.Any{knownAnnotation(t), unresolvableAnnotation()},
+	}.Build()
+	treq, err := NewRequest("/c1.connectorapi.baton.v1.BatonService/Hello", req, metadata.MD{})
+	require.NoError(t, err)
+
+	// No legacy view exists for a payload protojson cannot represent; the
+	// frame is sent alone and the reason is reported so the invoker can log
+	// it. A pre-frame connector fails on this payload — as it would have
+	// pre-frames, when the marshal itself failed.
+	payload, frameOnly, err := treq.marshalPayload()
+	require.NoError(t, err)
+	require.ErrorContains(t, frameOnly, "unable to resolve")
+
+	var wire map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(payload, &wire))
+	assert.Contains(t, wire, "frame")
+	assert.NotContains(t, wire, "method")
+	assert.NotContains(t, wire, "req")
+
+	// New connector: decodes the frame losslessly, method included.
+	rt := &Request{}
+	require.NoError(t, rt.UnmarshalJSON(payload))
+	assert.True(t, rt.wireV2)
+	assert.Equal(t, treq.Method(), rt.Method())
+	frameReq := &batonv1.BatonServiceHelloRequest{}
+	require.NoError(t, rt.UnmarshalRequest(frameReq))
+	require.Len(t, frameReq.GetAnnotations(), 2)
+	assert.Equal(t, unresolvableAnnotation().GetValue(), frameReq.GetAnnotations()[1].GetValue())
+}
+
+func TestServer_Handler_EchoesWireVersion(t *testing.T) {
+	ctx := t.Context()
+	s := NewServer(nil)
+
+	legacyReq, err := NewRequest("/c1.connectorapi.baton.v1.BatonService/Hello", &batonv1.BatonServiceHelloRequest{}, metadata.MD{})
+	require.NoError(t, err)
+
+	// A request that arrived legacy gets a legacy response.
+	resp, err := s.Handler(ctx, legacyReq)
+	require.NoError(t, err)
+	payload, err := resp.MarshalJSON()
+	require.NoError(t, err)
+	var wire map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(payload, &wire))
+	assert.Contains(t, wire, "status")
+	assert.NotContains(t, wire, "frame")
+
+	// A request that arrived as a frame gets a frame back.
+	dual, err := legacyReq.MarshalJSON()
+	require.NoError(t, err)
+	frameReq := &Request{}
+	require.NoError(t, frameReq.UnmarshalJSON(dual))
+	require.True(t, frameReq.wireV2)
+
+	resp, err = s.Handler(ctx, frameReq)
+	require.NoError(t, err)
+	payload, err = resp.MarshalJSON()
+	require.NoError(t, err)
+	wire = nil
+	require.NoError(t, json.Unmarshal(payload, &wire))
+	assert.Contains(t, wire, "frame")
+	assert.NotContains(t, wire, "status")
+
+	rt := &Response{}
+	require.NoError(t, rt.UnmarshalJSON(payload))
+	st, err := rt.Status()
+	require.NoError(t, err)
+	assert.NotNil(t, st)
+}
+
+func TestRequest_MarshalJSON_SizeGuardFallsBackToLegacy(t *testing.T) {
+	prev := maxDualEncodedPayload
+	maxDualEncodedPayload = 64
+	t.Cleanup(func() { maxDualEncodedPayload = prev })
+
+	treq, err := NewRequest("/c1.connectorapi.baton.v1.BatonService/Hello", batonv1.BatonServiceHelloRequest_builder{
+		HostId: "test-host",
+	}.Build(), metadata.MD{})
+	require.NoError(t, err)
+
+	payload, err := treq.MarshalJSON()
+	require.NoError(t, err)
+
+	var wire map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(payload, &wire))
+	assert.NotContains(t, wire, "frame")
+	assert.Contains(t, wire, "method")
+
+	// v2 peers accept the legacy fallback.
+	rt := &Request{}
+	require.NoError(t, rt.UnmarshalJSON(payload))
+	assert.False(t, rt.wireV2)
+	assert.Equal(t, treq.Method(), rt.Method())
+}
+
+func TestDecodeWireFrame_UnsupportedVersion(t *testing.T) {
+	rt := &Request{}
+	err := rt.UnmarshalJSON([]byte(`{"v": 3, "frame": "AA=="}`))
+	require.ErrorContains(t, err, "unsupported wire frame version 3")
+}


### PR DESCRIPTION
The lambda transport encodes frames with protojson, which must resolve every google.protobuf.Any against the process type registry. Connector- specific annotation types (e.g. baton-jira's CustomField on ticket schema custom fields) are not linked into every runtime, so the outbound marshal hard-failed the whole sync while the inbound filter silently dropped them — custom fields never survived the axiomatic runtime (CE-918).

Add a v2 wire encoding that carries the binary proto bytes of the transport frame, base64-embedded in the JSON payload. Binary proto copies Any payloads verbatim with no type resolution, so unknown annotation types cross the transport byte-identical to what a native connector emits, and registry-aware consumers decode them losslessly.

Version skew needs no negotiation state:

- Requests dual-encode: legacy protojson fields and the frame share one JSON object. Old connectors discard the unknown fields; new connectors prefer the frame. Oversized payloads drop the frame.
- Responses are frame-only exactly when the request carried a frame, which proves the invoker reads them. Legacy requests get legacy responses.
- When protojson cannot produce the legacy view at all (an Any the sending process does not link), the request goes out frame-only and the invoker logs why. The send side never prunes data it happens not to resolve: the sender's registry is no authority on what the receiver understands or needs, so a payload either arrives intact or fails loudly — the pre-frame behavior — rather than arriving silently degraded. The receive-side filter is unchanged: dropping what this process cannot use is a local decision.

Mixed-version pairings therefore behave exactly as they do today (loud failure on payloads the legacy encoding cannot represent); the fix turns on when both ends are frame-capable. Deploy ordering note: bump c1's baton-sdk and rebuild the axiomatic runtime promptly after release — until both land, exotic-annotation payloads keep failing exactly as they do today.

My quick handwritten hitting summary:
- This code is the send-side equivalent of this [PR](https://github.com/ConductorOne/baton-sdk/pull/958/changes)
- It also adds functionality to not lose the custom fields annotations (the above PR was just ignoring them), which is why they were being lost in the JC schema

**Here is a visual summary of how the changes will impact the shape of the protobuf**

1. Old v1 - pure protojson (what every request was before the PR)

{
  "method": "/c1.connector.v2.TicketsService/CreateTicket",
  "req": {
    "@type": "type.googleapis.com/c1.connector.v2.TicketsServiceCreateTicketRequest",
    "schema": {
      "id": "10001",
      "annotations": [
        {
          "@type": "type.googleapis.com/c1.connector.jira.v1.CustomField",
          "fieldId": "customfield_10042"
        }
      ]
    }
  },
  "headers": { "x-baton-connector-config-version": "12" }
}

(If the sending process does not link CustomField, this marshal hard-fails and the call never leaves the process — the CE-918 crash.)

2. New v1 - dual-encoded (what a new invoker sends when the legacy view is representable)

{
  "method": "/c1.connector.v2.TicketsService/CreateTicket",
  "req": {
    "@type": "type.googleapis.com/c1.connector.v2.TicketsServiceCreateTicketRequest",
    "schema": { "id": "10001", "annotations": [ ...same annotations... ] }
  },
  "headers": { "x-baton-connector-config-version": "12" },

  "v": 2,
  "frame": "CiwvYzEuY29ubmVjdG9yLnYyLlRpY2tldHNTZXJ2aWNlL0NyZWF0ZVRpY2tldBKk..."
}

3. New v2 - frame only

{
  "v": 2,
  "frame": "EqgBCkV0eXBlLmdvb2dsZWFwaXMuY29tL2MxLmNvbm5lY3Rvci52Mi5UaWNrZXRz..."
}

Used for (a) every response to a frame-bearing request, and (b) requests whose legacy view protojson cannot represent — an Any the sender does not link. In case (b) the invoker logs the reason; a pre-frame connector fails on such a payload, exactly as the failed marshal would have pre-frames.

https://linear.app/ductone/issue/CE-918
