### PR TITLE
log cleanup for stats

### DIFF
--- a/pkg/sync/sync_summary.go
+++ b/pkg/sync/sync_summary.go
@@ -1,0 +1,188 @@
+package sync //nolint:revive,nolintlint // we can't change the package name for backwards compatibility
+
+import (
+	"slices"
+	"strings"
+)
+
+// topConnectorCallStatsByResourceType caps how many method:resource_type
+// entries appear in the sync-complete log. The full set stays in the token.
+const topConnectorCallStatsByResourceType = 8
+
+// sessionStatsLogMinTotalMs is the aggregate session time below which idle
+// session stats are omitted from logs (errors/timeouts always surface).
+const sessionStatsLogMinTotalMs = 50
+
+func isWaitStepBucket(bucket string) bool {
+	switch {
+	case bucket == "rate_limit_wait", bucket == "retry_wait":
+		return true
+	case strings.HasPrefix(bucket, "rate_limit_wait:"), strings.HasPrefix(bucket, "retry_wait:"):
+		return true
+	default:
+		return false
+	}
+}
+
+func timedSyncOpBuckets() map[string]struct{} {
+	out := make(map[string]struct{}, len(timedSyncOps))
+	for _, op := range timedSyncOps {
+		out[op.String()] = struct{}{}
+	}
+	return out
+}
+
+// partitionStepDurationsForLog splits the token's step map into summable op
+// buckets (matching sync_steps_total_ms), wait buckets (of-which retries),
+// and everything else (checkpoint, connector-specific counters, …). Zero
+// entries are dropped so logs stay compact.
+func partitionStepDurationsForLog(all map[string]int64) (map[string]int64, map[string]int64, map[string]int64) {
+	var ops, waits, other map[string]int64
+	opSet := timedSyncOpBuckets()
+	for bucket, ms := range all {
+		if ms == 0 {
+			continue
+		}
+		switch {
+		case isWaitStepBucket(bucket):
+			if waits == nil {
+				waits = make(map[string]int64)
+			}
+			waits[bucket] = ms
+		default:
+			if _, ok := opSet[bucket]; ok {
+				if ops == nil {
+					ops = make(map[string]int64)
+				}
+				ops[bucket] = ms
+				continue
+			}
+			if other == nil {
+				other = make(map[string]int64)
+			}
+			other[bucket] = ms
+		}
+	}
+	return ops, waits, other
+}
+
+// partitionConnectorCallStatsForLog returns flat method stats for the primary
+// log field and the top-N method:resource_type entries by total_ms. Zero-count
+// flats and zero-duration labeled entries are omitted.
+func partitionConnectorCallStatsForLog(all map[string]ConnectorCallStat) (map[string]ConnectorCallStat, map[string]ConnectorCallStat) {
+	type ranked struct {
+		key  string
+		stat ConnectorCallStat
+	}
+	var flat map[string]ConnectorCallStat
+	var labeled []ranked
+	for key, stat := range all {
+		if strings.Contains(key, ":") {
+			// Labeled noise like list-static-entitlements:user with 0ms.
+			if stat.Count == 0 || (stat.TotalMs == 0 && stat.MaxMs == 0) {
+				continue
+			}
+			labeled = append(labeled, ranked{key: key, stat: stat})
+			continue
+		}
+		if stat.Count == 0 {
+			continue
+		}
+		if flat == nil {
+			flat = make(map[string]ConnectorCallStat)
+		}
+		flat[key] = stat
+	}
+	slices.SortFunc(labeled, func(a, b ranked) int {
+		switch {
+		case a.stat.TotalMs > b.stat.TotalMs:
+			return -1
+		case a.stat.TotalMs < b.stat.TotalMs:
+			return 1
+		case a.key < b.key:
+			return -1
+		case a.key > b.key:
+			return 1
+		default:
+			return 0
+		}
+	})
+	if n := topConnectorCallStatsByResourceType; len(labeled) > n {
+		labeled = labeled[:n]
+	}
+	var topByRT map[string]ConnectorCallStat
+	if len(labeled) > 0 {
+		topByRT = make(map[string]ConnectorCallStat, len(labeled))
+		for _, item := range labeled {
+			topByRT[item.key] = item.stat
+		}
+	}
+	return flat, topByRT
+}
+
+func sessionStatsDiverge(stats map[string]SessionStoreStat) bool {
+	for op, cacheStat := range stats {
+		suffix, ok := strings.CutPrefix(op, "connector.cache.")
+		if !ok {
+			continue
+		}
+		backend, ok := stats["connector."+suffix]
+		if !ok {
+			continue
+		}
+		delta := cacheStat.TotalMs - backend.TotalMs
+		if delta < 0 {
+			delta = -delta
+		}
+		threshold := cacheStat.TotalMs / 10
+		if threshold < 5 {
+			threshold = 5
+		}
+		if delta > threshold {
+			return true
+		}
+	}
+	return false
+}
+
+// filterSessionStatsForLog drops empty entries and reports whether the map is
+// worth logging: errors/timeouts, material aggregate time, or cache-vs-backend
+// divergence.
+func filterSessionStatsForLog(all map[string]SessionStoreStat) (map[string]SessionStoreStat, bool) {
+	if len(all) == 0 {
+		return nil, false
+	}
+	var totalMs, errors, timeouts int64
+	out := make(map[string]SessionStoreStat, len(all))
+	for op, stat := range all {
+		if stat.Count == 0 && stat.Errors == 0 && stat.Timeouts == 0 && stat.TotalMs == 0 {
+			continue
+		}
+		out[op] = stat
+		totalMs += stat.TotalMs
+		errors += stat.Errors
+		timeouts += stat.Timeouts
+	}
+	if len(out) == 0 {
+		return nil, false
+	}
+	worth := errors > 0 || timeouts > 0 || totalMs >= sessionStatsLogMinTotalMs || sessionStatsDiverge(out)
+	if !worth {
+		return nil, false
+	}
+	return out, true
+}
+
+func aggregateSessionStats(all map[string]SessionStoreStat) (int64, int64, int64, int64, int64) {
+	var count, errors, timeouts, totalMs, maxMs int64
+	for _, stat := range all {
+		count += stat.Count
+		errors += stat.Errors
+		timeouts += stat.Timeouts
+		totalMs += stat.TotalMs
+		if stat.MaxMs > maxMs {
+			maxMs = stat.MaxMs
+		}
+	}
+	return count, errors, timeouts, totalMs, maxMs
+}

--- a/pkg/sync/sync_summary_test.go
+++ b/pkg/sync/sync_summary_test.go
@@ -1,0 +1,180 @@
+package sync //nolint:revive,nolintlint // we can't change the package name for backwards compatibility
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestPartitionStepDurationsForLog(t *testing.T) {
+	ops, waits, other := partitionStepDurationsForLog(map[string]int64{
+		"list-grants":              1000,
+		"list-resources":           0, // omitted
+		"checkpoint":               29,
+		"rate_limit_wait":          50,
+		"rate_limit_wait:group":    50,
+		"retry_wait":               10,
+		"source_cache_tombstones":  0, // omitted
+		"source_cache_tombstones2": 3,
+	})
+	require.Equal(t, map[string]int64{"list-grants": 1000}, ops)
+	require.Equal(t, map[string]int64{
+		"rate_limit_wait":       50,
+		"rate_limit_wait:group": 50,
+		"retry_wait":            10,
+	}, waits)
+	require.Equal(t, map[string]int64{
+		"checkpoint":               29,
+		"source_cache_tombstones2": 3,
+	}, other)
+}
+
+func TestPartitionConnectorCallStatsForLog(t *testing.T) {
+	flat, byRT := partitionConnectorCallStatsForLog(map[string]ConnectorCallStat{
+		"list-grants":                        {Count: 626, TotalMs: 89988, MaxMs: 8042},
+		"list-grants:enterprise_application": {Count: 454, TotalMs: 78241, MaxMs: 1174},
+		"list-grants:group":                  {Count: 14, TotalMs: 10131, MaxMs: 8042},
+		"list-grants:user":                   {Count: 150, TotalMs: 262, MaxMs: 10},
+		"list-static-entitlements":           {Count: 7, TotalMs: 2, MaxMs: 2},
+		"list-static-entitlements:user":      {Count: 1, TotalMs: 0, MaxMs: 0}, // noise
+		"list-resources":                     {Count: 0, TotalMs: 0, MaxMs: 0}, // omitted
+	})
+	require.Equal(t, map[string]ConnectorCallStat{
+		"list-grants":              {Count: 626, TotalMs: 89988, MaxMs: 8042},
+		"list-static-entitlements": {Count: 7, TotalMs: 2, MaxMs: 2},
+	}, flat)
+	require.NotContains(t, byRT, "list-static-entitlements:user")
+	require.Equal(t, ConnectorCallStat{Count: 454, TotalMs: 78241, MaxMs: 1174}, byRT["list-grants:enterprise_application"])
+	require.Equal(t, ConnectorCallStat{Count: 14, TotalMs: 10131, MaxMs: 8042}, byRT["list-grants:group"])
+	require.Equal(t, ConnectorCallStat{Count: 150, TotalMs: 262, MaxMs: 10}, byRT["list-grants:user"])
+}
+
+func TestPartitionConnectorCallStatsForLogTopN(t *testing.T) {
+	all := map[string]ConnectorCallStat{
+		"list-grants": {Count: 1, TotalMs: 100, MaxMs: 100},
+	}
+	for i := 0; i < topConnectorCallStatsByResourceType+5; i++ {
+		all[fmt.Sprintf("list-grants:rt%02d", i)] = ConnectorCallStat{
+			Count: 1, TotalMs: int64(100 - i), MaxMs: int64(100 - i),
+		}
+	}
+	_, byRT := partitionConnectorCallStatsForLog(all)
+	require.Len(t, byRT, topConnectorCallStatsByResourceType)
+	require.Contains(t, byRT, "list-grants:rt00")
+	require.NotContains(t, byRT, fmt.Sprintf("list-grants:rt%02d", topConnectorCallStatsByResourceType))
+}
+
+func TestFilterSessionStatsForLog(t *testing.T) {
+	_, ok := filterSessionStatsForLog(nil)
+	require.False(t, ok)
+
+	_, ok = filterSessionStatsForLog(map[string]SessionStoreStat{
+		"connector.get": {Count: 3, TotalMs: 1},
+	})
+	require.False(t, ok, "sub-threshold idle session stats should be omitted")
+
+	out, ok := filterSessionStatsForLog(map[string]SessionStoreStat{
+		"connector.get": {Count: 3, TotalMs: 30},
+		"store.set":     {Count: 6, TotalMs: 40},
+	})
+	require.True(t, ok)
+	require.Len(t, out, 2)
+
+	out, ok = filterSessionStatsForLog(map[string]SessionStoreStat{
+		"connector.get": {Count: 1, Errors: 1, Timeouts: 1, TotalMs: 1, MaxMs: 1},
+	})
+	require.True(t, ok, "timeouts always surface")
+	require.EqualValues(t, 1, out["connector.get"].Timeouts)
+
+	out, ok = filterSessionStatsForLog(map[string]SessionStoreStat{
+		"connector.cache.get": {Count: 3, TotalMs: 100},
+		"connector.get":       {Count: 3, TotalMs: 10},
+	})
+	require.True(t, ok, "cache vs backend divergence should surface")
+	require.Len(t, out, 2)
+}
+
+func TestAggregateSessionStats(t *testing.T) {
+	count, errors, timeouts, totalMs, maxMs := aggregateSessionStats(map[string]SessionStoreStat{
+		"a": {Count: 2, Errors: 1, Timeouts: 1, TotalMs: 10, MaxMs: 8},
+		"b": {Count: 3, TotalMs: 5, MaxMs: 4},
+	})
+	require.EqualValues(t, 5, count)
+	require.EqualValues(t, 1, errors)
+	require.EqualValues(t, 1, timeouts)
+	require.EqualValues(t, 15, totalMs)
+	require.EqualValues(t, 8, maxMs)
+}
+
+func TestSyncSummaryFieldsShape(t *testing.T) {
+	s := &syncer{
+		recordStats: true,
+		syncID:      "sync-1",
+		syncType:    connectorstore.SyncTypeFull,
+		workerCount: 20,
+		state:       newState(),
+	}
+	s.state.AddStepDuration("list-grants", time.Second)
+	s.state.AddStepDuration("checkpoint", 29*time.Millisecond)
+	s.state.AddStepDuration("rate_limit_wait", 50*time.Millisecond)
+	s.state.AddStepDuration("source_cache_tombstones", 3*time.Millisecond)
+	s.state.RecordConnectorCall("list-grants", 100*time.Millisecond)
+	s.state.RecordConnectorCall("list-grants:group", 80*time.Millisecond)
+	// Sub-ms static entitlement labeled entry should not appear in by-RT log output.
+	s.state.RecordConnectorCall("list-static-entitlements:user", 0)
+	s.state.MergeSessionStat("connector.get", SessionStoreStat{Count: 1, TotalMs: 1})
+
+	fields := s.syncSummaryFields(trace.SpanFromContext(t.Context()))
+	byKey := zapFieldsByKey(t, fields)
+
+	require.Equal(t, map[string]int64{"list-grants": 1000}, byKey["sync_step_durations_ms"])
+	require.Equal(t, map[string]int64{"rate_limit_wait": 50}, byKey["sync_step_wait_ms"])
+	require.Equal(t, map[string]int64{"checkpoint": 29, "source_cache_tombstones": 3}, byKey["sync_step_other_ms"])
+	require.EqualValues(t, int64(1000), byKey["sync_steps_total_ms"])
+
+	flat, ok := byKey["connector_call_stats"].(map[string]ConnectorCallStat)
+	require.True(t, ok)
+	require.EqualValues(t, 1, flat["list-grants"].Count)
+	require.NotContains(t, flat, "list-grants:group")
+
+	byRT, ok := byKey["connector_call_stats_by_resource_type"].(map[string]ConnectorCallStat)
+	require.True(t, ok)
+	require.Contains(t, byRT, "list-grants:group")
+	require.NotContains(t, byRT, "list-static-entitlements:user")
+
+	_, hasSession := byKey["session_store_stats"]
+	require.False(t, hasSession, "idle session stats should not appear on the sync-complete log")
+}
+
+func zapFieldsByKey(t *testing.T, fields []zap.Field) map[string]any {
+	t.Helper()
+	out := make(map[string]any, len(fields))
+	for _, f := range fields {
+		switch f.Type {
+		case zapcore.StringType:
+			out[f.Key] = f.String
+		case zapcore.Int64Type, zapcore.Int32Type, zapcore.Int16Type, zapcore.Int8Type:
+			out[f.Key] = f.Integer
+		case zapcore.Uint64Type, zapcore.Uint32Type, zapcore.Uint16Type, zapcore.Uint8Type:
+			out[f.Key] = uint64(f.Integer) //nolint:gosec // test helper
+		case zapcore.BoolType:
+			out[f.Key] = f.Integer == 1
+		case zapcore.ReflectType, zapcore.ErrorType:
+			out[f.Key] = f.Interface
+		default:
+			// zap.Any / zap.Int use mixed encodings; fall back to Interface then Integer.
+			if f.Interface != nil {
+				out[f.Key] = f.Interface
+			} else {
+				out[f.Key] = f.Integer
+			}
+		}
+	}
+	return out
+}

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -414,17 +414,22 @@ func (s *syncer) observeConnectorCall(
 	}
 }
 
-// syncSummaryFields builds the timing summary. Bucket semantics: op buckets
-// are wall clock INCLUDING retry/rate-limit sleeps; the wait buckets (and
-// their :resource_type labeled variants) re-count that same time as an
-// "of which" decomposition. The full step-durations map is therefore not
-// summable — sync_steps_total_ms sums only the timedSyncOps buckets.
-// Connector call stats follow the same shape: method:resource_type entries
-// re-count their flat method entry, so only the unlabeled methods sum to
-// the true call totals.
+// syncSummaryFields builds the timing summary for logs and span attrs.
+//
+// Token state keeps the full maps (including method:resource_type and wait
+// labels). Logs/spans are a readable projection:
+//   - sync_step_durations_ms is only timedSyncOps (matches sync_steps_total_ms)
+//   - waits and other buckets (checkpoint, connector extras) are separate fields
+//   - connector_call_stats is flat methods; top-N by-RT is a sibling field
+//   - session span attrs are aggregates; per-op session maps stay log-only
 func (s *syncer) syncSummaryFields(span trace.Span) []zap.Field {
 	stepDurations := s.state.StepDurations()
 	callStats := s.state.ConnectorCallStats()
+	sessionStats := s.state.SessionStoreStats()
+
+	ops, waits, other := partitionStepDurationsForLog(stepDurations)
+	flatCalls, topCallsByRT := partitionConnectorCallStatsForLog(callStats)
+	sessionForLog, logSession := filterSessionStatsForLog(sessionStats)
 
 	var stepsTotalMs int64
 	for _, op := range timedSyncOps {
@@ -434,24 +439,17 @@ func (s *syncer) syncSummaryFields(span trace.Span) []zap.Field {
 	attrs := []attribute.KeyValue{
 		attribute.String("sync.type", string(s.syncType)),
 		attribute.Int64("sync.steps.total_ms", stepsTotalMs),
-		attribute.String("sync.completed_actions", strconv.FormatUint(s.state.GetCompletedActionsCount(), 10)),
+		attribute.Int64("sync.completed_actions", int64(s.state.GetCompletedActionsCount())), //nolint:gosec // action counts fit int64
 		attribute.Int("sync.worker_count", s.workerCount),
 	}
-	for _, bucket := range []string{
-		SyncResourceTypesOp.String(),
-		SyncResourcesOp.String(),
-		SyncTargetedResourceOp.String(),
-		SyncStaticEntitlementsOp.String(),
-		SyncEntitlementsOp.String(),
-		SyncGrantsOp.String(),
-		SyncExternalResourcesOp.String(),
-		SyncAssetsOp.String(),
-		"checkpoint",
-		"rate_limit_wait",
-		"retry_wait",
-	} {
+	for _, op := range timedSyncOps {
+		bucket := op.String()
 		key := strings.ReplaceAll(bucket, "-", "_")
 		attrs = append(attrs, attribute.Int64("sync.step."+key+".duration_ms", stepDurations[bucket]))
+	}
+	for _, waitBucket := range []string{"checkpoint", "rate_limit_wait", "retry_wait"} {
+		key := strings.ReplaceAll(waitBucket, "-", "_")
+		attrs = append(attrs, attribute.Int64("sync.step."+key+".duration_ms", stepDurations[waitBucket]))
 	}
 	for _, method := range connectorCallMethods {
 		key := strings.ReplaceAll(method, "-", "_")
@@ -462,14 +460,14 @@ func (s *syncer) syncSummaryFields(span trace.Span) []zap.Field {
 			attribute.Int64("sync.connector."+key+".max_ms", stat.MaxMs),
 		)
 	}
-	sessionStats := s.state.SessionStoreStats()
-	for op, stat := range sessionStats {
+	if len(sessionStats) > 0 {
+		count, errors, timeouts, totalMs, maxMs := aggregateSessionStats(sessionStats)
 		attrs = append(attrs,
-			attribute.Int64("sync.session."+op+".count", stat.Count),
-			attribute.Int64("sync.session."+op+".errors", stat.Errors),
-			attribute.Int64("sync.session."+op+".timeouts", stat.Timeouts),
-			attribute.Int64("sync.session."+op+".total_ms", stat.TotalMs),
-			attribute.Int64("sync.session."+op+".max_ms", stat.MaxMs),
+			attribute.Int64("sync.session.count", count),
+			attribute.Int64("sync.session.errors", errors),
+			attribute.Int64("sync.session.timeouts", timeouts),
+			attribute.Int64("sync.session.total_ms", totalMs),
+			attribute.Int64("sync.session.max_ms", maxMs),
 		)
 	}
 	span.SetAttributes(attrs...)
@@ -477,14 +475,26 @@ func (s *syncer) syncSummaryFields(span trace.Span) []zap.Field {
 	fields := []zap.Field{
 		zap.String("sync_id", s.syncID),
 		zap.String("sync_type", string(s.syncType)),
-		zap.Any("sync_step_durations_ms", stepDurations),
+		zap.Any("sync_step_durations_ms", ops),
 		zap.Int64("sync_steps_total_ms", stepsTotalMs),
-		zap.Any("connector_call_stats", callStats),
+		zap.Any("connector_call_stats", flatCalls),
 		zap.Uint64("completed_actions", s.state.GetCompletedActionsCount()),
 		zap.Int("worker_count", s.workerCount),
 	}
-	if len(sessionStats) > 0 {
-		fields = append(fields, zap.Any("session_store_stats", sessionStats))
+	if len(waits) > 0 {
+		fields = append(fields, zap.Any("sync_step_wait_ms", waits))
+	}
+	if len(other) > 0 {
+		// checkpoint, source_cache_*, and other non-op buckets — not part of
+		// sync_steps_total_ms. Keep them out of the primary map so a dedicated
+		// source-cache log line isn't duplicated under step durations.
+		fields = append(fields, zap.Any("sync_step_other_ms", other))
+	}
+	if len(topCallsByRT) > 0 {
+		fields = append(fields, zap.Any("connector_call_stats_by_resource_type", topCallsByRT))
+	}
+	if logSession {
+		fields = append(fields, zap.Any("session_store_stats", sessionForLog))
 	}
 	return fields
 }


### PR DESCRIPTION
Tighten sync-stats logging/spans so summaries are readable and summable: split ops vs waits/other, keep flat connector call stats with a top-N by-resource-type sibling, gate/aggregate session fields, and emit completed_actions as Int64.

