### PR TITLE
Phase 2: Rawdb choke point

### DIFF
--- a/pkg/dotc1z/engine/pebble/adapter.go
+++ b/pkg/dotc1z/engine/pebble/adapter.go
@@ -378,23 +378,40 @@ func (e *Engine) endSyncFinalize(ctx context.Context, existing *v3.SyncRunRecord
 	if err := e.PutSyncRunRecord(ctx, updated); err != nil {
 		return err
 	}
+	if e.test.endSyncPreFlushHook != nil {
+		e.test.endSyncPreFlushHook()
+	}
 	// Populate the stats sidecar BEFORE the durability flush. Stats
-	// is engine-meta keyspace; the EndFreshSync flush below covers
-	// the WAL fsync for both the sync_run record and the stats key.
-	// Failures here are non-fatal — Stats() falls back to legacy
-	// iteration on a missing sidecar, and the on-Open migration
-	// framework will backfill next time the file opens. We log a
-	// warning so the failure is visible in production telemetry but
-	// don't fail the sync end on stats-sidecar trouble.
+	// is engine-meta keyspace, committed pebble.Sync in
+	// writeSyncStats; the EndFreshSync flush below then bounds reopen
+	// WAL-replay cost for everything. Failures here are non-fatal — Stats() falls back to legacy
+	// O(N) iteration on a missing sidecar. NOTE: there is currently
+	// no on-Open backfill (the indexMigrations registry is
+	// intentionally empty), so a missing sidecar stays missing and
+	// every Stats() call pays the iteration cost. We log a warning so
+	// the failure is visible in production telemetry but don't fail
+	// the sync end on stats-sidecar trouble.
 	if err := e.PersistSyncStats(ctx, existing.GetSyncId()); err != nil {
-		ctxzap.Extract(ctx).Warn("pebble: persist sync stats sidecar failed; Stats() will fall back to O(N) iteration until the next Open backfills it",
+		ctxzap.Extract(ctx).Warn("pebble: persist sync stats sidecar failed; Stats() will fall back to O(N) iteration for this file",
 			zap.String("sync_id", existing.GetSyncId()),
 			zap.Error(err),
 		)
 	}
-	// Single flush + WAL fsync at sync end. This is the durability
-	// boundary — counterpart to MarkFreshSync at StartNewSync. After
-	// this returns, all writes from the sync are on disk.
+	// Single flush + WAL fsync at sync end. This is the counterpart to
+	// MarkFreshSync at StartNewSync; after it returns all of the sync's
+	// writes are SST-durable and the WAL is fsynced. Note the ordering
+	// above is CRASH-SAFE even though the pages were NoSync: every
+	// pebble.Sync commit in the finalize sequence (marker clears, the
+	// ended_at stamp, the stats key) rides pebble's sequential WAL, so
+	// each fsync also hardens every earlier NoSync page commit — a
+	// crash image can hold the finished verdict only if it also holds
+	// the pages. Pinned by TestEndSyncStampDurabilityCarriesPages
+	// (isolated: the stamp is the ONLY Sync between the pages and the
+	// crash cut) and TestEndSyncStampWindowImageComplete (the full
+	// default workload at the same cut). This flush's job is bounding
+	// reopen WAL-replay cost and hardening the NoSync case
+	// (WithDurability(DurabilityNoSync)), where the stamp itself was
+	// not synced.
 	return e.EndFreshSync(ctx)
 }
 

--- a/pkg/dotc1z/engine/pebble/adapter_clone_sync.go
+++ b/pkg/dotc1z/engine/pebble/adapter_clone_sync.go
@@ -111,7 +111,7 @@ func cloneSync(
 			Start: []byte{versionV3, typeCounter},
 			End:   upperBoundOf([]byte{versionV3, typeSession}),
 		}
-		if err := dest.db.Excise(ctx, span); err != nil {
+		if err := dest.db.ExciseRange(ctx, span); err != nil {
 			return fmt.Errorf("excise [%x, %x): %w", span.Start, span.End, err)
 		}
 		return nil

--- a/pkg/dotc1z/engine/pebble/assets.go
+++ b/pkg/dotc1z/engine/pebble/assets.go
@@ -23,7 +23,7 @@ func (e *Engine) PutAssetRecord(ctx context.Context, r *v3.AssetRecord) error {
 		if err != nil {
 			return err
 		}
-		return e.db.Set(encodeAssetKey(r.GetExternalId()), val, writeOpts(e.opts.durability))
+		return e.db.MetaSet(encodeAssetKey(r.GetExternalId()), val, writeOpts(e.opts.durability))
 	})
 }
 
@@ -42,7 +42,7 @@ func (e *Engine) GetAssetRecord(ctx context.Context, externalID string) (*v3.Ass
 
 func (e *Engine) DeleteAssetRecord(ctx context.Context, externalID string) error {
 	return e.withWrite(func() error {
-		return e.db.Delete(encodeAssetKey(externalID), writeOpts(e.opts.durability))
+		return e.db.MetaDelete(encodeAssetKey(externalID), writeOpts(e.opts.durability))
 	})
 }
 

--- a/pkg/dotc1z/engine/pebble/bulk_import.go
+++ b/pkg/dotc1z/engine/pebble/bulk_import.go
@@ -690,7 +690,7 @@ func (b *BulkSyncImport) Finish(ctx context.Context) error {
 		return nil
 	}
 	err := b.e.withWrite(func() error {
-		if err := b.e.db.Ingest(ctx, paths); err != nil {
+		if err := b.e.db.IngestSSTs(ctx, paths); err != nil {
 			return fmt.Errorf("bulk sync import: ingest: %w", err)
 		}
 		b.e.noteEntitlementKeyspaceWrite()

--- a/pkg/dotc1z/engine/pebble/bulk_import_dedupe_test.go
+++ b/pkg/dotc1z/engine/pebble/bulk_import_dedupe_test.go
@@ -25,6 +25,25 @@ func startBulkImport(t *testing.T, ctx context.Context) (*Adapter, *BulkSyncImpo
 	return store, b
 }
 
+// TestBulkImportAbortAfterEngineClose pins the retained-handle teardown
+// contract: a BulkSyncImport whose engine has already Closed must still
+// Abort cleanly (and Finish must fail, not crash). Regression guard for
+// the external parity review's finding — Engine.fs() read through e.db,
+// which Close nils, so Abort's staging-dir teardown nil-panicked; fs()
+// now serves the Open-time resolvedFS snapshot, which outlives db.
+func TestBulkImportAbortAfterEngineClose(t *testing.T) {
+	ctx := context.Background()
+	store, b := startBulkImport(t, ctx)
+	require.NoError(t, b.AddResourceTypes(ctx, v2.ResourceType_builder{Id: "app"}.Build()))
+
+	require.NoError(t, store.PebbleEngine().Close())
+	require.NotPanics(t, b.Abort, "Abort after engine Close must tear down staging dirs, not panic")
+
+	// And the other retained-handle shape: Finish after Abort/Close is
+	// an ordinary error.
+	require.Error(t, b.Finish(ctx))
+}
+
 // TestBulkImportEntitlementIdentityOrderDivergesFromExternalID pins the fix
 // for the AddEntitlements ordering bug: the converter feeds entitlements in
 // external-id string order, which does NOT match structural-identity tuple

--- a/pkg/dotc1z/engine/pebble/choke_point_meta_test.go
+++ b/pkg/dotc1z/engine/pebble/choke_point_meta_test.go
@@ -1,0 +1,339 @@
+package pebble
+
+// Meta-tests for the write choke point (internal/rawdb). This is the
+// INVERTED form of the old declare-your-raw-writes registry: instead
+// of every raw-writing file carrying a declaration, raw-write
+// primitives may not appear OUTSIDE internal/rawdb at all — the
+// compiler enforces it for real code (the raw *pebble.DB and the
+// generic batch/set/delete primitives are unexported there), and this
+// test closes the textual gaps the compiler can't see:
+//
+//  1. No production file in this package may reference the raw pebble
+//     write surface (a reintroduced *pebble.Batch field, a direct
+//     pebble.Open, a resurrected generic method on rawdb.DB).
+//  2. rawdb itself must keep its generic primitives unexported — an
+//     exported generic Set/Delete/NewBatch would reduce the choke
+//     point to an import-path convention.
+//  3. UnsafeForTesting() — the single raw escape hatch — may appear
+//     only in _test.go files, anywhere in the engine's client tree
+//     (this package, pkg/dotc1z, pkg/synccompactor).
+
+import (
+	"go/ast"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// rawWriteSignals are textual markers of raw pebble write usage that
+// must not appear in this package's production code outside
+// internal/rawdb. Kept call-shaped (trailing "(") or type-shaped so
+// prose comments don't false-positive; a genuinely innocent new match
+// belongs behind a rawdb family op anyway.
+var rawWriteSignals = []string{
+	"*pebble.Batch",
+	"pebble.Open(",
+	".db.Set(",
+	".db.Delete(",
+	".db.DeleteRange(",
+	".db.NewBatch(",
+	".db.Apply(",
+	".db.Ingest(",
+	".db.IngestAndExcise(",
+	".db.Excise(",
+	".db.LogData(",
+}
+
+func TestRawWriteSignalsOnlyInsideRawDB(t *testing.T) {
+	// Recursive: subpackages (codec, microtests) are inside the choke
+	// point's blast radius too — a *pebble.Batch surfacing in a
+	// subpackage API is a raw-write conduit exactly like one here.
+	err := filepath.WalkDir(".", func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if filepath.Clean(path) == filepath.Clean("internal/rawdb") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		name := d.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			return nil
+		}
+		src, readErr := os.ReadFile(path) //nolint:gosec // meta-test walking the repo's own source tree
+		if readErr != nil {
+			return readErr
+		}
+		for _, signal := range rawWriteSignals {
+			require.NotContainsf(t, string(src), signal,
+				"%s contains raw pebble write signal %q.\n"+
+					"Raw writes live ONLY inside internal/rawdb — add or extend a purpose-named family operation there "+
+					"(and state its obligations) instead of reintroducing a raw path.", path, signal)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+// TestRawDBExportsNoRawPebbleSurface parses internal/rawdb's AST and
+// rejects any EXPORTED function, method, struct field, or type alias
+// whose signature exposes a raw pebble write conduit (*pebble.DB,
+// *pebble.Batch, or a callback carrying either). Name-based checks
+// were bypassable (a future `WithRawDB(func(*pebble.DB))` or
+// `RawBatch() *pebble.Batch` would have passed a fixed-name list); a
+// type-based check makes the enforcement track what actually matters —
+// whether raw write capability can escape the package. The single
+// sanctioned exception is UnsafeForTesting (the testing.Testing()-
+// gated escape hatch).
+func TestRawDBExportsNoRawPebbleSurface(t *testing.T) {
+	fset, files := parseProductionDir(t, "internal/rawdb")
+
+	// rawConduit reports whether a type expression mentions pebble.DB
+	// or pebble.Batch (at any pointer/func/slice nesting depth).
+	var rawConduit func(expr ast.Expr) bool
+	rawConduit = func(expr ast.Expr) bool {
+		switch e := expr.(type) {
+		case *ast.StarExpr:
+			return rawConduit(e.X)
+		case *ast.SelectorExpr:
+			ident, ok := e.X.(*ast.Ident)
+			return ok && ident.Name == "pebble" && (e.Sel.Name == "DB" || e.Sel.Name == "Batch")
+		case *ast.FuncType:
+			if e.Params != nil {
+				for _, f := range e.Params.List {
+					if rawConduit(f.Type) {
+						return true
+					}
+				}
+			}
+			if e.Results != nil {
+				for _, f := range e.Results.List {
+					if rawConduit(f.Type) {
+						return true
+					}
+				}
+			}
+			return false
+		case *ast.ArrayType:
+			return rawConduit(e.Elt)
+		case *ast.MapType:
+			return rawConduit(e.Key) || rawConduit(e.Value)
+		case *ast.ChanType:
+			return rawConduit(e.Value)
+		}
+		return false
+	}
+
+	for _, f := range files {
+		ast.Inspect(f, func(n ast.Node) bool {
+			switch decl := n.(type) {
+			case *ast.FuncDecl:
+				if !decl.Name.IsExported() || decl.Name.Name == "UnsafeForTesting" {
+					return true
+				}
+				if rawConduit(&ast.FuncType{Params: decl.Type.Params, Results: decl.Type.Results}) {
+					t.Errorf("%s: exported %s exposes a raw pebble write conduit in its signature.\n"+
+						"The choke point's enforcement rests on raw capability never escaping internal/rawdb; "+
+						"add a purpose-named family operation instead.", fset.Position(decl.Pos()), decl.Name.Name)
+				}
+			case *ast.TypeSpec:
+				if !decl.Name.IsExported() {
+					return true
+				}
+				if st, ok := decl.Type.(*ast.StructType); ok {
+					for _, field := range st.Fields.List {
+						exported := len(field.Names) == 0 // embedded
+						for _, n := range field.Names {
+							if n.IsExported() {
+								exported = true
+							}
+						}
+						if exported && rawConduit(field.Type) {
+							t.Errorf("%s: exported type %s carries a raw pebble conduit in an exported field.",
+								fset.Position(field.Pos()), decl.Name.Name)
+						}
+					}
+				}
+				if rawConduit(decl.Type) {
+					t.Errorf("%s: exported type %s aliases a raw pebble conduit.",
+						fset.Position(decl.Pos()), decl.Name.Name)
+				}
+			}
+			return true
+		})
+	}
+}
+
+// walkClientTreeProductionGoFiles walks the engine's client tree
+// (this package + pkg/dotc1z + pkg/synccompactor) and yields every
+// production (non-_test) .go file's path and contents.
+func walkClientTreeProductionGoFiles(t *testing.T, visit func(root, path string, src []byte)) {
+	t.Helper()
+	roots := []string{
+		".",                      // this package (incl. internal/rawdb via walk)
+		"../..",                  // pkg/dotc1z (store layer)
+		"../../../synccompactor", // the DB() exemption client
+	}
+	for _, root := range roots {
+		err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				// Don't wander into the engine tree twice from "../..".
+				if root == "../.." && d.Name() == "engine" {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			name := d.Name()
+			if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+				return nil
+			}
+			src, readErr := os.ReadFile(path) //nolint:gosec // meta-test walking the repo's own source tree; no untrusted paths
+			if readErr != nil {
+				return readErr
+			}
+			visit(root, path, src)
+			return nil
+		})
+		require.NoError(t, err)
+	}
+}
+
+// TestUnsafeForTestingOnlyInTests walks the engine's client tree and
+// forbids the raw escape hatch outside _test.go files. The runtime
+// testing.Testing() panic already guards execution; this pins the
+// SOURCE so a production call site can't even ship dormant.
+func TestUnsafeForTestingOnlyInTests(t *testing.T) {
+	walkClientTreeProductionGoFiles(t, func(root, path string, src []byte) {
+		// The definition and its MergeView delegation are exempt — by
+		// EXACT path under this package's root only, so a spoofed
+		// nested .../internal/rawdb/ tree elsewhere cannot smuggle a
+		// production call site past the check (review finding, round 1
+		// of PR 2).
+		if root == "." && filepath.Clean(path) == filepath.Clean("internal/rawdb/rawdb.go") {
+			return
+		}
+		// The signal is USE-shaped — a selector (`x.UnsafeForTesting`),
+		// whitespace-tolerant so gofmt's multi-line chains
+		// (`eng.DB().\n\tUnsafeForTesting()`) still match (review
+		// finding, delta round). Covers direct calls, method values,
+		// and method expressions ((*T).UnsafeForTesting); a bare
+		// method DECLARATION doesn't match — a declaration grants
+		// nothing by itself, and any static production use goes
+		// through a selector. Known residual: reflection
+		// (MethodByName("Unsafe"+"ForTesting")) evades any source
+		// scan; the testing.Testing() runtime panic is the backstop
+		// that makes such a call inert in production.
+		require.Falsef(t, unsafeForTestingUse.Match(src),
+			"%s uses UnsafeForTesting in production code. The escape hatch exists solely for test "+
+				"fixtures constructing states the production API cannot express; production writes go "+
+				"through a rawdb family operation.", path)
+	})
+}
+
+// Selector-use signals for the source fences below: a dot immediately
+// followed by the name (`x.UnsafeForTesting`), or a dot at the end of
+// a line with the name on the gofmt continuation line
+// (`eng.DB().\n\tUnsafeForTesting()`). Deliberately NOT `\.\s*`: that
+// would also match prose in doc comments ("... delta round).
+// UnsafeForTesting stays ..."), and a same-line space between dot and
+// selector isn't a form gofmt'd code can take.
+var (
+	unsafeForTestingUse = regexp.MustCompile(`\.(\n\s*)?UnsafeForTesting\b`)
+	newFoldBatchUse     = regexp.MustCompile(`\.(\n\s*)?NewFoldBatch\b`)
+)
+
+// TestSeamsArmedOnlyInTests forbids ARMING the Engine's test-seam
+// field (Engine.test / testSeams, test_seams.go) outside _test.go
+// files. The seams stay compiled into production builds — build-tag
+// stripping was considered and rejected (a library can't control its
+// consumers' tags, and a default-off tag would make plain
+// `go test ./...` silently skip the crash-contract tests) — so this
+// fence is what keeps them permanently disarmed there: production
+// code may nil-check a hook, never install one.
+//
+// AST-based, not textual: it flags (a) any assignment whose LHS goes
+// through a `.test` selector (`e.test.hook = f`, `e.test = seams`)
+// and (b) any address-capture of it (`p := &e.test`, `&e.test.hook`),
+// which closes the aliasing route a substring scan misses (capture
+// the pointer once, assign through it later, no `.test` in sight).
+// Scope is exactly this package's production files: the fields are
+// unexported, so the compiler already guarantees no other package can
+// reach them.
+func TestSeamsArmedOnlyInTests(t *testing.T) {
+	fset, files := parseProductionDir(t, ".")
+
+	// throughTestField reports whether expr is, or dereferences into, a
+	// selector chain containing the field name "test" (Engine has no
+	// other field or method of that name, and this scan covers only
+	// this package).
+	var throughTestField func(expr ast.Expr) bool
+	throughTestField = func(expr ast.Expr) bool {
+		switch e := expr.(type) {
+		case *ast.SelectorExpr:
+			return e.Sel.Name == "test" || throughTestField(e.X)
+		case *ast.IndexExpr:
+			return throughTestField(e.X)
+		case *ast.ParenExpr:
+			return throughTestField(e.X)
+		case *ast.StarExpr:
+			return throughTestField(e.X)
+		}
+		return false
+	}
+
+	for _, f := range files {
+		ast.Inspect(f, func(n ast.Node) bool {
+			switch node := n.(type) {
+			case *ast.AssignStmt:
+				for _, lhs := range node.Lhs {
+					if throughTestField(lhs) {
+						t.Errorf("%s: assignment through Engine.test in production code. The seams exist "+
+							"solely for tests to inject failures and crash cuts; production paths must never "+
+							"arm them.", fset.Position(node.Pos()))
+					}
+				}
+			case *ast.UnaryExpr:
+				if node.Op == token.AND && throughTestField(node.X) {
+					t.Errorf("%s: address-capture of Engine.test in production code — an alias would let a "+
+						"later assignment arm a seam without naming .test. Pass the hook's VALUE if production "+
+						"code ever needs one.", fset.Position(node.Pos()))
+				}
+			}
+			return true
+		})
+	}
+}
+
+// TestFoldBatchOnlyInCompactor fences the one raw record-write conduit
+// the narrowed DB() handle carries: NewFoldBatch (generic Set/Delete/
+// Commit over record keyspaces, obligations handled by the fold
+// contract instead of derivation). Its only sanctioned production
+// clients are the fold compactor (pkg/synccompactor/pebble) and rawdb
+// itself; a NewFoldBatch call appearing anywhere else is a caller
+// routing around the typed Stage* obligations (review finding, delta
+// round: the DB() handle must not quietly become a second engine
+// write path).
+func TestFoldBatchOnlyInCompactor(t *testing.T) {
+	sep := string(filepath.Separator)
+	walkClientTreeProductionGoFiles(t, func(root, path string, src []byte) {
+		if root == "." && strings.HasPrefix(filepath.Clean(path), filepath.Clean("internal/rawdb")+sep) {
+			return // the definition + MergeView delegation
+		}
+		if root == "../../../synccompactor" && strings.Contains(filepath.ToSlash(filepath.Clean(path)), "/pebble/") {
+			return // the sanctioned fold-compactor client
+		}
+		require.Falsef(t, newFoldBatchUse.Match(src),
+			"%s uses NewFoldBatch outside the fold compactor. FoldBatch bypasses typed record staging "+
+				"by contract; record writes anywhere else go through a RecordBatch Stage* operation.", path)
+	})
+}

--- a/pkg/dotc1z/engine/pebble/cleanup.go
+++ b/pkg/dotc1z/engine/pebble/cleanup.go
@@ -92,7 +92,7 @@ func (e *Engine) ResetForNewSync(ctx context.Context) error {
 	// engine stays sealed until MarkFreshSync unseals it right after.
 	return e.withWriteAllowSealed(func() error {
 		for _, span := range spans {
-			if err := e.db.Excise(ctx, span); err != nil {
+			if err := e.db.ExciseRange(ctx, span); err != nil {
 				return fmt.Errorf("ResetForNewSync: excise [%x, %x): %w", span.Start, span.End, err)
 			}
 		}
@@ -206,10 +206,10 @@ func (e *Engine) Flush(ctx context.Context) error {
 	if e.closing.Load() {
 		return ErrEngineClosing
 	}
-	if err := e.db.Flush(); err != nil {
+	if err := e.db.FlushMemtables(); err != nil {
 		return fmt.Errorf("engine: flush: %w", err)
 	}
-	if err := e.db.LogData(nil, pebble.Sync); err != nil {
+	if err := e.db.WALSyncPoint(); err != nil {
 		return fmt.Errorf("engine: fsync WAL: %w", err)
 	}
 	return nil

--- a/pkg/dotc1z/engine/pebble/codec/reflect.go
+++ b/pkg/dotc1z/engine/pebble/codec/reflect.go
@@ -3,7 +3,6 @@ package codec
 import (
 	"fmt"
 
-	"github.com/cockroachdb/pebble/v2"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
@@ -62,12 +61,4 @@ func (c *ReflectCodec) DecodeValue(b []byte, dst proto.Message) error {
 			ErrCodecTypeMismatch, c.md.FullName(), dst.ProtoReflect().Descriptor().FullName())
 	}
 	return proto.Unmarshal(b, dst)
-}
-
-func (c *ReflectCodec) WriteIndexes(batch *pebble.Batch, msg proto.Message) error {
-	return ErrReflectMissingTable
-}
-
-func (c *ReflectCodec) DeleteIndexes(batch *pebble.Batch, msg proto.Message) error {
-	return ErrReflectMissingTable
 }

--- a/pkg/dotc1z/engine/pebble/codec/registry.go
+++ b/pkg/dotc1z/engine/pebble/codec/registry.go
@@ -3,7 +3,6 @@ package codec
 import (
 	"sync"
 
-	"github.com/cockroachdb/pebble/v2"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
@@ -32,14 +31,12 @@ type Codec interface {
 	// as the registered codec; mismatches return ErrCodecTypeMismatch.
 	DecodeValue(b []byte, dst proto.Message) error
 
-	// WriteIndexes appends all secondary-index entries for msg to
-	// batch. Called inside a pebble.Batch alongside the primary write.
-	WriteIndexes(batch *pebble.Batch, msg proto.Message) error
-
-	// DeleteIndexes appends index-entry deletions for msg to batch.
-	// Called during overwrite (after reading the previous value) and
-	// during explicit Delete. Same atomicity as WriteIndexes.
-	DeleteIndexes(batch *pebble.Batch, msg proto.Message) error
+	// NOTE: the interface once carried WriteIndexes/DeleteIndexes
+	// methods taking a raw pebble batch. They were vestigial (the only
+	// implementer returned ErrReflectMissingTable; no caller existed)
+	// and were removed when the write choke point (internal/rawdb)
+	// made raw batches unmintable outside rawdb — index staging is a
+	// rawdb family obligation now, not a codec concern.
 }
 
 // registry holds the codecs registered by generated init() functions.

--- a/pkg/dotc1z/engine/pebble/deferred_index.go
+++ b/pkg/dotc1z/engine/pebble/deferred_index.go
@@ -86,6 +86,22 @@ func appendGrantByPrincipalKeyFromPrimary(dst, primaryKey []byte) ([]byte, bool)
 	return dst, true
 }
 
+// appendGrantByNeedsExpansionKeyFromPrimary builds the
+// by_needs_expansion index key directly from a primary grant key: the
+// primary's separator+tail IS the index key's tail, byte-identical
+// (pinned by TestNeedsExpansionKeyHeaderSpliceFromPrimary), so the
+// splice is a header swap. Validates the same 6-segment shape as the
+// by_principal splice so a malformed key cannot silently produce a
+// malformed index entry. Wired into rawdb's typed record ops
+// (RecordDerivers.GrantNeedsExpansionKey).
+func appendGrantByNeedsExpansionKeyFromPrimary(dst, primaryKey []byte) ([]byte, bool) {
+	if _, ok := splitGrantPrimaryKey(primaryKey); !ok {
+		return dst, false
+	}
+	dst = append(dst, versionV3, typeIndex, idxGrantByNeedsExpansion)
+	return append(dst, primaryKey[2:]...), true
+}
+
 // deferredGrantStats carries the grant-keyspace stats accumulated during the
 // BuildDeferredGrantIndexes scan: the same numbers computeSyncStats derives
 // from its own full grant scan. Fusing them into the index scan removes a
@@ -525,7 +541,7 @@ func (e *Engine) buildDeferredGrantIndexesLocked(ctx context.Context) error {
 			zap.Int64("rows_rebuilt", rebuilt.rows),
 		)
 	case len(rebuilt.files) > 0:
-		if _, err := e.db.IngestAndExcise(ctx, rebuilt.files, nil, nil, pebble.KeyRange{
+		if err := e.db.ReplaceRangeWithSSTs(ctx, rebuilt.files, pebble.KeyRange{
 			Start: GrantLowerBound(),
 			End:   GrantUpperBound(),
 		}); err != nil {
@@ -564,7 +580,7 @@ func (e *Engine) buildDeferredGrantIndexesLocked(ctx context.Context) error {
 		}
 		mergeDone := time.Now()
 
-		_, err = e.db.IngestAndExcise(ctx, []string{sstPath}, nil, nil, pebble.KeyRange{
+		err = e.db.ReplaceRangeWithSSTs(ctx, []string{sstPath}, pebble.KeyRange{
 			Start: GrantByPrincipalLowerBound(),
 			End:   GrantByPrincipalUpperBound(),
 		})

--- a/pkg/dotc1z/engine/pebble/digest.go
+++ b/pkg/dotc1z/engine/pebble/digest.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/pebble/v2"
+
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/rawdb"
 )
 
 // Bucketed XOR set digests over bucket-hash indexes.
@@ -431,22 +433,22 @@ func (e *Engine) buildPartitionDigestAtWidth(ctx context.Context, spec digestInd
 			return err
 		}
 
-		batch := e.db.NewBatch()
+		batch := e.db.NewDigestBatch()
 		defer batch.Close()
 
 		// Clear any prior build (see function comment). In-batch
 		// ordering makes this safe: the Sets below land after the
 		// tombstone and survive it.
-		if err := batch.DeleteRange(nodeLower, nodeUpper, nil); err != nil {
+		if err := batch.DeleteRange(nodeLower, nodeUpper); err != nil {
 			return err
 		}
 		rootKey := encodeDigestNodeKey(spec.indexID, partition, digestLevelRoot, nil)
-		if err := batch.Set(rootKey, rootVal, nil); err != nil {
+		if err := batch.Set(rootKey, rootVal); err != nil {
 			return err
 		}
 		for i := range leaves {
 			key := encodeDigestNodeKey(spec.indexID, partition, digestLevelLeaf, leaves[i].prefix[:])
-			if err := batch.Set(key, leaves[i].val, nil); err != nil {
+			if err := batch.Set(key, leaves[i].val); err != nil {
 				return err
 			}
 		}
@@ -751,7 +753,7 @@ func (e *Engine) dirtyPartitionBuckets(ctx context.Context, spec digestIndexSpec
 // holding a built digest use this instead of updating nodes in place:
 // under the present-means-exact contract, a mutated partition's digest
 // is simply MISSING until the next seal-time build recalculates it.
-func dropPartitionDigest(batch *pebble.Batch, spec digestIndexSpec, partition string) error {
+func dropPartitionDigest(batch rawdb.Stager, spec digestIndexSpec, partition string) error {
 	lo := encodeDigestPartitionPrefix(spec.indexID, partition)
-	return batch.DeleteRange(lo, upperBoundOf(lo), nil)
+	return batch.DeleteRange(lo, upperBoundOf(lo))
 }

--- a/pkg/dotc1z/engine/pebble/engine.go
+++ b/pkg/dotc1z/engine/pebble/engine.go
@@ -202,6 +202,18 @@ func Open(ctx context.Context, dir string, opts ...Option) (*Engine, error) {
 
 	pebbleOpts := newPebbleOptions(o)
 
+	// DELIBERATE ASYMMETRY (do not "fix"): rawdb gets the UNWRAPPED FS
+	// (o.vfs, nil → vfs.Default), while pebble.Open internally wraps
+	// its clone of pebbleOpts.FS with disk-health middleware. So the
+	// DB's own IO is health-monitored but engine-managed IO through
+	// fs() (staged SSTs, checkpoint WAL cleanup) is not — exactly
+	// main's split, where staging was plain os.* (pinned in PR-1
+	// review: "only pebble's own IO gets the disk-health wrap").
+	// Passing the wrapped FS here would put staging writes under
+	// pebble's stall escalation (Logger.Fatalf on slow disks) — a
+	// production behavior change, not a cleanup. Both objects sit on
+	// the same underlying filesystem, so files interoperate; the
+	// MemFS lifecycle test pins that.
 	db, err := rawdb.Open(dir, pebbleOpts, o.vfs)
 	if err != nil {
 		// pebble.Open failure path: we minted a Cache (when no shared
@@ -219,6 +231,7 @@ func Open(ctx context.Context, dir string, opts ...Option) (*Engine, error) {
 		dbDir:      dir,
 		opts:       o,
 		pebbleOpts: pebbleOpts,
+		resolvedFS: db.FS(),
 	}
 	if s, ok := pebbleOpts.Experimental.CompactionScheduler.(*pausableCompactionScheduler); ok {
 		e.compactionScheduler = s

--- a/pkg/dotc1z/engine/pebble/engine.go
+++ b/pkg/dotc1z/engine/pebble/engine.go
@@ -17,6 +17,7 @@ import (
 
 	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/codec"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/rawdb"
 )
 
 // Engine is the v3 Pebble-backed storage engine. Methods are
@@ -27,10 +28,18 @@ import (
 //   - Close() releases all resources. After Close, all methods return
 //     ErrEngineClosing.
 type Engine struct {
-	db         *pebble.DB
+	// db is the write choke point: the raw *pebble.DB lives inside
+	// internal/rawdb and is reachable only through rawdb's exported,
+	// purpose-named operations (reads are passed through liberally).
+	// See the rawdb package doc for the enforcement model.
+	db         *rawdb.DB
 	dbDir      string
 	opts       *Options
 	pebbleOpts *pebble.Options
+	// resolvedFS is rawdb's Open-time FS resolution (WithVFS override
+	// or vfs.Default), snapshotted so fs() stays valid after Close
+	// nils db — see fs().
+	resolvedFS vfs.FS
 
 	// currentSync is the engine's open sync_id (raw 20-byte KSUID).
 	// Set by StartNewSync / ResumeSync / SetCurrentSync. Empty when
@@ -104,15 +113,10 @@ type Engine struct {
 	// built" instead of trusting nodes a crashed build half-committed.
 	grantDigestBuildPending atomic.Bool
 
-	// Test seams for the digest build/repair tests: a hook fired at
-	// named points inside buildGrantDigestsFromSpill
-	// (grant_digest_build_crash_test.go) and a batch flush-threshold
-	// override — shared by the build's fold and the streaming partition
-	// repair (repairOneGrantDigestPartitionLocked) — so a small test
-	// dataset exercises the mid-stream commit paths. Nil/zero in
-	// production.
-	testDigestBuildHook      func(stage string) error
-	testDigestNodeFlushBytes int
+	// test holds every test-only injection seam, sequestered on one
+	// field so hooks don't accumulate on the production struct. All
+	// zero in production; see testSeams (test_seams.go).
+	test testSeams
 
 	// synthLayer is the open wave-scoped layer session, if any (see
 	// BeginSynthesizedGrantLayer). Single producer: the expansion driver
@@ -198,7 +202,7 @@ func Open(ctx context.Context, dir string, opts ...Option) (*Engine, error) {
 
 	pebbleOpts := newPebbleOptions(o)
 
-	db, err := pebble.Open(dir, pebbleOpts)
+	db, err := rawdb.Open(dir, pebbleOpts, o.vfs)
 	if err != nil {
 		// pebble.Open failure path: we minted a Cache (when no shared
 		// cache was supplied) and won't reach Engine.Close. Unref it
@@ -218,6 +222,32 @@ func Open(ctx context.Context, dir string, opts ...Option) (*Engine, error) {
 	}
 	if s, ok := pebbleOpts.Experimental.CompactionScheduler.(*pausableCompactionScheduler); ok {
 		e.compactionScheduler = s
+	}
+	// Wire the record derivers: the key-format functions rawdb's typed
+	// record ops (StageGrant*/StageResource*/...) derive their
+	// obligations with. rawdb owns the composition — WHAT a record
+	// mutation must stage together, unforgettable by construction — and
+	// these closures own the byte formats (this package's keyspace ABI,
+	// pinned by its splice tests) plus the engine-state gates (digest
+	// armed probe, deferred-marker crash contract).
+	if err := db.SetRecordDerivers(rawdb.RecordDerivers{
+		GrantKeyValid: func(primaryKey []byte) bool {
+			_, ok := splitGrantPrimaryKey(primaryKey)
+			return ok
+		},
+		GrantByPrincipalKey:          appendGrantByPrincipalKeyFromPrimary,
+		GrantNeedsExpansionKey:       appendGrantByNeedsExpansionKeyFromPrimary,
+		StageGrantDigestInvalidation: e.stageGrantDigestInvalidationFromPrimaryKey,
+		ArmDeferredGrantIndex:        e.markDeferredIdxPending,
+		ResourceParent:               scanResourceParentRaw,
+		ResourceByParentKey:          encodeResourceByParentIndexKey,
+		GrantPrimaryPrefix:           []byte{versionV3, typeGrant},
+		ResourcePrimaryPrefix:        []byte{versionV3, typeResource},
+		EntitlementPrimaryPrefix:     []byte{versionV3, typeEntitlement},
+		ResourceTypePrimaryPrefix:    []byte{versionV3, typeResourceType},
+	}); err != nil {
+		_ = e.Close()
+		return nil, err
 	}
 	// Enforce the single-sync key-layout contract before touching any
 	// keys: reject an old multi-sync-layout file (which the current
@@ -314,7 +344,7 @@ func (e *Engine) Close() error {
 	// harden. A no-op when the memtable is already empty.
 	var err error
 	if !e.opts.readOnly {
-		if ferr := e.db.Flush(); ferr != nil {
+		if ferr := e.db.FlushMemtables(); ferr != nil {
 			err = fmt.Errorf("flush during close: %w", ferr)
 		}
 	}
@@ -500,11 +530,12 @@ func (e *Engine) EndFreshSync(ctx context.Context) error {
 			return nil
 		}
 		// Flush the memtable (turns NoSync-buffered writes into on-disk
-		// SSTs) and let pebble.LogData with Sync force-fsync the WAL tail.
-		if err := e.db.Flush(); err != nil {
+		// SSTs) and force-fsync the WAL tail (rawdb.WALSyncPoint =
+		// pebble.LogData(nil, Sync)).
+		if err := e.db.FlushMemtables(); err != nil {
 			return fmt.Errorf("EndFreshSync: flush: %w", err)
 		}
-		if err := e.db.LogData(nil, pebble.Sync); err != nil {
+		if err := e.db.WALSyncPoint(); err != nil {
 			return fmt.Errorf("EndFreshSync: fsync WAL: %w", err)
 		}
 		e.clearCurrentSync()
@@ -653,13 +684,30 @@ func (e *Engine) CurrentDBSizeBytes() (int64, error) {
 	return total, nil
 }
 
-// DB returns the underlying *pebble.DB. Exported for the
-// synccompactor/pebble package; callers must not Close it directly
-// (use Engine.Close) and must respect the engine's lifecycle. Returns
-// nil after Close. Callers that write the entitlement keyspace through
-// this handle (ingests, excises) must call InvalidateBareIDLookups
-// afterwards.
-func (e *Engine) DB() *pebble.DB { return e.db }
+// DB returns the engine's rawdb handle — the write choke point's
+// EXPLICIT EXEMPTION SURFACE. Exported for the synccompactor/pebble
+// package, whose merge/fold/overlay machinery writes the record
+// keyspaces outside the engine's writeMu barrier (fenced by call
+// ordering: the merge completes before the store's save/CheckpointTo
+// runs — see the checkpointMu inventory). The handle is *MergeDB
+// (= rawdb.MergeView) — deliberately NARROWER than *rawdb.DB: it
+// carries only the reads, bulk range ops, and the FoldBatch
+// constructor (the compactor's raw record-write conduit, fenced to
+// pkg/synccompactor/pebble by meta-test), so an external caller
+// cannot reach typed record staging
+// (NewRecordBatch) or session/meta/digest writes outside the engine's
+// lifecycle barrier — not even by type assertion, since the concrete
+// view has nothing more to recover. The raw *pebble.DB stays
+// unreachable (UnsafeForTesting is runtime-gated to tests). Callers
+// must respect the engine's lifecycle; returns nil after Close.
+// Callers that write the entitlement keyspace through this handle
+// (ingests, excises) must call InvalidateBareIDLookups afterwards.
+func (e *Engine) DB() *MergeDB {
+	if e.db == nil {
+		return nil
+	}
+	return e.db.MergeView()
+}
 
 // InvalidateBareIDLookups invalidates the lazily built bare-id lookup
 // state (see lookup.go). Engine write paths call this internally; it is
@@ -674,11 +722,16 @@ func (e *Engine) MigratedOnOpen() bool { return e.migratedOnOpen }
 // the WithVFS override when set, vfs.Default otherwise. This must be
 // the same FS the pebble.DB reads from — the staged SSTs the engine
 // hands to Ingest/IngestAndExcise are resolved through the DB's FS.
+//
+// Snapshotted from the rawdb handle at Open (resolvedFS) rather than
+// read through e.db on every call: Close nils e.db, but cleanup paths
+// legitimately outlive it — a retained BulkSyncImport's Abort/Finish
+// tears down its staging dirs through fs() after the engine closed
+// (review finding, external parity round: the e.db.FS() form
+// nil-panicked there, where main's opts-based fs() was safe). The
+// snapshot is a copy of rawdb's one resolution, not a second decision.
 func (e *Engine) fs() vfs.FS {
-	if e.opts.vfs != nil {
-		return e.opts.vfs
-	}
-	return vfs.Default
+	return e.resolvedFS
 }
 
 // prepareStagingDir mints a unique staging directory via os.MkdirTemp
@@ -758,13 +811,28 @@ func (e *Engine) CheckpointTo(ctx context.Context, destDir string) error {
 		return copyReadOnlyDBDir(e.fs(), e.dbDir, destDir)
 	}
 
-	if err := e.db.Flush(); err != nil {
+	if err := e.db.FlushMemtables(); err != nil {
 		return fmt.Errorf("checkpoint flush: %w", err)
 	}
 	if err := e.db.Checkpoint(destDir); err != nil {
 		return fmt.Errorf("checkpoint db %s: %w", destDir, err)
 	}
 	if err := truncateCheckpointWALs(e.fs(), destDir); err != nil {
+		// The checkpoint itself succeeded, so destDir exists; a caller
+		// that retries CheckpointTo with the same path would otherwise
+		// hard-fail pebble Checkpoint's dest-must-not-exist contract.
+		// Removal keeps the failure retryable (the clone-sync caller
+		// uses a fresh temp dir either way). If the removal ALSO fails
+		// — plausible, since whatever broke the truncate may still be
+		// broken — same-path retryability is NOT restored, so the
+		// cleanup failure rides along in the returned error instead of
+		// being swallowed.
+		if rmErr := e.fs().RemoveAll(destDir); rmErr != nil {
+			return errors.Join(
+				fmt.Errorf("checkpoint truncate WALs: %w", err),
+				fmt.Errorf("cleanup of %s also failed (retry needs a fresh dest or manual removal): %w", destDir, rmErr),
+			)
+		}
 		return fmt.Errorf("checkpoint truncate WALs: %w", err)
 	}
 

--- a/pkg/dotc1z/engine/pebble/entitlements.go
+++ b/pkg/dotc1z/engine/pebble/entitlements.go
@@ -31,7 +31,7 @@ func (e *Engine) PutEntitlementRecords(ctx context.Context, records ...*v3.Entit
 		if err := e.requireCurrentSync(); err != nil {
 			return err
 		}
-		priBatch := e.db.NewBatch()
+		priBatch := e.db.NewRecordBatch()
 		defer priBatch.Close()
 
 		fresh := e.IsFreshSync()
@@ -72,7 +72,7 @@ func (e *Engine) PutEntitlementRecords(ctx context.Context, records ...*v3.Entit
 			if err != nil {
 				return err
 			}
-			if err := priBatch.Set(key, val, nil); err != nil {
+			if err := priBatch.StageEntitlementPut(key, val); err != nil {
 				return err
 			}
 		}
@@ -120,9 +120,9 @@ func (e *Engine) DeleteEntitlementRecord(ctx context.Context, externalID string)
 			return err
 		}
 		key := encodeEntitlementIdentityKey(id)
-		batch := e.db.NewBatch()
+		batch := e.db.NewRecordBatch()
 		defer batch.Close()
-		if err := batch.Delete(key, nil); err != nil {
+		if err := batch.StageEntitlementDelete(key); err != nil {
 			return err
 		}
 		if err := batch.Commit(writeOpts(e.opts.durability)); err != nil {

--- a/pkg/dotc1z/engine/pebble/errorfs_sweep_test.go
+++ b/pkg/dotc1z/engine/pebble/errorfs_sweep_test.go
@@ -320,16 +320,20 @@ func (w sweepWorkload) expectedEntIDsPerPrincipal() []string {
 // duplicated, dropped, or cross-wired rows while keeping counts
 // plausible fails here.
 //
-// requireDigests: whether the digest oracle must find digest state
-// PRESENT (see verifyDigests) — true whenever the finishing EndSync
-// ran without injection (resumed/restarted/uninjected images), false
-// for images whose EndSync completed under an armed injector.
-// Production policy is technically weaker — EndSync downgrades ANY
-// digest build failure to a loud full drop and still finishes — but
-// on this harness's clean engines (MemFS, no injector) a soft digest
-// failure has no legitimate cause, so the oracle deliberately fails
-// CLOSED on it rather than shrugging it off as a legal drop.
-func (w sweepWorkload) verifyComplete(ctx context.Context, t *testing.T, e *Engine, syncID string, requireDigests bool, label string) {
+// requireDigests / requireStats: whether the optional-artifact legs
+// (verifyDigests / verifyStatsSidecar) must find their artifact
+// PRESENT — true whenever the finishing EndSync ran without injection
+// (resumed/restarted/uninjected images), false for images whose
+// EndSync completed under an armed injector. Production policy is
+// technically weaker — EndSync downgrades a digest build failure to a
+// loud full drop and a stats write failure to a warning, and still
+// finishes — but on this harness's clean engines (MemFS, no injector)
+// a soft failure of either has no legitimate cause, so the oracle
+// deliberately fails CLOSED rather than shrugging it off. Split into
+// two flags because the stamp-window tests cut their crash image
+// AFTER the digest build but BEFORE the stats write — digests owed,
+// stats structurally absent.
+func (w sweepWorkload) verifyComplete(ctx context.Context, t *testing.T, e *Engine, syncID string, requireDigests, requireStats bool, label string) {
 	t.Helper()
 	rec, err := e.GetSyncRunRecord(ctx, syncID)
 	require.NoErrorf(t, err, "%s: sync run record must exist", label)
@@ -372,6 +376,35 @@ func (w sweepWorkload) verifyComplete(ctx context.Context, t *testing.T, e *Engi
 	}
 
 	w.verifyDigests(ctx, t, e, requireDigests, label)
+	w.verifyStatsSidecar(ctx, t, e, syncID, requireStats, label)
+}
+
+// verifyStatsSidecar is the stats leg of the content oracle, closing
+// the sweep's last artifact blind spot (a torn or missing sidecar
+// previously passed verifyComplete). Same optional-artifact policy as
+// digests: PersistSyncStats failures are downgraded to a warning by
+// design, so an image whose finishing EndSync ran under injection may
+// legally lack the sidecar — but a PRESENT sidecar must be EXACT,
+// matching an independent O(N) recount of the image's keyspaces, and
+// an uninjected finish has no legitimate reason to lack it.
+func (w sweepWorkload) verifyStatsSidecar(ctx context.Context, t *testing.T, e *Engine, syncID string, requirePresent bool, label string) {
+	t.Helper()
+	stored, err := e.readSyncStats(ctx, syncID)
+	require.NoErrorf(t, err, "%s: stats sidecar must read cleanly (torn sidecar)", label)
+	if stored == nil {
+		require.Falsef(t, requirePresent,
+			"%s: stats sidecar absent on an image whose finishing EndSync ran uninjected — PersistSyncStats cannot legitimately have failed", label)
+		t.Logf("%s: stats sidecar absent (legal under injection)", label)
+		return
+	}
+	recount, err := e.computeSyncStats(ctx, syncID)
+	require.NoErrorf(t, err, "%s: recount for stats oracle", label)
+	require.Equalf(t, recount.GetGrants(), stored.GetGrants(), "%s: sidecar grants vs recount", label)
+	require.Equalf(t, recount.GetEntitlements(), stored.GetEntitlements(), "%s: sidecar entitlements vs recount", label)
+	require.Equalf(t, recount.GetResources(), stored.GetResources(), "%s: sidecar resources vs recount", label)
+	require.Equalf(t, recount.GetResourceTypes(), stored.GetResourceTypes(), "%s: sidecar resource_types vs recount", label)
+	require.Equalf(t, recount.GetResourcesByResourceType(), stored.GetResourcesByResourceType(), "%s: sidecar resources-by-rt vs recount", label)
+	require.Equalf(t, recount.GetGrantsByEntitlementResourceType(), stored.GetGrantsByEntitlementResourceType(), "%s: sidecar grants-by-ent-rt vs recount", label)
 }
 
 // verifyDigests is the digest half of the content oracle: on a
@@ -549,7 +582,14 @@ const (
 // replayPages selects the resume model: false = the pages were already
 // durable before the window (EndSync sweep), true = replay them (whole
 // sync soak).
-func verifyCrashImage(ctx context.Context, t *testing.T, w sweepWorkload, image *vfs.MemFS, cache *pebble.Cache, syncID string, replayPages bool, label string) crashImageOutcome {
+// injected: whether the run that produced the image injected any
+// fault. A finished image from an UNINJECTED run must carry digest
+// state (its EndSync had no legitimate reason to loud-drop); a
+// finished image from an injected run may legally lack it (review
+// finding, external parity round: the finished arm used to pass
+// requireDigests=false unconditionally, letting a clean-run image
+// with silently missing digests through).
+func verifyCrashImage(ctx context.Context, t *testing.T, w sweepWorkload, image *vfs.MemFS, cache *pebble.Cache, syncID string, replayPages bool, injected bool, label string) crashImageOutcome {
 	t.Helper()
 	e, err := Open(ctx, "sweep-db", WithVFS(image), WithSharedCache(cache), withPanicOnFatalLogger())
 	require.NoErrorf(t, err, "%s: the crash image must reopen", label)
@@ -565,7 +605,7 @@ func verifyCrashImage(ctx context.Context, t *testing.T, w sweepWorkload, image 
 		// (b) finished: everything the sync wrote must have been durable
 		// before the stamp — a finished-but-incomplete image is the lying
 		// artifact this harness exists to catch.
-		w.verifyComplete(ctx, t, e, syncID, false, label+" (finished image)")
+		w.verifyComplete(ctx, t, e, syncID, !injected, !injected, label+" (finished image)")
 		return outcomeFinishedComplete
 	case recErr == nil:
 		// (a) unfinished: must be discoverable and resume to completion.
@@ -580,7 +620,7 @@ func verifyCrashImage(ctx context.Context, t *testing.T, w sweepWorkload, image 
 			require.NoErrorf(t, w.write(ctx, a), "%s: resume page replay", label)
 		}
 		require.NoErrorf(t, a.EndSync(ctx), "%s: resumed EndSync must converge", label)
-		w.verifyComplete(ctx, t, e, syncID, true, label+" (resumed image)")
+		w.verifyComplete(ctx, t, e, syncID, true, true, label+" (resumed image)")
 		return outcomeUnfinishedResumed
 	default:
 		// (c) the record never became durable. Legal only when the crash
@@ -593,7 +633,7 @@ func verifyCrashImage(ctx context.Context, t *testing.T, w sweepWorkload, image 
 		require.NoErrorf(t, err, "%s: restart after empty image", label)
 		require.NoErrorf(t, w.write(ctx, a), "%s: restart page write", label)
 		require.NoErrorf(t, a.EndSync(ctx), "%s: restart EndSync", label)
-		w.verifyComplete(ctx, t, e, newID, true, label+" (restarted image)")
+		w.verifyComplete(ctx, t, e, newID, true, true, label+" (restarted image)")
 		return outcomeNoSyncRunRestarted
 	}
 }
@@ -665,12 +705,12 @@ func TestErrorFSEndSyncWindowSweep(t *testing.T) {
 			// last write op of the window — coverage proven. (A nonzero
 			// injected count with a green run means the injection only hit
 			// post-completion background work; verify and keep sweeping.)
-			outcomes[verifyCrashImage(ctx, t, w, res.image, cache, syncID, false, label+" (clean run)")]++
+			outcomes[verifyCrashImage(ctx, t, w, res.image, cache, syncID, false, res.injected > 0, label+" (clean run)")]++
 			covered = res.injected == 0
 			continue
 		}
 		require.Greaterf(t, res.injected, int64(0), "k=%d: EndSync failed with the injector armed but nothing injected: %v", k, res.err)
-		outcomes[verifyCrashImage(ctx, t, w, res.image, cache, syncID, false, label)]++
+		outcomes[verifyCrashImage(ctx, t, w, res.image, cache, syncID, false, true, label)]++
 	}
 	// The coverage evidence, not just a green run: every k below the
 	// terminator must have injected a fault, and both arms of the reopen
@@ -744,7 +784,7 @@ func TestErrorFSWholeSyncRandomSweepSoak(t *testing.T) {
 				// artifact was flushed, so the strict crash image must
 				// verify complete.
 				require.NotEmpty(t, syncID)
-				verifyCrashImage(ctx, t, w, res.image, cache, syncID, true, label+" (clean run)")
+				verifyCrashImage(ctx, t, w, res.image, cache, syncID, true, res.injected > 0, label+" (clean run)")
 				return
 			}
 			if syncID == "" {
@@ -753,7 +793,7 @@ func TestErrorFSWholeSyncRandomSweepSoak(t *testing.T) {
 				verifyEmptyImageRestarts(ctx, t, w, res.image, cache, label+" (pre-sync)")
 				return
 			}
-			verifyCrashImage(ctx, t, w, res.image, cache, syncID, true, label)
+			verifyCrashImage(ctx, t, w, res.image, cache, syncID, true, true, label)
 		})
 	}
 }
@@ -886,7 +926,7 @@ func TestEndSyncStampWindowImageComplete(t *testing.T) {
 	rec, err := ve.GetSyncRunRecord(ctx, syncID)
 	require.NoError(t, err, "the Sync-committed stamp must be in the crash image")
 	require.NotNil(t, rec.GetEndedAt(), "the image must read as finished")
-	w.verifyComplete(ctx, t, ve, syncID, true, "stamp-window image")
+	w.verifyComplete(ctx, t, ve, syncID, true, false, "stamp-window image")
 }
 
 // verifyEmptyImageRestarts asserts a crash image with no sync at all
@@ -901,5 +941,5 @@ func verifyEmptyImageRestarts(ctx context.Context, t *testing.T, w sweepWorkload
 	require.NoErrorf(t, err, "%s: restart", label)
 	require.NoErrorf(t, w.write(ctx, a), "%s: restart write", label)
 	require.NoErrorf(t, a.EndSync(ctx), "%s: restart EndSync", label)
-	w.verifyComplete(ctx, t, e, syncID, true, label+" (restarted)")
+	w.verifyComplete(ctx, t, e, syncID, true, true, label+" (restarted)")
 }

--- a/pkg/dotc1z/engine/pebble/errorfs_sweep_test.go
+++ b/pkg/dotc1z/engine/pebble/errorfs_sweep_test.go
@@ -319,7 +319,17 @@ func (w sweepWorkload) expectedEntIDsPerPrincipal() []string {
 // "resumes to completion" mean CORRECT completion: a resume that
 // duplicated, dropped, or cross-wired rows while keeping counts
 // plausible fails here.
-func (w sweepWorkload) verifyComplete(ctx context.Context, t *testing.T, e *Engine, syncID string, label string) {
+//
+// requireDigests: whether the digest oracle must find digest state
+// PRESENT (see verifyDigests) — true whenever the finishing EndSync
+// ran without injection (resumed/restarted/uninjected images), false
+// for images whose EndSync completed under an armed injector.
+// Production policy is technically weaker — EndSync downgrades ANY
+// digest build failure to a loud full drop and still finishes — but
+// on this harness's clean engines (MemFS, no injector) a soft digest
+// failure has no legitimate cause, so the oracle deliberately fails
+// CLOSED on it rather than shrugging it off as a legal drop.
+func (w sweepWorkload) verifyComplete(ctx context.Context, t *testing.T, e *Engine, syncID string, requireDigests bool, label string) {
 	t.Helper()
 	rec, err := e.GetSyncRunRecord(ctx, syncID)
 	require.NoErrorf(t, err, "%s: sync run record must exist", label)
@@ -360,6 +370,108 @@ func (w sweepWorkload) verifyComplete(ctx context.Context, t *testing.T, e *Engi
 		}), "%s: IterateGrantsByPrincipal(%s)", label, p)
 		require.ElementsMatchf(t, wantEnts, gotEnts, "%s: by_principal entitlement set for %s", label, p)
 	}
+
+	w.verifyDigests(ctx, t, e, requireDigests, label)
+}
+
+// verifyDigests is the digest half of the content oracle: on a
+// FINISHED store the seal-time build must have left every digest
+// artifact present AND exact. Three independently derived
+// representations have to agree, per entitlement:
+//
+//  1. the fold of content hashes recomputed from the PRIMARY grant
+//     records (ground truth — touches no digest state at all);
+//  2. the stored per-entitlement digest root (present-means-exact);
+//  3. the on-demand fold of the grant hash index
+//     (ComputeEntitlementBucketDigest) — pinning the index itself,
+//     which lives and dies with the digest nodes.
+//
+// Then the stored whole-file global root must equal the XOR/count fold
+// of the entitlement roots. A crash image whose resume produced
+// primaries without digests, digests without the hash index, or roots
+// over torn index ranges fails one of these legs; verifying rows alone
+// would have called such an image complete (review finding, edge/
+// resume round).
+//
+// Digests are an OPTIONAL artifact with a present-means-exact
+// contract: a mid-seal build failure is downgraded to a loud full
+// drop and EndSync still finishes (see RepairMissingGrantDigests), so
+// a finished injected image may legitimately carry NO digest state.
+// The oracle therefore branches on the global root: absent → every
+// entitlement root must be absent too (the safe "recalculate" state —
+// a partial presence would lie to the repair fast path); present →
+// the full three-way triangulation. Presence is still hard-required
+// where it must hold: clean-run and resumed images end with an
+// uninjected digest build. The one thing this can never accept is
+// present-but-wrong — the digest lie.
+func (w sweepWorkload) verifyDigests(ctx context.Context, t *testing.T, e *Engine, requireDigests bool, label string) {
+	t.Helper()
+
+	groot, gok, err := e.GetGrantDigestGlobalRoot(ctx)
+	require.NoErrorf(t, err, "%s: GetGrantDigestGlobalRoot", label)
+	if !gok {
+		require.Falsef(t, requireDigests, "%s: digest state absent on an image whose finishing EndSync ran uninjected — the build cannot legally have dropped", label)
+		// Consistent absence: no entitlement root may survive a drop.
+		for _, entID := range w.expectedEntIDsPerPrincipal() {
+			id := entitlementIdentityFromParts("app", "github", entID)
+			_, ok, err := e.GetEntitlementDigestRoot(ctx, id)
+			require.NoErrorf(t, err, "%s: GetEntitlementDigestRoot(%s)", label, entID)
+			require.Falsef(t, ok, "%s: global digest root absent but %s kept a root — partial digest state lies to the repair fast path", label, entID)
+		}
+		t.Logf("%s: digest state absent (legal drop); consistency verified", label)
+		return
+	}
+
+	type fold struct {
+		xor   [hashLen]byte
+		count int64
+	}
+	primary := map[string]*fold{}
+	require.NoErrorf(t, e.IterateGrants(ctx, func(r *v3.GrantRecord) bool {
+		h, err := grantContentHashForRecord(r)
+		require.NoErrorf(t, err, "%s: content hash for %s", label, r.GetExternalId())
+		gid, err := grantIdentityFromRecord(r)
+		require.NoErrorf(t, err, "%s: identity for %s", label, r.GetExternalId())
+		part := digestPartitionForEntitlement(gid.entitlement)
+		f := primary[part]
+		if f == nil {
+			f = &fold{}
+			primary[part] = f
+		}
+		xorInto(f.xor[:], h)
+		f.count++
+		return true
+	}), "%s: IterateGrants for digest oracle", label)
+
+	var globalXor [hashLen]byte
+	var globalCount int64
+	for _, entID := range w.expectedEntIDsPerPrincipal() {
+		id := entitlementIdentityFromParts("app", "github", entID)
+		part := digestPartitionForEntitlement(id)
+
+		root, ok, err := e.GetEntitlementDigestRoot(ctx, id)
+		require.NoErrorf(t, err, "%s: GetEntitlementDigestRoot(%s)", label, entID)
+		require.Truef(t, ok, "%s: finished store must have a digest root for %s (present-means-exact)", label, entID)
+
+		pf := primary[part]
+		require.NotNilf(t, pf, "%s: no primary grants found for %s", label, entID)
+		require.Equalf(t, pf.count, root.Count, "%s: stored root count vs primary fold for %s", label, entID)
+		require.Equalf(t, pf.xor[:], root.Hash, "%s: stored root hash vs primary fold for %s", label, entID)
+
+		idxHash, idxCount, err := e.ComputeEntitlementBucketDigest(ctx, id, DigestBucket{})
+		require.NoErrorf(t, err, "%s: ComputeEntitlementBucketDigest(%s)", label, entID)
+		require.Equalf(t, root.Count, idxCount, "%s: hash-index fold count vs stored root for %s", label, entID)
+		require.Equalf(t, root.Hash, idxHash, "%s: hash-index fold hash vs stored root for %s", label, entID)
+
+		xorInto(globalXor[:], root.Hash)
+		globalCount += root.Count
+	}
+	// Every grant-bearing partition must have been one of the expected
+	// entitlements — an unexpected partition means cross-wired identity.
+	require.Lenf(t, primary, len(w.expectedEntIDsPerPrincipal()), "%s: grant-bearing partition set", label)
+
+	require.Equalf(t, globalCount, groot.Count, "%s: global root count vs entitlement-root fold", label)
+	require.Equalf(t, globalXor[:], groot.Hash, "%s: global root hash vs entitlement-root fold", label)
 }
 
 // crashStepResult reports how one injected run surfaced its failure.
@@ -453,7 +565,7 @@ func verifyCrashImage(ctx context.Context, t *testing.T, w sweepWorkload, image 
 		// (b) finished: everything the sync wrote must have been durable
 		// before the stamp — a finished-but-incomplete image is the lying
 		// artifact this harness exists to catch.
-		w.verifyComplete(ctx, t, e, syncID, label+" (finished image)")
+		w.verifyComplete(ctx, t, e, syncID, false, label+" (finished image)")
 		return outcomeFinishedComplete
 	case recErr == nil:
 		// (a) unfinished: must be discoverable and resume to completion.
@@ -468,7 +580,7 @@ func verifyCrashImage(ctx context.Context, t *testing.T, w sweepWorkload, image 
 			require.NoErrorf(t, w.write(ctx, a), "%s: resume page replay", label)
 		}
 		require.NoErrorf(t, a.EndSync(ctx), "%s: resumed EndSync must converge", label)
-		w.verifyComplete(ctx, t, e, syncID, label+" (resumed image)")
+		w.verifyComplete(ctx, t, e, syncID, true, label+" (resumed image)")
 		return outcomeUnfinishedResumed
 	default:
 		// (c) the record never became durable. Legal only when the crash
@@ -481,7 +593,7 @@ func verifyCrashImage(ctx context.Context, t *testing.T, w sweepWorkload, image 
 		require.NoErrorf(t, err, "%s: restart after empty image", label)
 		require.NoErrorf(t, w.write(ctx, a), "%s: restart page write", label)
 		require.NoErrorf(t, a.EndSync(ctx), "%s: restart EndSync", label)
-		w.verifyComplete(ctx, t, e, newID, label+" (restarted image)")
+		w.verifyComplete(ctx, t, e, newID, true, label+" (restarted image)")
 		return outcomeNoSyncRunRestarted
 	}
 }
@@ -646,6 +758,137 @@ func TestErrorFSWholeSyncRandomSweepSoak(t *testing.T) {
 	}
 }
 
+// TestEndSyncStampDurabilityCarriesPages pins the WAL-prefix-
+// durability mechanism ITSELF: the finished stamp's pebble.Sync
+// commit must harden every earlier NoSync page commit (sequential
+// WAL). Isolation is the point — the default workload's EndSync
+// performs OTHER Sync commits before the stamp (digest-pending
+// marker arm/clear, deferred-marker clear), any of which would
+// harden the pages and make the pin vacuous (review finding, delta
+// round). So this variant strips them all: digests disabled, plain
+// inline grants only (no deferred marker), pages committed NoSync
+// with no clean close — leaving the ended_at stamp as the ONLY Sync
+// between the pages and the crash cut, which the endSyncPreFlushHook seam
+// takes immediately after the stamp (before the stats key's own
+// Sync). A strict image (UnsyncedDataPercent=0) that reads finished
+// but lost rows means the stamp's durability stopped carrying the
+// pages — the finished-but-incomplete lying artifact.
+func TestEndSyncStampDurabilityCarriesPages(t *testing.T) {
+	skipOnWindowsMemFS(t)
+	ctx := context.Background()
+	cache := pebble.NewCache(8 << 20)
+	defer cache.Unref()
+
+	fs := vfs.NewCrashableMem()
+	e, err := Open(ctx, "sweep-db",
+		WithVFS(fs), WithSharedCache(cache), withPanicOnFatalLogger(),
+		WithGrantDigestIndex(false))
+	require.NoError(t, err)
+	a := NewAdapter(e)
+	syncID, err := a.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+
+	// Inline-only pages: PutGrants writes by_principal inline and never
+	// arms the deferred marker, so endSyncFinalize runs NO marker
+	// clears and (digests off) no digest build — nothing Syncs between
+	// these NoSync commits and the stamp.
+	principals := []string{"alice", "bob", "carol"}
+	require.NoError(t, a.PutResourceTypes(ctx,
+		v2.ResourceType_builder{Id: "app"}.Build(),
+		v2.ResourceType_builder{Id: "user"}.Build()))
+	require.NoError(t, a.PutEntitlements(ctx, v2.Entitlement_builder{
+		Id: canonicalTestEntID("ent-00"),
+		Resource: v2.Resource_builder{
+			Id: v2.ResourceId_builder{ResourceType: "app", Resource: "github"}.Build(),
+		}.Build(),
+	}.Build()))
+	var gs []*v2.Grant
+	for _, p := range principals {
+		gs = append(gs, mkV2Grant("", "ent-00", "user", p))
+	}
+	require.NoError(t, a.PutGrants(ctx, gs...))
+	require.False(t, e.deferredIdxPending.Load(), "inline-only pages must not arm the deferred marker (isolation precondition)")
+
+	var image *vfs.MemFS
+	e.test.endSyncPreFlushHook = func() {
+		// The stamp is the only Sync since the pages; cut here.
+		image = fs.CrashClone(vfs.CrashCloneCfg{})
+	}
+	require.NoError(t, a.EndSync(ctx))
+	require.NotNil(t, image, "pre-flush hook must have fired")
+	require.NoError(t, e.Close())
+
+	ve, err := Open(ctx, "sweep-db", WithVFS(image), WithSharedCache(cache), withPanicOnFatalLogger(), WithGrantDigestIndex(false))
+	require.NoError(t, err, "stamp-window crash image must reopen")
+	defer func() { _ = ve.Close() }()
+	rec, err := ve.GetSyncRunRecord(ctx, syncID)
+	require.NoError(t, err, "the Sync-committed stamp must be in the crash image")
+	require.NotNil(t, rec.GetEndedAt(), "the image must read as finished")
+
+	va := NewAdapter(ve)
+	require.NoError(t, va.SetCurrentSync(ctx, syncID))
+	resp, err := va.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{}.Build())
+	require.NoError(t, err)
+	var wantIDs []string
+	for _, p := range principals {
+		wantIDs = append(wantIDs, canonicalTestGrantID("ent-00", "user", p))
+	}
+	gotIDs := make([]string, 0, len(resp.GetList()))
+	for _, g := range resp.GetList() {
+		gotIDs = append(gotIDs, g.GetId())
+	}
+	require.ElementsMatch(t, wantIDs, gotIDs,
+		"finished image lost NoSync page rows: the stamp's Sync no longer carries earlier commits (WAL prefix durability broken)")
+	for _, p := range principals {
+		n := 0
+		require.NoError(t, ve.IterateGrantsByPrincipal(ctx, "user", p, func(*v3.GrantRecord) bool {
+			n++
+			return true
+		}))
+		require.Equalf(t, 1, n, "by_principal for %s in the stamp-window image", p)
+	}
+}
+
+// TestEndSyncStampWindowImageComplete is the full-default-workload
+// companion: it cuts a strict crash image at the same post-stamp
+// hook and requires dichotomy conformance — the image reads finished,
+// so it must be content-complete, digests included. Unlike the
+// isolated variant above it makes NO claim about WHICH Sync hardened
+// the pages (the default EndSync has marker Syncs before the stamp);
+// it pins the caller-visible contract at this window for the
+// deferred+digest path.
+func TestEndSyncStampWindowImageComplete(t *testing.T) {
+	skipOnWindowsMemFS(t)
+	ctx := context.Background()
+	w := defaultSweepWorkload()
+	cache := pebble.NewCache(8 << 20)
+	defer cache.Unref()
+
+	fs := vfs.NewCrashableMem()
+	e, err := Open(ctx, "sweep-db", WithVFS(fs), WithSharedCache(cache), withPanicOnFatalLogger())
+	require.NoError(t, err)
+	a := NewAdapter(e)
+	syncID, err := a.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, w.write(ctx, a))
+
+	var image *vfs.MemFS
+	e.test.endSyncPreFlushHook = func() {
+		image = fs.CrashClone(vfs.CrashCloneCfg{})
+	}
+	require.NoError(t, a.EndSync(ctx))
+	require.NotNil(t, image, "pre-flush hook must have fired")
+	require.NoError(t, e.Close())
+
+	ve, err := Open(ctx, "sweep-db", WithVFS(image), WithSharedCache(cache), withPanicOnFatalLogger())
+	require.NoError(t, err, "stamp-window crash image must reopen")
+	defer func() { _ = ve.Close() }()
+	rec, err := ve.GetSyncRunRecord(ctx, syncID)
+	require.NoError(t, err, "the Sync-committed stamp must be in the crash image")
+	require.NotNil(t, rec.GetEndedAt(), "the image must read as finished")
+	w.verifyComplete(ctx, t, ve, syncID, true, "stamp-window image")
+}
+
 // verifyEmptyImageRestarts asserts a crash image with no sync at all
 // still opens and supports a fresh, complete sync.
 func verifyEmptyImageRestarts(ctx context.Context, t *testing.T, w sweepWorkload, image *vfs.MemFS, cache *pebble.Cache, label string) {
@@ -658,5 +901,5 @@ func verifyEmptyImageRestarts(ctx context.Context, t *testing.T, w sweepWorkload
 	require.NoErrorf(t, err, "%s: restart", label)
 	require.NoErrorf(t, w.write(ctx, a), "%s: restart write", label)
 	require.NoErrorf(t, a.EndSync(ctx), "%s: restart EndSync", label)
-	w.verifyComplete(ctx, t, e, syncID, label+" (restarted)")
+	w.verifyComplete(ctx, t, e, syncID, true, label+" (restarted)")
 }

--- a/pkg/dotc1z/engine/pebble/grant_digest.go
+++ b/pkg/dotc1z/engine/pebble/grant_digest.go
@@ -13,6 +13,7 @@ import (
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/codec"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/rawdb"
 )
 
 // Grant instantiation of the digest core (digest.go): the per-
@@ -503,7 +504,7 @@ func (e *Engine) IterateGrantsByEntitlementBucket(ctx context.Context, id entitl
 func (e *Engine) DropAllGrantDigests(ctx context.Context) error {
 	return e.withWrite(func() error {
 		e.grantDigestsPresent.Store(false)
-		return e.db.DeleteRange(DigestLowerBound(), DigestUpperBound(), writeOpts(e.opts.durability))
+		return e.db.DropKeyRange(DigestLowerBound(), DigestUpperBound(), writeOpts(e.opts.durability))
 	})
 }
 
@@ -521,10 +522,10 @@ func (e *Engine) DropAllGrantDigestState(ctx context.Context) error {
 	return e.withWrite(func() error {
 		e.grantDigestsPresent.Store(false)
 		opts := writeOpts(e.opts.durability)
-		if err := e.db.DeleteRange(DigestLowerBound(), DigestUpperBound(), opts); err != nil {
+		if err := e.db.DropKeyRange(DigestLowerBound(), DigestUpperBound(), opts); err != nil {
 			return err
 		}
-		return e.db.DeleteRange(GrantByEntPrincHashLowerBound(), GrantByEntPrincHashUpperBound(), opts)
+		return e.db.DropKeyRange(GrantByEntPrincHashLowerBound(), GrantByEntPrincHashUpperBound(), opts)
 	})
 }
 
@@ -543,11 +544,27 @@ func (e *Engine) DropAllGrantDigestState(ctx context.Context) error {
 // millions of grants) would bloat the LSM for no reason. The flag is
 // true only when digests actually exist: probed once at Open, set by
 // the seal build, cleared by ResetForNewSync and the Drop* paths.
-func (e *Engine) stageGrantDigestInvalidation(batch *pebble.Batch, id entitlementIdentity) error {
+// stageGrantDigestInvalidationFromPrimaryKey is the KEY-DERIVED form
+// wired into rawdb's typed record ops (RecordDerivers): the partition
+// is the entitlement region of the grant primary key, a plain
+// sub-slice (see splitGrantPrimaryKey) that is byte-identical to
+// digestPartitionForEntitlement of the decoded identity — the key IS
+// the identity encoding. Same armed gate as the identity form.
+func (e *Engine) stageGrantDigestInvalidationFromPrimaryKey(st rawdb.Stager, primaryKey []byte) error {
 	if !e.grantDigestsPresent.Load() {
 		return nil
 	}
-	partition := digestPartitionForEntitlement(id)
+	sep4, ok := splitGrantPrimaryKey(primaryKey)
+	if !ok {
+		// Fail closed: a record that reached a typed op already carried
+		// a well-formed identity key; swallowing would leave a
+		// stale-but-present digest (violates present-means-exact).
+		return fmt.Errorf("digest invalidation: grant key %x did not decode as a 6-segment identity", primaryKey)
+	}
+	return stageGrantDigestInvalidationForPartition(st, string(primaryKey[grantPrimaryKeyPrefixLen:sep4]))
+}
+
+func stageGrantDigestInvalidationForPartition(batch rawdb.Stager, partition string) error {
 	if err := dropPartitionDigest(batch, grantDigestSpec, partition); err != nil {
 		return err
 	}
@@ -555,11 +572,11 @@ func (e *Engine) stageGrantDigestInvalidation(batch *pebble.Batch, id entitlemen
 	// one partition's digest is invalidated the aggregate is stale too,
 	// so it must drop alongside it rather than linger looking present
 	// (present-means-exact — digest.go).
-	if err := batch.Delete(globalGrantDigestNodeKey(), nil); err != nil {
+	if err := batch.Delete(globalGrantDigestNodeKey()); err != nil {
 		return err
 	}
 	lo := encodeGrantByEntPrincHashEntPrefix(partition)
-	return batch.DeleteRange(lo, upperBoundOf(lo), nil)
+	return batch.DeleteRange(lo, upperBoundOf(lo))
 }
 
 // probeGrantDigestsPresent initializes the digests-present flag at

--- a/pkg/dotc1z/engine/pebble/grant_digest_build.go
+++ b/pkg/dotc1z/engine/pebble/grant_digest_build.go
@@ -16,6 +16,8 @@ import (
 	"github.com/cockroachdb/pebble/v2/vfs"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
+
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/rawdb"
 )
 
 // Seal-time construction of the by_entitlement_principal_hash index and
@@ -98,7 +100,7 @@ const digestNodeBatchFlushBytes = 4 << 20
 // batch becoming durable ahead of the marker would reopen exactly the
 // trust-a-crashed-build window the marker closes.
 func (e *Engine) markGrantDigestBuildPending() error {
-	if err := e.db.Set(encodeGrantDigestBuildPendingKey(), nil, pebble.Sync); err != nil {
+	if err := e.db.MetaSet(encodeGrantDigestBuildPendingKey(), nil, pebble.Sync); err != nil {
 		return fmt.Errorf("arm grant digest build marker: %w", err)
 	}
 	e.grantDigestBuildPending.Store(true)
@@ -114,7 +116,7 @@ func (e *Engine) markGrantDigestBuildPending() error {
 // marker's absence therefore certifies COMPLETE digest state on disk,
 // never a lucky partial one.
 func (e *Engine) clearGrantDigestBuildPending() error {
-	if err := e.db.Delete(encodeGrantDigestBuildPendingKey(), pebble.Sync); err != nil {
+	if err := e.db.MetaDelete(encodeGrantDigestBuildPendingKey(), pebble.Sync); err != nil {
 		return fmt.Errorf("clear grant digest build marker: %w", err)
 	}
 	e.grantDigestBuildPending.Store(false)
@@ -152,7 +154,7 @@ type grantDigestFold struct {
 	globalXor   [hashLen]byte
 	globalTotal int64
 
-	batch      *pebble.Batch
+	batch      *rawdb.DigestBatch
 	partitions int64
 	nodes      int64
 }
@@ -165,8 +167,8 @@ func newGrantDigestFold(e *Engine) (*grantDigestFold, error) {
 		opts = pebble.NoSync
 	}
 	flushBytes := digestNodeBatchFlushBytes
-	if e.testDigestNodeFlushBytes > 0 {
-		flushBytes = e.testDigestNodeFlushBytes
+	if e.test.digestNodeFlushBytes > 0 {
+		flushBytes = e.test.digestNodeFlushBytes
 	}
 	f := &grantDigestFold{
 		e:          e,
@@ -174,13 +176,13 @@ func newGrantDigestFold(e *Engine) (*grantDigestFold, error) {
 		flushBytes: flushBytes,
 		counts:     make([]int64, 1<<digestMaxWidthBits),
 		xors:       make([][hashLen]byte, 1<<digestMaxWidthBits),
-		batch:      e.db.NewBatch(),
+		batch:      e.db.NewDigestBatch(),
 	}
 	// The build only Sets nodes: clear every prior digest first so a
 	// reseal can't leave stale partitions (dropped entitlements, width
 	// changes) for the comparison merge scan to read. Leads the first
 	// batch; in-batch ordering keeps the new nodes on top.
-	if err := f.batch.DeleteRange(DigestLowerBound(), DigestUpperBound(), nil); err != nil {
+	if err := f.batch.DeleteRange(DigestLowerBound(), DigestUpperBound()); err != nil {
 		f.abort()
 		return nil, err
 	}
@@ -223,7 +225,7 @@ func (f *grantDigestFold) closePartition() error {
 	partition := string(f.partition)
 	width := chooseDigestWidth(f.total)
 	rootKey := encodeDigestNodeKey(grantDigestSpec.indexID, partition, digestLevelRoot, nil)
-	if err := f.batch.Set(rootKey, packDigestRoot(width, f.total, f.rootXor[:]), nil); err != nil {
+	if err := f.batch.Set(rootKey, packDigestRoot(width, f.total, f.rootXor[:])); err != nil {
 		return err
 	}
 	f.nodes++
@@ -245,7 +247,7 @@ func (f *grantDigestFold) closePartition() error {
 			var prefix [digestLeafPrefixLen]byte
 			binary.BigEndian.PutUint16(prefix[:], leafIdx<<shift)
 			leafKey := encodeDigestNodeKey(grantDigestSpec.indexID, partition, digestLevelLeaf, prefix[:])
-			if err := f.batch.Set(leafKey, packDigestLeaf(count, digest[:]), nil); err != nil {
+			if err := f.batch.Set(leafKey, packDigestLeaf(count, digest[:])); err != nil {
 				return err
 			}
 			f.nodes++
@@ -268,12 +270,12 @@ func (f *grantDigestFold) closePartition() error {
 			return err
 		}
 		f.batch.Close()
-		f.batch = f.e.db.NewBatch()
-		if f.e.testDigestBuildHook != nil {
+		f.batch = f.e.db.NewDigestBatch()
+		if f.e.test.digestBuildHook != nil {
 			// Crash-window seam: digest-node batches are now committed
 			// (durable under WAL replay) while the hash-index ingest has
 			// not run. See grant_digest_build_crash_test.go.
-			if err := f.e.testDigestBuildHook("node-batch-committed"); err != nil {
+			if err := f.e.test.digestBuildHook("node-batch-committed"); err != nil {
 				return err
 			}
 		}
@@ -292,7 +294,7 @@ func (f *grantDigestFold) finish() error {
 	if err := f.closePartition(); err != nil {
 		return err
 	}
-	if err := f.batch.Set(globalGrantDigestNodeKey(), packDigestLeaf(f.globalTotal, f.globalXor[:]), nil); err != nil {
+	if err := f.batch.Set(globalGrantDigestNodeKey(), packDigestLeaf(f.globalTotal, f.globalXor[:])); err != nil {
 		return err
 	}
 	f.nodes++
@@ -474,10 +476,10 @@ func (e *Engine) buildGrantDigestsFromSpill(ctx context.Context, dir string, has
 		// No grants at all — pebble rejects an empty SST, so clear any
 		// stale state directly, then give every entitlement its
 		// {count: 0} root (the "empty vs. never built" distinction).
-		if err := e.db.DeleteRange(DigestLowerBound(), DigestUpperBound(), opts); err != nil {
+		if err := e.db.DropKeyRange(DigestLowerBound(), DigestUpperBound(), opts); err != nil {
 			return err
 		}
-		if err := e.db.DeleteRange(GrantByEntPrincHashLowerBound(), GrantByEntPrincHashUpperBound(), opts); err != nil {
+		if err := e.db.DropKeyRange(GrantByEntPrincHashLowerBound(), GrantByEntPrincHashUpperBound(), opts); err != nil {
 			return err
 		}
 		if err := e.writeMissingEntitlementDigestRoots(ctx, opts); err != nil {
@@ -486,7 +488,7 @@ func (e *Engine) buildGrantDigestsFromSpill(ctx context.Context, dir string, has
 		// Zero grants still means the digest WAS built (present-means-
 		// exact — an absent global root would tell a manifest reader to
 		// recalculate instead of trusting "nothing to diff").
-		if err := e.db.Set(globalGrantDigestNodeKey(), packDigestLeaf(0, zeroDigest[:]), opts); err != nil {
+		if err := e.db.DigestSet(globalGrantDigestNodeKey(), packDigestLeaf(0, zeroDigest[:]), opts); err != nil {
 			return err
 		}
 		e.grantDigestsPresent.Store(true)
@@ -506,17 +508,17 @@ func (e *Engine) buildGrantDigestsFromSpill(ctx context.Context, dir string, has
 		return err
 	}
 	mergeDone := time.Now()
-	if e.testDigestBuildHook != nil {
+	if e.test.digestBuildHook != nil {
 		// Crash-window seam: every digest node INCLUDING the global root
 		// is committed, the ingest has not run. See
 		// grant_digest_build_crash_test.go.
-		if err := e.testDigestBuildHook("post-finish"); err != nil {
+		if err := e.test.digestBuildHook("post-finish"); err != nil {
 			return err
 		}
 	}
 
 	// Atomically replace the whole hash-index range with the merged SST.
-	if _, err := e.db.IngestAndExcise(ctx, []string{sstPath}, nil, nil, pebble.KeyRange{
+	if err := e.db.ReplaceRangeWithSSTs(ctx, []string{sstPath}, pebble.KeyRange{
 		Start: GrantByEntPrincHashLowerBound(),
 		End:   GrantByEntPrincHashUpperBound(),
 	}); err != nil {
@@ -564,7 +566,7 @@ func (e *Engine) writeMissingEntitlementDigestRoots(ctx context.Context, opts *p
 		return err
 	}
 	defer iter.Close()
-	batch := e.db.NewBatch()
+	batch := e.db.NewDigestBatch()
 	// Closure, not a bare defer: the loop rotates `batch` on flush and a
 	// receiver-bound defer would double-Close the first batch.
 	defer func() { batch.Close() }()
@@ -591,7 +593,7 @@ func (e *Engine) writeMissingEntitlementDigestRoots(ctx context.Context, opts *p
 		} else if !errors.Is(err, pebble.ErrNotFound) {
 			return err
 		}
-		if err := batch.Set(rootKey, emptyRoot, nil); err != nil {
+		if err := batch.Set(rootKey, emptyRoot); err != nil {
 			return err
 		}
 		if batch.Len() >= digestNodeBatchFlushBytes {
@@ -599,7 +601,7 @@ func (e *Engine) writeMissingEntitlementDigestRoots(ctx context.Context, opts *p
 				return err
 			}
 			batch.Close()
-			batch = e.db.NewBatch()
+			batch = e.db.NewDigestBatch()
 		}
 	}
 	if err := iter.Error(); err != nil {
@@ -731,10 +733,10 @@ func (e *Engine) dropAllGrantDigestStateLocked() error {
 	if e.IsFreshSync() {
 		opts = pebble.NoSync
 	}
-	if err := e.db.DeleteRange(DigestLowerBound(), DigestUpperBound(), opts); err != nil {
+	if err := e.db.DropKeyRange(DigestLowerBound(), DigestUpperBound(), opts); err != nil {
 		return err
 	}
-	if err := e.db.DeleteRange(GrantByEntPrincHashLowerBound(), GrantByEntPrincHashUpperBound(), opts); err != nil {
+	if err := e.db.DropKeyRange(GrantByEntPrincHashLowerBound(), GrantByEntPrincHashUpperBound(), opts); err != nil {
 		return err
 	}
 	return e.clearGrantDigestBuildPending()

--- a/pkg/dotc1z/engine/pebble/grant_digest_build_crash_test.go
+++ b/pkg/dotc1z/engine/pebble/grant_digest_build_crash_test.go
@@ -23,7 +23,7 @@ import (
 // index — the silent skip-entitlements-at-uplift failure mode.
 //
 // The kill is simulated by driving the REAL standalone build to a
-// sentinel error at a named point (testDigestBuildHook), bypassing
+// sentinel error at a named point (the digestBuildHook seam), bypassing
 // BuildGrantDigests's in-process drop handler — exactly a process
 // death's durable footprint (a clean Close then persists everything
 // committed, the maximal state a WAL replay could resurrect).
@@ -85,9 +85,9 @@ func TestGrantDigestBuildCrashMidMerge(t *testing.T) {
 			// Commit (and fire the hook) on every partition close so a
 			// small dataset exercises the mid-merge commit path; die
 			// after the first committed batch.
-			e.testDigestNodeFlushBytes = 1
+			e.test.digestNodeFlushBytes = 1
 			fired := 0
-			e.testDigestBuildHook = func(stage string) error {
+			e.test.digestBuildHook = func(stage string) error {
 				if stage != "node-batch-committed" {
 					return nil
 				}
@@ -117,7 +117,7 @@ func TestGrantDigestBuildCrashMidMerge(t *testing.T) {
 func TestGrantDigestBuildCrashPostFinish(t *testing.T) {
 	testGrantDigestBuildCrash(t,
 		func(e *Engine) {
-			e.testDigestBuildHook = func(stage string) error {
+			e.test.digestBuildHook = func(stage string) error {
 				if stage == "post-finish" {
 					return errDigestBuildKilled
 				}

--- a/pkg/dotc1z/engine/pebble/grant_digest_repair.go
+++ b/pkg/dotc1z/engine/pebble/grant_digest_repair.go
@@ -105,18 +105,18 @@ func (e *Engine) InvalidateGrantDigestPartitions(ctx context.Context, partitions
 		return nil
 	}
 	return e.withWrite(func() error {
-		batch := e.db.NewBatch()
+		batch := e.db.NewDigestBatch()
 		defer batch.Close()
 		for _, partition := range partitions {
 			if err := dropPartitionDigest(batch, grantDigestSpec, partition); err != nil {
 				return err
 			}
 			lo := encodeGrantByEntPrincHashEntPrefix(partition)
-			if err := batch.DeleteRange(lo, upperBoundOf(lo), nil); err != nil {
+			if err := batch.DeleteRange(lo, upperBoundOf(lo)); err != nil {
 				return err
 			}
 		}
-		if err := batch.Delete(globalGrantDigestNodeKey(), nil); err != nil {
+		if err := batch.Delete(globalGrantDigestNodeKey()); err != nil {
 			return err
 		}
 		opts := writeOpts(e.opts.durability)
@@ -424,18 +424,18 @@ func (e *Engine) repairOneGrantDigestPartitionLocked(ctx context.Context, partit
 		opts = pebble.NoSync
 	}
 	flushBytes := digestNodeBatchFlushBytes
-	if e.testDigestNodeFlushBytes > 0 {
-		flushBytes = e.testDigestNodeFlushBytes
+	if e.test.digestNodeFlushBytes > 0 {
+		flushBytes = e.test.digestNodeFlushBytes
 	}
 
 	// Pass 1: replace the hash-index range with the freshly-derived
 	// rows (a clean DeleteRange first: nothing may assume what, if
 	// anything, was left there). Closure defer, not a bound one: the
 	// loop rotates `hiBatch` on flush.
-	hiBatch := e.db.NewBatch()
+	hiBatch := e.db.NewDigestBatch()
 	defer func() { hiBatch.Close() }()
 	hiLower := encodeGrantByEntPrincHashEntPrefix(partition)
-	if err := hiBatch.DeleteRange(hiLower, upperBoundOf(hiLower), nil); err != nil {
+	if err := hiBatch.DeleteRange(hiLower, upperBoundOf(hiLower)); err != nil {
 		return err
 	}
 
@@ -473,7 +473,7 @@ func (e *Engine) repairOneGrantDigestPartitionLocked(ctx context.Context, partit
 		bh64 := grantPrincipalBucketHash64(key[sep4+1:])
 		scratch.keyBuf = appendGrantHashIndexKeyFromPrimary(scratch.keyBuf[:0], key, sep4, bh64)
 		binary.BigEndian.PutUint64(chb[:], ch64)
-		if err := hiBatch.Set(scratch.keyBuf, chb[:], nil); err != nil {
+		if err := hiBatch.Set(scratch.keyBuf, chb[:]); err != nil {
 			_ = iter.Close()
 			return err
 		}
@@ -484,7 +484,7 @@ func (e *Engine) repairOneGrantDigestPartitionLocked(ctx context.Context, partit
 				return err
 			}
 			hiBatch.Close()
-			hiBatch = e.db.NewBatch()
+			hiBatch = e.db.NewDigestBatch()
 		}
 	}
 	if err := iter.Error(); err != nil {
@@ -515,19 +515,19 @@ func (e *Engine) repairOneGrantDigestPartitionLocked(ctx context.Context, partit
 	if err != nil {
 		return err
 	}
-	digestBatch := e.db.NewBatch()
+	digestBatch := e.db.NewDigestBatch()
 	defer digestBatch.Close()
 	digestLower := encodeDigestPartitionPrefix(grantDigestSpec.indexID, partition)
-	if err := digestBatch.DeleteRange(digestLower, upperBoundOf(digestLower), nil); err != nil {
+	if err := digestBatch.DeleteRange(digestLower, upperBoundOf(digestLower)); err != nil {
 		return err
 	}
 	rootKey := encodeDigestNodeKey(grantDigestSpec.indexID, partition, digestLevelRoot, nil)
-	if err := digestBatch.Set(rootKey, rootVal, nil); err != nil {
+	if err := digestBatch.Set(rootKey, rootVal); err != nil {
 		return err
 	}
 	for i := range leaves {
 		leafKey := encodeDigestNodeKey(grantDigestSpec.indexID, partition, digestLevelLeaf, leaves[i].prefix[:])
-		if err := digestBatch.Set(leafKey, leaves[i].val, nil); err != nil {
+		if err := digestBatch.Set(leafKey, leaves[i].val); err != nil {
 			return err
 		}
 	}
@@ -581,7 +581,7 @@ func (e *Engine) recomputeGrantDigestGlobalRootLocked(ctx context.Context) error
 	if e.IsFreshSync() {
 		opts = pebble.NoSync
 	}
-	if err := e.db.Set(globalGrantDigestNodeKey(), packDigestLeaf(total, xor[:]), opts); err != nil {
+	if err := e.db.DigestSet(globalGrantDigestNodeKey(), packDigestLeaf(total, xor[:]), opts); err != nil {
 		return err
 	}
 	e.grantDigestsPresent.Store(true)

--- a/pkg/dotc1z/engine/pebble/grant_digest_repair_test.go
+++ b/pkg/dotc1z/engine/pebble/grant_digest_repair_test.go
@@ -62,7 +62,7 @@ func TestRepairMissingGrantDigestsLeavesGlobalRootMissingOnPartialFailure(t *tes
 	if badKey == nil {
 		t.Fatal("could not find ent-bad's grant primary key")
 	}
-	if err := e.db.Set(badKey, []byte{0xFF, 0xFF, 0xFF}, pebble.NoSync); err != nil {
+	if err := e.db.UnsafeForTesting().Set(badKey, []byte{0xFF, 0xFF, 0xFF}, pebble.NoSync); err != nil {
 		t.Fatalf("corrupt ent-bad grant value: %v", err)
 	}
 
@@ -358,7 +358,7 @@ func TestRepairMissingGrantDigestsCountsMalformedKeys(t *testing.T) {
 	partition := testEntPartition("ent-a")
 	lower, _ := grantPrimaryEntitlementBoundsFromPartition(partition)
 	malformed := append(append([]byte(nil), lower...), 'p', 0, 'q', 0, 'r')
-	if err := e.db.Set(malformed, []byte("junk"), pebble.NoSync); err != nil {
+	if err := e.db.UnsafeForTesting().Set(malformed, []byte("junk"), pebble.NoSync); err != nil {
 		t.Fatalf("inject malformed key: %v", err)
 	}
 
@@ -424,7 +424,7 @@ func TestRepairStreamsPartitionInBoundedBatches(t *testing.T) {
 	wantHash := dumpKeyRangeTest(t, e, GrantByEntPrincHashLowerBound(), GrantByEntPrincHashUpperBound())
 
 	// Rotate the repair's hash-index batch on every Set.
-	e.testDigestNodeFlushBytes = 1
+	e.test.digestNodeFlushBytes = 1
 
 	partition := testEntPartition("ent-big")
 	if err := e.InvalidateGrantDigestPartitions(ctx, []string{partition}); err != nil {

--- a/pkg/dotc1z/engine/pebble/grant_read_arena_test.go
+++ b/pkg/dotc1z/engine/pebble/grant_read_arena_test.go
@@ -31,7 +31,7 @@ func TestGrantReadArenaReconcileAbsent(t *testing.T) {
 	}.Build()
 	val, err := marshalRecord(r)
 	require.NoError(t, err)
-	require.NoError(t, e.db.Set(encodeGrantIdentityKey(grantIdentity{
+	require.NoError(t, e.db.UnsafeForTesting().Set(encodeGrantIdentityKey(grantIdentity{
 		entitlement:     entitlementIdentityFromParts("app", "github", "ent-A"),
 		principalTypeID: "user",
 		principalID:     "alice",

--- a/pkg/dotc1z/engine/pebble/grant_write_scale_bench_test.go
+++ b/pkg/dotc1z/engine/pebble/grant_write_scale_bench_test.go
@@ -95,7 +95,7 @@ func benchmarkGrantWriteScale(b *testing.B, putUnique, grantIndex bool) {
 				require.NoError(b, e.PutGrantRecords(ctx, recs...))
 			}
 		}
-		require.NoError(b, e.db.Flush())
+		require.NoError(b, e.db.FlushMemtables())
 
 		b.StopTimer()
 		require.NoError(b, e.Close())

--- a/pkg/dotc1z/engine/pebble/grants.go
+++ b/pkg/dotc1z/engine/pebble/grants.go
@@ -33,9 +33,10 @@ func (e *Engine) PutGrantRecord(ctx context.Context, r *v3.GrantRecord) error {
 	return e.PutGrantRecords(ctx, r)
 }
 
-// PutGrantRecords writes N grants in two pebble.Batches — one for
-// primary-key writes, one for index-key writes — and commits them
-// sequentially. This is the bulk path the adapter's PutGrants uses.
+// PutGrantRecords writes N grants through a single RecordBatch —
+// StageGrantPutInline derives the index obligations inside rawdb, so
+// primary and index keys land in one atomic commit. This is the bulk
+// path the adapter's PutGrants uses.
 //
 // Mutation safety. Connectors can legitimately emit the same
 // external_id twice within a single sync (paginated sources,
@@ -47,22 +48,24 @@ func (e *Engine) PutGrantRecord(ctx context.Context, r *v3.GrantRecord) error {
 // the load-bearing safety net that neither the old read-before-write
 // path nor a pure skip-Get path provides.
 //
-// Read-before-write index cleanup. On a NON-fresh sync the engine
-// must Get the prior primary value so it can delete the index keys
-// the previous sync wrote (entitlement/principal can change between
-// syncs). On a FRESH sync the keyspace is empty by construction
-// (StartNewSync excises it) so the Get is guaranteed to return
-// ErrNotFound and we skip it — saves an LSM lookup per record on the
-// bulk path.
+// Read-before-write overwrite probe. On a NON-fresh sync the engine
+// must Get the prior primary key so StageGrantPutInline can stage the
+// overwrite obligations — grant index keys are KEY-derived (identity
+// key), so the probe is an existence check, not a value read: the
+// stale-index cleanup and digest invalidation the deriver stages are
+// keyed off the same identity. On a FRESH sync the keyspace is empty
+// by construction (StartNewSync excises it) so the Get is guaranteed
+// to return ErrNotFound and we skip it — saves an LSM lookup per
+// record on the bulk path.
 //
-// Two batches. The primary keys arrive in roughly sorted order from
-// the adapter (V2→V3 translator preserves the connector's record
-// order, and most connectors emit grants clustered by entitlement
-// which tends to cluster external_ids). The index keys are sorted on
-// a totally different field (entitlement_id / principal), so
-// interleaving them in one batch makes Pebble's flushable-batch
-// promotion path quote sort. Splitting them lets each batch's
-// natural order survive.
+// One RecordBatch. Primary and index keys are staged into a single
+// batch via StageGrantPutInline, which derives the index obligations
+// inside rawdb — one commit, primary+index atomic. (This path
+// historically split primary and index keys into two batches to
+// preserve each key family's natural sort order for Pebble's
+// flushable-batch promotion; the choke-point migration collapsed
+// them, trading that micro-optimization for atomicity and
+// can't-forget index derivation.)
 //
 // Fresh-sync still uses pebble.NoSync — EndFreshSync does one
 // Flush+fsync at sync end to harden the data.
@@ -74,10 +77,8 @@ func (e *Engine) PutGrantRecords(ctx context.Context, records ...*v3.GrantRecord
 		if err := e.requireCurrentSync(); err != nil {
 			return err
 		}
-		priBatch := e.db.NewBatch()
-		defer priBatch.Close()
-		idxBatch := e.db.NewBatch()
-		defer idxBatch.Close()
+		batch := e.db.NewRecordBatch()
+		defer batch.Close()
 
 		fresh := e.IsFreshSync()
 		// skipGet fires exactly once per fresh sync — only the first
@@ -128,14 +129,12 @@ func (e *Engine) PutGrantRecords(ctx context.Context, records ...*v3.GrantRecord
 			if err != nil {
 				return err
 			}
+			hadOld := false
 			if !skipGet {
-				oldVal, closer, getErr := e.db.Get(key)
+				_, closer, getErr := e.db.Get(key)
 				switch {
 				case getErr == nil:
-					if err := e.deleteGrantIndexesRaw(idxBatch, r.GetExternalId(), oldVal); err != nil {
-						closer.Close()
-						return err
-					}
+					hadOld = true
 					closer.Close()
 				case errors.Is(getErr, pebble.ErrNotFound):
 					// no prior record — write unconditionally
@@ -143,10 +142,12 @@ func (e *Engine) PutGrantRecords(ctx context.Context, records ...*v3.GrantRecord
 					return fmt.Errorf("PutGrantRecords: get old: %w", getErr)
 				}
 			}
-			if err := priBatch.Set(key, val, nil); err != nil {
-				return err
-			}
-			if err := e.writeGrantIndexes(idxBatch, r); err != nil {
+			// One typed op stages the row and everything it owes:
+			// prior-row index cleanup, by_principal, needs_expansion,
+			// digest invalidation. Index keys derive from the primary
+			// key (identity-encoded), so the prior VALUE is not needed
+			// for cleanup — the Get above reduces to an existence probe.
+			if err := batch.StageGrantPutInline(key, val, hadOld, r.GetNeedsExpansion()); err != nil {
 				return err
 			}
 		}
@@ -154,14 +155,10 @@ func (e *Engine) PutGrantRecords(ctx context.Context, records ...*v3.GrantRecord
 		if fresh {
 			opts = pebble.NoSync
 		}
-		// One atomic commit: folding the index batch into the primary batch
-		// closes the durability gap where the primary commit landed but the
-		// index commit failed — a divergence that would persist in the saved
-		// artifact if the caller shipped it anyway.
-		if err := priBatch.Apply(idxBatch, nil); err != nil {
-			return err
-		}
-		return priBatch.Commit(opts)
+		// One atomic commit: primary rows and their index/invalidation
+		// obligations ride the same batch, so a primary commit landing
+		// without its index entries is unexpressible.
+		return batch.Commit(opts)
 	})
 }
 
@@ -200,10 +197,8 @@ func (e *Engine) PutExpandedGrantRecords(ctx context.Context, records []*v3.Gran
 		if err := e.requireCurrentSync(); err != nil {
 			return err
 		}
-		priBatch := e.db.NewBatch()
-		defer priBatch.Close()
-		idxBatch := e.db.NewBatch()
-		defer idxBatch.Close()
+		batch := e.db.NewRecordBatch()
+		defer batch.Close()
 
 		now := timestamppb.Now()
 
@@ -230,10 +225,12 @@ func (e *Engine) PutExpandedGrantRecords(ctx context.Context, records []*v3.Gran
 
 		// Scratch buffers reused across every record. pebble.Batch.Set
 		// and Delete copy their key/value arguments, so one buffer can
-		// back the primary key, the marshaled value, and each index key
-		// in turn — the per-record key/marshal allocations were the
-		// engine's hottest allocator on the expansion write path.
-		var keyScratch, valScratch, idxScratch []byte
+		// back the primary key and the marshaled value in turn — the
+		// per-record key/marshal allocations were the engine's hottest
+		// allocator on the expansion write path. (Index-key scratch
+		// lives inside the RecordBatch; the typed ops splice index keys
+		// from the primary key.)
+		var keyScratch, valScratch []byte
 		var prior v3.GrantRecord
 		for i, r := range records {
 			if r == nil {
@@ -249,12 +246,14 @@ func (e *Engine) PutExpandedGrantRecords(ctx context.Context, records []*v3.Gran
 			ext := r.GetExternalId()
 			keyScratch = appendGrantIdentityKey(keyScratch[:0], id)
 
+			hadOld := false
 			oldVal, closer, getErr := e.db.Get(keyScratch)
 			switch {
 			case getErr == nil:
 				// Preserve the prior record's expansion side-state +
-				// discovered_at (StoreExpandedGrants contract), then
-				// delete the index entries the prior value created.
+				// discovered_at (StoreExpandedGrants contract). The prior
+				// value's index cleanup is the typed op's obligation.
+				hadOld = true
 				prior.Reset()
 				if err := unmarshalRecord(oldVal, &prior); err != nil {
 					closer.Close()
@@ -263,12 +262,6 @@ func (e *Engine) PutExpandedGrantRecords(ctx context.Context, records []*v3.Gran
 				r.SetExpansion(prior.GetExpansion())
 				r.SetNeedsExpansion(prior.GetNeedsExpansion())
 				r.SetDiscoveredAt(prior.GetDiscoveredAt())
-				var err error
-				idxScratch, err = e.deleteGrantIndexesScratch(idxBatch, ext, oldVal, idxScratch)
-				if err != nil {
-					closer.Close()
-					return err
-				}
 				closer.Close()
 			case errors.Is(getErr, pebble.ErrNotFound):
 				// No prior record: discovered_at is stamped below unless the
@@ -285,23 +278,19 @@ func (e *Engine) PutExpandedGrantRecords(ctx context.Context, records []*v3.Gran
 				return err
 			}
 			valScratch = val
-			if err := priBatch.Set(keyScratch, val, nil); err != nil {
-				return err
-			}
-			idxScratch, err = e.writeGrantIndexesScratch(idxBatch, r, idxScratch)
-			if err != nil {
+			// Deferred regime: arms the rebuild marker, cleans the prior
+			// needs_expansion entry (by_principal is excised+rebuilt at
+			// seal), stages row + conditional needs_expansion + digest
+			// invalidation.
+			if err := batch.StageGrantPutDeferred(keyScratch, val, hadOld, r.GetNeedsExpansion()); err != nil {
 				return err
 			}
 		}
 
-		// One atomic commit: folding the index batch into the primary batch
-		// closes the durability gap where the primary commit landed but the
-		// index commit failed — a divergence that would persist in the saved
-		// artifact if the caller shipped it anyway.
-		if err := priBatch.Apply(idxBatch, nil); err != nil {
-			return err
-		}
-		return priBatch.Commit(pebble.NoSync)
+		// One atomic commit: rows and their obligations ride the same
+		// batch, so a primary commit landing without its index entries
+		// is unexpressible.
+		return batch.Commit(pebble.NoSync)
 	})
 }
 
@@ -320,13 +309,11 @@ func (e *Engine) PutSynthesizedGrantRecords(ctx context.Context, records []*v3.G
 		if err := e.requireCurrentSync(); err != nil {
 			return err
 		}
-		priBatch := e.db.NewBatch()
-		defer priBatch.Close()
-		idxBatch := e.db.NewBatch()
-		defer idxBatch.Close()
+		batch := e.db.NewRecordBatch()
+		defer batch.Close()
 
 		now := timestamppb.Now()
-		var keyScratch, valScratch, idxScratch []byte
+		var keyScratch, valScratch []byte
 		for _, r := range records {
 			if r == nil {
 				continue
@@ -344,22 +331,16 @@ func (e *Engine) PutSynthesizedGrantRecords(ctx context.Context, records []*v3.G
 				return err
 			}
 			valScratch = val
-			if err := priBatch.Set(keyScratch, val, nil); err != nil {
-				return err
-			}
-			idxScratch, err = e.writeGrantIndexesScratch(idxBatch, r, idxScratch)
-			if err != nil {
+			// Deferred regime; the caller guarantees brand-new identities,
+			// so there is no prior row to clean (hadOldVal=false).
+			if err := batch.StageGrantPutDeferred(keyScratch, val, false, r.GetNeedsExpansion()); err != nil {
 				return err
 			}
 		}
-		// One atomic commit: folding the index batch into the primary batch
-		// closes the durability gap where the primary commit landed but the
-		// index commit failed — a divergence that would persist in the saved
-		// artifact if the caller shipped it anyway.
-		if err := priBatch.Apply(idxBatch, nil); err != nil {
-			return err
-		}
-		return priBatch.Commit(pebble.NoSync)
+		// One atomic commit: rows and their obligations ride the same
+		// batch, so a primary commit landing without its index entries
+		// is unexpressible.
+		return batch.Commit(pebble.NoSync)
 	})
 }
 
@@ -587,7 +568,7 @@ func (e *Engine) ingestSynthLayerSegment(ctx context.Context, dir string, seg sy
 	}
 	e.checkpointMu.RLock()
 	defer e.checkpointMu.RUnlock()
-	if err := e.db.Ingest(ctx, []string{sstPath}); err != nil {
+	if err := e.db.IngestSSTs(ctx, []string{sstPath}); err != nil {
 		return fmt.Errorf("synth grant layer: ingest segment %s: %w", seg.name, err)
 	}
 	return nil
@@ -724,13 +705,11 @@ func (e *Engine) putSynthesizedGrantContributionsBatch(ctx context.Context, reco
 		if err := e.requireCurrentSync(); err != nil {
 			return err
 		}
-		priBatch := e.db.NewBatch()
-		defer priBatch.Close()
-		idxBatch := e.db.NewBatch()
-		defer idxBatch.Close()
+		batch := e.db.NewRecordBatch()
+		defer batch.Close()
 
 		now := timestamppb.Now()
-		var keyScratch, valScratch, idxScratch []byte
+		var keyScratch, valScratch []byte
 		var srcScratch batonGrant.Sources
 		r := &v3.GrantRecord{} // reused across rows; see fillSynthGrantRecord
 		for i := range records {
@@ -750,22 +729,16 @@ func (e *Engine) putSynthesizedGrantContributionsBatch(ctx context.Context, reco
 			// it after the base marshal matches the deterministic byte order.
 			val, srcScratch = appendGrantSourcesWire(val, srcScratch, rec.sources)
 			valScratch = val
-			if err := priBatch.Set(keyScratch, val, nil); err != nil {
-				return err
-			}
-			idxScratch, err = e.writeGrantIndexesForIdentityScratch(idxBatch, rec.id, false, idxScratch)
-			if err != nil {
+			// Deferred regime: synthesized grants are brand-new (no prior
+			// row) and never expandable (needsExpansion=false).
+			if err := batch.StageGrantPutDeferred(keyScratch, val, false, false); err != nil {
 				return err
 			}
 		}
-		// One atomic commit: folding the index batch into the primary batch
-		// closes the durability gap where the primary commit landed but the
-		// index commit failed — a divergence that would persist in the saved
-		// artifact if the caller shipped it anyway.
-		if err := priBatch.Apply(idxBatch, nil); err != nil {
-			return err
-		}
-		return priBatch.Commit(pebble.NoSync)
+		// One atomic commit: rows and their obligations ride the same
+		// batch, so a primary commit landing without its index entries
+		// is unexpressible.
+		return batch.Commit(pebble.NoSync)
 	})
 }
 
@@ -775,8 +748,8 @@ func (e *Engine) putSynthesizedGrantContributionsBatch(ctx context.Context, reco
 // mode, and the caller must guarantee each external_id appears at most once
 // across the whole sync (not just within this batch). Primary + index key/value
 // encoding — including the proto marshal — runs in parallel across GOMAXPROCS
-// workers; a single goroutine then Sets the pre-encoded bytes into two batches
-// and commits them (NoSync during a fresh sync).
+// workers; a single goroutine then stages the pre-encoded bytes into a single
+// RecordBatch and commits it (NoSync during a fresh sync).
 //
 // Unlike PutGrantRecords this skips the per-record db.Get that PutGrantRecords
 // performs on every batch after the first of a fresh sync. That read-before-
@@ -791,6 +764,15 @@ func (e *Engine) UnsafePutUniqueGrantRecords(ctx context.Context, records ...*v3
 		if !e.IsFreshSync() {
 			return errors.New("UnsafePutUniqueGrantRecords: sync is not fresh")
 		}
+		// Fail-loud defense (review suggestion): on the fresh syncs this
+		// path requires, digest state is provably absent (StartNewSync's
+		// ResetForNewSync excised it), so the typed ops' digest
+		// invalidation is a no-op. If digests ever read as present here,
+		// the freshness contract itself is broken — refuse rather than
+		// silently tombstone the digest keyspace of a trusted import.
+		if e.grantDigestsPresent.Load() {
+			return errors.New("UnsafePutUniqueGrantRecords: digest state present on a fresh sync; freshness contract violated")
+		}
 		// Consume the fresh-grants-empty bit: the keyspace is no longer
 		// provably empty, so a subsequent PutGrantRecords in this sync must
 		// take its read-before-write path to clean up index entries on
@@ -798,9 +780,9 @@ func (e *Engine) UnsafePutUniqueGrantRecords(ctx context.Context, records ...*v3
 		_ = e.takeFreshGrantsEmpty()
 
 		type encoded struct {
-			priKey  []byte
-			priVal  []byte
-			idxKeys [][]byte
+			priKey         []byte
+			priVal         []byte
+			needsExpansion bool
 		}
 		enc := make([]encoded, len(records))
 
@@ -856,9 +838,9 @@ func (e *Engine) UnsafePutUniqueGrantRecords(ctx context.Context, records ...*v3
 						return
 					}
 					enc[i] = encoded{
-						priKey:  encodeGrantIdentityKey(id),
-						priVal:  val,
-						idxKeys: grantIndexKeys(r),
+						priKey:         encodeGrantIdentityKey(id),
+						priVal:         val,
+						needsExpansion: r.GetNeedsExpansion(),
 					}
 				}
 			}(lo, hi)
@@ -868,21 +850,18 @@ func (e *Engine) UnsafePutUniqueGrantRecords(ctx context.Context, records ...*v3
 			return encErr
 		}
 
-		priBatch := e.db.NewBatch()
-		defer priBatch.Close()
-		idxBatch := e.db.NewBatch()
-		defer idxBatch.Close()
+		batch := e.db.NewRecordBatch()
+		defer batch.Close()
 		for i := range enc {
 			if enc[i].priKey == nil {
 				continue
 			}
-			if err := priBatch.Set(enc[i].priKey, enc[i].priVal, nil); err != nil {
+			// Inline regime, brand-new rows (caller-guaranteed unique):
+			// the typed op splices index keys from the primary key on the
+			// staging goroutine — cheaper than the encode-from-identity
+			// the parallel workers used to do, and unforgettable.
+			if err := batch.StageGrantPutInline(enc[i].priKey, enc[i].priVal, false, enc[i].needsExpansion); err != nil {
 				return err
-			}
-			for _, k := range enc[i].idxKeys {
-				if err := idxBatch.Set(k, nil, nil); err != nil {
-					return err
-				}
 			}
 		}
 
@@ -890,14 +869,10 @@ func (e *Engine) UnsafePutUniqueGrantRecords(ctx context.Context, records ...*v3
 		if e.IsFreshSync() {
 			opts = pebble.NoSync
 		}
-		// One atomic commit: folding the index batch into the primary batch
-		// closes the durability gap where the primary commit landed but the
-		// index commit failed — a divergence that would persist in the saved
-		// artifact if the caller shipped it anyway.
-		if err := priBatch.Apply(idxBatch, nil); err != nil {
-			return err
-		}
-		return priBatch.Commit(opts)
+		// One atomic commit: rows and their obligations ride the same
+		// batch, so a primary commit landing without its index entries
+		// is unexpressible.
+		return batch.Commit(opts)
 	})
 }
 
@@ -955,23 +930,20 @@ func (e *Engine) DeleteGrantByIdentityRefs(ctx context.Context, r *v3.GrantRecor
 func (e *Engine) deleteGrantByIdentityLocked(id grantIdentity) error {
 	key := encodeGrantIdentityKey(id)
 
-	batch := e.db.NewBatch()
-	defer batch.Close()
-
-	oldVal, closer, err := e.db.Get(key)
+	// Existence probe only: delete of non-existent stays a no-op, and
+	// the typed op derives all cleanup keys from the primary key.
+	_, closer, err := e.db.Get(key)
 	if err != nil {
 		if errors.Is(err, pebble.ErrNotFound) {
-			return nil // delete of non-existent is a no-op
+			return nil
 		}
-		return err
-	}
-	if err := e.deleteGrantIndexesRaw(batch, "", oldVal); err != nil {
-		closer.Close()
 		return err
 	}
 	closer.Close()
 
-	if err := batch.Delete(key, nil); err != nil {
+	batch := e.db.NewRecordBatch()
+	defer batch.Close()
+	if err := batch.StageGrantDelete(key); err != nil {
 		return err
 	}
 	return batch.Commit(writeOpts(e.opts.durability))
@@ -994,52 +966,15 @@ func grantIndexKeys(r *v3.GrantRecord) [][]byte {
 	return keys
 }
 
-// writeGrantIndexes adds index entries for r to batch. The
-// by_entitlement_principal_hash index and the digests over it are
-// deliberately NOT written here: both are derived from the primaries in
-// the fused deferred pass at seal time (BuildDeferredGrantIndexes),
-// never maintained inline. A write landing on a file whose digests are
-// already built (post-seal mutation) instead invalidates the touched
-// entitlement's digest state.
-func (e *Engine) writeGrantIndexes(batch *pebble.Batch, r *v3.GrantRecord) error {
-	for _, k := range grantIndexKeys(r) {
-		if err := batch.Set(k, nil, nil); err != nil {
-			return err
-		}
-	}
-	if e.grantDigestsPresent.Load() {
-		// Propagate a derivation failure rather than fail-open: the
-		// sibling paths (writeGrantIndexesForIdentityScratch,
-		// deleteGrantIndexesScratch) already take id as a given and
-		// can't silently skip invalidation either — a record that
-		// reaches here already had its identity derived to build the
-		// primary key, so this should be unreachable in practice, but
-		// swallowing it would leave a stale-but-present digest on the
-		// touched entitlement, violating present-means-exact.
-		id, err := grantIdentityFromRecord(r)
-		if err != nil {
-			return err
-		}
-		if err := e.stageGrantDigestInvalidation(batch, id.entitlement); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// writeGrantIndexesScratch is writeGrantIndexes that encodes each index
-// key into a single reused scratch buffer instead of allocating one
-// slice per key (grantIndexKeys allocates up to five). pebble.Batch.Set
-// copies the key, so the buffer is safe to overwrite between keys. The
-// index set and conditions MUST stay in lockstep with grantIndexKeys.
-// Returns the (possibly grown) scratch buffer for the next record.
-func (e *Engine) writeGrantIndexesScratch(batch *pebble.Batch, r *v3.GrantRecord, scratch []byte) ([]byte, error) {
-	id, err := grantIdentityFromRecord(r)
-	if err != nil {
-		return scratch, err
-	}
-	return e.writeGrantIndexesForIdentityScratch(batch, id, r.GetNeedsExpansion(), scratch)
-}
+// NOTE (2b): the per-path index/invalidation helper quartet
+// (writeGrantIndexes, writeGrantIndexesScratch,
+// writeGrantIndexesForIdentityScratch, deleteGrantIndexesScratch,
+// deleteGrantIndexesRaw) is GONE. Their obligations moved into rawdb's
+// typed record ops (StageGrantPutInline / StageGrantPutDeferred /
+// StageGrantDelete), which derive index keys from the primary key by
+// pinned byte splices and stage digest invalidation + the deferred
+// marker through the Open-wired RecordDerivers — a caller can no
+// longer stage a grant row and forget what it owes.
 
 // markDeferredIdxPending arms the deferred by_principal rebuild, durably.
 // The atomic flag serves in-process checks; the engine-meta marker survives
@@ -1051,7 +986,7 @@ func (e *Engine) markDeferredIdxPending() error {
 	if !e.deferredIdxPending.CompareAndSwap(false, true) {
 		return nil
 	}
-	if err := e.db.Set(encodeDeferredIdxPendingKey(), nil, pebble.Sync); err != nil {
+	if err := e.armDeferredMarkerDurably(); err != nil {
 		// Roll the CAS back so a retried write attempts the durable marker
 		// again. Leaving the flag armed with no durable key would make the
 		// in-process EndSync build the index (flag true) while a
@@ -1063,73 +998,55 @@ func (e *Engine) markDeferredIdxPending() error {
 	return nil
 }
 
+// armDeferredMarkerDurably commits the deferred-index marker's durable
+// half. Split out solely so tests can inject a commit failure
+// (the armDeferredMarkerHook seam) and pin the CAS rollback above — the
+// flag and the durable key must never disagree.
+func (e *Engine) armDeferredMarkerDurably() error {
+	if e.test.armDeferredMarkerHook != nil {
+		if err := e.test.armDeferredMarkerHook(); err != nil {
+			return err
+		}
+	}
+	return e.db.MetaSet(encodeDeferredIdxPendingKey(), nil, pebble.Sync)
+}
+
 // clearDeferredIdxPending drops both forms of the marker after a successful
 // rebuild. Runs under the write barrier so the flag reset and durable
 // delete can't interleave with a concurrent writer's markDeferredIdxPending
 // (which would leave the atomic flag armed but the durable marker deleted,
 // or vice versa).
+//
+// Durable delete FIRST, flag second — the same flag/key-agreement
+// contract as the arm side (markDeferredIdxPending). The old order
+// cleared the flag before the delete, so a failed delete left flag
+// false + key present: a retried EndSync then skipped the (idempotent)
+// rebuild and sealed fine, but the stale key forced a spurious rebuild
+// on the next open. With delete-first, a failure leaves BOTH armed —
+// the retried EndSync re-runs the rebuild and retries the clear.
+// (Review finding, edge/resume round.)
 func (e *Engine) clearDeferredIdxPending() error {
 	// AllowSealed: runs inside EndSync's sealed finalize window, right
 	// after the deferred build (see Adapter.EndSync).
 	return e.withWriteAllowSealed(func() error {
+		if err := e.clearDeferredMarkerDurably(); err != nil {
+			return err
+		}
 		e.deferredIdxPending.Store(false)
-		return e.db.Delete(encodeDeferredIdxPendingKey(), pebble.Sync)
+		return nil
 	})
 }
 
-// writeGrantIndexesForIdentityScratch writes the inline-maintained index keys
-// for one grant. by_principal is never written inline: it is scattered
-// relative to the entitlement-first write order, so it is always rebuilt as
-// one sorted SST at EndSync (deferredIdxPending → BuildDeferredGrantIndexes).
-func (e *Engine) writeGrantIndexesForIdentityScratch(batch *pebble.Batch, id grantIdentity, needsExpansion bool, scratch []byte) ([]byte, error) {
-	if err := e.markDeferredIdxPending(); err != nil {
-		return scratch, err
-	}
-	if needsExpansion {
-		scratch = appendGrantByNeedsExpansionIdentityIndexKey(scratch[:0], id)
-		if err := batch.Set(scratch, nil, nil); err != nil {
-			return scratch, err
+// clearDeferredMarkerDurably commits the marker's durable delete.
+// Split out for test failure injection (the clearDeferredMarkerHook seam),
+// mirroring armDeferredMarkerDurably.
+func (e *Engine) clearDeferredMarkerDurably() error {
+	if e.test.clearDeferredMarkerHook != nil {
+		if err := e.test.clearDeferredMarkerHook(); err != nil {
+			return err
 		}
 	}
-	// Post-seal mutation invalidation; no-op (one atomic load) during
-	// ordinary syncs — see stageGrantDigestInvalidation.
-	if err := e.stageGrantDigestInvalidation(batch, id.entitlement); err != nil {
-		return scratch, err
-	}
-	return scratch, nil
-}
-
-// deleteGrantIndexesScratch is the overwrite-cleanup counterpart of
-// writeGrantIndexesForIdentityScratch, encoding delete keys into a reused
-// scratch buffer. value is the prior record's marshaled bytes (borrowed from
-// the caller's pebble Get closer, which must outlive this call). by_principal
-// is not deleted inline for the same reason it is not written inline: the
-// whole family is excised and rebuilt from the primary keyspace at EndSync,
-// which also clears any stale entries an overwrite would have left. Returns
-// the (possibly grown) scratch buffer.
-func (e *Engine) deleteGrantIndexesScratch(batch *pebble.Batch, externalID string, value, scratch []byte) ([]byte, error) {
-	entRT, entRID, entID, principalRT, principalID, _, err := scanGrantIndexFieldsRaw(value)
-	if err != nil {
-		return scratch, err
-	}
-	if entID == "" || entRT == "" || entRID == "" || principalRT == "" || principalID == "" {
-		return scratch, nil
-	}
-	id := grantIdentity{
-		entitlement:     entitlementIdentityFromParts(entRT, entRID, entID),
-		principalTypeID: principalRT,
-		principalID:     principalID,
-	}
-	scratch = appendGrantByNeedsExpansionIdentityIndexKey(scratch[:0], id)
-	if err := batch.Delete(scratch, nil); err != nil {
-		return scratch, err
-	}
-	// Post-seal mutation invalidation; no-op (one atomic load) during
-	// ordinary syncs — see stageGrantDigestInvalidation.
-	if err := e.stageGrantDigestInvalidation(batch, id.entitlement); err != nil {
-		return scratch, err
-	}
-	return scratch, nil
+	return e.db.MetaDelete(encodeDeferredIdxPendingKey(), pebble.Sync)
 }
 
 // IterateGrants iterates all grants in primary-key order. yield returns

--- a/pkg/dotc1z/engine/pebble/id_index_format.go
+++ b/pkg/dotc1z/engine/pebble/id_index_format.go
@@ -87,7 +87,7 @@ func (e *Engine) readIDIndexFormat() (uint32, error) {
 func (e *Engine) writeIDIndexFormat(version uint32) error {
 	var buf [4]byte
 	binary.BigEndian.PutUint32(buf[:], version)
-	return e.db.Set(encodeIDIndexFormatKey(), buf[:], pebble.Sync)
+	return e.db.MetaSet(encodeIDIndexFormatKey(), buf[:], pebble.Sync)
 }
 
 func (e *Engine) verifyOrStampIDIndexFormat(ctx context.Context) error {

--- a/pkg/dotc1z/engine/pebble/id_index_migration.go
+++ b/pkg/dotc1z/engine/pebble/id_index_migration.go
@@ -95,7 +95,7 @@ func (e *Engine) migrateIDIndexFormatToStructuredV1(ctx context.Context) error {
 		{GrantByPrincipalResourceTypeLowerBound(), GrantByPrincipalResourceTypeUpperBound()},
 		{GrantByEntitlementResourceLowerBound(), GrantByEntitlementResourceUpperBound()},
 	} {
-		if err := e.db.DeleteRange(r[0], r[1], pebble.Sync); err != nil {
+		if err := e.db.DropKeyRange(r[0], r[1], pebble.Sync); err != nil {
 			return fmt.Errorf("id-index migration: delete dropped range: %w", err)
 		}
 	}
@@ -258,9 +258,9 @@ func finalizeMigrationSorter(ctx context.Context, fs vfs.FS, dir, name string, s
 
 func (e *Engine) replaceRangeWithSST(ctx context.Context, lower, upper []byte, path string) error {
 	if path == "" {
-		return e.db.DeleteRange(lower, upper, pebble.Sync)
+		return e.db.DropKeyRange(lower, upper, pebble.Sync)
 	}
-	_, err := e.db.IngestAndExcise(ctx, []string{path}, nil, nil, pebble.KeyRange{Start: lower, End: upper})
+	err := e.db.ReplaceRangeWithSSTs(ctx, []string{path}, pebble.KeyRange{Start: lower, End: upper})
 	return err
 }
 

--- a/pkg/dotc1z/engine/pebble/if_newer.go
+++ b/pkg/dotc1z/engine/pebble/if_newer.go
@@ -38,14 +38,15 @@ func (e *Engine) PutGrantRecordsIfNewer(ctx context.Context, records ...*v3.Gran
 		if err := e.requireCurrentSync(); err != nil {
 			return err
 		}
-		batch := e.db.NewBatch()
+		batch := e.db.NewRecordBatch()
 		defer batch.Close()
 		// No inline hash-index or digest maintenance here: both are
 		// derived at seal time (the fused deferred pass). But IfNewer is
 		// the partial-sync path — it mutates a CLONED sealed file whose
-		// digests are built — so the index write/delete helpers below
-		// stage the touched entitlements' digest invalidation
-		// (stageGrantDigestInvalidation) whenever digests are present.
+		// digests are built — so StageGrantPutInline's derivers stage
+		// the touched entitlements' digest invalidation whenever
+		// digests are present (StageGrantDigestInvalidation deriver,
+		// records.go).
 		written := 0
 		for _, r := range records {
 			if r == nil {
@@ -56,6 +57,7 @@ func (e *Engine) PutGrantRecordsIfNewer(ctx context.Context, records ...*v3.Gran
 				return err
 			}
 			key := encodeGrantIdentityKey(id)
+			hadOld := false
 			oldVal, closer, getErr := e.db.Get(key)
 			switch {
 			case getErr == nil:
@@ -68,10 +70,7 @@ func (e *Engine) PutGrantRecordsIfNewer(ctx context.Context, records ...*v3.Gran
 					closer.Close()
 					continue
 				}
-				if err := e.deleteGrantIndexesRaw(batch, r.GetExternalId(), oldVal); err != nil {
-					closer.Close()
-					return err
-				}
+				hadOld = true
 				closer.Close()
 			case errors.Is(getErr, pebble.ErrNotFound):
 				// no existing record — write unconditionally
@@ -82,10 +81,10 @@ func (e *Engine) PutGrantRecordsIfNewer(ctx context.Context, records ...*v3.Gran
 			if err != nil {
 				return err
 			}
-			if err := batch.Set(key, val, nil); err != nil {
-				return err
-			}
-			if err := e.writeGrantIndexes(batch, r); err != nil {
+			// Inline regime: the typed op stages the row plus prior-row
+			// index cleanup, both index entries, and digest invalidation
+			// (this IS the partial-sync path the invalidation exists for).
+			if err := batch.StageGrantPutInline(key, val, hadOld, r.GetNeedsExpansion()); err != nil {
 				return err
 			}
 			written++
@@ -107,7 +106,7 @@ func (e *Engine) PutResourceRecordsIfNewer(ctx context.Context, records ...*v3.R
 		if err := e.requireCurrentSync(); err != nil {
 			return err
 		}
-		batch := e.db.NewBatch()
+		batch := e.db.NewRecordBatch()
 		defer batch.Close()
 		written := 0
 		for _, r := range records {
@@ -127,11 +126,19 @@ func (e *Engine) PutResourceRecordsIfNewer(ctx context.Context, records ...*v3.R
 					closer.Close()
 					continue
 				}
-				if err := e.deleteResourceIndexesRaw(batch, r.GetResourceTypeId(), r.GetResourceId(), oldVal); err != nil {
+				val, err := marshalRecord(r)
+				if err != nil {
 					closer.Close()
 					return err
 				}
+				// Typed op consumes the prior value for by_parent cleanup.
+				err = batch.StageResourcePut(key, val, oldVal, r.GetResourceTypeId(), r.GetResourceId())
 				closer.Close()
+				if err != nil {
+					return err
+				}
+				written++
+				continue
 			case errors.Is(getErr, pebble.ErrNotFound):
 			default:
 				return fmt.Errorf("PutResourceRecordsIfNewer: get: %w", getErr)
@@ -140,10 +147,7 @@ func (e *Engine) PutResourceRecordsIfNewer(ctx context.Context, records ...*v3.R
 			if err != nil {
 				return err
 			}
-			if err := batch.Set(key, val, nil); err != nil {
-				return err
-			}
-			if err := e.writeResourceIndexes(batch, r); err != nil {
+			if err := batch.StageResourcePut(key, val, nil, r.GetResourceTypeId(), r.GetResourceId()); err != nil {
 				return err
 			}
 			written++
@@ -164,7 +168,7 @@ func (e *Engine) PutEntitlementRecordsIfNewer(ctx context.Context, records ...*v
 		if err := e.requireCurrentSync(); err != nil {
 			return err
 		}
-		batch := e.db.NewBatch()
+		batch := e.db.NewRecordBatch()
 		defer batch.Close()
 		written := 0
 		for _, r := range records {
@@ -197,7 +201,7 @@ func (e *Engine) PutEntitlementRecordsIfNewer(ctx context.Context, records ...*v
 			if err != nil {
 				return err
 			}
-			if err := batch.Set(key, val, nil); err != nil {
+			if err := batch.StageEntitlementPut(key, val); err != nil {
 				return err
 			}
 			written++
@@ -222,7 +226,7 @@ func (e *Engine) PutResourceTypeRecordsIfNewer(ctx context.Context, records ...*
 		if err := e.requireCurrentSync(); err != nil {
 			return err
 		}
-		batch := e.db.NewBatch()
+		batch := e.db.NewRecordBatch()
 		defer batch.Close()
 		written := 0
 		for _, r := range records {
@@ -250,7 +254,7 @@ func (e *Engine) PutResourceTypeRecordsIfNewer(ctx context.Context, records ...*
 			if err != nil {
 				return err
 			}
-			if err := batch.Set(key, val, nil); err != nil {
+			if err := batch.StageResourceTypePut(key, val); err != nil {
 				return err
 			}
 			written++

--- a/pkg/dotc1z/engine/pebble/index_migrations.go
+++ b/pkg/dotc1z/engine/pebble/index_migrations.go
@@ -141,5 +141,5 @@ func (e *Engine) readAppliedIndexVersion(name string) (uint32, error) {
 func (e *Engine) writeAppliedIndexVersion(name string, version uint32) error {
 	var buf [4]byte
 	binary.BigEndian.PutUint32(buf[:], version)
-	return e.db.Set(encodeIndexAppliedKey(name), buf[:], pebble.Sync)
+	return e.db.MetaSet(encodeIndexAppliedKey(name), buf[:], pebble.Sync)
 }

--- a/pkg/dotc1z/engine/pebble/index_migrations_test.go
+++ b/pkg/dotc1z/engine/pebble/index_migrations_test.go
@@ -64,8 +64,8 @@ func TestApplyIndexMigrationsBackfillsNeedsExpansion(t *testing.T) {
 	// version so the next Open sees an old c1z that needs
 	// migration.
 	idxKey := encodeGrantByNeedsExpansionIndexKey("g-pending")
-	require.NoErrorf(t, e.db.Delete(idxKey, pebble.Sync), "delete idx key")
-	require.NoErrorf(t, e.db.Delete(encodeIndexAppliedKey("grant_needs_expansion"), pebble.Sync), "delete applied-version key")
+	require.NoErrorf(t, e.db.UnsafeForTesting().Delete(idxKey, pebble.Sync), "delete idx key")
+	require.NoErrorf(t, e.db.UnsafeForTesting().Delete(encodeIndexAppliedKey("grant_needs_expansion"), pebble.Sync), "delete applied-version key")
 	// Sanity: pre-migration walk finds nothing.
 	pre := 0
 	require.NoErrorf(t, e.IterateGrantsByNeedsExpansion(ctx, func(*v3.GrantRecord) bool {

--- a/pkg/dotc1z/engine/pebble/internal/rawdb/families.go
+++ b/pkg/dotc1z/engine/pebble/internal/rawdb/families.go
@@ -82,11 +82,20 @@ type RecordBatch struct {
 	core    batch
 	db      *DB
 	scratch []byte
+	// stager is the batch's one Stager view, pre-built so the grant
+	// Stage* ops can pass &rb.stager to the digest-invalidation
+	// deriver without a per-op heap allocation (an inline
+	// &recordStager{rb} escapes through the indirect func-field call
+	// even when the deriver immediately no-ops on digest-absent
+	// syncs — one 8-byte alloc per staged grant on the bulk path).
+	stager recordStager
 }
 
 // NewRecordBatch mints a batch for record-keyspace mutations.
 func (d *DB) NewRecordBatch() *RecordBatch {
-	return &RecordBatch{core: batch{b: d.newBatch()}, db: d}
+	rb := &RecordBatch{core: batch{b: d.newBatch()}, db: d}
+	rb.stager.rb = rb
+	return rb
 }
 
 // Commit applies the staged writes with the given write options.

--- a/pkg/dotc1z/engine/pebble/internal/rawdb/families.go
+++ b/pkg/dotc1z/engine/pebble/internal/rawdb/families.go
@@ -1,0 +1,188 @@
+package rawdb
+
+// The per-family write surface. Each write family gets its own batch
+// type or purpose-named operations; the family is load-bearing — it
+// ties every write to its registry entry, its obligations, and its
+// crash contract, and it is the unit the meta-tests reason about.
+//
+// Two layers of enforcement: NOTHING outside internal/rawdb can mint
+// a raw batch or touch the raw DB at all (unexported primitives +
+// meta-tests), so every write arrives through a family-named
+// constructor; and the RECORD family goes further — its batch exposes
+// no generic staging at all, only typed Stage* operations
+// (records.go) that derive their index/digest/marker obligations
+// internally and assert key prefixes, so a record write physically
+// cannot forget its side effects. The other families (session, meta,
+// digest, fold) keep the uniform staged surface below.
+
+import (
+	"context"
+
+	"github.com/cockroachdb/pebble/v2"
+)
+
+// Stager is the staged-write surface shared by every family batch.
+// Helpers that legitimately serve two families take it instead of a
+// concrete batch type — today that is digest invalidation, which is
+// staged by RECORD mutations (post-seal partial syncs, via
+// RecordBatch) and by the digest REPAIR pass (via DigestBatch).
+type Stager interface {
+	Set(key, val []byte) error
+	Delete(key []byte) error
+	DeleteRange(start, end []byte) error
+}
+
+// batch is the shared staged-write core the family types embed.
+type batch struct {
+	b *pebble.Batch
+}
+
+// Set stages key → val.
+func (b *batch) Set(key, val []byte) error { return b.b.Set(key, val, nil) }
+
+// Delete stages a point delete.
+func (b *batch) Delete(key []byte) error { return b.b.Delete(key, nil) }
+
+// DeleteRange stages a range delete [start, end).
+func (b *batch) DeleteRange(start, end []byte) error { return b.b.DeleteRange(start, end, nil) }
+
+// Empty reports whether nothing was staged.
+func (b *batch) Empty() bool { return b.b.Empty() }
+
+// Count returns the number of staged operations.
+func (b *batch) Count() uint32 { return b.b.Count() }
+
+// Len returns the encoded batch size in bytes (flush-threshold checks).
+func (b *batch) Len() int { return len(b.b.Repr()) }
+
+// Commit applies the staged writes with the given write options.
+func (b *batch) Commit(o *pebble.WriteOptions) error { return b.b.Commit(o) }
+
+// Close releases the batch. Safe after Commit.
+func (b *batch) Close() error { return b.b.Close() }
+
+// === record family: grants / entitlements / resources / resource types ===
+//
+// The primary record keyspaces plus their inline-maintained index
+// families and the digest-invalidation markers a record mutation owes.
+// Clients: the Put*Records paths, the expanded/synthesized grant
+// writers, the IfNewer partial-sync paths, and delete paths.
+//
+// Phase 2b: RecordBatch exposes NO generic staging. The only way to
+// stage a record mutation is a typed Stage* operation (records.go)
+// that derives and stages everything the row owes in the same call —
+// the forgotten-obligation bug class (primary landed, index entry or
+// digest invalidation forgotten) is unexpressible. The compactor's
+// keep-newer fold, which legitimately stages raw keys it did not
+// encode, uses FoldBatch instead (records.go) via the Engine.DB
+// exemption surface.
+type RecordBatch struct {
+	// core is deliberately NOT embedded: embedding would promote the
+	// generic Set/Delete/DeleteRange onto the exported surface.
+	core    batch
+	db      *DB
+	scratch []byte
+}
+
+// NewRecordBatch mints a batch for record-keyspace mutations.
+func (d *DB) NewRecordBatch() *RecordBatch {
+	return &RecordBatch{core: batch{b: d.newBatch()}, db: d}
+}
+
+// Commit applies the staged writes with the given write options.
+func (rb *RecordBatch) Commit(o *pebble.WriteOptions) error { return rb.core.Commit(o) }
+
+// Close releases the batch. Safe after Commit.
+func (rb *RecordBatch) Close() error { return rb.core.Close() }
+
+// NOTE (2b): Absorb (the pri/idx two-batch fold) is gone — the typed
+// Stage* ops put a row and its obligations into ONE batch, so the
+// single-fsync atomicity the fold existed for is now structural.
+
+// === session family ===
+//
+// Connector scratch state, written even after EndSync seals the engine
+// (Cleanup clears sessions post-sync).
+
+// SessionSet writes one session row.
+func (d *DB) SessionSet(key, val []byte, o *pebble.WriteOptions) error { return d.set(key, val, o) }
+
+// SessionDelete removes one session row.
+func (d *DB) SessionDelete(key []byte, o *pebble.WriteOptions) error { return d.delete(key, o) }
+
+// SessionClearRange removes a whole session key range (sync- or
+// prefix-scoped clear).
+func (d *DB) SessionClearRange(start, end []byte, o *pebble.WriteOptions) error {
+	return d.deleteRange(start, end, o)
+}
+
+// SessionBatch stages multi-row session writes/deletes.
+type SessionBatch struct {
+	batch
+}
+
+// NewSessionBatch mints a batch for session-keyspace mutations.
+func (d *DB) NewSessionBatch() *SessionBatch { return &SessionBatch{batch{b: d.newBatch()}} }
+
+// === engine-meta family ===
+//
+// Single fixed keys: the keyspace/format stamps, index-migration
+// markers, the deferred-index and digest-build crash markers, the
+// sync-run record, the stats sidecar, counters, and asset rows.
+// Always single-key, never batched.
+
+// MetaSet writes one engine-meta / fixed-key row.
+func (d *DB) MetaSet(key, val []byte, o *pebble.WriteOptions) error { return d.set(key, val, o) }
+
+// MetaDelete removes one engine-meta / fixed-key row.
+func (d *DB) MetaDelete(key []byte, o *pebble.WriteOptions) error { return d.delete(key, o) }
+
+// === digest family: build / repair ===
+//
+// The seal-time digest build and the post-seal repair pass are the
+// ONLY writers of digest nodes and roots (record mutations only stage
+// invalidations, through RecordBatch). They commit node batches during
+// their scans and stamp the global root as a single write.
+
+// DigestBatch stages digest-node/root writes for the build/repair
+// passes.
+type DigestBatch struct {
+	batch
+}
+
+// NewDigestBatch mints a batch for digest-keyspace writes.
+func (d *DB) NewDigestBatch() *DigestBatch { return &DigestBatch{batch{b: d.newBatch()}} }
+
+// DigestSet writes one digest node/root row outside a batch (the
+// global root stamp at the end of build/repair).
+func (d *DB) DigestSet(key, val []byte, o *pebble.WriteOptions) error { return d.set(key, val, o) }
+
+// DropKeyRange deletes a whole keyspace range. Purpose-named per
+// caller in the registry: digest-state drops, hash-index drops,
+// and migration range replacement with an empty source.
+func (d *DB) DropKeyRange(start, end []byte, o *pebble.WriteOptions) error {
+	return d.deleteRange(start, end, o)
+}
+
+// === ingest family: deferred index build, digest build, bulk import,
+// synth-grant layer, id-index migration, compactor merges ===
+
+// IngestSSTs ingests externally built SSTs (bulk import, synth-layer
+// segments, compactor merge output). Paths must live on DB.FS().
+func (d *DB) IngestSSTs(ctx context.Context, paths []string) error {
+	return d.ingest(ctx, paths)
+}
+
+// ReplaceRangeWithSSTs atomically replaces span with the given SSTs
+// (IngestAndExcise): the deferred index build's by_principal swap, the
+// digest build's hash-index swap, the id-index migration's re-key, the
+// compactor's bucket replacement.
+func (d *DB) ReplaceRangeWithSSTs(ctx context.Context, paths []string, span pebble.KeyRange) error {
+	return d.ingestAndExcise(ctx, paths, span)
+}
+
+// ExciseRange atomically drops span without ingesting anything
+// (ResetForNewSync's wipe, the clone's engine-local scrub).
+func (d *DB) ExciseRange(ctx context.Context, span pebble.KeyRange) error {
+	return d.excise(ctx, span)
+}

--- a/pkg/dotc1z/engine/pebble/internal/rawdb/rawdb.go
+++ b/pkg/dotc1z/engine/pebble/internal/rawdb/rawdb.go
@@ -1,0 +1,220 @@
+// Package rawdb is the single owner of the engine's raw *pebble.DB —
+// the compiler-enforced write choke point for the v3 storage engine.
+//
+// THE ENFORCEMENT MODEL: the pebble handle is an unexported field of
+// DB, and the generic write primitives (set, delete, newBatch, ...)
+// are unexported functions of this package. Code outside internal/rawdb
+// physically cannot compose a raw write; it can only call the exported,
+// purpose-named operations below, each of which states its keyspace
+// family and carries that family's obligations (index maintenance,
+// digest invalidation, crash markers) inside the operation instead of
+// hoping every caller remembers them. Every recurring bug class this
+// engine has shipped — the forgotten index write, the skipped digest
+// invalidation, the fast-path flag that survived a failed mutation —
+// is a caller that forgot an obligation; this package makes the
+// obligation unforgettable by construction.
+//
+// What this package deliberately does NOT own: the engine's write
+// BARRIER (writeMu / writeWG / closing / sealed / checkpointMu) stays
+// in the pebble package. The barrier is lifecycle policy — who may
+// write when — while rawdb is write mechanics — what a write must do.
+// Callers arrive here already inside withWrite/withWriteAllowSealed;
+// the known barrier bypasses (the synth-layer worker's background
+// ingest, the compactor's DB() writes, cleanup's compaction driver)
+// are enumerated on the operations that serve them.
+//
+// Reads are exposed liberally (Get / NewIter / Metrics): the bug class
+// lives on the write side, and a read choke point would only add
+// friction.
+package rawdb
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/cockroachdb/pebble/v2/vfs"
+)
+
+// DB owns the raw pebble handle. Construct via Open; the pebble.DB is
+// reachable outside this package only through the exported operations.
+type DB struct {
+	db *pebble.DB
+	// fs is the filesystem the pebble.DB performs its IO through
+	// (pebble.Options.FS resolved: the WithVFS override or vfs.Default).
+	// Every SST this package stages for ingest MUST be created on it.
+	fs vfs.FS
+	// derivers are the engine-injected key-format functions the typed
+	// record ops (records.go) derive obligations with. Wired once via
+	// SetRecordDerivers at engine Open.
+	derivers *RecordDerivers
+	// merge is the pre-built narrowed view MergeView() hands out.
+	merge MergeView
+}
+
+// Open opens the pebble database at dir. opts is consumed by
+// pebble.Open exactly as given; fs must be the same filesystem the
+// options carry (or vfs.Default when opts.FS is nil), because staged
+// ingest files are created through it.
+func Open(dir string, opts *pebble.Options, fs vfs.FS) (*DB, error) {
+	db, err := pebble.Open(dir, opts)
+	if err != nil {
+		return nil, err
+	}
+	if fs == nil {
+		fs = vfs.Default
+	}
+	d := &DB{db: db, fs: fs}
+	d.merge = MergeView{db: d}
+	return d, nil
+}
+
+// Close closes the underlying pebble.DB. The engine's teardown
+// ordering (write barrier, worker drain) is the caller's job.
+func (d *DB) Close() error { return d.db.Close() }
+
+// FS returns the filesystem the DB's IO rides on. SSTs staged for
+// Ingest/IngestAndExcise must be created through it.
+func (d *DB) FS() vfs.FS { return d.fs }
+
+// === read surface (exposed liberally) ===
+
+// Get reads a key. Same contract as pebble.DB.Get, including
+// pebble.ErrNotFound and the caller-owned closer.
+func (d *DB) Get(key []byte) ([]byte, io.Closer, error) { return d.db.Get(key) }
+
+// NewIter opens an iterator. Same contract as pebble.DB.NewIter.
+func (d *DB) NewIter(o *pebble.IterOptions) (*pebble.Iterator, error) { return d.db.NewIter(o) }
+
+// Metrics returns pebble's metrics snapshot.
+func (d *DB) Metrics() *pebble.Metrics { return d.db.Metrics() }
+
+// EstimateDiskUsage estimates on-disk size of the key range.
+func (d *DB) EstimateDiskUsage(start, end []byte) (uint64, error) {
+	return d.db.EstimateDiskUsage(start, end)
+}
+
+// UnsafeForTesting returns the raw *pebble.DB — the single test escape
+// hatch through the choke point. Test fixtures legitimately construct
+// states the production API cannot express by design: corruption
+// planters (orphan index entries, tampered digests), crash fixtures,
+// and marker manipulation. Each caller is asserting "this state is now
+// unconstructible via the production API, and that is the point of my
+// test". Panics outside `go test` (testing.Testing()); the os-IO/raw-
+// write meta-tests additionally forbid it in non-test files.
+func (d *DB) UnsafeForTesting() *pebble.DB {
+	if !testing.Testing() {
+		panic("rawdb.UnsafeForTesting: called outside a test binary")
+	}
+	return d.db
+}
+
+// === the compactor's narrowed view ===
+
+// MergeView is the CONCRETE handle Engine.DB() hands the
+// synccompactor: reads, LSM stats, the bulk range/ingest ops, and the
+// fold-exempt batch — and nothing else. It must stay a concrete
+// struct, not an interface over *DB: Go interfaces are structural, so
+// an interface whose dynamic type is *DB would let any caller recover
+// the omitted write families with a type assertion
+// (`h.(interface{ MetaSet(...) error })`) — no internal-package import
+// required (review finding, delta round). A struct with only these
+// methods gives an assertion nothing to recover.
+//
+// NewFoldBatch is the one deliberate raw-write conduit here: the fold
+// compactor rewrites record keyspaces wholesale, with its obligations
+// handled by contract (digest state dropped, markers handled at the
+// store layer) rather than derivation. Its use is fenced to
+// pkg/synccompactor/pebble by meta-test.
+type MergeView struct {
+	db *DB
+}
+
+// MergeView returns the narrowed handle. Stable identity per DB (the
+// engine returns it to external callers on every DB() call).
+func (d *DB) MergeView() *MergeView { return &d.merge }
+
+func (v *MergeView) Get(key []byte) ([]byte, io.Closer, error) { return v.db.Get(key) }
+
+func (v *MergeView) NewIter(o *pebble.IterOptions) (*pebble.Iterator, error) {
+	return v.db.NewIter(o)
+}
+
+func (v *MergeView) Metrics() *pebble.Metrics { return v.db.Metrics() }
+
+func (v *MergeView) EstimateDiskUsage(start, end []byte) (uint64, error) {
+	return v.db.EstimateDiskUsage(start, end)
+}
+
+func (v *MergeView) DropKeyRange(start, end []byte, o *pebble.WriteOptions) error {
+	return v.db.DropKeyRange(start, end, o)
+}
+
+func (v *MergeView) IngestSSTs(ctx context.Context, paths []string) error {
+	return v.db.IngestSSTs(ctx, paths)
+}
+
+func (v *MergeView) ReplaceRangeWithSSTs(ctx context.Context, paths []string, span pebble.KeyRange) error {
+	return v.db.ReplaceRangeWithSSTs(ctx, paths, span)
+}
+
+func (v *MergeView) NewFoldBatch() *FoldBatch { return v.db.NewFoldBatch() }
+
+// UnsafeForTesting delegates to DB.UnsafeForTesting — same
+// testing.Testing() runtime gate, same meta-test source fence.
+func (v *MergeView) UnsafeForTesting() *pebble.DB { return v.db.UnsafeForTesting() }
+
+// === lifecycle operations (write-class, engine-lifecycle-named) ===
+
+// FlushMemtables forces the memtable out to L0 (pebble.DB.Flush,
+// blocking). Used by the engine's durability boundaries (EndSync
+// flush, pre-checkpoint flush, close).
+func (d *DB) FlushMemtables() error { return d.db.Flush() }
+
+// Checkpoint cuts a pebble checkpoint into destDir (created by pebble,
+// must not exist). Caller holds the engine's checkpoint barrier.
+func (d *DB) Checkpoint(destDir string) error { return d.db.Checkpoint(destDir) }
+
+// Compact manually compacts the given key range. Serves cleanup's
+// space-reclaim pass; deliberately barrier-free at the engine layer
+// (see the checkpointMu inventory).
+func (d *DB) Compact(ctx context.Context, start, end []byte, parallel bool) error {
+	return d.db.Compact(ctx, start, end, parallel)
+}
+
+// WALSyncPoint commits an empty synced log record: a durability fence
+// that guarantees every prior WAL entry is on disk without touching
+// any keyspace. (pebble.DB.LogData with Sync.)
+func (d *DB) WALSyncPoint() error {
+	return d.db.LogData(nil, pebble.Sync)
+}
+
+// === generic primitives: UNEXPORTED, by design ===
+//
+// These are the only functions in the engine allowed to touch the raw
+// pebble write API. Exported operations in this package's family files
+// compose them; nothing outside the package can. If you are tempted to
+// export one of these, you are about to reintroduce the bug class this
+// package exists to kill — add a purpose-named operation instead.
+
+func (d *DB) set(key, val []byte, o *pebble.WriteOptions) error { return d.db.Set(key, val, o) }
+
+func (d *DB) delete(key []byte, o *pebble.WriteOptions) error { return d.db.Delete(key, o) }
+
+func (d *DB) deleteRange(start, end []byte, o *pebble.WriteOptions) error {
+	return d.db.DeleteRange(start, end, o)
+}
+
+func (d *DB) newBatch() *pebble.Batch { return d.db.NewBatch() }
+
+func (d *DB) ingest(ctx context.Context, paths []string) error { return d.db.Ingest(ctx, paths) }
+
+func (d *DB) ingestAndExcise(ctx context.Context, paths []string, span pebble.KeyRange) error {
+	_, err := d.db.IngestAndExcise(ctx, paths, nil, nil, span)
+	return err
+}
+
+func (d *DB) excise(ctx context.Context, span pebble.KeyRange) error {
+	return d.db.Excise(ctx, span)
+}

--- a/pkg/dotc1z/engine/pebble/internal/rawdb/records.go
+++ b/pkg/dotc1z/engine/pebble/internal/rawdb/records.go
@@ -167,7 +167,7 @@ func (rb *RecordBatch) StageGrantPutInline(key, val []byte, hadOldVal, needsExpa
 			return err
 		}
 	}
-	return d.StageGrantDigestInvalidation(&recordStager{rb}, key)
+	return d.StageGrantDigestInvalidation(&rb.stager, key)
 }
 
 // StageGrantDelete stages one grant row's removal (INLINE regime:
@@ -199,7 +199,7 @@ func (rb *RecordBatch) StageGrantDelete(key []byte) error {
 	if err := rb.core.b.Delete(key, nil); err != nil {
 		return err
 	}
-	return d.StageGrantDigestInvalidation(&recordStager{rb}, key)
+	return d.StageGrantDigestInvalidation(&rb.stager, key)
 }
 
 // StageGrantPutDeferred stages one grant row in the DEFERRED index
@@ -234,7 +234,7 @@ func (rb *RecordBatch) StageGrantPutDeferred(key, val []byte, hadOldVal, needsEx
 			return err
 		}
 	}
-	return d.StageGrantDigestInvalidation(&recordStager{rb}, key)
+	return d.StageGrantDigestInvalidation(&rb.stager, key)
 }
 
 func (rb *RecordBatch) setGrantIndexKey(derive func(dst, primaryKey []byte) ([]byte, bool), key []byte) error {

--- a/pkg/dotc1z/engine/pebble/internal/rawdb/records.go
+++ b/pkg/dotc1z/engine/pebble/internal/rawdb/records.go
@@ -1,0 +1,389 @@
+package rawdb
+
+// Phase 2b: typed record-keyspace staging with obligation derivation
+// FOLDED INTO the ops. The forgotten-obligation bug class — a caller
+// staging a primary row and forgetting its index entries, digest
+// invalidation, prior-row index cleanup, or the deferred-index crash
+// marker — dies here: RecordBatch exposes no generic staging, and each
+// Stage* op computes and stages everything its mutation owes in the
+// same call.
+//
+// Grant index maintenance runs TWO REGIMES, and the ops mirror them
+// (unifying them behind a flag was considered and rejected — the
+// regimes differ in WHICH obligations exist, not how they're done):
+//
+//   - INLINE (StageGrantPutInline / StageGrantDelete): by_principal
+//     and by_needs_expansion maintained inline; overwrite/delete
+//     cleans BOTH; digest invalidation when digests are present. The
+//     PutGrantRecords and IfNewer paths, and post-seal deletes.
+//   - DEFERRED (StageGrantPutDeferred): the durable deferred-index
+//     marker is armed FIRST (via the engine-injected arm function —
+//     CAS-cheap per record, crash-contract-ordered before the batch
+//     can commit), only by_needs_expansion is written inline, and
+//     overwrite cleanup deliberately skips by_principal (the whole
+//     family is excised and rebuilt at seal). The expanded/synth
+//     grant writers.
+//
+// The derivation contract is BYTE-LEVEL and KEY-DERIVED: index keys
+// come from the encoded grant primary key by splice (by_principal:
+// segment permutation; by_needs_expansion: header swap; digest
+// partition: sub-slice) — the primary key IS the identity encoding,
+// so key-derived and value-derived obligations are identical by
+// construction, and the splices are pinned against decode+re-encode
+// by the engine's TestAppendGrantByPrincipalKeyFromPrimary /
+// TestNeedsExpansionKeyHeaderSpliceFromPrimary. The engine injects
+// the splice/scan functions once at Open (RecordDerivers): rawdb owns
+// the COMPOSITION (what must be staged together, unforgettable), the
+// engine owns the byte formats (its keyspace ABI).
+//
+// Every op asserts its key's family prefix — a Stage* call with a key
+// from the wrong keyspace fails loudly rather than landing where it
+// doesn't belong.
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/pebble/v2"
+)
+
+// RecordDerivers are the engine-injected functions the typed record
+// ops derive obligations with. Append-shaped functions write into dst
+// and return it (scratch reuse; the batch owns the scratch).
+type RecordDerivers struct {
+	// GrantKeyValid reports whether a grant primary key decodes as a
+	// 6-segment identity. Run unconditionally by every grant op: the
+	// splices validate implicitly, but obligation paths are
+	// conditional (a deferred put with needsExpansion=false and
+	// digests unarmed runs no splice at all), and a malformed key must
+	// never stage regardless of which obligations happen to fire.
+	GrantKeyValid func(primaryKey []byte) bool
+	// GrantByPrincipalKey appends the by_principal index key derived
+	// from a grant primary key (segment permutation). ok=false means
+	// the key did not decode as a 6-segment grant identity.
+	GrantByPrincipalKey func(dst, primaryKey []byte) ([]byte, bool)
+	// GrantNeedsExpansionKey appends the by_needs_expansion index key
+	// derived from a grant primary key (header swap).
+	GrantNeedsExpansionKey func(dst, primaryKey []byte) ([]byte, bool)
+	// StageGrantDigestInvalidation stages the digest invalidation a
+	// grant mutation owes for its entitlement partition when digest
+	// state exists (present-means-exact). Must internally no-op when
+	// digests are not armed — the armed probe is engine state.
+	StageGrantDigestInvalidation func(st Stager, grantPrimaryKey []byte) error
+	// ArmDeferredGrantIndex durably arms the deferred by_principal
+	// rebuild marker (CAS + fsync'd meta key; rollback on failure).
+	// Called by the DEFERRED regime before staging, per record —
+	// the engine's CAS makes repeat calls one atomic load.
+	ArmDeferredGrantIndex func() error
+
+	// ResourceParent scans a marshaled ResourceRecord value for its
+	// parent ref ("", "" = no parent, no index entry owed).
+	ResourceParent func(value []byte) (parentRT, parentID string, err error)
+	// ResourceByParentKey builds the by_parent index key.
+	ResourceByParentKey func(parentRT, parentID, childRT, childID string) []byte
+
+	// Family prefixes for the keyspace assertions.
+	GrantPrimaryPrefix        []byte
+	ResourcePrimaryPrefix     []byte
+	EntitlementPrimaryPrefix  []byte
+	ResourceTypePrimaryPrefix []byte
+}
+
+func (d *RecordDerivers) complete() error {
+	switch {
+	case d.GrantKeyValid == nil, d.GrantByPrincipalKey == nil, d.GrantNeedsExpansionKey == nil,
+		d.StageGrantDigestInvalidation == nil, d.ArmDeferredGrantIndex == nil,
+		d.ResourceParent == nil, d.ResourceByParentKey == nil:
+		return fmt.Errorf("rawdb: RecordDerivers incomplete: every derivation function is load-bearing")
+	case len(d.GrantPrimaryPrefix) == 0, len(d.ResourcePrimaryPrefix) == 0,
+		len(d.EntitlementPrimaryPrefix) == 0, len(d.ResourceTypePrimaryPrefix) == 0:
+		return fmt.Errorf("rawdb: RecordDerivers incomplete: family prefixes required for keyspace assertions")
+	}
+	return nil
+}
+
+// SetRecordDerivers wires the engine's derivation functions. Must be
+// called exactly once, at engine Open, before any record staging.
+func (d *DB) SetRecordDerivers(rd RecordDerivers) error {
+	if err := rd.complete(); err != nil {
+		return err
+	}
+	if d.derivers != nil {
+		return fmt.Errorf("rawdb: RecordDerivers already set")
+	}
+	d.derivers = &rd
+	return nil
+}
+
+func (d *DB) mustDerivers() *RecordDerivers {
+	if d.derivers == nil {
+		panic("rawdb: record staging before SetRecordDerivers — the engine must wire derivers at Open")
+	}
+	return d.derivers
+}
+
+func assertFamily(op string, key, prefix []byte) error {
+	if len(key) < len(prefix) || string(key[:len(prefix)]) != string(prefix) {
+		return fmt.Errorf("rawdb.%s: key %x is outside this op's keyspace family (want prefix %x) — use the family op that owns that keyspace", op, key, prefix)
+	}
+	return nil
+}
+
+// === grant staging ===
+
+// StageGrantPutInline stages one grant row in the INLINE index regime
+// and everything it owes: prior-row index cleanup (both families, when
+// hadOldVal — grant index keys derive from the primary key, which IS
+// the identity encoding, so cleanup needs only an existence fact, not
+// the prior bytes), the primary row, the by_principal entry, the
+// by_needs_expansion entry (when needsExpansion), and the digest
+// invalidation. needsExpansion comes from the caller's decoded record
+// (the write path has it; deriving it here would force a value scan).
+// Contrast StageResourcePut, which takes the prior VALUE bytes —
+// resource index keys derive from the value (parent ref), not the key.
+func (rb *RecordBatch) StageGrantPutInline(key, val []byte, hadOldVal, needsExpansion bool) error {
+	d := rb.db.mustDerivers()
+	if err := assertFamily("StageGrantPutInline", key, d.GrantPrimaryPrefix); err != nil {
+		return err
+	}
+	if !d.GrantKeyValid(key) {
+		return fmt.Errorf("rawdb.StageGrantPutInline: grant key %x did not decode as a 6-segment identity", key)
+	}
+	if hadOldVal {
+		if err := rb.deleteGrantIndexKey(d.GrantByPrincipalKey, key); err != nil {
+			return err
+		}
+		if err := rb.deleteGrantIndexKey(d.GrantNeedsExpansionKey, key); err != nil {
+			return err
+		}
+	}
+	if err := rb.core.b.Set(key, val, nil); err != nil {
+		return err
+	}
+	if err := rb.setGrantIndexKey(d.GrantByPrincipalKey, key); err != nil {
+		return err
+	}
+	if needsExpansion {
+		if err := rb.setGrantIndexKey(d.GrantNeedsExpansionKey, key); err != nil {
+			return err
+		}
+	}
+	return d.StageGrantDigestInvalidation(&recordStager{rb}, key)
+}
+
+// StageGrantDelete stages one grant row's removal (INLINE regime:
+// post-seal deletes on files whose by_principal index is live) and
+// everything it owes: both index entries' cleanup and the digest
+// invalidation.
+//
+// INTENTIONAL TIGHTENING vs the pre-2b helpers (review-verified): the
+// old value-derived cleanup silently SKIPPED index deletes AND the
+// digest invalidation when the prior value's identity fields were
+// missing (malformed legacy rows) — deleting the primary while leaving
+// a stale-but-present digest, a present-means-exact hole. Key-derived
+// cleanup cannot be skipped; tombstones on absent index keys are
+// harmless.
+func (rb *RecordBatch) StageGrantDelete(key []byte) error {
+	d := rb.db.mustDerivers()
+	if err := assertFamily("StageGrantDelete", key, d.GrantPrimaryPrefix); err != nil {
+		return err
+	}
+	if !d.GrantKeyValid(key) {
+		return fmt.Errorf("rawdb.StageGrantDelete: grant key %x did not decode as a 6-segment identity", key)
+	}
+	if err := rb.deleteGrantIndexKey(d.GrantByPrincipalKey, key); err != nil {
+		return err
+	}
+	if err := rb.deleteGrantIndexKey(d.GrantNeedsExpansionKey, key); err != nil {
+		return err
+	}
+	if err := rb.core.b.Delete(key, nil); err != nil {
+		return err
+	}
+	return d.StageGrantDigestInvalidation(&recordStager{rb}, key)
+}
+
+// StageGrantPutDeferred stages one grant row in the DEFERRED index
+// regime: the durable rebuild marker is armed first (crash contract —
+// an interrupted sync must rebuild at its resumed EndSync), only the
+// by_needs_expansion entry is maintained inline, overwrite cleanup
+// deliberately skips by_principal (the family is excised and rebuilt
+// wholesale at seal, which also clears stale entries), and the digest
+// invalidation is staged. hadOldVal selects overwrite cleanup of the
+// needs_expansion entry.
+func (rb *RecordBatch) StageGrantPutDeferred(key, val []byte, hadOldVal, needsExpansion bool) error {
+	d := rb.db.mustDerivers()
+	if err := assertFamily("StageGrantPutDeferred", key, d.GrantPrimaryPrefix); err != nil {
+		return err
+	}
+	if !d.GrantKeyValid(key) {
+		return fmt.Errorf("rawdb.StageGrantPutDeferred: grant key %x did not decode as a 6-segment identity", key)
+	}
+	if err := d.ArmDeferredGrantIndex(); err != nil {
+		return err
+	}
+	if hadOldVal {
+		if err := rb.deleteGrantIndexKey(d.GrantNeedsExpansionKey, key); err != nil {
+			return err
+		}
+	}
+	if err := rb.core.b.Set(key, val, nil); err != nil {
+		return err
+	}
+	if needsExpansion {
+		if err := rb.setGrantIndexKey(d.GrantNeedsExpansionKey, key); err != nil {
+			return err
+		}
+	}
+	return d.StageGrantDigestInvalidation(&recordStager{rb}, key)
+}
+
+func (rb *RecordBatch) setGrantIndexKey(derive func(dst, primaryKey []byte) ([]byte, bool), key []byte) error {
+	idx, ok := derive(rb.scratch[:0], key)
+	rb.scratch = idx
+	if !ok {
+		return fmt.Errorf("rawdb: grant key %x did not decode as a 6-segment identity", key)
+	}
+	return rb.core.b.Set(idx, nil, nil)
+}
+
+func (rb *RecordBatch) deleteGrantIndexKey(derive func(dst, primaryKey []byte) ([]byte, bool), key []byte) error {
+	idx, ok := derive(rb.scratch[:0], key)
+	rb.scratch = idx
+	if !ok {
+		return fmt.Errorf("rawdb: grant key %x did not decode as a 6-segment identity", key)
+	}
+	return rb.core.b.Delete(idx, nil)
+}
+
+// recordStager adapts RecordBatch's internal staging to the Stager
+// interface for the injected digest-invalidation composer, WITHOUT
+// exporting generic staging on RecordBatch itself.
+type recordStager struct{ rb *RecordBatch }
+
+func (s *recordStager) Set(key, val []byte) error { return s.rb.core.b.Set(key, val, nil) }
+func (s *recordStager) Delete(key []byte) error   { return s.rb.core.b.Delete(key, nil) }
+func (s *recordStager) DeleteRange(a, b []byte) error {
+	return s.rb.core.b.DeleteRange(a, b, nil)
+}
+
+// === resource staging ===
+
+// StageResourcePut stages one resource row plus its by_parent index
+// obligations: the prior value's entry is deleted when oldVal is
+// non-nil, the new value's entry is written when the record has a
+// parent. childRT/childID are the record's identity (the caller has
+// them decoded; they address, they are not obligations). Contrast
+// StageGrantPutInline, which takes only an existence bool — grant
+// index keys derive from the primary key, not the value.
+func (rb *RecordBatch) StageResourcePut(key, val, oldVal []byte, childRT, childID string) error {
+	d := rb.db.mustDerivers()
+	if err := assertFamily("StageResourcePut", key, d.ResourcePrimaryPrefix); err != nil {
+		return err
+	}
+	if oldVal != nil {
+		if err := rb.stageResourceParentDelete(d, oldVal, childRT, childID); err != nil {
+			return err
+		}
+	}
+	if err := rb.core.b.Set(key, val, nil); err != nil {
+		return err
+	}
+	parentRT, parentID, err := d.ResourceParent(val)
+	if err != nil {
+		return err
+	}
+	if parentID == "" {
+		return nil
+	}
+	return rb.core.b.Set(d.ResourceByParentKey(parentRT, parentID, childRT, childID), nil, nil)
+}
+
+// StageResourceDelete stages one resource row's removal plus its
+// by_parent index cleanup (from the prior value).
+func (rb *RecordBatch) StageResourceDelete(key, oldVal []byte, childRT, childID string) error {
+	d := rb.db.mustDerivers()
+	if err := assertFamily("StageResourceDelete", key, d.ResourcePrimaryPrefix); err != nil {
+		return err
+	}
+	if err := rb.stageResourceParentDelete(d, oldVal, childRT, childID); err != nil {
+		return err
+	}
+	return rb.core.b.Delete(key, nil)
+}
+
+func (rb *RecordBatch) stageResourceParentDelete(d *RecordDerivers, oldVal []byte, childRT, childID string) error {
+	parentRT, parentID, err := d.ResourceParent(oldVal)
+	if err != nil {
+		return err
+	}
+	if parentID == "" {
+		return nil
+	}
+	return rb.core.b.Delete(d.ResourceByParentKey(parentRT, parentID, childRT, childID), nil)
+}
+
+// === entitlement / resource-type staging ===
+//
+// Neither family owes inline index entries. The typed ops exist so the
+// generic primitives stay unexported and the keyspace assertion runs.
+// The engine-side bare-id lookup invalidation
+// (noteEntitlementKeyspaceWrite) is an in-memory ENGINE-state
+// obligation and stays with the engine's write paths.
+
+// StageEntitlementPut stages one entitlement row.
+func (rb *RecordBatch) StageEntitlementPut(key, val []byte) error {
+	d := rb.db.mustDerivers()
+	if err := assertFamily("StageEntitlementPut", key, d.EntitlementPrimaryPrefix); err != nil {
+		return err
+	}
+	return rb.core.b.Set(key, val, nil)
+}
+
+// StageEntitlementDelete stages one entitlement row's removal.
+func (rb *RecordBatch) StageEntitlementDelete(key []byte) error {
+	d := rb.db.mustDerivers()
+	if err := assertFamily("StageEntitlementDelete", key, d.EntitlementPrimaryPrefix); err != nil {
+		return err
+	}
+	return rb.core.b.Delete(key, nil)
+}
+
+// StageResourceTypePut stages one resource-type row.
+func (rb *RecordBatch) StageResourceTypePut(key, val []byte) error {
+	d := rb.db.mustDerivers()
+	if err := assertFamily("StageResourceTypePut", key, d.ResourceTypePrimaryPrefix); err != nil {
+		return err
+	}
+	return rb.core.b.Set(key, val, nil)
+}
+
+// StageResourceTypeDelete stages one resource-type row's removal.
+func (rb *RecordBatch) StageResourceTypeDelete(key []byte) error {
+	d := rb.db.mustDerivers()
+	if err := assertFamily("StageResourceTypeDelete", key, d.ResourceTypePrimaryPrefix); err != nil {
+		return err
+	}
+	return rb.core.b.Delete(key, nil)
+}
+
+// === fold family: the compactor's keep-newer merge ===
+//
+// The one surface that legitimately stages RAW keys it did not encode:
+// the fold copies winner rows and index entries verbatim from source
+// files and deletes incumbents' stale entries, with keys derived by
+// the synccompactor's own splice helpers (or borrowed byte-exact from
+// the sources). Generic by design — and confined by design: FoldBatch
+// is reachable only through Engine.DB() (the documented exemption
+// surface), and the engine package's meta-test forbids raw-write
+// signals in engine production code.
+type FoldBatch struct {
+	batch
+}
+
+// NewFoldBatch mints a generic staged batch for the compactor's
+// keep-newer fold and overlay writers. Engine production code must
+// not use it; see the choke-point meta-tests.
+func (d *DB) NewFoldBatch() *FoldBatch { return &FoldBatch{batch{b: d.newBatch()}} }
+
+var _ Stager = (*recordStager)(nil)
+var _ = pebble.Sync

--- a/pkg/dotc1z/engine/pebble/keyspace_version.go
+++ b/pkg/dotc1z/engine/pebble/keyspace_version.go
@@ -85,7 +85,7 @@ func (e *Engine) verifyOrStampKeyspaceVersion(ctx context.Context) error {
 func (e *Engine) stampKeyspaceVersion() error {
 	var buf [4]byte
 	binary.BigEndian.PutUint32(buf[:], keyspaceVersion)
-	return e.db.Set(encodeKeyspaceVersionKey(), buf[:], pebble.Sync)
+	return e.db.MetaSet(encodeKeyspaceVersionKey(), buf[:], pebble.Sync)
 }
 
 // isKeyspaceEmpty reports whether the DB holds any v3 key at all (data,

--- a/pkg/dotc1z/engine/pebble/memfs_lifecycle_test.go
+++ b/pkg/dotc1z/engine/pebble/memfs_lifecycle_test.go
@@ -45,7 +45,7 @@ func TestEngineLifecycleOverPureMemFS(t *testing.T) {
 	require.True(t, e.deferredIdxPending.Load(),
 		"the workload must arm the deferred rebuild so EndSync exercises SST staging over the MemFS")
 	require.NoError(t, a.EndSync(ctx))
-	w.verifyComplete(ctx, t, e, syncID, "sealed engine over MemFS")
+	w.verifyComplete(ctx, t, e, syncID, true, "sealed engine over MemFS")
 
 	// Writable checkpoint: cut it through the engine FS and reopen it
 	// as its own engine over the same MemFS. Covers db.Checkpoint +
@@ -53,7 +53,7 @@ func TestEngineLifecycleOverPureMemFS(t *testing.T) {
 	require.NoError(t, e.CheckpointTo(ctx, "memfs-checkpoint"))
 	ce, err := Open(ctx, "memfs-checkpoint", WithVFS(memFS))
 	require.NoError(t, err, "the checkpoint must be complete and openable on the engine FS")
-	w.verifyComplete(ctx, t, ce, syncID, "checkpoint reopened over MemFS")
+	w.verifyComplete(ctx, t, ce, syncID, true, "checkpoint reopened over MemFS")
 	require.NoError(t, ce.Close())
 	require.NoError(t, e.Close())
 
@@ -62,5 +62,5 @@ func TestEngineLifecycleOverPureMemFS(t *testing.T) {
 	e2, err := Open(ctx, "memfs-db", WithVFS(memFS))
 	require.NoError(t, err)
 	defer func() { _ = e2.Close() }()
-	w.verifyComplete(ctx, t, e2, syncID, "primary reopened over MemFS")
+	w.verifyComplete(ctx, t, e2, syncID, true, "primary reopened over MemFS")
 }

--- a/pkg/dotc1z/engine/pebble/memfs_lifecycle_test.go
+++ b/pkg/dotc1z/engine/pebble/memfs_lifecycle_test.go
@@ -45,7 +45,7 @@ func TestEngineLifecycleOverPureMemFS(t *testing.T) {
 	require.True(t, e.deferredIdxPending.Load(),
 		"the workload must arm the deferred rebuild so EndSync exercises SST staging over the MemFS")
 	require.NoError(t, a.EndSync(ctx))
-	w.verifyComplete(ctx, t, e, syncID, true, "sealed engine over MemFS")
+	w.verifyComplete(ctx, t, e, syncID, true, true, "sealed engine over MemFS")
 
 	// Writable checkpoint: cut it through the engine FS and reopen it
 	// as its own engine over the same MemFS. Covers db.Checkpoint +
@@ -53,7 +53,7 @@ func TestEngineLifecycleOverPureMemFS(t *testing.T) {
 	require.NoError(t, e.CheckpointTo(ctx, "memfs-checkpoint"))
 	ce, err := Open(ctx, "memfs-checkpoint", WithVFS(memFS))
 	require.NoError(t, err, "the checkpoint must be complete and openable on the engine FS")
-	w.verifyComplete(ctx, t, ce, syncID, true, "checkpoint reopened over MemFS")
+	w.verifyComplete(ctx, t, ce, syncID, true, true, "checkpoint reopened over MemFS")
 	require.NoError(t, ce.Close())
 	require.NoError(t, e.Close())
 
@@ -62,5 +62,5 @@ func TestEngineLifecycleOverPureMemFS(t *testing.T) {
 	e2, err := Open(ctx, "memfs-db", WithVFS(memFS))
 	require.NoError(t, err)
 	defer func() { _ = e2.Close() }()
-	w.verifyComplete(ctx, t, e2, syncID, true, "primary reopened over MemFS")
+	w.verifyComplete(ctx, t, e2, syncID, true, true, "primary reopened over MemFS")
 }

--- a/pkg/dotc1z/engine/pebble/merge_accessor.go
+++ b/pkg/dotc1z/engine/pebble/merge_accessor.go
@@ -11,6 +11,30 @@ import (
 	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/codec"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/rawdb"
+)
+
+// FoldBatch and MergeDB are exported aliases for the choke point's
+// fold-exempt batch and the narrowed compactor handle (internal/
+// rawdb). The synccompactor/pebble package — the choke point's one
+// sanctioned external client, via Engine.DB() — needs to NAME these
+// types in struct fields and signatures, which the internal-package
+// import fence forbids; an alias is referable without the import.
+//
+// MergeDB (= rawdb.MergeView) carries reads, LSM stats, the bulk
+// range/ingest ops, and the fold-exempt batch — and nothing else:
+// typed record staging (NewRecordBatch) and the session/meta/digest
+// write families are not on it, so the documented DB() exemption
+// cannot quietly grow into a second engine write path that bypasses
+// the lifecycle barrier. It is deliberately a CONCRETE struct, not an
+// interface over *rawdb.DB — an interface's dynamic type would let a
+// caller recover the omitted write families with a structural type
+// assertion (review finding, delta round). UnsafeForTesting stays
+// reachable for test fixtures; its testing.Testing() runtime gate
+// makes it inert in production.
+type (
+	FoldBatch = rawdb.FoldBatch
+	MergeDB   = rawdb.MergeView
 )
 
 // engineAccessor is implemented by *Adapter and by pkg/dotc1z's Pebble

--- a/pkg/dotc1z/engine/pebble/meta_ast_test.go
+++ b/pkg/dotc1z/engine/pebble/meta_ast_test.go
@@ -1,0 +1,62 @@
+package pebble
+
+// Shared AST loader for the source-fence meta-tests. Three of them
+// (the os-IO registry, the test-seam fence, and rawdb's no-raw-conduit
+// export check) inspect parsed Go source rather than raw bytes; this
+// cache parses each package directory once per test run and hands the
+// same ASTs to every consumer, so adding the next AST-based fence
+// costs a function, not another ParseDir.
+//
+// Production files only (_test.go excluded): every current consumer
+// fences what SHIPS. A future test-file-scoped check should add a
+// second cache rather than widen this one.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type parsedDir struct {
+	fset *token.FileSet
+	// files maps the parser's file path to its AST, production files
+	// only, across all packages found in the directory.
+	files map[string]*ast.File
+	err   error
+}
+
+var productionASTs = struct {
+	sync.Mutex
+	byDir map[string]*parsedDir
+}{byDir: map[string]*parsedDir{}}
+
+// parseProductionDir returns the cached parse of dir's production
+// (non-_test) .go files. Not recursive — callers name each package
+// directory they fence.
+func parseProductionDir(t *testing.T, dir string) (*token.FileSet, map[string]*ast.File) {
+	t.Helper()
+	productionASTs.Lock()
+	defer productionASTs.Unlock()
+	pd, ok := productionASTs.byDir[dir]
+	if !ok {
+		pd = &parsedDir{fset: token.NewFileSet(), files: map[string]*ast.File{}}
+		pkgs, err := parser.ParseDir(pd.fset, dir, func(fi os.FileInfo) bool {
+			return !strings.HasSuffix(fi.Name(), "_test.go")
+		}, 0)
+		pd.err = err
+		for _, pkg := range pkgs {
+			for path, f := range pkg.Files {
+				pd.files[path] = f
+			}
+		}
+		productionASTs.byDir[dir] = pd
+	}
+	require.NoError(t, pd.err)
+	return pd.fset, pd.files
+}

--- a/pkg/dotc1z/engine/pebble/os_io_allowlist_test.go
+++ b/pkg/dotc1z/engine/pebble/os_io_allowlist_test.go
@@ -28,9 +28,6 @@ package pebble
 import (
 	"fmt"
 	"go/ast"
-	"go/parser"
-	"go/token"
-	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -84,62 +81,56 @@ var allowedOSFileIO = map[string]map[string]string{
 }
 
 func TestOSFileIOCallsAreAllowlisted(t *testing.T) {
-	fset := token.NewFileSet()
-	pkgs, err := parser.ParseDir(fset, ".", func(fi os.FileInfo) bool {
-		return !strings.HasSuffix(fi.Name(), "_test.go")
-	}, 0)
-	require.NoError(t, err)
+	fset, files := parseProductionDir(t, ".")
 
 	// found: file -> os func -> positions.
 	found := map[string]map[string][]string{}
-	for _, pkg := range pkgs {
-		for path, f := range pkg.Files {
-			base := filepath.Base(path)
-			// Resolve the local name(s) the "os" import is bound to in
-			// THIS file — an aliased import (stdos "os") must not slip
-			// past the registry, and a dot-import would make os calls
-			// indistinguishable from package-local ones, so it is
-			// rejected outright.
-			osNames := map[string]bool{}
-			for _, imp := range f.Imports {
-				if imp.Path.Value != `"os"` {
-					continue
-				}
-				switch {
-				case imp.Name == nil:
-					osNames["os"] = true
-				case imp.Name.Name == ".":
-					require.Failf(t, "dot-import of os",
-						"%s dot-imports \"os\", which defeats this registry; use a named import", base)
-				case imp.Name.Name == "_":
-					// blank import: no callable name.
-				default:
-					osNames[imp.Name.Name] = true
-				}
-			}
-			if len(osNames) == 0 {
+	for path, f := range files {
+		base := filepath.Base(path)
+		// Resolve the local name(s) the "os" import is bound to in
+		// THIS file — an aliased import (stdos "os") must not slip
+		// past the registry, and a dot-import would make os calls
+		// indistinguishable from package-local ones, so it is
+		// rejected outright.
+		osNames := map[string]bool{}
+		for _, imp := range f.Imports {
+			if imp.Path.Value != `"os"` {
 				continue
 			}
-			ast.Inspect(f, func(n ast.Node) bool {
-				call, ok := n.(*ast.CallExpr)
-				if !ok {
-					return true
-				}
-				sel, ok := call.Fun.(*ast.SelectorExpr)
-				if !ok {
-					return true
-				}
-				ident, ok := sel.X.(*ast.Ident)
-				if !ok || !osNames[ident.Name] || !osFileIOFuncs[sel.Sel.Name] {
-					return true
-				}
-				if found[base] == nil {
-					found[base] = map[string][]string{}
-				}
-				found[base][sel.Sel.Name] = append(found[base][sel.Sel.Name], fset.Position(call.Pos()).String())
-				return true
-			})
+			switch {
+			case imp.Name == nil:
+				osNames["os"] = true
+			case imp.Name.Name == ".":
+				require.Failf(t, "dot-import of os",
+					"%s dot-imports \"os\", which defeats this registry; use a named import", base)
+			case imp.Name.Name == "_":
+				// blank import: no callable name.
+			default:
+				osNames[imp.Name.Name] = true
+			}
 		}
+		if len(osNames) == 0 {
+			continue
+		}
+		ast.Inspect(f, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			ident, ok := sel.X.(*ast.Ident)
+			if !ok || !osNames[ident.Name] || !osFileIOFuncs[sel.Sel.Name] {
+				return true
+			}
+			if found[base] == nil {
+				found[base] = map[string][]string{}
+			}
+			found[base][sel.Sel.Name] = append(found[base][sel.Sel.Name], fset.Position(call.Pos()).String())
+			return true
+		})
 	}
 
 	// Every found call must be registered.

--- a/pkg/dotc1z/engine/pebble/paginate.go
+++ b/pkg/dotc1z/engine/pebble/paginate.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/rawdb"
 )
 
 // DefaultPageSize matches the SQLite c1file's maxPageSize (10000).
@@ -98,7 +99,7 @@ func rangeAfter(prefix, cursor []byte) ([]byte, []byte, error) {
 // starting strictly after the last returned row.
 func iteratePrimaryPageWithKey[T proto.Message](
 	ctx context.Context,
-	db *pebble.DB,
+	db *rawdb.DB,
 	prefix, cursor []byte,
 	limit int,
 	newT func() T,
@@ -148,7 +149,7 @@ func iteratePrimaryPageWithKey[T proto.Message](
 
 func iterateGrantPrimaryPage(
 	ctx context.Context,
-	db *pebble.DB,
+	db *rawdb.DB,
 	prefix, cursor []byte,
 	limit int,
 ) ([]*v3.GrantRecord, string, error) {
@@ -195,7 +196,7 @@ func iterateGrantPrimaryPage(
 	return out, nextCursor, nil
 }
 
-func getGrantByIdentity(ctx context.Context, db *pebble.DB, id grantIdentity) (*v3.GrantRecord, error) {
+func getGrantByIdentity(ctx context.Context, db *rawdb.DB, id grantIdentity) (*v3.GrantRecord, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}

--- a/pkg/dotc1z/engine/pebble/raw_records.go
+++ b/pkg/dotc1z/engine/pebble/raw_records.go
@@ -5,7 +5,6 @@ import (
 	"math"
 	"time"
 
-	"github.com/cockroachdb/pebble/v2"
 	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -109,41 +108,11 @@ func rawTimestampNanos(value []byte) (int64, error) {
 	return seconds*int64(time.Second) + int64(nanos), nil
 }
 
-func (e *Engine) deleteResourceIndexesRaw(batch *pebble.Batch, resourceTypeID string, resourceID string, value []byte) error {
-	parentRT, parentID, err := scanResourceParentRaw(value)
-	if err != nil {
-		return err
-	}
-	if parentID == "" {
-		return nil
-	}
-	return batch.Delete(encodeResourceByParentIndexKey(parentRT, parentID, resourceTypeID, resourceID), nil)
-}
-
-func (e *Engine) deleteGrantIndexesRaw(batch *pebble.Batch, externalID string, value []byte) error {
-	entRT, entRID, entID, principalRT, principalID, _, err := scanGrantIndexFieldsRaw(value)
-	if err != nil {
-		return err
-	}
-	if entID == "" || entRT == "" || entRID == "" || principalRT == "" || principalID == "" {
-		return nil
-	}
-	id := grantIdentity{
-		entitlement:     entitlementIdentityFromParts(entRT, entRID, entID),
-		principalTypeID: principalRT,
-		principalID:     principalID,
-	}
-	if err := batch.Delete(encodeGrantByPrincipalIdentityIndexKey(id), nil); err != nil {
-		return err
-	}
-	// Post-seal mutation of a grant invalidates the touched entitlement's
-	// digest + hash-index state (no-op unless digests exist — see
-	// stageGrantDigestInvalidation).
-	if err := e.stageGrantDigestInvalidation(batch, id.entitlement); err != nil {
-		return err
-	}
-	return batch.Delete(encodeGrantByNeedsExpansionIdentityIndexKey(id), nil)
-}
+// NOTE (2b): deleteResourceIndexesRaw / deleteGrantIndexesRaw are GONE.
+// Prior-row index cleanup is an obligation of rawdb's typed record ops
+// (StageGrantPutInline/StageGrantDelete derive cleanup keys from the
+// primary key; StageResourcePut/StageResourceDelete consume the prior
+// value through the ResourceParent deriver).
 
 // scanGrantExternalIDRaw extracts only the stored external_id (field 2)
 // from a marshaled GrantRecord. Used by the bare-id grant lookup to check

--- a/pkg/dotc1z/engine/pebble/resource_types.go
+++ b/pkg/dotc1z/engine/pebble/resource_types.go
@@ -29,7 +29,7 @@ func (e *Engine) PutResourceTypeRecords(ctx context.Context, records ...*v3.Reso
 		if err := e.requireCurrentSync(); err != nil {
 			return err
 		}
-		batch := e.db.NewBatch()
+		batch := e.db.NewRecordBatch()
 		defer batch.Close()
 		fresh := e.IsFreshSync()
 		for _, r := range records {
@@ -41,7 +41,7 @@ func (e *Engine) PutResourceTypeRecords(ctx context.Context, records ...*v3.Reso
 			if err != nil {
 				return err
 			}
-			if err := batch.Set(key, val, nil); err != nil {
+			if err := batch.StageResourceTypePut(key, val); err != nil {
 				return err
 			}
 		}
@@ -69,7 +69,15 @@ func (e *Engine) GetResourceTypeRecord(ctx context.Context, externalID string) (
 
 func (e *Engine) DeleteResourceTypeRecord(ctx context.Context, externalID string) error {
 	return e.withWrite(func() error {
-		return e.db.Delete(encodeResourceTypeKey(externalID), writeOpts(e.opts.durability))
+		// Record family, not engine-meta: resource types are record
+		// rows. A one-op RecordBatch commit is durability-identical to
+		// the old single Delete (the commit carries the write options).
+		batch := e.db.NewRecordBatch()
+		defer batch.Close()
+		if err := batch.StageResourceTypeDelete(encodeResourceTypeKey(externalID)); err != nil {
+			return err
+		}
+		return batch.Commit(writeOpts(e.opts.durability))
 	})
 }
 

--- a/pkg/dotc1z/engine/pebble/resources.go
+++ b/pkg/dotc1z/engine/pebble/resources.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 
 	"github.com/cockroachdb/pebble/v2"
 
@@ -20,8 +21,9 @@ func (e *Engine) PutResourceRecord(ctx context.Context, r *v3.ResourceRecord) er
 	return e.PutResourceRecords(ctx, r)
 }
 
-// PutResourceRecords writes N resources in two pebble.Batches —
-// primary keys in one, by_parent index keys in the other. Mirrors
+// PutResourceRecords writes N resources through a single RecordBatch —
+// StageResourcePut derives the by_parent index obligations inside
+// rawdb, so primary and index land in one atomic commit. Mirrors
 // the PutGrantRecords pattern (RFC §3a Tier-B/C):
 //   - within-call dedup pre-pass keyed by (rt, res_id) drops earlier
 //     occurrences of repeated resources;
@@ -37,10 +39,8 @@ func (e *Engine) PutResourceRecords(ctx context.Context, records ...*v3.Resource
 		if err := e.requireCurrentSync(); err != nil {
 			return err
 		}
-		priBatch := e.db.NewBatch()
-		defer priBatch.Close()
-		idxBatch := e.db.NewBatch()
-		defer idxBatch.Close()
+		batch := e.db.NewRecordBatch()
+		defer batch.Close()
 
 		fresh := e.IsFreshSync()
 		skipGet := e.takeFreshResourcesEmpty()
@@ -73,25 +73,29 @@ func (e *Engine) PutResourceRecords(ctx context.Context, records ...*v3.Resource
 			if err != nil {
 				return err
 			}
+			var oldVal []byte
+			var oldCloser io.Closer
 			if !skipGet {
-				oldVal, closer, getErr := e.db.Get(key)
+				got, closer, getErr := e.db.Get(key)
 				switch {
 				case getErr == nil:
-					if err := e.deleteResourceIndexesRaw(idxBatch, r.GetResourceTypeId(), r.GetResourceId(), oldVal); err != nil {
-						closer.Close()
-						return err
-					}
-					closer.Close()
+					// The prior VALUE is genuinely needed here (unlike
+					// grants): the by_parent cleanup key depends on the old
+					// parent ref, which only the old bytes carry.
+					oldVal, oldCloser = got, closer
 				case errors.Is(getErr, pebble.ErrNotFound):
 					// no prior — write unconditionally
 				default:
 					return fmt.Errorf("PutResourceRecords: get old: %w", getErr)
 				}
 			}
-			if err := priBatch.Set(key, val, nil); err != nil {
-				return err
+			// One typed op stages the row and its by_parent obligations
+			// (old entry cleanup from oldVal, new entry from val).
+			err = batch.StageResourcePut(key, val, oldVal, r.GetResourceTypeId(), r.GetResourceId())
+			if oldCloser != nil {
+				_ = oldCloser.Close()
 			}
-			if err := e.writeResourceIndexes(idxBatch, r); err != nil {
+			if err != nil {
 				return err
 			}
 		}
@@ -99,14 +103,10 @@ func (e *Engine) PutResourceRecords(ctx context.Context, records ...*v3.Resource
 		if fresh {
 			opts = pebble.NoSync
 		}
-		// One atomic commit: folding the index batch into the primary batch
-		// closes the durability gap where the primary commit landed but the
-		// index commit failed — a divergence that would persist in the saved
-		// artifact if the caller shipped it anyway.
-		if err := priBatch.Apply(idxBatch, nil); err != nil {
-			return err
-		}
-		return priBatch.Commit(opts)
+		// One atomic commit: rows and their index obligations ride the
+		// same batch, so a primary commit landing without its index
+		// entries is unexpressible.
+		return batch.Commit(opts)
 	})
 }
 
@@ -128,7 +128,7 @@ func (e *Engine) DeleteResourceRecord(ctx context.Context, resourceTypeID, resou
 	return e.withWrite(func() error {
 		key := encodeResourceKey(resourceTypeID, resourceID)
 
-		batch := e.db.NewBatch()
+		batch := e.db.NewRecordBatch()
 		defer batch.Close()
 
 		oldVal, closer, err := e.db.Get(key)
@@ -138,28 +138,15 @@ func (e *Engine) DeleteResourceRecord(ctx context.Context, resourceTypeID, resou
 			}
 			return err
 		}
-		if err := e.deleteResourceIndexesRaw(batch, resourceTypeID, resourceID, oldVal); err != nil {
-			closer.Close()
-			return err
-		}
+		// The typed op stages the row's removal plus its by_parent
+		// cleanup derived from the prior value.
+		stageErr := batch.StageResourceDelete(key, oldVal, resourceTypeID, resourceID)
 		closer.Close()
-		if err := batch.Delete(key, nil); err != nil {
-			return err
+		if stageErr != nil {
+			return stageErr
 		}
 		return batch.Commit(writeOpts(e.opts.durability))
 	})
-}
-
-func (e *Engine) writeResourceIndexes(batch *pebble.Batch, r *v3.ResourceRecord) error {
-	parent := r.GetParent()
-	if parent == nil || parent.GetResourceId() == "" {
-		return nil
-	}
-	k := encodeResourceByParentIndexKey(
-		parent.GetResourceTypeId(), parent.GetResourceId(),
-		r.GetResourceTypeId(), r.GetResourceId(),
-	)
-	return batch.Set(k, nil, nil)
 }
 
 func (e *Engine) IterateResources(ctx context.Context, yield func(*v3.ResourceRecord) bool) error {

--- a/pkg/dotc1z/engine/pebble/session_store.go
+++ b/pkg/dotc1z/engine/pebble/session_store.go
@@ -282,7 +282,7 @@ func (e *Engine) SessionSet(ctx context.Context, key string, value []byte, opt .
 	// WRITES to the session keyspace after EndSync (connector Cleanup
 	// clears sessions post-sync so they don't ship in the saved c1z).
 	return e.withWriteAllowSealed(func() error {
-		return e.db.Set(keyBytes, val, writeOpts(e.opts.durability))
+		return e.db.SessionSet(keyBytes, val, writeOpts(e.opts.durability))
 	})
 }
 
@@ -294,7 +294,7 @@ func (e *Engine) SessionSetMany(ctx context.Context, values map[string][]byte, o
 
 	// See SessionSet for why the barrier is required and why AllowSealed.
 	return e.withWriteAllowSealed(func() error {
-		batch := e.db.NewBatch()
+		batch := e.db.NewSessionBatch()
 		defer batch.Close()
 
 		for key, value := range values {
@@ -308,7 +308,7 @@ func (e *Engine) SessionSetMany(ctx context.Context, values map[string][]byte, o
 			if err != nil {
 				return fmt.Errorf("error marshalling session record: %w", err)
 			}
-			if err := batch.Set(keyBytes, val, nil); err != nil {
+			if err := batch.Set(keyBytes, val); err != nil {
 				return fmt.Errorf("error setting session record: %w", err)
 			}
 		}
@@ -328,7 +328,7 @@ func (e *Engine) SessionDelete(ctx context.Context, key string, opt ...sessions.
 	keyBytes := encodeSessionKey(bag.SyncID, bag.Prefix+key)
 	// See SessionSet for why the barrier is required and why AllowSealed.
 	return e.withWriteAllowSealed(func() error {
-		return e.db.Delete(keyBytes, writeOpts(e.opts.durability))
+		return e.db.SessionDelete(keyBytes, writeOpts(e.opts.durability))
 	})
 }
 
@@ -341,7 +341,7 @@ func (e *Engine) SessionClear(ctx context.Context, opt ...sessions.SessionStoreO
 	if bag.Prefix == "" {
 		// See SessionSet for why the barrier is required and why AllowSealed.
 		return e.withWriteAllowSealed(func() error {
-			return e.db.DeleteRange(syncPrefix, upperBoundOf(syncPrefix), writeOpts(e.opts.durability))
+			return e.db.SessionClearRange(syncPrefix, upperBoundOf(syncPrefix), writeOpts(e.opts.durability))
 		})
 	}
 
@@ -357,7 +357,7 @@ func (e *Engine) SessionClear(ctx context.Context, opt ...sessions.SessionStoreO
 		}
 		defer iter.Close()
 
-		batch := e.db.NewBatch()
+		batch := e.db.NewSessionBatch()
 		defer batch.Close()
 		for iter.First(); iter.Valid(); iter.Next() {
 			if err := ctx.Err(); err != nil {
@@ -373,7 +373,7 @@ func (e *Engine) SessionClear(ctx context.Context, opt ...sessions.SessionStoreO
 			if !strings.HasPrefix(r.GetKey(), bag.Prefix) {
 				break
 			}
-			if err := batch.Delete(iter.Key(), nil); err != nil {
+			if err := batch.Delete(iter.Key()); err != nil {
 				return err
 			}
 		}

--- a/pkg/dotc1z/engine/pebble/sync_runs.go
+++ b/pkg/dotc1z/engine/pebble/sync_runs.go
@@ -38,7 +38,7 @@ func (e *Engine) PutSyncRunRecord(ctx context.Context, r *v3.SyncRunRecord) erro
 		if err != nil {
 			return err
 		}
-		return e.db.Set(encodeSyncRunKey(), val, writeOpts(e.opts.durability))
+		return e.db.MetaSet(encodeSyncRunKey(), val, writeOpts(e.opts.durability))
 	})
 }
 
@@ -92,7 +92,7 @@ func (e *Engine) DeleteSyncRunRecord(ctx context.Context, syncID string) error {
 		if stored.GetSyncId() != syncID {
 			return nil
 		}
-		return e.db.Delete(encodeSyncRunKey(), writeOpts(e.opts.durability))
+		return e.db.MetaDelete(encodeSyncRunKey(), writeOpts(e.opts.durability))
 	})
 }
 

--- a/pkg/dotc1z/engine/pebble/sync_stats_sidecar.go
+++ b/pkg/dotc1z/engine/pebble/sync_stats_sidecar.go
@@ -11,6 +11,7 @@ import (
 
 	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/codec"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/rawdb"
 )
 
 // Sync-stats sidecar. Populated by EndFreshSync (one full pass
@@ -26,8 +27,10 @@ import (
 //
 // Older c1z files (or files written by a pre-sidecar SDK) will be
 // missing this key. Stats() falls back to the legacy iterate-and-
-// count path in that case, and the on-Open migration framework
-// backfills the sidecar on writable opens so the next call is fast.
+// count path in that case. There is currently no on-Open backfill —
+// the indexMigrations registry is intentionally empty (see
+// TestSyncStatsSidecarBackfillOnOpen's skip note) — so a missing
+// sidecar stays missing until a migration is registered.
 
 // encodeSyncStatsKey returns the engine-meta key for the single
 // sync's SyncStatsRecord. The file holds one sync, so this is a fixed
@@ -91,15 +94,16 @@ func (e *Engine) writeSyncStats(ctx context.Context, rec *v3.SyncStatsRecord) er
 	// Flush→Checkpoint window (a WAL-only record landing mid-window would
 	// be truncated out of the saved snapshot).
 	return e.withWriteAllowSealed(func() error {
-		return e.db.Set(encodeSyncStatsKey(), val, pebble.Sync)
+		return e.db.MetaSet(encodeSyncStatsKey(), val, pebble.Sync)
 	})
 }
 
 // computeSyncStats does one full pass over the per-record-type
 // keyspaces for syncID and builds a SyncStatsRecord. This is the
-// O(N) work the sidecar is designed to avoid on read — only the
-// EndFreshSync write path and the on-Open migration backfill
-// invoke it.
+// O(N) work the sidecar is designed to avoid on read — only
+// PersistSyncStats (EndSync's sidecar write, when no stashed record
+// exists) invokes it. There is no on-Open backfill caller: the
+// indexMigrations registry is intentionally empty.
 //
 // This intentionally scans raw Pebble key/value ranges instead of using
 // Iterate*BySync. Counting keys and shallow-scanning only the grant grouping
@@ -314,7 +318,7 @@ func (e *Engine) PersistComputedSyncStats(ctx context.Context, syncID string, re
 	return e.writeSyncStats(ctx, rec)
 }
 
-func countKeyRange(ctx context.Context, db *pebble.DB, lower []byte, upper []byte, visit func(key []byte, value []byte) error) (int64, error) {
+func countKeyRange(ctx context.Context, db *rawdb.DB, lower []byte, upper []byte, visit func(key []byte, value []byte) error) (int64, error) {
 	iter, err := db.NewIter(&pebble.IterOptions{LowerBound: lower, UpperBound: upper})
 	if err != nil {
 		return 0, err

--- a/pkg/dotc1z/engine/pebble/sync_stats_sidecar_test.go
+++ b/pkg/dotc1z/engine/pebble/sync_stats_sidecar_test.go
@@ -90,8 +90,8 @@ func TestSyncStatsSidecarBackfillOnOpen(t *testing.T) {
 	require.NoErrorf(t, e.PersistSyncStats(ctx, syncID), "PersistSyncStats")
 	// Surgically delete the sidecar and the migration's applied-version
 	// stamp so the next Open's migrator re-runs.
-	require.NoError(t, e.db.Delete(encodeSyncStatsKey(), nil))
-	require.NoError(t, e.db.Delete(encodeIndexAppliedKey("sync_stats_sidecar"), nil))
+	require.NoError(t, e.db.UnsafeForTesting().Delete(encodeSyncStatsKey(), nil))
+	require.NoError(t, e.db.UnsafeForTesting().Delete(encodeIndexAppliedKey("sync_stats_sidecar"), nil))
 	require.NoErrorf(t, e.Close(), "Close")
 
 	// Re-open. The migration framework should backfill the sidecar.

--- a/pkg/dotc1z/engine/pebble/test_seams.go
+++ b/pkg/dotc1z/engine/pebble/test_seams.go
@@ -1,0 +1,49 @@
+package pebble
+
+// testSeams aggregates every test-only injection point on the Engine
+// behind a single field (Engine.test), so the production struct isn't
+// littered with hook fields and new seams have one obvious home. All
+// fields are nil/zero in production and only ever assigned by tests in
+// this package; production code must treat them as read-only.
+//
+// These are deliberately plain fields rather than build-tag-gated
+// machinery: a nil-func check is free, and tag-gating would break the
+// default `go test ./...` workflow (the package under test would need
+// the tag to compile the hook sites).
+type testSeams struct {
+	// digestBuildHook fires at named points inside
+	// buildGrantDigestsFromSpill (grant_digest_build_crash_test.go);
+	// digestNodeFlushBytes overrides the digest fold's batch
+	// flush threshold — shared by the build's fold and the streaming
+	// partition repair (repairOneGrantDigestPartitionLocked) — so a
+	// small test dataset exercises the mid-stream commit paths.
+	digestBuildHook      func(stage string) error
+	digestNodeFlushBytes int
+
+	// armDeferredMarkerHook / clearDeferredMarkerHook, when non-nil,
+	// run before the deferred-index marker's durable commit / delete —
+	// the in-process analogs of those writes failing. Tests use them
+	// to pin the flag/key-agreement contract on both edges: the
+	// in-memory flag and the durable key must never disagree (armed
+	// flag + absent key = in-process EndSync rebuilds while a
+	// crash+resume silently skips the rebuild; cleared flag + present
+	// key = spurious rebuild on the next open).
+	armDeferredMarkerHook   func() error
+	clearDeferredMarkerHook func() error
+
+	// endSyncPreFlushHook, when non-nil, runs inside endSyncFinalize
+	// IMMEDIATELY after the ended_at stamp commits — before the stats
+	// sidecar write and the EndFreshSync durability flush. Tests
+	// crash-clone the FS here to pin the WAL-prefix-durability
+	// contract: a Sync commit's WAL fsync also hardens every earlier
+	// NoSync page commit (sequential WAL; rotated WALs sync at
+	// rotation), so a crash image containing the finished verdict
+	// necessarily contains the pages — finished-but-incomplete is not
+	// expressible. The hook sits directly after the stamp (not after
+	// stats) so a stripped workload can make the stamp the ONLY Sync
+	// between the pages and the cut, attributing the hardening to the
+	// stamp itself rather than a neighboring Sync (review finding,
+	// delta round: the original post-stats placement made that
+	// attribution vacuous).
+	endSyncPreFlushHook func()
+}

--- a/pkg/dotc1z/engine/pebble/typed_record_ops_coverage_test.go
+++ b/pkg/dotc1z/engine/pebble/typed_record_ops_coverage_test.go
@@ -1,0 +1,328 @@
+package pebble
+
+// Direct engine-level coverage for the typed-op paths a coverage audit
+// (2026-07-17) found exercised only cross-package or not at all:
+// the synthesized-grant puts (deferred regime, driven in production by
+// pkg/sync's expander), the trusted-import path, DeleteResourceRecord
+// (exported but currently caller-less — kept honest here until its
+// removal is decided), and the IfNewer resource branches restructured
+// in 2b. Obligations are asserted directly against the index keyspaces
+// so a regression fails HERE, not two packages away in an equivalence
+// suite.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	batonGrant "github.com/conductorone/baton-sdk/pkg/types/grant"
+)
+
+func countKeys(t *testing.T, e *Engine, prefix []byte) int {
+	t.Helper()
+	iter, err := e.db.NewIter(&pebble.IterOptions{
+		LowerBound: prefix,
+		UpperBound: upperBoundOf(prefix),
+	})
+	require.NoError(t, err)
+	defer iter.Close()
+	n := 0
+	for iter.First(); iter.Valid(); iter.Next() {
+		n++
+	}
+	require.NoError(t, iter.Error())
+	return n
+}
+
+func testGrantRecord(ent, principal string) *v3.GrantRecord {
+	return v3.GrantRecord_builder{
+		ExternalId: "app:github:" + ent + ":user:" + principal,
+		Entitlement: v3.EntitlementRef_builder{
+			ResourceTypeId: "app", ResourceId: "github", EntitlementId: "app:github:" + ent,
+		}.Build(),
+		Principal: v3.PrincipalRef_builder{
+			ResourceTypeId: "user", ResourceId: principal,
+		}.Build(),
+		DiscoveredAt: timestamppb.Now(),
+	}.Build()
+}
+
+// TestPutSynthesizedGrantRecordsObligations drives the deferred-regime
+// synthesized put directly: rows land, the deferred marker is armed,
+// no needs_expansion entries appear (synth grants are never
+// expandable), and the seal-rebuilt by_principal serves every row.
+func TestPutSynthesizedGrantRecordsObligations(t *testing.T) {
+	ctx := context.Background()
+	a := newAdapter(t)
+	_, err := a.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	e := a.PebbleEngine()
+
+	require.NoError(t, e.PutSynthesizedGrantRecords(ctx, []*v3.GrantRecord{
+		testGrantRecord("ent-A", "alice"),
+		testGrantRecord("ent-A", "bob"),
+	}))
+	require.True(t, e.deferredIdxPending.Load(), "synthesized puts must arm the deferred rebuild marker")
+	require.Equal(t, 0, countKeys(t, e, encodeGrantByNeedsExpansionPrefix()),
+		"synthesized grants are never expandable")
+
+	require.NoError(t, a.EndSync(ctx))
+	for _, p := range []string{"alice", "bob"} {
+		n := 0
+		require.NoError(t, e.IterateGrantsByPrincipal(ctx, "user", p, func(*v3.GrantRecord) bool {
+			n++
+			return true
+		}))
+		require.Equalf(t, 1, n, "seal-rebuilt by_principal must serve %s", p)
+	}
+}
+
+// TestPutSynthesizedGrantContributionsBatchObligations drives the
+// non-layer contributions fallback (the expander path when no layer
+// session is open) through the same obligation assertions.
+func TestPutSynthesizedGrantContributionsBatchObligations(t *testing.T) {
+	ctx := context.Background()
+	a := newAdapter(t)
+	_, err := a.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	e := a.PebbleEngine()
+
+	dest := v3.EntitlementRef_builder{
+		ResourceTypeId: "app", ResourceId: "github", EntitlementId: "app:github:ent-A",
+	}.Build()
+	records := []synthesizedGrantRecord{
+		{
+			id: grantIdentity{
+				entitlement:     entitlementIdentityFromParts("app", "github", "app:github:ent-A"),
+				principalTypeID: "user",
+				principalID:     "carol",
+			},
+			entitlement: dest,
+			principal:   v3.PrincipalRef_builder{ResourceTypeId: "user", ResourceId: "carol"}.Build(),
+			sources:     batonGrant.Sources{{EntitlementID: "app:github:src", IsDirect: true}},
+		},
+	}
+	// Through the exported dispatcher so its counter bookkeeping and the
+	// batch body are both exercised.
+	require.NoError(t, e.PutSynthesizedGrantContributions(ctx, records))
+	require.True(t, e.deferredIdxPending.Load(), "contributions must arm the deferred rebuild marker")
+
+	require.NoError(t, a.EndSync(ctx))
+	n := 0
+	require.NoError(t, e.IterateGrantsByPrincipal(ctx, "user", "carol", func(r *v3.GrantRecord) bool {
+		require.NotEmpty(t, r.GetSources(), "contribution sources must round-trip the wire append")
+		n++
+		return true
+	}))
+	require.Equal(t, 1, n)
+}
+
+// TestUnsafePutUniqueGrantRecordsObligations covers the trusted-import
+// body: fresh-sync gate, parallel encode, inline-regime staging with
+// needs_expansion, and the digest-present refusal guard.
+func TestUnsafePutUniqueGrantRecordsObligations(t *testing.T) {
+	ctx := context.Background()
+	a := newAdapter(t)
+	syncID, err := a.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	e := a.PebbleEngine()
+
+	expandable := testGrantRecord("ent-A", "alice")
+	expandable.SetNeedsExpansion(true)
+	plain := testGrantRecord("ent-B", "bob")
+	require.NoError(t, e.UnsafePutUniqueGrantRecords(ctx, expandable, plain))
+
+	require.Equal(t, 2, countKeys(t, e, encodeGrantPrefix()), "both rows must land")
+	require.Equal(t, 1, countKeys(t, e, encodeGrantByNeedsExpansionPrefix()),
+		"inline regime must index exactly the expandable row")
+	require.Equal(t, 2, countKeys(t, e, GrantByPrincipalLowerBound()),
+		"inline regime must write by_principal for every row")
+
+	// Non-fresh syncs are refused (SetCurrentSync clears freshness).
+	require.NoError(t, a.EndSync(ctx))
+	require.NoError(t, a.SetCurrentSync(ctx, syncID))
+	require.ErrorContains(t, e.UnsafePutUniqueGrantRecords(ctx, testGrantRecord("ent-C", "carol")),
+		"sync is not fresh")
+}
+
+// TestDeleteResourceRecordObligations covers the exported delete path
+// end-to-end: the by_parent entry created by the put must be cleaned
+// by the delete, and deleting a non-existent resource is a no-op.
+// (DeleteResourceRecord currently has no in-repo callers; this test
+// keeps its obligations honest until removal is decided.)
+func TestDeleteResourceRecordObligations(t *testing.T) {
+	ctx := context.Background()
+	a := newAdapter(t)
+	_, err := a.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	e := a.PebbleEngine()
+
+	child := v3.ResourceRecord_builder{
+		ResourceTypeId: "group",
+		ResourceId:     "child-1",
+		Parent: v3.ResourceRef_builder{
+			ResourceTypeId: "org", ResourceId: "parent-1",
+		}.Build(),
+	}.Build()
+	require.NoError(t, e.PutResourceRecords(ctx, child))
+
+	byParentPrefix := []byte{versionV3, typeIndex, idxResourceByParent}
+	require.Equal(t, 1, countKeys(t, e, byParentPrefix), "put must index the parent edge")
+
+	require.NoError(t, e.DeleteResourceRecord(ctx, "group", "child-1"))
+	require.Equal(t, 0, countKeys(t, e, byParentPrefix), "delete must clean the parent edge")
+	_, err = e.GetResourceRecord(ctx, "group", "child-1")
+	require.ErrorIs(t, err, pebble.ErrNotFound)
+
+	// Non-existent delete: clean no-op.
+	require.NoError(t, e.DeleteResourceRecord(ctx, "group", "never-existed"))
+}
+
+// TestDeferredMarkerArmFailureRollsBackCAS pins the crash contract of
+// the deferred-index marker: when the marker's durable commit fails,
+// the in-memory CAS must roll back so flag and key never disagree.
+// An armed flag with no durable key is the silent-divergence state —
+// the in-process EndSync would rebuild by_principal while a
+// crash+resume, seeing no key, would skip the rebuild and seal an
+// artifact missing index rows.
+func TestDeferredMarkerArmFailureRollsBackCAS(t *testing.T) {
+	ctx := context.Background()
+	a := newAdapter(t)
+	_, err := a.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	e := a.PebbleEngine()
+
+	injected := errNoRetryArmFailure
+	e.test.armDeferredMarkerHook = func() error { return injected }
+
+	// The deferred-regime write must FAIL when the marker can't arm —
+	// committing deferred rows without the durable marker is the lie.
+	err = e.PutSynthesizedGrantRecords(ctx, []*v3.GrantRecord{testGrantRecord("ent-A", "alice")})
+	require.ErrorIs(t, err, injected, "deferred write must surface the arm failure")
+
+	// THE CONTRACT: flag rolled back, durable key absent — in agreement.
+	require.False(t, e.deferredIdxPending.Load(), "failed arm must roll the CAS back")
+	_, closer, getErr := e.db.Get(encodeDeferredIdxPendingKey())
+	require.ErrorIs(t, getErr, pebble.ErrNotFound, "no durable marker may exist after a failed arm")
+	if getErr == nil {
+		closer.Close()
+	}
+	// And no row from the failed batch may have landed (the batch was
+	// abandoned uncommitted).
+	require.Equal(t, 0, countKeys(t, e, encodeGrantPrefix()), "the failed batch must not have committed rows")
+
+	// Retry converges: with the fault gone, the same write arms the
+	// marker durably and lands.
+	e.test.armDeferredMarkerHook = nil
+	require.NoError(t, e.PutSynthesizedGrantRecords(ctx, []*v3.GrantRecord{testGrantRecord("ent-A", "alice")}))
+	require.True(t, e.deferredIdxPending.Load())
+	_, closer, getErr = e.db.Get(encodeDeferredIdxPendingKey())
+	require.NoError(t, getErr, "the retried arm must persist the durable marker")
+	closer.Close()
+
+	// The marker survives a reopen (the durable half is the point) and
+	// the resumed EndSync rebuilds the index.
+	require.NoError(t, a.EndSync(ctx))
+	n := 0
+	require.NoError(t, e.IterateGrantsByPrincipal(ctx, "user", "alice", func(*v3.GrantRecord) bool {
+		n++
+		return true
+	}))
+	require.Equal(t, 1, n)
+}
+
+var errNoRetryArmFailure = errors.New("injected deferred-marker arm failure")
+
+// TestDeferredMarkerClearFailureKeepsAgreement pins the CLEAR edge of
+// the flag/key-agreement contract: when the marker's durable delete
+// fails at EndSync, both halves must stay ARMED so the retried EndSync
+// re-runs the (idempotent) rebuild and retries the clear — never the
+// old flag-cleared/key-present split, which skipped the retry's
+// rebuild and left a stale key forcing a spurious rebuild at the next
+// open.
+func TestDeferredMarkerClearFailureKeepsAgreement(t *testing.T) {
+	ctx := context.Background()
+	a := newAdapter(t)
+	_, err := a.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	e := a.PebbleEngine()
+
+	// Deferred-regime write arms the marker.
+	require.NoError(t, e.PutSynthesizedGrantRecords(ctx, []*v3.GrantRecord{testGrantRecord("ent-A", "alice")}))
+	require.True(t, e.deferredIdxPending.Load())
+
+	injected := errors.New("injected deferred-marker clear failure")
+	e.test.clearDeferredMarkerHook = func() error { return injected }
+	err = a.EndSync(ctx)
+	require.ErrorIs(t, err, injected, "a failed marker clear must fail EndSync")
+
+	// THE CONTRACT: both halves still armed, in agreement.
+	require.True(t, e.deferredIdxPending.Load(), "failed clear must leave the flag armed")
+	_, closer, getErr := e.db.Get(encodeDeferredIdxPendingKey())
+	require.NoError(t, getErr, "failed clear must leave the durable key present")
+	closer.Close()
+
+	// Retry converges: rebuild re-runs (idempotent), clear succeeds,
+	// both halves disarm, and the index serves the rows.
+	e.test.clearDeferredMarkerHook = nil
+	require.NoError(t, a.EndSync(ctx))
+	require.False(t, e.deferredIdxPending.Load())
+	_, _, getErr = e.db.Get(encodeDeferredIdxPendingKey())
+	require.ErrorIs(t, getErr, pebble.ErrNotFound)
+	n := 0
+	require.NoError(t, e.IterateGrantsByPrincipal(ctx, "user", "alice", func(*v3.GrantRecord) bool {
+		n++
+		return true
+	}))
+	require.Equal(t, 1, n)
+}
+
+// TestPutResourceRecordsIfNewerBranches exercises all three branches
+// of the 2b-restructured control flow: no prior (write), prior older
+// (overwrite with by_parent swap), prior newer (skip).
+func TestPutResourceRecordsIfNewerBranches(t *testing.T) {
+	ctx := context.Background()
+	a := newAdapter(t)
+	_, err := a.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	e := a.PebbleEngine()
+
+	old := timestamppb.New(timestamppb.Now().AsTime().Add(-1000))
+	newer := timestamppb.Now()
+
+	mk := func(parent string, at *timestamppb.Timestamp) *v3.ResourceRecord {
+		b := v3.ResourceRecord_builder{
+			ResourceTypeId: "group",
+			ResourceId:     "r1",
+			DiscoveredAt:   at,
+		}
+		if parent != "" {
+			b.Parent = v3.ResourceRef_builder{ResourceTypeId: "org", ResourceId: parent}.Build()
+		}
+		return b.Build()
+	}
+	byParentPrefix := []byte{versionV3, typeIndex, idxResourceByParent}
+
+	// Branch 1: no prior → written, indexed under parent-A.
+	require.NoError(t, e.PutResourceRecordsIfNewer(ctx, mk("parent-A", old)))
+	require.Equal(t, 1, countKeys(t, e, byParentPrefix))
+
+	// Branch 2: strictly newer → overwritten, index swapped to parent-B.
+	require.NoError(t, e.PutResourceRecordsIfNewer(ctx, mk("parent-B", newer)))
+	require.Equal(t, 1, countKeys(t, e, byParentPrefix), "old parent edge must be cleaned, new one written")
+	got, err := e.GetResourceRecord(ctx, "group", "r1")
+	require.NoError(t, err)
+	require.Equal(t, "parent-B", got.GetParent().GetResourceId())
+
+	// Branch 3: not newer → skipped entirely (record and index untouched).
+	require.NoError(t, e.PutResourceRecordsIfNewer(ctx, mk("parent-C", old)))
+	got, err = e.GetResourceRecord(ctx, "group", "r1")
+	require.NoError(t, err)
+	require.Equal(t, "parent-B", got.GetParent().GetResourceId(), "stale write must not land")
+}

--- a/pkg/dotc1z/engine/pebble/typed_record_ops_coverage_test.go
+++ b/pkg/dotc1z/engine/pebble/typed_record_ops_coverage_test.go
@@ -144,11 +144,73 @@ func TestUnsafePutUniqueGrantRecordsObligations(t *testing.T) {
 	require.Equal(t, 2, countKeys(t, e, GrantByPrincipalLowerBound()),
 		"inline regime must write by_principal for every row")
 
+	// Digest-present refusal: on a fresh sync digest state is provably
+	// absent (StartNewSync excised it), so a present flag means the
+	// freshness contract itself broke — the guard must refuse rather
+	// than silently tombstone a trusted import's digest keyspace.
+	e.grantDigestsPresent.Store(true)
+	require.ErrorContains(t, e.UnsafePutUniqueGrantRecords(ctx, testGrantRecord("ent-C", "carol")),
+		"digest state present on a fresh sync")
+	e.grantDigestsPresent.Store(false)
+
 	// Non-fresh syncs are refused (SetCurrentSync clears freshness).
 	require.NoError(t, a.EndSync(ctx))
 	require.NoError(t, a.SetCurrentSync(ctx, syncID))
 	require.ErrorContains(t, e.UnsafePutUniqueGrantRecords(ctx, testGrantRecord("ent-C", "carol")),
 		"sync is not fresh")
+}
+
+// TestGrantDeleteMalformedValueStillCleansObligations pins the
+// key-derived cleanup contract that motivated the 2b delete-path
+// tightening: a grant whose stored VALUE is garbage (unmarshalable
+// legacy row) but whose KEY is well-formed must still get full index
+// cleanup and digest invalidation on delete. The pre-2b path derived
+// cleanup from the prior value and silently SKIPPED both when the
+// value's identity fields were missing — deleting the primary while
+// leaving a stale-but-present digest (a present-means-exact hole) and
+// orphan index rows. Key-derived cleanup cannot be skipped.
+func TestGrantDeleteMalformedValueStillCleansObligations(t *testing.T) {
+	ctx := context.Background()
+	a := newAdapter(t)
+	syncID, err := a.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	e := a.PebbleEngine()
+
+	// A healthy grant first, sealed so digests exist; rebind for the
+	// post-seal mutation (the partial-sync shape where digests are
+	// present and the delete's invalidation obligation is live).
+	require.NoError(t, e.PutGrantRecords(ctx, testGrantRecord("ent-A", "alice")))
+	require.NoError(t, a.EndSync(ctx))
+	require.NoError(t, a.SetCurrentSync(ctx, syncID))
+	_, ok, err := e.GetGrantDigestGlobalRoot(ctx)
+	require.NoError(t, err)
+	require.True(t, ok, "seal must build digests")
+
+	// Corrupt the stored VALUE in place (key untouched) — the malformed
+	// legacy-row shape the old value-derived cleanup choked on.
+	id := grantIdentity{
+		entitlement:     entitlementIdentityFromParts("app", "github", canonicalTestEntID("ent-A")),
+		principalTypeID: "user",
+		principalID:     "alice",
+	}
+	key := encodeGrantIdentityKey(id)
+	require.NoError(t, e.db.UnsafeForTesting().Set(key, []byte("\xff not a proto"), pebble.Sync))
+
+	// Delete via structural refs (DeleteGrantByIdentityRefs encodes the
+	// key from the record's refs; it never unmarshals the stored
+	// value). Both index families and the digest root must be cleaned
+	// even though the value is garbage.
+	rec := testGrantRecord("ent-A", "alice")
+	require.NoError(t, e.DeleteGrantByIdentityRefs(ctx, rec))
+
+	_, closer, err := e.db.Get(key)
+	require.ErrorIs(t, err, pebble.ErrNotFound, "primary must be gone")
+	_ = closer
+	require.Equal(t, 0, countKeys(t, e, GrantByPrincipalLowerBound()), "by_principal must be cleaned from the key alone")
+	require.Equal(t, 0, countKeys(t, e, encodeGrantByNeedsExpansionPrefix()), "needs_expansion must be cleaned from the key alone")
+	_, ok, err = e.GetGrantDigestGlobalRoot(ctx)
+	require.NoError(t, err)
+	require.False(t, ok, "digest must read as invalidated, never stale-but-present over a deleted row")
 }
 
 // TestDeleteResourceRecordObligations covers the exported delete path
@@ -226,8 +288,10 @@ func TestDeferredMarkerArmFailureRollsBackCAS(t *testing.T) {
 	require.NoError(t, getErr, "the retried arm must persist the durable marker")
 	closer.Close()
 
-	// The marker survives a reopen (the durable half is the point) and
-	// the resumed EndSync rebuilds the index.
+	// Same-process EndSync consumes the armed marker and rebuilds the
+	// index. (The crash side of the contract — the durable key
+	// re-arming the flag on a REOPEN — is pinned by the errorfs sweep's
+	// resume arm, not here; this test stays in-process.)
 	require.NoError(t, a.EndSync(ctx))
 	n := 0
 	require.NoError(t, e.IterateGrantsByPrincipal(ctx, "user", "alice", func(*v3.GrantRecord) bool {

--- a/pkg/dotc1z/engine/pebble/typed_record_ops_test.go
+++ b/pkg/dotc1z/engine/pebble/typed_record_ops_test.go
@@ -86,6 +86,10 @@ func TestTypedRecordOpsRejectWrongFamilyAndMalformedKeys(t *testing.T) {
 			"outside this op's keyspace family", "entitlement key must not stage as a grant")
 		require.ErrorContains(t, rb.StageResourceTypeDelete(grantKey),
 			"outside this op's keyspace family")
+		require.ErrorContains(t, rb.StageResourcePut(grantKey, []byte("v"), nil, "group", "g1"),
+			"outside this op's keyspace family", "grant key must not stage as a resource")
+		require.ErrorContains(t, rb.StageResourceDelete(entKey, nil, "group", "g1"),
+			"outside this op's keyspace family", "entitlement key must not stage as a resource delete")
 	})
 
 	t.Run("malformed grant key", func(t *testing.T) {

--- a/pkg/dotc1z/engine/pebble/typed_record_ops_test.go
+++ b/pkg/dotc1z/engine/pebble/typed_record_ops_test.go
@@ -1,0 +1,176 @@
+package pebble
+
+// Negative-path and end-to-end coverage for the 2b typed record ops
+// (internal/rawdb records.go) — the review-identified gaps: the family
+// assertions and malformed-key error paths had no direct tests, the
+// needs_expansion splice helper was only pinned indirectly, and no test
+// drove the deferred regime's OVERWRITE path (expanded grant over
+// expanded grant) through a seal.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	v2pb "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+)
+
+// TestAppendGrantByNeedsExpansionKeyFromPrimary pins the deriver
+// actually wired into rawdb against the from-identity encoder, and its
+// rejection of malformed keys — the header-splice equation itself is
+// pinned by TestNeedsExpansionKeyHeaderSpliceFromPrimary, but that
+// test never invoked this helper.
+func TestAppendGrantByNeedsExpansionKeyFromPrimary(t *testing.T) {
+	ids := []grantIdentity{
+		{
+			entitlement:     entitlementIdentity{resourceTypeID: "group", resourceID: "g1", stripped: true, tail: "member"},
+			principalTypeID: "user",
+			principalID:     "u1",
+		},
+		{
+			entitlement:     entitlementIdentity{resourceTypeID: "gr\x00oup", resourceID: "g\x011", tail: "\x00k\x00\x01"},
+			principalTypeID: "us\x01er",
+			principalID:     "u\x00\x001",
+		},
+	}
+	for _, id := range ids {
+		primary := encodeGrantIdentityKey(id)
+		got, ok := appendGrantByNeedsExpansionKeyFromPrimary(nil, primary)
+		require.True(t, ok, "well-formed primary must splice")
+		require.Equal(t, encodeGrantByNeedsExpansionIdentityIndexKey(id), got, "identity %+v", id)
+	}
+	for _, malformed := range [][]byte{
+		nil,
+		{},
+		{versionV3, typeGrant},
+		{versionV3, typeGrant, 0},              // zero segments
+		{versionV3, typeGrant, 0, 'a', 0, 'b'}, // two segments
+		{versionV3, typeEntitlement, 0, 'a', 0, 'b', 0, 'c', 0, 'd', 0, 'e', 0, 'f'}, // wrong family
+	} {
+		_, ok := appendGrantByNeedsExpansionKeyFromPrimary(nil, malformed)
+		require.False(t, ok, "malformed key %x must be rejected", malformed)
+	}
+}
+
+// TestTypedRecordOpsRejectWrongFamilyAndMalformedKeys drives the rawdb
+// typed ops' runtime guards directly: a key from the wrong keyspace
+// family must fail its op, a family-correct but structurally malformed
+// grant key must fail derivation, and an errored op must leave the
+// engine unharmed (batch abandoned, nothing committed, subsequent
+// writes fine).
+func TestTypedRecordOpsRejectWrongFamilyAndMalformedKeys(t *testing.T) {
+	ctx := context.Background()
+	a := newAdapter(t)
+	_, err := a.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	e := a.PebbleEngine()
+
+	grantKey := encodeGrantIdentityKey(grantIdentity{
+		entitlement:     entitlementIdentity{resourceTypeID: "app", resourceID: "github", stripped: true, tail: "member"},
+		principalTypeID: "user",
+		principalID:     "alice",
+	})
+	entKey := encodeEntitlementIdentityKey(entitlementIdentity{resourceTypeID: "app", resourceID: "github", stripped: true, tail: "member"})
+
+	t.Run("wrong family", func(t *testing.T) {
+		rb := e.db.NewRecordBatch()
+		defer rb.Close()
+		require.ErrorContains(t, rb.StageEntitlementPut(grantKey, []byte("v")),
+			"outside this op's keyspace family", "grant key must not stage as an entitlement")
+		require.ErrorContains(t, rb.StageGrantPutInline(entKey, []byte("v"), false, false),
+			"outside this op's keyspace family", "entitlement key must not stage as a grant")
+		require.ErrorContains(t, rb.StageResourceTypeDelete(grantKey),
+			"outside this op's keyspace family")
+	})
+
+	t.Run("malformed grant key", func(t *testing.T) {
+		rb := e.db.NewRecordBatch()
+		defer rb.Close()
+		// Family prefix right, segment structure wrong (2 segments, not 6).
+		malformed := []byte{versionV3, typeGrant, 0, 'a', 0, 'b'}
+		require.ErrorContains(t, rb.StageGrantPutInline(malformed, []byte("v"), false, false),
+			"did not decode as a 6-segment identity")
+		require.ErrorContains(t, rb.StageGrantPutDeferred(malformed, []byte("v"), false, false),
+			"did not decode as a 6-segment identity")
+		require.ErrorContains(t, rb.StageGrantDelete(malformed),
+			"did not decode as a 6-segment identity")
+	})
+
+	// An errored op abandons its batch; the engine keeps working.
+	require.NoError(t, a.PutGrants(ctx, mkV2Grant("g1", "ent-A", "user", "alice")))
+	resp, err := a.ListGrants(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, resp.GetList(), 1, "engine must keep serving writes after rejected typed ops")
+}
+
+// TestExpandedGrantOverwriteThroughSeal is the deferred regime's
+// overwrite path end-to-end: an inline-written expandable grant is
+// overwritten TWICE by the expander (the second write is the
+// hadOldVal=true deferred cleanup path), then the sync seals. The
+// saved state must have exactly consistent indexes: by_needs_expansion
+// agrees with the primary rows' flags (side-state preserved through
+// both overwrites), and the seal-rebuilt by_principal serves every
+// grant.
+func TestExpandedGrantOverwriteThroughSeal(t *testing.T) {
+	ctx := context.Background()
+	a := newAdapter(t)
+	_, err := a.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	e := a.PebbleEngine()
+
+	// Inline write with the expandable annotation → needs_expansion=true
+	// row + index entry via the inline regime.
+	annAny, err := anypb.New(v2pb.GrantExpandable_builder{
+		EntitlementIds: []string{"app:github:ent-B"},
+	}.Build())
+	require.NoError(t, err)
+	expandable := mkV2Grant("g1", "ent-A", "user", "alice")
+	expandable.SetAnnotations([]*anypb.Any{annAny})
+	require.NoError(t, a.PutGrants(ctx, expandable))
+
+	countNeedsExpansion := func() int {
+		n := 0
+		prefix := encodeGrantByNeedsExpansionPrefix()
+		iter, err := e.db.NewIter(&pebble.IterOptions{
+			LowerBound: prefix,
+			UpperBound: upperBoundOf(prefix),
+		})
+		require.NoError(t, err)
+		defer iter.Close()
+		for iter.First(); iter.Valid(); iter.Next() {
+			n++
+		}
+		require.NoError(t, iter.Error())
+		return n
+	}
+	require.Equal(t, 1, countNeedsExpansion(), "inline write must index the expandable grant")
+
+	// Two expander overwrites of the same identity. First: hadOldVal=true
+	// against the inline row. Second: hadOldVal=true against the deferred
+	// row — the exact path the review flagged as uncovered. Side-state
+	// (NeedsExpansion=true) must survive both (StoreExpandedGrants
+	// preservation contract), so the index entry must survive both.
+	for i := 0; i < 2; i++ {
+		require.NoError(t, a.Grants().StoreExpandedGrants(ctx, mkV2Grant("g1", "ent-A", "user", "alice")))
+		require.Equalf(t, 1, countNeedsExpansion(),
+			"overwrite %d must clean and rewrite exactly one needs_expansion entry", i+1)
+	}
+
+	require.NoError(t, a.EndSync(ctx))
+
+	// Seal-rebuilt by_principal serves the grant; needs_expansion index
+	// still agrees with the primary's preserved flag.
+	n := 0
+	require.NoError(t, e.IterateGrantsByPrincipal(ctx, "user", "alice", func(r *v3.GrantRecord) bool {
+		require.True(t, r.GetNeedsExpansion(), "preserved side-state must survive both overwrites")
+		n++
+		return true
+	}))
+	require.Equal(t, 1, n, "by_principal must serve the overwritten grant exactly once")
+	require.Equal(t, 1, countNeedsExpansion(), "sealed index state must agree with the primary flag")
+}

--- a/pkg/synccompactor/compactor_pebble_test.go
+++ b/pkg/synccompactor/compactor_pebble_test.go
@@ -1265,7 +1265,7 @@ func deletePebbleStatsSidecar(t testing.TB, ctx context.Context, path string) {
 	require.NoError(t, iter.Error())
 	require.NoError(t, iter.Close())
 	for _, key := range keys {
-		require.NoError(t, eng.DB().Delete(key, nil))
+		require.NoError(t, eng.DB().UnsafeForTesting().Delete(key, nil))
 	}
 	require.NoError(t, w.Close(ctx))
 }

--- a/pkg/synccompactor/pebble/compactor.go
+++ b/pkg/synccompactor/pebble/compactor.go
@@ -154,7 +154,7 @@ func (c *Compactor) Compact(ctx context.Context, source *enginepkg.Engine, syncI
 			// with zero SSTs (the ingest must reference at least one
 			// file), so we fall back to a RangeDelete + Flush.
 			_ = os.Remove(sstPath)
-			if err := dstDB.DeleteRange(plan.lower, plan.upper, pebble.Sync); err != nil {
+			if err := dstDB.DropKeyRange(plan.lower, plan.upper, pebble.Sync); err != nil {
 				return fmt.Errorf("compact: excise-only DeleteRange for %s: %w", plan.name, err)
 			}
 			continue
@@ -186,13 +186,7 @@ func (c *Compactor) Compact(ctx context.Context, source *enginepkg.Engine, syncI
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		if _, err := dstDB.IngestAndExcise(
-			ctx,
-			[]string{p.sstPath},
-			nil,
-			nil,
-			p.exciseSpan,
-		); err != nil {
+		if err := dstDB.ReplaceRangeWithSSTs(ctx, []string{p.sstPath}, p.exciseSpan); err != nil {
 			return fmt.Errorf("compact: IngestAndExcise: %w", err)
 		}
 	}

--- a/pkg/synccompactor/pebble/kway.go
+++ b/pkg/synccompactor/pebble/kway.go
@@ -752,7 +752,7 @@ func materializeSourceBucketToPebble(
 	}
 	primarySuccess = true
 	defer func() { _ = os.Remove(primaryPath) }()
-	if err := dest.DB().Ingest(ctx, []string{primaryPath}); err != nil {
+	if err := dest.DB().IngestSSTs(ctx, []string{primaryPath}); err != nil {
 		return fmt.Errorf("ingest direct primary %s: %w", bucket.name, err)
 	}
 	dest.InvalidateBareIDLookups()
@@ -1260,7 +1260,7 @@ func materializeRunFileBucket(ctx context.Context, dest *enginepkg.Engine, tmpDi
 	}
 	primarySuccess = true
 	defer func() { _ = os.Remove(primaryPath) }()
-	if err := dest.DB().Ingest(ctx, []string{primaryPath}); err != nil {
+	if err := dest.DB().IngestSSTs(ctx, []string{primaryPath}); err != nil {
 		return fmt.Errorf("ingest primary %s: %w", bucket.name, err)
 	}
 	dest.InvalidateBareIDLookups()
@@ -1381,7 +1381,7 @@ func (w *indexRunWriter) closeSortAndIngest(ctx context.Context, dest *enginepkg
 		return err
 	}
 	defer func() { _ = os.Remove(sstPath) }()
-	if err := dest.DB().Ingest(ctx, []string{sstPath}); err != nil {
+	if err := dest.DB().IngestSSTs(ctx, []string{sstPath}); err != nil {
 		return fmt.Errorf("ingest index %s: %w", w.name, err)
 	}
 	dest.InvalidateBareIDLookups()

--- a/pkg/synccompactor/pebble/merge.go
+++ b/pkg/synccompactor/pebble/merge.go
@@ -206,7 +206,7 @@ func mergeOneSource(ctx context.Context, dest *enginepkg.Engine, s SourceSync, d
 	return stats, nil
 }
 
-func mergeBucketRawIfNewer(ctx context.Context, dest *enginepkg.Engine, src *pebble.DB, bucket bucketSpec) (FoldStats, error) {
+func mergeBucketRawIfNewer(ctx context.Context, dest *enginepkg.Engine, src *enginepkg.MergeDB, bucket bucketSpec) (FoldStats, error) {
 	var stats FoldStats
 	lower, upper := bucket.syncRange()
 	iter, err := src.NewIter(&pebble.IterOptions{LowerBound: lower, UpperBound: upper})
@@ -216,18 +216,18 @@ func mergeBucketRawIfNewer(ctx context.Context, dest *enginepkg.Engine, src *peb
 	defer func() { _ = iter.Close() }()
 
 	destDB := dest.DB()
-	batch := destDB.NewBatch()
+	batch := destDB.NewFoldBatch()
 	defer func() { _ = batch.Close() }()
 	pending := 0
 	var scratch rawIndexScratch
 	// The closures see batch by reference, so flush's reassignment
 	// routes subsequent index writes to the fresh batch.
-	setIndexKey := func(key []byte) error { return batch.Set(key, nil, nil) }
+	setIndexKey := func(key []byte) error { return batch.Set(key, nil) }
 	// Each deleted index key is an incumbent's stale index entry: dead
 	// weight in the spliced base frames, counted toward FoldStats.
 	delIndexKey := func(key []byte) error {
 		stats.DeadBytes += int64(len(key))
-		return batch.Delete(key, nil)
+		return batch.Delete(key)
 	}
 	flush := func() error {
 		if batch.Empty() {
@@ -239,7 +239,7 @@ func mergeBucketRawIfNewer(ctx context.Context, dest *enginepkg.Engine, src *peb
 			return err
 		}
 		_ = batch.Close()
-		batch = destDB.NewBatch()
+		batch = destDB.NewFoldBatch()
 		pending = 0
 		return nil
 	}
@@ -289,7 +289,7 @@ func mergeBucketRawIfNewer(ctx context.Context, dest *enginepkg.Engine, src *peb
 		default:
 			return stats, fmt.Errorf("get incumbent: %w", getErr)
 		}
-		if err := batch.Set(key, value, nil); err != nil {
+		if err := batch.Set(key, value); err != nil {
 			return stats, err
 		}
 		if bucket.id == runBucketGrants {

--- a/pkg/synccompactor/pebble/overlay.go
+++ b/pkg/synccompactor/pebble/overlay.go
@@ -355,14 +355,14 @@ func overlayRestartBucket(ctx context.Context, dest *enginepkg.Engine, bucket bu
 		return err
 	}
 	writer.discard()
-	b := dest.DB().NewBatch()
+	b := dest.DB().NewFoldBatch()
 	defer func() { _ = b.Close() }()
 	lo, hi := bucket.syncRange()
-	if err := b.DeleteRange(lo, hi, nil); err != nil {
+	if err := b.DeleteRange(lo, hi); err != nil {
 		return err
 	}
 	for _, r := range bucketIndexRanges(bucket) {
-		if err := b.DeleteRange(r[0], r[1], nil); err != nil {
+		if err := b.DeleteRange(r[0], r[1]); err != nil {
 			return err
 		}
 	}
@@ -1141,7 +1141,7 @@ func overlayMaterializeWholeSourceBucketSST(
 	primarySuccess = true
 	defer func() { _ = os.Remove(primaryPath) }()
 	if wrotePrimary {
-		if err := dest.DB().Ingest(ctx, []string{primaryPath}); err != nil {
+		if err := dest.DB().IngestSSTs(ctx, []string{primaryPath}); err != nil {
 			return fmt.Errorf("overlay merge: ingest whole primary %s: %w", bucket.name, err)
 		}
 		dest.InvalidateBareIDLookups()
@@ -1234,7 +1234,7 @@ func overlayCopySourceIndexesSST(
 	if !wrote {
 		return nil
 	}
-	if err := dest.DB().Ingest(ctx, []string{sstPath}); err != nil {
+	if err := dest.DB().IngestSSTs(ctx, []string{sstPath}); err != nil {
 		return fmt.Errorf("overlay merge: ingest whole index %s: %w", bucket.name, err)
 	}
 	dest.InvalidateBareIDLookups()
@@ -1613,8 +1613,8 @@ type overlayBucketRawWriter struct {
 	dest      *enginepkg.Engine
 	bucket    bucketSpec
 	chunkSize int
-	primary   *cpebble.Batch
-	index     *cpebble.Batch
+	primary   *enginepkg.FoldBatch
+	index     *enginepkg.FoldBatch
 	count     int
 	scratch   rawIndexScratch
 	stats     *mergeStatsAccumulator
@@ -1634,14 +1634,14 @@ func newOverlayBucketRawWriter(dest *enginepkg.Engine, bucket bucketSpec, stats 
 		dest:      dest,
 		bucket:    bucket,
 		chunkSize: chunkSize,
-		primary:   dest.DB().NewBatch(),
-		index:     dest.DB().NewBatch(),
+		primary:   dest.DB().NewFoldBatch(),
+		index:     dest.DB().NewFoldBatch(),
 		stats:     stats,
 	}
 }
 
 func (w *overlayBucketRawWriter) addRaw(ctx context.Context, bucket bucketSpec, destKey []byte, destLower []byte, value []byte) error {
-	if err := w.primary.Set(destKey, value, nil); err != nil {
+	if err := w.primary.Set(destKey, value); err != nil {
 		return err
 	}
 	// Every addRaw call is a winner (the seen-set dedupe happens before
@@ -1656,7 +1656,7 @@ func (w *overlayBucketRawWriter) addRaw(ctx context.Context, bucket bucketSpec, 
 		return nil
 	}
 	if err := forEachIndexKeyFromRaw(bucket, destKey, destLower, value, &w.scratch, w.stats, func(key []byte) error {
-		return w.index.Set(key, nil, nil)
+		return w.index.Set(key, nil)
 	}); err != nil {
 		return err
 	}
@@ -1700,7 +1700,7 @@ func (w *overlayBucketRawWriter) replaceRaw(ctx context.Context, bucket bucketSp
 	// batch ops apply in order, so the Set below wins.
 	if bucket.forEachIndexKey != nil {
 		if err := forEachIndexKeyFromRaw(bucket, destKey, destLower, oldVal, &w.scratch, nil, func(key []byte) error {
-			return w.index.Delete(key, nil)
+			return w.index.Delete(key)
 		}); err != nil {
 			closer.Close()
 			return err
@@ -1733,12 +1733,12 @@ func (w *overlayBucketRawWriter) replaceRaw(ctx context.Context, bucket bucketSp
 		w.stats.regroupEntitlement(oldRT, newRT)
 	}
 	closer.Close()
-	if err := w.primary.Set(destKey, value, nil); err != nil {
+	if err := w.primary.Set(destKey, value); err != nil {
 		return err
 	}
 	if bucket.forEachIndexKey != nil {
 		if err := forEachIndexKeyFromRaw(bucket, destKey, destLower, value, &w.scratch, nil, func(key []byte) error {
-			return w.index.Set(key, nil, nil)
+			return w.index.Set(key, nil)
 		}); err != nil {
 			return err
 		}
@@ -1764,8 +1764,8 @@ func (w *overlayBucketRawWriter) flush(ctx context.Context) error {
 	if err := w.index.Commit(opts); err != nil {
 		return err
 	}
-	w.primary = w.dest.DB().NewBatch()
-	w.index = w.dest.DB().NewBatch()
+	w.primary = w.dest.DB().NewFoldBatch()
+	w.index = w.dest.DB().NewFoldBatch()
 	w.count = 0
 	return nil
 }
@@ -1797,7 +1797,7 @@ func (w *overlayBucketRawWriter) discard() {
 	if w.index != nil {
 		_ = w.index.Close()
 	}
-	w.primary = w.dest.DB().NewBatch()
-	w.index = w.dest.DB().NewBatch()
+	w.primary = w.dest.DB().NewFoldBatch()
+	w.index = w.dest.DB().NewFoldBatch()
 	w.count = 0
 }


### PR DESCRIPTION
## rawdb write choke point: make forgotten write obligations unexpressible

Stacked on #<PR1> (errorfs fault-injection harness) — rebase onto main after it merges.

### Why

Every recurring durability bug this engine has shipped is the same bug wearing different
clothes: a write path that forgot one of its obligations — the index entry that didn't get
written, the digest invalidation that didn't get staged, the crash marker that didn't get
cleared. Convention ("remember to call writeGrantIndexes") doesn't survive contact with new
call sites. This PR makes the obligations structural: a write physically cannot commit
without them.

### What

**`internal/rawdb` — the choke point.** The raw `*pebble.DB` moves into a new internal
package. The generic write primitives (`set`/`delete`/`newBatch`/`ingest`/...) are
unexported; code outside the package cannot compose a raw write at all. Everything arrives
through exported, purpose-named family operations (record / session / meta / digest /
fold), each carrying its keyspace family and crash contract.

**Typed record staging with obligation derivation.** `RecordBatch` exposes no generic
`Set`/`Delete` — only typed ops (`StageGrantPutInline`, `StageGrantPutDeferred`,
`StageGrantDelete`, `StageResourcePut`, ...) that derive and stage everything the mutation
owes in the same call: index entries (byte-level key splices, no value re-scans), prior-row
index cleanup, digest invalidation, and the deferred-index crash marker. The two grant
index regimes (inline vs deferred) are mirrored deliberately, not unified — they differ in
*which* obligations exist. Derivation functions are injected once at `Open`
(`SetRecordDerivers`, fail-closed if incomplete), and every op asserts its key belongs to
its family.

**Narrowed compactor handle.** `Engine.DB()` no longer returns the raw handle. It returns
`*rawdb.MergeView` — a concrete struct carrying only what the synccompactor needs (reads,
LSM stats, bulk range/ingest ops, the fold-exempt batch). Typed record staging and the
session/meta/digest families are unreachable through it, *including by type assertion*
(a concrete type, unlike an interface, gives an assertion nothing to recover). All
`MergeView` methods inline; `DB()` returns a pointer to a view pre-built at `Open` — zero
per-call cost.

**Meta-tests pin the architecture.** Four source-level fences, so regressions fail in CI
rather than in review:
- raw pebble write signals (`*pebble.Batch`, `.db.Set(`, ...) may not appear outside
  `internal/rawdb` (recursive scan);
- rawdb's exported surface may not leak a raw write conduit (AST type-check: no
  `*pebble.DB`/`*pebble.Batch` in any exported signature, field, or alias);
- `UnsafeForTesting` — the single raw escape hatch, runtime-gated by `testing.Testing()` —
  may not appear in production source anywhere in the engine's client tree
  (whitespace-tolerant selector scan);
- `NewFoldBatch` — the compactor's sanctioned raw record-write conduit — may not appear
  outside `pkg/synccompactor/pebble`.

### Real bugs found and fixed along the way

- **`clearDeferredIdxPending` ordering** (latent on main): the in-memory flag was cleared
  *before* the durable marker delete, so a failed delete left them disagreeing — a retried
  EndSync skipped the rebuild and left a stale marker forcing a spurious rebuild at next
  open. Now durable-delete-first, matching the arm side; both edges pinned by
  fault-injection tests.
- **Malformed grant keys** could stage through `StageGrantPutDeferred` unvalidated; the
  identity check now runs unconditionally in every grant op.
- **`CheckpointTo` retry**: a failed WAL truncate after a successful checkpoint stranded
  the dest dir, hard-failing any same-path retry against pebble's dest-must-not-exist
  contract. Now cleaned up, with cleanup failure surfaced via `errors.Join`.
- **Vestigial codec surface**: unimplemented `WriteIndexes`/`DeleteIndexes` (raw
  `*pebble.Batch` params) removed from the codec interface — caught by the recursive
  meta-test scan.

### New durability pins (extending the PR-1 harness)

- The EndSync fault sweep's oracle now triangulates digest state three ways per
  entitlement (content-hash fold recomputed from primary records vs stored digest root vs
  hash-index fold) plus the whole-file root — present-but-wrong digests fail everywhere;
  legal loud-drops must be *consistently* absent.
- `TestEndSyncStampDurabilityCarriesPages`: isolated pin of the WAL-prefix-durability
  contract — with digests off and inline-only grants, the finished stamp is the *only*
  Sync between the NoSync pages and a strict crash cut, proving the stamp's fsync carries
  the pages (finished-but-incomplete is unexpressible).
- `TestEndSyncStampWindowImageComplete`: same crash cut under the full default workload,
  pinning the caller-visible finished ⇒ complete dichotomy.
- Deferred-marker arm and clear failure paths both pinned (flag/durable-key agreement on
  every edge).

### Behavior deltas (deliberate, documented in code)

- Primary + index writes are staged into **one batch** as they're derived, instead of two
  batches merged via `Apply` before a single commit — the atomicity is unchanged (both
  shapes committed once), but the obligation now cannot be forgotten. Trade-offs are
  noise: one fewer batch allocation and repr memcpy per call; entry order within the
  batch is now interleaved rather than family-grouped, which only matters to pebble's
  flushable-batch sort at commits ≥ ~32 MiB (half of `MemTableSize`) — no live connector
  path approaches that.
- Digest invalidation stages once per op instead of once-on-cleanup + once-on-write
  (idempotent tombstones; net fewer batch bytes).
- `DeleteResourceTypeRecord` reshaped from a bare `Delete` to a one-op record batch
  (pebble routes both through the same `Apply` path).

### Testing

- Full `pkg/dotc1z/...` + `pkg/synccompactor/...` suites, `golangci-lint` clean.
- errorfs EndSync window sweep (exhaustive, self-terminating) and whole-sync randomized
  soak (`BATON_SOAK=1`), both with the digest oracle.
- Mutation-validated: deliberately skipping an obligation (e.g. the by_principal write)
  fails existing tests.
- Coverage audit closed every untested production path in the typed-op surface.
- Four rounds of dual adversarial review (two independent models per round); final delta
  round confirmed clean after fixes.