### PR TITLE
[CXP-778] lambda: default the v2 wire frame to off, gate it behind opt-in

### DIFF
--- a/pkg/lambda/grpc/client.go
+++ b/pkg/lambda/grpc/client.go
@@ -23,20 +23,51 @@ import (
 type lambdaTransport struct {
 	lambdaClient *lambda.Client
 	functionName string
+
+	// wireFramesEnabled gates the v2 dual-encoded wire frame (see wire.go).
+	// It defaults to false: some deployed lambda connectors predate the
+	// DiscardUnknown behavior the frame relies on and unmarshal transport
+	// JSON with strict protojson, so an unrecognized top-level "v"/"frame"
+	// pair fails their request decode outright rather than being ignored.
+	// Callers that know every target connector is on an SDK new enough to
+	// tolerate (or read) the frame can opt in with WithWireFrames.
+	wireFramesEnabled bool
+}
+
+// LambdaTransportOption configures a lambdaTransport constructed by
+// NewLambdaClientTransport.
+type LambdaTransportOption func(*lambdaTransport)
+
+// WithWireFrames opts a transport into the v2 dual-encoded wire frame,
+// which preserves annotation types the invoker's process cannot resolve.
+// Only enable this for connectors confirmed to run an SDK build that
+// tolerates unknown transport JSON fields (see wireFramesEnabled) — an
+// older connector will fail to decode the request entirely.
+func WithWireFrames(enabled bool) LambdaTransportOption {
+	return func(l *lambdaTransport) {
+		l.wireFramesEnabled = enabled
+	}
 }
 
 func (l *lambdaTransport) RoundTrip(ctx context.Context, req *Request) (*Response, error) {
-	payload, frameOnly, err := req.marshalPayload()
+	var payload []byte
+	var err error
+	if l.wireFramesEnabled {
+		var frameOnly error
+		payload, frameOnly, err = req.marshalPayload()
+		if frameOnly != nil {
+			ctxzap.Extract(ctx).Warn(
+				"lambda_transport: request has no legacy encoding, sending v2 frame only; a connector on a pre-frame SDK cannot process this call",
+				zap.String("method", req.Method()),
+				zap.String("function_name", l.functionName),
+				zap.NamedError("legacy_encoding_error", frameOnly),
+			)
+		}
+	} else {
+		payload, err = req.marshalLegacy()
+	}
 	if err != nil {
 		return nil, fmt.Errorf("lambda_transport: failed to marshal frame: %w", err)
-	}
-	if frameOnly != nil {
-		ctxzap.Extract(ctx).Warn(
-			"lambda_transport: request has no legacy encoding, sending v2 frame only; a connector on a pre-frame SDK cannot process this call",
-			zap.String("method", req.Method()),
-			zap.String("function_name", l.functionName),
-			zap.NamedError("legacy_encoding_error", frameOnly),
-		)
 	}
 
 	input := &lambda.InvokeInput{
@@ -99,11 +130,15 @@ func (l *lambdaTransport) RoundTrip(ctx context.Context, req *Request) (*Respons
 }
 
 // NewLambdaClientTransport returns a new client transport that invokes a lambda function.
-func NewLambdaClientTransport(ctx context.Context, client *lambda.Client, functionName string) (ClientTransport, error) {
-	return &lambdaTransport{
+func NewLambdaClientTransport(ctx context.Context, client *lambda.Client, functionName string, opts ...LambdaTransportOption) (ClientTransport, error) {
+	l := &lambdaTransport{
 		lambdaClient: client,
 		functionName: functionName,
-	}, nil
+	}
+	for _, opt := range opts {
+		opt(l)
+	}
+	return l, nil
 }
 
 type ClientTransport interface {

--- a/pkg/lambda/grpc/client_test.go
+++ b/pkg/lambda/grpc/client_test.go
@@ -1,10 +1,62 @@
 package grpc
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	batonv1 "github.com/conductorone/baton-sdk/pb/c1/connectorapi/baton/v1"
+	pbtransport "github.com/conductorone/baton-sdk/pb/c1/transport/v1"
 )
+
+// TestNewLambdaClientTransport_WireFramesDefaultOff documents the fix for
+// connectors that predate the DiscardUnknown transport unmarshal option:
+// they decode transport JSON with strict protojson and fail outright on an
+// unrecognized top-level field, so dual-encoding the v2 wire frame by
+// default breaks them. A transport must opt in with WithWireFrames before
+// it will send anything a strict-unmarshal connector can't read.
+func TestNewLambdaClientTransport_WireFramesDefaultOff(t *testing.T) {
+	transport, err := NewLambdaClientTransport(t.Context(), nil, "some-function")
+	require.NoError(t, err)
+	lt, ok := transport.(*lambdaTransport)
+	require.True(t, ok)
+	require.False(t, lt.wireFramesEnabled)
+
+	transport, err = NewLambdaClientTransport(t.Context(), nil, "some-function", WithWireFrames(true))
+	require.NoError(t, err)
+	lt, ok = transport.(*lambdaTransport)
+	require.True(t, ok)
+	require.True(t, lt.wireFramesEnabled)
+}
+
+// TestRequest_MarshalLegacy_NoFrameFields verifies the default (wire frames
+// disabled) payload shape is decodable by a connector that unmarshals
+// transport JSON with plain, strict protojson.Unmarshal — no
+// DiscardUnknown, no frame decoding — matching the earliest deployed lambda
+// connectors that predate both features.
+func TestRequest_MarshalLegacy_NoFrameFields(t *testing.T) {
+	req := batonv1.BatonServiceHelloRequest_builder{HostId: "test-host"}.Build()
+	treq, err := NewRequest("/c1.connectorapi.baton.v1.BatonService/Hello", req, metadata.MD{})
+	require.NoError(t, err)
+
+	payload, err := treq.marshalLegacy()
+	require.NoError(t, err)
+
+	var wire map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(payload, &wire))
+	require.NotContains(t, wire, "v")
+	require.NotContains(t, wire, "frame")
+	require.Contains(t, wire, "method")
+
+	// Strict protojson.Unmarshal — the pre-DiscardUnknown decode path —
+	// must succeed since no unrecognized fields are present.
+	legacyMsg := &pbtransport.Request{}
+	require.NoError(t, protojson.Unmarshal(payload, legacyMsg))
+	require.Equal(t, treq.Method(), legacyMsg.GetMethod())
+}
 
 func TestExtractMeaningfulLogLines(t *testing.T) {
 	cases := []struct {

--- a/pkg/lambda/grpc/transport.go
+++ b/pkg/lambda/grpc/transport.go
@@ -244,6 +244,17 @@ func (f *Request) marshalPayload() ([]byte, error, error) {
 	return dual, nil, nil
 }
 
+// marshalLegacy encodes the request as plain protojson, with no v2 wire
+// frame fields spliced in. This is the pre-frame encoding every deployed
+// lambda connector can decode, including ones built before DiscardUnknown
+// was added to the transport unmarshal path — those decode transport JSON
+// with strict protojson and fail outright on an unrecognized top-level
+// field, so they cannot tolerate the dual-encoded payload marshalPayload
+// produces.
+func (f *Request) marshalLegacy() ([]byte, error) {
+	return protojson.Marshal(f.msg)
+}
+
 func (f *Request) Method() string {
 	return f.msg.GetMethod()
 }


### PR DESCRIPTION
## Summary
- `pkg/lambda/grpc/wire.go`'s v2 wire frame (#1000, shipped in v0.18.2) dual-encodes every outbound lambda request by splicing top-level `v`/`frame` JSON fields onto the legacy protojson payload, assuming every peer discards unknown fields.
- That assumption doesn't hold for connectors still vendoring an SDK from before `DiscardUnknown` was added (#958, pre `cbcf7dcc`): their `Request.UnmarshalJSON` does a strict `protojson.Unmarshal` and fails outright (`unknown field "v"`) on the very first RPC of every sync (`GetMetadata`).
- This surfaced in production when `ductone/c1`'s baton-sdk bump (PR #21237) crossed v0.18.2 for the first time and started sending the extra fields to every lambda-hosted connector, including ones on pre-#958 SDKs.

## Fix
- Added `WithWireFrames(enabled bool)` as an explicit opt-in `LambdaTransportOption` on `NewLambdaClientTransport`; it defaults to `false`.
- `RoundTrip` now marshals through the new `Request.marshalLegacy()` by default — plain `protojson.Marshal`, no `v`/`frame` fields — which is byte-for-byte the pre-frame wire shape every deployed connector can decode.
- The dual-encoded/annotation-lossless frame path is unchanged and still available, but only sent once a caller explicitly opts in for connectors confirmed to run an SDK new enough to tolerate it.
- This restores compatibility purely by bumping the SDK dependency — no code change required on the invoker side (`ductone/c1`), since it doesn't currently pass `WithWireFrames`.

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/lambda/...` (74 passed)
- [x] Added `TestNewLambdaClientTransport_WireFramesDefaultOff` — confirms the transport defaults to frames disabled and `WithWireFrames(true)` flips it.
- [x] Added `TestRequest_MarshalLegacy_NoFrameFields` — confirms the default payload has no `v`/`frame` fields and round-trips through strict (non-`DiscardUnknown`) `protojson.Unmarshal`, simulating a pre-#958 connector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)