### PR TITLE
public interface for grant digest

### DIFF
--- a/pkg/dotc1z/engine/pebble/grant_digest.go
+++ b/pkg/dotc1z/engine/pebble/grant_digest.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cespare/xxhash/v2"
 	"github.com/cockroachdb/pebble/v2"
 
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/codec"
 )
@@ -46,7 +47,7 @@ var grantDigestSpec = digestIndexSpec{
 	partitionPrefix: encodeGrantByEntPrincHashEntPrefix,
 }
 
-// grantDigestABIVersion is the version of the content-hash / bucket-hash
+// GrantDigestABIVersion is the version of the content-hash / bucket-hash
 // definitions below (grantContentHash64, grantPrincipalBucketHash64).
 // Stamped into the manifest's GrantDigestRoot.abi_version so a future
 // ABI bump (a change to either hash's input framing) makes stored
@@ -54,7 +55,10 @@ var grantDigestSpec = digestIndexSpec{
 // construction, rather than silently comparing unrelated hash schemes.
 // Bump alongside any index-migration version bump that touches these
 // hashes (see index_migrations.go).
-const grantDigestABIVersion uint32 = 1
+//
+// Exported so consumers of GrantContentHash / GrantDigestAccumulator
+// can check a stored root's abi_version before comparing.
+const GrantDigestABIVersion uint32 = 1
 
 // digestLevelGlobalRoot is the node-key level for the whole-file grant
 // digest root (see globalGrantDigestNodeKey): the XOR fold of every
@@ -190,6 +194,84 @@ func grantContentHashForRecord(r *v3.GrantRecord) ([]byte, error) {
 	out := make([]byte, hashLen)
 	binary.BigEndian.PutUint64(out, h)
 	return out, nil
+}
+
+// GrantContentHash is the public form of the grant content hash
+// (grantContentHash64) computed from a v2 proto — the uint64 the stored
+// 8-byte big-endian hash encodes. Use it (or GrantDigestAccumulator,
+// its fold) to digest grants not held in a pebble file — e.g. a legacy
+// SQLite c1z — for comparison against engine-served digests.
+//
+// Hash grants as stored, not as emitted: expansion populates the
+// sources map after ingest, so raw connector output hashes differently
+// from what a sealed file digested. A grant missing its structural
+// identity errors — such a grant cannot exist in a pebble file.
+// Duplicates of one identity tuple drift from the disk fold (pebble
+// stores the tuple once), but the counts differ too, so the comparison
+// just reports a mismatch — never a false match.
+//
+// ABI: pinned to GrantDigestABIVersion alongside the internal forms.
+func GrantContentHash(g *v2.Grant) (uint64, error) {
+	ent := g.GetEntitlement()
+	entRes := ent.GetResource().GetId()
+	if entRes.GetResourceType() == "" || entRes.GetResource() == "" || ent.GetId() == "" {
+		return 0, fmt.Errorf("grant content hash: missing entitlement identity")
+	}
+	princ := g.GetPrincipal().GetId()
+	if princ.GetResourceType() == "" || princ.GetResource() == "" {
+		return 0, fmt.Errorf("grant content hash: missing principal identity")
+	}
+	id := grantIdentity{
+		entitlement:     entitlementIdentityFromParts(entRes.GetResourceType(), entRes.GetResource(), ent.GetId()),
+		principalTypeID: princ.GetResourceType(),
+		principalID:     princ.GetResource(),
+	}
+	key := encodeGrantIdentityKey(id)
+	sources := g.GetSources().GetSources()
+	srcs := make([][]byte, 0, len(sources))
+	for k := range sources {
+		srcs = append(srcs, []byte(k))
+	}
+	sortByteSlices(srcs)
+	h, _ := grantContentHash64(nil, key[grantPrimaryKeyPrefixLen:], srcs)
+	return h, nil
+}
+
+// GrantDigestAccumulator XOR/count-folds GrantContentHash over a set of
+// grants. Fold one entitlement's grants to reproduce its stored digest
+// root (GetEntitlementDigestRoot), or every grant in a sync to
+// reproduce the whole-file root (GetGrantDigestGlobalRoot / the
+// manifest's GrantDigestRoot.xor_digest — per-entitlement roots
+// XOR-combine, so the flat fold equals the fold of roots). Compare only
+// digests computed under the same GrantDigestABIVersion; see
+// GrantContentHash for the input contract.
+//
+// The zero value is ready to use. Not safe for concurrent use.
+type GrantDigestAccumulator struct {
+	xor   uint64
+	count int64
+}
+
+// Add folds one grant into the accumulator; a grant GrantContentHash
+// rejects leaves it unchanged.
+func (a *GrantDigestAccumulator) Add(g *v2.Grant) error {
+	h, err := GrantContentHash(g)
+	if err != nil {
+		return err
+	}
+	a.xor ^= h
+	a.count++
+	return nil
+}
+
+// Root returns the fold so far as a DigestRoot: Hash is the 8-byte
+// big-endian XOR fold, Count the number of grants added. Bits is 0
+// (root-only); compare Hash and Count.
+func (a *GrantDigestAccumulator) Root() DigestRoot {
+	return DigestRoot{
+		Hash:  binary.BigEndian.AppendUint64(nil, a.xor),
+		Count: a.count,
+	}
 }
 
 // sortByteSlices sorts byte slices ascending (bytes.Compare order).

--- a/pkg/dotc1z/engine/pebble/grant_digest_global_root_test.go
+++ b/pkg/dotc1z/engine/pebble/grant_digest_global_root_test.go
@@ -146,8 +146,8 @@ func TestManifestGrantDigestRoot(t *testing.T) {
 	if root == nil {
 		t.Fatal("expected manifest GrantDigestRoot to be present")
 	}
-	if root.GetAbiVersion() != grantDigestABIVersion {
-		t.Fatalf("manifest abi_version = %d, want %d", root.GetAbiVersion(), grantDigestABIVersion)
+	if root.GetAbiVersion() != GrantDigestABIVersion {
+		t.Fatalf("manifest abi_version = %d, want %d", root.GetAbiVersion(), GrantDigestABIVersion)
 	}
 	want, ok, err := e.GetGrantDigestGlobalRoot(ctx)
 	if err != nil || !ok {

--- a/pkg/dotc1z/engine/pebble/grant_digest_hash_test.go
+++ b/pkg/dotc1z/engine/pebble/grant_digest_hash_test.go
@@ -2,12 +2,15 @@ package pebble
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"testing"
 
 	"github.com/cespare/xxhash/v2"
+	"github.com/segmentio/ksuid"
 	"github.com/stretchr/testify/require"
 
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/codec"
 )
@@ -112,6 +115,153 @@ func TestGrantDigestSpliceMatchesEncode(t *testing.T) {
 			require.Equal(t, binary.BigEndian.Uint16(full[:digestBucketHashLen]), bucket)
 		})
 	}
+}
+
+// grantV2WithSources builds the v2 proto form of a grant for the public
+// hash API, with an optional source-entitlement set.
+func grantV2WithSources(entRT, entRID, entID, prt, pid string, sources ...string) *v2.Grant {
+	b := v2.Grant_builder{
+		Id: entID + ":" + prt + ":" + pid,
+		Entitlement: v2.Entitlement_builder{
+			Id: entID,
+			Resource: v2.Resource_builder{
+				Id: v2.ResourceId_builder{
+					ResourceType: entRT,
+					Resource:     entRID,
+				}.Build(),
+			}.Build(),
+		}.Build(),
+		Principal: v2.Resource_builder{
+			Id: v2.ResourceId_builder{
+				ResourceType: prt,
+				Resource:     pid,
+			}.Build(),
+		}.Build(),
+	}
+	if len(sources) > 0 {
+		m := make(map[string]*v2.GrantSources_GrantSource, len(sources))
+		for _, s := range sources {
+			m[s] = v2.GrantSources_GrantSource_builder{}.Build()
+		}
+		b.Sources = v2.GrantSources_builder{Sources: m}.Build()
+	}
+	return b.Build()
+}
+
+// TestGrantContentHashMatchesRecord pins the public from-v2 form of the
+// content hash (GrantContentHash) against the from-record reference
+// path (grantContentHashForRecord over the record V2GrantToV3 stores),
+// across the same escape/stripping edge cases the splice test covers.
+// A divergence would make an external consumer's digest mismatch a
+// pebble file holding identical grants.
+func TestGrantContentHashMatchesRecord(t *testing.T) {
+	cases := []struct {
+		name                 string
+		entRT, entRID, entID string
+		prt, pid             string
+		srcs                 []string
+	}{
+		{name: "plain opaque ent id", entRT: "app", entRID: "github", entID: "ent-1", prt: "user", pid: "user-42"},
+		{name: "stripped ent id", entRT: "app", entRID: "github", entID: "app:github:member", prt: "user", pid: "user-42"},
+		{name: "sources", entRT: "app", entRID: "github", entID: "ent-1", prt: "user", pid: "user-42", srcs: []string{"c-src", "a-src", "b-src"}},
+		{name: "embedded NUL", entRT: "a\x00pp", entRID: "git\x00hub", entID: "ent\x00x", prt: "us\x00er", pid: "id\x00", srcs: []string{"s\x00rc", "\x00"}},
+		{name: "escape byte", entRT: "a\x01pp", entRID: "hub", entID: "ent\x01x", prt: "us\x01er", pid: "\x01id", srcs: []string{"\x01", "\x00"}},
+		{name: "unicode", entRT: "приложение", entRID: "гитхаб", entID: "entitlé", prt: "usér", pid: "ид-42"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := grantV2WithSources(tc.entRT, tc.entRID, tc.entID, tc.prt, tc.pid, tc.srcs...)
+			want, err := grantContentHashForRecord(V2GrantToV3("", g))
+			require.NoError(t, err)
+			got, err := GrantContentHash(g)
+			require.NoError(t, err)
+			require.Equal(t, binary.BigEndian.Uint64(want), got, "public hash vs record reference")
+		})
+	}
+}
+
+// TestGrantContentHashMissingIdentity pins the error half of the
+// divergence contract: a grant missing any structural identity part
+// cannot exist in a pebble file, so it must error rather than hash.
+func TestGrantContentHashMissingIdentity(t *testing.T) {
+	full := func() *v2.Grant { return grantV2WithSources("app", "github", "ent-1", "user", "user-42") }
+	cases := []struct {
+		name   string
+		mutate func(*v2.Grant)
+	}{
+		{name: "nil grant", mutate: nil},
+		{name: "missing ent resource type", mutate: func(g *v2.Grant) { g.GetEntitlement().GetResource().GetId().SetResourceType("") }},
+		{name: "missing ent resource id", mutate: func(g *v2.Grant) { g.GetEntitlement().GetResource().GetId().SetResource("") }},
+		{name: "missing ent id", mutate: func(g *v2.Grant) { g.GetEntitlement().SetId("") }},
+		{name: "missing principal type", mutate: func(g *v2.Grant) { g.GetPrincipal().GetId().SetResourceType("") }},
+		{name: "missing principal id", mutate: func(g *v2.Grant) { g.GetPrincipal().GetId().SetResource("") }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var g *v2.Grant
+			if tc.mutate != nil {
+				g = full()
+				tc.mutate(g)
+			}
+			_, err := GrantContentHash(g)
+			require.Error(t, err)
+		})
+	}
+}
+
+// TestGrantDigestAccumulatorMatchesSealedRoots is the end-to-end pin for
+// the public digest surface: the same v2 grants are stored (via
+// V2GrantToV3) and sealed on one side, and folded through
+// GrantDigestAccumulator on the other. Per-entitlement folds must
+// reproduce each stored digest root, and the flat fold over every grant
+// must reproduce the whole-file global root — the property that lets an
+// external consumer compare a non-pebble grant set against an
+// engine-served digest with no engine in hand.
+func TestGrantDigestAccumulatorMatchesSealedRoots(t *testing.T) {
+	ctx := context.Background()
+	e, _ := newTestEngine(t)
+	require.NoError(t, e.SetCurrentSync(ksuid.New().String()))
+
+	entGrants := map[string][]*v2.Grant{
+		"ent-a": {
+			grantV2WithSources("app", "github", canonicalTestEntID("ent-a"), "user", "alice"),
+			grantV2WithSources("app", "github", canonicalTestEntID("ent-a"), "user", "bob", "src-2", "src-1"),
+			grantV2WithSources("app", "github", canonicalTestEntID("ent-a"), "group", "eng"),
+		},
+		"ent-b": {
+			grantV2WithSources("app", "github", canonicalTestEntID("ent-b"), "user", "alice", "src-1"),
+		},
+		"ent-zero": {},
+	}
+	for entID, grants := range entGrants {
+		putEnt(t, e, ctx, entID)
+		for _, g := range grants {
+			require.NoError(t, e.PutGrantRecords(ctx, V2GrantToV3("", g)), "PutGrantRecords(%s)", entID)
+		}
+	}
+	sealGrantDigests(t, e)
+
+	var global GrantDigestAccumulator
+	for entID, grants := range entGrants {
+		var acc GrantDigestAccumulator
+		for _, g := range grants {
+			require.NoError(t, acc.Add(g))
+			require.NoError(t, global.Add(g))
+		}
+		want, ok, err := e.GetEntitlementDigestRoot(ctx, testEntIdentity(entID))
+		require.NoError(t, err)
+		require.True(t, ok, "digest root present for %s", entID)
+		got := acc.Root()
+		require.Equal(t, want.Hash, got.Hash, "entitlement %s digest", entID)
+		require.Equal(t, want.Count, got.Count, "entitlement %s count", entID)
+	}
+
+	want, ok, err := e.GetGrantDigestGlobalRoot(ctx)
+	require.NoError(t, err)
+	require.True(t, ok, "global root present after seal")
+	got := global.Root()
+	require.Equal(t, want.Hash, got.Hash, "global digest")
+	require.Equal(t, want.Count, got.Count, "global count")
 }
 
 // TestGrantDigestPartitionPrefixFree pins the property bucketBounds and

--- a/pkg/dotc1z/engine/pebble/manifest.go
+++ b/pkg/dotc1z/engine/pebble/manifest.go
@@ -56,7 +56,7 @@ func BuildManifestWithSyncRuns(ctx context.Context, e *Engine, encoding c1zstore
 		m.SetGrantDigestRoot(c1zv3.GrantDigestRoot_builder{
 			XorDigest:  root.Hash,
 			Count:      root.Count,
-			AbiVersion: grantDigestABIVersion,
+			AbiVersion: GrantDigestABIVersion,
 		}.Build())
 	}
 	return m, nil


### PR DESCRIPTION
Add a new public interface to calculate grant digest hashes, and the current baton-sdk's hash digest's ABI version