### PR TITLE
PHASE 1: Fault injection harness for pebble

### DIFF
--- a/pkg/dotc1z/engine/pebble/bulk_import.go
+++ b/pkg/dotc1z/engine/pebble/bulk_import.go
@@ -73,9 +73,13 @@ type bulkSSTWriter struct {
 	count int
 }
 
-func newBulkSSTWriter(dir, name string) (*bulkSSTWriter, error) {
+// newBulkSSTWriter creates an SST staging file on fs. fs must be the
+// engine FS (Engine.fs()): the finished SST is handed to the pebble.DB's
+// Ingest/IngestAndExcise, which resolves the path through the DB's own
+// filesystem — creating it anywhere else breaks WithVFS engines.
+func newBulkSSTWriter(fs vfs.FS, dir, name string) (*bulkSSTWriter, error) {
 	path := filepath.Join(dir, name+".sst")
-	file, err := vfs.Default.Create(path, vfs.WriteCategoryUnspecified)
+	file, err := fs.Create(path, vfs.WriteCategoryUnspecified)
 	if err != nil {
 		return nil, fmt.Errorf("bulk sync import: create %q: %w", path, err)
 	}
@@ -211,7 +215,7 @@ func (e *Engine) StartBulkSyncImport(ctx context.Context, syncID string, tmpDir 
 	if cur := e.currentSyncBytes(); !bytes.Equal(cur, idBytes) {
 		return nil, fmt.Errorf("StartBulkSyncImport: sync %s is not the engine's current sync", syncID)
 	}
-	dir, err := os.MkdirTemp(tmpDir, "pebble-bulk-import-")
+	dir, err := e.prepareStagingDir(tmpDir, "pebble-bulk-import-")
 	if err != nil {
 		return nil, fmt.Errorf("StartBulkSyncImport: mkdir temp: %w", err)
 	}
@@ -236,7 +240,7 @@ func (e *Engine) StartBulkSyncImport(ctx context.Context, syncID string, tmpDir 
 		{&b.resourceTypes, "resource-types"},
 		{&b.resources, "resources"},
 	} {
-		sw, err := newBulkSSTWriter(dir, w.name)
+		sw, err := newBulkSSTWriter(e.fs(), dir, w.name)
 		if err != nil {
 			b.Abort()
 			return nil, err
@@ -645,9 +649,9 @@ func (b *BulkSyncImport) Finish(ctx context.Context) error {
 			sstPath := filepath.Join(b.dir, u.name+".sst")
 			var err error
 			if u.resolve != nil {
-				_, err = mergeSpillChunksToSSTResolvingDuplicates(ctx, sstPath, u.name, chunks, u.resolve)
+				_, err = mergeSpillChunksToSSTResolvingDuplicates(ctx, b.e.fs(), sstPath, u.name, chunks, u.resolve)
 			} else {
-				err = mergeSortedSpillChunksToSST(ctx, sstPath, u.name, chunks)
+				err = mergeSortedSpillChunksToSST(ctx, b.e.fs(), sstPath, u.name, chunks)
 			}
 			if err != nil {
 				results[slot].err = err
@@ -763,7 +767,7 @@ func (b *BulkSyncImport) teardown() {
 			w.abort()
 		}
 	}
-	_ = os.RemoveAll(b.dir)
+	b.e.removeStagingDir(b.dir)
 }
 
 // --- spill sorter: unordered (key[,value]) → background chunk sort →
@@ -1111,8 +1115,9 @@ func readSpillEntry(r io.Reader, key, val *[]byte, lenBuf *[4]byte) (bool, error
 
 // mergeSortedSpillChunksToSST heap-merges the sorted chunk files into a
 // single SST. Duplicate keys are corruption (the importer requires
-// globally unique tuples) and fail the merge.
-func mergeSortedSpillChunksToSST(ctx context.Context, sstPath, name string, chunks []string) error {
+// globally unique tuples) and fail the merge. fs is the engine FS the
+// SST is created on (chunk files are plain OS scratch — see spillSorter).
+func mergeSortedSpillChunksToSST(ctx context.Context, fs vfs.FS, sstPath, name string, chunks []string) error {
 	start := time.Now()
 	l := ctxzap.Extract(ctx)
 	readers := make([]*os.File, 0, len(chunks))
@@ -1142,7 +1147,7 @@ func mergeSortedSpillChunksToSST(ctx context.Context, sstPath, name string, chun
 		}
 	}
 
-	writer, err := newBulkSSTWriter(filepath.Dir(sstPath), name)
+	writer, err := newBulkSSTWriter(fs, filepath.Dir(sstPath), name)
 	if err != nil {
 		return err
 	}
@@ -1150,7 +1155,7 @@ func mergeSortedSpillChunksToSST(ctx context.Context, sstPath, name string, chun
 	defer func() {
 		_ = writer.finish()
 		if !success {
-			_ = os.Remove(sstPath)
+			_ = fs.Remove(sstPath)
 		}
 	}()
 	var last []byte
@@ -1222,6 +1227,7 @@ func mergeSortedSpillChunksToSST(ctx context.Context, sstPath, name string, chun
 // resolved.
 func mergeSpillChunksToSSTResolvingDuplicates(
 	ctx context.Context,
+	fs vfs.FS,
 	sstPath, name string,
 	chunks []string,
 	resolve func(key []byte, values [][]byte) ([]byte, error),
@@ -1255,7 +1261,7 @@ func mergeSpillChunksToSSTResolvingDuplicates(
 		}
 	}
 
-	writer, err := newBulkSSTWriter(filepath.Dir(sstPath), name)
+	writer, err := newBulkSSTWriter(fs, filepath.Dir(sstPath), name)
 	if err != nil {
 		return 0, err
 	}
@@ -1263,7 +1269,7 @@ func mergeSpillChunksToSSTResolvingDuplicates(
 	defer func() {
 		_ = writer.finish()
 		if !success {
-			_ = os.Remove(sstPath)
+			_ = fs.Remove(sstPath)
 		}
 	}()
 

--- a/pkg/dotc1z/engine/pebble/deferred_index.go
+++ b/pkg/dotc1z/engine/pebble/deferred_index.go
@@ -5,13 +5,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"runtime"
 	"sync"
 	"time"
 
 	"github.com/cockroachdb/pebble/v2"
+	"github.com/cockroachdb/pebble/v2/vfs"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
 
@@ -116,6 +116,7 @@ type rebuildBatch struct {
 // and flushed in ~8MiB batches over a small bounded channel: the scan blocks
 // when the writer falls more than a few batches behind. Single producer.
 type grantRebuildTee struct {
+	fs  vfs.FS
 	dir string
 
 	// Scan-thread state: the arena being filled.
@@ -137,8 +138,9 @@ type grantRebuildTee struct {
 	err error
 }
 
-func newGrantRebuildTee(dir string) *grantRebuildTee {
+func newGrantRebuildTee(fs vfs.FS, dir string) *grantRebuildTee {
 	t := &grantRebuildTee{
+		fs:   fs,
 		dir:  dir,
 		ch:   make(chan rebuildBatch, 4),
 		done: make(chan struct{}),
@@ -187,7 +189,7 @@ func (t *grantRebuildTee) run() {
 func (t *grantRebuildTee) writeBatch(b rebuildBatch) error {
 	for _, v := range b.views {
 		if t.writer == nil {
-			w, err := newBulkSSTWriter(t.dir, fmt.Sprintf("grant-rebuild-%03d", t.seq))
+			w, err := newBulkSSTWriter(t.fs, t.dir, fmt.Sprintf("grant-rebuild-%03d", t.seq))
 			if err != nil {
 				return err
 			}
@@ -331,11 +333,11 @@ func (e *Engine) buildDeferredGrantIndexesLocked(ctx context.Context) error {
 	}
 	start := time.Now()
 	l := ctxzap.Extract(ctx)
-	dir, err := os.MkdirTemp("", "pebble-deferred-idx-")
+	dir, err := e.prepareStagingDir("", "pebble-deferred-idx-")
 	if err != nil {
 		return fmt.Errorf("BuildDeferredGrantIndexes: mkdir temp: %w", err)
 	}
-	defer os.RemoveAll(dir)
+	defer e.removeStagingDir(dir)
 
 	sorters := min(4, max(2, runtime.GOMAXPROCS(0)/2))
 	sem := make(chan struct{}, sorters)
@@ -378,7 +380,7 @@ func (e *Engine) buildDeferredGrantIndexesLocked(ctx context.Context) error {
 	var totalKeys int64
 	grantsByEntRTPtr := map[string]*int64{}
 
-	rebuild := newGrantRebuildTee(dir)
+	rebuild := newGrantRebuildTee(e.fs(), dir)
 	rebuildFinished := false
 	defer func() {
 		if !rebuildFinished {
@@ -557,7 +559,7 @@ func (e *Engine) buildDeferredGrantIndexesLocked(ctx context.Context) error {
 			zap.Duration("scan", scanDone.Sub(start)),
 		)
 		sstPath := filepath.Join(dir, fmt.Sprintf("index-%02x.sst", idxGrantByPrincipal))
-		if err := mergeSortedSpillChunksToSST(ctx, sstPath, fmt.Sprintf("index-%02x", idxGrantByPrincipal), chunks); err != nil {
+		if err := mergeSortedSpillChunksToSST(ctx, e.fs(), sstPath, fmt.Sprintf("index-%02x", idxGrantByPrincipal), chunks); err != nil {
 			return err
 		}
 		mergeDone := time.Now()

--- a/pkg/dotc1z/engine/pebble/engine.go
+++ b/pkg/dotc1z/engine/pebble/engine.go
@@ -821,10 +821,16 @@ func copyReadOnlyDBDir(pfs vfs.FS, srcDir, destDir string) error {
 //
 // pfs is the engine FS (Engine.fs()) — db.Checkpoint wrote the
 // checkpoint through it, so the WALs to truncate live there, not
-// necessarily on the host filesystem. vfs has no Truncate, so the
-// truncation is a Create (same open-existing-with-O_TRUNC semantics
-// as os.Create on the default FS; permissions of an existing file are
-// untouched by O_CREATE|O_TRUNC).
+// necessarily on the host filesystem. vfs has no Truncate, and
+// vfs.Default.Create is REMOVE-then-recreate (not O_TRUNC — see its
+// hard-link rationale), so "Create the WAL path directly" could
+// unlink a WAL and then fail the recreate, which is exactly the
+// delete-changes-the-discovered-file-set hazard the truncate-not-
+// delete policy above exists to avoid. Instead the zero-byte
+// replacement is built at a side name and Rename'd over the WAL:
+// the original survives every failure before the rename, and the
+// rename replaces the path atomically on both the default FS and
+// MemFS.
 func truncateCheckpointWALs(pfs vfs.FS, destDir string) error {
 	names, err := pfs.List(destDir)
 	if err != nil {
@@ -841,11 +847,17 @@ func truncateCheckpointWALs(pfs vfs.FS, destDir string) error {
 			}
 			continue
 		}
-		f, err := pfs.Create(path, vfs.WriteCategoryUnspecified)
+		tmp := path + ".trunc"
+		f, err := pfs.Create(tmp, vfs.WriteCategoryUnspecified)
 		if err != nil {
 			return err
 		}
 		if err := f.Close(); err != nil {
+			_ = pfs.Remove(tmp)
+			return err
+		}
+		if err := pfs.Rename(tmp, path); err != nil {
+			_ = pfs.Remove(tmp)
 			return err
 		}
 	}

--- a/pkg/dotc1z/engine/pebble/engine.go
+++ b/pkg/dotc1z/engine/pebble/engine.go
@@ -670,6 +670,41 @@ func (e *Engine) InvalidateBareIDLookups() { e.noteEntitlementKeyspaceWrite() }
 // migration (see migratedOnOpen).
 func (e *Engine) MigratedOnOpen() bool { return e.migratedOnOpen }
 
+// fs returns the filesystem the engine performs its own IO through:
+// the WithVFS override when set, vfs.Default otherwise. This must be
+// the same FS the pebble.DB reads from — the staged SSTs the engine
+// hands to Ingest/IngestAndExcise are resolved through the DB's FS.
+func (e *Engine) fs() vfs.FS {
+	if e.opts.vfs != nil {
+		return e.opts.vfs
+	}
+	return vfs.Default
+}
+
+// prepareStagingDir mints a unique staging directory via os.MkdirTemp
+// and mirrors it onto the engine FS. SST files staged for ingest are
+// created through e.fs() (the pebble.DB resolves ingest paths through
+// that FS), while spill-chunk scratch is plain OS IO — so the directory
+// must exist on both. On the default FS the MkdirAll is a no-op.
+func (e *Engine) prepareStagingDir(tmpDir, pattern string) (string, error) {
+	dir, err := os.MkdirTemp(tmpDir, pattern)
+	if err != nil {
+		return "", err
+	}
+	if err := e.fs().MkdirAll(dir, 0o755); err != nil {
+		_ = os.RemoveAll(dir)
+		return "", err
+	}
+	return dir, nil
+}
+
+// removeStagingDir removes a staging directory from both filesystems
+// it exists on (see prepareStagingDir). Cleanup-path best effort.
+func (e *Engine) removeStagingDir(dir string) {
+	_ = e.fs().RemoveAll(dir)
+	_ = os.RemoveAll(dir)
+}
+
 // CheckpointTo writes a self-contained Pebble directory snapshot to
 // destDir. destDir must not exist yet. Pebble creates it and
 // hard-links SSTs where possible.
@@ -715,7 +750,7 @@ func (e *Engine) CheckpointTo(ctx context.Context, destDir string) error {
 	}
 
 	if e.opts.readOnly {
-		return copyReadOnlyDBDir(e.dbDir, destDir)
+		return copyReadOnlyDBDir(e.fs(), e.dbDir, destDir)
 	}
 
 	if err := e.db.Flush(); err != nil {
@@ -733,14 +768,15 @@ func (e *Engine) CheckpointTo(ctx context.Context, destDir string) error {
 
 // copyReadOnlyDBDir clones a read-only Pebble directory tree into
 // destDir. destDir must not exist yet, matching db.Checkpoint's
-// contract.
-func copyReadOnlyDBDir(srcDir, destDir string) error {
-	if _, err := os.Stat(destDir); err == nil {
+// contract. pfs is the engine FS (Engine.fs()) — the source tree was
+// written through it and the clone must land where the destination
+// open will look.
+func copyReadOnlyDBDir(pfs vfs.FS, srcDir, destDir string) error {
+	if _, err := pfs.Stat(destDir); err == nil {
 		return &os.PathError{Op: "checkpoint", Path: destDir, Err: fs.ErrExist}
 	} else if !errors.Is(err, fs.ErrNotExist) {
 		return err
 	}
-	pfs := vfs.Default
 	// Skip LOCK: the source engine holds an exclusive lock on it (on
 	// Windows the same process cannot reopen it for read). The clone
 	// gets a fresh LOCK when Pebble opens destDir.

--- a/pkg/dotc1z/engine/pebble/engine.go
+++ b/pkg/dotc1z/engine/pebble/engine.go
@@ -686,6 +686,11 @@ func (e *Engine) fs() vfs.FS {
 // created through e.fs() (the pebble.DB resolves ingest paths through
 // that FS), while spill-chunk scratch is plain OS IO — so the directory
 // must exist on both. On the default FS the MkdirAll is a no-op.
+//
+// Portability note: mirroring a host temp path onto a MemFS assumes
+// "/" separators (MemFS only splits on "/"). WithVFS with a MemFS is a
+// test-only configuration and the tests are unix-only; a Windows port
+// would need to stage under fs.PathJoin'd relative paths instead.
 func (e *Engine) prepareStagingDir(tmpDir, pattern string) (string, error) {
 	dir, err := os.MkdirTemp(tmpDir, pattern)
 	if err != nil {
@@ -759,7 +764,7 @@ func (e *Engine) CheckpointTo(ctx context.Context, destDir string) error {
 	if err := e.db.Checkpoint(destDir); err != nil {
 		return fmt.Errorf("checkpoint db %s: %w", destDir, err)
 	}
-	if err := truncateCheckpointWALs(destDir); err != nil {
+	if err := truncateCheckpointWALs(e.fs(), destDir); err != nil {
 		return fmt.Errorf("checkpoint truncate WALs: %w", err)
 	}
 
@@ -813,16 +818,34 @@ func copyReadOnlyDBDir(pfs vfs.FS, srcDir, destDir string) error {
 // (replay reads a clean EOF), whereas deleting the file would change
 // the file set pebble's open sequence discovers and validates against
 // the manifest's minUnflushedLogNum.
-func truncateCheckpointWALs(destDir string) error {
-	entries, err := os.ReadDir(destDir)
+//
+// pfs is the engine FS (Engine.fs()) — db.Checkpoint wrote the
+// checkpoint through it, so the WALs to truncate live there, not
+// necessarily on the host filesystem. vfs has no Truncate, so the
+// truncation is a Create (same open-existing-with-O_TRUNC semantics
+// as os.Create on the default FS; permissions of an existing file are
+// untouched by O_CREATE|O_TRUNC).
+func truncateCheckpointWALs(pfs vfs.FS, destDir string) error {
+	names, err := pfs.List(destDir)
 	if err != nil {
 		return err
 	}
-	for _, ent := range entries {
-		if ent.IsDir() || filepath.Ext(ent.Name()) != ".log" {
+	for _, name := range names {
+		if filepath.Ext(name) != ".log" {
 			continue
 		}
-		if err := os.Truncate(filepath.Join(destDir, ent.Name()), 0); err != nil {
+		path := pfs.PathJoin(destDir, name)
+		if info, err := pfs.Stat(path); err != nil || info.IsDir() {
+			if err != nil {
+				return err
+			}
+			continue
+		}
+		f, err := pfs.Create(path, vfs.WriteCategoryUnspecified)
+		if err != nil {
+			return err
+		}
+		if err := f.Close(); err != nil {
 			return err
 		}
 	}

--- a/pkg/dotc1z/engine/pebble/errorfs_sweep_test.go
+++ b/pkg/dotc1z/engine/pebble/errorfs_sweep_test.go
@@ -370,12 +370,24 @@ func runInjected(base *vfs.MemFS, inj *failFromInjector, e *Engine, gate *fatalG
 	return res
 }
 
+// crashImageOutcome names which arm of the reopen dichotomy a crash
+// image landed in — reported by the sweeps so the injection coverage
+// is visible in the test log, not just implied by a green run.
+type crashImageOutcome string
+
+const (
+	outcomeFinishedComplete   crashImageOutcome = "finished-and-complete"
+	outcomeUnfinishedResumed  crashImageOutcome = "unfinished-resumed-to-completion"
+	outcomeNoSyncRunRestarted crashImageOutcome = "no-sync-run-restarted"
+)
+
 // verifyCrashImage opens a clean engine over the crash clone and
-// asserts the reopen dichotomy, resuming when unfinished.
+// asserts the reopen dichotomy, resuming when unfinished. Returns the
+// outcome arm for the caller's coverage accounting.
 // replayPages selects the resume model: false = the pages were already
 // durable before the window (EndSync sweep), true = replay them (whole
 // sync soak).
-func verifyCrashImage(ctx context.Context, t *testing.T, w sweepWorkload, image *vfs.MemFS, cache *pebble.Cache, syncID string, replayPages bool, label string) {
+func verifyCrashImage(ctx context.Context, t *testing.T, w sweepWorkload, image *vfs.MemFS, cache *pebble.Cache, syncID string, replayPages bool, label string) crashImageOutcome {
 	t.Helper()
 	e, err := Open(ctx, "sweep-db", WithVFS(image), WithSharedCache(cache), withPanicOnFatalLogger())
 	require.NoErrorf(t, err, "%s: the crash image must reopen", label)
@@ -392,6 +404,7 @@ func verifyCrashImage(ctx context.Context, t *testing.T, w sweepWorkload, image 
 		// before the stamp — a finished-but-incomplete image is the lying
 		// artifact this harness exists to catch.
 		w.verifyComplete(ctx, t, e, syncID, label+" (finished image)")
+		return outcomeFinishedComplete
 	case recErr == nil:
 		// (a) unfinished: must be discoverable and resume to completion.
 		unfinished, err := e.LatestUnfinishedSyncRecord(ctx, nil)
@@ -406,6 +419,7 @@ func verifyCrashImage(ctx context.Context, t *testing.T, w sweepWorkload, image 
 		}
 		require.NoErrorf(t, a.EndSync(ctx), "%s: resumed EndSync must converge", label)
 		w.verifyComplete(ctx, t, e, syncID, label+" (resumed image)")
+		return outcomeUnfinishedResumed
 	default:
 		// (c) the record never became durable. Legal only when the crash
 		// predates the sync-run record's fsync — possible in the whole-sync
@@ -418,6 +432,7 @@ func verifyCrashImage(ctx context.Context, t *testing.T, w sweepWorkload, image 
 		require.NoErrorf(t, w.write(ctx, a), "%s: restart page write", label)
 		require.NoErrorf(t, a.EndSync(ctx), "%s: restart EndSync", label)
 		w.verifyComplete(ctx, t, e, newID, label+" (restarted image)")
+		return outcomeNoSyncRunRestarted
 	}
 }
 
@@ -456,7 +471,8 @@ func TestErrorFSEndSyncWindowSweep(t *testing.T) {
 
 	const maxK = 5000
 	covered := false
-	var k int64
+	var k, injectedRuns, fatalRuns int64
+	outcomes := map[crashImageOutcome]int64{}
 	for k = 0; !covered; k++ {
 		require.Less(t, k, int64(maxK), "EndSync window exceeded %d write ops; sweep runaway", maxK)
 
@@ -473,6 +489,12 @@ func TestErrorFSEndSyncWindowSweep(t *testing.T) {
 		res := runInjected(stepFS, inj, e, gate, k, func() error {
 			return a.EndSync(ctx)
 		})
+		if res.injected > 0 {
+			injectedRuns++
+		}
+		if res.fatal {
+			fatalRuns++
+		}
 
 		label := fmt.Sprintf("k=%d", k)
 		if res.err == nil {
@@ -480,14 +502,26 @@ func TestErrorFSEndSyncWindowSweep(t *testing.T) {
 			// last write op of the window — coverage proven. (A nonzero
 			// injected count with a green run means the injection only hit
 			// post-completion background work; verify and keep sweeping.)
-			verifyCrashImage(ctx, t, w, res.image, cache, syncID, false, label+" (clean run)")
+			outcomes[verifyCrashImage(ctx, t, w, res.image, cache, syncID, false, label+" (clean run)")]++
 			covered = res.injected == 0
 			continue
 		}
 		require.Greaterf(t, res.injected, int64(0), "k=%d: EndSync failed with the injector armed but nothing injected: %v", k, res.err)
-		verifyCrashImage(ctx, t, w, res.image, cache, syncID, false, label)
+		outcomes[verifyCrashImage(ctx, t, w, res.image, cache, syncID, false, label)]++
 	}
-	t.Logf("EndSync window covered: %d write-op failure points swept", k-1)
+	// The coverage evidence, not just a green run: every k below the
+	// terminator must have injected a fault, and both arms of the reopen
+	// dichotomy must be populated (all-finished would mean the injections
+	// never landed before the durability boundary; all-unfinished would
+	// mean the window's tail — post-stamp failures — was never reached).
+	require.Equalf(t, k-1, injectedRuns,
+		"every failure point below the terminator must inject (swept %d, injected %d)", k-1, injectedRuns)
+	require.Positivef(t, outcomes[outcomeUnfinishedResumed],
+		"no injection landed before the finished verdict; the sweep isn't reaching the window's body: %v", outcomes)
+	require.Positivef(t, outcomes[outcomeFinishedComplete],
+		"no injection landed after the finished verdict; the sweep isn't reaching the window's tail: %v", outcomes)
+	t.Logf("EndSync window covered: %d write-op failure points, all injected (%d pebble-fatal); crash-image outcomes: %v",
+		k-1, fatalRuns, outcomes)
 }
 
 // TestErrorFSWholeSyncRandomSweepSoak randomizes the failure point

--- a/pkg/dotc1z/engine/pebble/errorfs_sweep_test.go
+++ b/pkg/dotc1z/engine/pebble/errorfs_sweep_test.go
@@ -276,9 +276,35 @@ func (w sweepWorkload) write(ctx context.Context, a *Adapter) error {
 	return a.Grants().StoreExpandedGrants(ctx, expanded...)
 }
 
-// verifyComplete is the content oracle: every workload row is readable
-// through the primary keyspaces AND the by_principal index on a
-// finished store.
+// expectedGrantIDs is the exact external-id set the workload implies:
+// perPrinc connector grants plus one expanded grant per principal.
+func (w sweepWorkload) expectedGrantIDs() []string {
+	var ids []string
+	for _, p := range w.principals {
+		for i := 0; i < w.perPrinc; i++ {
+			ids = append(ids, canonicalTestGrantID(fmt.Sprintf("ent-%02d", i), "user", p))
+		}
+		ids = append(ids, canonicalTestGrantID(sweepExpandedEnt, "user", p))
+	}
+	return ids
+}
+
+// expectedEntIDsPerPrincipal is the exact entitlement-id set every
+// principal's by_principal slice must serve.
+func (w sweepWorkload) expectedEntIDsPerPrincipal() []string {
+	var ids []string
+	for i := 0; i < w.perPrinc; i++ {
+		ids = append(ids, canonicalTestEntID(fmt.Sprintf("ent-%02d", i)))
+	}
+	return append(ids, canonicalTestEntID(sweepExpandedEnt))
+}
+
+// verifyComplete is the content oracle: the EXACT workload row sets —
+// not just counts — are readable through the primary keyspaces AND the
+// by_principal index on a finished store. Set equality is what makes
+// "resumes to completion" mean CORRECT completion: a resume that
+// duplicated, dropped, or cross-wired rows while keeping counts
+// plausible fails here.
 func (w sweepWorkload) verifyComplete(ctx context.Context, t *testing.T, e *Engine, syncID string, label string) {
 	t.Helper()
 	rec, err := e.GetSyncRunRecord(ctx, syncID)
@@ -290,7 +316,11 @@ func (w sweepWorkload) verifyComplete(ctx context.Context, t *testing.T, e *Engi
 
 	resp, err := a.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{}.Build())
 	require.NoErrorf(t, err, "%s: ListGrants", label)
-	require.Lenf(t, resp.GetList(), len(w.principals)*(w.perPrinc+1), "%s: grant count", label)
+	gotGrantIDs := make([]string, 0, len(resp.GetList()))
+	for _, g := range resp.GetList() {
+		gotGrantIDs = append(gotGrantIDs, g.GetId())
+	}
+	require.ElementsMatchf(t, w.expectedGrantIDs(), gotGrantIDs, "%s: grant id set", label)
 
 	rresp, err := a.ListResources(ctx, v2.ResourcesServiceListResourcesRequest_builder{}.Build())
 	require.NoErrorf(t, err, "%s: ListResources", label)
@@ -301,14 +331,20 @@ func (w sweepWorkload) verifyComplete(ctx context.Context, t *testing.T, e *Engi
 	require.Lenf(t, eresp.GetList(), w.perPrinc+1, "%s: entitlement count", label)
 
 	// The by_principal index is rebuilt inside the EndSync window — the
-	// exact artifact a torn deferred build would corrupt or lose.
+	// exact artifact a torn deferred build would corrupt or lose. Each
+	// principal's slice must serve exactly its entitlement set, with
+	// records whose refs actually point at the principal being asked
+	// about (a cross-wired index entry fails the principal check).
+	wantEnts := w.expectedEntIDsPerPrincipal()
 	for _, p := range w.principals {
-		n := 0
-		require.NoErrorf(t, e.IterateGrantsByPrincipal(ctx, "user", p, func(*v3.GrantRecord) bool {
-			n++
+		var gotEnts []string
+		require.NoErrorf(t, e.IterateGrantsByPrincipal(ctx, "user", p, func(r *v3.GrantRecord) bool {
+			require.Equalf(t, "user", r.GetPrincipal().GetResourceTypeId(), "%s: %s index row principal type", label, p)
+			require.Equalf(t, p, r.GetPrincipal().GetResourceId(), "%s: %s index row principal id", label, p)
+			gotEnts = append(gotEnts, r.GetEntitlement().GetEntitlementId())
 			return true
 		}), "%s: IterateGrantsByPrincipal(%s)", label, p)
-		require.Equalf(t, w.perPrinc+1, n, "%s: by_principal must serve %s", label, p)
+		require.ElementsMatchf(t, wantEnts, gotEnts, "%s: by_principal entitlement set for %s", label, p)
 	}
 }
 

--- a/pkg/dotc1z/engine/pebble/errorfs_sweep_test.go
+++ b/pkg/dotc1z/engine/pebble/errorfs_sweep_test.go
@@ -45,8 +45,8 @@ package pebble
 // default CI and is exhaustive — injection arms when EndSync is called
 // and k self-calibrates upward until an armed run completes without
 // injecting anything, which proves the window was covered end-to-end.
-// The whole-sync randomized sweep (seeded, mixed unsynced-survival
-// rates) is env-gated behind BATON_SOAK.
+// The whole-sync randomized sweep (seeded failure points, strict
+// zero-unsynced-survival crash images) is env-gated behind BATON_SOAK.
 //
 // Out of scope for this harness:
 //   - The v3 envelope save (os-level IO in the dotc1z store layer's
@@ -170,6 +170,22 @@ func (g *fatalGate) err() error {
 
 func withFatalGate(g *fatalGate) Option {
 	return func(o *Options) { o.pebbleLogger = g }
+}
+
+// panicOnFatalLogger is for the sweep's NON-injected engines (baseline
+// build, crash-image verification): no failure is expected there, so a
+// pebble fatal is a genuine test failure and must fail FAST, not park.
+// A panic on the test goroutine fails the test with a stack; on a
+// background goroutine it kills the binary with the same stack —
+// either beats a parked gate nobody selects on (a CI hang).
+type panicOnFatalLogger struct{ discardPebbleLogger }
+
+func (panicOnFatalLogger) Fatalf(format string, args ...interface{}) {
+	panic(fmt.Sprintf("pebble fatal on a non-injected sweep engine: "+format, args...))
+}
+
+func withPanicOnFatalLogger() Option {
+	return func(o *Options) { o.pebbleLogger = panicOnFatalLogger{} }
 }
 
 // sweepWorkload is the fixed mini-sync the sweeps write and verify.
@@ -323,13 +339,22 @@ func runInjected(base *vfs.MemFS, inj *failFromInjector, e *Engine, gate *fatalG
 		res.fatal = true
 		res.err = gate.err()
 	}
+	// Snapshot the injection count the moment the body resolves — it
+	// answers "did the body's window inject?", which the window sweep's
+	// termination condition depends on; later background injections
+	// must not pollute it.
 	res.injected = inj.injected.Load()
-	inj.disarm()
-	// The crash image: only fsynced state survives. Cut before Close so
-	// post-failure healing writes can't reach it. (CrashClone blocks FS
-	// mutations for the copy, so the image is an atomic cut even with
-	// engine goroutines still running.)
+	// The crash image: only fsynced state survives. Cut while the
+	// injector is STILL ARMED and before Close — a background goroutine
+	// completing a write in a disarm-to-clone gap would heal state the
+	// image must not contain. Background injections in the read-to-clone
+	// gap only make the image more crashed, never healed — the safe
+	// direction. (CrashClone blocks FS mutations for the copy, so the
+	// image is an atomic cut even with engine goroutines still running;
+	// the clone runs on the base MemFS, not through the errorfs wrapper,
+	// so arming doesn't affect the cut itself.)
 	res.image = base.CrashClone(vfs.CrashCloneCfg{})
+	inj.disarm()
 	if res.fatal {
 		return res
 	}
@@ -352,7 +377,7 @@ func runInjected(base *vfs.MemFS, inj *failFromInjector, e *Engine, gate *fatalG
 // sync soak).
 func verifyCrashImage(ctx context.Context, t *testing.T, w sweepWorkload, image *vfs.MemFS, cache *pebble.Cache, syncID string, replayPages bool, label string) {
 	t.Helper()
-	e, err := Open(ctx, "sweep-db", WithVFS(image), WithSharedCache(cache), withFatalGate(newFatalGate()))
+	e, err := Open(ctx, "sweep-db", WithVFS(image), WithSharedCache(cache), withPanicOnFatalLogger())
 	require.NoErrorf(t, err, "%s: the crash image must reopen", label)
 	defer func() { _ = e.Close() }()
 
@@ -403,7 +428,7 @@ func verifyCrashImage(ctx context.Context, t *testing.T, w sweepWorkload, image 
 func buildSweepBaseline(ctx context.Context, t *testing.T, w sweepWorkload, cache *pebble.Cache) (*vfs.MemFS, string) {
 	t.Helper()
 	fs := vfs.NewCrashableMem()
-	e, err := Open(ctx, "sweep-db", WithVFS(fs), WithSharedCache(cache), withFatalGate(newFatalGate()))
+	e, err := Open(ctx, "sweep-db", WithVFS(fs), WithSharedCache(cache), withPanicOnFatalLogger())
 	require.NoError(t, err)
 	a := NewAdapter(e)
 	syncID, err := a.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
@@ -539,7 +564,7 @@ func TestErrorFSWholeSyncRandomSweepSoak(t *testing.T) {
 // still opens and supports a fresh, complete sync.
 func verifyEmptyImageRestarts(ctx context.Context, t *testing.T, w sweepWorkload, image *vfs.MemFS, cache *pebble.Cache, label string) {
 	t.Helper()
-	e, err := Open(ctx, "sweep-db", WithVFS(image), WithSharedCache(cache), withFatalGate(newFatalGate()))
+	e, err := Open(ctx, "sweep-db", WithVFS(image), WithSharedCache(cache), withPanicOnFatalLogger())
 	require.NoErrorf(t, err, "%s: empty crash image must reopen", label)
 	defer func() { _ = e.Close() }()
 	a := NewAdapter(e)

--- a/pkg/dotc1z/engine/pebble/errorfs_sweep_test.go
+++ b/pkg/dotc1z/engine/pebble/errorfs_sweep_test.go
@@ -67,6 +67,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -80,6 +81,19 @@ import (
 	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
 )
+
+// skipOnWindowsMemFS skips MemFS-backed tests on Windows: the engine
+// mirrors os.MkdirTemp staging paths onto the engine FS
+// (prepareStagingDir), and MemFS only understands "/" separators —
+// backslash host paths would collapse into flat names with undefined
+// semantics. WithVFS+MemFS is a test-only configuration; see the
+// portability note on prepareStagingDir.
+func skipOnWindowsMemFS(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("MemFS-backed engine tests assume '/' path separators; see prepareStagingDir portability note")
+	}
+}
 
 // failFromInjector injects errorfs.ErrInjected into the k-th
 // write-class op after arming — and, unless failOnce is set, every
@@ -498,6 +512,7 @@ func buildSweepBaseline(ctx context.Context, t *testing.T, w sweepWorkload, cach
 // completes without injecting anything — proof the whole window was
 // covered.
 func TestErrorFSEndSyncWindowSweep(t *testing.T) {
+	skipOnWindowsMemFS(t)
 	ctx := context.Background()
 	w := defaultSweepWorkload()
 	cache := pebble.NewCache(8 << 20)
@@ -564,6 +579,7 @@ func TestErrorFSEndSyncWindowSweep(t *testing.T) {
 // across the whole sync (open → pages → EndSync) with the strictest
 // crash image (no unsynced survival). Env-gated like the other soaks.
 func TestErrorFSWholeSyncRandomSweepSoak(t *testing.T) {
+	skipOnWindowsMemFS(t)
 	if os.Getenv("BATON_SOAK") == "" {
 		t.Skip("set BATON_SOAK=1 to run the whole-sync errorfs sweep")
 	}

--- a/pkg/dotc1z/engine/pebble/errorfs_sweep_test.go
+++ b/pkg/dotc1z/engine/pebble/errorfs_sweep_test.go
@@ -1,0 +1,551 @@
+package pebble
+
+// Fault-injection sweep for the engine's crash/error contract, over
+// pebble's errorfs + crashable MemFS.
+//
+// THE CONTRACT UNDER TEST: for ANY write/fsync failure surfaced to the
+// caller, followed by a crash (the handle is hard-discarded — no clean
+// close mutates state after the failure), the store must reopen as one
+// of:
+//
+//   (a) UNFINISHED — the sync is discoverable via
+//       LatestUnfinishedSyncRecord and resumes to completion (page
+//       replay where the model calls for it + a re-run EndSync ends
+//       green), after which the content oracle passes; or
+//   (b) FINISHED and content-complete — the failure hit after the
+//       finished verdict was durable, and everything the sync wrote is
+//       readable (primaries AND indexes).
+//
+// Anything else — finished-but-incomplete (a lying artifact),
+// unfinished-but-unresumable — is a real durability-ordering bug.
+//
+// Mechanics:
+//   - The engine runs over errorfs wrapping vfs.NewCrashableMem(). The
+//     WithVFS threading routes ALL SSTs the DB ever reads (staged
+//     deferred-index/digest/import SSTs included) through that FS;
+//     spill-chunk scratch is engine-private OS IO and deliberately
+//     outside the fault domain.
+//   - The injector fails the k-th write-class op — and in the window
+//     sweep every write after it (a dying disk does not recover; this
+//     also keeps post-failure background writes from healing the crash
+//     image). The whole-sync soak fails once instead; see
+//     failFromInjector.failOnce for why.
+//   - pebble escalates some failures (WAL commit, MANIFEST sync) to
+//     Logger.Fatalf, assuming it exits the process. The fatalGate
+//     records the fatal, signals the harness, and parks the calling
+//     goroutine — a wedged process, observed from outside. Such an
+//     engine is deliberately leaked (its lock state is undefined);
+//     the shared small cache keeps that cheap.
+//   - The "crash" is MemFS.CrashClone cut BEFORE any Close of the
+//     failed engine: only fsynced data is guaranteed into the clone
+//     (UnsyncedDataPercent=0 — the strictest image). Verification
+//     opens a clean engine (no errorfs) over the clone.
+//
+// Sweep shape (per the stack plan): the EndSync-window sweep runs in
+// default CI and is exhaustive — injection arms when EndSync is called
+// and k self-calibrates upward until an armed run completes without
+// injecting anything, which proves the window was covered end-to-end.
+// The whole-sync randomized sweep (seeded, mixed unsynced-survival
+// rates) is env-gated behind BATON_SOAK.
+//
+// Out of scope for this harness:
+//   - The v3 envelope save (os-level IO in the dotc1z store layer's
+//     Close path) — the engine FS never sees it.
+//   - IO failures inside an EndSync whose pages are still
+//     memtable-resident: those ingests ride pebble's flushable-ingest
+//     path (handleIngestAsFlushable), where WAL rotation treats any
+//     failure as a raw panic(err) whose unwind trips runtime lock
+//     faults — pebble is crash-only about that path, and no in-process
+//     recover can contain it. In production that failure IS a process
+//     crash, and its recovery contract (durable WAL prefix + resume)
+//     is exactly what the window sweep and the soak's CrashClone
+//     images already pin. Modeling the failure itself needs subprocess
+//     isolation — a candidate follow-up, not PR-1 scope.
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/cockroachdb/pebble/v2/vfs"
+	"github.com/cockroachdb/pebble/v2/vfs/errorfs"
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+)
+
+// failFromInjector injects errorfs.ErrInjected into the k-th
+// write-class op after arming — and, unless failOnce is set, every
+// write-class op after it (a dying disk does not recover, and nothing
+// may heal the crash image). Reads are never failed. Remove/RemoveAll
+// are never failed either: pebble's obsolete-file cleanup escalates
+// removal failures to a raw panic(err) on a background goroutine,
+// which no logger hook can contain — and file removal is never
+// durability-critical for the contract under test. Implements
+// errorfs.Injector.
+type failFromInjector struct {
+	// failOnce limits the injection to the single k-th op. The
+	// whole-sync soak needs this: fail-forever poisons background
+	// flushes and cleanup with cascading failures pebble escalates to
+	// raw panics. One transient failure per run still exercises every
+	// surfaced-error path.
+	failOnce bool
+
+	armed     atomic.Bool
+	remaining atomic.Int64
+	injected  atomic.Int64
+}
+
+func (f *failFromInjector) String() string { return "(FailFrom k on writes)" }
+
+func (f *failFromInjector) MaybeError(op errorfs.Op) error {
+	if !f.armed.Load() {
+		return nil
+	}
+	if op.Kind.ReadOrWrite() != errorfs.OpIsWrite {
+		return nil
+	}
+	if op.Kind == errorfs.OpRemove || op.Kind == errorfs.OpRemoveAll {
+		return nil
+	}
+	if n := f.remaining.Add(-1); n < 0 {
+		if f.failOnce && n < -1 {
+			return nil
+		}
+		f.injected.Add(1)
+		return errorfs.ErrInjected
+	}
+	return nil
+}
+
+// arm starts failing at the k-th write-class op from now.
+func (f *failFromInjector) arm(k int64) {
+	f.remaining.Store(k)
+	f.injected.Store(0)
+	f.armed.Store(true)
+}
+
+func (f *failFromInjector) disarm() { f.armed.Store(false) }
+
+// fatalGate replaces pebble's Fatalf (os.Exit) for injected engines.
+// Pebble escalates to Fatalf for failures it cannot unwind — a failed
+// WAL commit on the CALLER's goroutine, a failed MANIFEST sync on a
+// BACKGROUND flush goroutine — so neither os.Exit (kills the test
+// binary) nor panic (unrecoverable on pebble's own goroutines) works.
+// Instead Fatalf records the message, signals the harness, and PARKS
+// the calling goroutine forever: exactly what a wedged process looks
+// like from the outside. The harness treats a fired gate as the crash
+// and leaks the horked engine (its goroutines and small memtable —
+// the workload never grows past the initial arena) for the remainder
+// of the test binary.
+type fatalGate struct {
+	discardPebbleLogger
+	once sync.Once
+	ch   chan struct{}
+	msg  atomic.Pointer[string]
+}
+
+func newFatalGate() *fatalGate { return &fatalGate{ch: make(chan struct{})} }
+
+func (g *fatalGate) Fatalf(format string, args ...interface{}) {
+	msg := fmt.Sprintf(format, args...)
+	g.msg.Store(&msg)
+	g.once.Do(func() { close(g.ch) })
+	select {} // park: the engine is crashed from the harness's viewpoint
+}
+
+func (g *fatalGate) err() error {
+	if m := g.msg.Load(); m != nil {
+		return fmt.Errorf("pebble fatal: %s", *m)
+	}
+	return fmt.Errorf("pebble fatal")
+}
+
+func withFatalGate(g *fatalGate) Option {
+	return func(o *Options) { o.pebbleLogger = g }
+}
+
+// sweepWorkload is the fixed mini-sync the sweeps write and verify.
+// Small, but it crosses every EndSync phase: the expanded-grant page
+// arms the deferred by_principal rebuild (plain PutGrants writes
+// by_principal inline; only expanded writes defer), and the digest
+// index is on by default — so the sealed window covers staging-SST
+// writes, IngestAndExcise, the digest fold, the stats sidecar, the
+// ended_at stamp, and the durability flush.
+type sweepWorkload struct {
+	principals []string
+	perPrinc   int // connector grants per principal (distinct entitlements)
+}
+
+// expandedEntID is the entitlement the workload's expanded-grant page
+// targets (one expanded grant per principal).
+const sweepExpandedEnt = "ent-expanded"
+
+func defaultSweepWorkload() sweepWorkload {
+	return sweepWorkload{
+		principals: []string{"alice", "bob", "carol", "dave", "erin"},
+		perPrinc:   3,
+	}
+}
+
+// write replays the workload's pages into a bound sync. Idempotent
+// (puts are upserts) — resume paths call it again on the reopened
+// store, mirroring the connector-replay resume model.
+func (w sweepWorkload) write(ctx context.Context, a *Adapter) error {
+	if err := a.PutResourceTypes(ctx,
+		v2.ResourceType_builder{Id: "app"}.Build(),
+		v2.ResourceType_builder{Id: "user"}.Build(),
+	); err != nil {
+		return err
+	}
+	resources := []*v2.Resource{
+		v2.Resource_builder{
+			Id: v2.ResourceId_builder{ResourceType: "app", Resource: "github"}.Build(),
+		}.Build(),
+	}
+	for _, p := range w.principals {
+		resources = append(resources, v2.Resource_builder{
+			Id: v2.ResourceId_builder{ResourceType: "user", Resource: p}.Build(),
+		}.Build())
+	}
+	if err := a.PutResources(ctx, resources...); err != nil {
+		return err
+	}
+	ents := make([]*v2.Entitlement, 0, w.perPrinc+1)
+	for i := 0; i < w.perPrinc; i++ {
+		ents = append(ents, v2.Entitlement_builder{
+			Id: canonicalTestEntID(fmt.Sprintf("ent-%02d", i)),
+			Resource: v2.Resource_builder{
+				Id: v2.ResourceId_builder{ResourceType: "app", Resource: "github"}.Build(),
+			}.Build(),
+		}.Build())
+	}
+	ents = append(ents, v2.Entitlement_builder{
+		Id: canonicalTestEntID(sweepExpandedEnt),
+		Resource: v2.Resource_builder{
+			Id: v2.ResourceId_builder{ResourceType: "app", Resource: "github"}.Build(),
+		}.Build(),
+	}.Build())
+	if err := a.PutEntitlements(ctx, ents...); err != nil {
+		return err
+	}
+	// Two pages of grants, like a paginated connector.
+	var gs []*v2.Grant
+	for _, p := range w.principals {
+		for i := 0; i < w.perPrinc; i++ {
+			gs = append(gs, mkV2Grant("", fmt.Sprintf("ent-%02d", i), "user", p))
+		}
+	}
+	half := len(gs) / 2
+	if err := a.PutGrants(ctx, gs[:half]...); err != nil {
+		return err
+	}
+	if err := a.PutGrants(ctx, gs[half:]...); err != nil {
+		return err
+	}
+	// One expanded-grant page: takes the deferred-index write path
+	// (StoreExpandedGrants), arming the EndSync by_principal rebuild —
+	// the phase a plain PutGrants-only workload would never exercise.
+	var expanded []*v2.Grant
+	for _, p := range w.principals {
+		expanded = append(expanded, mkV2Grant("", sweepExpandedEnt, "user", p))
+	}
+	return a.Grants().StoreExpandedGrants(ctx, expanded...)
+}
+
+// verifyComplete is the content oracle: every workload row is readable
+// through the primary keyspaces AND the by_principal index on a
+// finished store.
+func (w sweepWorkload) verifyComplete(ctx context.Context, t *testing.T, e *Engine, syncID string, label string) {
+	t.Helper()
+	rec, err := e.GetSyncRunRecord(ctx, syncID)
+	require.NoErrorf(t, err, "%s: sync run record must exist", label)
+	require.NotNilf(t, rec.GetEndedAt(), "%s: sync must be finished", label)
+
+	a := NewAdapter(e)
+	require.NoErrorf(t, a.SetCurrentSync(ctx, syncID), "%s: bind sync for reads", label)
+
+	resp, err := a.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{}.Build())
+	require.NoErrorf(t, err, "%s: ListGrants", label)
+	require.Lenf(t, resp.GetList(), len(w.principals)*(w.perPrinc+1), "%s: grant count", label)
+
+	rresp, err := a.ListResources(ctx, v2.ResourcesServiceListResourcesRequest_builder{}.Build())
+	require.NoErrorf(t, err, "%s: ListResources", label)
+	require.Lenf(t, rresp.GetList(), 1+len(w.principals), "%s: resource count", label)
+
+	eresp, err := a.ListEntitlements(ctx, v2.EntitlementsServiceListEntitlementsRequest_builder{}.Build())
+	require.NoErrorf(t, err, "%s: ListEntitlements", label)
+	require.Lenf(t, eresp.GetList(), w.perPrinc+1, "%s: entitlement count", label)
+
+	// The by_principal index is rebuilt inside the EndSync window — the
+	// exact artifact a torn deferred build would corrupt or lose.
+	for _, p := range w.principals {
+		n := 0
+		require.NoErrorf(t, e.IterateGrantsByPrincipal(ctx, "user", p, func(*v3.GrantRecord) bool {
+			n++
+			return true
+		}), "%s: IterateGrantsByPrincipal(%s)", label, p)
+		require.Equalf(t, w.perPrinc+1, n, "%s: by_principal must serve %s", label, p)
+	}
+}
+
+// crashStepResult reports how one injected run surfaced its failure.
+type crashStepResult struct {
+	err      error // the surfaced failure (nil = the run completed)
+	fatal    bool  // pebble Logger.Fatalf fired (engine horked, leaked)
+	injected int64 // ops the injector actually failed
+	image    *vfs.MemFS
+}
+
+// runInjected runs body with the injector armed at k over base
+// (crashable). The body runs on its own goroutine because a pebble
+// fatal parks the goroutine it fires on — possibly one the body is
+// waiting on — so the harness selects on body-completion OR the fatal
+// gate. The crash clone is cut at the failure point BEFORE any close
+// can heal the FS; a fatal (or a close that itself wedges) leaks the
+// engine, which is the point: a crashed process closes nothing.
+func runInjected(base *vfs.MemFS, inj *failFromInjector, e *Engine, gate *fatalGate, k int64, body func() error) crashStepResult {
+	var res crashStepResult
+	inj.arm(k)
+	done := make(chan error, 1)
+	go func() { done <- body() }()
+	select {
+	case err := <-done:
+		res.err = err
+	case <-gate.ch:
+		res.fatal = true
+		res.err = gate.err()
+	}
+	res.injected = inj.injected.Load()
+	inj.disarm()
+	// The crash image: only fsynced state survives. Cut before Close so
+	// post-failure healing writes can't reach it. (CrashClone blocks FS
+	// mutations for the copy, so the image is an atomic cut even with
+	// engine goroutines still running.)
+	res.image = base.CrashClone(vfs.CrashCloneCfg{})
+	if res.fatal {
+		return res
+	}
+	// Close on a goroutine gated the same way: teardown can hit its own
+	// late fatal (a background flush observing the earlier injection).
+	closed := make(chan struct{})
+	go func() { _ = e.Close(); close(closed) }()
+	select {
+	case <-closed:
+	case <-gate.ch:
+		res.fatal = true // the run's outcome stands; the engine leaks
+	}
+	return res
+}
+
+// verifyCrashImage opens a clean engine over the crash clone and
+// asserts the reopen dichotomy, resuming when unfinished.
+// replayPages selects the resume model: false = the pages were already
+// durable before the window (EndSync sweep), true = replay them (whole
+// sync soak).
+func verifyCrashImage(ctx context.Context, t *testing.T, w sweepWorkload, image *vfs.MemFS, cache *pebble.Cache, syncID string, replayPages bool, label string) {
+	t.Helper()
+	e, err := Open(ctx, "sweep-db", WithVFS(image), WithSharedCache(cache), withFatalGate(newFatalGate()))
+	require.NoErrorf(t, err, "%s: the crash image must reopen", label)
+	defer func() { _ = e.Close() }()
+
+	rec, recErr := e.GetSyncRunRecord(ctx, syncID)
+	if recErr != nil {
+		require.ErrorIsf(t, recErr, pebble.ErrNotFound, "%s: sync-run lookup may only miss cleanly", label)
+	}
+
+	switch {
+	case recErr == nil && rec.GetEndedAt() != nil:
+		// (b) finished: everything the sync wrote must have been durable
+		// before the stamp — a finished-but-incomplete image is the lying
+		// artifact this harness exists to catch.
+		w.verifyComplete(ctx, t, e, syncID, label+" (finished image)")
+	case recErr == nil:
+		// (a) unfinished: must be discoverable and resume to completion.
+		unfinished, err := e.LatestUnfinishedSyncRecord(ctx, nil)
+		require.NoErrorf(t, err, "%s: LatestUnfinishedSyncRecord", label)
+		require.NotNilf(t, unfinished, "%s: an unstamped sync must be discoverable as unfinished (resumable)", label)
+		require.Equalf(t, syncID, unfinished.GetSyncId(), "%s: the unfinished sync must be ours", label)
+
+		a := NewAdapter(e)
+		require.NoErrorf(t, a.SetCurrentSync(ctx, syncID), "%s: rebind for resume", label)
+		if replayPages {
+			require.NoErrorf(t, w.write(ctx, a), "%s: resume page replay", label)
+		}
+		require.NoErrorf(t, a.EndSync(ctx), "%s: resumed EndSync must converge", label)
+		w.verifyComplete(ctx, t, e, syncID, label+" (resumed image)")
+	default:
+		// (c) the record never became durable. Legal only when the crash
+		// predates the sync-run record's fsync — possible in the whole-sync
+		// soak, impossible in the EndSync sweep (the baseline had it
+		// durable). The image must support a fresh sync from scratch.
+		require.Truef(t, replayPages, "%s: the sync-run record vanished from a baseline that had it durable", label)
+		a := NewAdapter(e)
+		newID, err := a.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+		require.NoErrorf(t, err, "%s: restart after empty image", label)
+		require.NoErrorf(t, w.write(ctx, a), "%s: restart page write", label)
+		require.NoErrorf(t, a.EndSync(ctx), "%s: restart EndSync", label)
+		w.verifyComplete(ctx, t, e, newID, label+" (restarted image)")
+	}
+}
+
+// buildSweepBaseline writes the workload into a fresh crashable MemFS
+// and closes the engine cleanly, leaving a fully synced pre-EndSync
+// image with the deferred-index marker durably armed. Returns the FS
+// and the open sync's id.
+func buildSweepBaseline(ctx context.Context, t *testing.T, w sweepWorkload, cache *pebble.Cache) (*vfs.MemFS, string) {
+	t.Helper()
+	fs := vfs.NewCrashableMem()
+	e, err := Open(ctx, "sweep-db", WithVFS(fs), WithSharedCache(cache), withFatalGate(newFatalGate()))
+	require.NoError(t, err)
+	a := NewAdapter(e)
+	syncID, err := a.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, w.write(ctx, a))
+	require.True(t, e.deferredIdxPending.Load(), "grant writes must arm the deferred index rebuild")
+	require.NoError(t, e.Close())
+	return fs, syncID
+}
+
+// TestErrorFSEndSyncWindowSweep exhaustively sweeps write-op failure
+// points across the EndSync window: for k = 0, 1, 2, ... the k-th
+// write-class op after EndSync begins (and every one after it) fails,
+// the FS is crash-cloned at the failure, and the clone must satisfy
+// the reopen dichotomy. The sweep self-terminates when an armed run
+// completes without injecting anything — proof the whole window was
+// covered.
+func TestErrorFSEndSyncWindowSweep(t *testing.T) {
+	ctx := context.Background()
+	w := defaultSweepWorkload()
+	cache := pebble.NewCache(8 << 20)
+	defer cache.Unref()
+
+	baseline, syncID := buildSweepBaseline(ctx, t, w, cache)
+
+	const maxK = 5000
+	covered := false
+	var k int64
+	for k = 0; !covered; k++ {
+		require.Less(t, k, int64(maxK), "EndSync window exceeded %d write ops; sweep runaway", maxK)
+
+		stepFS := baseline.CrashClone(vfs.CrashCloneCfg{})
+		inj := &failFromInjector{}
+		efs := errorfs.Wrap(stepFS, inj)
+
+		gate := newFatalGate()
+		e, err := Open(ctx, "sweep-db", WithVFS(efs), WithSharedCache(cache), withFatalGate(gate))
+		require.NoErrorf(t, err, "k=%d: open over injected FS (disarmed)", k)
+		a := NewAdapter(e)
+		require.NoError(t, a.SetCurrentSync(ctx, syncID))
+
+		res := runInjected(stepFS, inj, e, gate, k, func() error {
+			return a.EndSync(ctx)
+		})
+
+		label := fmt.Sprintf("k=%d", k)
+		if res.err == nil {
+			// The run completed. If nothing was injected, k walked past the
+			// last write op of the window — coverage proven. (A nonzero
+			// injected count with a green run means the injection only hit
+			// post-completion background work; verify and keep sweeping.)
+			verifyCrashImage(ctx, t, w, res.image, cache, syncID, false, label+" (clean run)")
+			covered = res.injected == 0
+			continue
+		}
+		require.Greaterf(t, res.injected, int64(0), "k=%d: EndSync failed with the injector armed but nothing injected: %v", k, res.err)
+		verifyCrashImage(ctx, t, w, res.image, cache, syncID, false, label)
+	}
+	t.Logf("EndSync window covered: %d write-op failure points swept", k-1)
+}
+
+// TestErrorFSWholeSyncRandomSweepSoak randomizes the failure point
+// across the whole sync (open → pages → EndSync) with the strictest
+// crash image (no unsynced survival). Env-gated like the other soaks.
+func TestErrorFSWholeSyncRandomSweepSoak(t *testing.T) {
+	if os.Getenv("BATON_SOAK") == "" {
+		t.Skip("set BATON_SOAK=1 to run the whole-sync errorfs sweep")
+	}
+	ctx := context.Background()
+	w := defaultSweepWorkload()
+	cache := pebble.NewCache(8 << 20)
+	defer cache.Unref()
+
+	for seed := int64(1); seed <= 60; seed++ {
+		t.Run(fmt.Sprintf("seed=%d", seed), func(t *testing.T) {
+			rng := rand.New(rand.NewSource(seed)) //nolint:gosec // deterministic seeded sweep, not cryptography
+			k := int64(rng.Intn(400))
+
+			fs := vfs.NewCrashableMem()
+			inj := &failFromInjector{failOnce: true}
+			efs := errorfs.Wrap(fs, inj)
+
+			gate := newFatalGate()
+			e, err := Open(ctx, "sweep-db", WithVFS(efs), WithSharedCache(cache), withFatalGate(gate))
+			require.NoError(t, err, "open before arming")
+			a := NewAdapter(e)
+
+			var syncID string
+			res := runInjected(fs, inj, e, gate, k, func() error {
+				var err error
+				syncID, err = a.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+				if err != nil {
+					return err
+				}
+				if err := w.write(ctx, a); err != nil {
+					return err
+				}
+				// Disarm before EndSync: the soak owns the OPEN + PAGES
+				// phase (undurable, memtable-resident state — the fresh-sync
+				// crash surface the window sweep's durable baseline can't
+				// reach). EndSync itself is the window sweep's territory —
+				// and with pages still in the memtable, EndSync's ingests
+				// take pebble's flushable-ingest path, where ANY injected
+				// failure is a raw panic(err) whose unwind faults the
+				// runtime (crash-only by design; not recoverable in-process;
+				// see the coverage-gap note in the file header).
+				inj.disarm()
+				return a.EndSync(ctx)
+			})
+
+			label := fmt.Sprintf("seed=%d k=%d", seed, k)
+			if res.err == nil {
+				// Failure point beyond the sync's op count (or only
+				// post-completion background work was hit): the finished
+				// artifact was flushed, so the strict crash image must
+				// verify complete.
+				require.NotEmpty(t, syncID)
+				verifyCrashImage(ctx, t, w, res.image, cache, syncID, true, label+" (clean run)")
+				return
+			}
+			if syncID == "" {
+				// StartNewSync itself failed; the image owes nothing beyond
+				// reopening clean and supporting a fresh sync.
+				verifyEmptyImageRestarts(ctx, t, w, res.image, cache, label+" (pre-sync)")
+				return
+			}
+			verifyCrashImage(ctx, t, w, res.image, cache, syncID, true, label)
+		})
+	}
+}
+
+// verifyEmptyImageRestarts asserts a crash image with no sync at all
+// still opens and supports a fresh, complete sync.
+func verifyEmptyImageRestarts(ctx context.Context, t *testing.T, w sweepWorkload, image *vfs.MemFS, cache *pebble.Cache, label string) {
+	t.Helper()
+	e, err := Open(ctx, "sweep-db", WithVFS(image), WithSharedCache(cache), withFatalGate(newFatalGate()))
+	require.NoErrorf(t, err, "%s: empty crash image must reopen", label)
+	defer func() { _ = e.Close() }()
+	a := NewAdapter(e)
+	syncID, err := a.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoErrorf(t, err, "%s: restart", label)
+	require.NoErrorf(t, w.write(ctx, a), "%s: restart write", label)
+	require.NoErrorf(t, a.EndSync(ctx), "%s: restart EndSync", label)
+	w.verifyComplete(ctx, t, e, syncID, label+" (restarted)")
+}

--- a/pkg/dotc1z/engine/pebble/grant_digest_build.go
+++ b/pkg/dotc1z/engine/pebble/grant_digest_build.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/pebble/v2"
+	"github.com/cockroachdb/pebble/v2/vfs"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
 )
@@ -339,7 +340,7 @@ func splitGrantHashIndexKey(key []byte) ([]byte, uint16, bool) {
 // fold. Same merge shape as mergeSortedSpillChunksToSST; duplicate
 // keys are corruption here too — (entitlement, principal) is the grant
 // primary identity, so the sorter sees exactly one row per grant.
-func mergeGrantHashChunksToSST(ctx context.Context, sstPath, name string, chunks []string, fold *grantDigestFold) error {
+func mergeGrantHashChunksToSST(ctx context.Context, fs vfs.FS, sstPath, name string, chunks []string, fold *grantDigestFold) error {
 	start := time.Now()
 	l := ctxzap.Extract(ctx)
 	readers := make([]*os.File, 0, len(chunks))
@@ -369,7 +370,7 @@ func mergeGrantHashChunksToSST(ctx context.Context, sstPath, name string, chunks
 		}
 	}
 
-	writer, err := newBulkSSTWriter(filepath.Dir(sstPath), name)
+	writer, err := newBulkSSTWriter(fs, filepath.Dir(sstPath), name)
 	if err != nil {
 		return err
 	}
@@ -377,7 +378,7 @@ func mergeGrantHashChunksToSST(ctx context.Context, sstPath, name string, chunks
 	defer func() {
 		_ = writer.finish()
 		if !success {
-			_ = os.Remove(sstPath)
+			_ = fs.Remove(sstPath)
 		}
 	}()
 	var last []byte
@@ -498,7 +499,7 @@ func (e *Engine) buildGrantDigestsFromSpill(ctx context.Context, dir string, has
 	}
 	defer fold.abort()
 	sstPath := filepath.Join(dir, fmt.Sprintf("index-%02x.sst", idxGrantByEntitlementPrincipalHash))
-	if err := mergeGrantHashChunksToSST(ctx, sstPath, fmt.Sprintf("index-%02x", idxGrantByEntitlementPrincipalHash), chunks, fold); err != nil {
+	if err := mergeGrantHashChunksToSST(ctx, e.fs(), sstPath, fmt.Sprintf("index-%02x", idxGrantByEntitlementPrincipalHash), chunks, fold); err != nil {
 		return err
 	}
 	if err := fold.finish(); err != nil {
@@ -653,11 +654,11 @@ func (e *Engine) buildGrantDigestsStandaloneLocked(ctx context.Context) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	dir, err := os.MkdirTemp("", "pebble-grant-digest-")
+	dir, err := e.prepareStagingDir("", "pebble-grant-digest-")
 	if err != nil {
 		return fmt.Errorf("BuildGrantDigests: mkdir temp: %w", err)
 	}
-	defer os.RemoveAll(dir)
+	defer e.removeStagingDir(dir)
 
 	sorters := min(4, max(2, runtime.GOMAXPROCS(0)/2))
 	sem := make(chan struct{}, sorters)

--- a/pkg/dotc1z/engine/pebble/grants.go
+++ b/pkg/dotc1z/engine/pebble/grants.go
@@ -531,7 +531,7 @@ func (e *Engine) takeSynthLayer() *synthGrantLayerSession {
 // initSynthLayerSession lazily allocates the session's temp dir, first
 // sorter, and background merge+ingest worker on the first Add.
 func (e *Engine) initSynthLayerSession(ctx context.Context, s *synthGrantLayerSession) error {
-	dir, err := os.MkdirTemp("", "pebble-synth-grant-layer-")
+	dir, err := e.prepareStagingDir("", "pebble-synth-grant-layer-")
 	if err != nil {
 		return fmt.Errorf("synth grant layer: mkdir temp: %w", err)
 	}
@@ -579,7 +579,7 @@ func (e *Engine) initSynthLayerSession(ctx context.Context, s *synthGrantLayerSe
 // discard it from the snapshot. checkpointMu is that barrier.
 func (e *Engine) ingestSynthLayerSegment(ctx context.Context, dir string, seg synthLayerSegment) error {
 	sstPath := filepath.Join(dir, seg.name+".sst")
-	if err := mergeSortedSpillChunksToSST(ctx, sstPath, seg.name, seg.chunks); err != nil {
+	if err := mergeSortedSpillChunksToSST(ctx, e.fs(), sstPath, seg.name, seg.chunks); err != nil {
 		return err
 	}
 	for _, chunk := range seg.chunks {
@@ -670,7 +670,7 @@ func (e *Engine) FinishSynthesizedGrantLayer(ctx context.Context) error {
 			return nil
 		}
 		if s.dir != "" {
-			defer os.RemoveAll(s.dir)
+			defer e.removeStagingDir(s.dir)
 		}
 		if s.sorter == nil {
 			return nil
@@ -714,7 +714,7 @@ func (e *Engine) AbortSynthesizedGrantLayer(ctx context.Context) error {
 		s.segWG.Wait()
 	}
 	if s.dir != "" {
-		_ = os.RemoveAll(s.dir)
+		e.removeStagingDir(s.dir)
 	}
 	return nil
 }

--- a/pkg/dotc1z/engine/pebble/id_index_migration.go
+++ b/pkg/dotc1z/engine/pebble/id_index_migration.go
@@ -389,7 +389,9 @@ func mergeGrantPrimaryMigrationChunksToSST(ctx context.Context, fs vfs.FS, sstPa
 		return err
 	}
 	if w.path != sstPath {
-		if err := os.Rename(w.path, sstPath); err != nil {
+		// Engine FS, not os: the writer created this SST through fs and
+		// the pebble.DB will read it at IngestAndExcise through fs.
+		if err := fs.Rename(w.path, sstPath); err != nil {
 			return err
 		}
 	}

--- a/pkg/dotc1z/engine/pebble/id_index_migration.go
+++ b/pkg/dotc1z/engine/pebble/id_index_migration.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/cockroachdb/pebble/v2"
+	"github.com/cockroachdb/pebble/v2/vfs"
+
 	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
@@ -22,11 +24,11 @@ import (
 func (e *Engine) migrateIDIndexFormatToStructuredV1(ctx context.Context) error {
 	start := time.Now()
 	l := ctxzap.Extract(ctx)
-	dir, err := os.MkdirTemp("", "pebble-id-index-migration-")
+	dir, err := e.prepareStagingDir("", "pebble-id-index-migration-")
 	if err != nil {
 		return fmt.Errorf("id-index migration: mkdir temp: %w", err)
 	}
-	defer os.RemoveAll(dir)
+	defer e.removeStagingDir(dir)
 
 	sortSem := make(chan struct{}, 4)
 	// 128MiB chunks (deferredIndexSpillChunkBytes), not the bulk import's
@@ -75,9 +77,9 @@ func (e *Engine) migrateIDIndexFormatToStructuredV1(ctx context.Context) error {
 		var path string
 		var err error
 		if r.name == "grant-primary" {
-			path, err = finalizeGrantPrimaryMigrationSorter(ctx, dir, r.name, r.sorter, byPrincipal, byNeedsExpansion)
+			path, err = finalizeGrantPrimaryMigrationSorter(ctx, e.fs(), dir, r.name, r.sorter, byPrincipal, byNeedsExpansion)
 		} else {
-			path, err = finalizeMigrationSorter(ctx, dir, r.name, r.sorter)
+			path, err = finalizeMigrationSorter(ctx, e.fs(), dir, r.name, r.sorter)
 		}
 		if err != nil {
 			return err
@@ -239,7 +241,7 @@ func (e *Engine) emitStructuredGrantMigration(ctx context.Context, primary *spil
 	return rows, iter.Error()
 }
 
-func finalizeMigrationSorter(ctx context.Context, dir, name string, sorter *spillSorter) (string, error) {
+func finalizeMigrationSorter(ctx context.Context, fs vfs.FS, dir, name string, sorter *spillSorter) (string, error) {
 	chunks, err := sorter.finalize()
 	if err != nil {
 		return "", err
@@ -248,7 +250,7 @@ func finalizeMigrationSorter(ctx context.Context, dir, name string, sorter *spil
 		return "", nil
 	}
 	path := filepath.Join(dir, name+".sst")
-	if err := mergeSortedSpillChunksToSST(ctx, path, name, chunks); err != nil {
+	if err := mergeSortedSpillChunksToSST(ctx, fs, path, name, chunks); err != nil {
 		return "", err
 	}
 	return path, nil
@@ -262,7 +264,7 @@ func (e *Engine) replaceRangeWithSST(ctx context.Context, lower, upper []byte, p
 	return err
 }
 
-func finalizeGrantPrimaryMigrationSorter(ctx context.Context, dir, name string, sorter, byPrincipal, byNeedsExpansion *spillSorter) (string, error) {
+func finalizeGrantPrimaryMigrationSorter(ctx context.Context, fs vfs.FS, dir, name string, sorter, byPrincipal, byNeedsExpansion *spillSorter) (string, error) {
 	chunks, err := sorter.finalize()
 	if err != nil {
 		return "", err
@@ -271,13 +273,13 @@ func finalizeGrantPrimaryMigrationSorter(ctx context.Context, dir, name string, 
 		return "", nil
 	}
 	path := filepath.Join(dir, name+".sst")
-	if err := mergeGrantPrimaryMigrationChunksToSST(ctx, path, name, chunks, byPrincipal, byNeedsExpansion); err != nil {
+	if err := mergeGrantPrimaryMigrationChunksToSST(ctx, fs, path, name, chunks, byPrincipal, byNeedsExpansion); err != nil {
 		return "", err
 	}
 	return path, nil
 }
 
-func mergeGrantPrimaryMigrationChunksToSST(ctx context.Context, sstPath, name string, chunks []string, byPrincipal, byNeedsExpansion *spillSorter) error {
+func mergeGrantPrimaryMigrationChunksToSST(ctx context.Context, fs vfs.FS, sstPath, name string, chunks []string, byPrincipal, byNeedsExpansion *spillSorter) error {
 	readers := make([]*os.File, 0, len(chunks))
 	defer func() {
 		for _, r := range readers {
@@ -305,7 +307,7 @@ func mergeGrantPrimaryMigrationChunksToSST(ctx context.Context, sstPath, name st
 		}
 	}
 
-	w, err := newBulkSSTWriter(filepath.Dir(sstPath), name)
+	w, err := newBulkSSTWriter(fs, filepath.Dir(sstPath), name)
 	if err != nil {
 		return err
 	}
@@ -313,7 +315,7 @@ func mergeGrantPrimaryMigrationChunksToSST(ctx context.Context, sstPath, name st
 	defer func() {
 		if !success {
 			_ = w.finish()
-			_ = os.Remove(w.path)
+			_ = fs.Remove(w.path)
 		}
 	}()
 

--- a/pkg/dotc1z/engine/pebble/memfs_lifecycle_test.go
+++ b/pkg/dotc1z/engine/pebble/memfs_lifecycle_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestEngineLifecycleOverPureMemFS(t *testing.T) {
+	skipOnWindowsMemFS(t)
 	ctx := context.Background()
 	w := defaultSweepWorkload()
 	memFS := vfs.NewMem()

--- a/pkg/dotc1z/engine/pebble/memfs_lifecycle_test.go
+++ b/pkg/dotc1z/engine/pebble/memfs_lifecycle_test.go
@@ -1,0 +1,65 @@
+package pebble
+
+// Behavioral guard for WithVFS coverage: the full engine lifecycle
+// runs over a PURE in-memory filesystem (vfs.NewMem — not a wrapped
+// vfs.Default). Any engine path that slips back to direct host IO for
+// something the DB reads fails here loudly: a file written through
+// os lands where the MemFS can't see it ("does not exist" at
+// ingest/open), and a file written through the MemFS can't be read
+// back through os. This is the dynamic complement of the static
+// registry in os_io_allowlist_test.go — the registry catches new call
+// sites at review time, this catches the read-back split at run time
+// (it is exactly the test that fails on the two bugs found in PR-1
+// review: truncateCheckpointWALs os.ReadDir'ing a MemFS checkpoint,
+// and the id-index migration os.Rename'ing a MemFS-created SST).
+//
+// Deliberately NOT covered, matching the engine-FS contract:
+// spill-chunk scratch (engine-private OS IO), clone-sync's envelope
+// save (host-path IO by contract), and the store layer above the
+// engine.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/pebble/v2/vfs"
+	"github.com/stretchr/testify/require"
+
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+)
+
+func TestEngineLifecycleOverPureMemFS(t *testing.T) {
+	ctx := context.Background()
+	w := defaultSweepWorkload()
+	memFS := vfs.NewMem()
+
+	// Sync: pages (including the expanded-grant page, which stages
+	// deferred-index SSTs at EndSync) + seal.
+	e, err := Open(ctx, "memfs-db", WithVFS(memFS))
+	require.NoError(t, err)
+	a := NewAdapter(e)
+	syncID, err := a.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, w.write(ctx, a))
+	require.True(t, e.deferredIdxPending.Load(),
+		"the workload must arm the deferred rebuild so EndSync exercises SST staging over the MemFS")
+	require.NoError(t, a.EndSync(ctx))
+	w.verifyComplete(ctx, t, e, syncID, "sealed engine over MemFS")
+
+	// Writable checkpoint: cut it through the engine FS and reopen it
+	// as its own engine over the same MemFS. Covers db.Checkpoint +
+	// truncateCheckpointWALs + a fresh Open, all FS-side.
+	require.NoError(t, e.CheckpointTo(ctx, "memfs-checkpoint"))
+	ce, err := Open(ctx, "memfs-checkpoint", WithVFS(memFS))
+	require.NoError(t, err, "the checkpoint must be complete and openable on the engine FS")
+	w.verifyComplete(ctx, t, ce, syncID, "checkpoint reopened over MemFS")
+	require.NoError(t, ce.Close())
+	require.NoError(t, e.Close())
+
+	// Reopen the primary after a clean close — open-time migrations and
+	// marker probes run FS-side too.
+	e2, err := Open(ctx, "memfs-db", WithVFS(memFS))
+	require.NoError(t, err)
+	defer func() { _ = e2.Close() }()
+	w.verifyComplete(ctx, t, e2, syncID, "primary reopened over MemFS")
+}

--- a/pkg/dotc1z/engine/pebble/options.go
+++ b/pkg/dotc1z/engine/pebble/options.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/pebble/v2"
+	"github.com/cockroachdb/pebble/v2/vfs"
 )
 
 // SDKPebbleFormat is the on-disk format version this SDK release
@@ -50,6 +51,21 @@ type Options struct {
 	// The write paths never maintain either inline, so this gates only
 	// the fused derivation at EndSync. See WithGrantDigestIndex.
 	grantDigestIndex bool
+
+	// vfs, when non-nil, overrides the filesystem the engine (and the
+	// pebble.DB under it) performs its IO through. nil means vfs.Default,
+	// which is also what pebble's EnsureDefaults picks — production
+	// callers are unchanged. See WithVFS.
+	vfs vfs.FS
+
+	// pebbleLogger, when non-nil, replaces discardPebbleLogger as the
+	// pebble.Options.Logger. Test-only (unexported, set by in-package
+	// tests via an inline Option): fault-injection tests need a Fatalf
+	// that panics recoverably instead of os.Exit(1) — pebble treats a
+	// failed WAL commit as fatal (db.go commitWrite), and a process
+	// exit would kill the whole test binary where the intent is to
+	// observe the "crash" and assert on what durably survived it.
+	pebbleLogger pebble.Logger
 }
 
 // Option is a functional option passed to Open.
@@ -93,6 +109,23 @@ func WithSlowQueryThreshold(d time.Duration) Option {
 	return func(o *Options) { o.slowQueryThreshold = d }
 }
 
+// WithVFS overrides the filesystem the engine performs its IO through.
+// This covers the pebble.DB itself (pebble.Options.FS) and the engine's
+// own SST staging (the deferred index build, digest build, bulk import,
+// synth layer, id-index migration — everything created through
+// newBulkSSTWriter and later handed to Ingest/IngestAndExcise), plus
+// the read-only checkpoint clone. Spill-chunk scratch files are NOT
+// routed through it: they are written and read back exclusively by
+// engine code (never by the pebble.DB), so they stay on the host OS
+// filesystem regardless of the engine FS.
+//
+// Intended for tests: fault injection (vfs/errorfs) and crash
+// simulation (vfs.NewCrashableMem). Production callers never set it;
+// nil (the default) means vfs.Default, matching pebble's own default.
+func WithVFS(fs vfs.FS) Option {
+	return func(o *Options) { o.vfs = fs }
+}
+
 // newPebbleOptions builds the *pebble.Options for the Engine. The
 // returned struct is consumed once at pebble.Open; the caller does
 // not retain a reference.
@@ -130,6 +163,12 @@ func newPebbleOptions(o *Options) *pebble.Options {
 		Comparer:   pebble.DefaultComparer,
 		ReadOnly:   o.readOnly,
 		Logger:     discardPebbleLogger{},
+		// nil FS means pebble's EnsureDefaults picks vfs.Default, so the
+		// no-override case is byte-identical to before WithVFS existed.
+		FS: o.vfs,
+	}
+	if o.pebbleLogger != nil {
+		opts.Logger = o.pebbleLogger
 	}
 	// Pausable variant of pebble's default ConcurrencyLimitScheduler so the
 	// engine can suppress automatic compactions during the EndSync-to-close

--- a/pkg/dotc1z/engine/pebble/options.go
+++ b/pkg/dotc1z/engine/pebble/options.go
@@ -53,18 +53,21 @@ type Options struct {
 	grantDigestIndex bool
 
 	// vfs, when non-nil, overrides the filesystem the engine (and the
-	// pebble.DB under it) performs its IO through. nil means vfs.Default,
-	// which is also what pebble's EnsureDefaults picks — production
-	// callers are unchanged. See WithVFS.
+	// pebble.DB under it) performs its IO through. nil leaves
+	// pebble.Options.FS nil, so pebble's EnsureDefaults applies its own
+	// default (disk-health-wrapped vfs.Default) exactly as before this
+	// option existed — production callers are unchanged. See WithVFS.
 	vfs vfs.FS
 
 	// pebbleLogger, when non-nil, replaces discardPebbleLogger as the
 	// pebble.Options.Logger. Test-only (unexported, set by in-package
 	// tests via an inline Option): fault-injection tests need a Fatalf
-	// that panics recoverably instead of os.Exit(1) — pebble treats a
-	// failed WAL commit as fatal (db.go commitWrite), and a process
-	// exit would kill the whole test binary where the intent is to
-	// observe the "crash" and assert on what durably survived it.
+	// that does NOT os.Exit(1) — pebble treats a failed WAL commit as
+	// fatal (db.go commitWrite), and a process exit would kill the
+	// whole test binary where the intent is to observe the "crash" and
+	// assert on what durably survived it. The sweep installs a gate
+	// that parks the goroutine and signals the harness on injected
+	// engines, and a fail-fast panicking logger on clean ones.
 	pebbleLogger pebble.Logger
 }
 
@@ -163,8 +166,9 @@ func newPebbleOptions(o *Options) *pebble.Options {
 		Comparer:   pebble.DefaultComparer,
 		ReadOnly:   o.readOnly,
 		Logger:     discardPebbleLogger{},
-		// nil FS means pebble's EnsureDefaults picks vfs.Default, so the
-		// no-override case is byte-identical to before WithVFS existed.
+		// nil FS gets pebble's own EnsureDefaults treatment
+		// (disk-health-wrapped vfs.Default), so the no-override case is
+		// byte-identical to before WithVFS existed.
 		FS: o.vfs,
 	}
 	if o.pebbleLogger != nil {

--- a/pkg/dotc1z/engine/pebble/os_io_allowlist_test.go
+++ b/pkg/dotc1z/engine/pebble/os_io_allowlist_test.go
@@ -1,0 +1,149 @@
+package pebble
+
+// Meta-test: every direct `os.` file-IO call in this package's
+// production code must be REGISTERED here with a reason.
+//
+// Why: the engine performs IO through Engine.fs() (WithVFS) so tests
+// can inject faults and run over an in-memory filesystem. The bug
+// class this guards against is split-brain IO — a file created
+// through one filesystem and read back (or renamed/removed) through
+// the other. Concrete instances caught during PR-1 review:
+// truncateCheckpointWALs os.ReadDir'ing a checkpoint the DB wrote
+// through its FS, and the id-index migration os.Rename'ing an SST it
+// created through the engine FS.
+//
+// The rule of thumb for what belongs on which side:
+//   - Anything the pebble.DB ever reads (staged SSTs, the DB dir,
+//     checkpoints) MUST go through Engine.fs().
+//   - Engine-private scratch that only engine code reads back (spill
+//     chunks) and host-side conveniences (MkdirTemp naming, the
+//     envelope save in clone-sync) stay on plain os — deliberately,
+//     per allowlist entry below.
+//
+// Adding a new os.* call site: if it can touch anything the DB reads,
+// use Engine.fs() instead. Otherwise add a (file, function) entry with
+// a reason. Entries that lose their last call site fail the test too,
+// so the registry can't rot.
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// osFileIOFuncs is the denylist: os package functions that touch the
+// filesystem. Non-IO os functions (Getenv, Exit, Stderr, IsNotExist,
+// error sentinels, type references) are not tracked.
+var osFileIOFuncs = map[string]bool{
+	"Create": true, "CreateTemp": true, "Open": true, "OpenFile": true,
+	"OpenRoot": true, "ReadDir": true, "ReadFile": true, "WriteFile": true,
+	"Truncate": true, "Remove": true, "RemoveAll": true, "Mkdir": true,
+	"MkdirAll": true, "MkdirTemp": true, "Rename": true, "Stat": true,
+	"Lstat": true, "Link": true, "Symlink": true, "Chmod": true,
+	"Chown": true, "Chtimes": true, "TempDir": true,
+}
+
+// allowedOSFileIO registers every sanctioned direct os file-IO call:
+// file -> os function -> reason. The reason is documentation enforced
+// to exist, not parsed.
+var allowedOSFileIO = map[string]map[string]string{
+	"engine.go": {
+		"MkdirTemp": "prepareStagingDir mints the unique host-side staging dir; the engine-FS mirror is created right after via fs.MkdirAll",
+		"RemoveAll": "prepareStagingDir failure path + removeStagingDir host-side half; the engine-FS half is removed via fs.RemoveAll",
+	},
+	"bulk_import.go": {
+		"Create": "writeSortedSpillChunk: spill-chunk scratch is engine-private; only readSpillEntry reads it back, never the DB",
+		"Open":   "spill-chunk merge readers (engine-private scratch, see Create)",
+		"Remove": "failed spill-chunk cleanup (engine-private scratch)",
+	},
+	"grants.go": {
+		"Remove": "ingestSynthLayerSegment deletes merged spill chunks (engine-private scratch)",
+	},
+	"grant_digest_build.go": {
+		"Open": "spill-chunk merge readers (engine-private scratch)",
+	},
+	"id_index_migration.go": {
+		"Open": "spill-chunk merge readers (engine-private scratch)",
+	},
+	"adapter_clone_sync.go": {
+		"Stat":      "clone-sync writes a v3 envelope to a caller-supplied host path; the whole save path is host IO by contract (out of engine-FS scope, like the store layer's envelope save)",
+		"MkdirTemp": "clone-sync staging dir for the checkpoint + envelope build (host IO by contract)",
+		"RemoveAll": "clone-sync staging dir cleanup (host IO by contract)",
+		"OpenFile":  "clone-sync envelope output file (host IO by contract)",
+		"Remove":    "clone-sync failed-output cleanup (host IO by contract)",
+		"Rename":    "clone-sync atomic tmp->final envelope publish (host IO by contract)",
+	},
+}
+
+func TestOSFileIOCallsAreAllowlisted(t *testing.T) {
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, ".", func(fi os.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, 0)
+	require.NoError(t, err)
+
+	// found: file -> os func -> positions.
+	found := map[string]map[string][]string{}
+	for _, pkg := range pkgs {
+		for path, f := range pkg.Files {
+			base := path[strings.LastIndex(path, "/")+1:]
+			ast.Inspect(f, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				sel, ok := call.Fun.(*ast.SelectorExpr)
+				if !ok {
+					return true
+				}
+				ident, ok := sel.X.(*ast.Ident)
+				if !ok || ident.Name != "os" || !osFileIOFuncs[sel.Sel.Name] {
+					return true
+				}
+				if found[base] == nil {
+					found[base] = map[string][]string{}
+				}
+				found[base][sel.Sel.Name] = append(found[base][sel.Sel.Name], fset.Position(call.Pos()).String())
+				return true
+			})
+		}
+	}
+
+	// Every found call must be registered.
+	var violations []string
+	for file, funcs := range found {
+		for fn, positions := range funcs {
+			if _, ok := allowedOSFileIO[file][fn]; !ok {
+				violations = append(violations,
+					fmt.Sprintf("os.%s in %s (%s)", fn, file, strings.Join(positions, ", ")))
+			}
+		}
+	}
+	sort.Strings(violations)
+	require.Emptyf(t, violations,
+		"unregistered direct os file-IO in the pebble engine package.\n"+
+			"If the file can ever be read by the pebble.DB (staged SSTs, DB dir, checkpoints), use Engine.fs() instead.\n"+
+			"If it is genuinely engine-private scratch or host-contract IO, register it in allowedOSFileIO with a reason.\nViolations:\n  %s",
+		strings.Join(violations, "\n  "))
+
+	// Every registered entry must still have a call site (no registry rot).
+	var stale []string
+	for file, funcs := range allowedOSFileIO {
+		for fn := range funcs {
+			if len(found[file][fn]) == 0 {
+				stale = append(stale, fmt.Sprintf("os.%s in %s", fn, file))
+			}
+		}
+	}
+	sort.Strings(stale)
+	require.Emptyf(t, stale,
+		"allowlist entries with no remaining call site — remove them so the registry stays honest:\n  %s",
+		strings.Join(stale, "\n  "))
+}

--- a/pkg/dotc1z/engine/pebble/os_io_allowlist_test.go
+++ b/pkg/dotc1z/engine/pebble/os_io_allowlist_test.go
@@ -94,6 +94,31 @@ func TestOSFileIOCallsAreAllowlisted(t *testing.T) {
 	for _, pkg := range pkgs {
 		for path, f := range pkg.Files {
 			base := path[strings.LastIndex(path, "/")+1:]
+			// Resolve the local name(s) the "os" import is bound to in
+			// THIS file — an aliased import (stdos "os") must not slip
+			// past the registry, and a dot-import would make os calls
+			// indistinguishable from package-local ones, so it is
+			// rejected outright.
+			osNames := map[string]bool{}
+			for _, imp := range f.Imports {
+				if imp.Path.Value != `"os"` {
+					continue
+				}
+				switch {
+				case imp.Name == nil:
+					osNames["os"] = true
+				case imp.Name.Name == ".":
+					require.Failf(t, "dot-import of os",
+						"%s dot-imports \"os\", which defeats this registry; use a named import", base)
+				case imp.Name.Name == "_":
+					// blank import: no callable name.
+				default:
+					osNames[imp.Name.Name] = true
+				}
+			}
+			if len(osNames) == 0 {
+				continue
+			}
 			ast.Inspect(f, func(n ast.Node) bool {
 				call, ok := n.(*ast.CallExpr)
 				if !ok {
@@ -104,7 +129,7 @@ func TestOSFileIOCallsAreAllowlisted(t *testing.T) {
 					return true
 				}
 				ident, ok := sel.X.(*ast.Ident)
-				if !ok || ident.Name != "os" || !osFileIOFuncs[sel.Sel.Name] {
+				if !ok || !osNames[ident.Name] || !osFileIOFuncs[sel.Sel.Name] {
 					return true
 				}
 				if found[base] == nil {

--- a/pkg/dotc1z/engine/pebble/os_io_allowlist_test.go
+++ b/pkg/dotc1z/engine/pebble/os_io_allowlist_test.go
@@ -31,6 +31,7 @@ import (
 	"go/parser"
 	"go/token"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"testing"
@@ -93,7 +94,7 @@ func TestOSFileIOCallsAreAllowlisted(t *testing.T) {
 	found := map[string]map[string][]string{}
 	for _, pkg := range pkgs {
 		for path, f := range pkg.Files {
-			base := path[strings.LastIndex(path, "/")+1:]
+			base := filepath.Base(path)
 			// Resolve the local name(s) the "os" import is bound to in
 			// THIS file — an aliased import (stdos "os") must not slip
 			// past the registry, and a dot-import would make os calls

--- a/vendor/github.com/cockroachdb/pebble/v2/vfs/errorfs/dsl.go
+++ b/vendor/github.com/cockroachdb/pebble/v2/vfs/errorfs/dsl.go
@@ -1,0 +1,286 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package errorfs
+
+import (
+	"fmt"
+	"go/token"
+	"math/rand/v2"
+	"path/filepath"
+	"strconv"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/v2/internal/dsl"
+)
+
+// Predicate encodes conditional logic that determines whether to inject an
+// error.
+type Predicate = dsl.Predicate[Op]
+
+// And returns a predicate that evaluates to true if all of the operands
+// evaluate to true.
+func And(operands ...Predicate) Predicate {
+	return dsl.And[Op](operands...)
+}
+
+// PathMatch returns a predicate that returns true if an operation's file path
+// matches the provided pattern according to filepath.Match.
+func PathMatch(pattern string) Predicate {
+	return &pathMatch{pattern: pattern}
+}
+
+type pathMatch struct {
+	pattern string
+}
+
+func (pm *pathMatch) String() string {
+	return fmt.Sprintf("(PathMatch %q)", pm.pattern)
+}
+
+func (pm *pathMatch) Evaluate(op Op) bool {
+	matched, err := filepath.Match(pm.pattern, op.Path)
+	if err != nil {
+		// Only possible error is ErrBadPattern, indicating an issue with
+		// the test itself.
+		panic(err)
+	}
+	return matched
+}
+
+var (
+	// Reads is a predicate that returns true iff an operation is a read
+	// operation.
+	Reads Predicate = opKindPred{kind: OpIsRead}
+	// Writes is a predicate that returns true iff an operation is a write
+	// operation.
+	Writes Predicate = opKindPred{kind: OpIsWrite}
+)
+
+type opFileReadAt struct {
+	// offset configures the predicate to evaluate to true only if the
+	// operation's offset exactly matches offset.
+	offset int64
+}
+
+func (o *opFileReadAt) String() string {
+	return fmt.Sprintf("(FileReadAt %d)", o.offset)
+}
+
+func (o *opFileReadAt) Evaluate(op Op) bool {
+	return op.Kind == OpFileReadAt && o.offset == op.Offset
+}
+
+type opKindPred struct {
+	kind OpReadWrite
+}
+
+func (p opKindPred) String() string      { return p.kind.String() }
+func (p opKindPred) Evaluate(op Op) bool { return p.kind == op.Kind.ReadOrWrite() }
+
+// Randomly constructs a new predicate that pseudorandomly evaluates to true
+// with probability p using randomness determinstically derived from seed.
+//
+// The predicate is deterministic with respect to file paths: its behavior for a
+// particular file is deterministic regardless of intervening evaluations for
+// operations on other files. This can be used to ensure determinism despite
+// nondeterministic concurrency if the concurrency is constrained to separate
+// files.
+func Randomly(p float64, seed int64) Predicate {
+	rs := &randomSeed{p: p}
+	rs.keyedPrng.init(seed)
+	return rs
+}
+
+type randomSeed struct {
+	// p defines the probability of an error being injected.
+	p float64
+	keyedPrng
+}
+
+func (rs *randomSeed) String() string {
+	if rs.rootSeed == 0 {
+		return fmt.Sprintf("(Randomly %.2f)", rs.p)
+	}
+	return fmt.Sprintf("(Randomly %.2f %d)", rs.p, rs.rootSeed)
+}
+
+func (rs *randomSeed) Evaluate(op Op) bool {
+	var ok bool
+	rs.keyedPrng.withKey(op.Path, func(prng *rand.Rand) {
+		ok = prng.Float64() < rs.p
+	})
+	return ok
+}
+
+// ParseDSL parses the provided string using the default DSL parser.
+func ParseDSL(s string) (Injector, error) {
+	return defaultParser.Parse(s)
+}
+
+var defaultParser = NewParser()
+
+// NewParser constructs a new parser for an encoding of a lisp-like DSL
+// describing error injectors.
+//
+// Errors:
+// - ErrInjected is the only error currently supported by the DSL.
+//
+// Injectors:
+//   - <ERROR>: An error by itself is an injector that injects an error every
+//     time.
+//   - (<ERROR> <PREDICATE>) is an injector that injects an error only when
+//     the operation satisfies the predicate.
+//
+// Predicates:
+//   - Reads is a constant predicate that evalutes to true iff the operation is a
+//     read operation (eg, Open, Read, ReadAt, Stat)
+//   - Writes is a constant predicate that evaluates to true iff the operation is
+//     a write operation (eg, Create, Rename, Write, WriteAt, etc).
+//   - (PathMatch <STRING>) is a predicate that evalutes to true iff the
+//     operation's file path matches the provided shell pattern.
+//   - (OnIndex <INTEGER>) is a predicate that evaluates to true only on the n-th
+//     invocation.
+//   - (And <PREDICATE> [PREDICATE]...) is a predicate that evaluates to true
+//     iff all the provided predicates evaluate to true. And short circuits on
+//     the first predicate to evaluate to false.
+//   - (Or <PREDICATE> [PREDICATE]...) is a predicate that evaluates to true iff
+//     at least one of the provided predicates evaluates to true. Or short
+//     circuits on the first predicate to evaluate to true.
+//   - (Not <PREDICATE>) is a predicate that evaluates to true iff its provided
+//     predicates evaluates to false.
+//   - (Randomly <FLOAT> [INTEGER]) is a predicate that pseudorandomly evaluates
+//     to true. The probability of evaluating to true is determined by the
+//     required float argument (must be ≤1). The optional second parameter is a
+//     pseudorandom seed, for adjusting the deterministic randomness.
+//   - Operation-specific:
+//     (OpFileReadAt <INTEGER>) is a predicate that evaluates to true iff
+//     an operation is a file ReadAt call with an offset that's exactly equal.
+//
+// Example: (ErrInjected (And (PathMatch "*.sst") (OnIndex 5))) is a rule set
+// that will inject an error on the 5-th I/O operation involving an sstable.
+func NewParser() *Parser {
+	p := &Parser{
+		predicates: dsl.NewPredicateParser[Op](),
+		injectors:  dsl.NewParser[Injector](),
+	}
+	p.predicates.DefineConstant("Reads", func() dsl.Predicate[Op] { return Reads })
+	p.predicates.DefineConstant("Writes", func() dsl.Predicate[Op] { return Writes })
+	p.predicates.DefineFunc("PathMatch",
+		func(p *dsl.Parser[dsl.Predicate[Op]], s *dsl.Scanner) dsl.Predicate[Op] {
+			pattern := s.ConsumeString()
+			s.Consume(token.RPAREN)
+			return PathMatch(pattern)
+		})
+	p.predicates.DefineFunc("OpFileReadAt",
+		func(p *dsl.Parser[dsl.Predicate[Op]], s *dsl.Scanner) dsl.Predicate[Op] {
+			return parseFileReadAtOp(s)
+		})
+	p.predicates.DefineFunc("Randomly",
+		func(p *dsl.Parser[dsl.Predicate[Op]], s *dsl.Scanner) dsl.Predicate[Op] {
+			return parseRandomly(s)
+		})
+	p.AddError(ErrInjected)
+	p.injectors.DefineFunc("RandomLatency",
+		func(_ *dsl.Parser[Injector], s *dsl.Scanner) Injector {
+			return parseRandomLatency(p, s)
+		})
+	return p
+}
+
+// A Parser parses the error-injecting DSL. It may be extended to include
+// additional errors through AddError.
+type Parser struct {
+	predicates *dsl.Parser[dsl.Predicate[Op]]
+	injectors  *dsl.Parser[Injector]
+}
+
+// Parse parses the error injection DSL, returning the parsed injector.
+func (p *Parser) Parse(s string) (Injector, error) {
+	return p.injectors.Parse(s)
+}
+
+// AddError defines a new error that may be used within the DSL parsed by
+// Parse and will inject the provided error.
+func (p *Parser) AddError(le LabelledError) {
+	// Define the error both as a constant that unconditionally injects the
+	// error, and as a function that injects the error only if the provided
+	// predicate evaluates to true.
+	p.injectors.DefineConstant(le.Label, func() Injector { return le })
+	p.injectors.DefineFunc(le.Label,
+		func(_ *dsl.Parser[Injector], s *dsl.Scanner) Injector {
+			pred := p.predicates.ParseFromPos(s, s.Scan())
+			s.Consume(token.RPAREN)
+			return le.If(pred)
+		})
+}
+
+// LabelledError is an error that also implements Injector, unconditionally
+// injecting itself. It implements String() by returning its label. It
+// implements Error() by returning its underlying error.
+type LabelledError struct {
+	error
+	Label     string
+	predicate Predicate
+}
+
+// String implements fmt.Stringer.
+func (le LabelledError) String() string {
+	if le.predicate == nil {
+		return le.Label
+	}
+	return fmt.Sprintf("(%s %s)", le.Label, le.predicate.String())
+}
+
+// MaybeError implements Injector.
+func (le LabelledError) MaybeError(op Op) error {
+	if le.predicate == nil || le.predicate.Evaluate(op) {
+		return errors.WithStack(le)
+	}
+	return nil
+}
+
+// If returns an Injector that returns the receiver error if the provided
+// predicate evalutes to true.
+func (le LabelledError) If(p Predicate) Injector {
+	le.predicate = p
+	return le
+}
+
+func parseFileReadAtOp(s *dsl.Scanner) *opFileReadAt {
+	lit := s.Consume(token.INT).Lit
+	off, err := strconv.ParseInt(lit, 10, 64)
+	if err != nil {
+		panic(err)
+	}
+	s.Consume(token.RPAREN)
+	return &opFileReadAt{offset: off}
+}
+
+func parseRandomly(s *dsl.Scanner) Predicate {
+	lit := s.Consume(token.FLOAT).Lit
+	p, err := strconv.ParseFloat(lit, 64)
+	if err != nil {
+		panic(err)
+	} else if p > 1.0 {
+		// NB: It's not possible for p to be less than zero because we don't
+		// try to parse the '-' token.
+		panic(errors.Newf("errorfs: Randomly proability p must be within p ≤ 1.0"))
+	}
+
+	var seed int64
+	tok := s.Scan()
+	switch tok.Kind {
+	case token.RPAREN:
+	case token.INT:
+		seed, err = strconv.ParseInt(tok.Lit, 10, 64)
+		if err != nil {
+			panic(err)
+		}
+		s.Consume(token.RPAREN)
+	default:
+		panic(errors.Errorf("errorfs: unexpected token %s; expected RPAREN | FLOAT", tok.String()))
+	}
+	return Randomly(p, seed)
+}

--- a/vendor/github.com/cockroachdb/pebble/v2/vfs/errorfs/errorfs.go
+++ b/vendor/github.com/cockroachdb/pebble/v2/vfs/errorfs/errorfs.go
@@ -1,0 +1,552 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package errorfs
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/errors/oserror"
+	"github.com/cockroachdb/pebble/v2/internal/dsl"
+	"github.com/cockroachdb/pebble/v2/vfs"
+)
+
+// ErrInjected is an error artificially injected for testing fs error paths.
+var ErrInjected = LabelledError{
+	error: errors.New("injected error"),
+	Label: "ErrInjected",
+}
+
+// Op describes a filesystem operation.
+type Op struct {
+	// Kind describes the particular kind of operation being performed.
+	Kind OpKind
+	// Path is the path of the file of the file being operated on.
+	Path string
+	// Offset is the offset of an operation. It's set for OpFileReadAt and
+	// OpFileWriteAt operations.
+	Offset int64
+}
+
+// OpKind is an enum describing the type of operation.
+type OpKind int
+
+const (
+	// OpCreate describes a create file operation.
+	OpCreate OpKind = iota
+	// OpLink describes a hardlink operation.
+	OpLink
+	// OpOpen describes a file open operation.
+	OpOpen
+	// OpOpenDir describes a directory open operation.
+	OpOpenDir
+	// OpRemove describes a remove file operation.
+	OpRemove
+	// OpRemoveAll describes a recursive remove operation.
+	OpRemoveAll
+	// OpRename describes a rename operation.
+	OpRename
+	// OpReuseForWrite describes a reuse for write operation.
+	OpReuseForWrite
+	// OpMkdirAll describes a make directory including parents operation.
+	OpMkdirAll
+	// OpLock describes a lock file operation.
+	OpLock
+	// OpList describes a list directory operation.
+	OpList
+	// OpFilePreallocate describes a file preallocate operation.
+	OpFilePreallocate
+	// OpStat describes a path-based stat operation.
+	OpStat
+	// OpGetDiskUsage describes a disk usage operation.
+	OpGetDiskUsage
+	// OpFileClose describes a close file operation.
+	OpFileClose
+	// OpFileRead describes a file read operation.
+	OpFileRead
+	// OpFileReadAt describes a file seek read operation.
+	OpFileReadAt
+	// OpFileWrite describes a file write operation.
+	OpFileWrite
+	// OpFileWriteAt describes a file seek write operation.
+	OpFileWriteAt
+	// OpFileStat describes a file stat operation.
+	OpFileStat
+	// OpFileSync describes a file sync operation.
+	OpFileSync
+	// OpFileSyncData describes a file sync operation.
+	OpFileSyncData
+	// OpFileSyncTo describes a file sync operation.
+	OpFileSyncTo
+	// OpFileFlush describes a file flush operation.
+	OpFileFlush
+)
+
+// ReadOrWrite returns the operation's kind.
+func (o OpKind) ReadOrWrite() OpReadWrite {
+	switch o {
+	case OpOpen, OpOpenDir, OpList, OpStat, OpGetDiskUsage, OpFileRead, OpFileReadAt, OpFileStat:
+		return OpIsRead
+	case OpCreate, OpLink, OpRemove, OpRemoveAll, OpRename, OpReuseForWrite, OpMkdirAll, OpLock, OpFileClose, OpFileWrite, OpFileWriteAt, OpFileSync, OpFileSyncData, OpFileSyncTo, OpFileFlush, OpFilePreallocate:
+		return OpIsWrite
+	default:
+		panic(fmt.Sprintf("unrecognized op %v\n", o))
+	}
+}
+
+// OpReadWrite is an enum describing whether an operation is a read or write
+// operation.
+type OpReadWrite int
+
+const (
+	// OpIsRead describes read operations.
+	OpIsRead OpReadWrite = iota
+	// OpIsWrite describes write operations.
+	OpIsWrite
+)
+
+// String implements fmt.Stringer.
+func (kind OpReadWrite) String() string {
+	switch kind {
+	case OpIsRead:
+		return "Reads"
+	case OpIsWrite:
+		return "Writes"
+	default:
+		panic(fmt.Sprintf("unrecognized OpKind %d", kind))
+	}
+}
+
+// OnIndex is a convenience function for constructing a dsl.OnIndex for use with
+// an error-injecting filesystem.
+func OnIndex(index int32) *InjectIndex {
+	return &InjectIndex{dsl.OnIndex[Op](index)}
+}
+
+// InjectIndex implements Injector, injecting an error at a specific index.
+type InjectIndex struct {
+	*dsl.Index[Op]
+}
+
+// MaybeError implements the Injector interface.
+//
+// TODO(jackson): Remove this implementation and update callers to compose it
+// with other injectors.
+func (ii *InjectIndex) MaybeError(op Op) error {
+	if !ii.Evaluate(op) {
+		return nil
+	}
+	return ErrInjected
+}
+
+// InjectorFunc implements the Injector interface for a function with
+// MaybeError's signature.
+type InjectorFunc func(Op) error
+
+// String implements fmt.Stringer.
+func (f InjectorFunc) String() string { return "<opaque func>" }
+
+// MaybeError implements the Injector interface.
+func (f InjectorFunc) MaybeError(op Op) error { return f(op) }
+
+// Injector injects errors into FS operations.
+type Injector interface {
+	fmt.Stringer
+	// MaybeError is invoked by an errorfs before an operation is executed. It
+	// is passed an enum indicating the type of operation and a path of the
+	// subject file or directory. If the operation takes two paths (eg,
+	// Rename, Link), the original source path is provided.
+	MaybeError(op Op) error
+}
+
+// Any returns an injector that injects an error if any of the provided
+// injectors inject an error. The error returned by the first injector to return
+// an error is used.
+func Any(injectors ...Injector) Injector {
+	return anyInjector(injectors)
+}
+
+type anyInjector []Injector
+
+func (a anyInjector) String() string {
+	var sb strings.Builder
+	sb.WriteString("(Any")
+	for _, inj := range a {
+		sb.WriteString(" ")
+		sb.WriteString(inj.String())
+	}
+	sb.WriteString(")")
+	return sb.String()
+}
+
+func (a anyInjector) MaybeError(op Op) error {
+	for _, inj := range a {
+		if err := inj.MaybeError(op); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Counter wraps an Injector, counting the number of errors injected. It may be
+// used in tests to ensure that when an error is injected, the error is
+// surfaced through the user interface.
+type Counter struct {
+	Injector
+	mu struct {
+		sync.Mutex
+		v       uint64
+		lastErr error
+	}
+}
+
+// String implements fmt.Stringer.
+func (c *Counter) String() string {
+	return c.Injector.String()
+}
+
+// MaybeError implements Injector.
+func (c *Counter) MaybeError(op Op) error {
+	err := c.Injector.MaybeError(op)
+	if err != nil {
+		c.mu.Lock()
+		c.mu.v++
+		c.mu.lastErr = err
+		c.mu.Unlock()
+	}
+	return err
+}
+
+// Load returns the number of errors injected.
+func (c *Counter) Load() uint64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.mu.v
+}
+
+// LastError returns the last non-nil error injected.
+func (c *Counter) LastError() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.mu.lastErr
+}
+
+// Toggle wraps an Injector. By default, Toggle injects nothing. When toggled on
+// through its On method, it begins injecting errors when the contained injector
+// injects them. It may be returned to its original state through Off.
+type Toggle struct {
+	Injector
+	on atomic.Bool
+}
+
+// String implements fmt.Stringer.
+func (t *Toggle) String() string {
+	return t.Injector.String()
+}
+
+// MaybeError implements Injector.
+func (t *Toggle) MaybeError(op Op) error {
+	if !t.on.Load() {
+		return nil
+	}
+	return t.Injector.MaybeError(op)
+}
+
+// On enables error injection.
+func (t *Toggle) On() { t.on.Store(true) }
+
+// Off disables error injection.
+func (t *Toggle) Off() { t.on.Store(false) }
+
+// FS implements vfs.FS, injecting errors into
+// its operations.
+type FS struct {
+	fs  vfs.FS
+	inj Injector
+}
+
+// Wrap wraps an existing vfs.FS implementation, returning a new
+// vfs.FS implementation that shadows operations to the provided FS.
+// It uses the provided Injector for deciding when to inject errors.
+// If an error is injected, FS propagates the error instead of
+// shadowing the operation.
+func Wrap(fs vfs.FS, inj Injector) *FS {
+	return &FS{
+		fs:  fs,
+		inj: inj,
+	}
+}
+
+// WrapFile wraps an existing vfs.File, returning a new vfs.File that shadows
+// operations to the provided vfs.File. It uses the provided Injector for
+// deciding when to inject errors. If an error is injected, the file
+// propagates the error instead of shadowing the operation.
+func WrapFile(f vfs.File, inj Injector) vfs.File {
+	return &errorFile{file: f, inj: inj}
+}
+
+// Unwrap returns the FS implementation underlying fs.
+// See pebble/vfs.Root.
+func (fs *FS) Unwrap() vfs.FS {
+	return fs.fs
+}
+
+// Create implements FS.Create.
+func (fs *FS) Create(name string, category vfs.DiskWriteCategory) (vfs.File, error) {
+	if err := fs.inj.MaybeError(Op{Kind: OpCreate, Path: name}); err != nil {
+		return nil, err
+	}
+	f, err := fs.fs.Create(name, category)
+	if err != nil {
+		return nil, err
+	}
+	return &errorFile{name, f, fs.inj}, nil
+}
+
+// Link implements FS.Link.
+func (fs *FS) Link(oldname, newname string) error {
+	if err := fs.inj.MaybeError(Op{Kind: OpLink, Path: oldname}); err != nil {
+		return err
+	}
+	return fs.fs.Link(oldname, newname)
+}
+
+// Open implements FS.Open.
+func (fs *FS) Open(name string, opts ...vfs.OpenOption) (vfs.File, error) {
+	if err := fs.inj.MaybeError(Op{Kind: OpOpen, Path: name}); err != nil {
+		return nil, err
+	}
+	f, err := fs.fs.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	ef := &errorFile{name, f, fs.inj}
+	for _, opt := range opts {
+		opt.Apply(ef)
+	}
+	return ef, nil
+}
+
+// OpenReadWrite implements FS.OpenReadWrite.
+func (fs *FS) OpenReadWrite(
+	name string, category vfs.DiskWriteCategory, opts ...vfs.OpenOption,
+) (vfs.File, error) {
+	if err := fs.inj.MaybeError(Op{Kind: OpOpen, Path: name}); err != nil {
+		return nil, err
+	}
+	f, err := fs.fs.OpenReadWrite(name, category)
+	if err != nil {
+		return nil, err
+	}
+	ef := &errorFile{name, f, fs.inj}
+	for _, opt := range opts {
+		opt.Apply(ef)
+	}
+	return ef, nil
+}
+
+// OpenDir implements FS.OpenDir.
+func (fs *FS) OpenDir(name string) (vfs.File, error) {
+	if err := fs.inj.MaybeError(Op{Kind: OpOpenDir, Path: name}); err != nil {
+		return nil, err
+	}
+	f, err := fs.fs.OpenDir(name)
+	if err != nil {
+		return nil, err
+	}
+	return &errorFile{name, f, fs.inj}, nil
+}
+
+// GetDiskUsage implements FS.GetDiskUsage.
+func (fs *FS) GetDiskUsage(path string) (vfs.DiskUsage, error) {
+	if err := fs.inj.MaybeError(Op{Kind: OpGetDiskUsage, Path: path}); err != nil {
+		return vfs.DiskUsage{}, err
+	}
+	return fs.fs.GetDiskUsage(path)
+}
+
+// PathBase implements FS.PathBase.
+func (fs *FS) PathBase(p string) string {
+	return fs.fs.PathBase(p)
+}
+
+// PathDir implements FS.PathDir.
+func (fs *FS) PathDir(p string) string {
+	return fs.fs.PathDir(p)
+}
+
+// PathJoin implements FS.PathJoin.
+func (fs *FS) PathJoin(elem ...string) string {
+	return fs.fs.PathJoin(elem...)
+}
+
+// Remove implements FS.Remove.
+func (fs *FS) Remove(name string) error {
+	if _, err := fs.fs.Stat(name); oserror.IsNotExist(err) {
+		return nil
+	}
+
+	if err := fs.inj.MaybeError(Op{Kind: OpRemove, Path: name}); err != nil {
+		return err
+	}
+	return fs.fs.Remove(name)
+}
+
+// RemoveAll implements FS.RemoveAll.
+func (fs *FS) RemoveAll(fullname string) error {
+	if err := fs.inj.MaybeError(Op{Kind: OpRemoveAll, Path: fullname}); err != nil {
+		return err
+	}
+	return fs.fs.RemoveAll(fullname)
+}
+
+// Rename implements FS.Rename.
+func (fs *FS) Rename(oldname, newname string) error {
+	if err := fs.inj.MaybeError(Op{Kind: OpRename, Path: oldname}); err != nil {
+		return err
+	}
+	return fs.fs.Rename(oldname, newname)
+}
+
+// ReuseForWrite implements FS.ReuseForWrite.
+func (fs *FS) ReuseForWrite(
+	oldname, newname string, category vfs.DiskWriteCategory,
+) (vfs.File, error) {
+	if err := fs.inj.MaybeError(Op{Kind: OpReuseForWrite, Path: oldname}); err != nil {
+		return nil, err
+	}
+	return fs.fs.ReuseForWrite(oldname, newname, category)
+}
+
+// MkdirAll implements FS.MkdirAll.
+func (fs *FS) MkdirAll(dir string, perm os.FileMode) error {
+	if err := fs.inj.MaybeError(Op{Kind: OpMkdirAll, Path: dir}); err != nil {
+		return err
+	}
+	return fs.fs.MkdirAll(dir, perm)
+}
+
+// Lock implements FS.Lock.
+func (fs *FS) Lock(name string) (io.Closer, error) {
+	if err := fs.inj.MaybeError(Op{Kind: OpLock, Path: name}); err != nil {
+		return nil, err
+	}
+	return fs.fs.Lock(name)
+}
+
+// List implements FS.List.
+func (fs *FS) List(dir string) ([]string, error) {
+	if err := fs.inj.MaybeError(Op{Kind: OpList, Path: dir}); err != nil {
+		return nil, err
+	}
+	return fs.fs.List(dir)
+}
+
+// Stat implements FS.Stat.
+func (fs *FS) Stat(name string) (vfs.FileInfo, error) {
+	if err := fs.inj.MaybeError(Op{Kind: OpStat, Path: name}); err != nil {
+		return nil, err
+	}
+	return fs.fs.Stat(name)
+}
+
+// errorFile implements vfs.File. The interface is implemented on the pointer
+// type to allow pointer equality comparisons.
+type errorFile struct {
+	path string
+	file vfs.File
+	inj  Injector
+}
+
+func (f *errorFile) Close() error {
+	// We don't inject errors during close as those calls should never fail in
+	// practice.
+	return f.file.Close()
+}
+
+func (f *errorFile) Read(p []byte) (int, error) {
+	if err := f.inj.MaybeError(Op{Kind: OpFileRead, Path: f.path}); err != nil {
+		return 0, err
+	}
+	return f.file.Read(p)
+}
+
+func (f *errorFile) ReadAt(p []byte, off int64) (int, error) {
+	if err := f.inj.MaybeError(Op{
+		Kind:   OpFileReadAt,
+		Path:   f.path,
+		Offset: off,
+	}); err != nil {
+		return 0, err
+	}
+	return f.file.ReadAt(p, off)
+}
+
+func (f *errorFile) Write(p []byte) (int, error) {
+	if err := f.inj.MaybeError(Op{Kind: OpFileWrite, Path: f.path}); err != nil {
+		return 0, err
+	}
+	return f.file.Write(p)
+}
+
+func (f *errorFile) WriteAt(p []byte, off int64) (int, error) {
+	if err := f.inj.MaybeError(Op{
+		Kind:   OpFileWriteAt,
+		Path:   f.path,
+		Offset: off,
+	}); err != nil {
+		return 0, err
+	}
+	return f.file.WriteAt(p, off)
+}
+
+func (f *errorFile) Stat() (vfs.FileInfo, error) {
+	if err := f.inj.MaybeError(Op{Kind: OpFileStat, Path: f.path}); err != nil {
+		return nil, err
+	}
+	return f.file.Stat()
+}
+
+func (f *errorFile) Prefetch(offset, length int64) error {
+	// TODO(radu): Consider error injection.
+	return f.file.Prefetch(offset, length)
+}
+
+func (f *errorFile) Preallocate(offset, length int64) error {
+	if err := f.inj.MaybeError(Op{Kind: OpFilePreallocate, Path: f.path}); err != nil {
+		return err
+	}
+	return f.file.Preallocate(offset, length)
+}
+
+func (f *errorFile) Sync() error {
+	if err := f.inj.MaybeError(Op{Kind: OpFileSync, Path: f.path}); err != nil {
+		return err
+	}
+	return f.file.Sync()
+}
+
+func (f *errorFile) SyncData() error {
+	if err := f.inj.MaybeError(Op{Kind: OpFileSyncData, Path: f.path}); err != nil {
+		return err
+	}
+	return f.file.SyncData()
+}
+
+func (f *errorFile) SyncTo(length int64) (fullSync bool, err error) {
+	if err := f.inj.MaybeError(Op{Kind: OpFileSyncTo, Path: f.path}); err != nil {
+		return false, err
+	}
+	return f.file.SyncTo(length)
+}
+
+func (f *errorFile) Fd() uintptr {
+	return f.file.Fd()
+}

--- a/vendor/github.com/cockroachdb/pebble/v2/vfs/errorfs/latency.go
+++ b/vendor/github.com/cockroachdb/pebble/v2/vfs/errorfs/latency.go
@@ -1,0 +1,147 @@
+package errorfs
+
+import (
+	"encoding/binary"
+	"fmt"
+	"go/token"
+	"hash/maphash"
+	"math/rand/v2"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/v2/internal/dsl"
+)
+
+// RandomLatency constructs an Injector that does not inject errors but instead
+// injects random latency into operations that match the provided predicate. The
+// amount of latency injected follows an exponential distribution with the
+// provided mean. Latency injected is derived from the provided seed and is
+// deterministic with respect to each file's path.
+//
+// If limit is nonzero, total latency injected over the lifetime of the Injector
+// is capped to limit.
+func RandomLatency(pred Predicate, mean time.Duration, seed int64, limit time.Duration) Injector {
+	rl := &randomLatency{
+		predicate: pred,
+		mean:      mean,
+		limit:     limit,
+	}
+	rl.keyedPrng.init(seed)
+	return rl
+}
+
+func parseRandomLatency(p *Parser, s *dsl.Scanner) Injector {
+	dur, err := time.ParseDuration(s.ConsumeString())
+	if err != nil {
+		panic(errors.Newf("parsing RandomLatency: %s", err))
+	}
+	lit := s.Consume(token.INT).Lit
+	seed, err := strconv.ParseInt(lit, 10, 64)
+	if err != nil {
+		panic(err)
+	}
+	var pred Predicate
+	tok := s.Scan()
+	if tok.Kind == token.LPAREN || tok.Kind == token.IDENT {
+		pred = p.predicates.ParseFromPos(s, tok)
+		tok = s.Scan()
+	}
+	if tok.Kind != token.RPAREN {
+		panic(errors.Errorf("errorfs: unexpected token %s; expected %s", tok.String(), token.RPAREN))
+	}
+	return RandomLatency(pred, dur, seed, 0 /* no limit */)
+}
+
+type randomLatency struct {
+	predicate Predicate
+	// mean is the mean duration injected each operation.
+	mean time.Duration
+	// limit configures a limit on total latency injected over the lifetime of
+	// the Injector if nonzero.
+	limit time.Duration
+	// agg is the aggregate latency injected over the lifetime of the Injector.
+	agg atomic.Int64
+	keyedPrng
+}
+
+func (rl *randomLatency) String() string {
+	if rl.predicate == nil {
+		return fmt.Sprintf("(RandomLatency %q %d)", rl.mean, rl.rootSeed)
+	}
+	return fmt.Sprintf("(RandomLatency %q %d %s)", rl.mean, rl.rootSeed, rl.predicate)
+}
+
+func (rl *randomLatency) MaybeError(op Op) error {
+	if rl.predicate != nil && !rl.predicate.Evaluate(op) {
+		return nil
+	}
+	var dur time.Duration
+	rl.keyedPrng.withKey(op.Path, func(prng *rand.Rand) {
+		// We cap the max latency to 100x: Otherwise, it seems possible
+		// (although very unlikely) ExpFloat64 generates a multiplier high
+		// enough that causes a test timeout.
+		dur = time.Duration(min(prng.ExpFloat64(), 20.0) * float64(rl.mean))
+	})
+
+	// Apply a limit on total latency injected over the lifetime of the
+	// Injector, if one is configured.
+	if rl.limit > 0 {
+		if v := time.Duration(rl.agg.Add(int64(dur))); v-dur > rl.limit {
+			// We'd already exceeded the limit before adding dur. Don't inject
+			// anything.
+			return nil
+		} else if v > rl.limit {
+			// We're about to exceed the limit. Cap the duration.
+			dur -= v - rl.limit
+		}
+	}
+
+	time.Sleep(dur)
+	return nil
+}
+
+// keyedPrng maintains a separate prng per-key that's deterministic with
+// respect to the key: its behavior for a particular key is deterministic
+// regardless of intervening evaluations for operations on other keys. This can
+// be used to ensure determinism despite nondeterministic concurrency if the
+// concurrency is constrained to separate keys.
+type keyedPrng struct {
+	rootSeed int64
+	mu       struct {
+		sync.Mutex
+		h           maphash.Hash
+		perFilePrng map[string]*rand.Rand
+	}
+}
+
+func (p *keyedPrng) init(rootSeed int64) {
+	p.rootSeed = rootSeed
+	p.mu.perFilePrng = make(map[string]*rand.Rand)
+}
+
+func (p *keyedPrng) withKey(key string, fn func(*rand.Rand)) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	prng, ok := p.mu.perFilePrng[key]
+	if !ok {
+		// This is the first time an operation has been performed on the key.
+		// Initialize the per-key prng by computing a deterministic hash of the
+		// key.
+		p.mu.h.Reset()
+		var b [8]byte
+		binary.LittleEndian.PutUint64(b[:], uint64(p.rootSeed))
+		if _, err := p.mu.h.Write(b[:]); err != nil {
+			panic(err)
+		}
+		if _, err := p.mu.h.WriteString(key); err != nil {
+			panic(err)
+		}
+		seed := p.mu.h.Sum64()
+		prng = rand.New(rand.NewPCG(0, seed))
+		p.mu.perFilePrng[key] = prng
+	}
+	fn(prng)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -321,6 +321,7 @@ github.com/cockroachdb/pebble/v2/sstable/valblk
 github.com/cockroachdb/pebble/v2/sstable/virtual
 github.com/cockroachdb/pebble/v2/vfs
 github.com/cockroachdb/pebble/v2/vfs/atomicfs
+github.com/cockroachdb/pebble/v2/vfs/errorfs
 github.com/cockroachdb/pebble/v2/wal
 # github.com/cockroachdb/redact v1.1.5
 ## explicit; go 1.14


### PR DESCRIPTION
## Summary

First slice of the sync-replay stack: fault-injection infrastructure for the Pebble engine, landed ahead of the upcoming write-path refactors so every later change merges under an IO-failure test gate.

### `WithVFS(vfs.FS)` engine option

The engine (and the `pebble.DB` under it) can now run over a caller-supplied filesystem. This required threading the FS through every path that stages SST files the DB later reads via `Ingest`/`IngestAndExcise` — the deferred index build, digest build, bulk import, synth-grant layer, id-index migration, all spill-chunk merges — plus staging-dir setup/teardown, the read-only checkpoint clone, and checkpoint WAL truncation. Spill-chunk scratch deliberately stays on plain OS IO (only engine code ever reads it back).

**Production callers are unchanged**: nil FS leaves `pebble.Options.FS` untouched (pebble's `EnsureDefaults` applies its usual disk-health-wrapped `vfs.Default`), and engine staging uses `vfs.Default` exactly as before. No per-row or per-batch path changed; the added work is a handful of syscalls per staging build / checkpoint.

### Fault-injection sweep (`errorfs` + crashable MemFS)

The contract under test: **after any surfaced write/fsync failure followed by a hard discard (crash image keeps only fsynced state; no clean close), the store must reopen either UNFINISHED-and-resume-to-completion, or FINISHED-and-content-complete.** Anything else — a finished-but-incomplete artifact, an unfinished-but-unresumable store — is a durability-ordering bug.

- `TestErrorFSEndSyncWindowSweep` (default CI, ~1s): exhaustive — fails the k-th write op **and every op after it** across the EndSync window, crash-clones at the failure point (injector still armed, so nothing can heal the image), and verifies the reopen dichotomy. Self-terminating when an armed run injects nothing, which proves full window coverage. The sweep also **self-asserts** its coverage: every k must inject, and both dichotomy arms must be populated (currently 34 points: 32 land unfinished-and-resume, 3 land finished-complete).
- `TestErrorFSWholeSyncRandomSweepSoak` (`BATON_SOAK`-gated): seeded random failure points across open + pages, with page-replay resume.
- The content oracle asserts **exact row-set equality**, not counts: the precise grant external-id set through the primary keyspace, and per principal the precise entitlement set through the `by_principal` index, with each index-served record's refs checked against the queried principal.
- **Validated by mutation testing**: seeding a stamp-before-index-build ordering bug fails the sweep immediately with the lying-artifact signature (`finished image: by_principal must serve alice`).

Harness design notes: pebble escalates WAL-commit/MANIFEST failures to `Logger.Fatalf` assuming process exit, so injected engines get a test-only logger that parks the goroutine and signals the harness (the horked engine is leaked, like a crashed process); non-injected engines get a fail-fast panicking logger. One documented coverage gap: IO failures inside an EndSync whose pages are still memtable-resident ride pebble's flushable-ingest path, where failures are raw panics by design — in production that's simply a process crash, whose recovery path *is* covered; modeling the failure itself would need subprocess isolation.

### Regression guards for split-brain IO

Review of this PR found three instances of one bug class: a file created through one filesystem and read/renamed/truncated through the other. Two guards now pin the class:

- `os_io_allowlist_test.go`: AST meta-test — every direct `os` file-IO call in the package must be registered with a reason; unregistered calls, stale registry entries, aliased imports, and dot-imports all fail.
- `memfs_lifecycle_test.go`: the full engine lifecycle (sync with deferred-index staging → EndSync → writable checkpoint → checkpoint reopen → primary reopen) over a **pure** in-memory FS, which fails loudly on any host-IO regression the DB can observe. This test reproduces all three review findings if their fixes are reverted.

### Notable fix that outlived review

`truncateCheckpointWALs` now builds each zero-byte WAL replacement at a side name and atomically renames it over the original — `vfs.Default.Create` is remove-then-recreate (not `O_TRUNC`), so creating the WAL path directly could have *deleted* a WAL on a failed recreate, the exact discovered-file-set hazard the truncate-not-delete policy exists to avoid.

## Review

Three adversarial review passes across two model families; five findings, all fixed and re-verified (disarm-before-clone image healing, checkpoint WAL truncation on the wrong FS, id-index SST rename on the wrong FS, hang-instead-of-fail on verify engines, allowlist import-alias bypass). Final targeted pass on the last delta came back clean.

## Test plan

- [x] Full suite green
- [x] Engine package under `-race`
- [x] Both sweeps incl. `BATON_SOAK=1` (60 seeds)
- [x] Mutation validation (seeded ordering bug caught at k=2, reverted)
- [x] `golangci-lint` clean; `GOOS=windows go vet` clean (MemFS-backed tests skip on Windows; meta-test enforces there)