### PR TITLE
filter safe dangling grants

### DIFF
--- a/pkg/sync/ingest_filter.go
+++ b/pkg/sync/ingest_filter.go
@@ -1,0 +1,237 @@
+package sync //nolint:revive,nolintlint // we can't change the package name for backwards compatibility
+
+// Fresh connector-page filtering for references into resource types that were
+// not scheduled for the current full sync. This stays in the sync engine:
+// hosted connector calls are stateless, while the engine has already stored
+// the selected resource-type set before entitlement and grant collection.
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	reader_v2 "github.com/conductorone/baton-sdk/pb/c1/reader/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+)
+
+type ingestFilterStats struct {
+	entitlementsDropped   atomic.Int64
+	grantsDropped         atomic.Int64
+	grantResourcesDropped atomic.Int64
+	expansionTypesDropped atomic.Int64
+	expansionsDropped     atomic.Int64
+}
+
+// scheduledResourceTypeExists reads the store's resource-type keyspace rather
+// than the raw option list. That handles the default "all types" selection and
+// resumes correctly. Definitive answers are cached across parallel workers.
+func (s *syncer) scheduledResourceTypeExists(ctx context.Context, resourceTypeID string) (bool, error) {
+	// Empty refs are malformed data, not evidence of a disabled type. Keep
+	// them on the normal write path so existing validation reports them.
+	if resourceTypeID == "" {
+		return true, nil
+	}
+	if exists, ok := s.scheduledResourceTypes.Load(resourceTypeID); ok {
+		return exists, nil
+	}
+	_, err := s.store.GetResourceType(ctx, reader_v2.ResourceTypesReaderServiceGetResourceTypeRequest_builder{
+		ResourceTypeId: resourceTypeID,
+	}.Build())
+	if err != nil && status.Code(err) != codes.NotFound {
+		// A read failure must never be converted into a drop verdict.
+		return false, fmt.Errorf("fresh-ingest resource-type probe for %q: %w", resourceTypeID, err)
+	}
+	exists := err == nil
+	s.scheduledResourceTypes.Store(resourceTypeID, exists)
+	return exists, nil
+}
+
+func (s *syncer) filterFreshEntitlements(
+	ctx context.Context,
+	entitlements []*v2.Entitlement,
+) ([]*v2.Entitlement, error) {
+	if s.syncType != connectorstore.SyncTypeFull || len(entitlements) == 0 {
+		return entitlements, nil
+	}
+	out := make([]*v2.Entitlement, 0, len(entitlements))
+	for _, entitlement := range entitlements {
+		if entitlement == nil || entitlement.GetResource().GetId() == nil {
+			out = append(out, entitlement)
+			continue
+		}
+		exists, err := s.scheduledResourceTypeExists(ctx, entitlement.GetResource().GetId().GetResourceType())
+		if err != nil {
+			return nil, err
+		}
+		if !exists {
+			s.ingestFilterStats.entitlementsDropped.Add(1)
+			continue
+		}
+		out = append(out, entitlement)
+	}
+	return out, nil
+}
+
+func hasExternalResourceMatch(annos annotations.Annotations) bool {
+	return annos.ContainsAny(
+		&v2.ExternalResourceMatchAll{},
+		&v2.ExternalResourceMatch{},
+		&v2.ExternalResourceMatchID{},
+	)
+}
+
+// filterGrantExpansionTypes intersects GrantExpandable.ResourceTypeIds with
+// scheduled types. If a non-empty filter becomes empty, the expansion
+// annotation must be removed: an empty ResourceTypeIds list means unfiltered
+// expansion and would incorrectly widen the connector's request.
+//
+// External-match carriers remain intact because their placeholder references
+// are transformed by the later external-resource matching phase.
+func (s *syncer) filterGrantExpansionTypes(
+	ctx context.Context,
+	grant *v2.Grant,
+	annos annotations.Annotations,
+) (*v2.Grant, error) {
+	if grant == nil || hasExternalResourceMatch(annos) {
+		return grant, nil
+	}
+	expandable := &v2.GrantExpandable{}
+	hasExpandable, err := annos.Pick(expandable)
+	if err != nil {
+		return nil, fmt.Errorf("fresh-ingest: parsing GrantExpandable on grant %q: %w", grant.GetId(), err)
+	}
+	if !hasExpandable || len(expandable.GetResourceTypeIds()) == 0 {
+		return grant, nil
+	}
+
+	filtered := make([]string, 0, len(expandable.GetResourceTypeIds()))
+	for _, resourceTypeID := range expandable.GetResourceTypeIds() {
+		exists, err := s.scheduledResourceTypeExists(ctx, resourceTypeID)
+		if err != nil {
+			return nil, err
+		}
+		if exists {
+			filtered = append(filtered, resourceTypeID)
+			continue
+		}
+		s.ingestFilterStats.expansionTypesDropped.Add(1)
+	}
+	if len(filtered) == len(expandable.GetResourceTypeIds()) {
+		return grant, nil
+	}
+
+	rewritten := make(annotations.Annotations, 0, len(annos))
+	for _, anno := range annos {
+		if !anno.MessageIs(expandable) {
+			rewritten = append(rewritten, anno)
+		}
+	}
+	if len(filtered) > 0 {
+		expandable.SetResourceTypeIds(filtered)
+		encoded, err := anypb.New(expandable)
+		if err != nil {
+			return nil, fmt.Errorf("fresh-ingest: encoding filtered GrantExpandable on grant %q: %w", grant.GetId(), err)
+		}
+		rewritten = append(rewritten, encoded)
+	} else {
+		s.ingestFilterStats.expansionsDropped.Add(1)
+	}
+	filteredGrant := proto.Clone(grant).(*v2.Grant)
+	filteredGrant.SetAnnotations(rewritten)
+	return filteredGrant, nil
+}
+
+func (s *syncer) filterFreshGrants(ctx context.Context, grants []*v2.Grant) ([]*v2.Grant, error) {
+	if s.syncType != connectorstore.SyncTypeFull || len(grants) == 0 {
+		return grants, nil
+	}
+	out := make([]*v2.Grant, 0, len(grants))
+	for _, grant := range grants {
+		if grant == nil || grant.GetEntitlement().GetResource().GetId() == nil || grant.GetPrincipal().GetId() == nil {
+			out = append(out, grant)
+			continue
+		}
+		annos := annotations.Annotations(grant.GetAnnotations())
+
+		entitlementTypeExists, err := s.scheduledResourceTypeExists(
+			ctx,
+			grant.GetEntitlement().GetResource().GetId().GetResourceType(),
+		)
+		if err != nil {
+			return nil, err
+		}
+		// No InsertResourceGrants exemption: uplift can never use a grant
+		// whose entitlement resource type is absent from the sync. Without
+		// the type row the resource fails uplift, so no AppResource,
+		// AppEntitlement, or binding is ever created — inserting the
+		// resource row alone does not resurrect the chain.
+		if !entitlementTypeExists {
+			s.ingestFilterStats.grantsDropped.Add(1)
+			continue
+		}
+
+		principalTypeExists, err := s.scheduledResourceTypeExists(ctx, grant.GetPrincipal().GetId().GetResourceType())
+		if err != nil {
+			return nil, err
+		}
+		// External match annotations own placeholder principals. This does
+		// not exempt the entitlement reference checked above.
+		if !principalTypeExists && !hasExternalResourceMatch(annos) {
+			s.ingestFilterStats.grantsDropped.Add(1)
+			continue
+		}
+
+		grant, err = s.filterGrantExpansionTypes(ctx, grant, annos)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, grant)
+	}
+	return out, nil
+}
+
+// filterFreshGrantResource reports whether a grant-discovered resource
+// (InsertResourceGrants) references a scheduled resource type. Uplift skips
+// resources whose type is absent from the sync's resource types, so storing
+// them is dead data even though the resource row itself could be written.
+func (s *syncer) filterFreshGrantResource(ctx context.Context, resource *v2.Resource) (bool, error) {
+	if s.syncType != connectorstore.SyncTypeFull || resource.GetId() == nil {
+		return true, nil
+	}
+	exists, err := s.scheduledResourceTypeExists(ctx, resource.GetId().GetResourceType())
+	if err != nil {
+		return false, err
+	}
+	if !exists {
+		s.ingestFilterStats.grantResourcesDropped.Add(1)
+	}
+	return exists, nil
+}
+
+func (s *syncer) logIngestFilterSummary(ctx context.Context) {
+	entitlements := s.ingestFilterStats.entitlementsDropped.Load()
+	grants := s.ingestFilterStats.grantsDropped.Load()
+	grantResources := s.ingestFilterStats.grantResourcesDropped.Load()
+	expansionTypes := s.ingestFilterStats.expansionTypesDropped.Load()
+	expansions := s.ingestFilterStats.expansionsDropped.Load()
+	if entitlements == 0 && grants == 0 && grantResources == 0 && expansionTypes == 0 && expansions == 0 {
+		return
+	}
+	// One aggregate warning per sync: never log individual rows or refs.
+	ctxzap.Extract(ctx).Warn("fresh ingest filtered references into resource types not scheduled for this sync",
+		zap.Int64("entitlements_dropped", entitlements),
+		zap.Int64("grants_dropped", grants),
+		zap.Int64("grant_discovered_resources_dropped", grantResources),
+		zap.Int64("expansion_resource_types_dropped", expansionTypes),
+		zap.Int64("expansions_dropped", expansions),
+	)
+}

--- a/pkg/sync/ingest_filter.go
+++ b/pkg/sync/ingest_filter.go
@@ -51,8 +51,46 @@ func (s *syncer) scheduledResourceTypeExists(ctx context.Context, resourceTypeID
 		return false, fmt.Errorf("fresh-ingest resource-type probe for %q: %w", resourceTypeID, err)
 	}
 	exists := err == nil
+	if !exists {
+		// The external-resource phase runs after entitlement and grant
+		// collection and copies user/group resource types (and their
+		// resources) from the external c1z into this sync. A reference that
+		// is dangling at collection time can therefore resolve by the time
+		// uplift reads the store, so it must not be dropped.
+		exists, err = s.externalResourceTypeWillBeCopied(ctx, resourceTypeID)
+		if err != nil {
+			return false, err
+		}
+	}
 	s.scheduledResourceTypes.Store(resourceTypeID, exists)
 	return exists, nil
+}
+
+// externalResourceTypeWillBeCopied reports whether the later external-resource
+// phase will copy resourceTypeID into this sync: an external reader is
+// configured and the type exists there carrying a user or group trait — the
+// only kinds SyncExternalResourcesUsersAndGroups and
+// SyncExternalResourcesWithGrantToEntitlement copy.
+func (s *syncer) externalResourceTypeWillBeCopied(ctx context.Context, resourceTypeID string) (bool, error) {
+	if s.externalResourceReader == nil {
+		return false, nil
+	}
+	resp, err := s.externalResourceReader.GetResourceType(ctx, reader_v2.ResourceTypesReaderServiceGetResourceTypeRequest_builder{
+		ResourceTypeId: resourceTypeID,
+	}.Build())
+	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return false, nil
+		}
+		// A read failure must never be converted into a drop verdict.
+		return false, fmt.Errorf("fresh-ingest external resource-type probe for %q: %w", resourceTypeID, err)
+	}
+	for _, trait := range resp.GetResourceType().GetTraits() {
+		if trait == v2.ResourceType_TRAIT_USER || trait == v2.ResourceType_TRAIT_GROUP {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func (s *syncer) filterFreshEntitlements(
@@ -64,7 +102,16 @@ func (s *syncer) filterFreshEntitlements(
 	}
 	out := make([]*v2.Entitlement, 0, len(entitlements))
 	for _, entitlement := range entitlements {
-		if entitlement == nil || entitlement.GetResource().GetId() == nil {
+		// A literal nil entry carries nothing to store or validate; engines
+		// skip nil writes inconsistently (pebble silently, sqlite not at
+		// all), so drop it here.
+		if entitlement == nil {
+			continue
+		}
+		// A missing resource ref is malformed-but-present data, not evidence
+		// of a disabled type. Keep it on the normal write path so existing
+		// validation reports it.
+		if entitlement.GetResource().GetId() == nil {
 			out = append(out, entitlement)
 			continue
 		}
@@ -156,7 +203,15 @@ func (s *syncer) filterFreshGrants(ctx context.Context, grants []*v2.Grant) ([]*
 	}
 	out := make([]*v2.Grant, 0, len(grants))
 	for _, grant := range grants {
-		if grant == nil || grant.GetEntitlement().GetResource().GetId() == nil || grant.GetPrincipal().GetId() == nil {
+		// A literal nil entry carries nothing to store or validate; drop it
+		// rather than relying on engine-dependent nil handling at write time.
+		if grant == nil {
+			continue
+		}
+		// Missing refs are malformed-but-present data, not evidence of a
+		// disabled type. Keep them on the normal write path so existing
+		// validation reports them.
+		if grant.GetEntitlement().GetResource().GetId() == nil || grant.GetPrincipal().GetId() == nil {
 			out = append(out, grant)
 			continue
 		}

--- a/pkg/sync/ingest_filter_test.go
+++ b/pkg/sync/ingest_filter_test.go
@@ -3,12 +3,17 @@ package sync //nolint:revive,nolintlint // we can't change the package name for 
 import (
 	"context"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/anypb"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	reader_v2 "github.com/conductorone/baton-sdk/pb/c1/reader/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z"
@@ -88,9 +93,23 @@ func TestFreshIngestFilterMirrorsMachineryExemptions(t *testing.T) {
 				annotations.New(&v2.InsertResourceGrants{})...,
 			)
 			plainDisabledPrincipal := ingestFilterGrant("plain-disabled-principal", goodEntitlement, disabled)
-			matchDisabledPrincipal := ingestFilterGrant(
-				"match-disabled-principal", goodEntitlement, disabled,
+			// Every external-match variant owns its placeholder principal, so
+			// all three exempt the principal-type check.
+			matchIDDisabledPrincipal := ingestFilterGrant(
+				"match-id-disabled-principal", goodEntitlement, disabled,
 				annotations.New(v2.ExternalResourceMatchID_builder{Id: "external-p1"}.Build())...,
+			)
+			matchAllDisabledPrincipal := ingestFilterGrant(
+				"match-all-disabled-principal", goodEntitlement, disabled,
+				annotations.New(v2.ExternalResourceMatchAll_builder{ResourceType: v2.ResourceType_TRAIT_USER}.Build())...,
+			)
+			matchKeyDisabledPrincipal := ingestFilterGrant(
+				"match-key-disabled-principal", goodEntitlement, disabled,
+				annotations.New(v2.ExternalResourceMatch_builder{
+					Key:          "email",
+					Value:        "external@example.com",
+					ResourceType: v2.ResourceType_TRAIT_USER,
+				}.Build())...,
 			)
 			matchDoesNotExemptEntitlement := ingestFilterGrant(
 				"match-disabled-entitlement", disabledEntitlement, disabled,
@@ -106,13 +125,15 @@ func TestFreshIngestFilterMirrorsMachineryExemptions(t *testing.T) {
 				plainDisabledEntitlement,
 				irgDisabledEntitlement,
 				plainDisabledPrincipal,
-				matchDisabledPrincipal,
+				matchIDDisabledPrincipal,
+				matchAllDisabledPrincipal,
+				matchKeyDisabledPrincipal,
 				matchDoesNotExemptEntitlement,
 				irgDoesNotExemptPrincipal,
 				good,
 			})
 			require.NoError(t, err)
-			require.Equal(t, []*v2.Grant{matchDisabledPrincipal, good}, grants)
+			require.Equal(t, []*v2.Grant{matchIDDisabledPrincipal, matchAllDisabledPrincipal, matchKeyDisabledPrincipal, good}, grants)
 			require.Equal(t, int64(1), s.ingestFilterStats.entitlementsDropped.Load())
 			require.Equal(t, int64(5), s.ingestFilterStats.grantsDropped.Load())
 		})
@@ -145,14 +166,28 @@ func TestFreshIngestFilterNarrowsExpansionWithoutWidening(t *testing.T) {
 		matchExpansion.GetAnnotations(),
 		annotations.New(v2.ExternalResourceMatchID_builder{Id: "external-user"}.Build())...,
 	))
+	matchAllExpansion := expandable("match-all", "iam_policy")
+	matchAllExpansion.SetAnnotations(append(
+		matchAllExpansion.GetAnnotations(),
+		annotations.New(v2.ExternalResourceMatchAll_builder{ResourceType: v2.ResourceType_TRAIT_USER}.Build())...,
+	))
+	matchKeyExpansion := expandable("match-key", "iam_policy")
+	matchKeyExpansion.SetAnnotations(append(
+		matchKeyExpansion.GetAnnotations(),
+		annotations.New(v2.ExternalResourceMatch_builder{
+			Key:          "email",
+			Value:        "external@example.com",
+			ResourceType: v2.ResourceType_TRAIT_USER,
+		}.Build())...,
+	))
 
 	s := &syncer{store: store, syncType: connectorstore.SyncTypeFull}
-	filtered, err := s.filterFreshGrants(ctx, []*v2.Grant{mixed, disabledOnly, unfiltered, matchExpansion})
+	filtered, err := s.filterFreshGrants(ctx, []*v2.Grant{mixed, disabledOnly, unfiltered, matchExpansion, matchAllExpansion, matchKeyExpansion})
 	require.NoError(t, err)
-	require.Len(t, filtered, 4, "filtering expansion metadata does not drop the base grant")
+	require.Len(t, filtered, 6, "filtering expansion metadata does not drop the base grant")
 	require.NotSame(t, mixed, filtered[0], "rewriting must not mutate connector-owned response objects")
 	require.NotSame(t, disabledOnly, filtered[1], "rewriting must not mutate connector-owned response objects")
-	mixed, disabledOnly, unfiltered, matchExpansion = filtered[0], filtered[1], filtered[2], filtered[3]
+	mixed, disabledOnly, unfiltered = filtered[0], filtered[1], filtered[2]
 
 	mixedExpansion := &v2.GrantExpandable{}
 	mixedAnnos := annotations.Annotations(mixed.GetAnnotations())
@@ -173,13 +208,17 @@ func TestFreshIngestFilterNarrowsExpansionWithoutWidening(t *testing.T) {
 	require.True(t, ok)
 	require.Empty(t, unfilteredExpansion.GetResourceTypeIds())
 
-	matchExpandable := &v2.GrantExpandable{}
-	matchAnnos := annotations.Annotations(matchExpansion.GetAnnotations())
-	ok, err = matchAnnos.Pick(matchExpandable)
-	require.NoError(t, err)
-	require.True(t, ok)
-	require.Equal(t, []string{"iam_policy"}, matchExpandable.GetResourceTypeIds(),
-		"external-match placeholders remain available for later remapping")
+	// All three external-match variants carry placeholders the later matching
+	// phase rewrites, so their expansion metadata must stay untouched.
+	for i, carrier := range []*v2.Grant{filtered[3], filtered[4], filtered[5]} {
+		carrierExpandable := &v2.GrantExpandable{}
+		carrierAnnos := annotations.Annotations(carrier.GetAnnotations())
+		ok, err = carrierAnnos.Pick(carrierExpandable)
+		require.NoError(t, err)
+		require.True(t, ok, "carrier %d", i)
+		require.Equal(t, []string{"iam_policy"}, carrierExpandable.GetResourceTypeIds(),
+			"external-match placeholders remain available for later remapping")
+	}
 }
 
 func TestFreshIngestFilterRunsInFullSyncPipeline(t *testing.T) {
@@ -257,14 +296,19 @@ func TestFreshIngestFilterBypassesPartialSyncs(t *testing.T) {
 
 // TestFreshIngestFilterExternalMatchResolvesUnknownPrincipalType exercises the
 // interplay between the fresh-ingest filter and the external-resource phase.
-// The connector emits two grants whose placeholder principals reference a
-// resource type it never lists ("hris_user"):
+// The connector emits three grants whose principals reference resource types
+// it never lists:
 //
-//   - one carries ExternalResourceMatch, so the filter must keep it; the
-//     external phase later rewrites it to the matched external user (whose
-//     "user" type is copied into the store by that phase), and
-//   - one carries no annotations, so nothing downstream could ever resolve it
-//     and the filter must drop it.
+//   - one carries ExternalResourceMatch on a placeholder type ("hris_user"),
+//     so the filter must keep it; the external phase later rewrites it to the
+//     matched external user (whose "user" type is copied into the store by
+//     that phase),
+//   - one carries no annotations but references the external c1z's "user"
+//     type directly; the external phase copies that type and its resources
+//     into the sync, so uplift can consume the grant and the filter must
+//     keep it, and
+//   - one carries no annotations on the placeholder type, so nothing
+//     downstream could ever resolve it and the filter must drop it.
 func TestFreshIngestFilterExternalMatchResolvesUnknownPrincipalType(t *testing.T) {
 	runWithSyncModes(t, func(t *testing.T, extraOpts []SyncOpt) {
 		ctx := t.Context()
@@ -275,6 +319,8 @@ func TestFreshIngestFilterExternalMatchResolvesUnknownPrincipalType(t *testing.T
 		externalUser, err := externalMc.AddUserProfile(ctx, "ext-user-1", map[string]any{
 			"external_id_match": "ext-1",
 		})
+		require.NoError(t, err)
+		directExternalUser, err := externalMc.AddUserProfile(ctx, "ext-user-2", map[string]any{})
 		require.NoError(t, err)
 
 		internalMc := newMockConnector()
@@ -296,6 +342,7 @@ func TestFreshIngestFilterExternalMatchResolvesUnknownPrincipalType(t *testing.T
 					ResourceType: v2.ResourceType_TRAIT_USER,
 				}.Build()),
 			),
+			gt.NewGrant(internalGroup, "member", directExternalUser.GetId()),
 			gt.NewGrant(internalGroup, "member", placeholder("never-resolved")),
 		}
 
@@ -331,15 +378,20 @@ func TestFreshIngestFilterExternalMatchResolvesUnknownPrincipalType(t *testing.T
 		}
 		require.ElementsMatch(t, []string{"group", "user"}, rtIDs)
 
-		// Exactly one grant survives: the annotated one, rewritten to the
-		// external principal. The unannotated dangling grant is gone.
+		// Exactly two grants survive: the annotated one, rewritten to the
+		// matched external principal, and the unannotated one that referenced
+		// the external "user" type directly. The unannotated placeholder
+		// grant is gone.
 		grantsResp, err := store.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{}.Build())
 		require.NoError(t, err)
-		require.Len(t, grantsResp.GetList(), 1)
-		surviving := grantsResp.GetList()[0]
-		require.Equal(t, externalUser.GetId().GetResourceType(), surviving.GetPrincipal().GetId().GetResourceType())
-		require.Equal(t, externalUser.GetId().GetResource(), surviving.GetPrincipal().GetId().GetResource())
-		require.Equal(t, internalGroup.GetId().GetResource(), surviving.GetEntitlement().GetResource().GetId().GetResource())
+		require.Len(t, grantsResp.GetList(), 2)
+		principalIDs := make([]string, 0, 2)
+		for _, surviving := range grantsResp.GetList() {
+			require.Equal(t, "user", surviving.GetPrincipal().GetId().GetResourceType())
+			require.Equal(t, internalGroup.GetId().GetResource(), surviving.GetEntitlement().GetResource().GetId().GetResource())
+			principalIDs = append(principalIDs, surviving.GetPrincipal().GetId().GetResource())
+		}
+		require.ElementsMatch(t, []string{externalUser.GetId().GetResource(), directExternalUser.GetId().GetResource()}, principalIDs)
 	})
 }
 
@@ -444,4 +496,237 @@ func TestFreshIngestFilterRunsBeforeExclusionGroupValidation(t *testing.T) {
 		entIDs = append(entIDs, ent.GetId())
 	}
 	require.Contains(t, entIDs, scheduledEnt.GetId())
+}
+
+// TestFreshIngestFilterDropsNilEntries: literal nil entries carry nothing to
+// store or validate and are dropped, while malformed-but-present records
+// (missing refs) stay on the normal write path. Neither counts as a
+// disabled-type drop.
+func TestFreshIngestFilterDropsNilEntries(t *testing.T) {
+	ctx, err := logging.Init(t.Context())
+	require.NoError(t, err)
+	store := newIngestFilterStore(ctx, t, c1zstore.EnginePebble)
+	require.NoError(t, store.PutResourceTypes(ctx,
+		v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build(),
+	))
+
+	s := &syncer{store: store, syncType: connectorstore.SyncTypeFull}
+
+	missingRefEnt := v2.Entitlement_builder{Id: "no-resource"}.Build()
+	goodEnt := ingestFilterEntitlement(ingestFilterResource("group", "g1"), "group:g1:member")
+	entitlements, err := s.filterFreshEntitlements(ctx, []*v2.Entitlement{nil, missingRefEnt, goodEnt})
+	require.NoError(t, err)
+	require.Equal(t, []*v2.Entitlement{missingRefEnt, goodEnt}, entitlements)
+
+	missingRefGrant := v2.Grant_builder{Id: "no-refs"}.Build()
+	goodGrant := ingestFilterGrant("good", goodEnt, ingestFilterResource("group", "g2"))
+	grants, err := s.filterFreshGrants(ctx, []*v2.Grant{nil, missingRefGrant, goodGrant})
+	require.NoError(t, err)
+	require.Equal(t, []*v2.Grant{missingRefGrant, goodGrant}, grants)
+
+	require.Zero(t, s.ingestFilterStats.entitlementsDropped.Load())
+	require.Zero(t, s.ingestFilterStats.grantsDropped.Load())
+}
+
+// resourceTypeProbeStore wraps a real store to observe or fail the
+// GetResourceType probes the fresh-ingest filter issues.
+type resourceTypeProbeStore struct {
+	c1zstore.Store
+	calls map[string]int
+	err   error
+}
+
+func (s *resourceTypeProbeStore) GetResourceType(
+	ctx context.Context,
+	req *reader_v2.ResourceTypesReaderServiceGetResourceTypeRequest,
+) (*reader_v2.ResourceTypesReaderServiceGetResourceTypeResponse, error) {
+	if s.calls != nil {
+		s.calls[req.GetResourceTypeId()]++
+	}
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.Store.GetResourceType(ctx, req)
+}
+
+// TestFreshIngestFilterProbeFailureFailsSyncNotDrops: a non-NotFound read
+// failure — from the local store or the external reader — must surface as an
+// error, never as a drop verdict.
+func TestFreshIngestFilterProbeFailureFailsSyncNotDrops(t *testing.T) {
+	ctx, err := logging.Init(t.Context())
+	require.NoError(t, err)
+	store := newIngestFilterStore(ctx, t, c1zstore.EnginePebble)
+	require.NoError(t, store.PutResourceTypes(ctx,
+		v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build(),
+	))
+
+	entitlement := ingestFilterEntitlement(ingestFilterResource("iam_policy", "p1"), "iam_policy:p1:assigned")
+	grant := ingestFilterGrant("g", entitlement, ingestFilterResource("iam_policy", "p2"))
+
+	t.Run("local store failure", func(t *testing.T) {
+		failing := &resourceTypeProbeStore{Store: store, err: status.Error(codes.Internal, "probe boom")}
+		s := &syncer{store: failing, syncType: connectorstore.SyncTypeFull}
+
+		_, err := s.filterFreshEntitlements(ctx, []*v2.Entitlement{entitlement})
+		require.ErrorContains(t, err, "probe boom")
+		_, err = s.filterFreshGrants(ctx, []*v2.Grant{grant})
+		require.ErrorContains(t, err, "probe boom")
+		require.Zero(t, s.ingestFilterStats.entitlementsDropped.Load())
+		require.Zero(t, s.ingestFilterStats.grantsDropped.Load())
+	})
+
+	t.Run("external reader failure", func(t *testing.T) {
+		external := newIngestFilterStore(ctx, t, c1zstore.EnginePebble)
+		failingExternal := &resourceTypeProbeStore{Store: external, err: status.Error(codes.Internal, "external boom")}
+		s := &syncer{store: store, externalResourceReader: failingExternal, syncType: connectorstore.SyncTypeFull}
+
+		_, err := s.filterFreshEntitlements(ctx, []*v2.Entitlement{entitlement})
+		require.ErrorContains(t, err, "external boom")
+		require.Zero(t, s.ingestFilterStats.entitlementsDropped.Load())
+	})
+}
+
+// TestFreshIngestFilterCachesProbeVerdicts: both positive and negative
+// verdicts are cached, so repeated references never re-probe the store.
+func TestFreshIngestFilterCachesProbeVerdicts(t *testing.T) {
+	ctx, err := logging.Init(t.Context())
+	require.NoError(t, err)
+	store := newIngestFilterStore(ctx, t, c1zstore.EnginePebble)
+	require.NoError(t, store.PutResourceTypes(ctx,
+		v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build(),
+	))
+
+	counting := &resourceTypeProbeStore{Store: store, calls: map[string]int{}}
+	s := &syncer{store: counting, syncType: connectorstore.SyncTypeFull}
+
+	group := ingestFilterResource("group", "g1")
+	disabled := ingestFilterResource("iam_policy", "p1")
+	entitlements := []*v2.Entitlement{
+		ingestFilterEntitlement(group, "group:g1:member"),
+		ingestFilterEntitlement(disabled, "iam_policy:p1:assigned"),
+	}
+	for range 3 {
+		filtered, err := s.filterFreshEntitlements(ctx, entitlements)
+		require.NoError(t, err)
+		require.Len(t, filtered, 1)
+	}
+	require.Equal(t, 1, counting.calls["group"], "positive verdicts are cached")
+	require.Equal(t, 1, counting.calls["iam_policy"], "negative verdicts are cached")
+}
+
+// TestFreshIngestFilterKeepsExternalSuppliedTypes: a reference into a type
+// the external-resource phase will copy into this sync (present in the
+// external c1z with a user or group trait) must be kept, while external types
+// without those traits are never copied and remain droppable.
+func TestFreshIngestFilterKeepsExternalSuppliedTypes(t *testing.T) {
+	ctx, err := logging.Init(t.Context())
+	require.NoError(t, err)
+	store := newIngestFilterStore(ctx, t, c1zstore.EnginePebble)
+	require.NoError(t, store.PutResourceTypes(ctx,
+		v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build(),
+	))
+
+	external := newIngestFilterStore(ctx, t, c1zstore.EnginePebble)
+	require.NoError(t, external.PutResourceTypes(ctx,
+		v2.ResourceType_builder{
+			Id:          "user",
+			DisplayName: "User",
+			Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_USER},
+		}.Build(),
+		v2.ResourceType_builder{Id: "widget", DisplayName: "Widget"}.Build(),
+	))
+
+	s := &syncer{store: store, externalResourceReader: external, syncType: connectorstore.SyncTypeFull}
+
+	group := ingestFilterResource("group", "g1")
+	externalUser := ingestFilterResource("user", "u1")
+	externalWidget := ingestFilterResource("widget", "w1")
+	groupEntitlement := ingestFilterEntitlement(group, "group:g1:member")
+
+	entitlements, err := s.filterFreshEntitlements(ctx, []*v2.Entitlement{
+		groupEntitlement,
+		ingestFilterEntitlement(externalUser, "user:u1:linked"),
+		ingestFilterEntitlement(externalWidget, "widget:w1:linked"),
+	})
+	require.NoError(t, err)
+	require.Len(t, entitlements, 2)
+	require.Equal(t, "user:u1:linked", entitlements[1].GetId(),
+		"user-traited external types will be copied into the sync; keep references to them")
+
+	grants, err := s.filterFreshGrants(ctx, []*v2.Grant{
+		ingestFilterGrant("external-user-principal", groupEntitlement, externalUser),
+		ingestFilterGrant("external-widget-principal", groupEntitlement, externalWidget),
+		ingestFilterGrant("unknown-principal", groupEntitlement, ingestFilterResource("hris_user", "p1")),
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"external-user-principal"}, grantIDs(grants),
+		"only user/group-traited external types are copied by the external phase")
+}
+
+// pagedResourceTypesMockConnector serves one resource type per page so tests
+// can pin behavior for types first seen on later pages.
+type pagedResourceTypesMockConnector struct {
+	*mockConnector
+}
+
+func (mc *pagedResourceTypesMockConnector) ListResourceTypes(
+	_ context.Context,
+	in *v2.ResourceTypesServiceListResourceTypesRequest,
+	_ ...grpc.CallOption,
+) (*v2.ResourceTypesServiceListResourceTypesResponse, error) {
+	idx := 0
+	if in.GetPageToken() != "" {
+		parsed, err := strconv.Atoi(in.GetPageToken())
+		if err != nil {
+			return nil, err
+		}
+		idx = parsed
+	}
+	if idx >= len(mc.rtDB) {
+		return v2.ResourceTypesServiceListResourceTypesResponse_builder{}.Build(), nil
+	}
+	next := ""
+	if idx+1 < len(mc.rtDB) {
+		next = strconv.Itoa(idx + 1)
+	}
+	return v2.ResourceTypesServiceListResourceTypesResponse_builder{
+		List:          []*v2.ResourceType{mc.rtDB[idx]},
+		NextPageToken: next,
+	}.Build(), nil
+}
+
+// TestFreshIngestFilterHandlesMultiPageResourceTypes: the resource-types step
+// completes (all pages stored) before entitlement and grant collection, so a
+// scheduled type first listed on a later page must never be dropped.
+func TestFreshIngestFilterHandlesMultiPageResourceTypes(t *testing.T) {
+	ctx := t.Context()
+	tempDir := t.TempDir()
+	c1zPath := filepath.Join(tempDir, "paged-resource-types.c1z")
+
+	mc := &pagedResourceTypesMockConnector{mockConnector: newMockConnector()}
+	// "group" arrives on page 1, "user" on page 2.
+	mc.rtDB = append(mc.rtDB, groupResourceType, userResourceType)
+	group, groupEntitlement, err := mc.AddGroup(ctx, "g1")
+	require.NoError(t, err)
+	user, err := mc.AddUser(ctx, "u1")
+	require.NoError(t, err)
+
+	mc.grantDB[group.GetId().GetResource()] = []*v2.Grant{
+		ingestFilterGrant("good", groupEntitlement, user),
+		ingestFilterGrant("disabled", groupEntitlement, ingestFilterResource("iam_policy", "p1")),
+	}
+
+	syncer, err := NewSyncer(ctx, mc, WithC1ZPath(c1zPath), WithTmpDir(tempDir))
+	require.NoError(t, err)
+	require.NoError(t, syncer.Sync(ctx))
+	require.NoError(t, syncer.Close(ctx))
+
+	store, err := dotc1z.NewC1ZFile(ctx, c1zPath)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, store.Close(ctx)) }()
+
+	grantsResp, err := store.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{}.Build())
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"good"}, grantIDs(grantsResp.GetList()),
+		"a type from a later resource-types page is scheduled, not disabled")
 }

--- a/pkg/sync/ingest_filter_test.go
+++ b/pkg/sync/ingest_filter_test.go
@@ -1,0 +1,447 @@
+package sync //nolint:revive,nolintlint // we can't change the package name for backwards compatibility
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
+	"github.com/conductorone/baton-sdk/pkg/logging"
+	gt "github.com/conductorone/baton-sdk/pkg/types/grant"
+)
+
+func ingestFilterResource(resourceTypeID, resourceID string) *v2.Resource {
+	return v2.Resource_builder{
+		Id: v2.ResourceId_builder{
+			ResourceType: resourceTypeID,
+			Resource:     resourceID,
+		}.Build(),
+		DisplayName: resourceID,
+	}.Build()
+}
+
+func ingestFilterEntitlement(resource *v2.Resource, id string) *v2.Entitlement {
+	return v2.Entitlement_builder{Resource: resource, Id: id, Slug: id}.Build()
+}
+
+func ingestFilterGrant(id string, entitlement *v2.Entitlement, principal *v2.Resource, annos ...*anypb.Any) *v2.Grant {
+	return v2.Grant_builder{
+		Id:          id,
+		Entitlement: entitlement,
+		Principal:   principal,
+		Annotations: annos,
+	}.Build()
+}
+
+func newIngestFilterStore(ctx context.Context, t *testing.T, engine c1zstore.Engine) c1zstore.Store {
+	t.Helper()
+	tmpDir := t.TempDir()
+	store, err := dotc1z.NewStore(ctx, filepath.Join(tmpDir, "filter.c1z"),
+		dotc1z.WithEngine(engine),
+		dotc1z.WithTmpDir(tmpDir),
+	)
+	require.NoError(t, err)
+	_, err = store.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, store.Close(context.Background()))
+	})
+	return store
+}
+
+func TestFreshIngestFilterMirrorsMachineryExemptions(t *testing.T) {
+	ctx, err := logging.Init(t.Context())
+	require.NoError(t, err)
+
+	for _, engine := range []c1zstore.Engine{c1zstore.EngineSQLite, c1zstore.EnginePebble} {
+		t.Run(string(engine), func(t *testing.T) {
+			store := newIngestFilterStore(ctx, t, engine)
+			require.NoError(t, store.PutResourceTypes(ctx,
+				v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build(),
+				v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build(),
+			))
+
+			group := ingestFilterResource("group", "g1")
+			user := ingestFilterResource("user", "u1")
+			disabled := ingestFilterResource("iam_policy", "p1")
+			goodEntitlement := ingestFilterEntitlement(group, "group:g1:member")
+			disabledEntitlement := ingestFilterEntitlement(disabled, "iam_policy:p1:assigned")
+			s := &syncer{store: store, syncType: connectorstore.SyncTypeFull}
+
+			entitlements, err := s.filterFreshEntitlements(ctx, []*v2.Entitlement{goodEntitlement, disabledEntitlement})
+			require.NoError(t, err)
+			require.Equal(t, []*v2.Entitlement{goodEntitlement}, entitlements)
+
+			plainDisabledEntitlement := ingestFilterGrant("plain-disabled-entitlement", disabledEntitlement, user)
+			// InsertResourceGrants does not exempt the entitlement-type check:
+			// uplift can't use a grant whose entitlement resource type is
+			// absent from the sync, so keeping it would be dead data.
+			irgDisabledEntitlement := ingestFilterGrant(
+				"irg-disabled-entitlement", disabledEntitlement, user,
+				annotations.New(&v2.InsertResourceGrants{})...,
+			)
+			plainDisabledPrincipal := ingestFilterGrant("plain-disabled-principal", goodEntitlement, disabled)
+			matchDisabledPrincipal := ingestFilterGrant(
+				"match-disabled-principal", goodEntitlement, disabled,
+				annotations.New(v2.ExternalResourceMatchID_builder{Id: "external-p1"}.Build())...,
+			)
+			matchDoesNotExemptEntitlement := ingestFilterGrant(
+				"match-disabled-entitlement", disabledEntitlement, disabled,
+				annotations.New(v2.ExternalResourceMatchID_builder{Id: "external-p1"}.Build())...,
+			)
+			irgDoesNotExemptPrincipal := ingestFilterGrant(
+				"irg-disabled-principal", disabledEntitlement, disabled,
+				annotations.New(&v2.InsertResourceGrants{})...,
+			)
+			good := ingestFilterGrant("good", goodEntitlement, user)
+
+			grants, err := s.filterFreshGrants(ctx, []*v2.Grant{
+				plainDisabledEntitlement,
+				irgDisabledEntitlement,
+				plainDisabledPrincipal,
+				matchDisabledPrincipal,
+				matchDoesNotExemptEntitlement,
+				irgDoesNotExemptPrincipal,
+				good,
+			})
+			require.NoError(t, err)
+			require.Equal(t, []*v2.Grant{matchDisabledPrincipal, good}, grants)
+			require.Equal(t, int64(1), s.ingestFilterStats.entitlementsDropped.Load())
+			require.Equal(t, int64(5), s.ingestFilterStats.grantsDropped.Load())
+		})
+	}
+}
+
+func TestFreshIngestFilterNarrowsExpansionWithoutWidening(t *testing.T) {
+	ctx, err := logging.Init(t.Context())
+	require.NoError(t, err)
+	store := newIngestFilterStore(ctx, t, c1zstore.EnginePebble)
+	require.NoError(t, store.PutResourceTypes(ctx,
+		v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build(),
+		v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build(),
+	))
+
+	group := ingestFilterResource("group", "g1")
+	user := ingestFilterResource("user", "u1")
+	entitlement := ingestFilterEntitlement(group, "group:g1:member")
+	expandable := func(id string, resourceTypeIDs ...string) *v2.Grant {
+		return ingestFilterGrant(id, entitlement, user, annotations.New(v2.GrantExpandable_builder{
+			EntitlementIds:  []string{"group:g2:member"},
+			ResourceTypeIds: resourceTypeIDs,
+		}.Build())...)
+	}
+	mixed := expandable("mixed", "user", "iam_policy")
+	disabledOnly := expandable("disabled-only", "iam_policy")
+	unfiltered := expandable("unfiltered")
+	matchExpansion := expandable("match", "iam_policy")
+	matchExpansion.SetAnnotations(append(
+		matchExpansion.GetAnnotations(),
+		annotations.New(v2.ExternalResourceMatchID_builder{Id: "external-user"}.Build())...,
+	))
+
+	s := &syncer{store: store, syncType: connectorstore.SyncTypeFull}
+	filtered, err := s.filterFreshGrants(ctx, []*v2.Grant{mixed, disabledOnly, unfiltered, matchExpansion})
+	require.NoError(t, err)
+	require.Len(t, filtered, 4, "filtering expansion metadata does not drop the base grant")
+	require.NotSame(t, mixed, filtered[0], "rewriting must not mutate connector-owned response objects")
+	require.NotSame(t, disabledOnly, filtered[1], "rewriting must not mutate connector-owned response objects")
+	mixed, disabledOnly, unfiltered, matchExpansion = filtered[0], filtered[1], filtered[2], filtered[3]
+
+	mixedExpansion := &v2.GrantExpandable{}
+	mixedAnnos := annotations.Annotations(mixed.GetAnnotations())
+	ok, err := mixedAnnos.Pick(mixedExpansion)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, []string{"user"}, mixedExpansion.GetResourceTypeIds())
+
+	disabledOnlyAnnos := annotations.Annotations(disabledOnly.GetAnnotations())
+	ok, err = disabledOnlyAnnos.Pick(&v2.GrantExpandable{})
+	require.NoError(t, err)
+	require.False(t, ok, "empty intersection must remove expansion; an empty filter means unfiltered")
+
+	unfilteredExpansion := &v2.GrantExpandable{}
+	unfilteredAnnos := annotations.Annotations(unfiltered.GetAnnotations())
+	ok, err = unfilteredAnnos.Pick(unfilteredExpansion)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Empty(t, unfilteredExpansion.GetResourceTypeIds())
+
+	matchExpandable := &v2.GrantExpandable{}
+	matchAnnos := annotations.Annotations(matchExpansion.GetAnnotations())
+	ok, err = matchAnnos.Pick(matchExpandable)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, []string{"iam_policy"}, matchExpandable.GetResourceTypeIds(),
+		"external-match placeholders remain available for later remapping")
+}
+
+func TestFreshIngestFilterRunsInFullSyncPipeline(t *testing.T) {
+	ctx, err := logging.Init(t.Context())
+	require.NoError(t, err)
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "pipeline.c1z")
+
+	policyRT := v2.ResourceType_builder{Id: "iam_policy", DisplayName: "IAM Policy"}.Build()
+	mc := newMockConnector()
+	mc.rtDB = append(mc.rtDB, groupResourceType, userResourceType, policyRT)
+	group, goodEntitlement, err := mc.AddGroup(ctx, "g1")
+	require.NoError(t, err)
+	user, err := mc.AddUser(ctx, "u1")
+	require.NoError(t, err)
+	disabled := ingestFilterResource("iam_policy", "p1")
+	disabledEntitlement := ingestFilterEntitlement(disabled, "iam_policy:p1:assigned")
+	mc.entDB[group.GetId().GetResource()] = append(mc.entDB[group.GetId().GetResource()], disabledEntitlement)
+	mc.grantDB[group.GetId().GetResource()] = []*v2.Grant{
+		ingestFilterGrant("good", goodEntitlement, user),
+		ingestFilterGrant("disabled-entitlement", disabledEntitlement, user),
+		ingestFilterGrant("disabled-principal", goodEntitlement, disabled),
+		ingestFilterGrant(
+			"match-carrier", goodEntitlement, disabled,
+			annotations.New(v2.ExternalResourceMatchID_builder{Id: "external-p1"}.Build())...,
+		),
+	}
+
+	syncer, err := NewSyncer(ctx, mc,
+		WithC1ZPath(path),
+		WithTmpDir(tmpDir),
+		WithStorageEngine(c1zstore.EnginePebble),
+		WithSyncResourceTypes([]string{"group", "user"}),
+	)
+	require.NoError(t, err)
+	require.NoError(t, syncer.Sync(ctx))
+	require.NoError(t, syncer.Close(ctx))
+
+	store, err := dotc1z.NewStore(ctx, path,
+		dotc1z.WithEngine(c1zstore.EnginePebble),
+		dotc1z.WithReadOnly(true),
+	)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, store.Close(ctx)) }()
+	latest, ok := store.(connectorstore.LatestFinishedSyncIDFetcher)
+	require.True(t, ok)
+	syncID, err := latest.LatestFinishedSyncID(ctx, connectorstore.SyncTypeFull)
+	require.NoError(t, err)
+	require.NoError(t, store.SetCurrentSync(ctx, syncID))
+	entitlementsResp, err := store.ListEntitlements(ctx, v2.EntitlementsServiceListEntitlementsRequest_builder{}.Build())
+	require.NoError(t, err)
+	for _, entitlement := range entitlementsResp.GetList() {
+		require.NotEqual(t, "iam_policy", entitlement.GetResource().GetId().GetResourceType())
+	}
+	grantsResp, err := store.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{}.Build())
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"good", "match-carrier"}, grantIDs(grantsResp.GetList()))
+}
+
+func grantIDs(grants []*v2.Grant) []string {
+	out := make([]string, 0, len(grants))
+	for _, grant := range grants {
+		out = append(out, grant.GetId())
+	}
+	return out
+}
+
+func TestFreshIngestFilterBypassesPartialSyncs(t *testing.T) {
+	s := &syncer{syncType: connectorstore.SyncTypePartial}
+	disabled := ingestFilterEntitlement(ingestFilterResource("iam_policy", "p1"), "iam_policy:p1:assigned")
+	entitlements, err := s.filterFreshEntitlements(t.Context(), []*v2.Entitlement{disabled})
+	require.NoError(t, err)
+	require.Equal(t, []*v2.Entitlement{disabled}, entitlements)
+}
+
+// TestFreshIngestFilterExternalMatchResolvesUnknownPrincipalType exercises the
+// interplay between the fresh-ingest filter and the external-resource phase.
+// The connector emits two grants whose placeholder principals reference a
+// resource type it never lists ("hris_user"):
+//
+//   - one carries ExternalResourceMatch, so the filter must keep it; the
+//     external phase later rewrites it to the matched external user (whose
+//     "user" type is copied into the store by that phase), and
+//   - one carries no annotations, so nothing downstream could ever resolve it
+//     and the filter must drop it.
+func TestFreshIngestFilterExternalMatchResolvesUnknownPrincipalType(t *testing.T) {
+	runWithSyncModes(t, func(t *testing.T, extraOpts []SyncOpt) {
+		ctx := t.Context()
+		tempDir := t.TempDir()
+
+		externalMc := newMockConnector()
+		externalMc.rtDB = append(externalMc.rtDB, userResourceType, groupResourceType)
+		externalUser, err := externalMc.AddUserProfile(ctx, "ext-user-1", map[string]any{
+			"external_id_match": "ext-1",
+		})
+		require.NoError(t, err)
+
+		internalMc := newMockConnector()
+		// The internal connector lists only "group": the placeholder type
+		// "hris_user" is never listed, and "user" only arrives when the
+		// external phase copies it over — after grant collection ran.
+		internalMc.rtDB = append(internalMc.rtDB, groupResourceType)
+		internalGroup, _, err := internalMc.AddGroup(ctx, "g1")
+		require.NoError(t, err)
+
+		placeholder := func(id string) *v2.ResourceId {
+			return v2.ResourceId_builder{ResourceType: "hris_user", Resource: id}.Build()
+		}
+		internalMc.grantDB[internalGroup.GetId().GetResource()] = []*v2.Grant{
+			gt.NewGrant(internalGroup, "member", placeholder("match-me"),
+				gt.WithAnnotation(v2.ExternalResourceMatch_builder{
+					Key:          "external_id_match",
+					Value:        "ext-1",
+					ResourceType: v2.ResourceType_TRAIT_USER,
+				}.Build()),
+			),
+			gt.NewGrant(internalGroup, "member", placeholder("never-resolved")),
+		}
+
+		externalC1zPath := filepath.Join(tempDir, "external.c1z")
+		externalOpts := append([]SyncOpt{WithC1ZPath(externalC1zPath), WithTmpDir(tempDir)}, extraOpts...)
+		externalSyncer, err := NewSyncer(ctx, externalMc, externalOpts...)
+		require.NoError(t, err)
+		require.NoError(t, externalSyncer.Sync(ctx))
+		require.NoError(t, externalSyncer.Close(ctx))
+
+		internalC1zPath := filepath.Join(tempDir, "internal.c1z")
+		internalOpts := append([]SyncOpt{
+			WithC1ZPath(internalC1zPath),
+			WithTmpDir(tempDir),
+			WithExternalResourceC1ZPath(externalC1zPath),
+		}, extraOpts...)
+		internalSyncer, err := NewSyncer(ctx, internalMc, internalOpts...)
+		require.NoError(t, err)
+		require.NoError(t, internalSyncer.Sync(ctx))
+		require.NoError(t, internalSyncer.Close(ctx))
+
+		store, err := dotc1z.NewC1ZFile(ctx, internalC1zPath)
+		require.NoError(t, err)
+		defer func() { require.NoError(t, store.Close(ctx)) }()
+
+		// The external phase copied the external "user" type into the sync;
+		// the placeholder type never lands in the store.
+		rtResp, err := store.ListResourceTypes(ctx, v2.ResourceTypesServiceListResourceTypesRequest_builder{}.Build())
+		require.NoError(t, err)
+		rtIDs := make([]string, 0, len(rtResp.GetList()))
+		for _, rt := range rtResp.GetList() {
+			rtIDs = append(rtIDs, rt.GetId())
+		}
+		require.ElementsMatch(t, []string{"group", "user"}, rtIDs)
+
+		// Exactly one grant survives: the annotated one, rewritten to the
+		// external principal. The unannotated dangling grant is gone.
+		grantsResp, err := store.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{}.Build())
+		require.NoError(t, err)
+		require.Len(t, grantsResp.GetList(), 1)
+		surviving := grantsResp.GetList()[0]
+		require.Equal(t, externalUser.GetId().GetResourceType(), surviving.GetPrincipal().GetId().GetResourceType())
+		require.Equal(t, externalUser.GetId().GetResource(), surviving.GetPrincipal().GetId().GetResource())
+		require.Equal(t, internalGroup.GetId().GetResource(), surviving.GetEntitlement().GetResource().GetId().GetResource())
+	})
+}
+
+// TestFreshIngestFilterInsertResourceGrantsResourceInserts verifies the
+// resource side of the InsertResourceGrants flow: a grant-discovered resource
+// of a scheduled type is written even when every grant that discovered it is
+// dropped for an unscheduled principal type, while a grant-discovered
+// resource of an unscheduled type is dropped along with its grant.
+func TestFreshIngestFilterInsertResourceGrantsResourceInserts(t *testing.T) {
+	ctx := t.Context()
+	tempDir := t.TempDir()
+	c1zPath := filepath.Join(tempDir, "irg-filter.c1z")
+
+	mc := newInsertResourceGrantsMockConnector(true)
+	// "shared_drive" is listed (scheduled); "secret_vault" never is.
+	mc.rtDB = append(mc.rtDB, v2.ResourceType_builder{Id: "shared_drive", DisplayName: "Shared Drive"}.Build())
+
+	group, _, err := mc.AddGroup(ctx, "g1")
+	require.NoError(t, err)
+	user, err := mc.AddUser(ctx, "u1")
+	require.NoError(t, err)
+
+	deadGrantDrive := ingestFilterResource("shared_drive", "d1")
+	liveGrantDrive := ingestFilterResource("shared_drive", "d2")
+	vault := ingestFilterResource("secret_vault", "v1")
+	hrisPrincipal := v2.ResourceId_builder{ResourceType: "hris_user", Resource: "p1"}.Build()
+
+	mc.grantDB[group.GetId().GetResource()] = []*v2.Grant{
+		// Dropped (unscheduled principal type), but d1 is still a legitimate
+		// discovery of a scheduled-type resource.
+		gt.NewGrant(deadGrantDrive, "access", hrisPrincipal),
+		// Survives; d2 discovered normally.
+		gt.NewGrant(liveGrantDrive, "access", user.GetId()),
+		// Dropped (unscheduled entitlement resource type); v1 must not be
+		// written — without its type row the whole chain is dead downstream.
+		gt.NewGrant(vault, "access", user.GetId()),
+	}
+
+	syncer, err := NewSyncer(ctx, mc, WithC1ZPath(c1zPath), WithTmpDir(tempDir))
+	require.NoError(t, err)
+	require.NoError(t, syncer.Sync(ctx))
+	require.NoError(t, syncer.Close(ctx))
+
+	store, err := dotc1z.NewC1ZFile(ctx, c1zPath)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, store.Close(ctx)) }()
+
+	drives, err := store.ListResources(ctx, v2.ResourcesServiceListResourcesRequest_builder{ResourceTypeId: "shared_drive"}.Build())
+	require.NoError(t, err)
+	driveIDs := make([]string, 0, len(drives.GetList()))
+	for _, r := range drives.GetList() {
+		driveIDs = append(driveIDs, r.GetId().GetResource())
+	}
+	require.ElementsMatch(t, []string{"d1", "d2"}, driveIDs)
+
+	vaults, err := store.ListResources(ctx, v2.ResourcesServiceListResourcesRequest_builder{ResourceTypeId: "secret_vault"}.Build())
+	require.NoError(t, err)
+	require.Empty(t, vaults.GetList(), "unscheduled-type resource must not be written")
+
+	grantsResp, err := store.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{}.Build())
+	require.NoError(t, err)
+	require.Len(t, grantsResp.GetList(), 1)
+	surviving := grantsResp.GetList()[0]
+	require.Equal(t, "d2", surviving.GetEntitlement().GetResource().GetId().GetResource())
+	require.Equal(t, "u1", surviving.GetPrincipal().GetId().GetResource())
+}
+
+// TestFreshIngestFilterRunsBeforeExclusionGroupValidation: an entitlement the
+// filter drops must not mutate exclusion-group state or fail the sync. Before
+// the ordering fix this sync failed with an "exclusion group used on multiple
+// resource types" error triggered by the filtered iam_policy entitlement.
+func TestFreshIngestFilterRunsBeforeExclusionGroupValidation(t *testing.T) {
+	ctx := t.Context()
+	tempDir := t.TempDir()
+	c1zPath := filepath.Join(tempDir, "exclusion-filter.c1z")
+
+	mc := newMockConnector()
+	mc.rtDB = append(mc.rtDB, groupResourceType, userResourceType)
+	group, _, err := mc.AddGroup(ctx, "g1")
+	require.NoError(t, err)
+
+	scheduledEnt := ingestFilterEntitlement(group, "group:g1:admin")
+	scheduledEnt.SetAnnotations(annotations.New(v2.EntitlementExclusionGroup_builder{ExclusionGroupId: "eg-1"}.Build()))
+	droppedEnt := ingestFilterEntitlement(ingestFilterResource("iam_policy", "p1"), "iam_policy:p1:assigned")
+	droppedEnt.SetAnnotations(annotations.New(v2.EntitlementExclusionGroup_builder{ExclusionGroupId: "eg-1"}.Build()))
+	mc.entDB[group.GetId().GetResource()] = append(mc.entDB[group.GetId().GetResource()], scheduledEnt, droppedEnt)
+
+	syncer, err := NewSyncer(ctx, mc, WithC1ZPath(c1zPath), WithTmpDir(tempDir))
+	require.NoError(t, err)
+	require.NoError(t, syncer.Sync(ctx))
+	require.NoError(t, syncer.Close(ctx))
+
+	store, err := dotc1z.NewC1ZFile(ctx, c1zPath)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, store.Close(ctx)) }()
+
+	entsResp, err := store.ListEntitlements(ctx, v2.EntitlementsServiceListEntitlementsRequest_builder{}.Build())
+	require.NoError(t, err)
+	entIDs := make([]string, 0, len(entsResp.GetList()))
+	for _, ent := range entsResp.GetList() {
+		require.NotEqual(t, "iam_policy", ent.GetResource().GetId().GetResourceType())
+		entIDs = append(entIDs, ent.GetId())
+	}
+	require.Contains(t, entIDs, scheduledEnt.GetId())
+}

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -158,6 +158,8 @@ type syncer struct {
 	syncID                              string
 	skipEGForResourceType               syncMap[string, bool]
 	skipEntitlementsForResourceType     syncMap[string, bool]
+	scheduledResourceTypes              syncMap[string, bool]
+	ingestFilterStats                   ingestFilterStats
 	skipEntitlementsAndGrants           bool
 	skipGrants                          bool
 	resourceTypeTraits                  syncMap[string, []v2.ResourceType_Trait]
@@ -871,6 +873,8 @@ func (s *syncer) Sync(ctx context.Context) error {
 		return s.returnSyncError(l, span, err)
 	}
 
+	s.logIngestFilterSummary(ctx)
+
 	// Force a checkpoint to clear completed actions & entitlement graph in sync_token.
 	s.state.ClearEntitlementGraph(ctx)
 	s.state.ClearExclusionGroupTracking(ctx)
@@ -1558,15 +1562,21 @@ func (s *syncer) syncEntitlementsForResource(ctx context.Context, action *Action
 	if err != nil {
 		return err
 	}
-	if err := s.validateEntitlementExclusionGroups(resp.GetList()); err != nil {
+	// Filter before exclusion-group validation: a dropped entitlement must not
+	// mutate exclusion-group state or fail the sync as if it had been ingested.
+	entitlements, err := s.filterFreshEntitlements(ctx, resp.GetList())
+	if err != nil {
+		return fmt.Errorf("sync-entitlements: filtering disabled-type references: %w", err)
+	}
+	if err := s.validateEntitlementExclusionGroups(entitlements); err != nil {
 		return err
 	}
-	err = s.store.PutEntitlements(ctx, resp.GetList()...)
+	err = s.store.PutEntitlements(ctx, entitlements...)
 	if err != nil {
 		return err
 	}
 
-	s.handleProgress(ctx, action, len(resp.GetList()))
+	s.handleProgress(ctx, action, len(entitlements))
 	if resp.GetNextPageToken() == "" {
 		s.counts.AddEntitlementsProgress(resourceID.ResourceType, 1)
 		s.counts.LogEntitlementsProgress(ctx, resourceID.GetResourceType())
@@ -2085,6 +2095,33 @@ func (s *syncer) syncGrantsForResource(ctx context.Context, action *Action) erro
 			}
 			g.SetAnnotations(append(annos, insertAny))
 		}
+
+		// Collect grant-discovered resources before fresh-ingest filtering:
+		// a resource of a scheduled type is a legitimate discovery (uplift
+		// creates an AppResource for it) even when the discovering grant is
+		// dropped for an unscheduled principal type. Resources of unscheduled
+		// types are skipped — uplift can't resolve their type, so the row
+		// would be dead data.
+		for _, g := range grants {
+			resource := g.GetEntitlement().GetResource()
+			ok, err := s.filterFreshGrantResource(ctx, resource)
+			if err != nil {
+				return fmt.Errorf("sync-grants-for-resource: filtering grant-discovered resource: %w", err)
+			}
+			if !ok {
+				continue
+			}
+			bid, err := bid.MakeBid(resource)
+			if err != nil {
+				return err
+			}
+			resourcesToInsertMap[bid] = resource
+		}
+	}
+
+	grants, err = s.filterFreshGrants(ctx, grants)
+	if err != nil {
+		return fmt.Errorf("sync-grants-for-resource: filtering disabled-type references: %w", err)
 	}
 
 	for _, grant := range grants {
@@ -2094,15 +2131,6 @@ func (s *syncer) syncGrantsForResource(ctx context.Context, action *Action) erro
 		}
 		if grantAnnos.ContainsAny(&v2.ExternalResourceMatchAll{}, &v2.ExternalResourceMatch{}, &v2.ExternalResourceMatchID{}) {
 			s.state.SetHasExternalResourcesGrants()
-		}
-
-		if insertResourceGrants {
-			resource := grant.GetEntitlement().GetResource()
-			bid, err := bid.MakeBid(resource)
-			if err != nil {
-				return err
-			}
-			resourcesToInsertMap[bid] = resource
 		}
 
 		if !s.state.ShouldFetchRelatedResources() {


### PR DESCRIPTION
## Summary
During full syncs, drop entitlements and grants that reference resource types not present in the current sync’s store (never listed / not selected via WithSyncResourceTypes). That matches what uplift already does: unknown principal/entitlement types are Debug-skipped and never become platform AEUB/AERB rows, so keeping them in the c1z is dead data.

Probe scheduled types via store GetResourceType (cached across workers); resume-safe because the store keyspace already reflects the run’s selection.
- Full syncs only; partial syncs are unchanged.
- External-match grants keep placeholder principals (rewritten after the external phase copies types/resources).
- InsertResourceGrants: still insert grant-discovered resources of scheduled types even when the discovering grant is dropped; do not insert resources (or keep grants) for unscheduled types — uplift can’t use either.
- Narrow GrantExpandable.ResourceTypeIds to scheduled types; remove the annotation if the intersection is empty (empty list would mean unfiltered expansion).
- Run the filter before exclusion-group validation so dropped entitlements can’t fail the sync.
- One aggregate warn at end of sync with drop counters.
