### PR TITLE
uhttp: drop stale pooled connections and add a bounded, safe retry

### DIFF
--- a/pkg/uhttp/errors.go
+++ b/pkg/uhttp/errors.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/http"
 	"net/url"
 	"strings"
 	"syscall"
@@ -56,4 +57,36 @@ func wrapTransientNetworkError(err error) error {
 
 func isHTTP2ClientConnectionLost(err error) bool {
 	return strings.Contains(err.Error(), "http2: client connection lost")
+}
+
+// requestNeverSent reports whether err was raised before any request bytes
+// were written: the TCP dial (including the dial to an HTTP proxy, which
+// net/http wraps with Op "proxyconnect"). Retrying such failures is safe
+// for every method because the server never saw the request.
+func requestNeverSent(err error) bool {
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		return opErr.Op == "dial" || opErr.Op == "proxyconnect"
+	}
+	return false
+}
+
+// isStaleConnectionError reports whether err looks like a pooled connection
+// that died between requests: the reset/EOF classes a proxy or origin
+// produces when it tore the connection down while it sat in the pool.
+func isStaleConnectionError(err error) bool {
+	return errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, io.ErrUnexpectedEOF) ||
+		isHTTP2ClientConnectionLost(err)
+}
+
+// declaredIdempotent mirrors net/http's Request.isReplayable: safe methods
+// are idempotent by definition, and other methods may declare idempotence
+// with an Idempotency-Key header (https://golang.org/issue/19943).
+func declaredIdempotent(req *http.Request) bool {
+	switch req.Method {
+	case "", http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodTrace:
+		return true
+	}
+	return req.Header.Get("Idempotency-Key") != "" || req.Header.Get("X-Idempotency-Key") != ""
 }

--- a/pkg/uhttp/transport.go
+++ b/pkg/uhttp/transport.go
@@ -74,6 +74,11 @@ type Transport struct {
 	nextCycle     time.Time
 	// lastActivityNs is the wall-clock unix-nano time of the last request.
 	lastActivityNs atomic.Int64
+	// gapMu serializes gap-triggered pool drops. The drop must complete
+	// before concurrent callers may treat the pool as live, so the fresh
+	// timestamp is published only after CloseIdleConnections returns and
+	// peers that observed the same gap block here until then.
+	gapMu sync.Mutex
 	// nowFn overrides time.Now in tests.
 	nowFn func() time.Time
 	mtx   sync.RWMutex
@@ -189,7 +194,18 @@ func (t *Transport) now() time.Time {
 // where a monotonic time.Since would report no gap at all.
 func (t *Transport) dropIdleConnectionsAfterGap(ctx context.Context) {
 	nowNs := t.now().UnixNano()
-	lastNs := t.lastActivityNs.Swap(nowNs)
+	lastNs := t.lastActivityNs.Load()
+	if lastNs == 0 || time.Duration(nowNs-lastNs) < staleConnectionGap {
+		return
+	}
+
+	// Serialize the drop and publish the fresh timestamp only after the
+	// pool is clean. Publishing first would let concurrent callers see a
+	// small gap and draw a presumed-dead connection while the drop is
+	// still running; instead they block here until it has completed.
+	t.gapMu.Lock()
+	defer t.gapMu.Unlock()
+	lastNs = t.lastActivityNs.Load()
 	if lastNs == 0 || time.Duration(nowNs-lastNs) < staleConnectionGap {
 		return
 	}
@@ -200,6 +216,7 @@ func (t *Transport) dropIdleConnectionsAfterGap(ctx context.Context) {
 		)
 	}
 	t.closeIdleConnections()
+	t.lastActivityNs.Store(nowNs)
 }
 
 // closeIdleConnections drops the pooled connections on the current base
@@ -275,9 +292,15 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		if retryReq, ok := retryableRequest(req, err); ok {
 			// A mass connection death (e.g. a proxy instance replaced) can
 			// leave further corpses in the pool; drop them so the retry
-			// dials fresh instead of drawing the next one.
+			// dials fresh instead of drawing the next one. Re-resolve the
+			// round tripper afterwards: cycle() may have swapped transports
+			// since rt was acquired, and the retry must run on the pool
+			// that was just dropped, not an older one still holding corpses.
 			if isStaleConnectionError(err) {
 				t.closeIdleConnections()
+				if freshRT, cycleErr := t.cycle(ctx); cycleErr == nil {
+					rt = freshRT
+				}
 			}
 			if t.log {
 				t.l(ctx).Debug("uhttp: retrying request after transport error",

--- a/pkg/uhttp/transport.go
+++ b/pkg/uhttp/transport.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/conductorone/baton-sdk/pkg/sdk"
@@ -14,6 +15,15 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/net/http2"
 )
+
+// staleConnectionGap is how long the transport can go unused before its
+// pooled connections are presumed dead and dropped on the next request.
+// The gap is measured on the wall clock, not the monotonic clock: in AWS
+// Lambda the monotonic clock does not advance while the execution
+// environment is frozen, so IdleConnTimeout never observes the gap, while
+// proxies and origins time the same connections out in real time.
+// 60s matches typical proxy idle timeouts (Squid defaults to ~60s).
+const staleConnectionGap = 60 * time.Second
 
 var loggedResponseHeaders = []string{
 	// Limit headers
@@ -55,11 +65,18 @@ type Transport struct {
 	userAgent       string
 	tlsClientConfig *tls.Config
 	roundTripper    http.RoundTripper
-	logger          *zap.Logger
-	log             bool
-	timeout         time.Duration
-	nextCycle       time.Time
-	mtx             sync.RWMutex
+	// baseTransport is the concrete transport inside roundTripper, kept so
+	// idle connections can be closed. Guarded by mtx.
+	baseTransport *http.Transport
+	logger        *zap.Logger
+	log           bool
+	timeout       time.Duration
+	nextCycle     time.Time
+	// lastActivityNs is the wall-clock unix-nano time of the last request.
+	lastActivityNs atomic.Int64
+	// nowFn overrides time.Now in tests.
+	nowFn func() time.Time
+	mtx   sync.RWMutex
 }
 
 func newTransport() *Transport {
@@ -92,12 +109,18 @@ func (t *Transport) cycle(ctx context.Context) (http.RoundTripper, error) {
 	// working RoundTripper with nil on transient make() errors --
 	// subsequent requests served by this Transport would then fail
 	// until the next successful cycle.
+	oldBase := t.baseTransport
 	newRoundTripper, err := t.make(ctx)
 	if err != nil {
 		return nil, err
 	}
 	t.roundTripper = newRoundTripper
 	t.nextCycle = n.Add(time.Minute * 5)
+	// The replaced pool would otherwise keep its connections open until
+	// their idle timers fire; close them now so they end with a clean FIN.
+	if oldBase != nil {
+		oldBase.CloseIdleConnections()
+	}
 	return t.roundTripper, nil
 }
 
@@ -147,11 +170,85 @@ func (t *Transport) make(_ context.Context) (http.RoundTripper, error) {
 	h2.PingTimeout = 15 * time.Second
 	var rv http.RoundTripper = baseTransport
 	rv = &userAgentTripper{next: rv, userAgent: t.userAgent}
+	t.baseTransport = baseTransport
 	return rv, nil
+}
+
+func (t *Transport) now() time.Time {
+	if t.nowFn != nil {
+		return t.nowFn()
+	}
+	return time.Now()
+}
+
+// dropIdleConnectionsAfterGap discards pooled connections when this
+// transport has been unused for longer than staleConnectionGap. After a
+// Lambda thaw the pool can hold connections that a proxy or origin closed
+// during the freeze, and reusing one fails with a connection reset; the
+// UnixNano comparison reads the wall clock, which is resynced on thaw,
+// where a monotonic time.Since would report no gap at all.
+func (t *Transport) dropIdleConnectionsAfterGap(ctx context.Context) {
+	nowNs := t.now().UnixNano()
+	lastNs := t.lastActivityNs.Swap(nowNs)
+	if lastNs == 0 || time.Duration(nowNs-lastNs) < staleConnectionGap {
+		return
+	}
+
+	if t.log {
+		t.l(ctx).Debug("uhttp: dropping idle connections after activity gap",
+			zap.Duration("gap", time.Duration(nowNs-lastNs)),
+		)
+	}
+	t.closeIdleConnections()
+}
+
+// closeIdleConnections drops the pooled connections on the current base
+// transport, if one has been built.
+func (t *Transport) closeIdleConnections() {
+	t.mtx.RLock()
+	bt := t.baseTransport
+	t.mtx.RUnlock()
+	if bt != nil {
+		bt.CloseIdleConnections()
+	}
+}
+
+// retryableRequest reports whether a failed request may be retried safely,
+// and returns the request to retry with. Two cases qualify: errors raised
+// before any request bytes were written (safe for every method), and
+// stale-pooled-connection errors on requests that declare idempotence via
+// a safe method or an Idempotency-Key header. net/http covers the second
+// case itself for HTTP/1.1 but never for HTTP/2, where its retry gate
+// requires a reused persistConn and h2 connections are always wrapped in
+// fresh ones.
+func retryableRequest(req *http.Request, err error) (*http.Request, bool) {
+	retrySafe := requestNeverSent(err) || (declaredIdempotent(req) && isStaleConnectionError(err))
+	if !retrySafe {
+		return nil, false
+	}
+	// The transport closes the original body on failure, so any request
+	// that carries one needs a fresh copy to be retried.
+	if req.Body == nil || req.Body == http.NoBody {
+		return req, true
+	}
+	if req.GetBody == nil {
+		return nil, false
+	}
+	body, err := req.GetBody()
+	if err != nil {
+		return nil, false
+	}
+	retryReq := req.Clone(req.Context())
+	retryReq.Body = body
+	return retryReq, true
 }
 
 func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	ctx := req.Context()
+	t.dropIdleConnectionsAfterGap(ctx)
+	// Record activity on completion too, so a single long request is not
+	// mistaken for an idle gap by the request that follows it.
+	defer func() { t.lastActivityNs.Store(t.now().UnixNano()) }()
 	rt, err := t.cycle(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("uhttp: cycle failed: %w", err)
@@ -174,6 +271,25 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		}
 	}()
 	resp, err := rt.RoundTrip(req)
+	if err != nil && req.Context().Err() == nil {
+		if retryReq, ok := retryableRequest(req, err); ok {
+			// A mass connection death (e.g. a proxy instance replaced) can
+			// leave further corpses in the pool; drop them so the retry
+			// dials fresh instead of drawing the next one.
+			if isStaleConnectionError(err) {
+				t.closeIdleConnections()
+			}
+			if t.log {
+				t.l(ctx).Debug("uhttp: retrying request after transport error",
+					zap.String("http.method", req.Method),
+					zap.String("http.url_details.host", req.URL.Host),
+					zap.String("http.url_details.path", req.URL.Path),
+					zap.Error(err),
+				)
+			}
+			resp, err = rt.RoundTrip(retryReq)
+		}
+	}
 	err = wrapTransientNetworkError(err)
 	if t.log {
 		duration := time.Since(start)

--- a/pkg/uhttp/transport_test.go
+++ b/pkg/uhttp/transport_test.go
@@ -3,10 +3,14 @@ package uhttp
 import (
 	"context"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
+	"strings"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -15,6 +19,282 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+// connCountingServer is an httptest server that counts connections the
+// server has accepted and seen closed.
+type connCountingServer struct {
+	*httptest.Server
+	mu     sync.Mutex
+	opened int
+	closed int
+}
+
+func newConnCountingServer(t *testing.T) *connCountingServer {
+	t.Helper()
+	s := &connCountingServer{}
+	s.Server = httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	s.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		switch state {
+		case http.StateNew:
+			s.opened++
+		case http.StateClosed:
+			s.closed++
+		default:
+		}
+	}
+	s.Start()
+	t.Cleanup(s.Close)
+	return s
+}
+
+func (s *connCountingServer) openedCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.opened
+}
+
+func (s *connCountingServer) closedCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.closed
+}
+
+func mustGet(t *testing.T, client *http.Client, url string) {
+	t.Helper()
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, nil)
+	require.NoError(t, err)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	_, err = io.Copy(io.Discard, resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+}
+
+// sequencedRoundTripper fails with errs in order (one per call), then
+// answers 200 OK, recording call count and each request's body.
+type sequencedRoundTripper struct {
+	mu     sync.Mutex
+	errs   []error
+	calls  int
+	bodies []string
+}
+
+func (s *sequencedRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	body := ""
+	if req.Body != nil {
+		b, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		_ = req.Body.Close()
+		body = string(b)
+	}
+	s.bodies = append(s.bodies, body)
+	call := s.calls
+	s.calls++
+	if call < len(s.errs) {
+		return nil, s.errs[call]
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("ok")),
+		Header:     http.Header{},
+	}, nil
+}
+
+func (s *sequencedRoundTripper) callCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+func connResetError() error {
+	return &url.Error{
+		Op:  "Post",
+		URL: "https://example.com",
+		Err: &net.OpError{
+			Op:  "read",
+			Net: "tcp",
+			Err: os.NewSyscallError("read", syscall.ECONNRESET),
+		},
+	}
+}
+
+func proxyConnectError() error {
+	return &url.Error{
+		Op:  "Post",
+		URL: "https://example.com",
+		Err: &net.OpError{
+			Op:  "proxyconnect",
+			Net: "tcp",
+			Err: fmt.Errorf("connect: connection timed out"),
+		},
+	}
+}
+
+func newRetryTestTransport(rt http.RoundTripper) *Transport {
+	return &Transport{
+		roundTripper: rt,
+		nextCycle:    time.Now().Add(time.Minute),
+	}
+}
+
+func postWithBody(t *testing.T, payload string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "https://example.com", strings.NewReader(payload))
+	require.NoError(t, err)
+	return req
+}
+
+func TestTransportRetriesDialPhaseErrorsForAnyMethod(t *testing.T) {
+	seq := &sequencedRoundTripper{errs: []error{proxyConnectError()}}
+	tp := newRetryTestTransport(seq)
+
+	resp, err := tp.RoundTrip(postWithBody(t, "payload"))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, 2, seq.callCount())
+	// The retried request carries a rewound copy of the body.
+	require.Equal(t, []string{"payload", "payload"}, seq.bodies)
+}
+
+func TestTransportRetriesStaleConnForDeclaredIdempotentPOST(t *testing.T) {
+	seq := &sequencedRoundTripper{errs: []error{connResetError()}}
+	tp := newRetryTestTransport(seq)
+
+	req := postWithBody(t, "payload")
+	req.Header.Set("Idempotency-Key", "test-key")
+	resp, err := tp.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, 2, seq.callCount())
+}
+
+func TestTransportRetriesStaleConnForGET(t *testing.T) {
+	seq := &sequencedRoundTripper{errs: []error{connResetError()}}
+	tp := newRetryTestTransport(seq)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://example.com", nil)
+	require.NoError(t, err)
+	resp, err := tp.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, 2, seq.callCount())
+}
+
+func TestTransportDropsIdlePoolBeforeStaleConnRetry(t *testing.T) {
+	srv := newConnCountingServer(t)
+
+	// Park one live idle connection in a real base transport's pool.
+	base := &http.Transport{}
+	t.Cleanup(base.CloseIdleConnections)
+	mustGet(t, &http.Client{Transport: base}, srv.URL)
+	require.Equal(t, 1, srv.openedCount())
+
+	seq := &sequencedRoundTripper{errs: []error{connResetError()}}
+	tp := newRetryTestTransport(seq)
+	tp.baseTransport = base
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://example.com", nil)
+	require.NoError(t, err)
+	resp, err := tp.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, 2, seq.callCount())
+
+	// The stale-connection retry must drop the pooled connections before
+	// its second attempt, so it cannot draw another dead connection after
+	// a mass death event.
+	require.Eventually(t, func() bool { return srv.closedCount() >= 1 }, 2*time.Second, 10*time.Millisecond)
+}
+
+func TestTransportDoesNotRetryStaleConnForUndeclaredPOST(t *testing.T) {
+	seq := &sequencedRoundTripper{errs: []error{connResetError()}}
+	tp := newRetryTestTransport(seq)
+
+	resp, err := tp.RoundTrip(postWithBody(t, "payload"))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	require.Error(t, err)
+	require.Equal(t, 1, seq.callCount())
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.Unavailable, st.Code())
+}
+
+func TestTransportDoesNotRetryWithoutRewindableBody(t *testing.T) {
+	seq := &sequencedRoundTripper{errs: []error{proxyConnectError()}}
+	tp := newRetryTestTransport(seq)
+
+	req := postWithBody(t, "payload")
+	req.GetBody = nil
+	resp, err := tp.RoundTrip(req)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	require.Error(t, err)
+	require.Equal(t, 1, seq.callCount())
+}
+
+func TestTransportDropsIdleConnectionsAfterWallClockGap(t *testing.T) {
+	srv := newConnCountingServer(t)
+
+	tp, err := NewTransport(t.Context())
+	require.NoError(t, err)
+
+	now := time.Now()
+	tp.nowFn = func() time.Time { return now }
+
+	client := &http.Client{Transport: tp}
+
+	mustGet(t, client, srv.URL)
+	require.Equal(t, 1, srv.openedCount())
+
+	// A short pause keeps the pooled connection.
+	now = now.Add(time.Second)
+	mustGet(t, client, srv.URL)
+	require.Equal(t, 1, srv.openedCount())
+
+	// A freeze-sized wall-clock gap drops the pool; the next request
+	// dials a fresh connection instead of reusing a presumed-dead one.
+	now = now.Add(staleConnectionGap + time.Second)
+	mustGet(t, client, srv.URL)
+	require.Equal(t, 2, srv.openedCount())
+	require.Eventually(t, func() bool { return srv.closedCount() >= 1 }, 2*time.Second, 10*time.Millisecond)
+}
+
+func TestTransportCycleClosesAbandonedConnections(t *testing.T) {
+	srv := newConnCountingServer(t)
+
+	tp, err := NewTransport(t.Context())
+	require.NoError(t, err)
+
+	client := &http.Client{Transport: tp}
+
+	mustGet(t, client, srv.URL)
+	require.Equal(t, 1, srv.openedCount())
+
+	// Force the next request to rebuild the round tripper.
+	tp.mtx.Lock()
+	tp.nextCycle = time.Time{}
+	tp.mtx.Unlock()
+
+	// The rebuild swaps in a fresh pool and closes the abandoned one.
+	mustGet(t, client, srv.URL)
+	require.Equal(t, 2, srv.openedCount())
+	require.Eventually(t, func() bool { return srv.closedCount() >= 1 }, 2*time.Second, 10*time.Millisecond)
+}
 
 type errorRoundTripper struct {
 	err error


### PR DESCRIPTION
Hosted connectors run on Lambda behind an egress proxy. Lambda freezes pause the monotonic clock, so IdleConnTimeout never observes the gap while the proxy and origins time out pooled connections in real time. The first requests after a thaw (or after a proxy instance replacement) then fail with "connection reset by peer", "unexpected EOF", or "http2: client connection lost", burning task-level retries.

Three changes to the uhttp Transport:

- Wall-clock gap detection: track last-activity time in wall-clock nanos (the wall clock is resynced on thaw; time.Since would measure the frozen monotonic clock and report no gap). On the first request after a 60s+ gap, close idle connections on both the HTTP/1.1 and HTTP/2 pools so requests dial fresh instead of reusing presumed-dead connections.

- cycle() now closes the pool it abandons when rebuilding the round tripper, instead of leaving connections to linger until their idle timers fire.

- A single bounded retry in RoundTrip for two provably-safe classes: dial-phase failures (dial/proxyconnect ops — no request bytes were written, safe for every method), and stale-connection errors (ECONNRESET, unexpected EOF, h2 connection lost) for requests that declare idempotence via a safe method or an Idempotency-Key header. net/http already retries the second class on HTTP/1.1 but never on HTTP/2, where its retry gate requires a reused persistConn and h2 connections are always wrapped in fresh ones. Retries require a rewindable body, and the idle pool is dropped before a stale-connection retry so the second attempt cannot draw another dead connection.

Includes connection-counting integration tests for the gap drop, the cycle close, and the pool drop before retry, plus unit tests for the retry gating (dial-phase any-method, declared-idempotent POST, GET, undeclared POST refused, non-rewindable body refused).