### PR TITLE
Make uhttp transport timeouts configurable and add connection retry-with-reconnect

### DIFF
--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -433,6 +433,13 @@ func MakeMainCommand[T field.Configurable](
 		}
 		runCtx = context.WithValue(runCtx, uhttp.ContextHTTPTimeoutKey, time.Duration(httpTimeout)*time.Second)
 
+		responseHeaderTimeout := v.GetInt(field.HttpResponseHeaderTimeoutField.GetName())
+		responseHeaderTimeoutField := field.HttpResponseHeaderTimeoutField
+		if _, err := field.ValidateField(&responseHeaderTimeoutField, responseHeaderTimeout); err != nil {
+			return err
+		}
+		runCtx = context.WithValue(runCtx, uhttp.ContextHTTPResponseHeaderTimeoutKey, time.Duration(responseHeaderTimeout)*time.Second)
+
 		storageEngine := v.GetString(field.StorageEngineField.GetName())
 		storageEngineField := field.StorageEngineField
 		if _, err := field.ValidateField(&storageEngineField, storageEngine); err != nil {
@@ -624,6 +631,13 @@ func MakeGRPCServerCommand[T field.Configurable](
 			return err
 		}
 		runCtx = context.WithValue(runCtx, uhttp.ContextHTTPTimeoutKey, time.Duration(httpTimeout)*time.Second)
+
+		responseHeaderTimeout := v.GetInt(field.HttpResponseHeaderTimeoutField.GetName())
+		responseHeaderTimeoutField := field.HttpResponseHeaderTimeoutField
+		if _, err := field.ValidateField(&responseHeaderTimeoutField, responseHeaderTimeout); err != nil {
+			return err
+		}
+		runCtx = context.WithValue(runCtx, uhttp.ContextHTTPResponseHeaderTimeoutKey, time.Duration(responseHeaderTimeout)*time.Second)
 
 		sessionStoreMaximumSize := v.GetInt(field.ServerSessionStoreMaximumSizeField.GetName())
 		sessionConstructor := getGRPCSessionStoreClient(runCtx, serverCfg)

--- a/pkg/field/defaults.go
+++ b/pkg/field/defaults.go
@@ -349,6 +349,16 @@ var (
 			r.Gte(1).Lte(1800)
 		}))
 
+	HttpResponseHeaderTimeoutField = IntField("http-response-header-timeout-seconds",
+		WithDescription("Time in seconds to wait for a server's response headers after sending a request "+
+			"(0 disables the timeout; useful for endpoints that block while generating a response). Max 1800."),
+		WithDefaultValue(60),
+		WithPersistent(true),
+		WithExportTarget(ExportTargetOps),
+		WithInt(func(r *IntRuler) {
+			r.Gte(0).Lte(1800)
+		}))
+
 	// StorageEngineField selects the dotc1z storage engine for sync tasks.
 	// Empty uses the baton-sdk default (sqlite for new files).
 	StorageEngineField = StringField("storage-engine",
@@ -467,6 +477,7 @@ var DefaultFields = append([]SchemaField{
 	healthCheckBindAddressField,
 
 	HttpTimeoutField,
+	HttpResponseHeaderTimeoutField,
 	StorageEngineField,
 	TaskConcurrencyField,
 }, platformDefaultFields...)

--- a/pkg/uhttp/client.go
+++ b/pkg/uhttp/client.go
@@ -19,6 +19,13 @@ type contextKeyType struct{}
 // from the CLI configuration to uhttp.NewClient.
 var ContextHTTPTimeoutKey = contextKeyType{}
 
+type responseHeaderTimeoutContextKeyType struct{}
+
+// ContextHTTPResponseHeaderTimeoutKey is the context key used to pass the HTTP
+// response-header timeout duration from the CLI configuration to the transport.
+// An explicit WithResponseHeaderTimeout option takes precedence over this value.
+var ContextHTTPResponseHeaderTimeoutKey = responseHeaderTimeoutContextKeyType{}
+
 type tlsClientConfigOption struct {
 	config *tls.Config
 }
@@ -78,6 +85,58 @@ func (o timeoutOption) Apply(c *Transport) {
 func WithTimeout(timeout time.Duration) Option {
 	return timeoutOption{timeout: timeout}
 }
+
+type idleConnTimeoutOption struct{ d time.Duration }
+
+func (o idleConnTimeoutOption) Apply(c *Transport) { d := o.d; c.idleConnTimeout = &d }
+
+// WithIdleConnTimeout sets how long an idle keep-alive connection stays in the
+// pool before being closed. Defaults to 30s -- intentionally shorter than common
+// proxy idle timeouts (Squid ~60s) so the client discards pooled connections
+// before the proxy silently drops them. Raise this ONLY if the upstream proxy's
+// idle timeout is also higher; a value at/above the proxy's timeout reintroduces
+// "http2: client connection lost" from stale-connection reuse. 0 = no limit.
+func WithIdleConnTimeout(d time.Duration) Option { return idleConnTimeoutOption{d} }
+
+type responseHeaderTimeoutOption struct{ d time.Duration }
+
+func (o responseHeaderTimeoutOption) Apply(c *Transport) { d := o.d; c.responseHeaderTimeout = &d }
+
+// WithResponseHeaderTimeout bounds the wait from finishing the request write to
+// the first byte of the response headers. Applies to HTTP/1.1 and -- because the
+// transport uses http2.ConfigureTransports -- to HTTP/2 as well. Defaults to 60s.
+// Raise this for endpoints that block before responding (e.g. synchronous report
+// generation), which would otherwise fail with "timeout awaiting response
+// headers". 0 = no timeout.
+func WithResponseHeaderTimeout(d time.Duration) Option { return responseHeaderTimeoutOption{d} }
+
+type http2KeepAliveOption struct{ readIdle, pingTimeout time.Duration }
+
+func (o http2KeepAliveOption) Apply(c *Transport) {
+	readIdle, ping := o.readIdle, o.pingTimeout
+	c.readIdleTimeout = &readIdle
+	c.pingTimeout = &ping
+}
+
+// WithHTTP2KeepAlive tunes the HTTP/2 PING health check. readIdle is how long a
+// connection may be silent before a PING is sent; pingTimeout is how long to wait
+// for the PING ack before declaring the connection dead ("http2: client
+// connection lost"). Total detection latency is readIdle+pingTimeout. Defaults
+// are 15s + 15s (= 30s). Increase to tolerate slow-but-alive servers longer at
+// the cost of slower dead-tunnel detection; readIdle of 0 disables the check.
+func WithHTTP2KeepAlive(readIdle, pingTimeout time.Duration) Option {
+	return http2KeepAliveOption{readIdle: readIdle, pingTimeout: pingTimeout}
+}
+
+type maxConnectionRetriesOption struct{ n int }
+
+func (o maxConnectionRetriesOption) Apply(c *Transport) { n := o.n; c.maxConnRetries = &n }
+
+// WithMaxConnectionRetries sets how many times a request is transparently
+// re-issued on a transient, reconnectable transport error (a dropped pooled or
+// tunneled connection). Only idempotent requests with a rewindable body are
+// retried. Defaults to 3; 0 disables retrying.
+func WithMaxConnectionRetries(n int) Option { return maxConnectionRetriesOption{n} }
 
 type Option interface {
 	Apply(*Transport)

--- a/pkg/uhttp/errors.go
+++ b/pkg/uhttp/errors.go
@@ -57,3 +57,25 @@ func wrapTransientNetworkError(err error) error {
 func isHTTP2ClientConnectionLost(err error) bool {
 	return strings.Contains(err.Error(), "http2: client connection lost")
 }
+
+// IsReconnectableError reports whether err is a transient connection-level
+// failure where re-dialing a fresh connection and replaying the request is
+// likely to succeed -- e.g. a proxy (Squid/NLB) silently dropped a pooled or
+// tunneled connection. It deliberately EXCLUDES timeout/DeadlineExceeded
+// errors: there the peer is reachable but slow, so replaying would just hit the
+// same wall.
+func IsReconnectableError(err error) bool {
+	if err == nil {
+		return false
+	}
+	switch {
+	case errors.Is(err, io.ErrUnexpectedEOF),
+		errors.Is(err, io.EOF),
+		errors.Is(err, syscall.ECONNRESET),
+		errors.Is(err, syscall.EPIPE),
+		errors.Is(err, net.ErrClosed),
+		isHTTP2ClientConnectionLost(err):
+		return true
+	}
+	return false
+}

--- a/pkg/uhttp/retry_test.go
+++ b/pkg/uhttp/retry_test.go
@@ -1,0 +1,241 @@
+package uhttp
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsReconnectableError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"http2 connection lost", errors.New("http2: client connection lost"), true},
+		{"econnreset", &net.OpError{Op: "read", Net: "tcp", Err: os.NewSyscallError("read", syscall.ECONNRESET)}, true},
+		{"epipe", os.NewSyscallError("write", syscall.EPIPE), true},
+		{"unexpected eof", io.ErrUnexpectedEOF, true},
+		{"eof", io.EOF, true},
+		{"net closed", net.ErrClosed, true},
+		{"deadline exceeded is not reconnectable", context.DeadlineExceeded, false},
+		{"unrelated error", errors.New("boom"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, IsReconnectableError(tc.err))
+		})
+	}
+}
+
+// fakeRoundTripper invokes fn on each RoundTrip, passing the zero-based attempt
+// number, and records how many times it was called.
+type fakeRoundTripper struct {
+	calls int
+	fn    func(attempt int, req *http.Request) (*http.Response, error)
+}
+
+func (f *fakeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	n := f.calls
+	f.calls++
+	return f.fn(n, req)
+}
+
+func okResponse() *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("ok")),
+		Header:     make(http.Header),
+	}
+}
+
+func testRetryTripper(next http.RoundTripper, maxAttempts int) *retryRoundTripper {
+	return &retryRoundTripper{next: next, max: maxAttempts, baseDelay: time.Millisecond, maxDelay: 2 * time.Millisecond}
+}
+
+func connLost() error { return errors.New("http2: client connection lost") }
+
+func getReq(t *testing.T) *http.Request {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.com", nil)
+	require.NoError(t, err)
+	return req
+}
+
+func TestRetryRoundTripper_RetriesIdempotentUntilSuccess(t *testing.T) {
+	f := &fakeRoundTripper{fn: func(attempt int, _ *http.Request) (*http.Response, error) {
+		if attempt < 2 {
+			return nil, connLost()
+		}
+		return okResponse(), nil
+	}}
+
+	resp, err := testRetryTripper(f, 3).RoundTrip(getReq(t))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, 3, f.calls) // 2 failures + 1 success
+}
+
+func TestRetryRoundTripper_SuccessOnFirstTry(t *testing.T) {
+	f := &fakeRoundTripper{fn: func(_ int, _ *http.Request) (*http.Response, error) {
+		return okResponse(), nil
+	}}
+
+	resp, err := testRetryTripper(f, 3).RoundTrip(getReq(t))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	require.NoError(t, err)
+	require.Equal(t, 1, f.calls)
+}
+
+func TestRetryRoundTripper_StopsAtMax(t *testing.T) {
+	f := &fakeRoundTripper{fn: func(_ int, _ *http.Request) (*http.Response, error) {
+		return nil, connLost()
+	}}
+
+	resp, err := testRetryTripper(f, 2).RoundTrip(getReq(t))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	require.Error(t, err)
+	require.Equal(t, 3, f.calls) // initial attempt + 2 retries
+}
+
+func TestRetryRoundTripper_DoesNotRetryNonReconnectable(t *testing.T) {
+	f := &fakeRoundTripper{fn: func(_ int, _ *http.Request) (*http.Response, error) {
+		return nil, errors.New("some non-connection error")
+	}}
+
+	resp, err := testRetryTripper(f, 3).RoundTrip(getReq(t))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	require.Error(t, err)
+	require.Equal(t, 1, f.calls)
+}
+
+func TestRetryRoundTripper_DoesNotRetryPOST(t *testing.T) {
+	f := &fakeRoundTripper{fn: func(_ int, _ *http.Request) (*http.Response, error) {
+		return nil, connLost()
+	}}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "https://example.com", strings.NewReader("payload"))
+	require.NoError(t, err)
+
+	resp, err := testRetryTripper(f, 3).RoundTrip(req)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	require.Error(t, err)
+	require.Equal(t, 1, f.calls) // non-idempotent, not retried
+}
+
+func TestRetryRoundTripper_RetriesPOSTWithIdempotencyKeyAndRewindsBody(t *testing.T) {
+	var bodies []string
+	f := &fakeRoundTripper{fn: func(attempt int, r *http.Request) (*http.Response, error) {
+		b, _ := io.ReadAll(r.Body)
+		bodies = append(bodies, string(b))
+		if attempt == 0 {
+			return nil, connLost()
+		}
+		return okResponse(), nil
+	}}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "https://example.com", strings.NewReader("payload"))
+	require.NoError(t, err)
+	req.Header.Set("Idempotency-Key", "abc")
+
+	resp, err := testRetryTripper(f, 3).RoundTrip(req)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	// Body was rewound and replayed intact on the retry.
+	require.Equal(t, []string{"payload", "payload"}, bodies)
+}
+
+func TestRetryRoundTripper_DoesNotRetryNonRewindableBody(t *testing.T) {
+	f := &fakeRoundTripper{fn: func(_ int, _ *http.Request) (*http.Response, error) {
+		return nil, connLost()
+	}}
+	req := getReq(t)
+	// A GET is idempotent, but a body without GetBody cannot be safely replayed.
+	req.Body = io.NopCloser(strings.NewReader("x"))
+	req.GetBody = nil
+
+	resp, err := testRetryTripper(f, 3).RoundTrip(req)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	require.Error(t, err)
+	require.Equal(t, 1, f.calls)
+}
+
+func TestRetryRoundTripper_StopsOnContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	f := &fakeRoundTripper{fn: func(attempt int, _ *http.Request) (*http.Response, error) {
+		if attempt == 0 {
+			cancel()
+		}
+		return nil, connLost()
+	}}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://example.com", nil)
+	require.NoError(t, err)
+
+	resp, err := testRetryTripper(f, 5).RoundTrip(req)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	require.Error(t, err)
+	require.Equal(t, 1, f.calls) // context cancelled after first failure; no retry
+}
+
+func TestResponseHeaderTimeout_OptionAndContextResolution(t *testing.T) {
+	t.Run("unset leaves nil (make applies default)", func(t *testing.T) {
+		tr, err := NewTransport(context.Background())
+		require.NoError(t, err)
+		require.Nil(t, tr.responseHeaderTimeout)
+	})
+	t.Run("resolved from context (CLI/config)", func(t *testing.T) {
+		ctx := context.WithValue(context.Background(), ContextHTTPResponseHeaderTimeoutKey, 90*time.Second)
+		tr, err := NewTransport(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, tr.responseHeaderTimeout)
+		require.Equal(t, 90*time.Second, *tr.responseHeaderTimeout)
+	})
+	t.Run("explicit option beats context", func(t *testing.T) {
+		ctx := context.WithValue(context.Background(), ContextHTTPResponseHeaderTimeoutKey, 90*time.Second)
+		tr, err := NewTransport(ctx, WithResponseHeaderTimeout(5*time.Minute))
+		require.NoError(t, err)
+		require.NotNil(t, tr.responseHeaderTimeout)
+		require.Equal(t, 5*time.Minute, *tr.responseHeaderTimeout)
+	})
+}
+
+func TestRetryRoundTripper_DisabledWhenMaxZero(t *testing.T) {
+	// max <= 0 is guarded at construction in make(); assert the tripper itself
+	// makes no retries when max is 0.
+	f := &fakeRoundTripper{fn: func(_ int, _ *http.Request) (*http.Response, error) {
+		return nil, connLost()
+	}}
+
+	resp, err := testRetryTripper(f, 0).RoundTrip(getReq(t))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	require.Error(t, err)
+	require.Equal(t, 1, f.calls)
+}

--- a/pkg/uhttp/transport.go
+++ b/pkg/uhttp/transport.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"math/rand/v2"
 	"net"
 	"net/http"
 	"sync"
@@ -13,6 +14,20 @@ import (
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
 	"golang.org/x/net/http2"
+)
+
+const (
+	defaultDialTimeout           = 30 * time.Second
+	defaultDialKeepAlive         = 30 * time.Second
+	defaultTLSHandshakeTimeout   = 10 * time.Second
+	defaultExpectContinueTimeout = 1 * time.Second
+	defaultIdleConnTimeout       = 30 * time.Second
+	defaultResponseHeaderTimeout = 60 * time.Second
+	defaultHTTP2ReadIdleTimeout  = 15 * time.Second
+	defaultHTTP2PingTimeout      = 15 * time.Second
+	defaultMaxConnectionRetries  = 3
+	defaultConnRetryBaseDelay    = 250 * time.Millisecond
+	defaultConnRetryMaxDelay     = 2 * time.Second
 )
 
 var loggedResponseHeaders = []string{
@@ -42,6 +57,13 @@ func NewTransport(ctx context.Context, options ...Option) (*Transport, error) {
 	for _, opt := range options {
 		opt.Apply(t)
 	}
+	// CLI/config-provided defaults fill in any value not set via an option.
+	// An explicit option always wins over the context value.
+	if t.responseHeaderTimeout == nil {
+		if d, ok := ctx.Value(ContextHTTPResponseHeaderTimeoutKey).(time.Duration); ok {
+			t.responseHeaderTimeout = &d
+		}
+	}
 	t.userAgent = t.userAgent + " baton-sdk/" + sdk.Version
 
 	_, err := t.cycle(ctx)
@@ -60,6 +82,15 @@ type Transport struct {
 	timeout         time.Duration
 	nextCycle       time.Time
 	mtx             sync.RWMutex
+
+	// Connection tuning. A nil pointer means "not set" and falls back to the
+	// corresponding default* constant in make(); this lets an explicit 0 mean
+	// "disabled/unlimited" (net/http semantics) rather than "use default".
+	idleConnTimeout       *time.Duration
+	responseHeaderTimeout *time.Duration
+	readIdleTimeout       *time.Duration
+	pingTimeout           *time.Duration
+	maxConnRetries        *int
 }
 
 func newTransport() *Transport {
@@ -122,18 +153,22 @@ func (t *Transport) make(_ context.Context) (http.RoundTripper, error) {
 	//   Lambda invocations.
 	// - ResponseHeaderTimeout bounds how long we wait for the proxy/server to
 	//   start responding, preventing zombie connections.
+	//
+	// These defaults are overridable per-connector via the With* options (and,
+	// for the response-header timeout, via CLI/config); see newTransport and
+	// the default* constants.
 	baseTransport := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
+			Timeout:   defaultDialTimeout,
+			KeepAlive: defaultDialKeepAlive,
 		}).DialContext,
 		ForceAttemptHTTP2:     true,
 		MaxIdleConns:          100,
-		IdleConnTimeout:       30 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
-		ResponseHeaderTimeout: 60 * time.Second,
+		IdleConnTimeout:       durationOr(t.idleConnTimeout, defaultIdleConnTimeout),
+		TLSHandshakeTimeout:   defaultTLSHandshakeTimeout,
+		ExpectContinueTimeout: defaultExpectContinueTimeout,
+		ResponseHeaderTimeout: durationOr(t.responseHeaderTimeout, defaultResponseHeaderTimeout),
 		TLSClientConfig:       t.tlsClientConfig,
 	}
 	// PING-frame keepalive: keeps streams alive across intermediaries (e.g.
@@ -143,11 +178,139 @@ func (t *Transport) make(_ context.Context) (http.RoundTripper, error) {
 	if err != nil {
 		return nil, err
 	}
-	h2.ReadIdleTimeout = 15 * time.Second
-	h2.PingTimeout = 15 * time.Second
+	h2.ReadIdleTimeout = durationOr(t.readIdleTimeout, defaultHTTP2ReadIdleTimeout)
+	h2.PingTimeout = durationOr(t.pingTimeout, defaultHTTP2PingTimeout)
+
 	var rv http.RoundTripper = baseTransport
+	// Transparently reconnect-and-retry transient connection-level failures so a
+	// proxy silently dropping a pooled/tunneled connection doesn't surface as a
+	// fatal error to the caller (e.g. aborting a whole sync).
+	if maxRetries := intOr(t.maxConnRetries, defaultMaxConnectionRetries); maxRetries > 0 {
+		rv = &retryRoundTripper{
+			next:      rv,
+			max:       maxRetries,
+			baseDelay: defaultConnRetryBaseDelay,
+			maxDelay:  defaultConnRetryMaxDelay,
+			log:       t.log,
+		}
+	}
 	rv = &userAgentTripper{next: rv, userAgent: t.userAgent}
 	return rv, nil
+}
+
+func durationOr(v *time.Duration, def time.Duration) time.Duration {
+	if v != nil {
+		return *v
+	}
+	return def
+}
+
+func intOr(v *int, def int) int {
+	if v != nil {
+		return *v
+	}
+	return def
+}
+
+// retryRoundTripper transparently re-issues a request on transient
+// connection-level failures (e.g. a proxy silently dropping a pooled or
+// tunneled connection). When the HTTP/2 health check tears down a dead
+// ClientConn it is evicted from the pool, so the retried RoundTrip dials a
+// fresh connection -- retry here also reconnects. Only reconnectable errors
+// (see IsReconnectableError) on idempotent, rewindable requests are retried;
+// slow-peer timeouts are not, since replaying would hit the same wall.
+type retryRoundTripper struct {
+	next      http.RoundTripper
+	max       int
+	baseDelay time.Duration
+	maxDelay  time.Duration
+	log       bool
+}
+
+func (rt *retryRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	canReplay := isIdempotentRequest(req) &&
+		(req.Body == nil || req.Body == http.NoBody || req.GetBody != nil)
+
+	var (
+		resp *http.Response
+		err  error
+	)
+	for attempt := 0; ; attempt++ {
+		if attempt > 0 {
+			if rerr := rewindBody(req); rerr != nil {
+				return nil, rerr
+			}
+		}
+		resp, err = rt.next.RoundTrip(req)
+		if err == nil {
+			return resp, nil
+		}
+		if !canReplay || attempt >= rt.max || !IsReconnectableError(err) {
+			return resp, err
+		}
+		if req.Context().Err() != nil {
+			return resp, err
+		}
+		if resp != nil && resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+		delay := retryBackoff(attempt+1, rt.baseDelay, rt.maxDelay)
+		if rt.log {
+			ctxzap.Extract(req.Context()).Debug("uhttp: retrying request after transient connection error",
+				zap.String("http.method", req.Method),
+				zap.String("http.url_details.host", req.URL.Host),
+				zap.String("http.url_details.path", req.URL.Path),
+				zap.Int("attempt", attempt+1),
+				zap.Duration("delay", delay),
+				zap.Error(err),
+			)
+		}
+		timer := time.NewTimer(delay)
+		select {
+		case <-req.Context().Done():
+			timer.Stop()
+			return resp, err
+		case <-timer.C:
+		}
+	}
+}
+
+// isIdempotentRequest reports whether re-issuing req is safe. It mirrors
+// net/http's notion of idempotency: the safe methods, plus any request carrying
+// an explicit idempotency key.
+func isIdempotentRequest(req *http.Request) bool {
+	switch req.Method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodTrace:
+		return true
+	}
+	return req.Header.Get("Idempotency-Key") != "" || req.Header.Get("X-Idempotency-Key") != ""
+}
+
+func rewindBody(req *http.Request) error {
+	if req.Body == nil || req.Body == http.NoBody || req.GetBody == nil {
+		return nil
+	}
+	body, err := req.GetBody()
+	if err != nil {
+		return fmt.Errorf("uhttp: cannot rewind request body for retry: %w", err)
+	}
+	req.Body = body
+	return nil
+}
+
+// retryBackoff returns exponential backoff with full jitter, capped at limit.
+func retryBackoff(attempt int, base, limit time.Duration) time.Duration {
+	if base <= 0 {
+		return 0
+	}
+	d := base
+	for i := 1; i < attempt && d < limit; i++ {
+		d *= 2
+	}
+	if d > limit {
+		d = limit
+	}
+	return rand.N(d + 1) //nolint:gosec // jitter only, not security-sensitive
 }
 
 func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {


### PR DESCRIPTION
## Summary

The `uhttp` transport hardcodes its connection timeouts — idle-conn (30s), response-header (60s), and the HTTP/2 PING keepalive (15s+15s = 30s). Those defaults were deliberately tuned for chatty API connectors behind an egress proxy, but two gaps fall out of them:

1. **A single transient connection blip can abort a whole sync.** When a proxy silently drops a pooled/tunneled connection, it surfaces as `http2: client connection lost` or `connection reset`, which `wrapTransientNetworkError` maps to `codes.Unavailable`. Nothing in `uhttp` retries it, so the error propagates up and the sync workflow discards its in-progress `c1z` and restarts. On a long, per-entity (N+1) walk through a flaky proxy, a run may rarely get an uninterrupted window to completion.
2. **No way to tolerate slow synchronous endpoints.** An endpoint that blocks before sending response headers (e.g. a report-generation call) hits the fixed 60s `ResponseHeaderTimeout` — which, because the transport uses `http2.ConfigureTransports`, applies over HTTP/2 too — with no knob to raise it.

## What changed

**Configurable timeouts** (`pkg/uhttp`): new options `WithIdleConnTimeout`, `WithResponseHeaderTimeout`, `WithHTTP2KeepAlive`, and `WithMaxConnectionRetries`. The tuning fields become nil-able pointers: a `nil` option preserves the existing default (via the new `default*` constants), so an explicit `0` can still mean "disabled/unlimited" per net/http semantics. **Timeout defaults are unchanged.**

**Retry-with-reconnect** (`pkg/uhttp`): a new `retryRoundTripper` sits below the error-wrapping layer and transparently replays a request on reconnectable transport errors (new `IsReconnectableError` helper — `http2 client connection lost`, `ECONNRESET`, `EPIPE`, `net.ErrClosed`, unexpected/EOF; **timeouts/`DeadlineExceeded` are deliberately excluded**). When the HTTP/2 health check tears down a dead `ClientConn` it is evicted from the pool, so the retried `RoundTrip` dials fresh — retry here also reconnects. Only **idempotent** requests (safe methods, or a request carrying an `Idempotency-Key`) with a **rewindable** body are retried; jittered exponential backoff is bounded by the request context.

**Config plumbing** (`pkg/field`, `pkg/cli`): a new `http-response-header-timeout-seconds` field (default 60, `0` disables) is injected into the run context and consumed by the transport. An explicit `WithResponseHeaderTimeout` option takes precedence over the config value, mirroring the existing `http-timeout-seconds` behavior.

## ⚠️ One behavior change

`WithMaxConnectionRetries` **defaults to 3** — previously there was no retry. This is the intended fix, and it's scoped tightly (idempotent + rewindable + reconnectable-only, context-bounded). To opt out, pass `WithMaxConnectionRetries(0)`. Happy to flip the default to opt-in (0) if reviewers prefer.

## Note

The retry sits at the transport layer, below `BaseHttpClient.Do`'s rate limiter, so a retried attempt does not take a fresh rate-limit token. For rare connection-death retries this is negligible; called out for visibility.

## Testing

`go test ./pkg/uhttp/... ./pkg/field/...` and `golangci-lint` pass. New tests cover error classification, retry-until-success, stop-at-max, non-reconnectable/non-idempotent/non-rewindable guards, body rewind on retry, context cancellation, and option-vs-config precedence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)