### PR TITLE
deturducken pebble engine

### DIFF
--- a/pkg/dotc1z/engine/equivalence/memory.go
+++ b/pkg/dotc1z/engine/equivalence/memory.go
@@ -27,7 +27,7 @@ func NewMemoryRef() *MemoryRef {
 	return &MemoryRef{bySync: map[string]map[string]*v3.GrantRecord{}}
 }
 
-func (m *MemoryRef) SetCurrentSync(syncID string) error {
+func (m *MemoryRef) SetCurrentSync(ctx context.Context, syncID string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.currentSync = syncID

--- a/pkg/dotc1z/engine/equivalence/runner.go
+++ b/pkg/dotc1z/engine/equivalence/runner.go
@@ -72,7 +72,7 @@ type Result struct {
 // same reference must produce the same Result.
 func RunWorkload(ctx context.Context, ref Reference, w Workload) (*Result, error) {
 	if cs, ok := ref.(currentSyncSetter); ok {
-		if err := cs.SetCurrentSync(w.SyncID); err != nil {
+		if err := cs.SetCurrentSync(ctx, w.SyncID); err != nil {
 			return nil, fmt.Errorf("equivalence: SetCurrentSync: %w", err)
 		}
 	}
@@ -248,9 +248,13 @@ type deleter interface {
 // currentSyncSetter is an optional capability — references that track
 // a "current sync" (like the Pebble engine) implement it so empty-
 // syncID reads route correctly. References that don't need it (like
-// the in-memory map) simply omit it.
+// the in-memory map) simply omit it. The signature MUST match
+// pebble.Engine.SetCurrentSync exactly: this is a structural probe,
+// so a signature drift doesn't fail the build — it silently stops
+// matching and every pebble workload dies with "no current sync"
+// (which is exactly how the PR 2.6 ctx-parameter addition surfaced).
 type currentSyncSetter interface {
-	SetCurrentSync(syncID string) error
+	SetCurrentSync(ctx context.Context, syncID string) error
 }
 
 // ErrNotImplemented is returned by reference adapters that don't

--- a/pkg/dotc1z/engine/pebble/adapter.go
+++ b/pkg/dotc1z/engine/pebble/adapter.go
@@ -21,6 +21,7 @@ import (
 	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
 )
 
 // Adapter wraps an *Engine and implements connectorstore.Writer
@@ -810,7 +811,7 @@ func (a *Adapter) ListResources(ctx context.Context, req *v2.ResourcesServiceLis
 	// them on the next call.
 	cursorFor := func(rec *v3.ResourceRecord) string {
 		if useParent {
-			return encodeCursor(encodeResourceByParentIndexKey(
+			return encodeCursor(keys.EncodeResourceByParentIndexKey(
 				parent.GetResourceType(), parent.GetResource(),
 				rec.GetResourceTypeId(), rec.GetResourceId(),
 			))

--- a/pkg/dotc1z/engine/pebble/adapter.go
+++ b/pkg/dotc1z/engine/pebble/adapter.go
@@ -36,8 +36,20 @@ import (
 // reads). Adapter survives as a type alias for compatibility.
 
 // Adapter is the Engine, by its historical name. The wrapping type
-// dissolved in PR 2.6; the alias keeps the many existing constructors
-// and fixtures compiling. New code should use *Engine directly.
+// dissolved when the layer collapsed; the alias keeps existing
+// constructors and fixtures compiling. New code should use *Engine
+// directly.
+//
+// DELIBERATE BREAK vs the old wrapper: a bare Adapter/Engine is NOT a
+// connectorstore.Writer anymore. The old type carried Close(ctx); the
+// Engine's teardown is Close() (no ctx), and a Go alias cannot carry
+// both signatures. The supported Writer — before and after — is the
+// pkg/dotc1z store (dotc1z.NewStore with the Pebble engine), whose
+// Close(ctx) owns the envelope save the bare engine never performed;
+// a bare handle "closing" a c1z without saving it was a trap, not a
+// contract. Every other Writer method remains on the Engine, so code
+// holding a concrete *Adapter compiles untouched except Close(ctx)
+// call sites, which drop the ctx.
 type Adapter = Engine
 
 // NewAdapter is a compatibility constructor from the dissolved-layer
@@ -45,10 +57,10 @@ type Adapter = Engine
 func NewAdapter(e *Engine) *Adapter { return e }
 
 // Compile-time checks for the optional connectorstore capabilities
-// that SQLite's *C1File also exposes. (connectorstore.Writer's
-// Close(ctx) lives on pkg/dotc1z's pebbleStore, which owns envelope
-// save; the Engine's Close() is the storage teardown. The full Writer
-// contract is asserted on the store via c1zstore.Store.)
+// that SQLite's *C1File also exposes. (The full connectorstore.Writer
+// contract is asserted on pkg/dotc1z's store via c1zstore.Store — see
+// the Adapter alias doc for why the bare engine is deliberately not a
+// Writer.)
 var (
 	_ connectorstore.LatestFinishedSyncIDFetcher  = (*Engine)(nil)
 	_ connectorstore.DBSizeProvider               = (*Engine)(nil)
@@ -193,9 +205,18 @@ func (e *Engine) SetCurrentSync(ctx context.Context, syncID string) error {
 // CurrentSyncStep returns the current sync's step string, or "". Read
 // from the durable SyncRunRecord on every call, exactly like SQLite's
 // CurrentSyncStep re-reads the sync_runs row — there is no in-memory
-// step cache to go stale (the pre-2.6 Adapter cached it and grew
+// step cache to go stale (the old Adapter cached it and grew
 // rehydration logic at every rebind to compensate).
+//
+// Holds lifecycleMu so the id read and the record read are one
+// snapshot with respect to the lifecycle transitions — without it, an
+// interleaved EndSync/SetCurrentSync between the two reads could
+// return a token for a sync the engine is no longer bound to (the old
+// Adapter's mutex gave the same guarantee over its cache; review
+// finding, final round).
 func (e *Engine) CurrentSyncStep(ctx context.Context) (string, error) {
+	e.lifecycleMu.Lock()
+	defer e.lifecycleMu.Unlock()
 	syncID := e.CurrentSyncID()
 	if syncID == "" {
 		return "", nil
@@ -647,9 +668,10 @@ func (e *Engine) PutAsset(ctx context.Context, assetRef *v2.AssetRef, contentTyp
 //
 // Callers that open through dotc1z.NewStore(..., WithEngine(EnginePebble))
 // get the real Cleanup; callers that use a bare Engine (unit tests,
-// embedding) silently get retention=disabled. The method exists so the
-// engine satisfies the connectorstore.Writer surface regardless of how
-// it was constructed.
+// embedding) silently get retention=disabled. Kept so the engine
+// serves the writer-shaped call sites that predate the layer collapse
+// (the bare engine is deliberately NOT a full connectorstore.Writer —
+// see the Adapter alias doc).
 func (e *Engine) Cleanup(ctx context.Context) error { return nil }
 
 // === GetAsset ===

--- a/pkg/dotc1z/engine/pebble/adapter.go
+++ b/pkg/dotc1z/engine/pebble/adapter.go
@@ -21,7 +21,7 @@ import (
 	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
-	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/rawdb"
 )
 
 // Adapter wraps an *Engine and implements connectorstore.Writer
@@ -811,7 +811,7 @@ func (a *Adapter) ListResources(ctx context.Context, req *v2.ResourcesServiceLis
 	// them on the next call.
 	cursorFor := func(rec *v3.ResourceRecord) string {
 		if useParent {
-			return encodeCursor(keys.EncodeResourceByParentIndexKey(
+			return encodeCursor(rawdb.EncodeResourceByParentIndexKey(
 				parent.GetResourceType(), parent.GetResource(),
 				rec.GetResourceTypeId(), rec.GetResourceId(),
 			))

--- a/pkg/dotc1z/engine/pebble/adapter.go
+++ b/pkg/dotc1z/engine/pebble/adapter.go
@@ -24,72 +24,43 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/rawdb"
 )
 
-// Adapter wraps an *Engine and implements connectorstore.Writer
-// (which embeds connectorstore.Reader) — the surface C1 + the syncer
-// call against the v3 Pebble engine. Translates v2 wire types ↔ v3
-// record types via translate_v2.go and routes Put/Get/List into the
-// engine's per-record-type methods.
-//
-// The adapter implements the common connectorstore writer and reader
-// paths directly. gRPC methods outside that surface fall through to
-// the embedded UnimplementedXxxServer stubs.
-//
-// Adapter is goroutine-safe modulo Close — concurrent reads + writes
-// are fine, but caller must serialize Close against other calls.
-type Adapter struct {
-	engine *Engine
+// This file is the Engine's connectorstore face: the sync lifecycle
+// (StartNewSync/ResumeSync/CheckpointSync/EndSync) and the v2
+// writer/reader surface C1 + the syncer call. It translates v2 wire
+// types ↔ v3 record types via translate_v2.go and routes Put/Get/List
+// into the per-record-type methods. Historically this was a separate
+// Adapter type wrapping the Engine; PR 2.6 dissolved that layer — the
+// Engine implements the surface directly, and the only sync-lifecycle
+// state is the engine's own currentSync binding plus the durable
+// SyncRunRecord (read on demand, like the SQLite engine's row-backed
+// reads). Adapter survives as a type alias for compatibility.
 
-	// embedded Unimplemented stubs for the gRPC service surfaces we
-	// implement partially. Each implemented method overrides the stub.
-	// GrantsReaderServiceServer is deliberately NOT stubbed: the Adapter
-	// implements it in full, and adapter_reader.go asserts the complete
-	// contract — re-adding the stub would make that assertion vacuous.
-	v2.UnimplementedResourceTypesServiceServer
-	reader_v2.UnimplementedResourceTypesReaderServiceServer
-	v2.UnimplementedResourcesServiceServer
-	reader_v2.UnimplementedResourcesReaderServiceServer
-	v2.UnimplementedEntitlementsServiceServer
-	reader_v2.UnimplementedEntitlementsReaderServiceServer
-	v2.UnimplementedGrantsServiceServer
-	reader_v2.UnimplementedSyncsReaderServiceServer
+// Adapter is the Engine, by its historical name. The wrapping type
+// dissolved in PR 2.6; the alias keeps the many existing constructors
+// and fixtures compiling. New code should use *Engine directly.
+type Adapter = Engine
 
-	mu      sync.Mutex
-	current syncRunState
-}
+// NewAdapter is a compatibility constructor from the dissolved-layer
+// era: the "adapter" IS the engine now.
+func NewAdapter(e *Engine) *Adapter { return e }
 
-// syncRunState tracks the currently-open sync. The connectorstore
-// interface treats sync IDs as opaque strings; we store the full
-// SyncRunRecord shape so EndSync / CheckpointSync can update the
-// sync_runs record.
-type syncRunState struct {
-	syncID    string
-	syncType  v3.SyncType
-	parentID  string
-	step      string
-	startedAt time.Time
-}
-
-// NewAdapter wraps an Engine. The engine must remain alive for the
-// lifetime of the adapter.
-func NewAdapter(e *Engine) *Adapter {
-	return &Adapter{engine: e}
-}
-
-// Compile-time checks for the full Writer interface and the optional
-// connectorstore capabilities that SQLite's *C1File also exposes.
+// Compile-time checks for the optional connectorstore capabilities
+// that SQLite's *C1File also exposes. (connectorstore.Writer's
+// Close(ctx) lives on pkg/dotc1z's pebbleStore, which owns envelope
+// save; the Engine's Close() is the storage teardown. The full Writer
+// contract is asserted on the store via c1zstore.Store.)
 var (
-	_ connectorstore.Writer                       = (*Adapter)(nil)
-	_ connectorstore.LatestFinishedSyncIDFetcher  = (*Adapter)(nil)
-	_ connectorstore.DBSizeProvider               = (*Adapter)(nil)
-	_ connectorstore.EntitlementGrantDigestReader = (*Adapter)(nil)
+	_ connectorstore.LatestFinishedSyncIDFetcher  = (*Engine)(nil)
+	_ connectorstore.DBSizeProvider               = (*Engine)(nil)
+	_ connectorstore.EntitlementGrantDigestReader = (*Engine)(nil)
 )
 
 // === sync lifecycle ===
 
 // StartNewSync creates a new sync_run record under a freshly-minted
 // sync_id. Returns the new sync_id.
-func (a *Adapter) StartNewSync(ctx context.Context, syncType connectorstore.SyncType, parentSyncID string) (string, error) {
-	return a.startNewSync(ctx, syncType, "", parentSyncID)
+func (e *Engine) StartNewSync(ctx context.Context, syncType connectorstore.SyncType, parentSyncID string) (string, error) {
+	return e.startNewSync(ctx, syncType, "", parentSyncID)
 }
 
 // StartNewSyncWithID is StartNewSync but adopts the caller-supplied
@@ -97,22 +68,22 @@ func (a *Adapter) StartNewSync(ctx context.Context, syncType connectorstore.Sync
 // (e.g. ToPebble) that must preserve the source sync's identity so the
 // produced file's sync_id matches the snapshot it was derived from.
 // syncID must be non-empty.
-func (a *Adapter) StartNewSyncWithID(ctx context.Context, syncType connectorstore.SyncType, syncID, parentSyncID string) (string, error) {
+func (e *Engine) StartNewSyncWithID(ctx context.Context, syncType connectorstore.SyncType, syncID, parentSyncID string) (string, error) {
 	if syncID == "" {
 		return "", errors.New("StartNewSyncWithID: empty syncID")
 	}
-	return a.startNewSync(ctx, syncType, syncID, parentSyncID)
+	return e.startNewSync(ctx, syncType, syncID, parentSyncID)
 }
 
 // startNewSync opens a new sync. An empty syncID mints a fresh ksuid;
 // a non-empty syncID is adopted verbatim (the single-sync file holds
 // exactly one sync, so any prior data is wiped first regardless).
-func (a *Adapter) startNewSync(ctx context.Context, syncType connectorstore.SyncType, syncID, parentSyncID string) (string, error) {
+func (e *Engine) startNewSync(ctx context.Context, syncType connectorstore.SyncType, syncID, parentSyncID string) (string, error) {
 	if syncID == "" {
 		syncID = ksuid.New().String()
 	}
-	a.mu.Lock()
-	defer a.mu.Unlock()
+	e.lifecycleMu.Lock()
+	defer e.lifecycleMu.Unlock()
 	// Single-sync contract: a v3 Pebble c1z holds exactly one sync.
 	// Keys carry no sync_id, so if a prior sync's data is present we
 	// must wipe it before starting — otherwise records the new sync
@@ -121,66 +92,50 @@ func (a *Adapter) startNewSync(ctx context.Context, syncType connectorstore.Sync
 	// MarkFreshSync skip-Get fast path depends on. A fresh engine
 	// (the common ToPebble/compaction case) has no sync-run and skips
 	// the wipe.
-	if existed, err := a.engine.hasSyncRun(); err != nil {
+	if existed, err := e.hasSyncRun(); err != nil {
 		return "", err
 	} else if existed {
-		if err := a.engine.ResetForNewSync(ctx); err != nil {
+		if err := e.ResetForNewSync(ctx); err != nil {
 			return "", err
 		}
 	}
 	// MarkFreshSync flips the engine into the perf-fast write path:
 	// pebble.NoSync per commit, skip read-before-write index cleanup.
 	// EndSync calls EndFreshSync to flush + fsync once at the end.
-	if err := a.engine.MarkFreshSync(syncID); err != nil {
+	if err := e.MarkFreshSync(syncID); err != nil {
 		return "", err
-	}
-	a.current = syncRunState{
-		syncID:    syncID,
-		syncType:  v2SyncTypeToV3(syncType),
-		parentID:  parentSyncID,
-		startedAt: time.Now(),
 	}
 	rec := v3.SyncRunRecord_builder{
 		SyncId:       syncID,
-		Type:         a.current.syncType,
+		Type:         v2SyncTypeToV3(syncType),
 		ParentSyncId: parentSyncID,
-		StartedAt:    timestamppb.New(a.current.startedAt),
+		StartedAt:    timestamppb.New(time.Now()),
 	}.Build()
-	if err := a.engine.PutSyncRunRecord(ctx, rec); err != nil {
-		a.current = syncRunState{}
-		a.engine.clearCurrentSync()
+	if err := e.PutSyncRunRecord(ctx, rec); err != nil {
+		e.clearCurrentSync()
 		return "", err
 	}
 	return syncID, nil
 }
 
 // ResumeSync attaches to an existing sync_run by id. Returns the
-// caller-provided id if it matches an existing record.
-func (a *Adapter) ResumeSync(ctx context.Context, syncType connectorstore.SyncType, syncID string) (string, error) {
+// caller-provided id if it matches an existing record. The persisted
+// checkpoint token needs no rehydration step: CurrentSyncStep reads
+// the SyncRunRecord on demand, so a resumed sync reports the on-disk
+// SyncToken by construction (the pre-2.6 Adapter cached it and had to
+// reload carefully — a stale/empty cache made the syncer's FSM restart
+// from InitOp every activity window).
+func (e *Engine) ResumeSync(ctx context.Context, syncType connectorstore.SyncType, syncID string) (string, error) {
 	if syncID == "" {
-		return "", errors.New("adapter.ResumeSync: empty syncID")
+		return "", errors.New("pebble.ResumeSync: empty syncID")
 	}
-	existing, err := a.engine.GetSyncRunRecord(ctx, syncID)
-	if err != nil {
+	if _, err := e.GetSyncRunRecord(ctx, syncID); err != nil {
 		return "", c1zstore.AdaptNotFound(fmt.Errorf("ResumeSync: lookup: %w", err), pebble.ErrNotFound)
 	}
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	if err := a.engine.SetCurrentSync(syncID); err != nil {
+	e.lifecycleMu.Lock()
+	defer e.lifecycleMu.Unlock()
+	if err := e.bindCurrentSync(syncID); err != nil {
 		return "", err
-	}
-	a.current = syncRunState{
-		syncID:   syncID,
-		syncType: existing.GetType(),
-		parentID: existing.GetParentSyncId(),
-		// Load the persisted checkpoint token back into the in-memory
-		// cache. CurrentSyncStep reads a.current.step directly, so
-		// omitting this makes a resumed sync report step "" and the
-		// syncer's state.Unmarshal("") restarts the FSM from InitOp —
-		// i.e. a full sync every activity window. CheckpointSync/EndSync
-		// round-trip SyncToken via the SyncRunRecord; resume must too.
-		step:      existing.GetSyncToken(),
-		startedAt: existing.GetStartedAt().AsTime(),
 	}
 	return syncID, nil
 }
@@ -203,77 +158,67 @@ func (a *Adapter) ResumeSync(ctx context.Context, syncType connectorstore.SyncTy
 //     exceeding one window never finished.
 //
 // Only when nothing is resumable do we start a new sync.
-func (a *Adapter) StartOrResumeSync(ctx context.Context, syncType connectorstore.SyncType, syncID string) (string, bool, error) {
+func (e *Engine) StartOrResumeSync(ctx context.Context, syncType connectorstore.SyncType, syncID string) (string, bool, error) {
 	if syncID != "" {
-		if _, err := a.engine.GetSyncRunRecord(ctx, syncID); err == nil {
-			id, err := a.ResumeSync(ctx, syncType, syncID)
+		if _, err := e.GetSyncRunRecord(ctx, syncID); err == nil {
+			id, err := e.ResumeSync(ctx, syncType, syncID)
 			return id, false, err
 		}
-	} else if rec, err := a.engine.LatestUnfinishedSyncRecord(ctx, syncTypeFilterFromConnectorstore(syncType)); err != nil {
+	} else if rec, err := e.LatestUnfinishedSyncRecord(ctx, syncTypeFilterFromConnectorstore(syncType)); err != nil {
 		return "", false, err
 	} else if rec != nil {
-		id, err := a.ResumeSync(ctx, syncType, rec.GetSyncId())
+		id, err := e.ResumeSync(ctx, syncType, rec.GetSyncId())
 		return id, false, err
 	}
-	id, err := a.StartNewSync(ctx, syncType, "")
+	id, err := e.StartNewSync(ctx, syncType, "")
 	return id, true, err
 }
 
 // SetCurrentSync rebinds the engine's current sync without creating a
 // new SyncRunRecord. Used by callers that previously called
-// StartNewSync/ResumeSync.
-func (a *Adapter) SetCurrentSync(ctx context.Context, syncID string) error {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	if err := a.engine.SetCurrentSync(syncID); err != nil {
+// StartNewSync/ResumeSync. A missing record is legal (the legitimate
+// "no checkpoint yet" case — CurrentSyncStep will report ""); any
+// other read failure propagates rather than silently binding a sync
+// whose step can't be read (SQLite's SetCurrentSync likewise returns
+// its getSync error).
+func (e *Engine) SetCurrentSync(ctx context.Context, syncID string) error {
+	e.lifecycleMu.Lock()
+	defer e.lifecycleMu.Unlock()
+	if _, err := e.GetSyncRunRecord(ctx, syncID); err != nil && !errors.Is(err, pebble.ErrNotFound) {
 		return err
 	}
-	// Rehydrate the in-memory cache from the persisted record so
-	// CurrentSyncStep reflects the on-disk SyncToken after a rebind —
-	// the same reason ResumeSync loads step. SQLite's CurrentSyncStep
-	// re-reads the sync_runs row on every call and so is immune; Pebble
-	// caches a.current.step, so a rebind that doesn't refresh it would
-	// report a stale (or empty) step and reset the FSM.
-	rec, err := a.engine.GetSyncRunRecord(ctx, syncID)
-	if err != nil {
-		// A genuine miss (no record under this id) is the legitimate
-		// "no checkpoint yet" case: bind the id with an empty step.
-		// Any OTHER error is a real read failure — propagate it rather
-		// than silently leaving step "" and resetting the FSM to a full
-		// re-sync (the failure class this whole path exists to avoid).
-		// SQLite's SetCurrentSync likewise returns its getSync error.
-		if errors.Is(err, pebble.ErrNotFound) {
-			a.current = syncRunState{syncID: syncID}
-			return nil
-		}
-		return err
-	}
-	a.current = syncRunState{
-		syncID:    syncID,
-		syncType:  rec.GetType(),
-		parentID:  rec.GetParentSyncId(),
-		step:      rec.GetSyncToken(),
-		startedAt: rec.GetStartedAt().AsTime(),
-	}
-	return nil
+	return e.bindCurrentSync(syncID)
 }
 
-// CurrentSyncStep returns the current sync's step string, or "".
-func (a *Adapter) CurrentSyncStep(ctx context.Context) (string, error) {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	return a.current.step, nil
+// CurrentSyncStep returns the current sync's step string, or "". Read
+// from the durable SyncRunRecord on every call, exactly like SQLite's
+// CurrentSyncStep re-reads the sync_runs row — there is no in-memory
+// step cache to go stale (the pre-2.6 Adapter cached it and grew
+// rehydration logic at every rebind to compensate).
+func (e *Engine) CurrentSyncStep(ctx context.Context) (string, error) {
+	syncID := e.CurrentSyncID()
+	if syncID == "" {
+		return "", nil
+	}
+	rec, err := e.GetSyncRunRecord(ctx, syncID)
+	if err != nil {
+		if errors.Is(err, pebble.ErrNotFound) {
+			return "", nil
+		}
+		return "", err
+	}
+	return rec.GetSyncToken(), nil
 }
 
 // CheckpointSync persists a step token to the open sync's record.
-func (a *Adapter) CheckpointSync(ctx context.Context, syncToken string) error {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	if a.current.syncID == "" {
+func (e *Engine) CheckpointSync(ctx context.Context, syncToken string) error {
+	e.lifecycleMu.Lock()
+	defer e.lifecycleMu.Unlock()
+	syncID := e.CurrentSyncID()
+	if syncID == "" {
 		return errors.New("CheckpointSync: no open sync")
 	}
-	a.current.step = syncToken
-	existing, err := a.engine.GetSyncRunRecord(ctx, a.current.syncID)
+	existing, err := e.GetSyncRunRecord(ctx, syncID)
 	if err != nil {
 		return err
 	}
@@ -285,19 +230,22 @@ func (a *Adapter) CheckpointSync(ctx context.Context, syncToken string) error {
 		EndedAt:      existing.GetEndedAt(),
 		SyncToken:    syncToken,
 	}.Build()
-	return a.engine.PutSyncRunRecord(ctx, updated)
+	return e.PutSyncRunRecord(ctx, updated)
 }
 
 // EndSync stamps the open sync_run's ended_at and detaches it. After
-// EndSync, the adapter has no current sync; SetCurrentSync or
-// StartNewSync are required for further writes.
-func (a *Adapter) EndSync(ctx context.Context) error {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	if a.current.syncID == "" {
+// EndSync, the engine has no current sync; SetCurrentSync or
+// StartNewSync are required for further writes. The binding itself is
+// cleared inside the finalize tail (EndFreshSync), so success leaves
+// no lifecycle state to reset here.
+func (e *Engine) EndSync(ctx context.Context) error {
+	e.lifecycleMu.Lock()
+	defer e.lifecycleMu.Unlock()
+	syncID := e.CurrentSyncID()
+	if syncID == "" {
 		return errors.New("EndSync: no open sync")
 	}
-	existing, err := a.engine.GetSyncRunRecord(ctx, a.current.syncID)
+	existing, err := e.GetSyncRunRecord(ctx, syncID)
 	if err != nil {
 		return err
 	}
@@ -316,16 +264,15 @@ func (a *Adapter) EndSync(ctx context.Context) error {
 	// from by_principal, in the saved artifact. Finalize's own steps run
 	// on AllowSealed paths; sync-run metadata stamps remain allowed.
 	// Sealing also pauses compactions for the EndSync-to-close window.
-	a.engine.seal()
-	if err := a.engine.endSyncFinalize(ctx, existing); err != nil {
+	e.seal()
+	if err := e.endSyncFinalize(ctx, existing); err != nil {
 		// On failure the sync stays bound and the caller may keep writing
 		// (or retry EndSync later): leave the sealed state and resume
 		// compactions, or L0 would accumulate until pebble stalls writes at
 		// L0StopWritesThreshold with nothing left to resume the scheduler.
-		a.engine.unseal()
+		e.unseal()
 		return err
 	}
-	a.current = syncRunState{}
 	return nil
 }
 
@@ -434,13 +381,13 @@ func (e *Engine) endSyncFinalize(ctx context.Context, existing *v3.SyncRunRecord
 // read+arena-private-write access patterns. Each worker writes to a
 // disjoint range of the records slice and uses its own arena, so no
 // shared mutable state across workers.
-func (a *Adapter) PutGrants(ctx context.Context, grants ...*v2.Grant) error {
-	syncID := a.currentSyncID()
+func (e *Engine) PutGrants(ctx context.Context, grants ...*v2.Grant) error {
+	syncID := e.CurrentSyncID()
 	if syncID == "" {
 		return ErrNoCurrentSync
 	}
 	records := translateGrants(syncID, grants)
-	if err := a.engine.PutGrantRecords(ctx, records...); err != nil {
+	if err := e.PutGrantRecords(ctx, records...); err != nil {
 		return fmt.Errorf("PutGrants: %w", err)
 	}
 	return nil
@@ -452,13 +399,13 @@ func (a *Adapter) PutGrants(ctx context.Context, grants ...*v2.Grant) error {
 // sync must be fresh, and the caller MUST guarantee each external_id appears at
 // most once across the whole sync (not just within this batch). Live connector
 // writes should use PutGrants.
-func (a *Adapter) UnsafePutUniqueGrants(ctx context.Context, grants ...*v2.Grant) error {
-	syncID := a.currentSyncID()
+func (e *Engine) UnsafePutUniqueGrants(ctx context.Context, grants ...*v2.Grant) error {
+	syncID := e.CurrentSyncID()
 	if syncID == "" {
 		return ErrNoCurrentSync
 	}
 	records := translateGrants(syncID, grants)
-	if err := a.engine.UnsafePutUniqueGrantRecords(ctx, records...); err != nil {
+	if err := e.UnsafePutUniqueGrantRecords(ctx, records...); err != nil {
 		return fmt.Errorf("UnsafePutUniqueGrants: %w", err)
 	}
 	return nil
@@ -556,8 +503,8 @@ func translateGrantsSerial(syncID string, grants []*v2.Grant, discoveredAt []*ti
 
 // PutResourceTypes writes a batch of resource types in a single
 // Pebble batch.
-func (a *Adapter) PutResourceTypes(ctx context.Context, rts ...*v2.ResourceType) error {
-	syncID := a.currentSyncID()
+func (e *Engine) PutResourceTypes(ctx context.Context, rts ...*v2.ResourceType) error {
+	syncID := e.CurrentSyncID()
 	if syncID == "" {
 		return ErrNoCurrentSync
 	}
@@ -576,15 +523,15 @@ func (a *Adapter) PutResourceTypes(ctx context.Context, rts ...*v2.ResourceType)
 		}
 		records = append(records, rec)
 	}
-	if err := a.engine.PutResourceTypeRecords(ctx, records...); err != nil {
+	if err := e.PutResourceTypeRecords(ctx, records...); err != nil {
 		return fmt.Errorf("PutResourceTypes: %w", err)
 	}
 	return nil
 }
 
 // PutResources writes a batch of resources in a single Pebble batch.
-func (a *Adapter) PutResources(ctx context.Context, resources ...*v2.Resource) error {
-	syncID := a.currentSyncID()
+func (e *Engine) PutResources(ctx context.Context, resources ...*v2.Resource) error {
+	syncID := e.CurrentSyncID()
 	if syncID == "" {
 		return ErrNoCurrentSync
 	}
@@ -603,15 +550,15 @@ func (a *Adapter) PutResources(ctx context.Context, resources ...*v2.Resource) e
 		}
 		records = append(records, rec)
 	}
-	if err := a.engine.PutResourceRecords(ctx, records...); err != nil {
+	if err := e.PutResourceRecords(ctx, records...); err != nil {
 		return fmt.Errorf("PutResources: %w", err)
 	}
 	return nil
 }
 
 // PutEntitlements writes a batch of entitlements in a single Pebble batch.
-func (a *Adapter) PutEntitlements(ctx context.Context, entitlements ...*v2.Entitlement) error {
-	syncID := a.currentSyncID()
+func (e *Engine) PutEntitlements(ctx context.Context, entitlements ...*v2.Entitlement) error {
+	syncID := e.CurrentSyncID()
 	if syncID == "" {
 		return ErrNoCurrentSync
 	}
@@ -630,7 +577,7 @@ func (a *Adapter) PutEntitlements(ctx context.Context, entitlements ...*v2.Entit
 		}
 		records = append(records, rec)
 	}
-	if err := a.engine.PutEntitlementRecords(ctx, records...); err != nil {
+	if err := e.PutEntitlementRecords(ctx, records...); err != nil {
 		return fmt.Errorf("PutEntitlements: %w", err)
 	}
 	return nil
@@ -639,12 +586,12 @@ func (a *Adapter) PutEntitlements(ctx context.Context, entitlements ...*v2.Entit
 // DeleteGrant removes a grant by its raw public id, resolved through the
 // bare-id lookup edge. Callers holding the full grant should prefer
 // DeleteGrantByRefs, which needs no id-string resolution.
-func (a *Adapter) DeleteGrant(ctx context.Context, grantID string) error {
-	syncID := a.currentSyncID()
+func (e *Engine) DeleteGrant(ctx context.Context, grantID string) error {
+	syncID := e.CurrentSyncID()
 	if syncID == "" {
 		return ErrNoCurrentSync
 	}
-	return a.engine.DeleteGrantRecord(ctx, grantID)
+	return e.DeleteGrantRecord(ctx, grantID)
 }
 
 // DeleteGrantByRefs removes a grant addressed by the structured refs of the
@@ -654,8 +601,8 @@ func (a *Adapter) DeleteGrant(ctx context.Context, grantID string) error {
 // interactive/CLI edges (see lookup.go). A grant whose refs cannot derive
 // an identity could not have been stored in the first place, so there is
 // nothing a string could correctly address here.
-func (a *Adapter) DeleteGrantByRefs(ctx context.Context, grant *v2.Grant) error {
-	syncID := a.currentSyncID()
+func (e *Engine) DeleteGrantByRefs(ctx context.Context, grant *v2.Grant) error {
+	syncID := e.CurrentSyncID()
 	if syncID == "" {
 		return ErrNoCurrentSync
 	}
@@ -663,15 +610,15 @@ func (a *Adapter) DeleteGrantByRefs(ctx context.Context, grant *v2.Grant) error 
 	if _, err := grantIdentityFromRecord(rec); err != nil {
 		return fmt.Errorf("DeleteGrantByRefs: grant %q: %w", grant.GetId(), err)
 	}
-	return a.engine.DeleteGrantByIdentityRefs(ctx, rec)
+	return e.DeleteGrantByIdentityRefs(ctx, rec)
 }
 
 // PutAsset writes a single asset row. assetRef carries the
 // (resource_type, resource_id) pair we use as the external_id —
 // joined with a "/" separator since the engine's AssetRecord PK is
 // (sync_id, external_id).
-func (a *Adapter) PutAsset(ctx context.Context, assetRef *v2.AssetRef, contentType string, data []byte) error {
-	syncID := a.currentSyncID()
+func (e *Engine) PutAsset(ctx context.Context, assetRef *v2.AssetRef, contentType string, data []byte) error {
+	syncID := e.CurrentSyncID()
 	if syncID == "" {
 		return ErrNoCurrentSync
 	}
@@ -689,41 +636,36 @@ func (a *Adapter) PutAsset(ctx context.Context, assetRef *v2.AssetRef, contentTy
 		Data:         data,
 		DiscoveredAt: timestamppb.Now(),
 	}.Build()
-	return a.engine.PutAssetRecord(ctx, rec)
+	return e.PutAssetRecord(ctx, rec)
 }
 
-// Cleanup on the bare Adapter is a no-op. The real Pebble
+// Cleanup on the bare Engine is a no-op. The real Pebble
 // retention policy lives on pkg/dotc1z's Pebble store wrapper
 // (pebble_store.go) — it needs access to caller-supplied options
 // (SyncLimit, SkipCleanup) that the engine itself doesn't track,
 // plus the dirty-flag plumbing on the wrapper.
 //
 // Callers that open through dotc1z.NewStore(..., WithEngine(EnginePebble))
-// get the real Cleanup; callers that build a bare Adapter (unit
-// tests, embedding) silently get retention=disabled. The method is
-// kept on the Adapter only to satisfy the connectorstore.Writer
-// interface contract regardless of how the adapter was constructed.
-func (a *Adapter) Cleanup(ctx context.Context) error { return nil }
-
-// Close shuts down the engine. After Close, all methods return errors.
-func (a *Adapter) Close(ctx context.Context) error {
-	return a.engine.Close()
-}
+// get the real Cleanup; callers that use a bare Engine (unit tests,
+// embedding) silently get retention=disabled. The method exists so the
+// engine satisfies the connectorstore.Writer surface regardless of how
+// it was constructed.
+func (e *Engine) Cleanup(ctx context.Context) error { return nil }
 
 // === GetAsset ===
 
 // GetAsset returns the (content_type, data-reader) for the given
 // asset. The returned reader is backed by a bytes.Reader over the
 // fully-materialized blob.
-func (a *Adapter) GetAsset(ctx context.Context, req *v2.AssetServiceGetAssetRequest) (string, io.Reader, error) {
-	syncID := a.currentSyncID()
+func (e *Engine) GetAsset(ctx context.Context, req *v2.AssetServiceGetAssetRequest) (string, io.Reader, error) {
+	syncID := e.CurrentSyncID()
 	if syncID == "" {
 		return "", nil, ErrNoCurrentSync
 	}
 	if req == nil || req.GetAsset() == nil {
 		return "", nil, errors.New("GetAsset: nil request")
 	}
-	rec, err := a.engine.GetAssetRecord(ctx, req.GetAsset().GetId())
+	rec, err := e.GetAssetRecord(ctx, req.GetAsset().GetId())
 	if err != nil {
 		return "", nil, c1zstore.AdaptNotFound(err, pebble.ErrNotFound)
 	}
@@ -747,8 +689,8 @@ func (a *Adapter) GetAsset(ctx context.Context, req *v2.AssetServiceGetAssetRequ
 //     grants.resource_id / resource_type_id (the entitlement's
 //     resource columns). Callers who want to filter by principal
 //     should use ListGrantsForPrincipal instead.
-func (a *Adapter) ListGrants(ctx context.Context, req *v2.GrantsServiceListGrantsRequest) (*v2.GrantsServiceListGrantsResponse, error) {
-	syncID, err := a.resolveActiveSync(ctx, req.GetActiveSyncId(), req.GetAnnotations())
+func (e *Engine) ListGrants(ctx context.Context, req *v2.GrantsServiceListGrantsRequest) (*v2.GrantsServiceListGrantsResponse, error) {
+	syncID, err := e.resolveActiveSync(ctx, req.GetActiveSyncId(), req.GetAnnotations())
 	if err != nil {
 		return nil, err
 	}
@@ -760,10 +702,10 @@ func (a *Adapter) ListGrants(ctx context.Context, req *v2.GrantsServiceListGrant
 	var records []*v3.GrantRecord
 	var nextCursor string
 	if r := req.GetResource(); r != nil && r.GetId() != nil {
-		records, nextCursor, err = a.engine.PaginateGrantsByEntitlementResource(ctx,
+		records, nextCursor, err = e.PaginateGrantsByEntitlementResource(ctx,
 			r.GetId().GetResourceType(), r.GetId().GetResource(), cursor, limit)
 	} else {
-		records, nextCursor, err = a.engine.PaginateGrants(ctx, cursor, limit)
+		records, nextCursor, err = e.PaginateGrants(ctx, cursor, limit)
 	}
 	if err != nil {
 		return nil, c1zstore.AdaptNotFound(err, pebble.ErrNotFound)
@@ -788,8 +730,8 @@ func (a *Adapter) ListGrants(ctx context.Context, req *v2.GrantsServiceListGrant
 // only resource_type_id is set, we still iterate the full primary
 // range and post-filter — adding a by_resource_type index is a
 // future-work item if this path becomes hot.
-func (a *Adapter) ListResources(ctx context.Context, req *v2.ResourcesServiceListResourcesRequest) (*v2.ResourcesServiceListResourcesResponse, error) {
-	syncID, err := a.resolveActiveSync(ctx, req.GetActiveSyncId(), req.GetAnnotations())
+func (e *Engine) ListResources(ctx context.Context, req *v2.ResourcesServiceListResourcesRequest) (*v2.ResourcesServiceListResourcesResponse, error) {
+	syncID, err := e.resolveActiveSync(ctx, req.GetActiveSyncId(), req.GetAnnotations())
 	if err != nil {
 		return nil, err
 	}
@@ -836,10 +778,10 @@ func (a *Adapter) ListResources(ctx context.Context, req *v2.ResourcesServiceLis
 		var records []*v3.ResourceRecord
 		var err error
 		if useParent {
-			records, nextCursor, err = a.engine.PaginateResourcesByParent(ctx,
+			records, nextCursor, err = e.PaginateResourcesByParent(ctx,
 				parent.GetResourceType(), parent.GetResource(), cursor, fetchLimit)
 		} else {
-			records, nextCursor, err = a.engine.PaginateResources(ctx, cursor, fetchLimit)
+			records, nextCursor, err = e.PaginateResources(ctx, cursor, fetchLimit)
 		}
 		if err != nil {
 			return nil, c1zstore.AdaptNotFound(err, pebble.ErrNotFound)
@@ -876,8 +818,8 @@ func (a *Adapter) ListResources(ctx context.Context, req *v2.ResourcesServiceLis
 
 // ListResourceTypes returns up to page_size resource_types. Pagination
 // matches SQLite (see ListGrants).
-func (a *Adapter) ListResourceTypes(ctx context.Context, req *v2.ResourceTypesServiceListResourceTypesRequest) (*v2.ResourceTypesServiceListResourceTypesResponse, error) {
-	syncID, err := a.resolveActiveSync(ctx, req.GetActiveSyncId(), req.GetAnnotations())
+func (e *Engine) ListResourceTypes(ctx context.Context, req *v2.ResourceTypesServiceListResourceTypesRequest) (*v2.ResourceTypesServiceListResourceTypesResponse, error) {
+	syncID, err := e.resolveActiveSync(ctx, req.GetActiveSyncId(), req.GetAnnotations())
 	if err != nil {
 		return nil, err
 	}
@@ -885,7 +827,7 @@ func (a *Adapter) ListResourceTypes(ctx context.Context, req *v2.ResourceTypesSe
 		return nil, ErrNoCurrentSync
 	}
 	limit := clampPageSize(req.GetPageSize())
-	records, nextCursor, err := a.engine.PaginateResourceTypes(ctx, req.GetPageToken(), limit)
+	records, nextCursor, err := e.PaginateResourceTypes(ctx, req.GetPageToken(), limit)
 	if err != nil {
 		return nil, c1zstore.AdaptNotFound(err, pebble.ErrNotFound)
 	}
@@ -902,8 +844,8 @@ func (a *Adapter) ListResourceTypes(ctx context.Context, req *v2.ResourceTypesSe
 // ListEntitlements returns up to page_size entitlements, optionally
 // filtered by Resource (resource_type_id, resource_id). Pagination
 // matches SQLite (see ListGrants).
-func (a *Adapter) ListEntitlements(ctx context.Context, req *v2.EntitlementsServiceListEntitlementsRequest) (*v2.EntitlementsServiceListEntitlementsResponse, error) {
-	syncID, err := a.resolveActiveSync(ctx, req.GetActiveSyncId(), req.GetAnnotations())
+func (e *Engine) ListEntitlements(ctx context.Context, req *v2.EntitlementsServiceListEntitlementsRequest) (*v2.EntitlementsServiceListEntitlementsResponse, error) {
+	syncID, err := e.resolveActiveSync(ctx, req.GetActiveSyncId(), req.GetAnnotations())
 	if err != nil {
 		return nil, err
 	}
@@ -915,10 +857,10 @@ func (a *Adapter) ListEntitlements(ctx context.Context, req *v2.EntitlementsServ
 	var records []*v3.EntitlementRecord
 	var nextCursor string
 	if r := req.GetResource(); r != nil && r.GetId() != nil {
-		records, nextCursor, err = a.engine.PaginateEntitlementsByResource(ctx,
+		records, nextCursor, err = e.PaginateEntitlementsByResource(ctx,
 			r.GetId().GetResourceType(), r.GetId().GetResource(), cursor, limit)
 	} else {
-		records, nextCursor, err = a.engine.PaginateEntitlements(ctx, cursor, limit)
+		records, nextCursor, err = e.PaginateEntitlements(ctx, cursor, limit)
 	}
 	if err != nil {
 		return nil, c1zstore.AdaptNotFound(err, pebble.ErrNotFound)
@@ -937,7 +879,7 @@ func (a *Adapter) ListEntitlements(ctx context.Context, req *v2.EntitlementsServ
 // ListEntitlements that some connectors expose for static (compile-
 // time-known) entitlements. C1File returns an empty list; the
 // Pebble adapter mirrors that contract.
-func (a *Adapter) ListStaticEntitlements(
+func (e *Engine) ListStaticEntitlements(
 	_ context.Context,
 	_ *v2.EntitlementsServiceListStaticEntitlementsRequest,
 ) (*v2.EntitlementsServiceListStaticEntitlementsResponse, error) {
@@ -950,12 +892,12 @@ func (a *Adapter) ListStaticEntitlements(
 // === reader_v2 surface ===
 
 // GetGrant fetches a single grant by ID.
-func (a *Adapter) GetGrant(ctx context.Context, req *reader_v2.GrantsReaderServiceGetGrantRequest) (*reader_v2.GrantsReaderServiceGetGrantResponse, error) {
-	syncID := a.currentSyncID()
+func (e *Engine) GetGrant(ctx context.Context, req *reader_v2.GrantsReaderServiceGetGrantRequest) (*reader_v2.GrantsReaderServiceGetGrantResponse, error) {
+	syncID := e.CurrentSyncID()
 	if syncID == "" {
 		return nil, ErrNoCurrentSync
 	}
-	rec, err := a.engine.GetGrantRecord(ctx, req.GetGrantId())
+	rec, err := e.GetGrantRecord(ctx, req.GetGrantId())
 	if err != nil {
 		return nil, c1zstore.AdaptNotFound(err, pebble.ErrNotFound)
 	}
@@ -968,8 +910,8 @@ func (a *Adapter) GetGrant(ctx context.Context, req *reader_v2.GrantsReaderServi
 // the given type. Implements connectorstore.LatestFinishedSyncIDFetcher.
 // Delegates to Engine.LatestFinishedSyncRecord; see that method for
 // the predicate + tiebreaker contract.
-func (a *Adapter) LatestFinishedSyncID(ctx context.Context, syncType connectorstore.SyncType) (string, error) {
-	latest, err := a.engine.LatestFinishedSyncRecord(ctx, syncTypeFilterFromConnectorstore(syncType))
+func (e *Engine) LatestFinishedSyncID(ctx context.Context, syncType connectorstore.SyncType) (string, error) {
+	latest, err := e.LatestFinishedSyncRecord(ctx, syncTypeFilterFromConnectorstore(syncType))
 	if err != nil {
 		return "", err
 	}
@@ -991,17 +933,9 @@ func syncTypeFilterFromConnectorstore(t connectorstore.SyncType) func(v3.SyncTyp
 	return func(got v3.SyncType) bool { return got == want }
 }
 
-// CurrentDBSizeBytes returns the current uncompressed Pebble working-set size
-// on disk. Implements connectorstore.DBSizeProvider for progress logging
-// parity with the SQLite-backed *dotc1z.C1File.
-func (a *Adapter) CurrentDBSizeBytes() (int64, error) {
-	return a.engine.CurrentDBSizeBytes()
-}
-
-// Metadata describes the storage backing this adapter. The Pebble
-// adapter always reports the v3 format; PayloadEncoding is set by
-// the writer at envelope time and is not directly visible on the
-// Adapter itself — pkg/dotc1z's Pebble store wrapper
+// Metadata describes the storage backing this engine. Always reports
+// the v3 format; PayloadEncoding is set by the writer at envelope time
+// and is not directly visible here — pkg/dotc1z's Pebble store wrapper
 // (pebble_store.go) overrides this method to fill PayloadEncoding
 // from its configured value.
 //
@@ -1010,7 +944,7 @@ func (a *Adapter) CurrentDBSizeBytes() (int64, error) {
 // import would cycle. The values match c1zstore.EnginePebble.String()
 // and dotc1z.C1ZFormatV3.String() — see connectorstore.StoreMetadata
 // docs for the canonical value list.
-func (a *Adapter) Metadata() connectorstore.StoreMetadata {
+func (e *Engine) Metadata() connectorstore.StoreMetadata {
 	return connectorstore.StoreMetadata{
 		Engine: "pebble",
 		Format: "v3",
@@ -1018,21 +952,6 @@ func (a *Adapter) Metadata() connectorstore.StoreMetadata {
 }
 
 // === helpers ===
-
-// currentSyncID returns the adapter's current sync id under the
-// adapter's lock.
-func (a *Adapter) currentSyncID() string {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	return a.current.syncID
-}
-
-// CurrentSyncID returns the adapter's current sync id, or "" when no
-// sync is active. Used by pkg/dotc1z's Pebble store to drive the
-// retention policy at Cleanup.
-func (a *Adapter) CurrentSyncID() string {
-	return a.currentSyncID()
-}
 
 // resolveActiveSync picks the sync_id a List* read should scope to.
 //
@@ -1048,11 +967,11 @@ func (a *Adapter) CurrentSyncID() string {
 // Returns ("", nil) when no sync resolves. A malformed SyncDetails
 // annotation surfaces as a non-nil error so callers don't silently
 // fall through to the wrong sync.
-func (a *Adapter) resolveActiveSync(ctx context.Context, reqSyncID string, annos []*anypb.Any) (string, error) {
+func (e *Engine) resolveActiveSync(ctx context.Context, reqSyncID string, annos []*anypb.Any) (string, error) {
 	if reqSyncID != "" {
 		return reqSyncID, nil
 	}
-	return a.resolveActiveSyncForReader(ctx, annos)
+	return e.resolveActiveSyncForReader(ctx, annos)
 }
 
 // v2SyncTypeToV3 maps the connectorstore.SyncType string to the v3

--- a/pkg/dotc1z/engine/pebble/adapter.go
+++ b/pkg/dotc1z/engine/pebble/adapter.go
@@ -341,7 +341,7 @@ func (e *Engine) endSyncFinalize(ctx context.Context, existing *v3.SyncRunRecord
 	// full grant scan also accumulates the grant portion of the stats via
 	// stashDeferredGrantStats, letting PersistSyncStats skip a second
 	// O(grants) pass over the keyspace).
-	if e.deferredIdxPending.Load() {
+	if e.db.DeferredIdxPending() {
 		if err := e.BuildDeferredGrantIndexes(ctx); err != nil {
 			return fmt.Errorf("EndSync: build deferred grant indexes: %w", err)
 		}

--- a/pkg/dotc1z/engine/pebble/adapter_clone_sync.go
+++ b/pkg/dotc1z/engine/pebble/adapter_clone_sync.go
@@ -46,7 +46,7 @@ import (
 // clone_sync.go).
 func cloneSync(
 	ctx context.Context,
-	a *Adapter,
+	e *Engine,
 	encoding c1zstore.PayloadEncoding,
 	outPath, syncID string,
 	opts ...c1zstore.CloneSyncOption,
@@ -59,7 +59,7 @@ func cloneSync(
 
 	resolved := syncID
 	if resolved == "" {
-		latest, err := a.LatestFinishedSyncID(ctx, connectorstore.SyncTypeFull)
+		latest, err := e.LatestFinishedSyncID(ctx, connectorstore.SyncTypeFull)
 		if err != nil {
 			return err
 		}
@@ -69,7 +69,7 @@ func cloneSync(
 		resolved = latest
 	}
 
-	srcRun, err := a.engine.GetSyncRunRecord(ctx, resolved)
+	srcRun, err := e.GetSyncRunRecord(ctx, resolved)
 	if err != nil {
 		if errors.Is(err, pebble.ErrNotFound) {
 			return status.Errorf(codes.NotFound, "clone-sync: sync %q not found", resolved)
@@ -92,7 +92,7 @@ func cloneSync(
 	}()
 	checkpointDir := filepath.Join(cloneTmp, "checkpoint")
 
-	if err := a.engine.CheckpointTo(ctx, checkpointDir); err != nil {
+	if err := e.CheckpointTo(ctx, checkpointDir); err != nil {
 		return fmt.Errorf("clone-sync: checkpoint source: %w", err)
 	}
 

--- a/pkg/dotc1z/engine/pebble/adapter_file_ops.go
+++ b/pkg/dotc1z/engine/pebble/adapter_file_ops.go
@@ -11,8 +11,8 @@ import (
 // the single sync's data into a fresh c1z (used by `baton clone`);
 // GenerateSyncDiff is unsupported (single-sync contract — see
 // ErrDiffUnsupported).
-func (a *Adapter) FileOps() c1zstore.FileOps {
-	return pebbleFileOps{a: a, encoding: c1zstore.PayloadEncodingTarZstd}
+func (e *Engine) FileOps() c1zstore.FileOps {
+	return pebbleFileOps{e: e, encoding: c1zstore.PayloadEncodingTarZstd}
 }
 
 // FileOpsWithEncoding returns a FileOps that emits new c1z files
@@ -20,12 +20,12 @@ func (a *Adapter) FileOps() c1zstore.FileOps {
 // pkg/dotc1z to propagate its configured encoding (e.g.
 // PayloadEncodingTar for callers that want uncompressed envelopes)
 // through to CloneSync's output file.
-func (a *Adapter) FileOpsWithEncoding(encoding c1zstore.PayloadEncoding) c1zstore.FileOps {
-	return pebbleFileOps{a: a, encoding: encoding}
+func (e *Engine) FileOpsWithEncoding(encoding c1zstore.PayloadEncoding) c1zstore.FileOps {
+	return pebbleFileOps{e: e, encoding: encoding}
 }
 
 type pebbleFileOps struct {
-	a        *Adapter
+	e        *Engine
 	encoding c1zstore.PayloadEncoding
 }
 
@@ -34,7 +34,7 @@ type pebbleFileOps struct {
 // range-copy every sync-scoped keyspace into a fresh engine,
 // checkpoint, and emit a v3 envelope.
 func (f pebbleFileOps) CloneSync(ctx context.Context, outPath string, syncID string, opts ...c1zstore.CloneSyncOption) error {
-	return cloneSync(ctx, f.a, f.encoding, outPath, syncID, opts...)
+	return cloneSync(ctx, f.e, f.encoding, outPath, syncID, opts...)
 }
 
 // CopyIsolateSync falls back to cloneSync for the Pebble engine. The
@@ -43,12 +43,12 @@ func (f pebbleFileOps) CloneSync(ctx context.Context, outPath string, syncID str
 // the target sync's keyspace into a fresh engine, so it has no whale-rebuild
 // cost to avoid.
 func (f pebbleFileOps) CopyIsolateSync(ctx context.Context, outPath string, syncID string, opts ...c1zstore.CloneSyncOption) error {
-	return cloneSync(ctx, f.a, f.encoding, outPath, syncID, opts...)
+	return cloneSync(ctx, f.e, f.encoding, outPath, syncID, opts...)
 }
 
 // GenerateSyncDiff is unsupported on the Pebble v3 engine — a c1z
 // holds exactly one sync by contract, so base + applied syncs can't be
 // co-resident in one file. Always returns ErrDiffUnsupported.
 func (f pebbleFileOps) GenerateSyncDiff(ctx context.Context, baseSyncID, appliedSyncID string) (string, error) {
-	return generateSyncDiff(ctx, f.a, baseSyncID, appliedSyncID)
+	return generateSyncDiff(ctx, f.e, baseSyncID, appliedSyncID)
 }

--- a/pkg/dotc1z/engine/pebble/adapter_grants_store.go
+++ b/pkg/dotc1z/engine/pebble/adapter_grants_store.go
@@ -24,12 +24,12 @@ import (
 // idxGrantByNeedsExpansion index. The *Page methods walk that index and
 // return real expandable rows (see TestExpansionAnnotationRoundtrip and
 // the live PendingExpansion path).
-func (a *Adapter) Grants() c1zstore.GrantStore {
-	return pebbleGrantStore{a: a}
+func (e *Engine) Grants() c1zstore.GrantStore {
+	return pebbleGrantStore{e: e}
 }
 
 type pebbleGrantStore struct {
-	a *Adapter
+	e *Engine
 }
 
 var expandedGrantImmutableAnnotationAny = func() *anypb.Any {
@@ -62,7 +62,7 @@ var expandedGrantImmutableAnnotationAny = func() *anypb.Any {
 // Caught by TestStoreExpandedGrantsPreservesExpansion and the
 // SQLite conformance test of the same name.
 func (g pebbleGrantStore) StoreExpandedGrants(ctx context.Context, grants ...*v2.Grant) error {
-	syncID := g.a.currentSyncID()
+	syncID := g.e.CurrentSyncID()
 	if syncID == "" {
 		return ErrNoCurrentSync
 	}
@@ -84,7 +84,7 @@ func (g pebbleGrantStore) StoreExpandedGrants(ctx context.Context, grants ...*v2
 	// PutExpandedGrantRecords stamps/preserves it. The returned pointers alias
 	// the arena, which outlives this call's use of `merged`.
 	merged := g.translateExpanded(syncID, grants)
-	return g.a.engine.PutExpandedGrantRecords(ctx, merged)
+	return g.e.PutExpandedGrantRecords(ctx, merged)
 }
 
 // StoreNewExpandedGrants is the fast path for synthesized expanded grants. The
@@ -92,7 +92,7 @@ func (g pebbleGrantStore) StoreExpandedGrants(ctx context.Context, grants ...*v2
 // can skip the read-before-write Get used to preserve side-state and clean stale
 // indexes for updates.
 func (g pebbleGrantStore) StoreNewExpandedGrants(ctx context.Context, grants ...*v2.Grant) error {
-	syncID := g.a.currentSyncID()
+	syncID := g.e.CurrentSyncID()
 	if syncID == "" {
 		return ErrNoCurrentSync
 	}
@@ -100,7 +100,7 @@ func (g pebbleGrantStore) StoreNewExpandedGrants(ctx context.Context, grants ...
 		return nil
 	}
 	merged := g.translateExpanded(syncID, grants)
-	return g.a.engine.PutSynthesizedGrantRecords(ctx, merged)
+	return g.e.PutSynthesizedGrantRecords(ctx, merged)
 }
 
 // appendSynthesizedGrantRecords translates one destination's synthesized
@@ -141,7 +141,7 @@ func appendSynthesizedGrantRecords(records []synthesizedGrantRecord, dest *v2.En
 }
 
 func (g pebbleGrantStore) StoreNewExpandedGrantContributions(ctx context.Context, dest *v2.Entitlement, principals []*v3.PrincipalRef, sources []batonGrant.Sources) error {
-	if g.a.currentSyncID() == "" {
+	if g.e.CurrentSyncID() == "" {
 		return ErrNoCurrentSync
 	}
 	if len(principals) == 0 {
@@ -159,7 +159,7 @@ func (g pebbleGrantStore) StoreNewExpandedGrantContributions(ctx context.Context
 	if err != nil {
 		return err
 	}
-	return g.a.engine.PutSynthesizedGrantContributions(ctx, records)
+	return g.e.PutSynthesizedGrantContributions(ctx, records)
 }
 
 // BeginExpandedGrantLayer opens a layer-scoped synthesized-grant layer session
@@ -167,10 +167,10 @@ func (g pebbleGrantStore) StoreNewExpandedGrantContributions(ctx context.Context
 // by_principal index is not deferred); callers fall back to
 // StoreNewExpandedGrantContributions.
 func (g pebbleGrantStore) BeginExpandedGrantLayer(ctx context.Context) (bool, error) {
-	if g.a.currentSyncID() == "" {
+	if g.e.CurrentSyncID() == "" {
 		return false, ErrNoCurrentSync
 	}
-	return g.a.engine.BeginSynthesizedGrantLayer(ctx)
+	return g.e.BeginSynthesizedGrantLayer(ctx)
 }
 
 // AddExpandedGrantLayerContributions streams one destination's synthesized
@@ -192,15 +192,15 @@ func (g pebbleGrantStore) AddExpandedGrantLayerContributions(ctx context.Context
 	if err != nil {
 		return err
 	}
-	return g.a.engine.AddSynthesizedGrantLayerContributions(ctx, records)
+	return g.e.AddSynthesizedGrantLayerContributions(ctx, records)
 }
 
 func (g pebbleGrantStore) FinishExpandedGrantLayer(ctx context.Context) error {
-	return g.a.engine.FinishSynthesizedGrantLayer(ctx)
+	return g.e.FinishSynthesizedGrantLayer(ctx)
 }
 
 func (g pebbleGrantStore) AbortExpandedGrantLayer(ctx context.Context) error {
-	return g.a.engine.AbortSynthesizedGrantLayer(ctx)
+	return g.e.AbortSynthesizedGrantLayer(ctx)
 }
 
 func (g pebbleGrantStore) translateExpanded(syncID string, grants []*v2.Grant) []*v3.GrantRecord {
@@ -238,11 +238,11 @@ func (g pebbleGrantStore) translateExpanded(syncID string, grants []*v2.Grant) [
 // index scan (e.g. partial overwrite) is skipped — same orphan
 // semantic as the by_entitlement / by_principal indexes.
 func (g pebbleGrantStore) PendingExpansionPage(ctx context.Context, pageToken string) ([]c1zstore.PendingExpansion, string, error) {
-	syncID := g.a.currentSyncID()
+	syncID := g.e.CurrentSyncID()
 	if syncID == "" {
 		return nil, "", ErrNoCurrentSync
 	}
-	records, next, err := g.a.engine.PaginateGrantsByNeedsExpansion(ctx, pageToken, DefaultPageSize)
+	records, next, err := g.e.PaginateGrantsByNeedsExpansion(ctx, pageToken, DefaultPageSize)
 	if err != nil {
 		return nil, "", c1zstore.AdaptNotFound(err, pebble.ErrNotFound)
 	}
@@ -307,11 +307,11 @@ func (g pebbleGrantStore) PendingExpansion(ctx context.Context) iter.Seq2[c1zsto
 // processGrantsWithExternalPrincipals and c1's fileClientWrapper —
 // behave identically across engines.
 func (g pebbleGrantStore) ListWithAnnotationsPage(ctx context.Context, pageToken string) ([]c1zstore.GrantAnnotation, string, error) {
-	syncID := g.a.currentSyncID()
+	syncID := g.e.CurrentSyncID()
 	if syncID == "" {
 		return nil, "", ErrNoCurrentSync
 	}
-	records, next, err := g.a.engine.PaginateGrants(ctx, pageToken, DefaultPageSize)
+	records, next, err := g.e.PaginateGrants(ctx, pageToken, DefaultPageSize)
 	if err != nil {
 		return nil, "", c1zstore.AdaptNotFound(err, pebble.ErrNotFound)
 	}
@@ -350,13 +350,13 @@ func (g pebbleGrantStore) ListWithAnnotationsForResourcePage(
 		return nil, "", errors.New("ListWithAnnotationsForResourcePage: nil resource")
 	}
 	if syncID == "" {
-		syncID = g.a.currentSyncID()
+		syncID = g.e.CurrentSyncID()
 	}
 	if syncID == "" {
 		return nil, "", ErrNoCurrentSync
 	}
 	limit := clampPageSize(pageSize)
-	records, next, err := g.a.engine.PaginateGrantsByEntitlementResource(ctx,
+	records, next, err := g.e.PaginateGrantsByEntitlementResource(ctx,
 		resource.GetId().GetResourceType(), resource.GetId().GetResource(),
 		pageToken, limit)
 	if err != nil {

--- a/pkg/dotc1z/engine/pebble/adapter_reader.go
+++ b/pkg/dotc1z/engine/pebble/adapter_reader.go
@@ -32,15 +32,15 @@ var _ reader_v2.GrantsReaderServiceServer = (*Adapter)(nil)
 
 // GetEntitlement fetches a single entitlement by ID. Implements
 // reader_v2.EntitlementsReaderServiceServer.
-func (a *Adapter) GetEntitlement(ctx context.Context, req *reader_v2.EntitlementsReaderServiceGetEntitlementRequest) (*reader_v2.EntitlementsReaderServiceGetEntitlementResponse, error) {
-	syncID, err := a.resolveActiveSyncForReader(ctx, req.GetAnnotations())
+func (e *Engine) GetEntitlement(ctx context.Context, req *reader_v2.EntitlementsReaderServiceGetEntitlementRequest) (*reader_v2.EntitlementsReaderServiceGetEntitlementResponse, error) {
+	syncID, err := e.resolveActiveSyncForReader(ctx, req.GetAnnotations())
 	if err != nil {
 		return nil, err
 	}
 	if syncID == "" {
 		return nil, ErrNoCurrentSync
 	}
-	rec, err := a.engine.GetEntitlementRecord(ctx, req.GetEntitlementId())
+	rec, err := e.GetEntitlementRecord(ctx, req.GetEntitlementId())
 	err = c1zstore.AdaptNotFound(err, pebble.ErrNotFound)
 	if err != nil {
 		return nil, err
@@ -52,8 +52,8 @@ func (a *Adapter) GetEntitlement(ctx context.Context, req *reader_v2.Entitlement
 
 // GetResource fetches a single resource by (resource_type_id,
 // resource_id). Implements reader_v2.ResourcesReaderServiceServer.
-func (a *Adapter) GetResource(ctx context.Context, req *reader_v2.ResourcesReaderServiceGetResourceRequest) (*reader_v2.ResourcesReaderServiceGetResourceResponse, error) {
-	syncID, err := a.resolveActiveSyncForReader(ctx, req.GetAnnotations())
+func (e *Engine) GetResource(ctx context.Context, req *reader_v2.ResourcesReaderServiceGetResourceRequest) (*reader_v2.ResourcesReaderServiceGetResourceResponse, error) {
+	syncID, err := e.resolveActiveSyncForReader(ctx, req.GetAnnotations())
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +64,7 @@ func (a *Adapter) GetResource(ctx context.Context, req *reader_v2.ResourcesReade
 	if rid == nil {
 		return nil, errors.New("GetResource: nil resource_id")
 	}
-	rec, err := a.engine.GetResourceRecord(ctx, rid.GetResourceType(), rid.GetResource())
+	rec, err := e.GetResourceRecord(ctx, rid.GetResourceType(), rid.GetResource())
 	err = c1zstore.AdaptNotFound(err, pebble.ErrNotFound)
 	if err != nil {
 		return nil, err
@@ -76,15 +76,15 @@ func (a *Adapter) GetResource(ctx context.Context, req *reader_v2.ResourcesReade
 
 // GetResourceType fetches a single resource_type by ID. Implements
 // reader_v2.ResourceTypesReaderServiceServer.
-func (a *Adapter) GetResourceType(ctx context.Context, req *reader_v2.ResourceTypesReaderServiceGetResourceTypeRequest) (*reader_v2.ResourceTypesReaderServiceGetResourceTypeResponse, error) {
-	syncID, err := a.resolveActiveSyncForReader(ctx, req.GetAnnotations())
+func (e *Engine) GetResourceType(ctx context.Context, req *reader_v2.ResourceTypesReaderServiceGetResourceTypeRequest) (*reader_v2.ResourceTypesReaderServiceGetResourceTypeResponse, error) {
+	syncID, err := e.resolveActiveSyncForReader(ctx, req.GetAnnotations())
 	if err != nil {
 		return nil, err
 	}
 	if syncID == "" {
 		return nil, ErrNoCurrentSync
 	}
-	rec, err := a.engine.GetResourceTypeRecord(ctx, req.GetResourceTypeId())
+	rec, err := e.GetResourceTypeRecord(ctx, req.GetResourceTypeId())
 	err = c1zstore.AdaptNotFound(err, pebble.ErrNotFound)
 	if err != nil {
 		return nil, err
@@ -99,11 +99,11 @@ func (a *Adapter) GetResourceType(ctx context.Context, req *reader_v2.ResourceTy
 // omitted. Callers detect partial misses by length comparison.
 //
 //nolint:revive // method name mirrors the protobuf-generated gRPC server interface
-func (a *Adapter) ListResourcesByIds(
+func (e *Engine) ListResourcesByIds(
 	ctx context.Context,
 	req *reader_v2.ResourcesReaderServiceListResourcesByIdsRequest,
 ) (*reader_v2.ResourcesReaderServiceListResourcesByIdsResponse, error) {
-	syncID, err := a.resolveActiveSyncForReader(ctx, req.GetAnnotations())
+	syncID, err := e.resolveActiveSyncForReader(ctx, req.GetAnnotations())
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +119,7 @@ func (a *Adapter) ListResourcesByIds(
 		if id == nil {
 			continue
 		}
-		rec, err := a.engine.GetResourceRecord(ctx, id.GetResourceType(), id.GetResource())
+		rec, err := e.GetResourceRecord(ctx, id.GetResourceType(), id.GetResource())
 		if err != nil {
 			if errors.Is(err, pebble.ErrNotFound) {
 				continue
@@ -137,11 +137,11 @@ func (a *Adapter) ListResourcesByIds(
 // external_ids. Missing rows are silently omitted.
 //
 //nolint:revive // method name mirrors the protobuf-generated gRPC server interface
-func (a *Adapter) ListEntitlementsByIds(
+func (e *Engine) ListEntitlementsByIds(
 	ctx context.Context,
 	req *reader_v2.EntitlementsReaderServiceListEntitlementsByIdsRequest,
 ) (*reader_v2.EntitlementsReaderServiceListEntitlementsByIdsResponse, error) {
-	syncID, err := a.resolveActiveSyncForReader(ctx, req.GetAnnotations())
+	syncID, err := e.resolveActiveSyncForReader(ctx, req.GetAnnotations())
 	if err != nil {
 		return nil, err
 	}
@@ -157,7 +157,7 @@ func (a *Adapter) ListEntitlementsByIds(
 		if id == "" {
 			continue
 		}
-		rec, err := a.engine.GetEntitlementRecord(ctx, id)
+		rec, err := e.GetEntitlementRecord(ctx, id)
 		if err != nil {
 			if errors.Is(err, pebble.ErrNotFound) {
 				continue
@@ -180,17 +180,17 @@ func (a *Adapter) ListEntitlementsByIds(
 // streamingPrincipalGroupStream additionally fails loudly if the order
 // invariant is ever violated, and the differential/parity suites compare
 // the sorted and unsorted evaluators against SQLite.
-func (a *Adapter) GrantsForEntitlementPrincipalSorted() bool { return true }
+func (e *Engine) GrantsForEntitlementPrincipalSorted() bool { return true }
 
 // ListGrantsForEntitlement paginates grants on a specific
 // entitlement, optionally narrowed by principal_id or
 // principal_resource_type_ids. Implements
 // reader_v2.GrantsReaderServiceServer.
-func (a *Adapter) ListGrantsForEntitlement(
+func (e *Engine) ListGrantsForEntitlement(
 	ctx context.Context,
 	req *reader_v2.GrantsReaderServiceListGrantsForEntitlementRequest,
 ) (*reader_v2.GrantsReaderServiceListGrantsForEntitlementResponse, error) {
-	syncID, err := a.resolveActiveSyncForReader(ctx, req.GetAnnotations())
+	syncID, err := e.resolveActiveSyncForReader(ctx, req.GetAnnotations())
 	if err != nil {
 		return nil, err
 	}
@@ -201,7 +201,7 @@ func (a *Adapter) ListGrantsForEntitlement(
 	if ent == nil || ent.GetId() == "" {
 		return nil, errors.New("ListGrantsForEntitlement: missing entitlement id")
 	}
-	entIdentity, err := a.entitlementIdentityForRequest(ctx, ent)
+	entIdentity, err := e.entitlementIdentityForRequest(ctx, ent)
 	if err != nil {
 		if errors.Is(err, pebble.ErrNotFound) {
 			// Unknown entitlement → no grants, matching the legacy
@@ -248,10 +248,10 @@ func (a *Adapter) ListGrantsForEntitlement(
 		var records []*v3.GrantRecord
 		var next string
 		if principalID != nil {
-			records, next, err = a.engine.PaginateGrantsByEntitlementPrincipal(ctx,
+			records, next, err = e.PaginateGrantsByEntitlementPrincipal(ctx,
 				entIdentity, principalID.GetResourceType(), principalID.GetResource(), cursor, fetchLimit)
 		} else {
-			records, next, err = a.engine.PaginateGrantsByEntitlement(ctx,
+			records, next, err = e.PaginateGrantsByEntitlement(ctx,
 				entIdentity, cursor, fetchLimit)
 		}
 		if err != nil {
@@ -297,13 +297,13 @@ func (a *Adapter) ListGrantsForEntitlement(
 // by grant expansion prefetch. It avoids materializing full grant records when
 // the caller only needs to know which principals already have a descendant
 // entitlement grant.
-func (a *Adapter) ListGrantPrincipalKeysForEntitlement(
+func (e *Engine) ListGrantPrincipalKeysForEntitlement(
 	ctx context.Context,
 	entitlement *v2.Entitlement,
 	pageToken string,
 	pageSize uint32,
 ) ([]string, string, error) {
-	syncID, err := a.resolveActiveSyncForReader(ctx, nil)
+	syncID, err := e.resolveActiveSyncForReader(ctx, nil)
 	if err != nil {
 		return nil, "", err
 	}
@@ -313,14 +313,14 @@ func (a *Adapter) ListGrantPrincipalKeysForEntitlement(
 	if entitlement == nil || entitlement.GetId() == "" {
 		return nil, "", errors.New("ListGrantPrincipalKeysForEntitlement: missing entitlement id")
 	}
-	entIdentity, err := a.entitlementIdentityForRequest(ctx, entitlement)
+	entIdentity, err := e.entitlementIdentityForRequest(ctx, entitlement)
 	if err != nil {
 		if errors.Is(err, pebble.ErrNotFound) {
 			return nil, "", nil
 		}
 		return nil, "", err
 	}
-	keys, next, err := a.engine.PaginateGrantPrincipalKeysByEntitlement(ctx, entIdentity, pageToken, clampPageSize(pageSize))
+	keys, next, err := e.PaginateGrantPrincipalKeysByEntitlement(ctx, entIdentity, pageToken, clampPageSize(pageSize))
 	if err != nil {
 		return nil, "", c1zstore.AdaptNotFound(err, pebble.ErrNotFound)
 	}
@@ -333,14 +333,14 @@ func (a *Adapter) ListGrantPrincipalKeysForEntitlement(
 // exactly from structured parts; otherwise the raw id string resolves
 // through the bare-id lookup (exactly-one rule; pebble.ErrNotFound when the
 // id matches nothing).
-func (a *Adapter) entitlementIdentityForRequest(ctx context.Context, ent *v2.Entitlement) (entitlementIdentity, error) {
+func (e *Engine) entitlementIdentityForRequest(ctx context.Context, ent *v2.Entitlement) (entitlementIdentity, error) {
 	if ent == nil || ent.GetId() == "" {
 		return entitlementIdentity{}, errors.New("missing entitlement id")
 	}
 	if res := ent.GetResource(); res.GetId().GetResourceType() != "" && res.GetId().GetResource() != "" {
 		return entitlementIdentityFromParts(res.GetId().GetResourceType(), res.GetId().GetResource(), ent.GetId()), nil
 	}
-	return a.engine.resolveGrantScanEntitlementIdentity(ctx, ent.GetId())
+	return e.resolveGrantScanEntitlementIdentity(ctx, ent.GetId())
 }
 
 // ListGrantsForPrincipal returns all grants where the given principal_id is
@@ -348,11 +348,11 @@ func (a *Adapter) entitlementIdentityForRequest(ctx context.Context, ent *v2.Ent
 // optional Entitlement field narrows results to a single entitlement — since
 // entitlement + principal is the full primary grant key, that case is an O(1)
 // point lookup. Implements reader_v2.GrantsReaderServiceServer.
-func (a *Adapter) ListGrantsForPrincipal(
+func (e *Engine) ListGrantsForPrincipal(
 	ctx context.Context,
 	req *reader_v2.GrantsReaderServiceListGrantsForPrincipalRequest,
 ) (*reader_v2.GrantsReaderServiceListGrantsForPrincipalResponse, error) {
-	syncID, err := a.resolveActiveSyncForReader(ctx, req.GetAnnotations())
+	syncID, err := e.resolveActiveSyncForReader(ctx, req.GetAnnotations())
 	if err != nil {
 		return nil, err
 	}
@@ -370,7 +370,7 @@ func (a *Adapter) ListGrantsForPrincipal(
 	if ent := req.GetEntitlement(); ent != nil && ent.GetId() != "" {
 		// Entitlement + principal is the full primary grant key, so this
 		// is a point lookup rather than a filtered by_principal scan.
-		entIdentity, err := a.entitlementIdentityForRequest(ctx, ent)
+		entIdentity, err := e.entitlementIdentityForRequest(ctx, ent)
 		if err != nil {
 			if errors.Is(err, pebble.ErrNotFound) {
 				// Unknown entitlement → no grants, matching the legacy
@@ -379,13 +379,13 @@ func (a *Adapter) ListGrantsForPrincipal(
 			}
 			return nil, err
 		}
-		records, next, err = a.engine.PaginateGrantsByEntitlementPrincipal(ctx,
+		records, next, err = e.PaginateGrantsByEntitlementPrincipal(ctx,
 			entIdentity, principal.GetResourceType(), principal.GetResource(), cursor, limit)
 		if err != nil {
 			return nil, c1zstore.AdaptNotFound(err, pebble.ErrNotFound)
 		}
 	} else {
-		records, next, err = a.engine.PaginateGrantsByPrincipal(ctx,
+		records, next, err = e.PaginateGrantsByPrincipal(ctx,
 			principal.GetResourceType(), principal.GetResource(), cursor, limit)
 		if err != nil {
 			return nil, c1zstore.AdaptNotFound(err, pebble.ErrNotFound)
@@ -406,11 +406,11 @@ func (a *Adapter) ListGrantsForPrincipal(
 // The cursor is the by_principal index key.
 //
 // Implements reader_v2.GrantsReaderServiceServer.
-func (a *Adapter) ListGrantsForResourceType(
+func (e *Engine) ListGrantsForResourceType(
 	ctx context.Context,
 	req *reader_v2.GrantsReaderServiceListGrantsForResourceTypeRequest,
 ) (*reader_v2.GrantsReaderServiceListGrantsForResourceTypeResponse, error) {
-	syncID, err := a.resolveActiveSyncForReader(ctx, req.GetAnnotations())
+	syncID, err := e.resolveActiveSyncForReader(ctx, req.GetAnnotations())
 	if err != nil {
 		return nil, err
 	}
@@ -423,7 +423,7 @@ func (a *Adapter) ListGrantsForResourceType(
 	}
 	limit := clampPageSize(req.GetPageSize())
 	cursor := req.GetPageToken()
-	records, next, err := a.engine.PaginateGrantsByPrincipalResourceType(ctx, rtFilter, cursor, limit)
+	records, next, err := e.PaginateGrantsByPrincipalResourceType(ctx, rtFilter, cursor, limit)
 	if err != nil {
 		return nil, c1zstore.AdaptNotFound(err, pebble.ErrNotFound)
 	}
@@ -439,16 +439,16 @@ func (a *Adapter) ListGrantsForResourceType(
 
 // GetSync fetches a single sync_run record by ID. Implements
 // reader_v2.SyncsReaderServiceServer.
-func (a *Adapter) GetSync(ctx context.Context, req *reader_v2.SyncsReaderServiceGetSyncRequest) (*reader_v2.SyncsReaderServiceGetSyncResponse, error) {
+func (e *Engine) GetSync(ctx context.Context, req *reader_v2.SyncsReaderServiceGetSyncRequest) (*reader_v2.SyncsReaderServiceGetSyncResponse, error) {
 	if req.GetSyncId() == "" {
 		return nil, errors.New("GetSync: empty sync_id")
 	}
-	rec, err := a.engine.GetSyncRunRecord(ctx, req.GetSyncId())
+	rec, err := e.GetSyncRunRecord(ctx, req.GetSyncId())
 	if err != nil {
 		return nil, c1zstore.AdaptNotFound(err, pebble.ErrNotFound)
 	}
 
-	stats, err := a.syncStatsForRun(ctx, rec)
+	stats, err := e.syncStatsForRun(ctx, rec)
 	if err != nil {
 		return nil, err
 	}
@@ -462,7 +462,7 @@ func (a *Adapter) GetSync(ctx context.Context, req *reader_v2.SyncsReaderService
 // the natural sync_id (KSUID) order — KSUIDs sort by timestamp, so
 // this is also chronological. Implements
 // reader_v2.SyncsReaderServiceServer.
-func (a *Adapter) ListSyncs(ctx context.Context, req *reader_v2.SyncsReaderServiceListSyncsRequest) (*reader_v2.SyncsReaderServiceListSyncsResponse, error) {
+func (e *Engine) ListSyncs(ctx context.Context, req *reader_v2.SyncsReaderServiceListSyncsRequest) (*reader_v2.SyncsReaderServiceListSyncsResponse, error) {
 	limit := clampPageSize(req.GetPageSize())
 	cursorBytes, err := decodeCursor(req.GetPageToken())
 	if err != nil {
@@ -473,7 +473,7 @@ func (a *Adapter) ListSyncs(ctx context.Context, req *reader_v2.SyncsReaderServi
 	if err != nil {
 		return nil, err
 	}
-	iter, err := a.engine.NewIter(&pebble.IterOptions{
+	iter, err := e.NewIter(&pebble.IterOptions{
 		LowerBound: lower,
 		UpperBound: upper,
 	})
@@ -498,7 +498,7 @@ func (a *Adapter) ListSyncs(ctx context.Context, req *reader_v2.SyncsReaderServi
 		}
 		lastKey = append(lastKey[:0], iter.Key()...)
 
-		stats, err := a.syncStatsForRun(ctx, r)
+		stats, err := e.syncStatsForRun(ctx, r)
 		if err != nil {
 			return nil, err
 		}
@@ -526,8 +526,8 @@ func (a *Adapter) ListSyncs(ctx context.Context, req *reader_v2.SyncsReaderServi
 // Future work: if this becomes hot, a "latest by type" sidecar key
 // keyed on (typeFinishedSyncByType | type) → sync_id would let
 // Engine.LatestFinishedSyncRecord short-circuit to O(1).
-func (a *Adapter) GetLatestFinishedSync(ctx context.Context, req *reader_v2.SyncsReaderServiceGetLatestFinishedSyncRequest) (*reader_v2.SyncsReaderServiceGetLatestFinishedSyncResponse, error) {
-	latest, err := a.engine.LatestFinishedSyncRecord(ctx, syncTypeFilterFromString(req.GetSyncType()))
+func (e *Engine) GetLatestFinishedSync(ctx context.Context, req *reader_v2.SyncsReaderServiceGetLatestFinishedSyncRequest) (*reader_v2.SyncsReaderServiceGetLatestFinishedSyncResponse, error) {
+	latest, err := e.LatestFinishedSyncRecord(ctx, syncTypeFilterFromString(req.GetSyncType()))
 	if err != nil {
 		return nil, err
 	}
@@ -535,7 +535,7 @@ func (a *Adapter) GetLatestFinishedSync(ctx context.Context, req *reader_v2.Sync
 		return reader_v2.SyncsReaderServiceGetLatestFinishedSyncResponse_builder{}.Build(), nil
 	}
 
-	stats, err := a.syncStatsForRun(ctx, latest)
+	stats, err := e.syncStatsForRun(ctx, latest)
 	if err != nil {
 		return nil, err
 	}
@@ -549,18 +549,18 @@ func (a *Adapter) GetLatestFinishedSync(ctx context.Context, req *reader_v2.Sync
 // sidecar and falling back to computeSyncStats. Token timings are
 // present only when EndSync persisted them into the sidecar; older
 // count-only caches and iteration fallbacks return counts alone.
-func (a *Adapter) syncStatsForRun(ctx context.Context, rec *v3.SyncRunRecord) (*reader_v2.SyncStats, error) {
+func (e *Engine) syncStatsForRun(ctx context.Context, rec *v3.SyncRunRecord) (*reader_v2.SyncStats, error) {
 	if rec == nil {
 		return nil, nil
 	}
-	stats, _, err := CachedSyncStats(ctx, a.engine, rec.GetSyncId())
+	stats, _, err := CachedSyncStats(ctx, e, rec.GetSyncId())
 	if err != nil {
 		return nil, c1zstore.AdaptNotFound(err, pebble.ErrNotFound)
 	}
 	if stats != nil {
 		return stats, nil
 	}
-	computedStats, err := a.engine.computeSyncStats(ctx, rec.GetSyncId())
+	computedStats, err := e.computeSyncStats(ctx, rec.GetSyncId())
 	if err != nil {
 		return nil, c1zstore.AdaptNotFound(err, pebble.ErrNotFound)
 	}
@@ -623,7 +623,7 @@ func v3SyncTypeToString(t v3.SyncType) string {
 // lookups, surfaces as a non-nil error so callers don't silently fall
 // through to the wrong sync (matching SQLite's resolveSyncIDForRead,
 // which propagates those errors rather than swallowing them).
-func (a *Adapter) resolveActiveSyncForReader(ctx context.Context, annos []*anypb.Any) (string, error) {
+func (e *Engine) resolveActiveSyncForReader(ctx context.Context, annos []*anypb.Any) (string, error) {
 	annoSyncID, err := sdkannotations.GetSyncIdFromAnnotations(annos)
 	if err != nil {
 		return "", fmt.Errorf("pebble: read sync_id from annotations: %w", err)
@@ -631,10 +631,10 @@ func (a *Adapter) resolveActiveSyncForReader(ctx context.Context, annos []*anypb
 	if annoSyncID != "" {
 		return annoSyncID, nil
 	}
-	if id := a.currentSyncID(); id != "" {
+	if id := e.CurrentSyncID(); id != "" {
 		return id, nil
 	}
-	id, err := a.LatestFinishedSyncID(ctx, connectorstore.SyncTypeAny)
+	id, err := e.LatestFinishedSyncID(ctx, connectorstore.SyncTypeAny)
 	if err != nil {
 		return "", fmt.Errorf("pebble: latest finished sync: %w", err)
 	}
@@ -645,7 +645,7 @@ func (a *Adapter) resolveActiveSyncForReader(ctx context.Context, annos []*anypb
 	// latest in-progress sync (started within the last week). Lets
 	// reads against a c1z whose only sync was interrupted before
 	// EndSync resolve to that sync instead of ErrNoCurrentSync.
-	rec, err := a.engine.LatestUnfinishedSyncRecord(ctx, nil)
+	rec, err := e.LatestUnfinishedSyncRecord(ctx, nil)
 	if err != nil {
 		return "", fmt.Errorf("pebble: latest unfinished sync: %w", err)
 	}
@@ -655,13 +655,13 @@ func (a *Adapter) resolveActiveSyncForReader(ctx context.Context, annos []*anypb
 	return "", nil
 }
 
-func (a *Adapter) InitCurrentSync(ctx context.Context) error {
-	id, err := a.resolveActiveSyncForReader(ctx, nil)
+func (e *Engine) InitCurrentSync(ctx context.Context) error {
+	id, err := e.resolveActiveSyncForReader(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("pebble: error resolving active sync: %w", err)
 	}
 	if id != "" {
-		return a.SetCurrentSync(ctx, id)
+		return e.SetCurrentSync(ctx, id)
 	}
 	return nil
 }
@@ -674,8 +674,8 @@ func (a *Adapter) InitCurrentSync(ctx context.Context) error {
 // matches nothing; an AMBIGUOUS id stays an error — a lossy string must
 // never guess which digest to answer with. A nil stub or empty Id is an
 // error, matching ListGrantsForEntitlement.
-func (a *Adapter) digestEntitlementIdentity(ctx context.Context, ent *v2.Entitlement) (entitlementIdentity, bool, error) {
-	id, err := a.entitlementIdentityForRequest(ctx, ent)
+func (e *Engine) digestEntitlementIdentity(ctx context.Context, ent *v2.Entitlement) (entitlementIdentity, bool, error) {
+	id, err := e.entitlementIdentityForRequest(ctx, ent)
 	if err != nil {
 		if errors.Is(err, pebble.ErrNotFound) {
 			return entitlementIdentity{}, false, nil
@@ -692,19 +692,19 @@ func (a *Adapter) digestEntitlementIdentity(ctx context.Context, ent *v2.Entitle
 // no digest was built for it (e.g. WithGrantDigestIndex(false), a file
 // that predates the digest, or a post-seal mutation invalidated it). A
 // nil error with found=false means "no digest".
-func (a *Adapter) GetEntitlementGrantDigest(ctx context.Context, ent *v2.Entitlement) (connectorstore.GrantDigest, bool, error) {
-	syncID, err := a.resolveActiveSyncForReader(ctx, nil)
+func (e *Engine) GetEntitlementGrantDigest(ctx context.Context, ent *v2.Entitlement) (connectorstore.GrantDigest, bool, error) {
+	syncID, err := e.resolveActiveSyncForReader(ctx, nil)
 	if err != nil {
 		return connectorstore.GrantDigest{}, false, err
 	}
 	if syncID == "" {
 		return connectorstore.GrantDigest{}, false, nil
 	}
-	id, ok, err := a.digestEntitlementIdentity(ctx, ent)
+	id, ok, err := e.digestEntitlementIdentity(ctx, ent)
 	if err != nil || !ok {
 		return connectorstore.GrantDigest{}, false, err
 	}
-	root, ok, err := a.engine.GetEntitlementDigestRoot(ctx, id)
+	root, ok, err := e.GetEntitlementDigestRoot(ctx, id)
 	if err != nil || !ok {
 		return connectorstore.GrantDigest{}, false, err
 	}
@@ -719,22 +719,22 @@ func (a *Adapter) GetEntitlementGrantDigest(ctx context.Context, ent *v2.Entitle
 // level it scans the grant index directly (O(grants)) instead of
 // erroring; the level is clamped to the bucket-hash resolution
 // (digestMaxWidthBits).
-func (a *Adapter) GetEntitlementGrantDigestNodes(ctx context.Context, ent *v2.Entitlement, level int) ([]connectorstore.GrantDigestNode, bool, error) {
+func (e *Engine) GetEntitlementGrantDigestNodes(ctx context.Context, ent *v2.Entitlement, level int) ([]connectorstore.GrantDigestNode, bool, error) {
 	if level < 0 {
 		return nil, false, fmt.Errorf("pebble: negative grant-digest level %d", level)
 	}
-	syncID, err := a.resolveActiveSyncForReader(ctx, nil)
+	syncID, err := e.resolveActiveSyncForReader(ctx, nil)
 	if err != nil {
 		return nil, false, err
 	}
 	if syncID == "" {
 		return nil, false, nil
 	}
-	id, ok, err := a.digestEntitlementIdentity(ctx, ent)
+	id, ok, err := e.digestEntitlementIdentity(ctx, ent)
 	if err != nil || !ok {
 		return nil, false, err
 	}
-	root, ok, err := a.engine.GetEntitlementDigestRoot(ctx, id)
+	root, ok, err := e.GetEntitlementDigestRoot(ctx, id)
 	if err != nil || !ok {
 		return nil, false, err
 	}
@@ -751,9 +751,9 @@ func (a *Adapter) GetEntitlementGrantDigestNodes(ctx context.Context, ent *v2.En
 	partition := digestPartitionForEntitlement(id)
 	var folded []foldedBucket
 	if bits <= root.Bits {
-		folded, err = a.engine.foldedLeafBuckets(ctx, grantDigestSpec, partition, bits)
+		folded, err = e.foldedLeafBuckets(ctx, grantDigestSpec, partition, bits)
 	} else {
-		folded, err = a.engine.computeBucketsAtWidth(ctx, grantDigestSpec, partition, bits)
+		folded, err = e.computeBucketsAtWidth(ctx, grantDigestSpec, partition, bits)
 	}
 	if err != nil {
 		return nil, false, err
@@ -775,23 +775,23 @@ func (a *Adapter) GetEntitlementGrantDigestNodes(ctx context.Context, ent *v2.En
 // Bucket Level 0 scans the whole entitlement; a finer Level is clamped
 // to the bucket-hash resolution. Yields nothing when there is no active
 // sync or a bare entitlement id resolves to nothing.
-func (a *Adapter) ScanEntitlementGrantBucket(ctx context.Context, ent *v2.Entitlement, bucket connectorstore.GrantDigestBucket, yield func(*v2.Grant) bool) error {
+func (e *Engine) ScanEntitlementGrantBucket(ctx context.Context, ent *v2.Entitlement, bucket connectorstore.GrantDigestBucket, yield func(*v2.Grant) bool) error {
 	if bucket.Level < 0 {
 		return fmt.Errorf("pebble: negative grant-digest level %d", bucket.Level)
 	}
-	syncID, err := a.resolveActiveSyncForReader(ctx, nil)
+	syncID, err := e.resolveActiveSyncForReader(ctx, nil)
 	if err != nil {
 		return err
 	}
 	if syncID == "" {
 		return nil
 	}
-	id, ok, err := a.digestEntitlementIdentity(ctx, ent)
+	id, ok, err := e.digestEntitlementIdentity(ctx, ent)
 	if err != nil || !ok {
 		return err
 	}
 	bits := min(bucket.Level, digestMaxWidthBits)
-	return a.engine.IterateGrantsByEntitlementBucket(ctx, id, DigestBucket{Index: bucket.Index, Bits: bits}, func(r *v3.GrantRecord) bool {
+	return e.IterateGrantsByEntitlementBucket(ctx, id, DigestBucket{Index: bucket.Index, Bits: bits}, func(r *v3.GrantRecord) bool {
 		return yield(V3GrantToV2(r))
 	})
 }

--- a/pkg/dotc1z/engine/pebble/adapter_reader.go
+++ b/pkg/dotc1z/engine/pebble/adapter_reader.go
@@ -473,7 +473,7 @@ func (a *Adapter) ListSyncs(ctx context.Context, req *reader_v2.SyncsReaderServi
 	if err != nil {
 		return nil, err
 	}
-	iter, err := a.engine.DB().NewIter(&pebble.IterOptions{
+	iter, err := a.engine.NewIter(&pebble.IterOptions{
 		LowerBound: lower,
 		UpperBound: upper,
 	})

--- a/pkg/dotc1z/engine/pebble/adapter_stats.go
+++ b/pkg/dotc1z/engine/pebble/adapter_stats.go
@@ -24,8 +24,8 @@ import (
 // accepts any sync; otherwise we filter by the sync_run's type. An
 // empty syncID resolves to the latest finished sync of that type
 // (NotFound if none).
-func (a *Adapter) Stats(ctx context.Context, syncType connectorstore.SyncType, syncID string) (map[string]int64, error) {
-	stats, err := a.stats(ctx, syncType, syncID)
+func (e *Engine) Stats(ctx context.Context, syncType connectorstore.SyncType, syncID string) (map[string]int64, error) {
+	stats, err := e.stats(ctx, syncType, syncID)
 	if err != nil {
 		return nil, err
 	}
@@ -36,21 +36,21 @@ func (a *Adapter) Stats(ctx context.Context, syncType connectorstore.SyncType, s
 }
 
 // StatsV2 returns structured stats for the given sync.
-func (a *Adapter) StatsV2(ctx context.Context, syncType connectorstore.SyncType, syncID string) (*reader_v2.SyncStats, error) {
-	stats, err := a.stats(ctx, syncType, syncID)
+func (e *Engine) StatsV2(ctx context.Context, syncType connectorstore.SyncType, syncID string) (*reader_v2.SyncStats, error) {
+	stats, err := e.stats(ctx, syncType, syncID)
 	if err != nil {
 		return nil, err
 	}
 	return SyncStatsFromRecord(stats), nil
 }
 
-func (a *Adapter) stats(ctx context.Context, syncType connectorstore.SyncType, syncID string) (*v3.SyncStatsRecord, error) {
+func (e *Engine) stats(ctx context.Context, syncType connectorstore.SyncType, syncID string) (*v3.SyncStatsRecord, error) {
 	if syncID == "" {
 		// Match SQLite C1File.stats: empty syncID resolves to the
 		// latest finished sync of the requested type, never the
 		// in-progress current sync.
 		var err error
-		syncID, err = a.LatestFinishedSyncID(ctx, syncType)
+		syncID, err = e.LatestFinishedSyncID(ctx, syncType)
 		if err != nil {
 			return nil, err
 		}
@@ -61,7 +61,7 @@ func (a *Adapter) stats(ctx context.Context, syncType connectorstore.SyncType, s
 
 	// Match SQLite C1File.stats: missing sync → NotFound; type
 	// mismatch → InvalidArgument.
-	sr, err := a.engine.GetSyncRunRecord(ctx, syncID)
+	sr, err := e.GetSyncRunRecord(ctx, syncID)
 	if err != nil {
 		return nil, c1zstore.AdaptNotFound(err, pebble.ErrNotFound)
 	}
@@ -79,16 +79,16 @@ func (a *Adapter) stats(ctx context.Context, syncType connectorstore.SyncType, s
 	// Incremental that bypass EndFreshSync) fall through to the
 	// legacy path below. Token timings are written into the sidecar
 	// at EndSync; older count-only sidecars are returned as-is.
-	if cached, err := a.engine.readSyncStats(ctx, syncID); err == nil && cached != nil {
+	if cached, err := e.readSyncStats(ctx, syncID); err == nil && cached != nil {
 		return cached, nil
 	}
-	return a.statsFromIteration(ctx, syncID)
+	return e.statsFromIteration(ctx, syncID)
 }
 
 // statsFromIteration is the legacy O(N) path retained as the
 // sidecar fallback. Used by older c1z files that predate the
 // sidecar and by sync types that don't go through EndFreshSync.
-func (a *Adapter) statsFromIteration(ctx context.Context, syncID string) (*v3.SyncStatsRecord, error) {
+func (e *Engine) statsFromIteration(ctx context.Context, syncID string) (*v3.SyncStatsRecord, error) {
 	stats := &v3.SyncStatsRecord{
 		SyncId:                          syncID,
 		ResourceTypes:                   0,
@@ -101,34 +101,34 @@ func (a *Adapter) statsFromIteration(ctx context.Context, syncID string) (*v3.Sy
 		EntitlementsByResourceType:      make(map[string]int64),
 	}
 
-	if err := a.engine.IterateResourceTypes(ctx, func(r *v3.ResourceTypeRecord) bool {
+	if err := e.IterateResourceTypes(ctx, func(r *v3.ResourceTypeRecord) bool {
 		stats.ResourceTypes++
 		return true
 	}); err != nil {
 		return nil, err
 	}
-	if err := a.engine.IterateResources(ctx, func(r *v3.ResourceRecord) bool {
+	if err := e.IterateResources(ctx, func(r *v3.ResourceRecord) bool {
 		stats.Resources++
 		stats.ResourcesByResourceType[r.GetResourceTypeId()]++
 		return true
 	}); err != nil {
 		return nil, err
 	}
-	if err := a.engine.IterateEntitlements(ctx, func(e *v3.EntitlementRecord) bool {
+	if err := e.IterateEntitlements(ctx, func(e *v3.EntitlementRecord) bool {
 		stats.Entitlements++
 		stats.EntitlementsByResourceType[e.GetResource().GetResourceTypeId()]++
 		return true
 	}); err != nil {
 		return nil, err
 	}
-	if err := a.engine.IterateGrants(ctx, func(g *v3.GrantRecord) bool {
+	if err := e.IterateGrants(ctx, func(g *v3.GrantRecord) bool {
 		stats.Grants++
 		stats.GrantsByEntitlementResourceType[g.GetEntitlement().GetResourceTypeId()]++
 		return true
 	}); err != nil {
 		return nil, err
 	}
-	if err := a.engine.IterateAssets(ctx, func(*v3.AssetRecord) bool {
+	if err := e.IterateAssets(ctx, func(*v3.AssetRecord) bool {
 		stats.Assets++
 		return true
 	}); err != nil {
@@ -180,10 +180,10 @@ func errNoFinishedSync(syncType connectorstore.SyncType) error {
 // Empty syncID resolves to the latest finished sync of syncType
 // (matching Stats / SQLite grantStats), and returns NotFound when
 // none exists.
-func (a *Adapter) GrantStats(ctx context.Context, syncType connectorstore.SyncType, syncID string) (map[string]int64, error) {
+func (e *Engine) GrantStats(ctx context.Context, syncType connectorstore.SyncType, syncID string) (map[string]int64, error) {
 	if syncID == "" {
 		var err error
-		syncID, err = a.LatestFinishedSyncID(ctx, syncType)
+		syncID, err = e.LatestFinishedSyncID(ctx, syncType)
 		if err != nil {
 			return nil, err
 		}
@@ -191,7 +191,7 @@ func (a *Adapter) GrantStats(ctx context.Context, syncType connectorstore.SyncTy
 			return nil, errNoFinishedSync(syncType)
 		}
 	}
-	sr, err := a.engine.GetSyncRunRecord(ctx, syncID)
+	sr, err := e.GetSyncRunRecord(ctx, syncID)
 	if err == nil && sr != nil {
 		if syncType != connectorstore.SyncTypeAny &&
 			syncType != connectorstore.SyncType(v3SyncTypeToString(sr.GetType())) {
@@ -199,7 +199,7 @@ func (a *Adapter) GrantStats(ctx context.Context, syncType connectorstore.SyncTy
 		}
 	}
 	// Fast path: sidecar.
-	if stats, err := a.engine.readSyncStats(ctx, syncID); err == nil && stats != nil {
+	if stats, err := e.readSyncStats(ctx, syncID); err == nil && stats != nil {
 		out := make(map[string]int64, len(stats.GetGrantsByEntitlementResourceType()))
 		for rt, n := range stats.GetGrantsByEntitlementResourceType() {
 			out[rt] = n
@@ -208,7 +208,7 @@ func (a *Adapter) GrantStats(ctx context.Context, syncType connectorstore.SyncTy
 	}
 	// Fallback: iterate.
 	counts := map[string]int64{}
-	if err := a.engine.IterateGrants(ctx, func(rec *v3.GrantRecord) bool {
+	if err := e.IterateGrants(ctx, func(rec *v3.GrantRecord) bool {
 		// Match SQLite's `resource_type_id` column semantic on
 		// the grants table — that's the *entitlement's*
 		// resource type, not the principal's.
@@ -225,6 +225,6 @@ func (a *Adapter) GrantStats(ctx context.Context, syncType connectorstore.SyncTy
 // SQLite equivalent returns the .c1z file path; for Pebble we don't
 // have a single file, so this returns the engine's directory. Used
 // by tooling that wants to copy or inspect the storage.
-func (a *Adapter) OutputFilepath() (string, error) {
-	return a.engine.DBDir(), nil
+func (e *Engine) OutputFilepath() (string, error) {
+	return e.DBDir(), nil
 }

--- a/pkg/dotc1z/engine/pebble/adapter_streaming.go
+++ b/pkg/dotc1z/engine/pebble/adapter_streaming.go
@@ -13,14 +13,14 @@ import (
 
 // StreamGrants yields grants for syncID, optionally narrowed by
 // opts. Implements connectorstore.StreamingReader.
-func (a *Adapter) StreamGrants(
+func (e *Engine) StreamGrants(
 	ctx context.Context,
 	syncID string,
 	opts connectorstore.StreamGrantsOptions,
 ) iter.Seq2[*v2.Grant, error] {
 	return func(yield func(*v2.Grant, error) bool) {
 		if syncID == "" {
-			resolved, err := a.resolveActiveSyncForReader(ctx, nil)
+			resolved, err := e.resolveActiveSyncForReader(ctx, nil)
 			if err != nil {
 				yield(nil, err)
 				return
@@ -52,11 +52,11 @@ func (a *Adapter) StreamGrants(
 		var err error
 		switch {
 		case opts.EntitlementID != "":
-			err = a.engine.IterateGrantsByEntitlement(ctx, opts.EntitlementID, cb)
+			err = e.IterateGrantsByEntitlement(ctx, opts.EntitlementID, cb)
 		case opts.PrincipalResourceType != "" && opts.PrincipalResourceID == "":
-			err = a.engine.IterateGrantsByPrincipalResourceType(ctx, opts.PrincipalResourceType, cb)
+			err = e.IterateGrantsByPrincipalResourceType(ctx, opts.PrincipalResourceType, cb)
 		default:
-			err = a.engine.IterateGrants(ctx, cb)
+			err = e.IterateGrants(ctx, cb)
 		}
 		if iterErr != nil {
 			yield(nil, iterErr)
@@ -70,14 +70,14 @@ func (a *Adapter) StreamGrants(
 
 // StreamResources yields resources for syncID, optionally narrowed
 // by resource_type. Implements connectorstore.StreamingReader.
-func (a *Adapter) StreamResources(
+func (e *Engine) StreamResources(
 	ctx context.Context,
 	syncID string,
 	opts connectorstore.StreamResourcesOptions,
 ) iter.Seq2[*v2.Resource, error] {
 	return func(yield func(*v2.Resource, error) bool) {
 		if syncID == "" {
-			resolved, err := a.resolveActiveSyncForReader(ctx, nil)
+			resolved, err := e.resolveActiveSyncForReader(ctx, nil)
 			if err != nil {
 				yield(nil, err)
 				return
@@ -89,7 +89,7 @@ func (a *Adapter) StreamResources(
 			return
 		}
 		var iterErr error
-		err := a.engine.IterateResources(ctx, func(rec *v3.ResourceRecord) bool {
+		err := e.IterateResources(ctx, func(rec *v3.ResourceRecord) bool {
 			if err := ctx.Err(); err != nil {
 				iterErr = err
 				return false
@@ -111,13 +111,13 @@ func (a *Adapter) StreamResources(
 
 // StreamEntitlements yields all entitlements for syncID.
 // Implements connectorstore.StreamingReader.
-func (a *Adapter) StreamEntitlements(
+func (e *Engine) StreamEntitlements(
 	ctx context.Context,
 	syncID string,
 ) iter.Seq2[*v2.Entitlement, error] {
 	return func(yield func(*v2.Entitlement, error) bool) {
 		if syncID == "" {
-			resolved, err := a.resolveActiveSyncForReader(ctx, nil)
+			resolved, err := e.resolveActiveSyncForReader(ctx, nil)
 			if err != nil {
 				yield(nil, err)
 				return
@@ -129,7 +129,7 @@ func (a *Adapter) StreamEntitlements(
 			return
 		}
 		var iterErr error
-		err := a.engine.IterateEntitlements(ctx, func(rec *v3.EntitlementRecord) bool {
+		err := e.IterateEntitlements(ctx, func(rec *v3.EntitlementRecord) bool {
 			if err := ctx.Err(); err != nil {
 				iterErr = err
 				return false

--- a/pkg/dotc1z/engine/pebble/adapter_sync_meta.go
+++ b/pkg/dotc1z/engine/pebble/adapter_sync_meta.go
@@ -18,12 +18,12 @@ import (
 // records live in Pebble under typeSyncRun; methods here walk
 // IterateAllSyncRuns + GetSyncRunRecord + PutSyncRunRecord on the
 // engine.
-func (a *Adapter) SyncMeta() c1zstore.SyncMeta {
-	return pebbleSyncMeta{a: a}
+func (e *Engine) SyncMeta() c1zstore.SyncMeta {
+	return pebbleSyncMeta{e: e}
 }
 
 type pebbleSyncMeta struct {
-	a *Adapter
+	e *Engine
 }
 
 // MarkSyncSupportsDiff sets supports_diff = true on the named sync's
@@ -40,12 +40,12 @@ func (s pebbleSyncMeta) MarkSyncSupportsDiff(ctx context.Context, syncID string)
 	if syncID == "" {
 		return errors.New("MarkSyncSupportsDiff: empty syncID")
 	}
-	r, err := s.a.engine.GetSyncRunRecord(ctx, syncID)
+	r, err := s.e.GetSyncRunRecord(ctx, syncID)
 	if err != nil {
 		return c1zstore.AdaptNotFound(fmt.Errorf("MarkSyncSupportsDiff: get: %w", err), pebble.ErrNotFound)
 	}
 	r.SetSupportsDiff(true)
-	if err := s.a.engine.PutSyncRunRecord(ctx, r); err != nil {
+	if err := s.e.PutSyncRunRecord(ctx, r); err != nil {
 		return fmt.Errorf("MarkSyncSupportsDiff: put: %w", err)
 	}
 	return nil
@@ -70,7 +70,7 @@ func (s pebbleSyncMeta) LatestFinishedSyncOfAnyType(ctx context.Context) (*c1zst
 // translates the result into the exported c1zstore.SyncRun shape.
 // typeOK is passed through verbatim; nil matches any sync type.
 func (s pebbleSyncMeta) latestFinishedSync(ctx context.Context, typeOK func(v3.SyncType) bool) (*c1zstore.SyncRun, error) {
-	best, err := s.a.engine.LatestFinishedSyncRecord(ctx, typeOK)
+	best, err := s.e.LatestFinishedSyncRecord(ctx, typeOK)
 	if err != nil {
 		return nil, err
 	}
@@ -84,12 +84,12 @@ func (s pebbleSyncMeta) latestFinishedSync(ctx context.Context, typeOK func(v3.S
 // Delegates to Adapter.Stats, which reads the EndFreshSync stats
 // sidecar (O(1)) when present and falls back to iteration when not.
 func (s pebbleSyncMeta) Stats(ctx context.Context, syncType connectorstore.SyncType, syncID string) (map[string]int64, error) {
-	return s.a.Stats(ctx, syncType, syncID)
+	return s.e.Stats(ctx, syncType, syncID)
 }
 
 // StatsV2 implements SyncMeta. Signature matches *C1File.StatsV2 exactly.
 func (s pebbleSyncMeta) StatsV2(ctx context.Context, syncType connectorstore.SyncType, syncID string) (*reader_v2.SyncStats, error) {
-	return s.a.StatsV2(ctx, syncType, syncID)
+	return s.e.StatsV2(ctx, syncType, syncID)
 }
 
 // RecalculateStats recomputes the stats sidecar for syncID from the
@@ -99,12 +99,12 @@ func (s pebbleSyncMeta) StatsV2(ctx context.Context, syncType connectorstore.Syn
 // sync is named.
 func (s pebbleSyncMeta) RecalculateStats(ctx context.Context, syncID string) error {
 	if syncID == "" {
-		syncID = s.a.currentSyncID()
+		syncID = s.e.CurrentSyncID()
 	}
 	if syncID == "" {
 		return errors.New("RecalculateStats: empty syncID and no current sync")
 	}
-	return s.a.engine.PersistSyncStats(ctx, syncID)
+	return s.e.PersistSyncStats(ctx, syncID)
 }
 
 // syncRunRecordToExported translates the Pebble v3.SyncRunRecord
@@ -145,9 +145,9 @@ func syncRunRecordToExported(r *v3.SyncRunRecord) *c1zstore.SyncRun {
 // which would silently pick the wrong sync to prune. Sorting on
 // started_at (with sync_id tiebreaker) matches the SQLite engine's
 // ListSyncRuns ORDER BY id ASC semantics.
-func (a *Adapter) sortedSyncRuns(ctx context.Context) ([]c1zstore.SyncRun, error) {
+func (e *Engine) sortedSyncRuns(ctx context.Context) ([]c1zstore.SyncRun, error) {
 	var out []c1zstore.SyncRun
-	err := a.engine.IterateAllSyncRuns(ctx, func(r *v3.SyncRunRecord) bool {
+	err := e.IterateAllSyncRuns(ctx, func(r *v3.SyncRunRecord) bool {
 		cand := c1zstore.SyncRun{
 			ID:           r.GetSyncId(),
 			Type:         syncTypeV3ToConnectorstore(r.GetType()),
@@ -193,8 +193,8 @@ func (a *Adapter) sortedSyncRuns(ctx context.Context) ([]c1zstore.SyncRun, error
 // c1zstore.SelectSyncsToDelete depends on this ordering so "drop the
 // oldest overflow" trims the right end. Used by pkg/dotc1z's Pebble
 // store to drive the retention policy at Cleanup.
-func (a *Adapter) CleanupCandidates(ctx context.Context) ([]c1zstore.SyncRun, error) {
-	out, err := a.sortedSyncRuns(ctx)
+func (e *Engine) CleanupCandidates(ctx context.Context) ([]c1zstore.SyncRun, error) {
+	out, err := e.sortedSyncRuns(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("pebble CleanupCandidates: IterateAllSyncRuns: %w", err)
 	}
@@ -210,8 +210,8 @@ func (a *Adapter) CleanupCandidates(ctx context.Context) ([]c1zstore.SyncRun, er
 // ListSyncRuns and are not used. It backs the c1z sanitizer's
 // source-side sync-graph-metadata read (linked_sync_id, supports_diff),
 // which the gRPC reader surface does not carry.
-func (a *Adapter) ListSyncRuns(ctx context.Context, pageToken string, pageSize uint32) ([]*c1zstore.SyncRun, string, error) {
-	runs, err := a.sortedSyncRuns(ctx)
+func (e *Engine) ListSyncRuns(ctx context.Context, pageToken string, pageSize uint32) ([]*c1zstore.SyncRun, string, error) {
+	runs, err := e.sortedSyncRuns(ctx)
 	if err != nil {
 		return nil, "", fmt.Errorf("pebble ListSyncRuns: %w", err)
 	}

--- a/pkg/dotc1z/engine/pebble/adapter_test.go
+++ b/pkg/dotc1z/engine/pebble/adapter_test.go
@@ -127,13 +127,13 @@ func TestAdapterEndSyncClearsEngineCurrentSync(t *testing.T) {
 	// record write must now fail rather than land an orphan record with
 	// no sync run. The seal check fires first — it is the explicit
 	// post-EndSync state; ErrNoCurrentSync would catch it anyway.
-	err = a.engine.PutGrantRecord(ctx, makeGrant(syncID, "g2", "ent-B", "bob"))
+	err = a.PutGrantRecord(ctx, makeGrant(syncID, "g2", "ent-B", "bob"))
 	require.ErrorIs(t, err, ErrEngineSealed, "direct engine write after EndSync: got %v, want ErrEngineSealed", err)
 
 	// Reads do NOT gate on the bound sync: the finished sync's data
 	// persists and stays readable through the engine after EndSync.
 	count := 0
-	err = a.engine.IterateGrantsByEntitlement(ctx, canonicalTestEntID("ent-A"), func(*v3.GrantRecord) bool {
+	err = a.IterateGrantsByEntitlement(ctx, canonicalTestEntID("ent-A"), func(*v3.GrantRecord) bool {
 		count++
 		return true
 	})
@@ -246,8 +246,10 @@ func TestAdapterResumeSync(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, a.PutGrants(ctx, mkV2Grant("g1", "ent", "user", "alice")))
 	require.NoError(t, a.CheckpointSync(ctx, "step-7"), "CheckpointSync")
-	// Simulate restart by zeroing in-memory state.
-	a.current = syncRunState{}
+	// Simulate restart by clearing the engine's bound sync (the only
+	// in-memory lifecycle state post-2.6; the step token lives on the
+	// durable SyncRunRecord).
+	a.clearCurrentSync()
 
 	// Resume.
 	id2, err := a.ResumeSync(ctx, connectorstore.SyncTypeFull, id1)

--- a/pkg/dotc1z/engine/pebble/adapter_test.go
+++ b/pkg/dotc1z/engine/pebble/adapter_test.go
@@ -315,6 +315,13 @@ func TestAdapterCurrentDBSizeBytes(t *testing.T) {
 	for i := 0; i < 25; i++ {
 		require.NoError(t, a.PutGrants(ctx, mkV2Grant(ksuid.New().String(), "ent", "user", ksuid.New().String())), "PutGrants")
 	}
+	// Quiesce the WAL before sampling: NoSync commits hand records to
+	// pebble's LogWriter, whose flush loop appends to the file
+	// ASYNCHRONOUSLY — without a sync point the on-disk size keeps
+	// growing between the two samples below and the equality is a race
+	// (flaked on slow Windows CI). LogData(nil, Sync) drains and fsyncs
+	// the buffer, making the size stable for both reads.
+	require.NoError(t, e.db.WALSyncPoint(), "quiesce WAL before size sampling")
 
 	after, err := a.CurrentDBSizeBytes()
 	require.NoError(t, err, "CurrentDBSizeBytes after writes")

--- a/pkg/dotc1z/engine/pebble/bulk_import.go
+++ b/pkg/dotc1z/engine/pebble/bulk_import.go
@@ -27,7 +27,7 @@ import (
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/codec"
-	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/rawdb"
 )
 
 // ErrBulkImportOutOfOrder is returned by BulkSyncImport's ordered add
@@ -455,7 +455,7 @@ func (b *BulkSyncImport) AddResourcesWithDiscoveredAt(ctx context.Context, resou
 		}
 		b.resourcesByRT[rec.GetResourceTypeId()]++
 		if parent := rec.GetParent(); parent != nil && parent.GetResourceId() != "" {
-			k := keys.EncodeResourceByParentIndexKey(
+			k := rawdb.EncodeResourceByParentIndexKey(
 				parent.GetResourceTypeId(), parent.GetResourceId(),
 				rec.GetResourceTypeId(), rec.GetResourceId(),
 			)

--- a/pkg/dotc1z/engine/pebble/bulk_import.go
+++ b/pkg/dotc1z/engine/pebble/bulk_import.go
@@ -27,6 +27,7 @@ import (
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/codec"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
 )
 
 // ErrBulkImportOutOfOrder is returned by BulkSyncImport's ordered add
@@ -454,7 +455,7 @@ func (b *BulkSyncImport) AddResourcesWithDiscoveredAt(ctx context.Context, resou
 		}
 		b.resourcesByRT[rec.GetResourceTypeId()]++
 		if parent := rec.GetParent(); parent != nil && parent.GetResourceId() != "" {
-			k := encodeResourceByParentIndexKey(
+			k := keys.EncodeResourceByParentIndexKey(
 				parent.GetResourceTypeId(), parent.GetResourceId(),
 				rec.GetResourceTypeId(), rec.GetResourceId(),
 			)

--- a/pkg/dotc1z/engine/pebble/choke_point_meta_test.go
+++ b/pkg/dotc1z/engine/pebble/choke_point_meta_test.go
@@ -214,17 +214,18 @@ func walkClientTreeProductionGoFiles(t *testing.T, visit func(root, path string,
 // SOURCE so a production call site can't even ship dormant.
 func TestUnsafeForTestingOnlyInTests(t *testing.T) {
 	walkClientTreeProductionGoFiles(t, func(root, path string, src []byte) {
-		// The definition and its MergeView delegation are exempt — by
-		// EXACT path under this package's root only, so a spoofed
-		// nested .../internal/rawdb/ tree elsewhere cannot smuggle a
-		// production call site past the check (review finding, round 1
-		// of PR 2).
-		if root == "." && filepath.Clean(path) == filepath.Clean("internal/rawdb/rawdb.go") {
+		// The definition (rawdb.go) and the Engine merge surface's
+		// delegation (merge_surface.go) are exempt — by EXACT path
+		// under this package's root only, so a spoofed nested tree
+		// elsewhere cannot smuggle a production call site past the
+		// check (review finding, round 1 of PR 2).
+		if root == "." && (filepath.Clean(path) == filepath.Clean("internal/rawdb/rawdb.go") ||
+			filepath.Clean(path) == "merge_surface.go") {
 			return
 		}
 		// The signal is USE-shaped — a selector (`x.UnsafeForTesting`),
 		// whitespace-tolerant so gofmt's multi-line chains
-		// (`eng.DB().\n\tUnsafeForTesting()`) still match (review
+		// (`eng.\n\tUnsafeForTesting()`) still match (review
 		// finding, delta round). Covers direct calls, method values,
 		// and method expressions ((*T).UnsafeForTesting); a bare
 		// method DECLARATION doesn't match — a declaration grants
@@ -243,14 +244,11 @@ func TestUnsafeForTestingOnlyInTests(t *testing.T) {
 // Selector-use signals for the source fences below: a dot immediately
 // followed by the name (`x.UnsafeForTesting`), or a dot at the end of
 // a line with the name on the gofmt continuation line
-// (`eng.DB().\n\tUnsafeForTesting()`). Deliberately NOT `\.\s*`: that
+// (`eng.\n\tUnsafeForTesting()`). Deliberately NOT `\.\s*`: that
 // would also match prose in doc comments ("... delta round).
 // UnsafeForTesting stays ..."), and a same-line space between dot and
 // selector isn't a form gofmt'd code can take.
-var (
-	unsafeForTestingUse = regexp.MustCompile(`\.(\n\s*)?UnsafeForTesting\b`)
-	newFoldBatchUse     = regexp.MustCompile(`\.(\n\s*)?NewFoldBatch\b`)
-)
+var unsafeForTestingUse = regexp.MustCompile(`\.(\n\s*)?UnsafeForTesting\b`)
 
 // TestSeamsArmedOnlyInTests forbids ARMING the Engine's test-seam
 // field (Engine.test / testSeams, test_seams.go) outside _test.go
@@ -314,26 +312,34 @@ func TestSeamsArmedOnlyInTests(t *testing.T) {
 	}
 }
 
-// TestFoldBatchOnlyInCompactor fences the one raw record-write conduit
-// the narrowed DB() handle carries: NewFoldBatch (generic Set/Delete/
-// Commit over record keyspaces, obligations handled by the fold
-// contract instead of derivation). Its only sanctioned production
-// clients are the fold compactor (pkg/synccompactor/pebble) and rawdb
-// itself; a NewFoldBatch call appearing anywhere else is a caller
+// mergeSurfaceWriteUse are the selector signals for the Engine merge
+// surface's raw write ops (merge_surface.go): NewFoldBatch (generic
+// Set/Delete/Commit over record keyspaces, obligations handled by the
+// fold contract instead of derivation) plus the bulk range/ingest ops
+// promoted from the old DB() handle. Whitespace-tolerant like the
+// UnsafeForTesting signal.
+var mergeSurfaceWriteUse = regexp.MustCompile(`\.(\n\s*)?(NewFoldBatch|DropKeyRange|IngestSSTs|ReplaceRangeWithSSTs)\b`)
+
+// TestMergeSurfaceWritesOnlyInCompactor fences the raw write conduits
+// the Engine merge surface carries. Their only sanctioned production
+// clients are the fold compactor (pkg/synccompactor/pebble), rawdb
+// itself, and THIS package's engine internals (which reach the same
+// ops through e.db — legitimately: digest drops, session clears,
+// deferred-index ingest all ride them under the write barrier). A use
+// appearing in the store layer or any other package is a caller
 // routing around the typed Stage* obligations (review finding, delta
-// round: the DB() handle must not quietly become a second engine
-// write path).
-func TestFoldBatchOnlyInCompactor(t *testing.T) {
-	sep := string(filepath.Separator)
+// round: the exemption surface must not quietly become a second
+// engine write path).
+func TestMergeSurfaceWritesOnlyInCompactor(t *testing.T) {
 	walkClientTreeProductionGoFiles(t, func(root, path string, src []byte) {
-		if root == "." && strings.HasPrefix(filepath.Clean(path), filepath.Clean("internal/rawdb")+sep) {
-			return // the definition + MergeView delegation
+		if root == "." {
+			return // engine package + internal/: the ops' home
 		}
 		if root == "../../../synccompactor" && strings.Contains(filepath.ToSlash(filepath.Clean(path)), "/pebble/") {
 			return // the sanctioned fold-compactor client
 		}
-		require.Falsef(t, newFoldBatchUse.Match(src),
-			"%s uses NewFoldBatch outside the fold compactor. FoldBatch bypasses typed record staging "+
-				"by contract; record writes anywhere else go through a RecordBatch Stage* operation.", path)
+		require.Falsef(t, mergeSurfaceWriteUse.Match(src),
+			"%s uses an Engine merge-surface write op outside the fold compactor. These bypass typed "+
+				"record staging by contract; record writes anywhere else go through the engine's typed APIs.", path)
 	})
 }

--- a/pkg/dotc1z/engine/pebble/choke_point_meta_test.go
+++ b/pkg/dotc1z/engine/pebble/choke_point_meta_test.go
@@ -317,28 +317,43 @@ func TestSeamsArmedOnlyInTests(t *testing.T) {
 // Set/Delete/Commit over record keyspaces, obligations handled by the
 // fold contract instead of derivation) plus the bulk range/ingest ops
 // promoted from the old DB() handle. Whitespace-tolerant like the
-// UnsafeForTesting signal.
-var mergeSurfaceWriteUse = regexp.MustCompile(`\.(\n\s*)?(NewFoldBatch|DropKeyRange|IngestSSTs|ReplaceRangeWithSSTs)\b`)
+// UnsafeForTesting signal. dbQualifiedMergeWriteUse matches the same
+// ops reached through a `.db` field selector — the engine's OWN
+// rawdb-handle calls (digest drops, session clears, deferred-index
+// ingest, all under the write barrier), which are legitimate and are
+// blanked out of a file before the fence scan so the fence still
+// catches an Engine-method use like `e.NewFoldBatch()` in engine
+// production code (review finding, 2.5 round: a root-"." blanket
+// exemption silently weakened this fence vs its pre-2.5 form).
+var (
+	mergeSurfaceWriteUse     = regexp.MustCompile(`\.(\n\s*)?(NewFoldBatch|DropKeyRange|IngestSSTs|ReplaceRangeWithSSTs)\b`)
+	dbQualifiedMergeWriteUse = regexp.MustCompile(`\.db\.(NewFoldBatch|DropKeyRange|IngestSSTs|ReplaceRangeWithSSTs)\b`)
+)
 
 // TestMergeSurfaceWritesOnlyInCompactor fences the raw write conduits
 // the Engine merge surface carries. Their only sanctioned production
 // clients are the fold compactor (pkg/synccompactor/pebble), rawdb
-// itself, and THIS package's engine internals (which reach the same
-// ops through e.db — legitimately: digest drops, session clears,
-// deferred-index ingest all ride them under the write barrier). A use
-// appearing in the store layer or any other package is a caller
+// itself (definitions + internal use), merge_surface.go (the
+// delegating definitions), and the engine package's own `.db`
+// rawdb-handle calls. Any other use — an Engine-method call in engine
+// production code, the store layer, other packages — is a caller
 // routing around the typed Stage* obligations (review finding, delta
 // round: the exemption surface must not quietly become a second
 // engine write path).
 func TestMergeSurfaceWritesOnlyInCompactor(t *testing.T) {
+	sep := string(filepath.Separator)
 	walkClientTreeProductionGoFiles(t, func(root, path string, src []byte) {
-		if root == "." {
-			return // engine package + internal/: the ops' home
+		if root == "." && (filepath.Clean(path) == "merge_surface.go" ||
+			strings.HasPrefix(filepath.Clean(path), filepath.Clean("internal/rawdb")+sep)) {
+			return // the ops' definitions
 		}
 		if root == "../../../synccompactor" && strings.Contains(filepath.ToSlash(filepath.Clean(path)), "/pebble/") {
 			return // the sanctioned fold-compactor client
 		}
-		require.Falsef(t, mergeSurfaceWriteUse.Match(src),
+		// Blank the engine's legitimate `.db.<op>` rawdb calls, then
+		// scan what remains.
+		scrubbed := dbQualifiedMergeWriteUse.ReplaceAll(src, nil)
+		require.Falsef(t, mergeSurfaceWriteUse.Match(scrubbed),
 			"%s uses an Engine merge-surface write op outside the fold compactor. These bypass typed "+
 				"record staging by contract; record writes anywhere else go through the engine's typed APIs.", path)
 	})

--- a/pkg/dotc1z/engine/pebble/cleanup.go
+++ b/pkg/dotc1z/engine/pebble/cleanup.go
@@ -98,7 +98,7 @@ func (e *Engine) ResetForNewSync(ctx context.Context) error {
 		}
 		// The record-type span above covers typeDigest and the hash
 		// index too; disarm the mutation-path digest invalidation.
-		e.grantDigestsPresent.Store(false)
+		e.db.SetGrantDigestsPresent(false)
 		// The digest-build crash marker lives in the preserved
 		// engine-meta range, but the excise just removed everything it
 		// was guarding against trusting — consume it (only reachable

--- a/pkg/dotc1z/engine/pebble/cleanup_test.go
+++ b/pkg/dotc1z/engine/pebble/cleanup_test.go
@@ -10,6 +10,7 @@ import (
 
 	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
 )
 
 // Store-level Cleanup behavior (retention policy, dirty bit, env
@@ -116,7 +117,7 @@ func TestSyncScopedRangesCoverEveryWrittenIndex(t *testing.T) {
 	}
 	written = append(written,
 		writtenKey{idxResourceByParent, "resource_by_parent",
-			encodeResourceByParentIndexKey("folder", "root", "doc", "d1")},
+			keys.EncodeResourceByParentIndexKey("folder", "root", "doc", "d1")},
 	)
 
 	covered := func(k []byte) bool {

--- a/pkg/dotc1z/engine/pebble/cleanup_test.go
+++ b/pkg/dotc1z/engine/pebble/cleanup_test.go
@@ -66,14 +66,14 @@ func TestResetForNewSyncReclaimsDiskImmediately(t *testing.T) {
 
 	dataLo := []byte{versionV3, typeResourceType}
 	dataHi := []byte{versionV3, typeEngineMeta}
-	before, err := e.DB().EstimateDiskUsage(dataLo, dataHi)
+	before, err := e.EstimateDiskUsage(dataLo, dataHi)
 	require.NoErrorf(t, err, "EstimateDiskUsage (before)")
 	require.NotZero(t, before, "sanity: expected non-zero on-disk usage for the finished sync's data span")
 
 	// Replacement sync: StartNewSync excises the prior sync's data.
 	_, err = a.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
 	require.NoErrorf(t, err, "StartNewSync (replacement)")
-	after, err := e.DB().EstimateDiskUsage(dataLo, dataHi)
+	after, err := e.EstimateDiskUsage(dataLo, dataHi)
 	require.NoErrorf(t, err, "EstimateDiskUsage (after)")
 	// The excise drops fully-covered SSTs from the manifest, so the
 	// data span's estimated usage collapses to (near) zero immediately

--- a/pkg/dotc1z/engine/pebble/cleanup_test.go
+++ b/pkg/dotc1z/engine/pebble/cleanup_test.go
@@ -10,7 +10,7 @@ import (
 
 	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
-	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/rawdb"
 )
 
 // Store-level Cleanup behavior (retention policy, dirty bit, env
@@ -117,7 +117,7 @@ func TestSyncScopedRangesCoverEveryWrittenIndex(t *testing.T) {
 	}
 	written = append(written,
 		writtenKey{idxResourceByParent, "resource_by_parent",
-			keys.EncodeResourceByParentIndexKey("folder", "root", "doc", "d1")},
+			rawdb.EncodeResourceByParentIndexKey("folder", "root", "doc", "d1")},
 	)
 
 	covered := func(k []byte) bool {

--- a/pkg/dotc1z/engine/pebble/deferred_index.go
+++ b/pkg/dotc1z/engine/pebble/deferred_index.go
@@ -15,7 +15,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/codec"
-	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/rawdb"
 )
 
 // deferredIndexSpillChunkBytes is the spill-chunk arena size for the deferred
@@ -379,7 +379,7 @@ func (e *Engine) buildDeferredGrantIndexesLocked(ctx context.Context) error {
 				rebuildScanErr = err
 			}
 		}
-		idxKey, ok := keys.AppendGrantByPrincipalKeyFromPrimary(idxKeyScratch[:0], iter.Key())
+		idxKey, ok := rawdb.AppendGrantByPrincipalKeyFromPrimary(idxKeyScratch[:0], iter.Key())
 		idxKeyScratch = idxKey
 		if !ok {
 			// Only possible on key-layout drift or corruption: every grant

--- a/pkg/dotc1z/engine/pebble/deferred_index.go
+++ b/pkg/dotc1z/engine/pebble/deferred_index.go
@@ -1,7 +1,6 @@
 package pebble
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -16,6 +15,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/codec"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
 )
 
 // deferredIndexSpillChunkBytes is the spill-chunk arena size for the deferred
@@ -39,68 +39,6 @@ import (
 // freelist sized to the sort concurrency, so retained (idle) arenas
 // are capped at the same order.
 const deferredIndexSpillChunkBytes = 128 << 20
-
-// appendGrantByPrincipalKeyFromPrimary builds the by_principal index key
-// directly from a primary grant key by permuting its tuple segments, into
-// dst. The primary tail is ent_rt|ent_rid|ent_kind|ent_name|p_rt|p_id and the
-// index tail is p_rt|p_id|ent_rt|ent_rid|ent_kind|ent_name — the segments are
-// already escaped, and the tuple escaping is canonical, so splicing the raw
-// bytes is byte-identical to decode + re-encode
-// (encodeGrantByPrincipalIdentityIndexKey ∘ decodeGrantIdentityKey) while
-// skipping six string allocations and a fresh key buffer per row. That
-// decode/re-encode pair was ~7GB of allocations per whale deferred build.
-// Returns ok=false for keys that do not have exactly six segments.
-//
-// Pinned against the decode+re-encode path by
-// TestAppendGrantByPrincipalKeyFromPrimary.
-func appendGrantByPrincipalKeyFromPrimary(dst, primaryKey []byte) ([]byte, bool) {
-	const prefixLen = 3 // versionV3 | typeGrant | separator
-	if len(primaryKey) < prefixLen || primaryKey[0] != versionV3 || primaryKey[1] != typeGrant || primaryKey[2] != 0 {
-		return dst, false
-	}
-	tail := primaryKey[prefixLen:]
-	// Split into exactly six escaped segments on bare separator bytes (the
-	// escape rules guarantee segments contain no bare 0x00).
-	var segs [6][]byte
-	rest := tail
-	for i := 0; i < 5; i++ {
-		sep := bytes.IndexByte(rest, 0)
-		if sep < 0 {
-			return dst, false
-		}
-		segs[i] = rest[:sep] // #nosec G602 -- false positive: IndexByte returned >= 0 above, so sep < len(rest).
-		rest = rest[sep+1:]
-	}
-	if bytes.IndexByte(rest, 0) >= 0 {
-		return dst, false
-	}
-	segs[5] = rest
-
-	dst = append(dst, versionV3, typeIndex, idxGrantByPrincipal, 0)
-	for i, idx := range [6]int{4, 5, 0, 1, 2, 3} { // p_rt, p_id, ent_rt, ent_rid, ent_kind, ent_name
-		if i > 0 {
-			dst = append(dst, 0)
-		}
-		dst = append(dst, segs[idx]...)
-	}
-	return dst, true
-}
-
-// appendGrantByNeedsExpansionKeyFromPrimary builds the
-// by_needs_expansion index key directly from a primary grant key: the
-// primary's separator+tail IS the index key's tail, byte-identical
-// (pinned by TestNeedsExpansionKeyHeaderSpliceFromPrimary), so the
-// splice is a header swap. Validates the same 6-segment shape as the
-// by_principal splice so a malformed key cannot silently produce a
-// malformed index entry. Wired into rawdb's typed record ops
-// (RecordDerivers.GrantNeedsExpansionKey).
-func appendGrantByNeedsExpansionKeyFromPrimary(dst, primaryKey []byte) ([]byte, bool) {
-	if _, ok := splitGrantPrimaryKey(primaryKey); !ok {
-		return dst, false
-	}
-	dst = append(dst, versionV3, typeIndex, idxGrantByNeedsExpansion)
-	return append(dst, primaryKey[2:]...), true
-}
 
 // deferredGrantStats carries the grant-keyspace stats accumulated during the
 // BuildDeferredGrantIndexes scan: the same numbers computeSyncStats derives
@@ -441,7 +379,7 @@ func (e *Engine) buildDeferredGrantIndexesLocked(ctx context.Context) error {
 				rebuildScanErr = err
 			}
 		}
-		idxKey, ok := appendGrantByPrincipalKeyFromPrimary(idxKeyScratch[:0], iter.Key())
+		idxKey, ok := keys.AppendGrantByPrincipalKeyFromPrimary(idxKeyScratch[:0], iter.Key())
 		idxKeyScratch = idxKey
 		if !ok {
 			// Only possible on key-layout drift or corruption: every grant

--- a/pkg/dotc1z/engine/pebble/deferred_index_key_test.go
+++ b/pkg/dotc1z/engine/pebble/deferred_index_key_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
 )
 
 // TestAppendGrantByPrincipalKeyFromPrimary pins the raw-splice fast path to
@@ -45,13 +47,13 @@ func TestAppendGrantByPrincipalKeyFromPrimary(t *testing.T) {
 		require.True(t, ok, "%+v: decodeGrantIdentityKey failed", id)
 		want := encodeGrantByPrincipalIdentityIndexKey(decoded)
 
-		got, ok := appendGrantByPrincipalKeyFromPrimary(nil, primary)
+		got, ok := keys.AppendGrantByPrincipalKeyFromPrimary(nil, primary)
 		require.True(t, ok, "%+v: splice failed", id)
 		require.Equal(t, want, got, "%+v: spliced index key diverged from decode+re-encode", id)
 
 		// Scratch reuse must not change the output.
 		scratch := make([]byte, 0, 256)
-		got2, ok := appendGrantByPrincipalKeyFromPrimary(scratch[:0], primary)
+		got2, ok := keys.AppendGrantByPrincipalKeyFromPrimary(scratch[:0], primary)
 		require.True(t, ok)
 		require.Equal(t, want, got2)
 	}
@@ -99,7 +101,7 @@ func TestAppendGrantByPrincipalKeyFromPrimaryRejectsMalformed(t *testing.T) {
 		encodeGrantPrimaryEntitlementResourcePrefix("rt", "rid"),
 	}
 	for _, key := range cases {
-		_, ok := appendGrantByPrincipalKeyFromPrimary(nil, key)
+		_, ok := keys.AppendGrantByPrincipalKeyFromPrimary(nil, key)
 		require.Falsef(t, ok, "key %x: expected splice to reject malformed input", key)
 	}
 }

--- a/pkg/dotc1z/engine/pebble/deferred_index_key_test.go
+++ b/pkg/dotc1z/engine/pebble/deferred_index_key_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/rawdb"
 )
 
 // TestAppendGrantByPrincipalKeyFromPrimary pins the raw-splice fast path to
@@ -47,13 +47,13 @@ func TestAppendGrantByPrincipalKeyFromPrimary(t *testing.T) {
 		require.True(t, ok, "%+v: decodeGrantIdentityKey failed", id)
 		want := encodeGrantByPrincipalIdentityIndexKey(decoded)
 
-		got, ok := keys.AppendGrantByPrincipalKeyFromPrimary(nil, primary)
+		got, ok := rawdb.AppendGrantByPrincipalKeyFromPrimary(nil, primary)
 		require.True(t, ok, "%+v: splice failed", id)
 		require.Equal(t, want, got, "%+v: spliced index key diverged from decode+re-encode", id)
 
 		// Scratch reuse must not change the output.
 		scratch := make([]byte, 0, 256)
-		got2, ok := keys.AppendGrantByPrincipalKeyFromPrimary(scratch[:0], primary)
+		got2, ok := rawdb.AppendGrantByPrincipalKeyFromPrimary(scratch[:0], primary)
 		require.True(t, ok)
 		require.Equal(t, want, got2)
 	}
@@ -101,7 +101,7 @@ func TestAppendGrantByPrincipalKeyFromPrimaryRejectsMalformed(t *testing.T) {
 		encodeGrantPrimaryEntitlementResourcePrefix("rt", "rid"),
 	}
 	for _, key := range cases {
-		_, ok := keys.AppendGrantByPrincipalKeyFromPrimary(nil, key)
+		_, ok := rawdb.AppendGrantByPrincipalKeyFromPrimary(nil, key)
 		require.Falsef(t, ok, "key %x: expected splice to reject malformed input", key)
 	}
 }

--- a/pkg/dotc1z/engine/pebble/deferred_index_resume_test.go
+++ b/pkg/dotc1z/engine/pebble/deferred_index_resume_test.go
@@ -45,7 +45,7 @@ func TestDeferredIndexPendingSurvivesReopen(t *testing.T) {
 		}.Build())
 	}
 	require.NoError(t, a.Grants().StoreExpandedGrants(ctx, grants...))
-	require.True(t, e.deferredIdxPending.Load(), "expanded writes must arm the deferred index flag")
+	require.True(t, e.db.DeferredIdxPending(), "expanded writes must arm the deferred index flag")
 	require.NoError(t, e.Close())
 
 	// Process B: reopen, resume the same sync, write NOTHING (the idempotent
@@ -53,7 +53,7 @@ func TestDeferredIndexPendingSurvivesReopen(t *testing.T) {
 	e2, err := Open(ctx, dir)
 	require.NoError(t, err)
 	defer e2.Close()
-	require.True(t, e2.deferredIdxPending.Load(), "the pending marker must survive the reopen")
+	require.True(t, e2.db.DeferredIdxPending(), "the pending marker must survive the reopen")
 
 	a2 := NewAdapter(e2)
 	require.NoError(t, a2.SetCurrentSync(ctx, syncID))
@@ -74,5 +74,5 @@ func TestDeferredIndexPendingSurvivesReopen(t *testing.T) {
 	e3, err := Open(ctx, dir)
 	require.NoError(t, err)
 	defer e3.Close()
-	require.False(t, e3.deferredIdxPending.Load(), "a successful rebuild must clear the durable marker")
+	require.False(t, e3.db.DeferredIdxPending(), "a successful rebuild must clear the durable marker")
 }

--- a/pkg/dotc1z/engine/pebble/digest.go
+++ b/pkg/dotc1z/engine/pebble/digest.go
@@ -461,7 +461,7 @@ func (e *Engine) buildPartitionDigestAtWidth(ctx context.Context, spec digestInd
 		if err := batch.Commit(opts); err != nil {
 			return err
 		}
-		e.grantDigestsPresent.Store(true)
+		e.db.SetGrantDigestsPresent(true)
 		return nil
 	})
 }

--- a/pkg/dotc1z/engine/pebble/digest.go
+++ b/pkg/dotc1z/engine/pebble/digest.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/cockroachdb/pebble/v2"
 
-	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/rawdb"
 )
 
@@ -419,13 +418,13 @@ func (e *Engine) foldPartitionNodes(ctx context.Context, spec digestIndexSpec, p
 // Test-only today (no production caller). If a future production path
 // reuses this for the grant digest specifically, it MUST also either
 // invalidate or recompute the whole-file global root
-// (keys.GlobalGrantDigestNodeKey) alongside it:
+// (rawdb.GlobalGrantDigestNodeKey) alongside it:
 // RepairMissingGrantDigests's fast path trusts the global root's mere
 // presence to mean every partition is present and correct, and this
 // function rewrites one partition's content without touching that
 // root at all.
 func (e *Engine) buildPartitionDigestAtWidth(ctx context.Context, spec digestIndexSpec, partition string, widthBits int) error {
-	nodeLower := keys.DigestPartitionPrefix(spec.indexID, partition)
+	nodeLower := rawdb.DigestPartitionPrefix(spec.indexID, partition)
 	nodeUpper := upperBoundOf(nodeLower)
 
 	return e.withWrite(func() error {
@@ -755,6 +754,6 @@ func (e *Engine) dirtyPartitionBuckets(ctx context.Context, spec digestIndexSpec
 // under the present-means-exact contract, a mutated partition's digest
 // is simply MISSING until the next seal-time build recalculates it.
 func dropPartitionDigest(batch rawdb.Stager, spec digestIndexSpec, partition string) error {
-	lo := keys.DigestPartitionPrefix(spec.indexID, partition)
+	lo := rawdb.DigestPartitionPrefix(spec.indexID, partition)
 	return batch.DeleteRange(lo, upperBoundOf(lo))
 }

--- a/pkg/dotc1z/engine/pebble/digest.go
+++ b/pkg/dotc1z/engine/pebble/digest.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cockroachdb/pebble/v2"
 
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/rawdb"
 )
 
@@ -418,13 +419,13 @@ func (e *Engine) foldPartitionNodes(ctx context.Context, spec digestIndexSpec, p
 // Test-only today (no production caller). If a future production path
 // reuses this for the grant digest specifically, it MUST also either
 // invalidate or recompute the whole-file global root
-// (globalGrantDigestNodeKey) alongside it:
+// (keys.GlobalGrantDigestNodeKey) alongside it:
 // RepairMissingGrantDigests's fast path trusts the global root's mere
 // presence to mean every partition is present and correct, and this
 // function rewrites one partition's content without touching that
 // root at all.
 func (e *Engine) buildPartitionDigestAtWidth(ctx context.Context, spec digestIndexSpec, partition string, widthBits int) error {
-	nodeLower := encodeDigestPartitionPrefix(spec.indexID, partition)
+	nodeLower := keys.DigestPartitionPrefix(spec.indexID, partition)
 	nodeUpper := upperBoundOf(nodeLower)
 
 	return e.withWrite(func() error {
@@ -754,6 +755,6 @@ func (e *Engine) dirtyPartitionBuckets(ctx context.Context, spec digestIndexSpec
 // under the present-means-exact contract, a mutated partition's digest
 // is simply MISSING until the next seal-time build recalculates it.
 func dropPartitionDigest(batch rawdb.Stager, spec digestIndexSpec, partition string) error {
-	lo := encodeDigestPartitionPrefix(spec.indexID, partition)
+	lo := keys.DigestPartitionPrefix(spec.indexID, partition)
 	return batch.DeleteRange(lo, upperBoundOf(lo))
 }

--- a/pkg/dotc1z/engine/pebble/digest_test.go
+++ b/pkg/dotc1z/engine/pebble/digest_test.go
@@ -244,7 +244,7 @@ func TestGrantDigestIncludesExpandedGrants(t *testing.T) {
 	if err := e.PutExpandedGrantRecords(ctx, []*v3.GrantRecord{exp}); err != nil {
 		t.Fatalf("PutExpandedGrantRecords: %v", err)
 	}
-	if !e.deferredIdxPending.Load() {
+	if !e.db.DeferredIdxPending() {
 		t.Fatal("expected the expansion write to arm the deferred-index marker")
 	}
 	if err := a.EndSync(ctx); err != nil {
@@ -727,7 +727,7 @@ func TestGrantDigestZeroGrantRootsAtEndSync(t *testing.T) {
 	if err := e.PutGrantRecords(ctx, makeGrant("", "g1", "ent-with", "alice")); err != nil {
 		t.Fatalf("PutGrantRecords: %v", err)
 	}
-	if e.deferredIdxPending.Load() {
+	if e.db.DeferredIdxPending() {
 		t.Fatal("inline grant writes must not arm the deferred marker (precondition for this test)")
 	}
 	if err := a.EndSync(ctx); err != nil {

--- a/pkg/dotc1z/engine/pebble/digest_test.go
+++ b/pkg/dotc1z/engine/pebble/digest_test.go
@@ -13,7 +13,7 @@ import (
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
-	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/rawdb"
 )
 
 // putEnt writes an entitlement record whose external_id is the
@@ -91,7 +91,7 @@ func sealGrantDigests(t testing.TB, e *Engine) {
 // partitions and digested indexes) — i.e. everything callers of this
 // helper actually assert shapes about (root-only, root+leaves, ...).
 // It excludes the whole-file grant-digest global root (see
-// keys.GlobalGrantDigestNodeKey): that node lives in the same typeDigest
+// rawdb.GlobalGrantDigestNodeKey): that node lives in the same typeDigest
 // keyspace but is a single fold-of-everything summary the seal build
 // writes once per file, not a per-partition node, so counting it here
 // would throw off every existing "N nodes for this one entitlement"
@@ -153,7 +153,7 @@ func countKeyRangeTest(t testing.TB, e *Engine, lo, hi []byte) int {
 // partition.
 func entHashIndexRowCount(t testing.TB, e *Engine, entID string) int {
 	t.Helper()
-	prefix := keys.GrantHashIndexEntitlementPrefix(testEntPartition(entID))
+	prefix := rawdb.GrantHashIndexEntitlementPrefix(testEntPartition(entID))
 	return countKeyRangeTest(t, e, prefix, upperBoundOf(prefix))
 }
 
@@ -944,7 +944,7 @@ func TestHashIndexIsHashOrdered(t *testing.T) {
 	}
 	seedEntitlement(t, e, "ent-A", grants)
 
-	entPrefix := keys.GrantHashIndexEntitlementPrefix(testEntPartition("ent-A"))
+	entPrefix := rawdb.GrantHashIndexEntitlementPrefix(testEntPartition("ent-A"))
 	iter, err := e.db.NewIter(&pebble.IterOptions{LowerBound: entPrefix, UpperBound: upperBoundOf(entPrefix)})
 	if err != nil {
 		t.Fatal(err)
@@ -1324,7 +1324,7 @@ func TestSealRebuildDropsStaleIndexRows(t *testing.T) {
 	}
 	sealGrantDigests(t, e)
 
-	entPrefix := keys.GrantHashIndexEntitlementPrefix(testEntPartition("ent-A"))
+	entPrefix := rawdb.GrantHashIndexEntitlementPrefix(testEntPartition("ent-A"))
 	principals := map[string]bool{}
 	iter, err := e.db.NewIter(&pebble.IterOptions{LowerBound: entPrefix, UpperBound: upperBoundOf(entPrefix)})
 	if err != nil {

--- a/pkg/dotc1z/engine/pebble/digest_test.go
+++ b/pkg/dotc1z/engine/pebble/digest_test.go
@@ -523,7 +523,7 @@ func seedEntitlement(t testing.TB, e *Engine, entID string, grants []*v3.GrantRe
 	t.Helper()
 	ctx := context.Background()
 	syncID := ksuid.New().String()
-	if err := e.SetCurrentSync(syncID); err != nil {
+	if err := e.bindCurrentSync(syncID); err != nil {
 		t.Fatalf("SetCurrentSync: %v", err)
 	}
 	putEnt(t, e, ctx, entID)
@@ -552,7 +552,7 @@ func seedEntitlementAtWidth(t testing.TB, e *Engine, entID string, grants []*v3.
 	t.Helper()
 	ctx := context.Background()
 	syncID := ksuid.New().String()
-	if err := e.SetCurrentSync(syncID); err != nil {
+	if err := e.bindCurrentSync(syncID); err != nil {
 		t.Fatalf("SetCurrentSync: %v", err)
 	}
 	putEnt(t, e, ctx, entID)
@@ -1022,7 +1022,7 @@ func TestFusedFoldMatchesPartitionRebuild(t *testing.T) {
 	ctx := context.Background()
 	e, _ := newTestEngine(t)
 	syncID := ksuid.New().String()
-	if err := e.SetCurrentSync(syncID); err != nil {
+	if err := e.bindCurrentSync(syncID); err != nil {
 		t.Fatalf("SetCurrentSync: %v", err)
 	}
 	counts := map[string]int64{"ent-big": 600, "ent-small": 10, "ent-zero": 0}
@@ -1266,7 +1266,7 @@ func TestDigestPutInvalidatesOnlyTouchedPartition(t *testing.T) {
 	ctx := context.Background()
 	e, _ := newTestEngine(t)
 	syncID := ksuid.New().String()
-	if err := e.SetCurrentSync(syncID); err != nil {
+	if err := e.bindCurrentSync(syncID); err != nil {
 		t.Fatalf("SetCurrentSync: %v", err)
 	}
 	putEnt(t, e, ctx, "ent-A")
@@ -1365,7 +1365,7 @@ func TestGrantDigestSpillMerge(t *testing.T) {
 	ctx := context.Background()
 	e, _ := newTestEngine(t)
 	syncID := ksuid.New().String()
-	if err := e.SetCurrentSync(syncID); err != nil {
+	if err := e.bindCurrentSync(syncID); err != nil {
 		t.Fatalf("SetCurrentSync: %v", err)
 	}
 	// One big entitlement that will span many tiny runs, plus small
@@ -1496,7 +1496,7 @@ func TestDigestMissingRootWholeDirty(t *testing.T) {
 	// B holds the same grants but never builds a digest.
 	eb, _ := newTestEngine(t)
 	syncB := ksuid.New().String()
-	if err := eb.SetCurrentSync(syncB); err != nil {
+	if err := eb.bindCurrentSync(syncB); err != nil {
 		t.Fatal(err)
 	}
 	putEnt(t, eb, ctx, "ent-A")

--- a/pkg/dotc1z/engine/pebble/digest_test.go
+++ b/pkg/dotc1z/engine/pebble/digest_test.go
@@ -13,6 +13,7 @@ import (
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
 )
 
 // putEnt writes an entitlement record whose external_id is the
@@ -90,7 +91,7 @@ func sealGrantDigests(t testing.TB, e *Engine) {
 // partitions and digested indexes) — i.e. everything callers of this
 // helper actually assert shapes about (root-only, root+leaves, ...).
 // It excludes the whole-file grant-digest global root (see
-// globalGrantDigestNodeKey): that node lives in the same typeDigest
+// keys.GlobalGrantDigestNodeKey): that node lives in the same typeDigest
 // keyspace but is a single fold-of-everything summary the seal build
 // writes once per file, not a per-partition node, so counting it here
 // would throw off every existing "N nodes for this one entitlement"
@@ -152,7 +153,7 @@ func countKeyRangeTest(t testing.TB, e *Engine, lo, hi []byte) int {
 // partition.
 func entHashIndexRowCount(t testing.TB, e *Engine, entID string) int {
 	t.Helper()
-	prefix := encodeGrantByEntPrincHashEntPrefix(testEntPartition(entID))
+	prefix := keys.GrantHashIndexEntitlementPrefix(testEntPartition(entID))
 	return countKeyRangeTest(t, e, prefix, upperBoundOf(prefix))
 }
 
@@ -943,7 +944,7 @@ func TestHashIndexIsHashOrdered(t *testing.T) {
 	}
 	seedEntitlement(t, e, "ent-A", grants)
 
-	entPrefix := encodeGrantByEntPrincHashEntPrefix(testEntPartition("ent-A"))
+	entPrefix := keys.GrantHashIndexEntitlementPrefix(testEntPartition("ent-A"))
 	iter, err := e.db.NewIter(&pebble.IterOptions{LowerBound: entPrefix, UpperBound: upperBoundOf(entPrefix)})
 	if err != nil {
 		t.Fatal(err)
@@ -1323,7 +1324,7 @@ func TestSealRebuildDropsStaleIndexRows(t *testing.T) {
 	}
 	sealGrantDigests(t, e)
 
-	entPrefix := encodeGrantByEntPrincHashEntPrefix(testEntPartition("ent-A"))
+	entPrefix := keys.GrantHashIndexEntitlementPrefix(testEntPartition("ent-A"))
 	principals := map[string]bool{}
 	iter, err := e.db.NewIter(&pebble.IterOptions{LowerBound: entPrefix, UpperBound: upperBoundOf(entPrefix)})
 	if err != nil {

--- a/pkg/dotc1z/engine/pebble/endsync_repair_test.go
+++ b/pkg/dotc1z/engine/pebble/endsync_repair_test.go
@@ -14,7 +14,7 @@ import (
 
 	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
-	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/rawdb"
 )
 
 // capturingCore/newCapturingLogger let a test observe the zap messages
@@ -148,7 +148,7 @@ func TestEndSyncSecondCallTakesTargetedRepairPath(t *testing.T) {
 	// ent-B's digest nodes must be byte-identical to what the FIRST
 	// seal produced — proof the targeted repair never touched it.
 	afterSecondSeal := dumpDigestNodes(t, e)
-	entBPrefix := keys.DigestPartitionPrefix(grantDigestSpec.indexID, testEntPartition("ent-B"))
+	entBPrefix := rawdb.DigestPartitionPrefix(grantDigestSpec.indexID, testEntPartition("ent-B"))
 	for k, v := range afterFirstSeal {
 		if !bytesHasPrefix(k, entBPrefix) {
 			continue

--- a/pkg/dotc1z/engine/pebble/endsync_repair_test.go
+++ b/pkg/dotc1z/engine/pebble/endsync_repair_test.go
@@ -14,6 +14,7 @@ import (
 
 	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
 )
 
 // capturingCore/newCapturingLogger let a test observe the zap messages
@@ -147,7 +148,7 @@ func TestEndSyncSecondCallTakesTargetedRepairPath(t *testing.T) {
 	// ent-B's digest nodes must be byte-identical to what the FIRST
 	// seal produced — proof the targeted repair never touched it.
 	afterSecondSeal := dumpDigestNodes(t, e)
-	entBPrefix := encodeDigestPartitionPrefix(grantDigestSpec.indexID, testEntPartition("ent-B"))
+	entBPrefix := keys.DigestPartitionPrefix(grantDigestSpec.indexID, testEntPartition("ent-B"))
 	for k, v := range afterFirstSeal {
 		if !bytesHasPrefix(k, entBPrefix) {
 			continue

--- a/pkg/dotc1z/engine/pebble/engine.go
+++ b/pkg/dotc1z/engine/pebble/engine.go
@@ -644,6 +644,19 @@ func (e *Engine) CurrentDBSizeBytes() (int64, error) {
 		return 0, errors.New("pebble engine: db dir is empty")
 	}
 	pfs := e.fs()
+	// No-follow stat, matching main's filepath.WalkDir semantics: a
+	// symlink inside the DB dir must be skipped, not traversed (a link
+	// to a foreign directory would count files outside the DB; a
+	// self-link would loop). vfs.FS has no Lstat, so the default FS
+	// uses os.Lstat directly (allowlisted); MemFS cannot represent
+	// symlinks, so Stat is equivalent there (review finding, 2.5
+	// round).
+	stat := func(path string) (os.FileInfo, error) {
+		if pfs == vfs.Default {
+			return os.Lstat(path)
+		}
+		return pfs.Stat(path)
+	}
 	var walk func(dir string) (int64, error)
 	walk = func(dir string) (int64, error) {
 		names, err := pfs.List(dir)
@@ -653,7 +666,7 @@ func (e *Engine) CurrentDBSizeBytes() (int64, error) {
 		var total int64
 		for _, name := range names {
 			path := pfs.PathJoin(dir, name)
-			info, err := pfs.Stat(path)
+			info, err := stat(path)
 			if err != nil {
 				if errors.Is(err, fs.ErrNotExist) {
 					// Compaction can remove files mid-walk; skip.

--- a/pkg/dotc1z/engine/pebble/engine.go
+++ b/pkg/dotc1z/engine/pebble/engine.go
@@ -15,6 +15,8 @@ import (
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"google.golang.org/protobuf/proto"
 
+	v2pb "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	reader_v2 "github.com/conductorone/baton-sdk/pb/c1/reader/v2"
 	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/codec"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/rawdb"
@@ -36,6 +38,29 @@ type Engine struct {
 	dbDir      string
 	opts       *Options
 	pebbleOpts *pebble.Options
+
+	// Embedded Unimplemented stubs for the gRPC service surfaces the
+	// engine's connectorstore face (adapter.go / adapter_reader.go)
+	// implements partially. Each implemented method overrides the
+	// stub. GrantsReaderServiceServer is deliberately NOT stubbed: the
+	// engine implements it in full, and adapter_reader.go asserts the
+	// complete contract — re-adding the stub would make that assertion
+	// vacuous.
+	v2pb.UnimplementedResourceTypesServiceServer
+	reader_v2.UnimplementedResourceTypesReaderServiceServer
+	v2pb.UnimplementedResourcesServiceServer
+	reader_v2.UnimplementedResourcesReaderServiceServer
+	v2pb.UnimplementedEntitlementsServiceServer
+	reader_v2.UnimplementedEntitlementsReaderServiceServer
+	v2pb.UnimplementedGrantsServiceServer
+	reader_v2.UnimplementedSyncsReaderServiceServer
+
+	// lifecycleMu serializes the sync-lifecycle transitions
+	// (StartNewSync/ResumeSync/SetCurrentSync/CheckpointSync/EndSync),
+	// whose bodies are read-check-write sequences over the sync-run
+	// record + the currentSync binding. Formerly the Adapter layer's
+	// mutex; the record writes themselves ride the write barrier.
+	lifecycleMu sync.Mutex
 	// resolvedFS is rawdb's Open-time FS resolution (WithVFS override
 	// or vfs.Default), snapshotted so fs() stays valid after Close
 	// nils db — see fs().
@@ -341,7 +366,7 @@ func (e *Engine) Close() error {
 // use this value. Clears the freshSync flag — a bare SetCurrentSync
 // is conservative (treats the sync as resumable, so writes keep
 // fsync + read-before-write).
-func (e *Engine) SetCurrentSync(syncID string) error {
+func (e *Engine) bindCurrentSync(syncID string) error {
 	idBytes, err := codec.EncodeSyncID(syncID)
 	if err != nil {
 		return err
@@ -532,6 +557,19 @@ func (e *Engine) currentSyncBytes() []byte {
 	out := make([]byte, len(e.currentSync))
 	copy(out, e.currentSync)
 	return out
+}
+
+// CurrentSyncID returns the bound sync's id string, or "" when no sync
+// is bound. THE single source of truth for "which sync is open" — the
+// old Adapter-level syncRunState cache that shadowed it was deleted
+// (PR 2.6): lifecycle readers decode this binding, and everything else
+// about the open sync (step token, type, parent) is read from the
+// durable SyncRunRecord on demand, exactly like the SQLite engine's
+// row-backed reads.
+func (e *Engine) CurrentSyncID() string {
+	e.currentSyncMu.RLock()
+	defer e.currentSyncMu.RUnlock()
+	return codec.DecodeSyncID(e.currentSync)
 }
 
 // requireCurrentSync returns ErrNoCurrentSync unless a sync is bound

--- a/pkg/dotc1z/engine/pebble/engine.go
+++ b/pkg/dotc1z/engine/pebble/engine.go
@@ -663,34 +663,10 @@ func (e *Engine) CurrentDBSizeBytes() (int64, error) {
 	return total, nil
 }
 
-// DB returns the engine's rawdb handle — the write choke point's
-// EXPLICIT EXEMPTION SURFACE. Exported for the synccompactor/pebble
-// package, whose merge/fold/overlay machinery writes the record
-// keyspaces outside the engine's writeMu barrier (fenced by call
-// ordering: the merge completes before the store's save/CheckpointTo
-// runs — see the checkpointMu inventory). The handle is *MergeDB
-// (= rawdb.MergeView) — deliberately NARROWER than *rawdb.DB: it
-// carries only the reads, bulk range ops, and the FoldBatch
-// constructor (the compactor's raw record-write conduit, fenced to
-// pkg/synccompactor/pebble by meta-test), so an external caller
-// cannot reach typed record staging
-// (NewRecordBatch) or session/meta/digest writes outside the engine's
-// lifecycle barrier — not even by type assertion, since the concrete
-// view has nothing more to recover. The raw *pebble.DB stays
-// unreachable (UnsafeForTesting is runtime-gated to tests). Callers
-// must respect the engine's lifecycle; returns nil after Close.
-// Callers that write the entitlement keyspace through this handle
-// (ingests, excises) must call InvalidateBareIDLookups afterwards.
-func (e *Engine) DB() *MergeDB {
-	if e.db == nil {
-		return nil
-	}
-	return e.db.MergeView()
-}
-
 // InvalidateBareIDLookups invalidates the lazily built bare-id lookup
-// state (see lookup.go). Engine write paths call this internally; it is
-// exported for callers that mutate the keyspace through DB() directly.
+// state (see lookup.go). Engine write paths call this internally; it
+// is exported for callers that mutate the entitlement keyspace through
+// the merge surface (merge_surface.go) directly.
 func (e *Engine) InvalidateBareIDLookups() { e.noteEntitlementKeyspaceWrite() }
 
 // MigratedOnOpen reports whether this Open ran the in-place id-index

--- a/pkg/dotc1z/engine/pebble/engine.go
+++ b/pkg/dotc1z/engine/pebble/engine.go
@@ -243,7 +243,7 @@ func Open(ctx context.Context, dir string, opts ...Option) (*Engine, error) {
 		return nil, err
 	}
 	// Restore the durable deferred-index marker (see
-	// keys.DeferredIdxPendingKey): a prior process may have deferred
+	// rawdb.DeferredIdxPendingKey): a prior process may have deferred
 	// by_principal writes and been interrupted before the EndSync
 	// rebuild (rawdb owns the marker's crash contract).
 	if err := e.db.RestoreDeferredIdxPending(); err != nil {

--- a/pkg/dotc1z/engine/pebble/engine.go
+++ b/pkg/dotc1z/engine/pebble/engine.go
@@ -17,6 +17,7 @@ import (
 
 	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/codec"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/rawdb"
 )
 
@@ -245,15 +246,15 @@ func Open(ctx context.Context, dir string, opts ...Option) (*Engine, error) {
 	// armed probe, deferred-marker crash contract).
 	if err := db.SetRecordDerivers(rawdb.RecordDerivers{
 		GrantKeyValid: func(primaryKey []byte) bool {
-			_, ok := splitGrantPrimaryKey(primaryKey)
+			_, ok := keys.SplitGrantPrimaryKey(primaryKey)
 			return ok
 		},
-		GrantByPrincipalKey:          appendGrantByPrincipalKeyFromPrimary,
-		GrantNeedsExpansionKey:       appendGrantByNeedsExpansionKeyFromPrimary,
+		GrantByPrincipalKey:          keys.AppendGrantByPrincipalKeyFromPrimary,
+		GrantNeedsExpansionKey:       keys.AppendGrantByNeedsExpansionKeyFromPrimary,
 		StageGrantDigestInvalidation: e.stageGrantDigestInvalidationFromPrimaryKey,
 		ArmDeferredGrantIndex:        e.markDeferredIdxPending,
-		ResourceParent:               scanResourceParentRaw,
-		ResourceByParentKey:          encodeResourceByParentIndexKey,
+		ResourceParent:               keys.ScanResourceParentRaw,
+		ResourceByParentKey:          keys.EncodeResourceByParentIndexKey,
 		GrantPrimaryPrefix:           []byte{versionV3, typeGrant},
 		ResourcePrimaryPrefix:        []byte{versionV3, typeResource},
 		EntitlementPrimaryPrefix:     []byte{versionV3, typeEntitlement},

--- a/pkg/dotc1z/engine/pebble/engine.go
+++ b/pkg/dotc1z/engine/pebble/engine.go
@@ -17,7 +17,6 @@ import (
 
 	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/codec"
-	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/rawdb"
 )
 
@@ -89,18 +88,11 @@ type Engine struct {
 	deferredGrantStatsMu sync.Mutex
 	deferredGrantStats   *deferredGrantStats
 
-	// deferredIdxPending is set by grant writes that skipped the inline
-	// by_principal index write (all of them: the index family is scattered
-	// relative to the entitlement-first write order, so it is always built
-	// as one sorted SST at EndSync — see BuildDeferredGrantIndexes).
-	deferredIdxPending atomic.Bool
-
-	// grantDigestsPresent reports whether the digest keyspace holds any
-	// nodes — i.e. whether a grant mutation must invalidate the touched
-	// entitlement's digest + hash-index ranges
-	// (stageGrantDigestInvalidation). Probed once at Open, set by the
-	// seal-time build, cleared by ResetForNewSync and the Drop* paths.
-	grantDigestsPresent atomic.Bool
+	// The deferred-index rebuild flag and the digests-present flag live
+	// ON rawdb (e.db.DeferredIdxPending / e.db.GrantDigestsPresent):
+	// they are write-side crash-contract state the choke point's typed
+	// record ops consume directly (the deferred regime arms the marker;
+	// the digest-invalidation obligation gates on presence).
 
 	// grantDigestBuildPending mirrors the durable digest-build marker
 	// (encodeGrantDigestBuildPendingKey): true between a digest build's
@@ -237,32 +229,6 @@ func Open(ctx context.Context, dir string, opts ...Option) (*Engine, error) {
 	if s, ok := pebbleOpts.Experimental.CompactionScheduler.(*pausableCompactionScheduler); ok {
 		e.compactionScheduler = s
 	}
-	// Wire the record derivers: the key-format functions rawdb's typed
-	// record ops (StageGrant*/StageResource*/...) derive their
-	// obligations with. rawdb owns the composition — WHAT a record
-	// mutation must stage together, unforgettable by construction — and
-	// these closures own the byte formats (this package's keyspace ABI,
-	// pinned by its splice tests) plus the engine-state gates (digest
-	// armed probe, deferred-marker crash contract).
-	if err := db.SetRecordDerivers(rawdb.RecordDerivers{
-		GrantKeyValid: func(primaryKey []byte) bool {
-			_, ok := keys.SplitGrantPrimaryKey(primaryKey)
-			return ok
-		},
-		GrantByPrincipalKey:          keys.AppendGrantByPrincipalKeyFromPrimary,
-		GrantNeedsExpansionKey:       keys.AppendGrantByNeedsExpansionKeyFromPrimary,
-		StageGrantDigestInvalidation: e.stageGrantDigestInvalidationFromPrimaryKey,
-		ArmDeferredGrantIndex:        e.markDeferredIdxPending,
-		ResourceParent:               keys.ScanResourceParentRaw,
-		ResourceByParentKey:          keys.EncodeResourceByParentIndexKey,
-		GrantPrimaryPrefix:           []byte{versionV3, typeGrant},
-		ResourcePrimaryPrefix:        []byte{versionV3, typeResource},
-		EntitlementPrimaryPrefix:     []byte{versionV3, typeEntitlement},
-		ResourceTypePrimaryPrefix:    []byte{versionV3, typeResourceType},
-	}); err != nil {
-		_ = e.Close()
-		return nil, err
-	}
 	// Enforce the single-sync key-layout contract before touching any
 	// keys: reject an old multi-sync-layout file (which the current
 	// encoders would silently mis-decode) and stamp a fresh writable
@@ -277,12 +243,10 @@ func Open(ctx context.Context, dir string, opts ...Option) (*Engine, error) {
 		return nil, err
 	}
 	// Restore the durable deferred-index marker (see
-	// encodeDeferredIdxPendingKey): a prior process may have deferred
-	// by_principal writes and been interrupted before the EndSync rebuild.
-	if _, closer, err := e.db.Get(encodeDeferredIdxPendingKey()); err == nil {
-		closer.Close()
-		e.deferredIdxPending.Store(true)
-	} else if !errors.Is(err, pebble.ErrNotFound) {
+	// keys.DeferredIdxPendingKey): a prior process may have deferred
+	// by_principal writes and been interrupted before the EndSync
+	// rebuild (rawdb owns the marker's crash contract).
+	if err := e.db.RestoreDeferredIdxPending(); err != nil {
 		_ = e.Close()
 		return nil, err
 	}
@@ -310,8 +274,9 @@ func Open(ctx context.Context, dir string, opts ...Option) (*Engine, error) {
 		return nil, err
 	}
 	// Arm the mutation-path digest invalidation iff the file actually
-	// holds digest nodes (one bounded seek; see grant_digest.go).
-	if err := e.probeGrantDigestsPresent(); err != nil {
+	// holds digest nodes (one bounded seek; rawdb owns the flag its
+	// record ops gate on).
+	if err := e.db.ProbeGrantDigestsPresent(); err != nil {
 		_ = e.Close()
 		return nil, err
 	}

--- a/pkg/dotc1z/engine/pebble/engine.go
+++ b/pkg/dotc1z/engine/pebble/engine.go
@@ -634,28 +634,49 @@ func (e *Engine) DBDir() string {
 // database directory. This is the Pebble equivalent of C1File's SQLite
 // DBSizeProvider capability: it reports the uncompressed working set on disk,
 // including WAL/log, MANIFEST, OPTIONS, and SST files currently present.
+//
+// Walks through the engine FS, not the host FS (review follow-up): a
+// WithVFS engine's DB dir lives on the injected filesystem, where a
+// host filepath.WalkDir either errors or measures an unrelated
+// directory. On the default FS this is the same walk it always was.
 func (e *Engine) CurrentDBSizeBytes() (int64, error) {
 	if e.dbDir == "" {
 		return 0, errors.New("pebble engine: db dir is empty")
 	}
-	var total int64
-	if err := filepath.WalkDir(e.dbDir, func(path string, d fs.DirEntry, err error) error {
+	pfs := e.fs()
+	var walk func(dir string) (int64, error)
+	walk = func(dir string) (int64, error) {
+		names, err := pfs.List(dir)
 		if err != nil {
-			return err
+			return 0, err
 		}
-		if d.IsDir() {
-			return nil
+		var total int64
+		for _, name := range names {
+			path := pfs.PathJoin(dir, name)
+			info, err := pfs.Stat(path)
+			if err != nil {
+				if errors.Is(err, fs.ErrNotExist) {
+					// Compaction can remove files mid-walk; skip.
+					continue
+				}
+				return 0, fmt.Errorf("stat %s: %w", path, err)
+			}
+			switch {
+			case info.IsDir():
+				sub, err := walk(path)
+				if err != nil {
+					return 0, err
+				}
+				total += sub
+			case info.Mode().IsRegular():
+				total += info.Size()
+			}
 		}
-		info, err := d.Info()
-		if err != nil {
-			return fmt.Errorf("stat %s: %w", path, err)
-		}
-		if info.Mode().IsRegular() {
-			total += info.Size()
-		}
-		return nil
-	}); err != nil {
-		if os.IsNotExist(err) {
+		return total, nil
+	}
+	total, err := walk(e.dbDir)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
 			return 0, fmt.Errorf("pebble engine: db dir missing: %w", err)
 		}
 		return 0, err

--- a/pkg/dotc1z/engine/pebble/engine_test.go
+++ b/pkg/dotc1z/engine/pebble/engine_test.go
@@ -98,7 +98,7 @@ func TestEngineCurrentDBSizeBytes(t *testing.T) {
 	require.Equal(t, want, initial, "CurrentDBSizeBytes initial")
 
 	syncID := ksuid.New().String()
-	require.NoError(t, e.SetCurrentSync(syncID))
+	require.NoError(t, e.bindCurrentSync(syncID))
 	for i := 0; i < 50; i++ {
 		err := e.PutGrantRecord(ctx, makeGrant(syncID, ksuid.New().String(), "github-read", ksuid.New().String()))
 		require.NoError(t, err, "PutGrantRecord")
@@ -116,7 +116,7 @@ func TestPutGetGrantRecord(t *testing.T) {
 	e, _ := newTestEngine(t)
 
 	syncID := ksuid.New().String()
-	require.NoError(t, e.SetCurrentSync(syncID))
+	require.NoError(t, e.bindCurrentSync(syncID))
 
 	// Custom stored external id: addressable only by identity, not by the
 	// concat id string (which no longer equals the stored public id).
@@ -141,7 +141,7 @@ func TestIterateGrantsBySync(t *testing.T) {
 	ctx := context.Background()
 	e, _ := newTestEngine(t)
 	syncID := ksuid.New().String()
-	require.NoError(t, e.SetCurrentSync(syncID))
+	require.NoError(t, e.bindCurrentSync(syncID))
 
 	const n = 100
 	for i := 0; i < n; i++ {
@@ -166,7 +166,7 @@ func TestIterateByEntitlement(t *testing.T) {
 	ctx := context.Background()
 	e, _ := newTestEngine(t)
 	syncID := ksuid.New().String()
-	require.NoError(t, e.SetCurrentSync(syncID))
+	require.NoError(t, e.bindCurrentSync(syncID))
 
 	// 5 grants on entitlement A, 3 on entitlement B.
 	for i := 0; i < 5; i++ {
@@ -197,7 +197,7 @@ func TestIterateByPrincipal(t *testing.T) {
 	ctx := context.Background()
 	e, _ := newTestEngine(t)
 	syncID := ksuid.New().String()
-	require.NoError(t, e.SetCurrentSync(syncID))
+	require.NoError(t, e.bindCurrentSync(syncID))
 
 	const alicePrincipal = "alice"
 	const bobPrincipal = "bob"
@@ -231,7 +231,7 @@ func TestDeleteGrantRecord(t *testing.T) {
 	ctx := context.Background()
 	e, _ := newTestEngine(t)
 	syncID := ksuid.New().String()
-	require.NoError(t, e.SetCurrentSync(syncID))
+	require.NoError(t, e.bindCurrentSync(syncID))
 
 	r := makeGrant(syncID, canonicalTestGrantID("ent-X", "user", "user-X"), "ent-X", "user-X")
 	require.NoError(t, e.PutGrantRecord(ctx, r))
@@ -255,7 +255,7 @@ func TestCheckpointToReadOnly(t *testing.T) {
 	ctx := context.Background()
 	e, dir := newTestEngine(t)
 	syncID := ksuid.New().String()
-	require.NoError(t, e.SetCurrentSync(syncID))
+	require.NoError(t, e.bindCurrentSync(syncID))
 	r := makeGrant(syncID, canonicalTestGrantID("e1", "user", "p1"), "e1", "p1")
 	require.NoError(t, e.PutGrantRecord(ctx, r))
 	require.NoError(t, e.Close())
@@ -281,7 +281,7 @@ func TestCheckpointTo(t *testing.T) {
 	ctx := context.Background()
 	e, dir := newTestEngine(t)
 	syncID := ksuid.New().String()
-	require.NoError(t, e.SetCurrentSync(syncID))
+	require.NoError(t, e.bindCurrentSync(syncID))
 
 	r := makeGrant(syncID, canonicalTestGrantID("e1", "user", "p1"), "e1", "p1")
 	require.NoError(t, e.PutGrantRecord(ctx, r))
@@ -307,7 +307,7 @@ func TestSaveDoesNotCloseOnError(t *testing.T) {
 	ctx := context.Background()
 	e, dir := newTestEngine(t)
 	syncID := ksuid.New().String()
-	err := e.SetCurrentSync(syncID)
+	err := e.bindCurrentSync(syncID)
 	require.NoError(t, err)
 
 	err = e.Save(ctx, filepath.Join(dir, "out.c1z3"))
@@ -322,7 +322,7 @@ func TestConcurrentGrantOverwriteIndexes(t *testing.T) {
 	ctx := context.Background()
 	e, _ := newTestEngine(t)
 	syncID := ksuid.New().String()
-	err := e.SetCurrentSync(syncID)
+	err := e.bindCurrentSync(syncID)
 	require.NoError(t, err)
 
 	const writes = 64
@@ -364,7 +364,7 @@ func TestEmptySyncIDFallsBackToCurrent(t *testing.T) {
 	ctx := context.Background()
 	e, _ := newTestEngine(t)
 	syncID := ksuid.New().String()
-	require.NoError(t, e.SetCurrentSync(syncID))
+	require.NoError(t, e.bindCurrentSync(syncID))
 
 	// Put with explicit sync id...
 	sdkID := canonicalTestGrantID("e1", "user", "p1")

--- a/pkg/dotc1z/engine/pebble/engine_test.go
+++ b/pkg/dotc1z/engine/pebble/engine_test.go
@@ -3,6 +3,7 @@ package pebble
 import (
 	"context"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -28,6 +29,17 @@ func newTestEngine(t testing.TB, opts ...Option) (*Engine, string) {
 	return e, dir
 }
 
+// regularFileSizeUnder is the independent oracle for
+// CurrentDBSizeBytes: a walk-and-sum over regular files. It MUST stat
+// through os.Lstat — the same mechanism production uses — not
+// WalkDir's DirEntry.Info: on Windows the two read different size
+// views of a file with an open write handle (DirEntry.Info comes from
+// FindFirstFile directory metadata; Lstat's GetFileAttributesEx fast
+// path lags it), and pebble's active WAL is exactly such a file, so a
+// mixed-mechanism comparison diverges by however much WAL the sync
+// appended (caught by Windows CI). Same-mechanism sides make the
+// comparison OS-independent while still independently checking the
+// recursion, the regular-file filter, and the summing.
 func regularFileSizeUnder(t *testing.T, dir string) int64 {
 	t.Helper()
 	var total int64
@@ -38,7 +50,7 @@ func regularFileSizeUnder(t *testing.T, dir string) int64 {
 		if d.IsDir() {
 			return nil
 		}
-		info, err := d.Info()
+		info, err := os.Lstat(path)
 		if err != nil {
 			return err
 		}

--- a/pkg/dotc1z/engine/pebble/entitlement_stats_test.go
+++ b/pkg/dotc1z/engine/pebble/entitlement_stats_test.go
@@ -55,7 +55,7 @@ func TestSidecarEntitlementsByResourceType(t *testing.T) {
 	require.Equal(t, int64(3), stats.GetEntitlements(), "entitlements total")
 	require.Equal(t, map[string]int64{"group": 2, "user": 1}, stats.GetEntitlementsByResourceType())
 
-	_ = store.Close(ctx)
+	_ = store.Close()
 }
 
 // TestBulkImportComputedStatsEntitlementsByResourceType exercises the

--- a/pkg/dotc1z/engine/pebble/errorfs_sweep_test.go
+++ b/pkg/dotc1z/engine/pebble/errorfs_sweep_test.go
@@ -651,7 +651,7 @@ func buildSweepBaseline(ctx context.Context, t *testing.T, w sweepWorkload, cach
 	syncID, err := a.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
 	require.NoError(t, err)
 	require.NoError(t, w.write(ctx, a))
-	require.True(t, e.deferredIdxPending.Load(), "grant writes must arm the deferred index rebuild")
+	require.True(t, e.db.DeferredIdxPending(), "grant writes must arm the deferred index rebuild")
 	require.NoError(t, e.Close())
 	return fs, syncID
 }
@@ -847,7 +847,7 @@ func TestEndSyncStampDurabilityCarriesPages(t *testing.T) {
 		gs = append(gs, mkV2Grant("", "ent-00", "user", p))
 	}
 	require.NoError(t, a.PutGrants(ctx, gs...))
-	require.False(t, e.deferredIdxPending.Load(), "inline-only pages must not arm the deferred marker (isolation precondition)")
+	require.False(t, e.db.DeferredIdxPending(), "inline-only pages must not arm the deferred marker (isolation precondition)")
 
 	var image *vfs.MemFS
 	e.test.endSyncPreFlushHook = func() {

--- a/pkg/dotc1z/engine/pebble/grant_digest.go
+++ b/pkg/dotc1z/engine/pebble/grant_digest.go
@@ -13,7 +13,7 @@ import (
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/codec"
-	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/rawdb"
 )
 
 // Grant instantiation of the digest core (digest.go): the per-
@@ -39,13 +39,13 @@ import (
 // framing, while letting the seal-time build run allocation-free.
 
 // grantDigestSpec wires the grant hash index into the digest core. The
-// index's key layout (see keys.GrantHashIndexEntitlementPrefix) satisfies
+// index's key layout (see rawdb.GrantHashIndexEntitlementPrefix) satisfies
 // the digestIndexSpec shape contract: partition prefix, then the raw
 // digestBucketHashLen-byte bucket hash, then the principal tail; the
 // value is the grant content hash.
 var grantDigestSpec = digestIndexSpec{
 	indexID:         idxGrantByEntitlementPrincipalHash,
-	partitionPrefix: keys.GrantHashIndexEntitlementPrefix,
+	partitionPrefix: rawdb.GrantHashIndexEntitlementPrefix,
 }
 
 // GrantDigestABIVersion is the version of the content-hash / bucket-hash
@@ -62,8 +62,8 @@ var grantDigestSpec = digestIndexSpec{
 const GrantDigestABIVersion uint32 = 1
 
 // The whole-file grant digest root's node-key level lives in
-// internal/keys (keys.DigestLevelGlobalRoot, consumed by
-// keys.GlobalGrantDigestNodeKey): the XOR fold of every
+// internal/keys (rawdb.DigestLevelGlobalRoot, consumed by
+// rawdb.GlobalGrantDigestNodeKey): the XOR fold of every
 // per-entitlement root's digest, plus the total grant count, across
 // the whole sync. It is NOT part of the generic digest.go core (which
 // only knows about per-partition roots/leaves at digestLevelRoot /
@@ -280,7 +280,7 @@ func sortByteSlices(s [][]byte) {
 
 // grantPrimaryKeyPrefixLen is the byte length of the grant primary-key
 // header: versionV3 | typeGrant | separator.
-const grantPrimaryKeyPrefixLen = keys.GrantPrimaryKeyPrefixLen
+const grantPrimaryKeyPrefixLen = rawdb.GrantPrimaryKeyPrefixLen
 
 // grantHashIndexKeyPrefixLen is the byte length of the hash-index key
 // header: versionV3 | typeIndex | idxGrantByEntitlementPrincipalHash |
@@ -296,9 +296,9 @@ const grantHashIndexKeyPrefixLen = 4
 //
 // The segments are already escaped and the tuple encoding is
 // canonical, so the raw byte splice is byte-identical to
-// decode + re-encode (same trick as keys.AppendGrantByPrincipalKeyFromPrimary,
+// decode + re-encode (same trick as rawdb.AppendGrantByPrincipalKeyFromPrimary,
 // pinned by TestGrantDigestSpliceMatchesEncode). sep4 must come from
-// keys.SplitGrantPrimaryKey on the same key.
+// rawdb.SplitGrantPrimaryKey on the same key.
 func appendGrantHashIndexKeyFromPrimary(dst, primaryKey []byte, sep4 int, bucketHash64 uint64) []byte {
 	var bh [8]byte
 	binary.BigEndian.PutUint64(bh[:], bucketHash64)
@@ -314,7 +314,7 @@ func appendGrantHashIndexKeyFromPrimary(dst, primaryKey []byte, sep4 int, bucket
 // hash-index entries. The hash bytes may contain 0x00, so the 4th
 // separator is found by counting separators from the LEFT (the walk
 // never crosses the hash region — see the positional-decoding note on
-// keys.GrantHashIndexEntitlementPrefix).
+// rawdb.GrantHashIndexEntitlementPrefix).
 func grantPrimaryKeyFromHashIndexKey(dst, idxKey []byte) ([]byte, bool) {
 	if len(idxKey) < grantHashIndexKeyPrefixLen ||
 		idxKey[0] != versionV3 || idxKey[1] != typeIndex ||
@@ -369,7 +369,7 @@ func (e *Engine) GetGrantDigestGlobalRoot(ctx context.Context) (DigestRoot, bool
 		// hash index that was never ingested.
 		return DigestRoot{}, false, nil
 	}
-	val, closer, err := e.db.Get(keys.GlobalGrantDigestNodeKey())
+	val, closer, err := e.db.Get(rawdb.GlobalGrantDigestNodeKey())
 	if err != nil {
 		if errors.Is(err, pebble.ErrNotFound) {
 			return DigestRoot{}, false, nil

--- a/pkg/dotc1z/engine/pebble/grant_digest.go
+++ b/pkg/dotc1z/engine/pebble/grant_digest.go
@@ -14,7 +14,6 @@ import (
 	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/codec"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
-	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/rawdb"
 )
 
 // Grant instantiation of the digest core (digest.go): the per-
@@ -460,7 +459,7 @@ func (e *Engine) IterateGrantsByEntitlementBucket(ctx context.Context, id entitl
 // successful seal recalculates them.
 func (e *Engine) DropAllGrantDigests(ctx context.Context) error {
 	return e.withWrite(func() error {
-		e.grantDigestsPresent.Store(false)
+		e.db.SetGrantDigestsPresent(false)
 		return e.db.DropKeyRange(DigestLowerBound(), DigestUpperBound(), writeOpts(e.opts.durability))
 	})
 }
@@ -477,7 +476,7 @@ func (e *Engine) DropAllGrantDigests(ctx context.Context) error {
 // them), so this must never be collapsed into one span.
 func (e *Engine) DropAllGrantDigestState(ctx context.Context) error {
 	return e.withWrite(func() error {
-		e.grantDigestsPresent.Store(false)
+		e.db.SetGrantDigestsPresent(false)
 		opts := writeOpts(e.opts.durability)
 		if err := e.db.DropKeyRange(DigestLowerBound(), DigestUpperBound(), opts); err != nil {
 			return err
@@ -486,70 +485,10 @@ func (e *Engine) DropAllGrantDigestState(ctx context.Context) error {
 	})
 }
 
-// stageGrantDigestInvalidation stages the post-seal invalidation for
-// one entitlement into batch: DeleteRange over the entitlement's
-// digest partition (present-means-exact — a mutated partition's digest
-// must read as missing, see digest.go) AND over its hash-index range
-// (the index is derived at seal and is equally stale after a
-// mutation). v1 never updates either in place.
-//
-// Gated on grantDigestsPresent so the ordinary sync paths pay nothing:
-// during a fresh sync both keyspaces are empty by construction
-// (ResetForNewSync wiped them; only the seal build writes them), and a
-// resumed unfinished sync never built them — emitting two range
-// tombstones per record there (e.g. PutExpandedGrantRecords over
-// millions of grants) would bloat the LSM for no reason. The flag is
-// true only when digests actually exist: probed once at Open, set by
-// the seal build, cleared by ResetForNewSync and the Drop* paths.
-// stageGrantDigestInvalidationFromPrimaryKey is the KEY-DERIVED form
-// wired into rawdb's typed record ops (RecordDerivers): the partition
-// is the entitlement region of the grant primary key, a plain
-// sub-slice (see keys.SplitGrantPrimaryKey) that is byte-identical to
-// digestPartitionForEntitlement of the decoded identity — the key IS
-// the identity encoding. Same armed gate as the identity form.
-func (e *Engine) stageGrantDigestInvalidationFromPrimaryKey(st rawdb.Stager, primaryKey []byte) error {
-	if !e.grantDigestsPresent.Load() {
-		return nil
-	}
-	sep4, ok := keys.SplitGrantPrimaryKey(primaryKey)
-	if !ok {
-		// Fail closed: a record that reached a typed op already carried
-		// a well-formed identity key; swallowing would leave a
-		// stale-but-present digest (violates present-means-exact).
-		return fmt.Errorf("digest invalidation: grant key %x did not decode as a 6-segment identity", primaryKey)
-	}
-	return stageGrantDigestInvalidationForPartition(st, string(primaryKey[grantPrimaryKeyPrefixLen:sep4]))
-}
-
-func stageGrantDigestInvalidationForPartition(batch rawdb.Stager, partition string) error {
-	if err := dropPartitionDigest(batch, grantDigestSpec, partition); err != nil {
-		return err
-	}
-	// The whole-file root is the fold of every partition's root; once
-	// one partition's digest is invalidated the aggregate is stale too,
-	// so it must drop alongside it rather than linger looking present
-	// (present-means-exact — digest.go).
-	if err := batch.Delete(keys.GlobalGrantDigestNodeKey()); err != nil {
-		return err
-	}
-	lo := keys.GrantHashIndexEntitlementPrefix(partition)
-	return batch.DeleteRange(lo, upperBoundOf(lo))
-}
-
-// probeGrantDigestsPresent initializes the digests-present flag at
-// Open: one bounded seek over the digest keyspace. Present digests on
-// a reopened sealed file arm the mutation-path invalidation
-// (stageGrantDigestInvalidation); absent digests keep those paths
-// tombstone-free.
-func (e *Engine) probeGrantDigestsPresent() error {
-	iter, err := e.db.NewIter(&pebble.IterOptions{
-		LowerBound: DigestLowerBound(),
-		UpperBound: DigestUpperBound(),
-	})
-	if err != nil {
-		return err
-	}
-	defer iter.Close()
-	e.grantDigestsPresent.Store(iter.First())
-	return iter.Error()
-}
+// The per-record digest-invalidation obligation (partition nodes +
+// whole-file root + hash-index range, present-means-exact) lives in
+// rawdb itself (RecordBatch.stageGrantDigestInvalidation), KEY-DERIVED
+// from the grant primary key and gated on the digests-present flag.
+// The engine-side batch form for callers that invalidate MANY named
+// partitions at once is InvalidateGrantDigestPartitions (repair /
+// compaction), which hoists the global-root delete out of the loop.

--- a/pkg/dotc1z/engine/pebble/grant_digest.go
+++ b/pkg/dotc1z/engine/pebble/grant_digest.go
@@ -13,6 +13,7 @@ import (
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/codec"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/rawdb"
 )
 
@@ -39,13 +40,13 @@ import (
 // framing, while letting the seal-time build run allocation-free.
 
 // grantDigestSpec wires the grant hash index into the digest core. The
-// index's key layout (see encodeGrantByEntPrincHashEntPrefix) satisfies
+// index's key layout (see keys.GrantHashIndexEntitlementPrefix) satisfies
 // the digestIndexSpec shape contract: partition prefix, then the raw
 // digestBucketHashLen-byte bucket hash, then the principal tail; the
 // value is the grant content hash.
 var grantDigestSpec = digestIndexSpec{
 	indexID:         idxGrantByEntitlementPrincipalHash,
-	partitionPrefix: encodeGrantByEntPrincHashEntPrefix,
+	partitionPrefix: keys.GrantHashIndexEntitlementPrefix,
 }
 
 // GrantDigestABIVersion is the version of the content-hash / bucket-hash
@@ -61,8 +62,9 @@ var grantDigestSpec = digestIndexSpec{
 // can check a stored root's abi_version before comparing.
 const GrantDigestABIVersion uint32 = 1
 
-// digestLevelGlobalRoot is the node-key level for the whole-file grant
-// digest root (see globalGrantDigestNodeKey): the XOR fold of every
+// The whole-file grant digest root's node-key level lives in
+// internal/keys (keys.DigestLevelGlobalRoot, consumed by
+// keys.GlobalGrantDigestNodeKey): the XOR fold of every
 // per-entitlement root's digest, plus the total grant count, across
 // the whole sync. It is NOT part of the generic digest.go core (which
 // only knows about per-partition roots/leaves at digestLevelRoot /
@@ -70,16 +72,6 @@ const GrantDigestABIVersion uint32 = 1
 // specific manifest need, so a level value the core never produces
 // keeps the global node's key disjoint from every per-partition node
 // regardless of what any entitlement's partition bytes happen to be.
-const digestLevelGlobalRoot byte = 2
-
-// globalGrantDigestNodeKey returns the storage key for the whole-file
-// grant digest root: a level-digestLevelGlobalRoot node under an empty
-// partition. Its value is packed exactly like a leaf (packDigestLeaf /
-// unpackDigestLeaf: count(8 BE) || digest(hashLen)) — there is no
-// bucket-width concept for a whole-sync aggregate.
-func globalGrantDigestNodeKey() []byte {
-	return encodeDigestNodeKey(grantDigestSpec.indexID, "", digestLevelGlobalRoot, nil)
-}
 
 // digestPartitionForEntitlement returns the digest partition for an
 // entitlement identity: its encoded primary-key tail as a string (see
@@ -289,47 +281,12 @@ func sortByteSlices(s [][]byte) {
 
 // grantPrimaryKeyPrefixLen is the byte length of the grant primary-key
 // header: versionV3 | typeGrant | separator.
-const grantPrimaryKeyPrefixLen = 3
+const grantPrimaryKeyPrefixLen = keys.GrantPrimaryKeyPrefixLen
 
 // grantHashIndexKeyPrefixLen is the byte length of the hash-index key
 // header: versionV3 | typeIndex | idxGrantByEntitlementPrincipalHash |
 // separator.
 const grantHashIndexKeyPrefixLen = 4
-
-// splitGrantPrimaryKey locates the partition/principal boundary of a
-// grant primary key: the byte offset of the 4th tuple separator in the
-// key (the one that ends the entitlement's 4 identity segments). It
-// also validates the overall 6-segment shape, exactly like
-// appendGrantByPrincipalKeyFromPrimary. Returns ok=false for keys that
-// are not well-formed 6-segment grant identities.
-//
-// With the returned sep4 in hand every region is a plain sub-slice:
-//
-//	partition          = key[grantPrimaryKeyPrefixLen:sep4]
-//	principal segments = key[sep4+1:]
-func splitGrantPrimaryKey(primaryKey []byte) (int, bool) {
-	if len(primaryKey) < grantPrimaryKeyPrefixLen ||
-		primaryKey[0] != versionV3 || primaryKey[1] != typeGrant || primaryKey[2] != 0 {
-		return 0, false
-	}
-	sep4 := 0
-	off := grantPrimaryKeyPrefixLen
-	for i := range 5 {
-		sep := bytes.IndexByte(primaryKey[off:], 0)
-		if sep < 0 {
-			return 0, false
-		}
-		off += sep
-		if i == 3 {
-			sep4 = off
-		}
-		off++
-	}
-	if bytes.IndexByte(primaryKey[off:], 0) >= 0 {
-		return 0, false
-	}
-	return sep4, true
-}
 
 // appendGrantHashIndexKeyFromPrimary builds the
 // by_entitlement_principal_hash index key by SPLICING a grant primary
@@ -340,9 +297,9 @@ func splitGrantPrimaryKey(primaryKey []byte) (int, bool) {
 //
 // The segments are already escaped and the tuple encoding is
 // canonical, so the raw byte splice is byte-identical to
-// decode + re-encode (same trick as appendGrantByPrincipalKeyFromPrimary,
+// decode + re-encode (same trick as keys.AppendGrantByPrincipalKeyFromPrimary,
 // pinned by TestGrantDigestSpliceMatchesEncode). sep4 must come from
-// splitGrantPrimaryKey on the same key.
+// keys.SplitGrantPrimaryKey on the same key.
 func appendGrantHashIndexKeyFromPrimary(dst, primaryKey []byte, sep4 int, bucketHash64 uint64) []byte {
 	var bh [8]byte
 	binary.BigEndian.PutUint64(bh[:], bucketHash64)
@@ -358,7 +315,7 @@ func appendGrantHashIndexKeyFromPrimary(dst, primaryKey []byte, sep4 int, bucket
 // hash-index entries. The hash bytes may contain 0x00, so the 4th
 // separator is found by counting separators from the LEFT (the walk
 // never crosses the hash region — see the positional-decoding note on
-// encodeGrantByEntPrincHashEntPrefix).
+// keys.GrantHashIndexEntitlementPrefix).
 func grantPrimaryKeyFromHashIndexKey(dst, idxKey []byte) ([]byte, bool) {
 	if len(idxKey) < grantHashIndexKeyPrefixLen ||
 		idxKey[0] != versionV3 || idxKey[1] != typeIndex ||
@@ -413,7 +370,7 @@ func (e *Engine) GetGrantDigestGlobalRoot(ctx context.Context) (DigestRoot, bool
 		// hash index that was never ingested.
 		return DigestRoot{}, false, nil
 	}
-	val, closer, err := e.db.Get(globalGrantDigestNodeKey())
+	val, closer, err := e.db.Get(keys.GlobalGrantDigestNodeKey())
 	if err != nil {
 		if errors.Is(err, pebble.ErrNotFound) {
 			return DigestRoot{}, false, nil
@@ -547,14 +504,14 @@ func (e *Engine) DropAllGrantDigestState(ctx context.Context) error {
 // stageGrantDigestInvalidationFromPrimaryKey is the KEY-DERIVED form
 // wired into rawdb's typed record ops (RecordDerivers): the partition
 // is the entitlement region of the grant primary key, a plain
-// sub-slice (see splitGrantPrimaryKey) that is byte-identical to
+// sub-slice (see keys.SplitGrantPrimaryKey) that is byte-identical to
 // digestPartitionForEntitlement of the decoded identity — the key IS
 // the identity encoding. Same armed gate as the identity form.
 func (e *Engine) stageGrantDigestInvalidationFromPrimaryKey(st rawdb.Stager, primaryKey []byte) error {
 	if !e.grantDigestsPresent.Load() {
 		return nil
 	}
-	sep4, ok := splitGrantPrimaryKey(primaryKey)
+	sep4, ok := keys.SplitGrantPrimaryKey(primaryKey)
 	if !ok {
 		// Fail closed: a record that reached a typed op already carried
 		// a well-formed identity key; swallowing would leave a
@@ -572,10 +529,10 @@ func stageGrantDigestInvalidationForPartition(batch rawdb.Stager, partition stri
 	// one partition's digest is invalidated the aggregate is stale too,
 	// so it must drop alongside it rather than linger looking present
 	// (present-means-exact — digest.go).
-	if err := batch.Delete(globalGrantDigestNodeKey()); err != nil {
+	if err := batch.Delete(keys.GlobalGrantDigestNodeKey()); err != nil {
 		return err
 	}
-	lo := encodeGrantByEntPrincHashEntPrefix(partition)
+	lo := keys.GrantHashIndexEntitlementPrefix(partition)
 	return batch.DeleteRange(lo, upperBoundOf(lo))
 }
 

--- a/pkg/dotc1z/engine/pebble/grant_digest_build.go
+++ b/pkg/dotc1z/engine/pebble/grant_digest_build.go
@@ -17,7 +17,6 @@ import (
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
 
-	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/rawdb"
 )
 
@@ -67,7 +66,7 @@ type grantHashRowScratch struct {
 //
 // key/value are only borrowed (the sorter copies before returning).
 func appendGrantHashIndexRow(sorter *spillSorter, primaryKey, value []byte, s *grantHashRowScratch) error {
-	sep4, ok := keys.SplitGrantPrimaryKey(primaryKey)
+	sep4, ok := rawdb.SplitGrantPrimaryKey(primaryKey)
 	if !ok {
 		// The caller skips rows that already failed the by_principal
 		// splice; reaching here means the two splitters disagree.
@@ -295,7 +294,7 @@ func (f *grantDigestFold) finish() error {
 	if err := f.closePartition(); err != nil {
 		return err
 	}
-	if err := f.batch.Set(keys.GlobalGrantDigestNodeKey(), packDigestLeaf(f.globalTotal, f.globalXor[:])); err != nil {
+	if err := f.batch.Set(rawdb.GlobalGrantDigestNodeKey(), packDigestLeaf(f.globalTotal, f.globalXor[:])); err != nil {
 		return err
 	}
 	f.nodes++
@@ -489,7 +488,7 @@ func (e *Engine) buildGrantDigestsFromSpill(ctx context.Context, dir string, has
 		// Zero grants still means the digest WAS built (present-means-
 		// exact — an absent global root would tell a manifest reader to
 		// recalculate instead of trusting "nothing to diff").
-		if err := e.db.DigestSet(keys.GlobalGrantDigestNodeKey(), packDigestLeaf(0, zeroDigest[:]), opts); err != nil {
+		if err := e.db.DigestSet(rawdb.GlobalGrantDigestNodeKey(), packDigestLeaf(0, zeroDigest[:]), opts); err != nil {
 			return err
 		}
 		e.db.SetGrantDigestsPresent(true)
@@ -687,7 +686,7 @@ func (e *Engine) buildGrantDigestsStandaloneLocked(ctx context.Context) error {
 	var scanned, droppedMalformedKeys int64
 	var scratch grantHashRowScratch
 	for iter.First(); iter.Valid(); iter.Next() {
-		if _, ok := keys.SplitGrantPrimaryKey(iter.Key()); !ok {
+		if _, ok := rawdb.SplitGrantPrimaryKey(iter.Key()); !ok {
 			// Same key-layout-drift/corruption case the deferred pass
 			// counts; such rows cannot be represented in the digests.
 			droppedMalformedKeys++

--- a/pkg/dotc1z/engine/pebble/grant_digest_build.go
+++ b/pkg/dotc1z/engine/pebble/grant_digest_build.go
@@ -492,7 +492,7 @@ func (e *Engine) buildGrantDigestsFromSpill(ctx context.Context, dir string, has
 		if err := e.db.DigestSet(keys.GlobalGrantDigestNodeKey(), packDigestLeaf(0, zeroDigest[:]), opts); err != nil {
 			return err
 		}
-		e.grantDigestsPresent.Store(true)
+		e.db.SetGrantDigestsPresent(true)
 		return e.clearGrantDigestBuildPending()
 	}
 
@@ -531,7 +531,7 @@ func (e *Engine) buildGrantDigestsFromSpill(ctx context.Context, dir string, has
 	if err := e.writeMissingEntitlementDigestRoots(ctx, opts); err != nil {
 		return err
 	}
-	e.grantDigestsPresent.Store(true)
+	e.db.SetGrantDigestsPresent(true)
 	// The digest state is complete: consume the crash marker. Its
 	// fsync'd delete also makes every NoSync node batch above durable
 	// (WAL prefix ordering), so "marker absent" always means "complete
@@ -729,7 +729,7 @@ func (e *Engine) buildGrantDigestsStandaloneLocked(ctx context.Context) error {
 // LAST — WAL prefix ordering makes the (possibly NoSync) tombstones
 // above durable before the marker's absence is.
 func (e *Engine) dropAllGrantDigestStateLocked() error {
-	e.grantDigestsPresent.Store(false)
+	e.db.SetGrantDigestsPresent(false)
 	opts := writeOpts(e.opts.durability)
 	if e.IsFreshSync() {
 		opts = pebble.NoSync

--- a/pkg/dotc1z/engine/pebble/grant_digest_build.go
+++ b/pkg/dotc1z/engine/pebble/grant_digest_build.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
 
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/rawdb"
 )
 
@@ -66,7 +67,7 @@ type grantHashRowScratch struct {
 //
 // key/value are only borrowed (the sorter copies before returning).
 func appendGrantHashIndexRow(sorter *spillSorter, primaryKey, value []byte, s *grantHashRowScratch) error {
-	sep4, ok := splitGrantPrimaryKey(primaryKey)
+	sep4, ok := keys.SplitGrantPrimaryKey(primaryKey)
 	if !ok {
 		// The caller skips rows that already failed the by_principal
 		// splice; reaching here means the two splitters disagree.
@@ -294,7 +295,7 @@ func (f *grantDigestFold) finish() error {
 	if err := f.closePartition(); err != nil {
 		return err
 	}
-	if err := f.batch.Set(globalGrantDigestNodeKey(), packDigestLeaf(f.globalTotal, f.globalXor[:])); err != nil {
+	if err := f.batch.Set(keys.GlobalGrantDigestNodeKey(), packDigestLeaf(f.globalTotal, f.globalXor[:])); err != nil {
 		return err
 	}
 	f.nodes++
@@ -488,7 +489,7 @@ func (e *Engine) buildGrantDigestsFromSpill(ctx context.Context, dir string, has
 		// Zero grants still means the digest WAS built (present-means-
 		// exact — an absent global root would tell a manifest reader to
 		// recalculate instead of trusting "nothing to diff").
-		if err := e.db.DigestSet(globalGrantDigestNodeKey(), packDigestLeaf(0, zeroDigest[:]), opts); err != nil {
+		if err := e.db.DigestSet(keys.GlobalGrantDigestNodeKey(), packDigestLeaf(0, zeroDigest[:]), opts); err != nil {
 			return err
 		}
 		e.grantDigestsPresent.Store(true)
@@ -686,7 +687,7 @@ func (e *Engine) buildGrantDigestsStandaloneLocked(ctx context.Context) error {
 	var scanned, droppedMalformedKeys int64
 	var scratch grantHashRowScratch
 	for iter.First(); iter.Valid(); iter.Next() {
-		if _, ok := splitGrantPrimaryKey(iter.Key()); !ok {
+		if _, ok := keys.SplitGrantPrimaryKey(iter.Key()); !ok {
 			// Same key-layout-drift/corruption case the deferred pass
 			// counts; such rows cannot be represented in the digests.
 			droppedMalformedKeys++

--- a/pkg/dotc1z/engine/pebble/grant_digest_build_crash_test.go
+++ b/pkg/dotc1z/engine/pebble/grant_digest_build_crash_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
-	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/rawdb"
 )
 
 // Crash-window tests for the grant digest build's durable pending
@@ -104,7 +104,7 @@ func TestGrantDigestBuildCrashMidMerge(t *testing.T) {
 			// global root only rides fold.finish()'s final batch.
 			require.NotZero(t, countKeyRangeTest(t, e, DigestLowerBound(), DigestUpperBound()),
 				"mid-merge kill must leave committed digest nodes behind")
-			require.False(t, rawKeyPresent(t, e, keys.GlobalGrantDigestNodeKey()),
+			require.False(t, rawKeyPresent(t, e, rawdb.GlobalGrantDigestNodeKey()),
 				"the global root must not be durable before fold.finish()")
 		},
 	)
@@ -126,7 +126,7 @@ func TestGrantDigestBuildCrashPostFinish(t *testing.T) {
 			}
 		},
 		func(t *testing.T, e *Engine) {
-			require.True(t, rawKeyPresent(t, e, keys.GlobalGrantDigestNodeKey()),
+			require.True(t, rawKeyPresent(t, e, rawdb.GlobalGrantDigestNodeKey()),
 				"post-finish kill must leave the global root durable")
 		},
 	)

--- a/pkg/dotc1z/engine/pebble/grant_digest_build_crash_test.go
+++ b/pkg/dotc1z/engine/pebble/grant_digest_build_crash_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
 )
 
 // Crash-window tests for the grant digest build's durable pending
@@ -103,7 +104,7 @@ func TestGrantDigestBuildCrashMidMerge(t *testing.T) {
 			// global root only rides fold.finish()'s final batch.
 			require.NotZero(t, countKeyRangeTest(t, e, DigestLowerBound(), DigestUpperBound()),
 				"mid-merge kill must leave committed digest nodes behind")
-			require.False(t, rawKeyPresent(t, e, globalGrantDigestNodeKey()),
+			require.False(t, rawKeyPresent(t, e, keys.GlobalGrantDigestNodeKey()),
 				"the global root must not be durable before fold.finish()")
 		},
 	)
@@ -125,7 +126,7 @@ func TestGrantDigestBuildCrashPostFinish(t *testing.T) {
 			}
 		},
 		func(t *testing.T, e *Engine) {
-			require.True(t, rawKeyPresent(t, e, globalGrantDigestNodeKey()),
+			require.True(t, rawKeyPresent(t, e, keys.GlobalGrantDigestNodeKey()),
 				"post-finish kill must leave the global root durable")
 		},
 	)

--- a/pkg/dotc1z/engine/pebble/grant_digest_build_crash_test.go
+++ b/pkg/dotc1z/engine/pebble/grant_digest_build_crash_test.go
@@ -179,7 +179,7 @@ func testGrantDigestBuildCrash(t *testing.T, arm func(*Engine), assertPoisoned f
 	require.False(t, rawKeyPresent(t, e2, encodeGrantDigestBuildPendingKey()))
 	require.Zero(t, countKeyRangeTest(t, e2, DigestLowerBound(), DigestUpperBound()),
 		"reopen must drop every digest node the crashed build committed")
-	require.False(t, e2.grantDigestsPresent.Load())
+	require.False(t, e2.db.GrantDigestsPresent())
 
 	// Resume the sync and rerun EndSync — the standalone build runs
 	// again, from scratch.

--- a/pkg/dotc1z/engine/pebble/grant_digest_global_root_test.go
+++ b/pkg/dotc1z/engine/pebble/grant_digest_global_root_test.go
@@ -20,7 +20,7 @@ func TestGrantDigestGlobalRootMatchesFold(t *testing.T) {
 	ctx := context.Background()
 	e, _ := newTestEngine(t)
 	syncID := ksuid.New().String()
-	if err := e.SetCurrentSync(syncID); err != nil {
+	if err := e.bindCurrentSync(syncID); err != nil {
 		t.Fatalf("SetCurrentSync: %v", err)
 	}
 	counts := map[string]int64{"ent-a": 5, "ent-b": 3, "ent-zero": 0}
@@ -72,7 +72,7 @@ func TestGrantDigestGlobalRootEmptySync(t *testing.T) {
 	ctx := context.Background()
 	e, _ := newTestEngine(t)
 	syncID := ksuid.New().String()
-	if err := e.SetCurrentSync(syncID); err != nil {
+	if err := e.bindCurrentSync(syncID); err != nil {
 		t.Fatalf("SetCurrentSync: %v", err)
 	}
 	sealGrantDigests(t, e)
@@ -170,7 +170,7 @@ func TestManifestGrantDigestRootAbsentWithoutDigests(t *testing.T) {
 	ctx := context.Background()
 	e, _ := newTestEngine(t, WithGrantDigestIndex(false))
 	syncID := ksuid.New().String()
-	if err := e.SetCurrentSync(syncID); err != nil {
+	if err := e.bindCurrentSync(syncID); err != nil {
 		t.Fatalf("SetCurrentSync: %v", err)
 	}
 	putEnt(t, e, ctx, "ent-A")

--- a/pkg/dotc1z/engine/pebble/grant_digest_hash_test.go
+++ b/pkg/dotc1z/engine/pebble/grant_digest_hash_test.go
@@ -13,6 +13,7 @@ import (
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/codec"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
 )
 
 // The seal-time digest build never decodes anything: the hash-index key
@@ -68,8 +69,8 @@ func TestGrantDigestSpliceMatchesEncode(t *testing.T) {
 			val, err := marshalRecord(rec)
 			require.NoError(t, err)
 
-			sep4, ok := splitGrantPrimaryKey(priKey)
-			require.True(t, ok, "splitGrantPrimaryKey")
+			sep4, ok := keys.SplitGrantPrimaryKey(priKey)
+			require.True(t, ok, "keys.SplitGrantPrimaryKey")
 
 			// The partition region of the primary key is exactly the
 			// encoded entitlement identity tail.
@@ -97,7 +98,7 @@ func TestGrantDigestSpliceMatchesEncode(t *testing.T) {
 
 			// Index key splice == reference built entirely from encoders.
 			idxKey := appendGrantHashIndexKeyFromPrimary(nil, priKey, sep4, wantBH64)
-			ref := encodeGrantByEntPrincHashEntPrefix(string(partition))
+			ref := keys.GrantHashIndexEntitlementPrefix(string(partition))
 			ref = append(ref, principalBucketHash(tc.prt, tc.pid)...)
 			ref = codec.AppendTupleStrings(ref, tc.prt, tc.pid)
 			require.Equal(t, ref, idxKey, "index key: splice vs encode")
@@ -280,7 +281,7 @@ func TestGrantDigestPartitionPrefixFree(t *testing.T) {
 	}
 	prefixes := make([][]byte, len(ids))
 	for i, id := range ids {
-		prefixes[i] = encodeGrantByEntPrincHashEntPrefix(digestPartitionForEntitlement(id))
+		prefixes[i] = keys.GrantHashIndexEntitlementPrefix(digestPartitionForEntitlement(id))
 	}
 	for i := range prefixes {
 		for j := range prefixes {

--- a/pkg/dotc1z/engine/pebble/grant_digest_hash_test.go
+++ b/pkg/dotc1z/engine/pebble/grant_digest_hash_test.go
@@ -221,7 +221,7 @@ func TestGrantContentHashMissingIdentity(t *testing.T) {
 func TestGrantDigestAccumulatorMatchesSealedRoots(t *testing.T) {
 	ctx := context.Background()
 	e, _ := newTestEngine(t)
-	require.NoError(t, e.SetCurrentSync(ksuid.New().String()))
+	require.NoError(t, e.bindCurrentSync(ksuid.New().String()))
 
 	entGrants := map[string][]*v2.Grant{
 		"ent-a": {

--- a/pkg/dotc1z/engine/pebble/grant_digest_hash_test.go
+++ b/pkg/dotc1z/engine/pebble/grant_digest_hash_test.go
@@ -13,7 +13,7 @@ import (
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/codec"
-	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/rawdb"
 )
 
 // The seal-time digest build never decodes anything: the hash-index key
@@ -69,8 +69,8 @@ func TestGrantDigestSpliceMatchesEncode(t *testing.T) {
 			val, err := marshalRecord(rec)
 			require.NoError(t, err)
 
-			sep4, ok := keys.SplitGrantPrimaryKey(priKey)
-			require.True(t, ok, "keys.SplitGrantPrimaryKey")
+			sep4, ok := rawdb.SplitGrantPrimaryKey(priKey)
+			require.True(t, ok, "rawdb.SplitGrantPrimaryKey")
 
 			// The partition region of the primary key is exactly the
 			// encoded entitlement identity tail.
@@ -98,7 +98,7 @@ func TestGrantDigestSpliceMatchesEncode(t *testing.T) {
 
 			// Index key splice == reference built entirely from encoders.
 			idxKey := appendGrantHashIndexKeyFromPrimary(nil, priKey, sep4, wantBH64)
-			ref := keys.GrantHashIndexEntitlementPrefix(string(partition))
+			ref := rawdb.GrantHashIndexEntitlementPrefix(string(partition))
 			ref = append(ref, principalBucketHash(tc.prt, tc.pid)...)
 			ref = codec.AppendTupleStrings(ref, tc.prt, tc.pid)
 			require.Equal(t, ref, idxKey, "index key: splice vs encode")
@@ -281,7 +281,7 @@ func TestGrantDigestPartitionPrefixFree(t *testing.T) {
 	}
 	prefixes := make([][]byte, len(ids))
 	for i, id := range ids {
-		prefixes[i] = keys.GrantHashIndexEntitlementPrefix(digestPartitionForEntitlement(id))
+		prefixes[i] = rawdb.GrantHashIndexEntitlementPrefix(digestPartitionForEntitlement(id))
 	}
 	for i := range prefixes {
 		for j := range prefixes {

--- a/pkg/dotc1z/engine/pebble/grant_digest_repair.go
+++ b/pkg/dotc1z/engine/pebble/grant_digest_repair.go
@@ -10,6 +10,8 @@ import (
 	"github.com/cockroachdb/pebble/v2"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
+
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
 )
 
 // Targeted repair of the grant hash index + digests: heal exactly the
@@ -40,7 +42,7 @@ import (
 // InvalidateGrantDigestPartitions). ok is false for a key that does
 // not parse as a 6-segment grant identity.
 func GrantPartitionFromPrimaryKey(key []byte) (string, bool) {
-	sep4, ok := splitGrantPrimaryKey(key)
+	sep4, ok := keys.SplitGrantPrimaryKey(key)
 	if !ok {
 		return "", false
 	}
@@ -66,9 +68,9 @@ func grantPrimaryEntitlementBoundsFromPartition(partition string) ([]byte, []byt
 // specifically — the unit recomputeGrantDigestGlobalRootLocked folds
 // into the whole-file root. The global root's own key uses
 // digestLevelGlobalRoot, a different level value, so it never matches
-// here by construction (globalGrantDigestNodeKey). Finding the level
+// here by construction (keys.GlobalGrantDigestNodeKey). Finding the level
 // byte by scanning for the next bare 0x00 after indexID is safe
-// because the partition region is TUPLE-ESCAPED (encodeDigestPartitionPrefix),
+// because the partition region is TUPLE-ESCAPED (keys.DigestPartitionPrefix),
 // unlike the hash-index key's raw splice — a bare 0x00 there can only
 // be the separator ending it, never embedded partition data.
 func isGrantDigestRootKey(key []byte) bool {
@@ -111,12 +113,12 @@ func (e *Engine) InvalidateGrantDigestPartitions(ctx context.Context, partitions
 			if err := dropPartitionDigest(batch, grantDigestSpec, partition); err != nil {
 				return err
 			}
-			lo := encodeGrantByEntPrincHashEntPrefix(partition)
+			lo := keys.GrantHashIndexEntitlementPrefix(partition)
 			if err := batch.DeleteRange(lo, upperBoundOf(lo)); err != nil {
 				return err
 			}
 		}
-		if err := batch.Delete(globalGrantDigestNodeKey()); err != nil {
+		if err := batch.Delete(keys.GlobalGrantDigestNodeKey()); err != nil {
 			return err
 		}
 		opts := writeOpts(e.opts.durability)
@@ -434,7 +436,7 @@ func (e *Engine) repairOneGrantDigestPartitionLocked(ctx context.Context, partit
 	// loop rotates `hiBatch` on flush.
 	hiBatch := e.db.NewDigestBatch()
 	defer func() { hiBatch.Close() }()
-	hiLower := encodeGrantByEntPrincHashEntPrefix(partition)
+	hiLower := keys.GrantHashIndexEntitlementPrefix(partition)
 	if err := hiBatch.DeleteRange(hiLower, upperBoundOf(hiLower)); err != nil {
 		return err
 	}
@@ -452,7 +454,7 @@ func (e *Engine) repairOneGrantDigestPartitionLocked(ctx context.Context, partit
 			return err
 		}
 		key, value := iter.Key(), iter.Value()
-		sep4, ok := splitGrantPrimaryKey(key)
+		sep4, ok := keys.SplitGrantPrimaryKey(key)
 		if !ok {
 			// Same key-layout-drift/corruption case the build paths
 			// count: such rows cannot be represented in the digests.
@@ -517,7 +519,7 @@ func (e *Engine) repairOneGrantDigestPartitionLocked(ctx context.Context, partit
 	}
 	digestBatch := e.db.NewDigestBatch()
 	defer digestBatch.Close()
-	digestLower := encodeDigestPartitionPrefix(grantDigestSpec.indexID, partition)
+	digestLower := keys.DigestPartitionPrefix(grantDigestSpec.indexID, partition)
 	if err := digestBatch.DeleteRange(digestLower, upperBoundOf(digestLower)); err != nil {
 		return err
 	}
@@ -581,7 +583,7 @@ func (e *Engine) recomputeGrantDigestGlobalRootLocked(ctx context.Context) error
 	if e.IsFreshSync() {
 		opts = pebble.NoSync
 	}
-	if err := e.db.DigestSet(globalGrantDigestNodeKey(), packDigestLeaf(total, xor[:]), opts); err != nil {
+	if err := e.db.DigestSet(keys.GlobalGrantDigestNodeKey(), packDigestLeaf(total, xor[:]), opts); err != nil {
 		return err
 	}
 	e.grantDigestsPresent.Store(true)

--- a/pkg/dotc1z/engine/pebble/grant_digest_repair.go
+++ b/pkg/dotc1z/engine/pebble/grant_digest_repair.go
@@ -103,7 +103,7 @@ func isGrantDigestRootKey(key []byte) bool {
 // an O(file) rebuild. No-op when partitions is empty or no digest has
 // ever been built for this file.
 func (e *Engine) InvalidateGrantDigestPartitions(ctx context.Context, partitions []string) error {
-	if len(partitions) == 0 || !e.grantDigestsPresent.Load() {
+	if len(partitions) == 0 || !e.db.GrantDigestsPresent() {
 		return nil
 	}
 	return e.withWrite(func() error {
@@ -201,7 +201,7 @@ func (e *Engine) RepairMissingGrantDigests(ctx context.Context) error {
 			return fmt.Errorf("RepairMissingGrantDigests: drop digest state left by an interrupted build: %w", err)
 		}
 	}
-	if !e.grantDigestsPresent.Load() {
+	if !e.db.GrantDigestsPresent() {
 		return e.BuildGrantDigests(ctx)
 	}
 	err := e.repairMissingGrantDigestsAttempt(ctx)
@@ -536,7 +536,7 @@ func (e *Engine) repairOneGrantDigestPartitionLocked(ctx context.Context, partit
 	if err := digestBatch.Commit(opts); err != nil {
 		return err
 	}
-	e.grantDigestsPresent.Store(true)
+	e.db.SetGrantDigestsPresent(true)
 	return nil
 }
 
@@ -586,6 +586,6 @@ func (e *Engine) recomputeGrantDigestGlobalRootLocked(ctx context.Context) error
 	if err := e.db.DigestSet(keys.GlobalGrantDigestNodeKey(), packDigestLeaf(total, xor[:]), opts); err != nil {
 		return err
 	}
-	e.grantDigestsPresent.Store(true)
+	e.db.SetGrantDigestsPresent(true)
 	return nil
 }

--- a/pkg/dotc1z/engine/pebble/grant_digest_repair.go
+++ b/pkg/dotc1z/engine/pebble/grant_digest_repair.go
@@ -11,7 +11,7 @@ import (
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
 
-	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/rawdb"
 )
 
 // Targeted repair of the grant hash index + digests: heal exactly the
@@ -42,7 +42,7 @@ import (
 // InvalidateGrantDigestPartitions). ok is false for a key that does
 // not parse as a 6-segment grant identity.
 func GrantPartitionFromPrimaryKey(key []byte) (string, bool) {
-	sep4, ok := keys.SplitGrantPrimaryKey(key)
+	sep4, ok := rawdb.SplitGrantPrimaryKey(key)
 	if !ok {
 		return "", false
 	}
@@ -68,9 +68,9 @@ func grantPrimaryEntitlementBoundsFromPartition(partition string) ([]byte, []byt
 // specifically — the unit recomputeGrantDigestGlobalRootLocked folds
 // into the whole-file root. The global root's own key uses
 // digestLevelGlobalRoot, a different level value, so it never matches
-// here by construction (keys.GlobalGrantDigestNodeKey). Finding the level
+// here by construction (rawdb.GlobalGrantDigestNodeKey). Finding the level
 // byte by scanning for the next bare 0x00 after indexID is safe
-// because the partition region is TUPLE-ESCAPED (keys.DigestPartitionPrefix),
+// because the partition region is TUPLE-ESCAPED (rawdb.DigestPartitionPrefix),
 // unlike the hash-index key's raw splice — a bare 0x00 there can only
 // be the separator ending it, never embedded partition data.
 func isGrantDigestRootKey(key []byte) bool {
@@ -113,12 +113,12 @@ func (e *Engine) InvalidateGrantDigestPartitions(ctx context.Context, partitions
 			if err := dropPartitionDigest(batch, grantDigestSpec, partition); err != nil {
 				return err
 			}
-			lo := keys.GrantHashIndexEntitlementPrefix(partition)
+			lo := rawdb.GrantHashIndexEntitlementPrefix(partition)
 			if err := batch.DeleteRange(lo, upperBoundOf(lo)); err != nil {
 				return err
 			}
 		}
-		if err := batch.Delete(keys.GlobalGrantDigestNodeKey()); err != nil {
+		if err := batch.Delete(rawdb.GlobalGrantDigestNodeKey()); err != nil {
 			return err
 		}
 		opts := writeOpts(e.opts.durability)
@@ -436,7 +436,7 @@ func (e *Engine) repairOneGrantDigestPartitionLocked(ctx context.Context, partit
 	// loop rotates `hiBatch` on flush.
 	hiBatch := e.db.NewDigestBatch()
 	defer func() { hiBatch.Close() }()
-	hiLower := keys.GrantHashIndexEntitlementPrefix(partition)
+	hiLower := rawdb.GrantHashIndexEntitlementPrefix(partition)
 	if err := hiBatch.DeleteRange(hiLower, upperBoundOf(hiLower)); err != nil {
 		return err
 	}
@@ -454,7 +454,7 @@ func (e *Engine) repairOneGrantDigestPartitionLocked(ctx context.Context, partit
 			return err
 		}
 		key, value := iter.Key(), iter.Value()
-		sep4, ok := keys.SplitGrantPrimaryKey(key)
+		sep4, ok := rawdb.SplitGrantPrimaryKey(key)
 		if !ok {
 			// Same key-layout-drift/corruption case the build paths
 			// count: such rows cannot be represented in the digests.
@@ -519,7 +519,7 @@ func (e *Engine) repairOneGrantDigestPartitionLocked(ctx context.Context, partit
 	}
 	digestBatch := e.db.NewDigestBatch()
 	defer digestBatch.Close()
-	digestLower := keys.DigestPartitionPrefix(grantDigestSpec.indexID, partition)
+	digestLower := rawdb.DigestPartitionPrefix(grantDigestSpec.indexID, partition)
 	if err := digestBatch.DeleteRange(digestLower, upperBoundOf(digestLower)); err != nil {
 		return err
 	}
@@ -583,7 +583,7 @@ func (e *Engine) recomputeGrantDigestGlobalRootLocked(ctx context.Context) error
 	if e.IsFreshSync() {
 		opts = pebble.NoSync
 	}
-	if err := e.db.DigestSet(keys.GlobalGrantDigestNodeKey(), packDigestLeaf(total, xor[:]), opts); err != nil {
+	if err := e.db.DigestSet(rawdb.GlobalGrantDigestNodeKey(), packDigestLeaf(total, xor[:]), opts); err != nil {
 		return err
 	}
 	e.db.SetGrantDigestsPresent(true)

--- a/pkg/dotc1z/engine/pebble/grant_digest_repair_test.go
+++ b/pkg/dotc1z/engine/pebble/grant_digest_repair_test.go
@@ -353,7 +353,7 @@ func TestRepairMissingGrantDigestsCountsMalformedKeys(t *testing.T) {
 	sealGrantDigests(t, e)
 
 	// A key inside ent-a's primary range with SEVEN tuple segments —
-	// the key-layout-drift/corruption shape splitGrantPrimaryKey
+	// the key-layout-drift/corruption shape keys.SplitGrantPrimaryKey
 	// rejects (a well-formed grant identity has exactly six).
 	partition := testEntPartition("ent-a")
 	lower, _ := grantPrimaryEntitlementBoundsFromPartition(partition)

--- a/pkg/dotc1z/engine/pebble/grant_digest_repair_test.go
+++ b/pkg/dotc1z/engine/pebble/grant_digest_repair_test.go
@@ -25,7 +25,7 @@ func TestRepairMissingGrantDigestsLeavesGlobalRootMissingOnPartialFailure(t *tes
 	ctx := context.Background()
 	e, _ := newTestEngine(t)
 	syncID := ksuid.New().String()
-	if err := e.SetCurrentSync(syncID); err != nil {
+	if err := e.bindCurrentSync(syncID); err != nil {
 		t.Fatalf("SetCurrentSync: %v", err)
 	}
 	putEnt(t, e, ctx, "ent-good")
@@ -93,7 +93,7 @@ func TestRepairMissingGrantDigestsHealsOnlyInvalidatedPartition(t *testing.T) {
 	ctx := context.Background()
 	e, _ := newTestEngine(t)
 	syncID := ksuid.New().String()
-	if err := e.SetCurrentSync(syncID); err != nil {
+	if err := e.bindCurrentSync(syncID); err != nil {
 		t.Fatalf("SetCurrentSync: %v", err)
 	}
 	counts := map[string]int64{"ent-a": 5, "ent-b": 600, "ent-c": 3}
@@ -152,7 +152,7 @@ func TestRepairMissingGrantDigestsRediscoversInvalidatedOrphan(t *testing.T) {
 	ctx := context.Background()
 	e, _ := newTestEngine(t)
 	syncID := ksuid.New().String()
-	if err := e.SetCurrentSync(syncID); err != nil {
+	if err := e.bindCurrentSync(syncID); err != nil {
 		t.Fatalf("SetCurrentSync: %v", err)
 	}
 	putEnt(t, e, ctx, "ent-real")
@@ -192,7 +192,7 @@ func TestRepairMissingGrantDigestsRediscoversZeroGrantEntitlement(t *testing.T) 
 	ctx := context.Background()
 	e, _ := newTestEngine(t)
 	syncID := ksuid.New().String()
-	if err := e.SetCurrentSync(syncID); err != nil {
+	if err := e.bindCurrentSync(syncID); err != nil {
 		t.Fatalf("SetCurrentSync: %v", err)
 	}
 	putEnt(t, e, ctx, "ent-empty")
@@ -235,7 +235,7 @@ func TestRepairMissingGrantDigestsFallsBackWhenNeverBuilt(t *testing.T) {
 	ctx := context.Background()
 	e, _ := newTestEngine(t)
 	syncID := ksuid.New().String()
-	if err := e.SetCurrentSync(syncID); err != nil {
+	if err := e.bindCurrentSync(syncID); err != nil {
 		t.Fatalf("SetCurrentSync: %v", err)
 	}
 	putEnt(t, e, ctx, "ent-A")
@@ -340,7 +340,7 @@ func TestRepairMissingGrantDigestsCountsMalformedKeys(t *testing.T) {
 	ctx := context.Background()
 	e, _ := newTestEngine(t)
 	syncID := ksuid.New().String()
-	if err := e.SetCurrentSync(syncID); err != nil {
+	if err := e.bindCurrentSync(syncID); err != nil {
 		t.Fatalf("SetCurrentSync: %v", err)
 	}
 	putEnt(t, e, ctx, "ent-a")
@@ -406,7 +406,7 @@ func TestRepairStreamsPartitionInBoundedBatches(t *testing.T) {
 	ctx := context.Background()
 	e, _ := newTestEngine(t)
 	syncID := ksuid.New().String()
-	if err := e.SetCurrentSync(syncID); err != nil {
+	if err := e.bindCurrentSync(syncID); err != nil {
 		t.Fatalf("SetCurrentSync: %v", err)
 	}
 	for entID, n := range map[string]int{"ent-big": 700, "ent-small": 2} {

--- a/pkg/dotc1z/engine/pebble/grant_digest_repair_test.go
+++ b/pkg/dotc1z/engine/pebble/grant_digest_repair_test.go
@@ -353,7 +353,7 @@ func TestRepairMissingGrantDigestsCountsMalformedKeys(t *testing.T) {
 	sealGrantDigests(t, e)
 
 	// A key inside ent-a's primary range with SEVEN tuple segments —
-	// the key-layout-drift/corruption shape keys.SplitGrantPrimaryKey
+	// the key-layout-drift/corruption shape rawdb.SplitGrantPrimaryKey
 	// rejects (a well-formed grant identity has exactly six).
 	partition := testEntPartition("ent-a")
 	lower, _ := grantPrimaryEntitlementBoundsFromPartition(partition)

--- a/pkg/dotc1z/engine/pebble/grants.go
+++ b/pkg/dotc1z/engine/pebble/grants.go
@@ -597,7 +597,7 @@ func (e *Engine) AddSynthesizedGrantLayerContributions(ctx context.Context, reco
 			// (cheap) rebuild at EndSync. The reverse order could leave an
 			// initialized session whose later Adds skip this block, ingesting
 			// rows with the rebuild unarmed.
-			if err := e.markDeferredIdxPending(); err != nil {
+			if err := e.db.ArmDeferredGrantIndex(); err != nil {
 				return err
 			}
 			if err := e.initSynthLayerSession(ctx, s); err != nil {
@@ -770,7 +770,7 @@ func (e *Engine) UnsafePutUniqueGrantRecords(ctx context.Context, records ...*v3
 		// invalidation is a no-op. If digests ever read as present here,
 		// the freshness contract itself is broken — refuse rather than
 		// silently tombstone the digest keyspace of a trusted import.
-		if e.grantDigestsPresent.Load() {
+		if e.db.GrantDigestsPresent() {
 			return errors.New("UnsafePutUniqueGrantRecords: digest state present on a fresh sync; freshness contract violated")
 		}
 		// Consume the fresh-grants-empty bit: the keyspace is no longer
@@ -976,77 +976,23 @@ func grantIndexKeys(r *v3.GrantRecord) [][]byte {
 // marker through the Open-wired RecordDerivers — a caller can no
 // longer stage a grant row and forget what it owes.
 
-// markDeferredIdxPending arms the deferred by_principal rebuild, durably.
-// The atomic flag serves in-process checks; the engine-meta marker survives
-// a process restart so a resumed sync still runs the rebuild at EndSync
-// even when the resume itself writes nothing (see
-// encodeDeferredIdxPendingKey). The CAS keeps the durable write to one per
-// arming, off the per-record hot path.
-func (e *Engine) markDeferredIdxPending() error {
-	if !e.deferredIdxPending.CompareAndSwap(false, true) {
-		return nil
-	}
-	if err := e.armDeferredMarkerDurably(); err != nil {
-		// Roll the CAS back so a retried write attempts the durable marker
-		// again. Leaving the flag armed with no durable key would make the
-		// in-process EndSync build the index (flag true) while a
-		// crash+resume silently skipped it (key absent) — exactly the
-		// divergence the durable marker exists to close.
-		e.deferredIdxPending.Store(false)
-		return fmt.Errorf("arm deferred index marker: %w", err)
-	}
-	return nil
-}
+// The deferred-marker arm/clear contract (CAS + durable key agreement
+// on both edges) lives on rawdb (ArmDeferredGrantIndex /
+// ClearDeferredGrantIndexMarker): the marker is write-side crash
+// state the typed record ops consume directly.
 
-// armDeferredMarkerDurably commits the deferred-index marker's durable
-// half. Split out solely so tests can inject a commit failure
-// (the armDeferredMarkerHook seam) and pin the CAS rollback above — the
-// flag and the durable key must never disagree.
-func (e *Engine) armDeferredMarkerDurably() error {
-	if e.test.armDeferredMarkerHook != nil {
-		if err := e.test.armDeferredMarkerHook(); err != nil {
-			return err
-		}
-	}
-	return e.db.MetaSet(encodeDeferredIdxPendingKey(), nil, pebble.Sync)
-}
-
-// clearDeferredIdxPending drops both forms of the marker after a successful
-// rebuild. Runs under the write barrier so the flag reset and durable
-// delete can't interleave with a concurrent writer's markDeferredIdxPending
-// (which would leave the atomic flag armed but the durable marker deleted,
-// or vice versa).
-//
-// Durable delete FIRST, flag second — the same flag/key-agreement
-// contract as the arm side (markDeferredIdxPending). The old order
-// cleared the flag before the delete, so a failed delete left flag
-// false + key present: a retried EndSync then skipped the (idempotent)
-// rebuild and sealed fine, but the stale key forced a spurious rebuild
-// on the next open. With delete-first, a failure leaves BOTH armed —
-// the retried EndSync re-runs the rebuild and retries the clear.
-// (Review finding, edge/resume round.)
+// clearDeferredIdxPending drops both forms of the marker after a
+// successful rebuild, under the engine write barrier so the clear
+// can't interleave with a concurrent writer's arm (which would leave
+// the atomic flag armed but the durable marker deleted, or vice
+// versa). Ordering and failure semantics live in rawdb's
+// ClearDeferredGrantIndexMarker.
 func (e *Engine) clearDeferredIdxPending() error {
 	// AllowSealed: runs inside EndSync's sealed finalize window, right
 	// after the deferred build (see Adapter.EndSync).
 	return e.withWriteAllowSealed(func() error {
-		if err := e.clearDeferredMarkerDurably(); err != nil {
-			return err
-		}
-		e.deferredIdxPending.Store(false)
-		return nil
+		return e.db.ClearDeferredGrantIndexMarker()
 	})
-}
-
-// clearDeferredMarkerDurably commits the marker's durable delete.
-// Split out for test failure injection (the clearDeferredMarkerHook seam),
-// mirroring armDeferredMarkerDurably.
-func (e *Engine) clearDeferredMarkerDurably() error {
-	if e.test.clearDeferredMarkerHook != nil {
-		if err := e.test.clearDeferredMarkerHook(); err != nil {
-			return err
-		}
-	}
-	return e.db.MetaDelete(encodeDeferredIdxPendingKey(), pebble.Sync)
 }
 
 // IterateGrants iterates all grants in primary-key order. yield returns

--- a/pkg/dotc1z/engine/pebble/grants_for_entitlements.go
+++ b/pkg/dotc1z/engine/pebble/grants_for_entitlements.go
@@ -28,11 +28,11 @@ import (
 // ORDER — the cursor resumes by positional index, so a reorder is
 // as fatal as a drop/add; any change to the list (including order)
 // restarts from the beginning rather than silently mis-paginating.
-func (a *Adapter) ListGrantsForEntitlements(
+func (e *Engine) ListGrantsForEntitlements(
 	ctx context.Context,
 	req *reader_v2.GrantsReaderServiceListGrantsForEntitlementsRequest,
 ) (*reader_v2.GrantsReaderServiceListGrantsForEntitlementsResponse, error) {
-	syncID, err := a.resolveActiveSyncForReader(ctx, req.GetAnnotations())
+	syncID, err := e.resolveActiveSyncForReader(ctx, req.GetAnnotations())
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ EntitlementLoop:
 		if ents[i].GetId() == "" {
 			continue
 		}
-		entID, err := a.entitlementIdentityForRequest(ctx, ents[i])
+		entID, err := e.entitlementIdentityForRequest(ctx, ents[i])
 		if err != nil {
 			if errors.Is(err, pebble.ErrNotFound) {
 				continue // unknown entitlement → no grants
@@ -82,7 +82,7 @@ EntitlementLoop:
 				return nil, err
 			}
 			remaining := limit - len(out)
-			records, next, err := a.engine.PaginateGrantsByEntitlement(ctx, entID, intraCursor, remaining)
+			records, next, err := e.PaginateGrantsByEntitlement(ctx, entID, intraCursor, remaining)
 			if err != nil {
 				return nil, c1zstore.AdaptNotFound(err, pebble.ErrNotFound)
 			}

--- a/pkg/dotc1z/engine/pebble/id_index_format.go
+++ b/pkg/dotc1z/engine/pebble/id_index_format.go
@@ -29,7 +29,7 @@ func encodeIDIndexFormatKey() []byte {
 	return codec.AppendTupleStrings(buf, "grant_entitlement_id_format")
 }
 
-// The deferred-index rebuild marker (keys.DeferredIdxPendingKey) and
+// The deferred-index rebuild marker (rawdb.DeferredIdxPendingKey) and
 // its arm/clear/restore contract moved to rawdb, which owns the
 // deferred-index crash state (see rawdb.ArmDeferredGrantIndex).
 

--- a/pkg/dotc1z/engine/pebble/id_index_format.go
+++ b/pkg/dotc1z/engine/pebble/id_index_format.go
@@ -29,18 +29,9 @@ func encodeIDIndexFormatKey() []byte {
 	return codec.AppendTupleStrings(buf, "grant_entitlement_id_format")
 }
 
-// encodeDeferredIdxPendingKey is the durable marker that grant writes have
-// skipped the inline by_principal index and a deferred rebuild is owed. The
-// in-memory deferredIdxPending flag alone cannot survive a process restart:
-// a sync interrupted after its expansion writes and resumed in a fresh
-// process would otherwise write nothing (idempotent re-run), never re-arm
-// the flag, and EndSync would skip the rebuild — saving a "finished" c1z
-// whose by_principal index misses every deferred-written grant.
-func encodeDeferredIdxPendingKey() []byte {
-	buf := make([]byte, 0, 2+len("deferred_grant_idx_pending"))
-	buf = append(buf, versionV3, typeEngineMeta)
-	return codec.AppendTupleStrings(buf, "deferred_grant_idx_pending")
-}
+// The deferred-index rebuild marker (keys.DeferredIdxPendingKey) and
+// its arm/clear/restore contract moved to rawdb, which owns the
+// deferred-index crash state (see rawdb.ArmDeferredGrantIndex).
 
 // encodeGrantDigestBuildPendingKey is the durable marker that a grant
 // digest build is mid-flight: armed (fsync'd) before the build's first

--- a/pkg/dotc1z/engine/pebble/id_index_migration.go
+++ b/pkg/dotc1z/engine/pebble/id_index_migration.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/pebble/v2/vfs"
 
 	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
@@ -363,7 +364,7 @@ func mergeGrantPrimaryMigrationChunksToSST(ctx context.Context, fs vfs.FS, sstPa
 		// permutation; by_needs_expansion shares the primary's exact tail
 		// (header swap only). Only the flag needs a value read, via a
 		// single-field shallow scan.
-		idxKey, ok := appendGrantByPrincipalKeyFromPrimary(idxKeyScratch[:0], key)
+		idxKey, ok := keys.AppendGrantByPrincipalKeyFromPrimary(idxKeyScratch[:0], key)
 		idxKeyScratch = idxKey
 		if !ok {
 			return fmt.Errorf("id-index migration: grant primary key %x did not decode as a 6-segment identity", key)

--- a/pkg/dotc1z/engine/pebble/id_index_migration.go
+++ b/pkg/dotc1z/engine/pebble/id_index_migration.go
@@ -14,7 +14,7 @@ import (
 	"github.com/cockroachdb/pebble/v2/vfs"
 
 	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
-	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/rawdb"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
@@ -364,7 +364,7 @@ func mergeGrantPrimaryMigrationChunksToSST(ctx context.Context, fs vfs.FS, sstPa
 		// permutation; by_needs_expansion shares the primary's exact tail
 		// (header swap only). Only the flag needs a value read, via a
 		// single-field shallow scan.
-		idxKey, ok := keys.AppendGrantByPrincipalKeyFromPrimary(idxKeyScratch[:0], key)
+		idxKey, ok := rawdb.AppendGrantByPrincipalKeyFromPrimary(idxKeyScratch[:0], key)
 		idxKeyScratch = idxKey
 		if !ok {
 			return fmt.Errorf("id-index migration: grant primary key %x did not decode as a 6-segment identity", key)

--- a/pkg/dotc1z/engine/pebble/if_newer_test.go
+++ b/pkg/dotc1z/engine/pebble/if_newer_test.go
@@ -102,7 +102,7 @@ func grantsByPrincipal(t *testing.T, ctx context.Context, e *Engine, principal s
 func TestPutGrantRecordsIfNewerSkipsStale(t *testing.T) {
 	ctx := context.Background()
 	e, _ := newTestEngine(t)
-	require.NoError(t, e.SetCurrentSync(ksuid.New().String()))
+	require.NoError(t, e.bindCurrentSync(ksuid.New().String()))
 
 	older := time.Unix(1000, 0).UTC()
 	newer := time.Unix(2000, 0).UTC()
@@ -148,7 +148,7 @@ func TestPutGrantRecordsIfNewerSkipsStale(t *testing.T) {
 func TestPutRecordsIfNewerRejectsOlderAllTypes(t *testing.T) {
 	ctx := context.Background()
 	e, _ := newTestEngine(t)
-	require.NoError(t, e.SetCurrentSync(ksuid.New().String()))
+	require.NoError(t, e.bindCurrentSync(ksuid.New().String()))
 
 	older := time.Unix(1000, 0).UTC()
 	newer := time.Unix(2000, 0).UTC()

--- a/pkg/dotc1z/engine/pebble/internal/keys/keys.go
+++ b/pkg/dotc1z/engine/pebble/internal/keys/keys.go
@@ -320,3 +320,26 @@ func GrantHashIndexEntitlementPrefix(partition string) []byte {
 // (codec.KeyUpperBound re-exported for range builders here and in
 // rawdb).
 func UpperBound(prefix []byte) []byte { return codec.KeyUpperBound(prefix) }
+
+// === engine-meta markers owned by rawdb ===
+
+// DeferredIdxPendingKey is the durable marker that grant writes have
+// skipped the inline by_principal index and a deferred rebuild is
+// owed. The in-memory flag alone cannot survive a process restart: a
+// sync interrupted after its expansion writes and resumed in a fresh
+// process would otherwise write nothing (idempotent re-run), never
+// re-arm the flag, and EndSync would skip the rebuild — saving a
+// "finished" c1z whose by_principal index misses every
+// deferred-written grant.
+func DeferredIdxPendingKey() []byte {
+	buf := make([]byte, 0, 2+len("deferred_grant_idx_pending"))
+	buf = append(buf, VersionV3, TypeEngineMeta)
+	return codec.AppendTupleStrings(buf, "deferred_grant_idx_pending")
+}
+
+// DigestKeyspaceBounds bounds the entire digest keyspace (all digested
+// indexes) — the presence-probe range for the digests-present flag.
+func DigestKeyspaceBounds() ([]byte, []byte) {
+	lo := []byte{VersionV3, TypeDigest}
+	return lo, UpperBound(lo)
+}

--- a/pkg/dotc1z/engine/pebble/internal/keys/keys.go
+++ b/pkg/dotc1z/engine/pebble/internal/keys/keys.go
@@ -1,0 +1,322 @@
+// Package keys holds the v3 keyspace ABI shared by the engine package
+// and internal/rawdb: the type/index discriminator bytes, the grant
+// primary-key splices, the resource value scanners, and the digest
+// invalidation key builders. It exists so rawdb's typed record ops can
+// DERIVE their obligations directly instead of having the engine
+// inject derivation closures at Open (the pre-2.5 RecordDerivers
+// shape) — rawdb owns what a record mutation must stage together, and
+// this package owns the byte formats both sides agree on.
+//
+// Everything here is a pure function over bytes/strings: no engine
+// state, no pebble handles. The full key-layout convention (header
+// shapes, tuple encoding, prefix pairing) is documented in the engine
+// package's keys.go, which re-exports these discriminators for its own
+// encoders; the byte formats are an on-disk ABI shared with every v3
+// c1z file. See the codec package for the escape rules.
+package keys
+
+import (
+	"bytes"
+	"fmt"
+
+	"google.golang.org/protobuf/encoding/protowire"
+
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/codec"
+)
+
+// Type-discriminator bytes for the v3 keyspace. Each top-level
+// keyspace occupies one byte.
+const (
+	VersionV3 byte = 0x03
+
+	TypeResourceType byte = 0x01
+	TypeResource     byte = 0x02
+	TypeEntitlement  byte = 0x03
+	TypeGrant        byte = 0x04
+	TypeAsset        byte = 0x05
+	TypeSyncRun      byte = 0x06
+	TypeIndex        byte = 0x07
+	TypeCounter      byte = 0x08
+	TypeSession      byte = 0x09
+	TypeDigest       byte = 0x0A
+	TypeEngineMeta   byte = 0xFF
+)
+
+// Index-discriminator bytes (second byte after TypeIndex). One byte
+// per declared index across all record types; reuse across record
+// types is fine because the index key is scoped by the type byte that
+// preceded it.
+const (
+	IdxResourceByParent             byte = 0x01
+	IdxEntitlementByResource        byte = 0x02 // retired: served by entitlement primary key prefixes.
+	IdxGrantByEntitlement           byte = 0x03 // retired: grant primary keys are entitlement-first.
+	IdxGrantByPrincipal             byte = 0x04
+	IdxGrantByNeedsExpansion        byte = 0x05
+	IdxGrantByPrincipalResourceType byte = 0x06 // retired: served by IdxGrantByPrincipal prefix scans.
+	IdxGrantByEntitlementResource   byte = 0x07 // retired: served by grant primary entitlement-resource prefix scans.
+	// IdxGrantByEntitlementPrincipalHash sorts grants by
+	// (entitlement identity, hash(principal identity)). Unlike every
+	// other grant index its entries carry a VALUE (the grant content
+	// hash). It is the substrate the per-entitlement grant digest
+	// (TypeDigest) folds over; built ONLY by the seal-time deferred
+	// pass, never maintained inline. See the engine's digest.go and
+	// grant_digest.go.
+	IdxGrantByEntitlementPrincipalHash byte = 0x08
+)
+
+// GrantPrimaryKeyPrefixLen is the byte length of the grant primary-key
+// header: VersionV3 | TypeGrant | separator.
+const GrantPrimaryKeyPrefixLen = 3
+
+// DigestLevelGlobalRoot is the digest node-key level for the
+// whole-file grant digest root (see GlobalGrantDigestNodeKey). It is
+// deliberately a level value the generic digest core never produces
+// (root=0, leaf=1), keeping the global node's key disjoint from every
+// per-partition node regardless of partition bytes.
+const DigestLevelGlobalRoot byte = 2
+
+// === grant primary-key splices ===
+
+// SplitGrantPrimaryKey locates the partition/principal boundary of a
+// grant primary key: the byte offset of the 4th tuple separator in the
+// key (the one that ends the entitlement's 4 identity segments). It
+// also validates the overall 6-segment shape, exactly like
+// AppendGrantByPrincipalKeyFromPrimary. Returns ok=false for keys that
+// are not well-formed 6-segment grant identities.
+//
+// With the returned sep4 in hand every region is a plain sub-slice:
+//
+//	partition          = key[GrantPrimaryKeyPrefixLen:sep4]
+//	principal segments = key[sep4+1:]
+func SplitGrantPrimaryKey(primaryKey []byte) (int, bool) {
+	if len(primaryKey) < GrantPrimaryKeyPrefixLen ||
+		primaryKey[0] != VersionV3 || primaryKey[1] != TypeGrant || primaryKey[2] != 0 {
+		return 0, false
+	}
+	sep4 := 0
+	off := GrantPrimaryKeyPrefixLen
+	for i := range 5 {
+		sep := bytes.IndexByte(primaryKey[off:], 0)
+		if sep < 0 {
+			return 0, false
+		}
+		off += sep
+		if i == 3 {
+			sep4 = off
+		}
+		off++
+	}
+	if bytes.IndexByte(primaryKey[off:], 0) >= 0 {
+		return 0, false
+	}
+	return sep4, true
+}
+
+// AppendGrantByPrincipalKeyFromPrimary builds the by_principal index key
+// directly from a primary grant key by permuting its tuple segments, into
+// dst. The primary tail is ent_rt|ent_rid|ent_kind|ent_name|p_rt|p_id and the
+// index tail is p_rt|p_id|ent_rt|ent_rid|ent_kind|ent_name — the segments are
+// already escaped, and the tuple escaping is canonical, so splicing the raw
+// bytes is byte-identical to decode + re-encode while skipping six string
+// allocations and a fresh key buffer per row (that decode/re-encode pair was
+// ~7GB of allocations per whale deferred build). Returns ok=false for keys
+// that do not have exactly six segments.
+//
+// Pinned against the decode+re-encode path by the engine's
+// TestAppendGrantByPrincipalKeyFromPrimary.
+func AppendGrantByPrincipalKeyFromPrimary(dst, primaryKey []byte) ([]byte, bool) {
+	if len(primaryKey) < GrantPrimaryKeyPrefixLen ||
+		primaryKey[0] != VersionV3 || primaryKey[1] != TypeGrant || primaryKey[2] != 0 {
+		return dst, false
+	}
+	tail := primaryKey[GrantPrimaryKeyPrefixLen:]
+	// Split into exactly six escaped segments on bare separator bytes (the
+	// escape rules guarantee segments contain no bare 0x00).
+	var segs [6][]byte
+	rest := tail
+	for i := 0; i < 5; i++ {
+		sep := bytes.IndexByte(rest, 0)
+		if sep < 0 {
+			return dst, false
+		}
+		segs[i] = rest[:sep] // #nosec G602 -- false positive: IndexByte returned >= 0 above, so sep < len(rest).
+		rest = rest[sep+1:]
+	}
+	if bytes.IndexByte(rest, 0) >= 0 {
+		return dst, false
+	}
+	segs[5] = rest
+
+	dst = append(dst, VersionV3, TypeIndex, IdxGrantByPrincipal, 0)
+	for i, idx := range [6]int{4, 5, 0, 1, 2, 3} { // p_rt, p_id, ent_rt, ent_rid, ent_kind, ent_name
+		if i > 0 {
+			dst = append(dst, 0)
+		}
+		dst = append(dst, segs[idx]...)
+	}
+	return dst, true
+}
+
+// AppendGrantByNeedsExpansionKeyFromPrimary builds the
+// by_needs_expansion index key directly from a primary grant key: the
+// primary's separator+tail IS the index key's tail, byte-identical
+// (pinned by the engine's TestNeedsExpansionKeyHeaderSpliceFromPrimary),
+// so the splice is a header swap. Validates the same 6-segment shape as
+// the by_principal splice so a malformed key cannot silently produce a
+// malformed index entry.
+func AppendGrantByNeedsExpansionKeyFromPrimary(dst, primaryKey []byte) ([]byte, bool) {
+	if _, ok := SplitGrantPrimaryKey(primaryKey); !ok {
+		return dst, false
+	}
+	dst = append(dst, VersionV3, TypeIndex, IdxGrantByNeedsExpansion)
+	return append(dst, primaryKey[2:]...), true
+}
+
+// === resource index key + value scanners ===
+
+// EncodeResourceByParentIndexKey: index of children-by-parent:
+//
+//	v3 | TypeIndex | IdxResourceByParent | 0x00 |
+//	    parent_rt | 0x00 | parent_id | 0x00 | child_rt | 0x00 | child_id
+func EncodeResourceByParentIndexKey(parentRT, parentID, childRT, childID string) []byte {
+	buf := make([]byte, 0, 64)
+	buf = append(buf, VersionV3, TypeIndex, IdxResourceByParent)
+	buf = codec.AppendTupleSeparator(buf)
+	return codec.AppendTupleStrings(buf, parentRT, parentID, childRT, childID)
+}
+
+// ScanResourceParentRaw scans a marshaled v3 ResourceRecord value for
+// its parent ref (field 6) without a full unmarshal. ("", "") = no
+// parent. Keeps the LAST occurrence of the field, approximating proto
+// merge semantics; values written by this SDK carry at most one
+// occurrence, so this only matters for foreign writers.
+func ScanResourceParentRaw(value []byte) (string, string, error) {
+	var rt, id string
+	for len(value) > 0 {
+		num, typ, n := protowire.ConsumeTag(value)
+		if n < 0 {
+			return "", "", protowire.ParseError(n)
+		}
+		value = value[n:]
+		if num != 6 {
+			n = protowire.ConsumeFieldValue(num, typ, value)
+			if n < 0 {
+				return "", "", protowire.ParseError(n)
+			}
+			value = value[n:]
+			continue
+		}
+		if typ != protowire.BytesType {
+			return "", "", fmt.Errorf("raw record: resource parent has wire type %v", typ)
+		}
+		msg, n := protowire.ConsumeBytes(value)
+		if n < 0 {
+			return "", "", protowire.ParseError(n)
+		}
+		var err error
+		rt, id, err = ScanResourceRefRaw(msg)
+		if err != nil {
+			return "", "", err
+		}
+		value = value[n:]
+	}
+	return rt, id, nil
+}
+
+// ScanResourceRefRaw extracts (resource_type_id, resource_id) from a
+// marshaled ResourceRef/ResourceId-shaped message (fields 1 and 2).
+func ScanResourceRefRaw(value []byte) (string, string, error) {
+	var rt, id []byte
+	err := ScanResourceRefRawBytes(value, func(num protowire.Number, val []byte) {
+		switch num {
+		case 1:
+			rt = val
+		case 2:
+			id = val
+		default:
+		}
+	})
+	return string(rt), string(id), err
+}
+
+// ScanResourceRefRawBytes walks a marshaled ref-shaped message and
+// hands the raw bytes of fields 1-3 to set. Borrowed bytes: valid only
+// during the callback.
+func ScanResourceRefRawBytes(value []byte, set func(protowire.Number, []byte)) error {
+	for len(value) > 0 {
+		num, typ, n := protowire.ConsumeTag(value)
+		if n < 0 {
+			return protowire.ParseError(n)
+		}
+		value = value[n:]
+		if typ != protowire.BytesType {
+			n = protowire.ConsumeFieldValue(num, typ, value)
+			if n < 0 {
+				return protowire.ParseError(n)
+			}
+			value = value[n:]
+			continue
+		}
+		b, n := protowire.ConsumeBytes(value)
+		if n < 0 {
+			return protowire.ParseError(n)
+		}
+		switch num {
+		case 1, 2, 3:
+			set(num, b)
+		default:
+		}
+		value = value[n:]
+	}
+	return nil
+}
+
+// === grant digest invalidation keys ===
+//
+// A grant mutation on a digest-armed file owes three tombstone sets
+// (present-means-exact — a mutated partition's digest must read as
+// missing, never stale-but-present): the entitlement partition's
+// digest node range, the whole-file global root (the fold of every
+// partition root is stale once any partition is), and the partition's
+// hash-index range. The builders below give rawdb (and the engine's
+// digest repair paths) those ranges from raw partition bytes.
+
+// DigestPartitionPrefix is the prefix of every digest node key for one
+// (index, partition): v3 | TypeDigest | indexID | 0x00 | esc(partition) | 0x00.
+// The partition is tuple-ESCAPED here, unlike in the hash-index key:
+// node keys carry a level byte and a raw bucket prefix after it, so the
+// partition must parse as a single ordinary tuple element.
+func DigestPartitionPrefix(indexID byte, partition string) []byte {
+	buf := make([]byte, 0, 7+len(partition))
+	buf = append(buf, VersionV3, TypeDigest)
+	buf = append(buf, indexID)
+	buf = codec.AppendTupleSeparator(buf)
+	buf = codec.AppendTupleStrings(buf, partition)
+	return codec.AppendTupleSeparator(buf)
+}
+
+// GlobalGrantDigestNodeKey returns the storage key for the whole-file
+// grant digest root: a level-DigestLevelGlobalRoot node under an empty
+// partition of the grant digest index.
+func GlobalGrantDigestNodeKey() []byte {
+	buf := DigestPartitionPrefix(IdxGrantByEntitlementPrincipalHash, "")
+	return append(buf, DigestLevelGlobalRoot)
+}
+
+// GrantHashIndexEntitlementPrefix is the by-value prefix bounding one
+// entitlement partition's rows in the by_entitlement_principal_hash
+// index: v3 | TypeIndex | idx | 0x00 | partition | 0x00. The partition
+// bytes are already escaped (they are a raw sub-slice of the grant
+// primary key), so unlike DigestPartitionPrefix there is no re-escape.
+func GrantHashIndexEntitlementPrefix(partition string) []byte {
+	buf := make([]byte, 0, 6+len(partition))
+	buf = append(buf, VersionV3, TypeIndex, IdxGrantByEntitlementPrincipalHash)
+	buf = codec.AppendTupleSeparator(buf)
+	buf = append(buf, partition...)
+	return codec.AppendTupleSeparator(buf)
+}
+
+// UpperBound returns the exclusive upper bound for a key prefix
+// (codec.KeyUpperBound re-exported for range builders here and in
+// rawdb).
+func UpperBound(prefix []byte) []byte { return codec.KeyUpperBound(prefix) }

--- a/pkg/dotc1z/engine/pebble/internal/rawdb/families.go
+++ b/pkg/dotc1z/engine/pebble/internal/rawdb/families.go
@@ -82,20 +82,11 @@ type RecordBatch struct {
 	core    batch
 	db      *DB
 	scratch []byte
-	// stager is the batch's one Stager view, pre-built so the grant
-	// Stage* ops can pass &rb.stager to the digest-invalidation
-	// deriver without a per-op heap allocation (an inline
-	// &recordStager{rb} escapes through the indirect func-field call
-	// even when the deriver immediately no-ops on digest-absent
-	// syncs — one 8-byte alloc per staged grant on the bulk path).
-	stager recordStager
 }
 
 // NewRecordBatch mints a batch for record-keyspace mutations.
 func (d *DB) NewRecordBatch() *RecordBatch {
-	rb := &RecordBatch{core: batch{b: d.newBatch()}, db: d}
-	rb.stager.rb = rb
-	return rb
+	return &RecordBatch{core: batch{b: d.newBatch()}, db: d}
 }
 
 // Commit applies the staged writes with the given write options.

--- a/pkg/dotc1z/engine/pebble/internal/rawdb/families.go
+++ b/pkg/dotc1z/engine/pebble/internal/rawdb/families.go
@@ -68,14 +68,14 @@ func (b *batch) Close() error { return b.b.Close() }
 // Clients: the Put*Records paths, the expanded/synthesized grant
 // writers, the IfNewer partial-sync paths, and delete paths.
 //
-// Phase 2b: RecordBatch exposes NO generic staging. The only way to
-// stage a record mutation is a typed Stage* operation (records.go)
-// that derives and stages everything the row owes in the same call —
-// the forgotten-obligation bug class (primary landed, index entry or
+// RecordBatch exposes NO generic staging. The only way to stage a
+// record mutation is a typed Stage* operation (records.go) that
+// derives and stages everything the row owes in the same call — the
+// forgotten-obligation bug class (primary landed, index entry or
 // digest invalidation forgotten) is unexpressible. The compactor's
 // keep-newer fold, which legitimately stages raw keys it did not
-// encode, uses FoldBatch instead (records.go) via the Engine.DB
-// exemption surface.
+// encode, uses FoldBatch instead (records.go) via the Engine merge
+// surface (the engine package's merge_surface.go).
 type RecordBatch struct {
 	// core is deliberately NOT embedded: embedding would promote the
 	// generic Set/Delete/DeleteRange onto the exported surface.

--- a/pkg/dotc1z/engine/pebble/internal/rawdb/keyspace.go
+++ b/pkg/dotc1z/engine/pebble/internal/rawdb/keyspace.go
@@ -1,19 +1,14 @@
-// Package keys holds the v3 keyspace ABI shared by the engine package
-// and internal/rawdb: the type/index discriminator bytes, the grant
-// primary-key splices, the resource value scanners, and the digest
-// invalidation key builders. It exists so rawdb's typed record ops can
-// DERIVE their obligations directly instead of having the engine
-// inject derivation closures at Open (the pre-2.5 RecordDerivers
-// shape) — rawdb owns what a record mutation must stage together, and
-// this package owns the byte formats both sides agree on.
-//
-// Everything here is a pure function over bytes/strings: no engine
-// state, no pebble handles. The full key-layout convention (header
-// shapes, tuple encoding, prefix pairing) is documented in the engine
-// package's keys.go, which re-exports these discriminators for its own
-// encoders; the byte formats are an on-disk ABI shared with every v3
-// c1z file. See the codec package for the escape rules.
-package keys
+// The v3 keyspace ABI the choke point enforces: the type/index
+// discriminator bytes, the grant primary-key splices, the resource
+// value scanners, and the digest invalidation key builders. The typed
+// record ops derive their obligations from these directly; the engine
+// package imports them for its own encoders and read paths. Everything
+// here is a pure function over bytes/strings: no engine state, no
+// pebble handles. The full key-layout convention (header shapes,
+// tuple encoding, prefix pairing) is documented in the engine
+// package's keys.go; the byte formats are an on-disk ABI shared with
+// every v3 c1z file. See the codec package for the escape rules.
+package rawdb
 
 import (
 	"bytes"

--- a/pkg/dotc1z/engine/pebble/internal/rawdb/rawdb.go
+++ b/pkg/dotc1z/engine/pebble/internal/rawdb/rawdb.go
@@ -49,9 +49,6 @@ type DB struct {
 	// (pebble.Options.FS resolved: the WithVFS override or vfs.Default).
 	// Every SST this package stages for ingest MUST be created on it.
 	fs vfs.FS
-	// merge is the pre-built narrowed view MergeView() hands out.
-	merge MergeView
-
 	// deferredIdxPending mirrors the durable deferred-index marker
 	// (keys.DeferredIdxPendingKey): grant writes that skipped the
 	// inline by_principal index owe a rebuild at EndSync. The flag and
@@ -93,9 +90,7 @@ func Open(dir string, opts *pebble.Options, fs vfs.FS) (*DB, error) {
 	if fs == nil {
 		fs = vfs.Default
 	}
-	d := &DB{db: db, fs: fs}
-	d.merge = MergeView{db: d}
-	return d, nil
+	return &DB{db: db, fs: fs}, nil
 }
 
 // Close closes the underlying pebble.DB. The engine's teardown
@@ -137,61 +132,6 @@ func (d *DB) UnsafeForTesting() *pebble.DB {
 	}
 	return d.db
 }
-
-// === the compactor's narrowed view ===
-
-// MergeView is the CONCRETE handle Engine.DB() hands the
-// synccompactor: reads, LSM stats, the bulk range/ingest ops, and the
-// fold-exempt batch — and nothing else. It must stay a concrete
-// struct, not an interface over *DB: Go interfaces are structural, so
-// an interface whose dynamic type is *DB would let any caller recover
-// the omitted write families with a type assertion
-// (`h.(interface{ MetaSet(...) error })`) — no internal-package import
-// required (review finding, delta round). A struct with only these
-// methods gives an assertion nothing to recover.
-//
-// NewFoldBatch is the one deliberate raw-write conduit here: the fold
-// compactor rewrites record keyspaces wholesale, with its obligations
-// handled by contract (digest state dropped, markers handled at the
-// store layer) rather than derivation. Its use is fenced to
-// pkg/synccompactor/pebble by meta-test.
-type MergeView struct {
-	db *DB
-}
-
-// MergeView returns the narrowed handle. Stable identity per DB (the
-// engine returns it to external callers on every DB() call).
-func (d *DB) MergeView() *MergeView { return &d.merge }
-
-func (v *MergeView) Get(key []byte) ([]byte, io.Closer, error) { return v.db.Get(key) }
-
-func (v *MergeView) NewIter(o *pebble.IterOptions) (*pebble.Iterator, error) {
-	return v.db.NewIter(o)
-}
-
-func (v *MergeView) Metrics() *pebble.Metrics { return v.db.Metrics() }
-
-func (v *MergeView) EstimateDiskUsage(start, end []byte) (uint64, error) {
-	return v.db.EstimateDiskUsage(start, end)
-}
-
-func (v *MergeView) DropKeyRange(start, end []byte, o *pebble.WriteOptions) error {
-	return v.db.DropKeyRange(start, end, o)
-}
-
-func (v *MergeView) IngestSSTs(ctx context.Context, paths []string) error {
-	return v.db.IngestSSTs(ctx, paths)
-}
-
-func (v *MergeView) ReplaceRangeWithSSTs(ctx context.Context, paths []string, span pebble.KeyRange) error {
-	return v.db.ReplaceRangeWithSSTs(ctx, paths, span)
-}
-
-func (v *MergeView) NewFoldBatch() *FoldBatch { return v.db.NewFoldBatch() }
-
-// UnsafeForTesting delegates to DB.UnsafeForTesting — same
-// testing.Testing() runtime gate, same meta-test source fence.
-func (v *MergeView) UnsafeForTesting() *pebble.DB { return v.db.UnsafeForTesting() }
 
 // === deferred-index marker + digest-presence state ===
 //

--- a/pkg/dotc1z/engine/pebble/internal/rawdb/rawdb.go
+++ b/pkg/dotc1z/engine/pebble/internal/rawdb/rawdb.go
@@ -37,8 +37,6 @@ import (
 
 	"github.com/cockroachdb/pebble/v2"
 	"github.com/cockroachdb/pebble/v2/vfs"
-
-	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
 )
 
 // DB owns the raw pebble handle. Construct via Open; the pebble.DB is
@@ -50,7 +48,7 @@ type DB struct {
 	// Every SST this package stages for ingest MUST be created on it.
 	fs vfs.FS
 	// deferredIdxPending mirrors the durable deferred-index marker
-	// (keys.DeferredIdxPendingKey): grant writes that skipped the
+	// (DeferredIdxPendingKey): grant writes that skipped the
 	// inline by_principal index owe a rebuild at EndSync. The flag and
 	// the durable key must never disagree — armed flag + absent key
 	// means an in-process EndSync rebuilds while a crash+resume
@@ -170,7 +168,7 @@ func (d *DB) armDeferredMarkerDurably() error {
 			return err
 		}
 	}
-	return d.set(keys.DeferredIdxPendingKey(), nil, pebble.Sync)
+	return d.set(DeferredIdxPendingKey(), nil, pebble.Sync)
 }
 
 // ClearDeferredGrantIndexMarker drops both halves of the marker after
@@ -187,7 +185,7 @@ func (d *DB) ClearDeferredGrantIndexMarker() error {
 			return err
 		}
 	}
-	if err := d.delete(keys.DeferredIdxPendingKey(), pebble.Sync); err != nil {
+	if err := d.delete(DeferredIdxPendingKey(), pebble.Sync); err != nil {
 		return err
 	}
 	d.deferredIdxPending.Store(false)
@@ -199,7 +197,7 @@ func (d *DB) ClearDeferredGrantIndexMarker() error {
 // process may have deferred by_principal writes and been interrupted
 // before the EndSync rebuild.
 func (d *DB) RestoreDeferredIdxPending() error {
-	_, closer, err := d.db.Get(keys.DeferredIdxPendingKey())
+	_, closer, err := d.db.Get(DeferredIdxPendingKey())
 	switch {
 	case err == nil:
 		closer.Close()
@@ -224,7 +222,7 @@ func (d *DB) SetGrantDigestsPresent(present bool) { d.grantDigestsPresent.Store(
 // ProbeGrantDigestsPresent initializes the presence flag with one
 // bounded seek over the digest keyspace (the Open-time probe).
 func (d *DB) ProbeGrantDigestsPresent() error {
-	lo, hi := keys.DigestKeyspaceBounds()
+	lo, hi := DigestKeyspaceBounds()
 	iter, err := d.db.NewIter(&pebble.IterOptions{LowerBound: lo, UpperBound: hi})
 	if err != nil {
 		return err

--- a/pkg/dotc1z/engine/pebble/internal/rawdb/rawdb.go
+++ b/pkg/dotc1z/engine/pebble/internal/rawdb/rawdb.go
@@ -30,11 +30,15 @@ package rawdb
 
 import (
 	"context"
+	"errors"
 	"io"
+	"sync/atomic"
 	"testing"
 
 	"github.com/cockroachdb/pebble/v2"
 	"github.com/cockroachdb/pebble/v2/vfs"
+
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
 )
 
 // DB owns the raw pebble handle. Construct via Open; the pebble.DB is
@@ -45,12 +49,36 @@ type DB struct {
 	// (pebble.Options.FS resolved: the WithVFS override or vfs.Default).
 	// Every SST this package stages for ingest MUST be created on it.
 	fs vfs.FS
-	// derivers are the engine-injected key-format functions the typed
-	// record ops (records.go) derive obligations with. Wired once via
-	// SetRecordDerivers at engine Open.
-	derivers *RecordDerivers
 	// merge is the pre-built narrowed view MergeView() hands out.
 	merge MergeView
+
+	// deferredIdxPending mirrors the durable deferred-index marker
+	// (keys.DeferredIdxPendingKey): grant writes that skipped the
+	// inline by_principal index owe a rebuild at EndSync. The flag and
+	// the durable key must never disagree — armed flag + absent key
+	// means an in-process EndSync rebuilds while a crash+resume
+	// silently skips the rebuild; cleared flag + present key forces a
+	// spurious rebuild at the next open. ArmDeferredGrantIndex and
+	// ClearDeferredGrantIndexMarker maintain the agreement on both
+	// edges (durable half first; rollback/abort on failure), and
+	// RestoreDeferredIdxPending re-arms from the key at Open.
+	deferredIdxPending atomic.Bool
+
+	// grantDigestsPresent reports whether the digest keyspace holds
+	// any nodes — the gate for the record ops' digest-invalidation
+	// obligation (present-means-exact: mutations on a digest-armed
+	// file must tombstone their partition; on a digest-free file the
+	// tombstones would be pure LSM bloat). Probed at Open
+	// (ProbeGrantDigestsPresent), set true by the engine's seal-time
+	// build, cleared by the engine's drop/reset paths.
+	grantDigestsPresent atomic.Bool
+
+	// testArmDeferredMarkerHook / testClearDeferredMarkerHook run
+	// before the marker's durable commit / delete — the in-process
+	// analogs of those writes failing. Installed only via
+	// SetDeferredMarkerTestHooks (testing-gated).
+	testArmDeferredMarkerHook   func() error
+	testClearDeferredMarkerHook func() error
 }
 
 // Open opens the pebble database at dir. opts is consumed by
@@ -164,6 +192,118 @@ func (v *MergeView) NewFoldBatch() *FoldBatch { return v.db.NewFoldBatch() }
 // UnsafeForTesting delegates to DB.UnsafeForTesting — same
 // testing.Testing() runtime gate, same meta-test source fence.
 func (v *MergeView) UnsafeForTesting() *pebble.DB { return v.db.UnsafeForTesting() }
+
+// === deferred-index marker + digest-presence state ===
+//
+// Write-side crash-contract state lives ON the choke point: the
+// deferred marker's arm/clear are themselves durable writes with
+// ordering obligations, and the digests-present flag gates an
+// obligation the typed record ops stage. (Pre-2.5 these lived on the
+// engine and arrived as injected closures.)
+
+// DeferredIdxPending reports whether a deferred by_principal rebuild
+// is owed (see the field doc).
+func (d *DB) DeferredIdxPending() bool { return d.deferredIdxPending.Load() }
+
+// ArmDeferredGrantIndex durably arms the deferred-index rebuild
+// marker: CAS on the in-memory flag (repeat calls are one atomic
+// load — the deferred write paths call this per record), then the
+// fsync'd meta key. On a failed durable write the CAS rolls back so
+// the flag and the key never disagree (armed flag + absent key = an
+// in-process EndSync rebuilds while a crash+resume silently skips
+// it). Called by StageGrantPutDeferred and by the engine's synth-layer
+// ingest path.
+func (d *DB) ArmDeferredGrantIndex() error {
+	if !d.deferredIdxPending.CompareAndSwap(false, true) {
+		return nil
+	}
+	if err := d.armDeferredMarkerDurably(); err != nil {
+		d.deferredIdxPending.Store(false)
+		return err
+	}
+	return nil
+}
+
+func (d *DB) armDeferredMarkerDurably() error {
+	if d.testArmDeferredMarkerHook != nil {
+		if err := d.testArmDeferredMarkerHook(); err != nil {
+			return err
+		}
+	}
+	return d.set(keys.DeferredIdxPendingKey(), nil, pebble.Sync)
+}
+
+// ClearDeferredGrantIndexMarker drops both halves of the marker after
+// a successful rebuild. Durable delete FIRST, flag second — the same
+// agreement contract as the arm side: a failed delete leaves BOTH
+// armed, so the retried EndSync re-runs the (idempotent) rebuild and
+// retries the clear, never the flag-cleared/key-present split that
+// skipped the retry's rebuild and left a stale key forcing a spurious
+// rebuild at the next open. The caller owns the write barrier (the
+// engine runs this inside EndSync's sealed finalize window).
+func (d *DB) ClearDeferredGrantIndexMarker() error {
+	if d.testClearDeferredMarkerHook != nil {
+		if err := d.testClearDeferredMarkerHook(); err != nil {
+			return err
+		}
+	}
+	if err := d.delete(keys.DeferredIdxPendingKey(), pebble.Sync); err != nil {
+		return err
+	}
+	d.deferredIdxPending.Store(false)
+	return nil
+}
+
+// RestoreDeferredIdxPending re-arms the in-memory flag from the
+// durable marker — the Open-time half of the crash contract: a prior
+// process may have deferred by_principal writes and been interrupted
+// before the EndSync rebuild.
+func (d *DB) RestoreDeferredIdxPending() error {
+	_, closer, err := d.db.Get(keys.DeferredIdxPendingKey())
+	switch {
+	case err == nil:
+		closer.Close()
+		d.deferredIdxPending.Store(true)
+		return nil
+	case errors.Is(err, pebble.ErrNotFound):
+		return nil
+	default:
+		return err
+	}
+}
+
+// GrantDigestsPresent reports whether digest state exists (the record
+// ops' invalidation gate).
+func (d *DB) GrantDigestsPresent() bool { return d.grantDigestsPresent.Load() }
+
+// SetGrantDigestsPresent flips the presence flag. The engine owns the
+// transitions: true after a completed seal-time build, false on the
+// drop/reset paths (whose durable deletes ride their own batches).
+func (d *DB) SetGrantDigestsPresent(present bool) { d.grantDigestsPresent.Store(present) }
+
+// ProbeGrantDigestsPresent initializes the presence flag with one
+// bounded seek over the digest keyspace (the Open-time probe).
+func (d *DB) ProbeGrantDigestsPresent() error {
+	lo, hi := keys.DigestKeyspaceBounds()
+	iter, err := d.db.NewIter(&pebble.IterOptions{LowerBound: lo, UpperBound: hi})
+	if err != nil {
+		return err
+	}
+	defer iter.Close()
+	d.grantDigestsPresent.Store(iter.First())
+	return iter.Error()
+}
+
+// SetDeferredMarkerTestHooks installs failure-injection hooks for the
+// marker's durable arm/clear. Test-only, same runtime gate as
+// UnsafeForTesting; pass nil to uninstall.
+func (d *DB) SetDeferredMarkerTestHooks(armHook, clearHook func() error) {
+	if !testing.Testing() {
+		panic("rawdb.SetDeferredMarkerTestHooks: called outside a test binary")
+	}
+	d.testArmDeferredMarkerHook = armHook
+	d.testClearDeferredMarkerHook = clearHook
+}
 
 // === lifecycle operations (write-class, engine-lifecycle-named) ===
 

--- a/pkg/dotc1z/engine/pebble/internal/rawdb/records.go
+++ b/pkg/dotc1z/engine/pebble/internal/rawdb/records.go
@@ -41,16 +41,14 @@ package rawdb
 
 import (
 	"fmt"
-
-	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
 )
 
 // Family prefixes for the keyspace assertions.
 var (
-	grantPrimaryPrefix        = []byte{keys.VersionV3, keys.TypeGrant}
-	resourcePrimaryPrefix     = []byte{keys.VersionV3, keys.TypeResource}
-	entitlementPrimaryPrefix  = []byte{keys.VersionV3, keys.TypeEntitlement}
-	resourceTypePrimaryPrefix = []byte{keys.VersionV3, keys.TypeResourceType}
+	grantPrimaryPrefix        = []byte{VersionV3, TypeGrant}
+	resourcePrimaryPrefix     = []byte{VersionV3, TypeResource}
+	entitlementPrimaryPrefix  = []byte{VersionV3, TypeEntitlement}
+	resourceTypePrimaryPrefix = []byte{VersionV3, TypeResourceType}
 )
 
 func assertFamily(op string, key, prefix []byte) error {
@@ -76,7 +74,7 @@ func (rb *RecordBatch) StageGrantPutInline(key, val []byte, hadOldVal, needsExpa
 	if err := assertFamily("StageGrantPutInline", key, grantPrimaryPrefix); err != nil {
 		return err
 	}
-	sep4, ok := keys.SplitGrantPrimaryKey(key)
+	sep4, ok := SplitGrantPrimaryKey(key)
 	if !ok {
 		return fmt.Errorf("rawdb.StageGrantPutInline: grant key %x did not decode as a 6-segment identity", key)
 	}
@@ -118,7 +116,7 @@ func (rb *RecordBatch) StageGrantDelete(key []byte) error {
 	if err := assertFamily("StageGrantDelete", key, grantPrimaryPrefix); err != nil {
 		return err
 	}
-	sep4, ok := keys.SplitGrantPrimaryKey(key)
+	sep4, ok := SplitGrantPrimaryKey(key)
 	if !ok {
 		return fmt.Errorf("rawdb.StageGrantDelete: grant key %x did not decode as a 6-segment identity", key)
 	}
@@ -146,7 +144,7 @@ func (rb *RecordBatch) StageGrantPutDeferred(key, val []byte, hadOldVal, needsEx
 	if err := assertFamily("StageGrantPutDeferred", key, grantPrimaryPrefix); err != nil {
 		return err
 	}
-	sep4, ok := keys.SplitGrantPrimaryKey(key)
+	sep4, ok := SplitGrantPrimaryKey(key)
 	if !ok {
 		return fmt.Errorf("rawdb.StageGrantPutDeferred: grant key %x did not decode as a 6-segment identity", key)
 	}
@@ -170,7 +168,7 @@ func (rb *RecordBatch) StageGrantPutDeferred(key, val []byte, hadOldVal, needsEx
 }
 
 func (rb *RecordBatch) setByPrincipalKey(key []byte) error {
-	idx, ok := keys.AppendGrantByPrincipalKeyFromPrimary(rb.scratch[:0], key)
+	idx, ok := AppendGrantByPrincipalKeyFromPrimary(rb.scratch[:0], key)
 	rb.scratch = idx
 	if !ok {
 		return fmt.Errorf("rawdb: grant key %x did not decode as a 6-segment identity", key)
@@ -179,7 +177,7 @@ func (rb *RecordBatch) setByPrincipalKey(key []byte) error {
 }
 
 func (rb *RecordBatch) deleteByPrincipalKey(key []byte) error {
-	idx, ok := keys.AppendGrantByPrincipalKeyFromPrimary(rb.scratch[:0], key)
+	idx, ok := AppendGrantByPrincipalKeyFromPrimary(rb.scratch[:0], key)
 	rb.scratch = idx
 	if !ok {
 		return fmt.Errorf("rawdb: grant key %x did not decode as a 6-segment identity", key)
@@ -188,7 +186,7 @@ func (rb *RecordBatch) deleteByPrincipalKey(key []byte) error {
 }
 
 func (rb *RecordBatch) setNeedsExpansionKey(key []byte) error {
-	idx, ok := keys.AppendGrantByNeedsExpansionKeyFromPrimary(rb.scratch[:0], key)
+	idx, ok := AppendGrantByNeedsExpansionKeyFromPrimary(rb.scratch[:0], key)
 	rb.scratch = idx
 	if !ok {
 		return fmt.Errorf("rawdb: grant key %x did not decode as a 6-segment identity", key)
@@ -197,7 +195,7 @@ func (rb *RecordBatch) setNeedsExpansionKey(key []byte) error {
 }
 
 func (rb *RecordBatch) deleteNeedsExpansionKey(key []byte) error {
-	idx, ok := keys.AppendGrantByNeedsExpansionKeyFromPrimary(rb.scratch[:0], key)
+	idx, ok := AppendGrantByNeedsExpansionKeyFromPrimary(rb.scratch[:0], key)
 	rb.scratch = idx
 	if !ok {
 		return fmt.Errorf("rawdb: grant key %x did not decode as a 6-segment identity", key)
@@ -221,16 +219,16 @@ func (rb *RecordBatch) stageGrantDigestInvalidation(primaryKey []byte, sep4 int)
 	if !rb.db.grantDigestsPresent.Load() {
 		return nil
 	}
-	partition := string(primaryKey[keys.GrantPrimaryKeyPrefixLen:sep4])
-	lo := keys.DigestPartitionPrefix(keys.IdxGrantByEntitlementPrincipalHash, partition)
-	if err := rb.core.b.DeleteRange(lo, keys.UpperBound(lo), nil); err != nil {
+	partition := string(primaryKey[GrantPrimaryKeyPrefixLen:sep4])
+	lo := DigestPartitionPrefix(IdxGrantByEntitlementPrincipalHash, partition)
+	if err := rb.core.b.DeleteRange(lo, UpperBound(lo), nil); err != nil {
 		return err
 	}
-	if err := rb.core.b.Delete(keys.GlobalGrantDigestNodeKey(), nil); err != nil {
+	if err := rb.core.b.Delete(GlobalGrantDigestNodeKey(), nil); err != nil {
 		return err
 	}
-	hlo := keys.GrantHashIndexEntitlementPrefix(partition)
-	return rb.core.b.DeleteRange(hlo, keys.UpperBound(hlo), nil)
+	hlo := GrantHashIndexEntitlementPrefix(partition)
+	return rb.core.b.DeleteRange(hlo, UpperBound(hlo), nil)
 }
 
 // === resource staging ===
@@ -254,14 +252,14 @@ func (rb *RecordBatch) StageResourcePut(key, val, oldVal []byte, childRT, childI
 	if err := rb.core.b.Set(key, val, nil); err != nil {
 		return err
 	}
-	parentRT, parentID, err := keys.ScanResourceParentRaw(val)
+	parentRT, parentID, err := ScanResourceParentRaw(val)
 	if err != nil {
 		return err
 	}
 	if parentID == "" {
 		return nil
 	}
-	return rb.core.b.Set(keys.EncodeResourceByParentIndexKey(parentRT, parentID, childRT, childID), nil, nil)
+	return rb.core.b.Set(EncodeResourceByParentIndexKey(parentRT, parentID, childRT, childID), nil, nil)
 }
 
 // StageResourceDelete stages one resource row's removal plus its
@@ -277,14 +275,14 @@ func (rb *RecordBatch) StageResourceDelete(key, oldVal []byte, childRT, childID 
 }
 
 func (rb *RecordBatch) stageResourceParentDelete(oldVal []byte, childRT, childID string) error {
-	parentRT, parentID, err := keys.ScanResourceParentRaw(oldVal)
+	parentRT, parentID, err := ScanResourceParentRaw(oldVal)
 	if err != nil {
 		return err
 	}
 	if parentID == "" {
 		return nil
 	}
-	return rb.core.b.Delete(keys.EncodeResourceByParentIndexKey(parentRT, parentID, childRT, childID), nil)
+	return rb.core.b.Delete(EncodeResourceByParentIndexKey(parentRT, parentID, childRT, childID), nil)
 }
 
 // === entitlement / resource-type staging ===

--- a/pkg/dotc1z/engine/pebble/internal/rawdb/records.go
+++ b/pkg/dotc1z/engine/pebble/internal/rawdb/records.go
@@ -6,10 +6,8 @@ package rawdb
 // prior-row index cleanup, or the deferred-index crash marker — dies
 // here: RecordBatch exposes no generic staging, and each Stage* op
 // computes and stages everything its mutation owes in the same call,
-// deriving directly from the shared keyspace ABI (internal/keys).
-// (Pre-2.5 this derivation arrived as engine-injected closures
-// (RecordDerivers) because rawdb could not import its parent package;
-// the keys extraction dissolved that inversion.)
+// deriving directly from the keyspace ABI this package owns
+// (keyspace.go).
 //
 // Grant index maintenance runs TWO REGIMES, and the ops mirror them
 // (unifying them behind a flag was considered and rejected — the

--- a/pkg/dotc1z/engine/pebble/internal/rawdb/records.go
+++ b/pkg/dotc1z/engine/pebble/internal/rawdb/records.go
@@ -1,12 +1,15 @@
 package rawdb
 
-// Phase 2b: typed record-keyspace staging with obligation derivation
-// FOLDED INTO the ops. The forgotten-obligation bug class — a caller
-// staging a primary row and forgetting its index entries, digest
-// invalidation, prior-row index cleanup, or the deferred-index crash
-// marker — dies here: RecordBatch exposes no generic staging, and each
-// Stage* op computes and stages everything its mutation owes in the
-// same call.
+// Typed record-keyspace staging with obligation derivation FOLDED INTO
+// the ops. The forgotten-obligation bug class — a caller staging a
+// primary row and forgetting its index entries, digest invalidation,
+// prior-row index cleanup, or the deferred-index crash marker — dies
+// here: RecordBatch exposes no generic staging, and each Stage* op
+// computes and stages everything its mutation owes in the same call,
+// deriving directly from the shared keyspace ABI (internal/keys).
+// (Pre-2.5 this derivation arrived as engine-injected closures
+// (RecordDerivers) because rawdb could not import its parent package;
+// the keys extraction dissolved that inversion.)
 //
 // Grant index maintenance runs TWO REGIMES, and the ops mirror them
 // (unifying them behind a flag was considered and rejected — the
@@ -17,12 +20,11 @@ package rawdb
 //     cleans BOTH; digest invalidation when digests are present. The
 //     PutGrantRecords and IfNewer paths, and post-seal deletes.
 //   - DEFERRED (StageGrantPutDeferred): the durable deferred-index
-//     marker is armed FIRST (via the engine-injected arm function —
-//     CAS-cheap per record, crash-contract-ordered before the batch
-//     can commit), only by_needs_expansion is written inline, and
-//     overwrite cleanup deliberately skips by_principal (the whole
-//     family is excised and rebuilt at seal). The expanded/synth
-//     grant writers.
+//     marker is armed FIRST (ArmDeferredGrantIndex — CAS-cheap per
+//     record, crash-contract-ordered before the batch can commit),
+//     only by_needs_expansion is written inline, and overwrite cleanup
+//     deliberately skips by_principal (the whole family is excised and
+//     rebuilt at seal). The expanded/synth grant writers.
 //
 // The derivation contract is BYTE-LEVEL and KEY-DERIVED: index keys
 // come from the encoded grant primary key by splice (by_principal:
@@ -31,10 +33,7 @@ package rawdb
 // so key-derived and value-derived obligations are identical by
 // construction, and the splices are pinned against decode+re-encode
 // by the engine's TestAppendGrantByPrincipalKeyFromPrimary /
-// TestNeedsExpansionKeyHeaderSpliceFromPrimary. The engine injects
-// the splice/scan functions once at Open (RecordDerivers): rawdb owns
-// the COMPOSITION (what must be staged together, unforgettable), the
-// engine owns the byte formats (its keyspace ABI).
+// TestNeedsExpansionKeyHeaderSpliceFromPrimary.
 //
 // Every op asserts its key's family prefix — a Stage* call with a key
 // from the wrong keyspace fails loudly rather than landing where it
@@ -43,83 +42,16 @@ package rawdb
 import (
 	"fmt"
 
-	"github.com/cockroachdb/pebble/v2"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
 )
 
-// RecordDerivers are the engine-injected functions the typed record
-// ops derive obligations with. Append-shaped functions write into dst
-// and return it (scratch reuse; the batch owns the scratch).
-type RecordDerivers struct {
-	// GrantKeyValid reports whether a grant primary key decodes as a
-	// 6-segment identity. Run unconditionally by every grant op: the
-	// splices validate implicitly, but obligation paths are
-	// conditional (a deferred put with needsExpansion=false and
-	// digests unarmed runs no splice at all), and a malformed key must
-	// never stage regardless of which obligations happen to fire.
-	GrantKeyValid func(primaryKey []byte) bool
-	// GrantByPrincipalKey appends the by_principal index key derived
-	// from a grant primary key (segment permutation). ok=false means
-	// the key did not decode as a 6-segment grant identity.
-	GrantByPrincipalKey func(dst, primaryKey []byte) ([]byte, bool)
-	// GrantNeedsExpansionKey appends the by_needs_expansion index key
-	// derived from a grant primary key (header swap).
-	GrantNeedsExpansionKey func(dst, primaryKey []byte) ([]byte, bool)
-	// StageGrantDigestInvalidation stages the digest invalidation a
-	// grant mutation owes for its entitlement partition when digest
-	// state exists (present-means-exact). Must internally no-op when
-	// digests are not armed — the armed probe is engine state.
-	StageGrantDigestInvalidation func(st Stager, grantPrimaryKey []byte) error
-	// ArmDeferredGrantIndex durably arms the deferred by_principal
-	// rebuild marker (CAS + fsync'd meta key; rollback on failure).
-	// Called by the DEFERRED regime before staging, per record —
-	// the engine's CAS makes repeat calls one atomic load.
-	ArmDeferredGrantIndex func() error
-
-	// ResourceParent scans a marshaled ResourceRecord value for its
-	// parent ref ("", "" = no parent, no index entry owed).
-	ResourceParent func(value []byte) (parentRT, parentID string, err error)
-	// ResourceByParentKey builds the by_parent index key.
-	ResourceByParentKey func(parentRT, parentID, childRT, childID string) []byte
-
-	// Family prefixes for the keyspace assertions.
-	GrantPrimaryPrefix        []byte
-	ResourcePrimaryPrefix     []byte
-	EntitlementPrimaryPrefix  []byte
-	ResourceTypePrimaryPrefix []byte
-}
-
-func (d *RecordDerivers) complete() error {
-	switch {
-	case d.GrantKeyValid == nil, d.GrantByPrincipalKey == nil, d.GrantNeedsExpansionKey == nil,
-		d.StageGrantDigestInvalidation == nil, d.ArmDeferredGrantIndex == nil,
-		d.ResourceParent == nil, d.ResourceByParentKey == nil:
-		return fmt.Errorf("rawdb: RecordDerivers incomplete: every derivation function is load-bearing")
-	case len(d.GrantPrimaryPrefix) == 0, len(d.ResourcePrimaryPrefix) == 0,
-		len(d.EntitlementPrimaryPrefix) == 0, len(d.ResourceTypePrimaryPrefix) == 0:
-		return fmt.Errorf("rawdb: RecordDerivers incomplete: family prefixes required for keyspace assertions")
-	}
-	return nil
-}
-
-// SetRecordDerivers wires the engine's derivation functions. Must be
-// called exactly once, at engine Open, before any record staging.
-func (d *DB) SetRecordDerivers(rd RecordDerivers) error {
-	if err := rd.complete(); err != nil {
-		return err
-	}
-	if d.derivers != nil {
-		return fmt.Errorf("rawdb: RecordDerivers already set")
-	}
-	d.derivers = &rd
-	return nil
-}
-
-func (d *DB) mustDerivers() *RecordDerivers {
-	if d.derivers == nil {
-		panic("rawdb: record staging before SetRecordDerivers — the engine must wire derivers at Open")
-	}
-	return d.derivers
-}
+// Family prefixes for the keyspace assertions.
+var (
+	grantPrimaryPrefix        = []byte{keys.VersionV3, keys.TypeGrant}
+	resourcePrimaryPrefix     = []byte{keys.VersionV3, keys.TypeResource}
+	entitlementPrimaryPrefix  = []byte{keys.VersionV3, keys.TypeEntitlement}
+	resourceTypePrimaryPrefix = []byte{keys.VersionV3, keys.TypeResourceType}
+)
 
 func assertFamily(op string, key, prefix []byte) error {
 	if len(key) < len(prefix) || string(key[:len(prefix)]) != string(prefix) {
@@ -141,33 +73,33 @@ func assertFamily(op string, key, prefix []byte) error {
 // Contrast StageResourcePut, which takes the prior VALUE bytes —
 // resource index keys derive from the value (parent ref), not the key.
 func (rb *RecordBatch) StageGrantPutInline(key, val []byte, hadOldVal, needsExpansion bool) error {
-	d := rb.db.mustDerivers()
-	if err := assertFamily("StageGrantPutInline", key, d.GrantPrimaryPrefix); err != nil {
+	if err := assertFamily("StageGrantPutInline", key, grantPrimaryPrefix); err != nil {
 		return err
 	}
-	if !d.GrantKeyValid(key) {
+	sep4, ok := keys.SplitGrantPrimaryKey(key)
+	if !ok {
 		return fmt.Errorf("rawdb.StageGrantPutInline: grant key %x did not decode as a 6-segment identity", key)
 	}
 	if hadOldVal {
-		if err := rb.deleteGrantIndexKey(d.GrantByPrincipalKey, key); err != nil {
+		if err := rb.deleteByPrincipalKey(key); err != nil {
 			return err
 		}
-		if err := rb.deleteGrantIndexKey(d.GrantNeedsExpansionKey, key); err != nil {
+		if err := rb.deleteNeedsExpansionKey(key); err != nil {
 			return err
 		}
 	}
 	if err := rb.core.b.Set(key, val, nil); err != nil {
 		return err
 	}
-	if err := rb.setGrantIndexKey(d.GrantByPrincipalKey, key); err != nil {
+	if err := rb.setByPrincipalKey(key); err != nil {
 		return err
 	}
 	if needsExpansion {
-		if err := rb.setGrantIndexKey(d.GrantNeedsExpansionKey, key); err != nil {
+		if err := rb.setNeedsExpansionKey(key); err != nil {
 			return err
 		}
 	}
-	return d.StageGrantDigestInvalidation(&rb.stager, key)
+	return rb.stageGrantDigestInvalidation(key, sep4)
 }
 
 // StageGrantDelete stages one grant row's removal (INLINE regime:
@@ -183,23 +115,23 @@ func (rb *RecordBatch) StageGrantPutInline(key, val []byte, hadOldVal, needsExpa
 // cleanup cannot be skipped; tombstones on absent index keys are
 // harmless.
 func (rb *RecordBatch) StageGrantDelete(key []byte) error {
-	d := rb.db.mustDerivers()
-	if err := assertFamily("StageGrantDelete", key, d.GrantPrimaryPrefix); err != nil {
+	if err := assertFamily("StageGrantDelete", key, grantPrimaryPrefix); err != nil {
 		return err
 	}
-	if !d.GrantKeyValid(key) {
+	sep4, ok := keys.SplitGrantPrimaryKey(key)
+	if !ok {
 		return fmt.Errorf("rawdb.StageGrantDelete: grant key %x did not decode as a 6-segment identity", key)
 	}
-	if err := rb.deleteGrantIndexKey(d.GrantByPrincipalKey, key); err != nil {
+	if err := rb.deleteByPrincipalKey(key); err != nil {
 		return err
 	}
-	if err := rb.deleteGrantIndexKey(d.GrantNeedsExpansionKey, key); err != nil {
+	if err := rb.deleteNeedsExpansionKey(key); err != nil {
 		return err
 	}
 	if err := rb.core.b.Delete(key, nil); err != nil {
 		return err
 	}
-	return d.StageGrantDigestInvalidation(&rb.stager, key)
+	return rb.stageGrantDigestInvalidation(key, sep4)
 }
 
 // StageGrantPutDeferred stages one grant row in the DEFERRED index
@@ -211,18 +143,18 @@ func (rb *RecordBatch) StageGrantDelete(key []byte) error {
 // invalidation is staged. hadOldVal selects overwrite cleanup of the
 // needs_expansion entry.
 func (rb *RecordBatch) StageGrantPutDeferred(key, val []byte, hadOldVal, needsExpansion bool) error {
-	d := rb.db.mustDerivers()
-	if err := assertFamily("StageGrantPutDeferred", key, d.GrantPrimaryPrefix); err != nil {
+	if err := assertFamily("StageGrantPutDeferred", key, grantPrimaryPrefix); err != nil {
 		return err
 	}
-	if !d.GrantKeyValid(key) {
+	sep4, ok := keys.SplitGrantPrimaryKey(key)
+	if !ok {
 		return fmt.Errorf("rawdb.StageGrantPutDeferred: grant key %x did not decode as a 6-segment identity", key)
 	}
-	if err := d.ArmDeferredGrantIndex(); err != nil {
+	if err := rb.db.ArmDeferredGrantIndex(); err != nil {
 		return err
 	}
 	if hadOldVal {
-		if err := rb.deleteGrantIndexKey(d.GrantNeedsExpansionKey, key); err != nil {
+		if err := rb.deleteNeedsExpansionKey(key); err != nil {
 			return err
 		}
 	}
@@ -230,15 +162,15 @@ func (rb *RecordBatch) StageGrantPutDeferred(key, val []byte, hadOldVal, needsEx
 		return err
 	}
 	if needsExpansion {
-		if err := rb.setGrantIndexKey(d.GrantNeedsExpansionKey, key); err != nil {
+		if err := rb.setNeedsExpansionKey(key); err != nil {
 			return err
 		}
 	}
-	return d.StageGrantDigestInvalidation(&rb.stager, key)
+	return rb.stageGrantDigestInvalidation(key, sep4)
 }
 
-func (rb *RecordBatch) setGrantIndexKey(derive func(dst, primaryKey []byte) ([]byte, bool), key []byte) error {
-	idx, ok := derive(rb.scratch[:0], key)
+func (rb *RecordBatch) setByPrincipalKey(key []byte) error {
+	idx, ok := keys.AppendGrantByPrincipalKeyFromPrimary(rb.scratch[:0], key)
 	rb.scratch = idx
 	if !ok {
 		return fmt.Errorf("rawdb: grant key %x did not decode as a 6-segment identity", key)
@@ -246,8 +178,8 @@ func (rb *RecordBatch) setGrantIndexKey(derive func(dst, primaryKey []byte) ([]b
 	return rb.core.b.Set(idx, nil, nil)
 }
 
-func (rb *RecordBatch) deleteGrantIndexKey(derive func(dst, primaryKey []byte) ([]byte, bool), key []byte) error {
-	idx, ok := derive(rb.scratch[:0], key)
+func (rb *RecordBatch) deleteByPrincipalKey(key []byte) error {
+	idx, ok := keys.AppendGrantByPrincipalKeyFromPrimary(rb.scratch[:0], key)
 	rb.scratch = idx
 	if !ok {
 		return fmt.Errorf("rawdb: grant key %x did not decode as a 6-segment identity", key)
@@ -255,15 +187,50 @@ func (rb *RecordBatch) deleteGrantIndexKey(derive func(dst, primaryKey []byte) (
 	return rb.core.b.Delete(idx, nil)
 }
 
-// recordStager adapts RecordBatch's internal staging to the Stager
-// interface for the injected digest-invalidation composer, WITHOUT
-// exporting generic staging on RecordBatch itself.
-type recordStager struct{ rb *RecordBatch }
+func (rb *RecordBatch) setNeedsExpansionKey(key []byte) error {
+	idx, ok := keys.AppendGrantByNeedsExpansionKeyFromPrimary(rb.scratch[:0], key)
+	rb.scratch = idx
+	if !ok {
+		return fmt.Errorf("rawdb: grant key %x did not decode as a 6-segment identity", key)
+	}
+	return rb.core.b.Set(idx, nil, nil)
+}
 
-func (s *recordStager) Set(key, val []byte) error { return s.rb.core.b.Set(key, val, nil) }
-func (s *recordStager) Delete(key []byte) error   { return s.rb.core.b.Delete(key, nil) }
-func (s *recordStager) DeleteRange(a, b []byte) error {
-	return s.rb.core.b.DeleteRange(a, b, nil)
+func (rb *RecordBatch) deleteNeedsExpansionKey(key []byte) error {
+	idx, ok := keys.AppendGrantByNeedsExpansionKeyFromPrimary(rb.scratch[:0], key)
+	rb.scratch = idx
+	if !ok {
+		return fmt.Errorf("rawdb: grant key %x did not decode as a 6-segment identity", key)
+	}
+	return rb.core.b.Delete(idx, nil)
+}
+
+// stageGrantDigestInvalidation stages the post-seal digest
+// invalidation a grant mutation owes for its entitlement partition,
+// when digest state exists (present-means-exact — a mutated
+// partition's digest must read as missing, never stale-but-present):
+// DeleteRange over the partition's digest nodes, the whole-file global
+// root (the fold of every partition root is stale once any partition
+// is), and the partition's hash-index range. Gated on the
+// digests-present flag so ordinary sync paths pay nothing — during a
+// fresh sync both keyspaces are empty by construction, and emitting
+// tombstones per record there would bloat the LSM for no reason. The
+// partition is the entitlement region of the grant primary key, a
+// plain sub-slice (sep4 from SplitGrantPrimaryKey on the same key).
+func (rb *RecordBatch) stageGrantDigestInvalidation(primaryKey []byte, sep4 int) error {
+	if !rb.db.grantDigestsPresent.Load() {
+		return nil
+	}
+	partition := string(primaryKey[keys.GrantPrimaryKeyPrefixLen:sep4])
+	lo := keys.DigestPartitionPrefix(keys.IdxGrantByEntitlementPrincipalHash, partition)
+	if err := rb.core.b.DeleteRange(lo, keys.UpperBound(lo), nil); err != nil {
+		return err
+	}
+	if err := rb.core.b.Delete(keys.GlobalGrantDigestNodeKey(), nil); err != nil {
+		return err
+	}
+	hlo := keys.GrantHashIndexEntitlementPrefix(partition)
+	return rb.core.b.DeleteRange(hlo, keys.UpperBound(hlo), nil)
 }
 
 // === resource staging ===
@@ -276,50 +243,48 @@ func (s *recordStager) DeleteRange(a, b []byte) error {
 // StageGrantPutInline, which takes only an existence bool — grant
 // index keys derive from the primary key, not the value.
 func (rb *RecordBatch) StageResourcePut(key, val, oldVal []byte, childRT, childID string) error {
-	d := rb.db.mustDerivers()
-	if err := assertFamily("StageResourcePut", key, d.ResourcePrimaryPrefix); err != nil {
+	if err := assertFamily("StageResourcePut", key, resourcePrimaryPrefix); err != nil {
 		return err
 	}
 	if oldVal != nil {
-		if err := rb.stageResourceParentDelete(d, oldVal, childRT, childID); err != nil {
+		if err := rb.stageResourceParentDelete(oldVal, childRT, childID); err != nil {
 			return err
 		}
 	}
 	if err := rb.core.b.Set(key, val, nil); err != nil {
 		return err
 	}
-	parentRT, parentID, err := d.ResourceParent(val)
+	parentRT, parentID, err := keys.ScanResourceParentRaw(val)
 	if err != nil {
 		return err
 	}
 	if parentID == "" {
 		return nil
 	}
-	return rb.core.b.Set(d.ResourceByParentKey(parentRT, parentID, childRT, childID), nil, nil)
+	return rb.core.b.Set(keys.EncodeResourceByParentIndexKey(parentRT, parentID, childRT, childID), nil, nil)
 }
 
 // StageResourceDelete stages one resource row's removal plus its
 // by_parent index cleanup (from the prior value).
 func (rb *RecordBatch) StageResourceDelete(key, oldVal []byte, childRT, childID string) error {
-	d := rb.db.mustDerivers()
-	if err := assertFamily("StageResourceDelete", key, d.ResourcePrimaryPrefix); err != nil {
+	if err := assertFamily("StageResourceDelete", key, resourcePrimaryPrefix); err != nil {
 		return err
 	}
-	if err := rb.stageResourceParentDelete(d, oldVal, childRT, childID); err != nil {
+	if err := rb.stageResourceParentDelete(oldVal, childRT, childID); err != nil {
 		return err
 	}
 	return rb.core.b.Delete(key, nil)
 }
 
-func (rb *RecordBatch) stageResourceParentDelete(d *RecordDerivers, oldVal []byte, childRT, childID string) error {
-	parentRT, parentID, err := d.ResourceParent(oldVal)
+func (rb *RecordBatch) stageResourceParentDelete(oldVal []byte, childRT, childID string) error {
+	parentRT, parentID, err := keys.ScanResourceParentRaw(oldVal)
 	if err != nil {
 		return err
 	}
 	if parentID == "" {
 		return nil
 	}
-	return rb.core.b.Delete(d.ResourceByParentKey(parentRT, parentID, childRT, childID), nil)
+	return rb.core.b.Delete(keys.EncodeResourceByParentIndexKey(parentRT, parentID, childRT, childID), nil)
 }
 
 // === entitlement / resource-type staging ===
@@ -332,8 +297,7 @@ func (rb *RecordBatch) stageResourceParentDelete(d *RecordDerivers, oldVal []byt
 
 // StageEntitlementPut stages one entitlement row.
 func (rb *RecordBatch) StageEntitlementPut(key, val []byte) error {
-	d := rb.db.mustDerivers()
-	if err := assertFamily("StageEntitlementPut", key, d.EntitlementPrimaryPrefix); err != nil {
+	if err := assertFamily("StageEntitlementPut", key, entitlementPrimaryPrefix); err != nil {
 		return err
 	}
 	return rb.core.b.Set(key, val, nil)
@@ -341,8 +305,7 @@ func (rb *RecordBatch) StageEntitlementPut(key, val []byte) error {
 
 // StageEntitlementDelete stages one entitlement row's removal.
 func (rb *RecordBatch) StageEntitlementDelete(key []byte) error {
-	d := rb.db.mustDerivers()
-	if err := assertFamily("StageEntitlementDelete", key, d.EntitlementPrimaryPrefix); err != nil {
+	if err := assertFamily("StageEntitlementDelete", key, entitlementPrimaryPrefix); err != nil {
 		return err
 	}
 	return rb.core.b.Delete(key, nil)
@@ -350,8 +313,7 @@ func (rb *RecordBatch) StageEntitlementDelete(key []byte) error {
 
 // StageResourceTypePut stages one resource-type row.
 func (rb *RecordBatch) StageResourceTypePut(key, val []byte) error {
-	d := rb.db.mustDerivers()
-	if err := assertFamily("StageResourceTypePut", key, d.ResourceTypePrimaryPrefix); err != nil {
+	if err := assertFamily("StageResourceTypePut", key, resourceTypePrimaryPrefix); err != nil {
 		return err
 	}
 	return rb.core.b.Set(key, val, nil)
@@ -359,8 +321,7 @@ func (rb *RecordBatch) StageResourceTypePut(key, val []byte) error {
 
 // StageResourceTypeDelete stages one resource-type row's removal.
 func (rb *RecordBatch) StageResourceTypeDelete(key []byte) error {
-	d := rb.db.mustDerivers()
-	if err := assertFamily("StageResourceTypeDelete", key, d.ResourceTypePrimaryPrefix); err != nil {
+	if err := assertFamily("StageResourceTypeDelete", key, resourceTypePrimaryPrefix); err != nil {
 		return err
 	}
 	return rb.core.b.Delete(key, nil)
@@ -373,9 +334,9 @@ func (rb *RecordBatch) StageResourceTypeDelete(key []byte) error {
 // files and deletes incumbents' stale entries, with keys derived by
 // the synccompactor's own splice helpers (or borrowed byte-exact from
 // the sources). Generic by design — and confined by design: FoldBatch
-// is reachable only through Engine.DB() (the documented exemption
-// surface), and the engine package's meta-test forbids raw-write
-// signals in engine production code.
+// is reachable only through the engine's documented exemption surface,
+// and the engine package's meta-test fences its production use to the
+// fold compactor.
 type FoldBatch struct {
 	batch
 }
@@ -384,6 +345,3 @@ type FoldBatch struct {
 // keep-newer fold and overlay writers. Engine production code must
 // not use it; see the choke-point meta-tests.
 func (d *DB) NewFoldBatch() *FoldBatch { return &FoldBatch{batch{b: d.newBatch()}} }
-
-var _ Stager = (*recordStager)(nil)
-var _ = pebble.Sync

--- a/pkg/dotc1z/engine/pebble/keys.go
+++ b/pkg/dotc1z/engine/pebble/keys.go
@@ -2,7 +2,7 @@ package pebble
 
 import (
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/codec"
-	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/rawdb"
 )
 
 // Key layout convention.
@@ -56,30 +56,30 @@ import (
 // formats directly); aliased here so the engine's encoders read
 // naturally. See internal/keys for the per-byte docs.
 const (
-	versionV3 = keys.VersionV3
+	versionV3 = rawdb.VersionV3
 
-	typeResourceType = keys.TypeResourceType
-	typeResource     = keys.TypeResource
-	typeEntitlement  = keys.TypeEntitlement
-	typeGrant        = keys.TypeGrant
-	typeAsset        = keys.TypeAsset
-	typeSyncRun      = keys.TypeSyncRun
-	typeIndex        = keys.TypeIndex
-	typeCounter      = keys.TypeCounter
-	typeSession      = keys.TypeSession
-	typeDigest       = keys.TypeDigest
-	typeEngineMeta   = keys.TypeEngineMeta
+	typeResourceType = rawdb.TypeResourceType
+	typeResource     = rawdb.TypeResource
+	typeEntitlement  = rawdb.TypeEntitlement
+	typeGrant        = rawdb.TypeGrant
+	typeAsset        = rawdb.TypeAsset
+	typeSyncRun      = rawdb.TypeSyncRun
+	typeIndex        = rawdb.TypeIndex
+	typeCounter      = rawdb.TypeCounter
+	typeSession      = rawdb.TypeSession
+	typeDigest       = rawdb.TypeDigest
+	typeEngineMeta   = rawdb.TypeEngineMeta
 )
 
 const (
-	idxResourceByParent                = keys.IdxResourceByParent
-	idxEntitlementByResource           = keys.IdxEntitlementByResource
-	idxGrantByEntitlement              = keys.IdxGrantByEntitlement
-	idxGrantByPrincipal                = keys.IdxGrantByPrincipal
-	idxGrantByNeedsExpansion           = keys.IdxGrantByNeedsExpansion
-	idxGrantByPrincipalResourceType    = keys.IdxGrantByPrincipalResourceType
-	idxGrantByEntitlementResource      = keys.IdxGrantByEntitlementResource
-	idxGrantByEntitlementPrincipalHash = keys.IdxGrantByEntitlementPrincipalHash
+	idxResourceByParent                = rawdb.IdxResourceByParent
+	idxEntitlementByResource           = rawdb.IdxEntitlementByResource
+	idxGrantByEntitlement              = rawdb.IdxGrantByEntitlement
+	idxGrantByPrincipal                = rawdb.IdxGrantByPrincipal
+	idxGrantByNeedsExpansion           = rawdb.IdxGrantByNeedsExpansion
+	idxGrantByPrincipalResourceType    = rawdb.IdxGrantByPrincipalResourceType
+	idxGrantByEntitlementResource      = rawdb.IdxGrantByEntitlementResource
+	idxGrantByEntitlementPrincipalHash = rawdb.IdxGrantByEntitlementPrincipalHash
 )
 
 // --- Grant ---
@@ -329,7 +329,7 @@ func GrantByEntPrincHashUpperBound() []byte {
 // fold-to-coarser-width merge is a single contiguous scan of this
 // range. See digest.go for the node value framing.
 func encodeDigestNodeKey(indexID byte, partition string, level byte, bucketPrefix []byte) []byte {
-	buf := keys.DigestPartitionPrefix(indexID, partition)
+	buf := rawdb.DigestPartitionPrefix(indexID, partition)
 	buf = append(buf, level)
 	return append(buf, bucketPrefix...)
 }

--- a/pkg/dotc1z/engine/pebble/keys.go
+++ b/pkg/dotc1z/engine/pebble/keys.go
@@ -2,6 +2,7 @@ package pebble
 
 import (
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/codec"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
 )
 
 // Key layout convention.
@@ -49,43 +50,36 @@ import (
 // are an ABI: every v3 c1z file depends on them. Changing them
 // requires a keyspace-version bump (see the stamp in engine.go).
 
-// Type-discriminator bytes for the v3 keyspace. Each top-level
-// keyspace occupies one byte.
+// Type- and index-discriminator bytes for the v3 keyspace. The
+// canonical definitions live in internal/keys (the keyspace ABI shared
+// with rawdb, whose typed record ops derive obligations from these
+// formats directly); aliased here so the engine's encoders read
+// naturally. See internal/keys for the per-byte docs.
 const (
-	versionV3 byte = 0x03
+	versionV3 = keys.VersionV3
 
-	typeResourceType byte = 0x01
-	typeResource     byte = 0x02
-	typeEntitlement  byte = 0x03
-	typeGrant        byte = 0x04
-	typeAsset        byte = 0x05
-	typeSyncRun      byte = 0x06
-	typeIndex        byte = 0x07
-	typeCounter      byte = 0x08
-	typeSession      byte = 0x09
-	typeDigest       byte = 0x0A
-	typeEngineMeta   byte = 0xFF
+	typeResourceType = keys.TypeResourceType
+	typeResource     = keys.TypeResource
+	typeEntitlement  = keys.TypeEntitlement
+	typeGrant        = keys.TypeGrant
+	typeAsset        = keys.TypeAsset
+	typeSyncRun      = keys.TypeSyncRun
+	typeIndex        = keys.TypeIndex
+	typeCounter      = keys.TypeCounter
+	typeSession      = keys.TypeSession
+	typeDigest       = keys.TypeDigest
+	typeEngineMeta   = keys.TypeEngineMeta
 )
 
-// Index-discriminator bytes (second byte after typeIndex). One byte
-// per declared index across all record types; reuse across record
-// types is fine because the index key is scoped by the type byte that
-// preceded it.
 const (
-	idxResourceByParent             byte = 0x01
-	idxEntitlementByResource        byte = 0x02 // retired: served by entitlement primary key prefixes.
-	idxGrantByEntitlement           byte = 0x03 // retired: grant primary keys are entitlement-first.
-	idxGrantByPrincipal             byte = 0x04
-	idxGrantByNeedsExpansion        byte = 0x05
-	idxGrantByPrincipalResourceType byte = 0x06 // retired: served by idxGrantByPrincipal prefix scans.
-	idxGrantByEntitlementResource   byte = 0x07 // retired: served by grant primary entitlement-resource prefix scans.
-	// idxGrantByEntitlementPrincipalHash sorts grants by
-	// (entitlement identity, hash(principal identity)). Unlike every
-	// other grant index its entries carry a VALUE (the grant content
-	// hash). It is the substrate the per-entitlement grant digest
-	// (typeDigest) folds over; built ONLY by the seal-time deferred
-	// pass, never maintained inline. See digest.go and grant_digest.go.
-	idxGrantByEntitlementPrincipalHash byte = 0x08
+	idxResourceByParent                = keys.IdxResourceByParent
+	idxEntitlementByResource           = keys.IdxEntitlementByResource
+	idxGrantByEntitlement              = keys.IdxGrantByEntitlement
+	idxGrantByPrincipal                = keys.IdxGrantByPrincipal
+	idxGrantByNeedsExpansion           = keys.IdxGrantByNeedsExpansion
+	idxGrantByPrincipalResourceType    = keys.IdxGrantByPrincipalResourceType
+	idxGrantByEntitlementResource      = keys.IdxGrantByEntitlementResource
+	idxGrantByEntitlementPrincipalHash = keys.IdxGrantByEntitlementPrincipalHash
 )
 
 // --- Grant ---
@@ -303,37 +297,6 @@ func appendEntitlementIdentityTail(dst []byte, id entitlementIdentity) []byte {
 	return codec.AppendTupleStrings(dst, id.resourceTypeID, id.resourceID, id.flagComponent(), id.tail)
 }
 
-// encodeGrantByEntPrincHashEntPrefix is the by-value prefix for "all
-// hash-index rows under this entitlement partition", in principal-hash
-// order. partition is the raw encoded entitlement tail (see the
-// partition convention above) and is appended RAW — it is already
-// tuple-encoded. The trailing separator is load-bearing (see the
-// keys.go convention doc); the raw bucket hash follows it. Its output
-// length is also the offset decoders use to locate the raw hash region.
-//
-// The full index key shape (see grant_digest.go for the hash and value
-// definitions):
-//
-//	v3 | typeIndex | idxGrantByEntitlementPrincipalHash | 0x00 |
-//	    ent_rt | 0x00 | ent_rid | 0x00 | ent_flag | 0x00 | ent_tail | 0x00 |
-//	    <raw bucketHash: digestBucketHashLen bytes> |
-//	    principal_rt | 0x00 | principal_id
-//	  -> value: grant content hash (xxHash64, 8 bytes)
-//
-// (entitlement identity, principal identity) is the grant PRIMARY
-// identity, so the index holds exactly one row per grant by
-// construction. Because the bucket hash is raw it can contain 0x00, so
-// generic tuple walkers must NOT be pointed past the partition prefix —
-// their walk would derail on hash bytes. Decode positionally: the hash
-// occupies exactly digestBucketHashLen bytes after the prefix.
-func encodeGrantByEntPrincHashEntPrefix(partition string) []byte {
-	buf := make([]byte, 0, 6+len(partition))
-	buf = append(buf, versionV3, typeIndex, idxGrantByEntitlementPrincipalHash)
-	buf = codec.AppendTupleSeparator(buf)
-	buf = append(buf, partition...)
-	return codec.AppendTupleSeparator(buf)
-}
-
 // GrantByEntPrincHashLowerBound / UpperBound bound the entire
 // by_entitlement_principal_hash index. Exported for the
 // cleanup/clone/compaction keyspace plans.
@@ -366,24 +329,9 @@ func GrantByEntPrincHashUpperBound() []byte {
 // fold-to-coarser-width merge is a single contiguous scan of this
 // range. See digest.go for the node value framing.
 func encodeDigestNodeKey(indexID byte, partition string, level byte, bucketPrefix []byte) []byte {
-	buf := encodeDigestPartitionPrefix(indexID, partition)
+	buf := keys.DigestPartitionPrefix(indexID, partition)
 	buf = append(buf, level)
 	return append(buf, bucketPrefix...)
-}
-
-// encodeDigestPartitionPrefix is the prefix of every digest node key
-// for one (index, partition) — the range a rebuild clears before
-// writing (the build only Sets nodes; without the leading DeleteRange a
-// width change or an emptied bucket would leave stale nodes for the
-// comparison merge scan to read) and the range the invalidation paths
-// remove when a record mutation invalidates the partition.
-func encodeDigestPartitionPrefix(indexID byte, partition string) []byte {
-	buf := make([]byte, 0, 7+len(partition))
-	buf = append(buf, versionV3, typeDigest)
-	buf = append(buf, indexID)
-	buf = codec.AppendTupleSeparator(buf)
-	buf = codec.AppendTupleStrings(buf, partition)
-	return codec.AppendTupleSeparator(buf)
 }
 
 // DigestLowerBound / UpperBound bound the entire digest keyspace (all
@@ -435,20 +383,6 @@ func encodeResourceKey(resourceTypeID, resourceID string) []byte {
 // encodeResourcePrefix is the by-type prefix for resources.
 func encodeResourcePrefix() []byte {
 	return []byte{versionV3, typeResource}
-}
-
-// encodeResourceByParentIndexKey: index of children-by-parent:
-//
-//	v3 | typeIndex | idxResourceByParent | 0x00 |
-//	    parent_rt | 0x00 | parent_id | 0x00 | child_rt | 0x00 | child_id
-//
-// Paired with encodeResourceByParentPrefix (by-value prefix, with
-// trailing sep).
-func encodeResourceByParentIndexKey(parentRT, parentID, childRT, childID string) []byte {
-	buf := make([]byte, 0, 64)
-	buf = append(buf, versionV3, typeIndex, idxResourceByParent)
-	buf = codec.AppendTupleSeparator(buf)
-	return codec.AppendTupleStrings(buf, parentRT, parentID, childRT, childID)
 }
 
 // encodeResourceByParentPrefix is the by-value prefix for "all

--- a/pkg/dotc1z/engine/pebble/lookup_test.go
+++ b/pkg/dotc1z/engine/pebble/lookup_test.go
@@ -42,7 +42,7 @@ func lookupTestGrant(externalID, entRT, entRID, entID, principalRT, principalID 
 func TestBareIDEntitlementLookupExactlyOne(t *testing.T) {
 	ctx := context.Background()
 	e, _ := newTestEngine(t)
-	require.NoError(t, e.SetCurrentSync(ksuid.New().String()))
+	require.NoError(t, e.bindCurrentSync(ksuid.New().String()))
 
 	require.NoError(t, e.PutEntitlementRecords(ctx,
 		lookupTestEnt("app", "github", "opaque-ent"),
@@ -88,7 +88,7 @@ func TestBareIDEntitlementLookupExactlyOne(t *testing.T) {
 func TestBareIDEntitlementLookupInvalidation(t *testing.T) {
 	ctx := context.Background()
 	e, _ := newTestEngine(t)
-	require.NoError(t, e.SetCurrentSync(ksuid.New().String()))
+	require.NoError(t, e.bindCurrentSync(ksuid.New().String()))
 
 	require.NoError(t, e.PutEntitlementRecords(ctx, lookupTestEnt("app", "github", "first")))
 	_, err := e.GetEntitlementRecord(ctx, "first")
@@ -114,7 +114,7 @@ func TestBareIDEntitlementLookupInvalidation(t *testing.T) {
 func TestBareIDGrantLookupExactlyOne(t *testing.T) {
 	ctx := context.Background()
 	e, _ := newTestEngine(t)
-	require.NoError(t, e.SetCurrentSync(ksuid.New().String()))
+	require.NoError(t, e.bindCurrentSync(ksuid.New().String()))
 
 	require.NoError(t, e.PutEntitlementRecords(ctx,
 		lookupTestEnt("app", "github", "opaque-ent"),
@@ -189,7 +189,7 @@ func TestBareIDGrantLookupExactlyOne(t *testing.T) {
 func TestDeleteGrantByIdentityRefsIsExact(t *testing.T) {
 	ctx := context.Background()
 	e, _ := newTestEngine(t)
-	require.NoError(t, e.SetCurrentSync(ksuid.New().String()))
+	require.NoError(t, e.bindCurrentSync(ksuid.New().String()))
 
 	shared := "app:github:read:user:alice"
 	a := lookupTestGrant(shared, "app", "github", "app:github:read", "user", "alice")

--- a/pkg/dotc1z/engine/pebble/memfs_lifecycle_test.go
+++ b/pkg/dotc1z/engine/pebble/memfs_lifecycle_test.go
@@ -47,6 +47,13 @@ func TestEngineLifecycleOverPureMemFS(t *testing.T) {
 	require.NoError(t, a.EndSync(ctx))
 	w.verifyComplete(ctx, t, e, syncID, true, true, "sealed engine over MemFS")
 
+	// The DB-size walk must ride the engine FS too: over a pure MemFS
+	// a host-FS walk would error ("db dir missing") or measure an
+	// unrelated host directory (review follow-up, PR 1 round).
+	size, err := e.CurrentDBSizeBytes()
+	require.NoError(t, err, "CurrentDBSizeBytes must walk the engine FS")
+	require.Positive(t, size, "a sealed sync must have bytes on the engine FS")
+
 	// Writable checkpoint: cut it through the engine FS and reopen it
 	// as its own engine over the same MemFS. Covers db.Checkpoint +
 	// truncateCheckpointWALs + a fresh Open, all FS-side.

--- a/pkg/dotc1z/engine/pebble/memfs_lifecycle_test.go
+++ b/pkg/dotc1z/engine/pebble/memfs_lifecycle_test.go
@@ -42,7 +42,7 @@ func TestEngineLifecycleOverPureMemFS(t *testing.T) {
 	syncID, err := a.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
 	require.NoError(t, err)
 	require.NoError(t, w.write(ctx, a))
-	require.True(t, e.deferredIdxPending.Load(),
+	require.True(t, e.db.DeferredIdxPending(),
 		"the workload must arm the deferred rebuild so EndSync exercises SST staging over the MemFS")
 	require.NoError(t, a.EndSync(ctx))
 	w.verifyComplete(ctx, t, e, syncID, true, true, "sealed engine over MemFS")

--- a/pkg/dotc1z/engine/pebble/merge_accessor.go
+++ b/pkg/dotc1z/engine/pebble/merge_accessor.go
@@ -11,7 +11,6 @@ import (
 	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/codec"
-	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/rawdb"
 )
 
@@ -260,7 +259,7 @@ func ResourceIndexKeys(r *v3.ResourceRecord) [][]byte {
 	if parent == nil || parent.GetResourceId() == "" {
 		return nil
 	}
-	return [][]byte{keys.EncodeResourceByParentIndexKey(parent.GetResourceTypeId(), parent.GetResourceId(), r.GetResourceTypeId(), r.GetResourceId())}
+	return [][]byte{rawdb.EncodeResourceByParentIndexKey(parent.GetResourceTypeId(), parent.GetResourceId(), r.GetResourceTypeId(), r.GetResourceId())}
 }
 
 func ForEachResourceIndexKey(r *v3.ResourceRecord, yield func([]byte) error) error {
@@ -268,14 +267,14 @@ func ForEachResourceIndexKey(r *v3.ResourceRecord, yield func([]byte) error) err
 	if parent == nil || parent.GetResourceId() == "" {
 		return nil
 	}
-	return yield(keys.EncodeResourceByParentIndexKey(parent.GetResourceTypeId(), parent.GetResourceId(), r.GetResourceTypeId(), r.GetResourceId()))
+	return yield(rawdb.EncodeResourceByParentIndexKey(parent.GetResourceTypeId(), parent.GetResourceId(), r.GetResourceTypeId(), r.GetResourceId()))
 }
 
 func ForEachResourceIndexKeyRaw(parentRT string, parentID string, resourceTypeID string, resourceID string, yield func([]byte) error) error {
 	if parentID == "" {
 		return nil
 	}
-	return yield(keys.EncodeResourceByParentIndexKey(parentRT, parentID, resourceTypeID, resourceID))
+	return yield(rawdb.EncodeResourceByParentIndexKey(parentRT, parentID, resourceTypeID, resourceID))
 }
 
 // Byte-slice appenders let merge/overlay code build index keys from borrowed

--- a/pkg/dotc1z/engine/pebble/merge_accessor.go
+++ b/pkg/dotc1z/engine/pebble/merge_accessor.go
@@ -22,31 +22,31 @@ import (
 // is referable without the import.
 type FoldBatch = rawdb.FoldBatch
 
-// engineAccessor is implemented by *Adapter and by pkg/dotc1z's Pebble
-// store wrapper (which embeds *Adapter and overrides the method with a
-// nil-safe version).
+// engineAccessor is implemented by *Engine itself and by pkg/dotc1z's
+// Pebble store wrapper (which embeds *Engine and overrides the method
+// with a nil-safe version).
 type engineAccessor interface {
 	PebbleEngine() *Engine
 }
 
-// PebbleEngine returns the underlying *Engine. Nil-safe so AsEngine can
-// probe arbitrary writers.
-func (a *Adapter) PebbleEngine() *Engine {
-	if a == nil {
+// PebbleEngine returns the engine. Nil-safe so AsEngine can probe
+// arbitrary writers.
+func (e *Engine) PebbleEngine() *Engine {
+	if e == nil {
 		return nil
 	}
-	return a.engine
+	return e
 }
 
 // AsEngine recovers the underlying *Engine from a connectorstore.Writer
 // produced by dotc1z.NewStore for the Pebble engine. NewStore returns a
-// wrapper that embeds *Adapter; a bare *Adapter is also accepted for
-// callers that construct one directly. Returns (nil, false) for any
+// wrapper that embeds *Engine; a bare *Engine is also accepted for
+// callers that hold one directly. Returns (nil, false) for any
 // non-Pebble store, so a caller can branch on the engine without
 // importing internal types.
 func AsEngine(w connectorstore.Writer) (*Engine, bool) {
-	if a, ok := w.(engineAccessor); ok {
-		if e := a.PebbleEngine(); e != nil {
+	if acc, ok := w.(engineAccessor); ok {
+		if e := acc.PebbleEngine(); e != nil {
 			return e, true
 		}
 	}
@@ -197,17 +197,15 @@ func MarkStoreDirty(w connectorstore.Writer) bool {
 // owns a parent temp directory and wants one bulk cleanup after closing many
 // read-only source stores.
 func CloseEngineOnly(w connectorstore.Writer) error {
-	switch s := w.(type) {
-	case engineOnlyCloser:
+	if s, ok := w.(engineOnlyCloser); ok {
 		return s.CloseEngineOnly()
-	case *Adapter:
-		if s == nil || s.engine == nil {
-			return nil
-		}
-		return s.engine.Close()
-	default:
-		return nil
 	}
+	// A bare *Engine (no store wrapper) closes directly — there is no
+	// temp-dir teardown to skip.
+	if e, ok := AsEngine(w); ok {
+		return e.Close()
+	}
+	return nil
 }
 
 // NormalizeForFixtureSave flushes and compacts one sync in a Pebble

--- a/pkg/dotc1z/engine/pebble/merge_accessor.go
+++ b/pkg/dotc1z/engine/pebble/merge_accessor.go
@@ -11,6 +11,7 @@ import (
 	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/codec"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/rawdb"
 )
 
@@ -274,7 +275,7 @@ func ResourceIndexKeys(r *v3.ResourceRecord) [][]byte {
 	if parent == nil || parent.GetResourceId() == "" {
 		return nil
 	}
-	return [][]byte{encodeResourceByParentIndexKey(parent.GetResourceTypeId(), parent.GetResourceId(), r.GetResourceTypeId(), r.GetResourceId())}
+	return [][]byte{keys.EncodeResourceByParentIndexKey(parent.GetResourceTypeId(), parent.GetResourceId(), r.GetResourceTypeId(), r.GetResourceId())}
 }
 
 func ForEachResourceIndexKey(r *v3.ResourceRecord, yield func([]byte) error) error {
@@ -282,14 +283,14 @@ func ForEachResourceIndexKey(r *v3.ResourceRecord, yield func([]byte) error) err
 	if parent == nil || parent.GetResourceId() == "" {
 		return nil
 	}
-	return yield(encodeResourceByParentIndexKey(parent.GetResourceTypeId(), parent.GetResourceId(), r.GetResourceTypeId(), r.GetResourceId()))
+	return yield(keys.EncodeResourceByParentIndexKey(parent.GetResourceTypeId(), parent.GetResourceId(), r.GetResourceTypeId(), r.GetResourceId()))
 }
 
 func ForEachResourceIndexKeyRaw(parentRT string, parentID string, resourceTypeID string, resourceID string, yield func([]byte) error) error {
 	if parentID == "" {
 		return nil
 	}
-	return yield(encodeResourceByParentIndexKey(parentRT, parentID, resourceTypeID, resourceID))
+	return yield(keys.EncodeResourceByParentIndexKey(parentRT, parentID, resourceTypeID, resourceID))
 }
 
 // Byte-slice appenders let merge/overlay code build index keys from borrowed

--- a/pkg/dotc1z/engine/pebble/merge_accessor.go
+++ b/pkg/dotc1z/engine/pebble/merge_accessor.go
@@ -15,28 +15,13 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/rawdb"
 )
 
-// FoldBatch and MergeDB are exported aliases for the choke point's
-// fold-exempt batch and the narrowed compactor handle (internal/
-// rawdb). The synccompactor/pebble package — the choke point's one
-// sanctioned external client, via Engine.DB() — needs to NAME these
-// types in struct fields and signatures, which the internal-package
-// import fence forbids; an alias is referable without the import.
-//
-// MergeDB (= rawdb.MergeView) carries reads, LSM stats, the bulk
-// range/ingest ops, and the fold-exempt batch — and nothing else:
-// typed record staging (NewRecordBatch) and the session/meta/digest
-// write families are not on it, so the documented DB() exemption
-// cannot quietly grow into a second engine write path that bypasses
-// the lifecycle barrier. It is deliberately a CONCRETE struct, not an
-// interface over *rawdb.DB — an interface's dynamic type would let a
-// caller recover the omitted write families with a structural type
-// assertion (review finding, delta round). UnsafeForTesting stays
-// reachable for test fixtures; its testing.Testing() runtime gate
-// makes it inert in production.
-type (
-	FoldBatch = rawdb.FoldBatch
-	MergeDB   = rawdb.MergeView
-)
+// FoldBatch is an exported alias for the choke point's fold-exempt
+// batch (internal/rawdb). The synccompactor/pebble package — the
+// choke point's one sanctioned external client, via the Engine's
+// merge surface (merge_surface.go) — needs to NAME the type in struct
+// fields, which the internal-package import fence forbids; an alias
+// is referable without the import.
+type FoldBatch = rawdb.FoldBatch
 
 // engineAccessor is implemented by *Adapter and by pkg/dotc1z's Pebble
 // store wrapper (which embeds *Adapter and overrides the method with a

--- a/pkg/dotc1z/engine/pebble/merge_surface.go
+++ b/pkg/dotc1z/engine/pebble/merge_surface.go
@@ -88,10 +88,16 @@ func (e *Engine) ReplaceRangeWithSSTs(ctx context.Context, paths []string, span 
 
 // NewFoldBatch mints the compactor's generic staged batch (the one
 // sanctioned raw record-write conduit; see the fold-family doc in
-// rawdb and the meta-test fence). Returns nil after Close.
+// rawdb and the meta-test fence). Panics with an explicit message
+// after Close: unlike the error-returning ops above, callers stage
+// into the batch without a per-call error path, so a nil return would
+// only defer the crash to an anonymous nil deref at the first Set —
+// and a closed engine here means the compactor's call-ordering fence
+// (merge completes before save/Close) was violated, which is a
+// programming error, not a runtime condition to handle.
 func (e *Engine) NewFoldBatch() *FoldBatch {
 	if e.db == nil {
-		return nil
+		panic("pebble engine: NewFoldBatch on a closed engine — the fold must complete before the engine closes")
 	}
 	return e.db.NewFoldBatch()
 }
@@ -99,7 +105,11 @@ func (e *Engine) NewFoldBatch() *FoldBatch {
 // UnsafeForTesting returns the raw *pebble.DB — the single raw escape
 // hatch through the choke point, for test fixtures constructing states
 // the production API cannot express. Panics outside `go test`
-// (testing.Testing(), enforced inside rawdb) and after Close.
+// (testing.Testing(), enforced inside rawdb) and, explicitly, after
+// Close.
 func (e *Engine) UnsafeForTesting() *pebble.DB {
+	if e.db == nil {
+		panic("pebble engine: UnsafeForTesting on a closed engine")
+	}
 	return e.db.UnsafeForTesting()
 }

--- a/pkg/dotc1z/engine/pebble/merge_surface.go
+++ b/pkg/dotc1z/engine/pebble/merge_surface.go
@@ -1,0 +1,105 @@
+package pebble
+
+// The write choke point's EXPLICIT EXEMPTION SURFACE, promoted onto
+// Engine (this replaced the Engine.DB() handle — one less wrapper to
+// hold, and every call nil-checks the engine's lifecycle instead of
+// trusting a retained handle). Exported for the synccompactor/pebble
+// package, whose merge/fold/overlay machinery reads source files and
+// writes the record keyspaces outside the engine's writeMu barrier —
+// fenced by call ordering: the merge completes before the store's
+// save/CheckpointTo runs (see the checkpointMu inventory).
+//
+// The surface carries only what the compactor needs — reads, LSM
+// stats, the bulk range/ingest ops, and the fold-exempt batch. Typed
+// record staging (NewRecordBatch) and the session/meta/digest write
+// families are NOT reachable from outside the engine package; the raw
+// *pebble.DB stays unreachable (UnsafeForTesting is runtime-gated to
+// tests). The choke-point meta-tests fence production use of
+// NewFoldBatch and the bulk write ops to the fold compactor; this
+// file's delegating definitions are the fence's sanctioned exception.
+//
+// Callers that write the entitlement keyspace through this surface
+// (ingests, excises) must call InvalidateBareIDLookups afterwards.
+
+import (
+	"context"
+	"io"
+
+	"github.com/cockroachdb/pebble/v2"
+)
+
+// Get reads a key. Same contract as pebble.DB.Get, including
+// pebble.ErrNotFound and the caller-owned closer.
+func (e *Engine) Get(key []byte) ([]byte, io.Closer, error) {
+	if e.db == nil {
+		return nil, nil, ErrEngineClosing
+	}
+	return e.db.Get(key)
+}
+
+// NewIter opens an iterator. Same contract as pebble.DB.NewIter.
+func (e *Engine) NewIter(o *pebble.IterOptions) (*pebble.Iterator, error) {
+	if e.db == nil {
+		return nil, ErrEngineClosing
+	}
+	return e.db.NewIter(o)
+}
+
+// Metrics returns pebble's metrics snapshot, or nil after Close.
+func (e *Engine) Metrics() *pebble.Metrics {
+	if e.db == nil {
+		return nil
+	}
+	return e.db.Metrics()
+}
+
+// EstimateDiskUsage estimates on-disk size of the key range.
+func (e *Engine) EstimateDiskUsage(start, end []byte) (uint64, error) {
+	if e.db == nil {
+		return 0, ErrEngineClosing
+	}
+	return e.db.EstimateDiskUsage(start, end)
+}
+
+// DropKeyRange stages and commits a range tombstone over [start, end).
+func (e *Engine) DropKeyRange(start, end []byte, o *pebble.WriteOptions) error {
+	if e.db == nil {
+		return ErrEngineClosing
+	}
+	return e.db.DropKeyRange(start, end, o)
+}
+
+// IngestSSTs ingests externally built SSTs (created on the engine FS).
+func (e *Engine) IngestSSTs(ctx context.Context, paths []string) error {
+	if e.db == nil {
+		return ErrEngineClosing
+	}
+	return e.db.IngestSSTs(ctx, paths)
+}
+
+// ReplaceRangeWithSSTs atomically replaces span with the given SSTs
+// (pebble IngestAndExcise).
+func (e *Engine) ReplaceRangeWithSSTs(ctx context.Context, paths []string, span pebble.KeyRange) error {
+	if e.db == nil {
+		return ErrEngineClosing
+	}
+	return e.db.ReplaceRangeWithSSTs(ctx, paths, span)
+}
+
+// NewFoldBatch mints the compactor's generic staged batch (the one
+// sanctioned raw record-write conduit; see the fold-family doc in
+// rawdb and the meta-test fence). Returns nil after Close.
+func (e *Engine) NewFoldBatch() *FoldBatch {
+	if e.db == nil {
+		return nil
+	}
+	return e.db.NewFoldBatch()
+}
+
+// UnsafeForTesting returns the raw *pebble.DB — the single raw escape
+// hatch through the choke point, for test fixtures constructing states
+// the production API cannot express. Panics outside `go test`
+// (testing.Testing(), enforced inside rawdb) and after Close.
+func (e *Engine) UnsafeForTesting() *pebble.DB {
+	return e.db.UnsafeForTesting()
+}

--- a/pkg/dotc1z/engine/pebble/mutation_test.go
+++ b/pkg/dotc1z/engine/pebble/mutation_test.go
@@ -25,7 +25,7 @@ func TestPutGrantRecordOverwriteCleansIndexes(t *testing.T) {
 	ctx := context.Background()
 	e, _ := newTestEngine(t)
 	syncID := ksuid.New().String()
-	require.NoError(t, e.SetCurrentSync(syncID))
+	require.NoError(t, e.bindCurrentSync(syncID))
 
 	// Initial: grant g1 on ent-A, principal alice
 	g1Old := makeGrant(syncID, "g1", "ent-A", "alice")
@@ -79,7 +79,7 @@ func TestPutResourceRecordOverwriteCleansIndexes(t *testing.T) {
 	ctx := context.Background()
 	e, _ := newTestEngine(t)
 	syncID := ksuid.New().String()
-	require.NoError(t, e.SetCurrentSync(syncID))
+	require.NoError(t, e.bindCurrentSync(syncID))
 
 	mkRes := func(parentRT, parentID string) *v3.ResourceRecord {
 		return v3.ResourceRecord_builder{
@@ -116,7 +116,7 @@ func TestPutEntitlementRecordOverwriteCleansIndexes(t *testing.T) {
 	ctx := context.Background()
 	e, _ := newTestEngine(t)
 	syncID := ksuid.New().String()
-	require.NoError(t, e.SetCurrentSync(syncID))
+	require.NoError(t, e.bindCurrentSync(syncID))
 	mkEnt := func(resID string) *v3.EntitlementRecord {
 		return v3.EntitlementRecord_builder{
 			ExternalId: "read",
@@ -169,7 +169,7 @@ func TestFreshSyncDuplicateExternalIDCleansIndexes(t *testing.T) {
 		expected int
 	}{{"ent-A", 1}, {"ent-B", 1}} {
 		n := 0
-		err := a.engine.IterateGrantsByEntitlement(ctx, canonicalTestEntID(c.ent), func(*v3.GrantRecord) bool {
+		err := a.IterateGrantsByEntitlement(ctx, canonicalTestEntID(c.ent), func(*v3.GrantRecord) bool {
 			n++
 			return true
 		})
@@ -182,7 +182,7 @@ func TestFreshSyncDuplicateExternalIDCleansIndexes(t *testing.T) {
 		expected  int
 	}{{"alice", 1}, {"bob", 1}} {
 		n := 0
-		err := a.engine.IterateGrantsByPrincipal(ctx, "user", c.principal, func(*v3.GrantRecord) bool {
+		err := a.IterateGrantsByPrincipal(ctx, "user", c.principal, func(*v3.GrantRecord) bool {
 			n++
 			return true
 		})
@@ -283,7 +283,7 @@ func TestFreshSyncWithinCallDuplicateExternalIDDedup(t *testing.T) {
 		expected int
 	}{{"ent-A", 1}, {"ent-B", 1}} {
 		n := 0
-		err := a.engine.IterateGrantsByEntitlement(ctx, canonicalTestEntID(c.ent), func(*v3.GrantRecord) bool {
+		err := a.IterateGrantsByEntitlement(ctx, canonicalTestEntID(c.ent), func(*v3.GrantRecord) bool {
 			n++
 			return true
 		})
@@ -295,7 +295,7 @@ func TestFreshSyncWithinCallDuplicateExternalIDDedup(t *testing.T) {
 		expected  int
 	}{{"alice", 1}, {"bob", 1}} {
 		n := 0
-		err := a.engine.IterateGrantsByPrincipal(ctx, "user", c.principal, func(*v3.GrantRecord) bool {
+		err := a.IterateGrantsByPrincipal(ctx, "user", c.principal, func(*v3.GrantRecord) bool {
 			n++
 			return true
 		})
@@ -321,7 +321,7 @@ func TestNonFreshSyncOverwriteWorksThroughAdapter(t *testing.T) {
 
 	// ent-A should now be empty (old index cleaned up).
 	n := 0
-	err = a.engine.IterateGrantsByEntitlement(ctx, canonicalTestEntID("ent-A"), func(*v3.GrantRecord) bool {
+	err = a.IterateGrantsByEntitlement(ctx, canonicalTestEntID("ent-A"), func(*v3.GrantRecord) bool {
 		n++
 		return true
 	})
@@ -329,7 +329,7 @@ func TestNonFreshSyncOverwriteWorksThroughAdapter(t *testing.T) {
 	require.Equal(t, 1, n, "ent-A after structured-identity add")
 	// ent-B should have 1.
 	n = 0
-	err = a.engine.IterateGrantsByEntitlement(ctx, canonicalTestEntID("ent-B"), func(*v3.GrantRecord) bool {
+	err = a.IterateGrantsByEntitlement(ctx, canonicalTestEntID("ent-B"), func(*v3.GrantRecord) bool {
 		n++
 		return true
 	})
@@ -343,7 +343,7 @@ func TestDeleteThenPutCleansAndRewrites(t *testing.T) {
 	ctx := context.Background()
 	e, _ := newTestEngine(t)
 	syncID := ksuid.New().String()
-	require.NoError(t, e.SetCurrentSync(syncID))
+	require.NoError(t, e.bindCurrentSync(syncID))
 	for i := 0; i < 5; i++ {
 		p := "alice-" + strconv.Itoa(i)
 		require.NoError(t, e.PutGrantRecord(ctx, makeGrant(syncID, canonicalTestGrantID("ent-A", "user", p), "ent-A", p)))

--- a/pkg/dotc1z/engine/pebble/os_io_allowlist_test.go
+++ b/pkg/dotc1z/engine/pebble/os_io_allowlist_test.go
@@ -55,6 +55,7 @@ var allowedOSFileIO = map[string]map[string]string{
 	"engine.go": {
 		"MkdirTemp": "prepareStagingDir mints the unique host-side staging dir; the engine-FS mirror is created right after via fs.MkdirAll",
 		"RemoveAll": "prepareStagingDir failure path + removeStagingDir host-side half; the engine-FS half is removed via fs.RemoveAll",
+		"Lstat":     "CurrentDBSizeBytes no-follow stat on the default FS (vfs.FS has no Lstat; symlinks must be skipped, not traversed)",
 	},
 	"bulk_import.go": {
 		"Create": "writeSortedSpillChunk: spill-chunk scratch is engine-private; only readSpillEntry reads it back, never the DB",

--- a/pkg/dotc1z/engine/pebble/paginate_test.go
+++ b/pkg/dotc1z/engine/pebble/paginate_test.go
@@ -269,7 +269,7 @@ func TestPaginationClampedPageSize(t *testing.T) {
 	ctx := context.Background()
 	e, _ := newTestEngine(t)
 	syncID := ksuid.New().String()
-	require.NoError(t, e.SetCurrentSync(syncID))
+	require.NoError(t, e.bindCurrentSync(syncID))
 	const total = 50
 	for i := 0; i < total; i++ {
 		r := &v3.GrantRecord{}

--- a/pkg/dotc1z/engine/pebble/pending_expansion_test.go
+++ b/pkg/dotc1z/engine/pebble/pending_expansion_test.go
@@ -113,7 +113,7 @@ func TestPebbleGrantStorePendingExpansionPage(t *testing.T) {
 		}.Build(),
 		NeedsExpansion: true,
 	}.Build()
-	require.NoErrorf(t, a.engine.PutGrantRecord(ctx, rec), "PutGrantRecord")
+	require.NoErrorf(t, a.PutGrantRecord(ctx, rec), "PutGrantRecord")
 
 	rows, _, err := a.Grants().PendingExpansionPage(ctx, "")
 	require.NoErrorf(t, err, "PendingExpansionPage")

--- a/pkg/dotc1z/engine/pebble/production_bench_test.go
+++ b/pkg/dotc1z/engine/pebble/production_bench_test.go
@@ -154,7 +154,7 @@ func BenchmarkPebbleAdapterWriteGrant(b *testing.B) {
 	// timing through Close captures the hardening cost. Unlike the
 	// dotc1z store's Close, the bare adapter's Close is engine-only (no
 	// c1z compression/save), so it stays a clean write+flush measurement.
-	if err := a.Close(ctx); err != nil {
+	if err := a.Close(); err != nil {
 		b.Fatalf("Close: %v", err)
 	}
 	b.StopTimer()

--- a/pkg/dotc1z/engine/pebble/raw_records.go
+++ b/pkg/dotc1z/engine/pebble/raw_records.go
@@ -8,7 +8,7 @@ import (
 	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/rawdb"
 )
 
 const (
@@ -177,7 +177,7 @@ func scanGrantEntitlementResourceTypeRaw(value []byte) ([]byte, error) {
 		if n < 0 {
 			return nil, protowire.ParseError(n)
 		}
-		if err := keys.ScanResourceRefRawBytes(msg, func(fnum protowire.Number, val []byte) {
+		if err := rawdb.ScanResourceRefRawBytes(msg, func(fnum protowire.Number, val []byte) {
 			if fnum == 1 {
 				entRT = val
 			}
@@ -274,7 +274,7 @@ func scanEntitlementResourceTypeRaw(value []byte) ([]byte, error) {
 		if n < 0 {
 			return nil, protowire.ParseError(n)
 		}
-		if err := keys.ScanResourceRefRawBytes(msg, func(fnum protowire.Number, val []byte) {
+		if err := rawdb.ScanResourceRefRawBytes(msg, func(fnum protowire.Number, val []byte) {
 			if fnum == 1 {
 				rt = val
 			}
@@ -310,7 +310,7 @@ func scanEntitlementResourceRaw(value []byte) (string, string, error) {
 			return "", "", protowire.ParseError(n)
 		}
 		var err error
-		rt, id, err = keys.ScanResourceRefRaw(msg)
+		rt, id, err = rawdb.ScanResourceRefRaw(msg)
 		if err != nil {
 			return "", "", err
 		}
@@ -347,7 +347,7 @@ func scanEntitlementIdentityFieldsRaw(value []byte) (string, string, string, err
 				return "", "", "", protowire.ParseError(n)
 			}
 			var err error
-			rt, id, err = keys.ScanResourceRefRaw(msg)
+			rt, id, err = rawdb.ScanResourceRefRaw(msg)
 			if err != nil {
 				return "", "", "", err
 			}
@@ -456,7 +456,7 @@ func scanGrantNeedsExpansionRaw(value []byte) (bool, error) {
 
 func scanEntitlementRefRaw(value []byte) (string, string, string, error) {
 	var rt, rid, eid []byte
-	err := keys.ScanResourceRefRawBytes(value, func(num protowire.Number, val []byte) {
+	err := rawdb.ScanResourceRefRawBytes(value, func(num protowire.Number, val []byte) {
 		switch num {
 		case 1:
 			rt = val
@@ -472,7 +472,7 @@ func scanEntitlementRefRaw(value []byte) (string, string, string, error) {
 
 func scanPrincipalRefRaw(value []byte) (string, string, error) {
 	var rt, id []byte
-	err := keys.ScanResourceRefRawBytes(value, func(num protowire.Number, val []byte) {
+	err := rawdb.ScanResourceRefRawBytes(value, func(num protowire.Number, val []byte) {
 		switch num {
 		case 1:
 			rt = val

--- a/pkg/dotc1z/engine/pebble/raw_records.go
+++ b/pkg/dotc1z/engine/pebble/raw_records.go
@@ -7,6 +7,8 @@ import (
 
 	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
 )
 
 const (
@@ -175,7 +177,7 @@ func scanGrantEntitlementResourceTypeRaw(value []byte) ([]byte, error) {
 		if n < 0 {
 			return nil, protowire.ParseError(n)
 		}
-		if err := scanResourceRefRawBytes(msg, func(fnum protowire.Number, val []byte) {
+		if err := keys.ScanResourceRefRawBytes(msg, func(fnum protowire.Number, val []byte) {
 			if fnum == 1 {
 				entRT = val
 			}
@@ -195,7 +197,7 @@ func scanGrantEntitlementResourceTypeRaw(value []byte) ([]byte, error) {
 // appended to keys — pass a recycled keys[:0] to reuse its backing
 // array across calls. The seal-time grant digest build calls this once
 // per grant (see appendGrantHashIndexRow).
-func scanGrantSourceKeysRawBytes(value []byte, keys [][]byte) ([][]byte, error) {
+func scanGrantSourceKeysRawBytes(value []byte, out [][]byte) ([][]byte, error) {
 	for len(value) > 0 {
 		num, typ, n := protowire.ConsumeTag(value)
 		if n < 0 {
@@ -229,7 +231,7 @@ func scanGrantSourceKeysRawBytes(value []byte, keys [][]byte) ([][]byte, error) 
 				if kn < 0 {
 					return nil, protowire.ParseError(kn)
 				}
-				keys = append(keys, k)
+				out = append(out, k)
 				entry = entry[kn:]
 			} else {
 				en = protowire.ConsumeFieldValue(eNum, eTyp, entry)
@@ -240,7 +242,7 @@ func scanGrantSourceKeysRawBytes(value []byte, keys [][]byte) ([][]byte, error) 
 			}
 		}
 	}
-	return keys, nil
+	return out, nil
 }
 
 // scanEntitlementResourceTypeRaw extracts only the entitlement's
@@ -272,7 +274,7 @@ func scanEntitlementResourceTypeRaw(value []byte) ([]byte, error) {
 		if n < 0 {
 			return nil, protowire.ParseError(n)
 		}
-		if err := scanResourceRefRawBytes(msg, func(fnum protowire.Number, val []byte) {
+		if err := keys.ScanResourceRefRawBytes(msg, func(fnum protowire.Number, val []byte) {
 			if fnum == 1 {
 				rt = val
 			}
@@ -282,43 +284,6 @@ func scanEntitlementResourceTypeRaw(value []byte) ([]byte, error) {
 		value = value[n:]
 	}
 	return rt, nil
-}
-
-// scanResourceParentRaw and scanEntitlementResourceRaw keep the LAST
-// occurrence of the target field, matching scanGrantIndexFieldsRaw and
-// approximating proto merge semantics. Values written by this SDK carry
-// at most one occurrence, so this only matters for foreign writers.
-func scanResourceParentRaw(value []byte) (string, string, error) {
-	var rt, id string
-	for len(value) > 0 {
-		num, typ, n := protowire.ConsumeTag(value)
-		if n < 0 {
-			return "", "", protowire.ParseError(n)
-		}
-		value = value[n:]
-		if num != 6 {
-			n = protowire.ConsumeFieldValue(num, typ, value)
-			if n < 0 {
-				return "", "", protowire.ParseError(n)
-			}
-			value = value[n:]
-			continue
-		}
-		if typ != protowire.BytesType {
-			return "", "", fmt.Errorf("raw record: resource parent has wire type %v", typ)
-		}
-		msg, n := protowire.ConsumeBytes(value)
-		if n < 0 {
-			return "", "", protowire.ParseError(n)
-		}
-		var err error
-		rt, id, err = scanResourceRefRaw(msg)
-		if err != nil {
-			return "", "", err
-		}
-		value = value[n:]
-	}
-	return rt, id, nil
 }
 
 func scanEntitlementResourceRaw(value []byte) (string, string, error) {
@@ -345,7 +310,7 @@ func scanEntitlementResourceRaw(value []byte) (string, string, error) {
 			return "", "", protowire.ParseError(n)
 		}
 		var err error
-		rt, id, err = scanResourceRefRaw(msg)
+		rt, id, err = keys.ScanResourceRefRaw(msg)
 		if err != nil {
 			return "", "", err
 		}
@@ -382,7 +347,7 @@ func scanEntitlementIdentityFieldsRaw(value []byte) (string, string, string, err
 				return "", "", "", protowire.ParseError(n)
 			}
 			var err error
-			rt, id, err = scanResourceRefRaw(msg)
+			rt, id, err = keys.ScanResourceRefRaw(msg)
 			if err != nil {
 				return "", "", "", err
 			}
@@ -489,23 +454,9 @@ func scanGrantNeedsExpansionRaw(value []byte) (bool, error) {
 	return needsExpansion, nil
 }
 
-func scanResourceRefRaw(value []byte) (string, string, error) {
-	var rt, id []byte
-	err := scanResourceRefRawBytes(value, func(num protowire.Number, val []byte) {
-		switch num {
-		case 1:
-			rt = val
-		case 2:
-			id = val
-		default:
-		}
-	})
-	return string(rt), string(id), err
-}
-
 func scanEntitlementRefRaw(value []byte) (string, string, string, error) {
 	var rt, rid, eid []byte
-	err := scanResourceRefRawBytes(value, func(num protowire.Number, val []byte) {
+	err := keys.ScanResourceRefRawBytes(value, func(num protowire.Number, val []byte) {
 		switch num {
 		case 1:
 			rt = val
@@ -521,7 +472,7 @@ func scanEntitlementRefRaw(value []byte) (string, string, string, error) {
 
 func scanPrincipalRefRaw(value []byte) (string, string, error) {
 	var rt, id []byte
-	err := scanResourceRefRawBytes(value, func(num protowire.Number, val []byte) {
+	err := keys.ScanResourceRefRawBytes(value, func(num protowire.Number, val []byte) {
 		switch num {
 		case 1:
 			rt = val
@@ -531,33 +482,4 @@ func scanPrincipalRefRaw(value []byte) (string, string, error) {
 		}
 	})
 	return string(rt), string(id), err
-}
-
-func scanResourceRefRawBytes(value []byte, set func(protowire.Number, []byte)) error {
-	for len(value) > 0 {
-		num, typ, n := protowire.ConsumeTag(value)
-		if n < 0 {
-			return protowire.ParseError(n)
-		}
-		value = value[n:]
-		if typ != protowire.BytesType {
-			n = protowire.ConsumeFieldValue(num, typ, value)
-			if n < 0 {
-				return protowire.ParseError(n)
-			}
-			value = value[n:]
-			continue
-		}
-		b, n := protowire.ConsumeBytes(value)
-		if n < 0 {
-			return protowire.ParseError(n)
-		}
-		switch num {
-		case 1, 2, 3:
-			set(num, b)
-		default:
-		}
-		value = value[n:]
-	}
-	return nil
 }

--- a/pkg/dotc1z/engine/pebble/records_test.go
+++ b/pkg/dotc1z/engine/pebble/records_test.go
@@ -16,7 +16,7 @@ func TestPutGetResourceType(t *testing.T) {
 	ctx := context.Background()
 	e, _ := newTestEngine(t)
 	syncID := ksuid.New().String()
-	require.NoError(t, e.SetCurrentSync(syncID))
+	require.NoError(t, e.bindCurrentSync(syncID))
 
 	r := v3.ResourceTypeRecord_builder{
 		ExternalId:   "user",
@@ -34,7 +34,7 @@ func TestIterateResourceTypesBySync(t *testing.T) {
 	ctx := context.Background()
 	e, _ := newTestEngine(t)
 	syncID := ksuid.New().String()
-	require.NoError(t, e.SetCurrentSync(syncID))
+	require.NoError(t, e.bindCurrentSync(syncID))
 	for i := 0; i < 20; i++ {
 		r := v3.ResourceTypeRecord_builder{
 			ExternalId:  ksuid.New().String(),
@@ -54,7 +54,7 @@ func TestResourceWithParentIndex(t *testing.T) {
 	ctx := context.Background()
 	e, _ := newTestEngine(t)
 	syncID := ksuid.New().String()
-	require.NoError(t, e.SetCurrentSync(syncID))
+	require.NoError(t, e.bindCurrentSync(syncID))
 
 	parent := v3.ResourceRecord_builder{
 		ResourceTypeId: "group",
@@ -105,7 +105,7 @@ func TestEntitlementByResourceIndex(t *testing.T) {
 	ctx := context.Background()
 	e, _ := newTestEngine(t)
 	syncID := ksuid.New().String()
-	require.NoError(t, e.SetCurrentSync(syncID))
+	require.NoError(t, e.bindCurrentSync(syncID))
 
 	// 4 entitlements on group/admins, 2 on group/devs.
 	for i := 0; i < 4; i++ {
@@ -147,7 +147,7 @@ func TestAssetRoundtrip(t *testing.T) {
 	ctx := context.Background()
 	e, _ := newTestEngine(t)
 	syncID := ksuid.New().String()
-	require.NoError(t, e.SetCurrentSync(syncID))
+	require.NoError(t, e.bindCurrentSync(syncID))
 
 	payload := []byte("PNGfakebytes\x00\x01\x02")
 	r := v3.AssetRecord_builder{

--- a/pkg/dotc1z/engine/pebble/sync_stats_sidecar_test.go
+++ b/pkg/dotc1z/engine/pebble/sync_stats_sidecar_test.go
@@ -57,7 +57,7 @@ func TestSyncStatsSidecarRoundtrip(t *testing.T) {
 	require.Equal(t, int64(2), m["resource_types"], "Stats resource_types")
 	require.Equal(t, int64(2), m["user"], "Stats user count")
 	require.Equal(t, int64(1), m["group"], "Stats group count")
-	_ = store.Close(ctx)
+	_ = store.Close()
 }
 
 // TestSyncStatsSidecarBackfillOnOpen exercises the migration path:
@@ -118,10 +118,9 @@ func TestSyncStatsSidecarFallback(t *testing.T) {
 	require.NoError(t, e.PutGrantRecord(ctx, makeGrant(syncID, "g1", "ent", "u1")))
 	// Don't call PersistSyncStats — leaves the sidecar missing.
 
-	// The Adapter.statsFromIteration helper still produces correct
-	// counts. We exercise it directly to avoid the Stats() fast-path.
-	a := &Adapter{engine: e}
-	got, err := a.statsFromIteration(ctx, syncID)
+	// The statsFromIteration helper still produces correct counts.
+	// Exercise it directly to avoid the Stats() fast-path.
+	got, err := e.statsFromIteration(ctx, syncID)
 	require.NoErrorf(t, err, "statsFromIteration")
 	require.Equal(t, int64(1), got.GetGrants(), "fallback grants")
 }

--- a/pkg/dotc1z/engine/pebble/test_seams.go
+++ b/pkg/dotc1z/engine/pebble/test_seams.go
@@ -20,16 +20,8 @@ type testSeams struct {
 	digestBuildHook      func(stage string) error
 	digestNodeFlushBytes int
 
-	// armDeferredMarkerHook / clearDeferredMarkerHook, when non-nil,
-	// run before the deferred-index marker's durable commit / delete —
-	// the in-process analogs of those writes failing. Tests use them
-	// to pin the flag/key-agreement contract on both edges: the
-	// in-memory flag and the durable key must never disagree (armed
-	// flag + absent key = in-process EndSync rebuilds while a
-	// crash+resume silently skips the rebuild; cleared flag + present
-	// key = spurious rebuild on the next open).
-	armDeferredMarkerHook   func() error
-	clearDeferredMarkerHook func() error
+	// The deferred-marker arm/clear failure hooks moved to rawdb with
+	// the marker itself (rawdb.SetDeferredMarkerTestHooks).
 
 	// endSyncPreFlushHook, when non-nil, runs inside endSyncFinalize
 	// IMMEDIATELY after the ended_at stamp commits — before the stats

--- a/pkg/dotc1z/engine/pebble/typed_record_ops_coverage_test.go
+++ b/pkg/dotc1z/engine/pebble/typed_record_ops_coverage_test.go
@@ -21,7 +21,7 @@ import (
 
 	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
-	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/rawdb"
 	batonGrant "github.com/conductorone/baton-sdk/pkg/types/grant"
 )
 
@@ -271,7 +271,7 @@ func TestDeferredMarkerArmFailureRollsBackCAS(t *testing.T) {
 
 	// THE CONTRACT: flag rolled back, durable key absent — in agreement.
 	require.False(t, e.db.DeferredIdxPending(), "failed arm must roll the CAS back")
-	_, closer, getErr := e.db.Get(keys.DeferredIdxPendingKey())
+	_, closer, getErr := e.db.Get(rawdb.DeferredIdxPendingKey())
 	require.ErrorIs(t, getErr, pebble.ErrNotFound, "no durable marker may exist after a failed arm")
 	if getErr == nil {
 		closer.Close()
@@ -285,7 +285,7 @@ func TestDeferredMarkerArmFailureRollsBackCAS(t *testing.T) {
 	e.db.SetDeferredMarkerTestHooks(nil, nil)
 	require.NoError(t, e.PutSynthesizedGrantRecords(ctx, []*v3.GrantRecord{testGrantRecord("ent-A", "alice")}))
 	require.True(t, e.db.DeferredIdxPending())
-	_, closer, getErr = e.db.Get(keys.DeferredIdxPendingKey())
+	_, closer, getErr = e.db.Get(rawdb.DeferredIdxPendingKey())
 	require.NoError(t, getErr, "the retried arm must persist the durable marker")
 	closer.Close()
 
@@ -329,7 +329,7 @@ func TestDeferredMarkerClearFailureKeepsAgreement(t *testing.T) {
 
 	// THE CONTRACT: both halves still armed, in agreement.
 	require.True(t, e.db.DeferredIdxPending(), "failed clear must leave the flag armed")
-	_, closer, getErr := e.db.Get(keys.DeferredIdxPendingKey())
+	_, closer, getErr := e.db.Get(rawdb.DeferredIdxPendingKey())
 	require.NoError(t, getErr, "failed clear must leave the durable key present")
 	closer.Close()
 
@@ -338,7 +338,7 @@ func TestDeferredMarkerClearFailureKeepsAgreement(t *testing.T) {
 	e.db.SetDeferredMarkerTestHooks(nil, nil)
 	require.NoError(t, a.EndSync(ctx))
 	require.False(t, e.db.DeferredIdxPending())
-	_, _, getErr = e.db.Get(keys.DeferredIdxPendingKey())
+	_, _, getErr = e.db.Get(rawdb.DeferredIdxPendingKey())
 	require.ErrorIs(t, getErr, pebble.ErrNotFound)
 	n := 0
 	require.NoError(t, e.IterateGrantsByPrincipal(ctx, "user", "alice", func(*v3.GrantRecord) bool {

--- a/pkg/dotc1z/engine/pebble/typed_record_ops_coverage_test.go
+++ b/pkg/dotc1z/engine/pebble/typed_record_ops_coverage_test.go
@@ -21,6 +21,7 @@ import (
 
 	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
 	batonGrant "github.com/conductorone/baton-sdk/pkg/types/grant"
 )
 
@@ -68,7 +69,7 @@ func TestPutSynthesizedGrantRecordsObligations(t *testing.T) {
 		testGrantRecord("ent-A", "alice"),
 		testGrantRecord("ent-A", "bob"),
 	}))
-	require.True(t, e.deferredIdxPending.Load(), "synthesized puts must arm the deferred rebuild marker")
+	require.True(t, e.db.DeferredIdxPending(), "synthesized puts must arm the deferred rebuild marker")
 	require.Equal(t, 0, countKeys(t, e, encodeGrantByNeedsExpansionPrefix()),
 		"synthesized grants are never expandable")
 
@@ -111,7 +112,7 @@ func TestPutSynthesizedGrantContributionsBatchObligations(t *testing.T) {
 	// Through the exported dispatcher so its counter bookkeeping and the
 	// batch body are both exercised.
 	require.NoError(t, e.PutSynthesizedGrantContributions(ctx, records))
-	require.True(t, e.deferredIdxPending.Load(), "contributions must arm the deferred rebuild marker")
+	require.True(t, e.db.DeferredIdxPending(), "contributions must arm the deferred rebuild marker")
 
 	require.NoError(t, a.EndSync(ctx))
 	n := 0
@@ -148,10 +149,10 @@ func TestUnsafePutUniqueGrantRecordsObligations(t *testing.T) {
 	// absent (StartNewSync excised it), so a present flag means the
 	// freshness contract itself broke — the guard must refuse rather
 	// than silently tombstone a trusted import's digest keyspace.
-	e.grantDigestsPresent.Store(true)
+	e.db.SetGrantDigestsPresent(true)
 	require.ErrorContains(t, e.UnsafePutUniqueGrantRecords(ctx, testGrantRecord("ent-C", "carol")),
 		"digest state present on a fresh sync")
-	e.grantDigestsPresent.Store(false)
+	e.db.SetGrantDigestsPresent(false)
 
 	// Non-fresh syncs are refused (SetCurrentSync clears freshness).
 	require.NoError(t, a.EndSync(ctx))
@@ -261,7 +262,7 @@ func TestDeferredMarkerArmFailureRollsBackCAS(t *testing.T) {
 	e := a.PebbleEngine()
 
 	injected := errNoRetryArmFailure
-	e.test.armDeferredMarkerHook = func() error { return injected }
+	e.db.SetDeferredMarkerTestHooks(func() error { return injected }, nil)
 
 	// The deferred-regime write must FAIL when the marker can't arm —
 	// committing deferred rows without the durable marker is the lie.
@@ -269,8 +270,8 @@ func TestDeferredMarkerArmFailureRollsBackCAS(t *testing.T) {
 	require.ErrorIs(t, err, injected, "deferred write must surface the arm failure")
 
 	// THE CONTRACT: flag rolled back, durable key absent — in agreement.
-	require.False(t, e.deferredIdxPending.Load(), "failed arm must roll the CAS back")
-	_, closer, getErr := e.db.Get(encodeDeferredIdxPendingKey())
+	require.False(t, e.db.DeferredIdxPending(), "failed arm must roll the CAS back")
+	_, closer, getErr := e.db.Get(keys.DeferredIdxPendingKey())
 	require.ErrorIs(t, getErr, pebble.ErrNotFound, "no durable marker may exist after a failed arm")
 	if getErr == nil {
 		closer.Close()
@@ -281,10 +282,10 @@ func TestDeferredMarkerArmFailureRollsBackCAS(t *testing.T) {
 
 	// Retry converges: with the fault gone, the same write arms the
 	// marker durably and lands.
-	e.test.armDeferredMarkerHook = nil
+	e.db.SetDeferredMarkerTestHooks(nil, nil)
 	require.NoError(t, e.PutSynthesizedGrantRecords(ctx, []*v3.GrantRecord{testGrantRecord("ent-A", "alice")}))
-	require.True(t, e.deferredIdxPending.Load())
-	_, closer, getErr = e.db.Get(encodeDeferredIdxPendingKey())
+	require.True(t, e.db.DeferredIdxPending())
+	_, closer, getErr = e.db.Get(keys.DeferredIdxPendingKey())
 	require.NoError(t, getErr, "the retried arm must persist the durable marker")
 	closer.Close()
 
@@ -319,25 +320,25 @@ func TestDeferredMarkerClearFailureKeepsAgreement(t *testing.T) {
 
 	// Deferred-regime write arms the marker.
 	require.NoError(t, e.PutSynthesizedGrantRecords(ctx, []*v3.GrantRecord{testGrantRecord("ent-A", "alice")}))
-	require.True(t, e.deferredIdxPending.Load())
+	require.True(t, e.db.DeferredIdxPending())
 
 	injected := errors.New("injected deferred-marker clear failure")
-	e.test.clearDeferredMarkerHook = func() error { return injected }
+	e.db.SetDeferredMarkerTestHooks(nil, func() error { return injected })
 	err = a.EndSync(ctx)
 	require.ErrorIs(t, err, injected, "a failed marker clear must fail EndSync")
 
 	// THE CONTRACT: both halves still armed, in agreement.
-	require.True(t, e.deferredIdxPending.Load(), "failed clear must leave the flag armed")
-	_, closer, getErr := e.db.Get(encodeDeferredIdxPendingKey())
+	require.True(t, e.db.DeferredIdxPending(), "failed clear must leave the flag armed")
+	_, closer, getErr := e.db.Get(keys.DeferredIdxPendingKey())
 	require.NoError(t, getErr, "failed clear must leave the durable key present")
 	closer.Close()
 
 	// Retry converges: rebuild re-runs (idempotent), clear succeeds,
 	// both halves disarm, and the index serves the rows.
-	e.test.clearDeferredMarkerHook = nil
+	e.db.SetDeferredMarkerTestHooks(nil, nil)
 	require.NoError(t, a.EndSync(ctx))
-	require.False(t, e.deferredIdxPending.Load())
-	_, _, getErr = e.db.Get(encodeDeferredIdxPendingKey())
+	require.False(t, e.db.DeferredIdxPending())
+	_, _, getErr = e.db.Get(keys.DeferredIdxPendingKey())
 	require.ErrorIs(t, getErr, pebble.ErrNotFound)
 	n := 0
 	require.NoError(t, e.IterateGrantsByPrincipal(ctx, "user", "alice", func(*v3.GrantRecord) bool {

--- a/pkg/dotc1z/engine/pebble/typed_record_ops_test.go
+++ b/pkg/dotc1z/engine/pebble/typed_record_ops_test.go
@@ -18,7 +18,7 @@ import (
 	v2pb "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
-	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/rawdb"
 )
 
 // TestAppendGrantByNeedsExpansionKeyFromPrimary pins the deriver
@@ -41,7 +41,7 @@ func TestAppendGrantByNeedsExpansionKeyFromPrimary(t *testing.T) {
 	}
 	for _, id := range ids {
 		primary := encodeGrantIdentityKey(id)
-		got, ok := keys.AppendGrantByNeedsExpansionKeyFromPrimary(nil, primary)
+		got, ok := rawdb.AppendGrantByNeedsExpansionKeyFromPrimary(nil, primary)
 		require.True(t, ok, "well-formed primary must splice")
 		require.Equal(t, encodeGrantByNeedsExpansionIdentityIndexKey(id), got, "identity %+v", id)
 	}
@@ -53,7 +53,7 @@ func TestAppendGrantByNeedsExpansionKeyFromPrimary(t *testing.T) {
 		{versionV3, typeGrant, 0, 'a', 0, 'b'}, // two segments
 		{versionV3, typeEntitlement, 0, 'a', 0, 'b', 0, 'c', 0, 'd', 0, 'e', 0, 'f'}, // wrong family
 	} {
-		_, ok := keys.AppendGrantByNeedsExpansionKeyFromPrimary(nil, malformed)
+		_, ok := rawdb.AppendGrantByNeedsExpansionKeyFromPrimary(nil, malformed)
 		require.False(t, ok, "malformed key %x must be rejected", malformed)
 	}
 }

--- a/pkg/dotc1z/engine/pebble/typed_record_ops_test.go
+++ b/pkg/dotc1z/engine/pebble/typed_record_ops_test.go
@@ -18,6 +18,7 @@ import (
 	v2pb "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/keys"
 )
 
 // TestAppendGrantByNeedsExpansionKeyFromPrimary pins the deriver
@@ -40,7 +41,7 @@ func TestAppendGrantByNeedsExpansionKeyFromPrimary(t *testing.T) {
 	}
 	for _, id := range ids {
 		primary := encodeGrantIdentityKey(id)
-		got, ok := appendGrantByNeedsExpansionKeyFromPrimary(nil, primary)
+		got, ok := keys.AppendGrantByNeedsExpansionKeyFromPrimary(nil, primary)
 		require.True(t, ok, "well-formed primary must splice")
 		require.Equal(t, encodeGrantByNeedsExpansionIdentityIndexKey(id), got, "identity %+v", id)
 	}
@@ -52,7 +53,7 @@ func TestAppendGrantByNeedsExpansionKeyFromPrimary(t *testing.T) {
 		{versionV3, typeGrant, 0, 'a', 0, 'b'}, // two segments
 		{versionV3, typeEntitlement, 0, 'a', 0, 'b', 0, 'c', 0, 'd', 0, 'e', 0, 'f'}, // wrong family
 	} {
-		_, ok := appendGrantByNeedsExpansionKeyFromPrimary(nil, malformed)
+		_, ok := keys.AppendGrantByNeedsExpansionKeyFromPrimary(nil, malformed)
 		require.False(t, ok, "malformed key %x must be rejected", malformed)
 	}
 }

--- a/pkg/dotc1z/pebble_store.go
+++ b/pkg/dotc1z/pebble_store.go
@@ -111,8 +111,7 @@ func (pebbleDriver) OpenStore(ctx context.Context, outputFilePath string, opts S
 		encoding = fileEncoding
 	}
 
-	adapter := pebble.NewAdapter(e)
-	err = adapter.InitCurrentSync(ctx)
+	err = e.InitCurrentSync(ctx)
 	if err != nil {
 		// Close the engine before removing its directory: a live pebble DB
 		// holds open fds and background goroutines that would otherwise
@@ -124,8 +123,7 @@ func (pebbleDriver) OpenStore(ctx context.Context, outputFilePath string, opts S
 	}
 
 	return &pebbleStore{
-		Adapter:         adapter,
-		engine:          e,
+		Engine:          e,
 		outputFilePath:  outputFilePath,
 		tmpDir:          tmpDir,
 		readOnly:        opts.ReadOnly,
@@ -205,8 +203,7 @@ func payloadEncodingFromProto(enc c1zv3.PayloadEncoding) c1zstore.PayloadEncodin
 }
 
 type pebbleStore struct {
-	*pebble.Adapter
-	engine          *pebble.Engine
+	*pebble.Engine
 	outputFilePath  string
 	tmpDir          string
 	readOnly        bool
@@ -287,7 +284,7 @@ func (f pebbleStoreFileOps) GenerateSyncDiff(ctx context.Context, baseSyncID, ap
 // — see pebble.BuildManifest). Callers see the value the writer
 // will actually use, not the literal option supplied.
 func (s *pebbleStore) Metadata() connectorstore.StoreMetadata {
-	md := s.Adapter.Metadata()
+	md := s.Engine.Metadata()
 	enc := s.payloadEncoding
 	if enc == c1zstore.PayloadEncodingUnspecified {
 		enc = c1zstore.PayloadEncodingIndexedZstd
@@ -303,7 +300,7 @@ func (s *pebbleStore) PebbleEngine() *pebble.Engine {
 	if s == nil {
 		return nil
 	}
-	return s.engine
+	return s.Engine
 }
 
 // CloseEngineOnly closes the Pebble engine without removing the
@@ -312,7 +309,7 @@ func (s *pebbleStore) PebbleEngine() *pebble.Engine {
 // pebble.CloseEngineOnly, where a caller owns a parent temp directory
 // and does one bulk cleanup after closing many read-only sources.
 func (s *pebbleStore) CloseEngineOnly() error {
-	if s == nil || s.engine == nil {
+	if s == nil || s.Engine == nil {
 		return nil
 	}
 	s.closeMu.Lock()
@@ -326,7 +323,7 @@ func (s *pebbleStore) CloseEngineOnly() error {
 	}
 	s.closed = true
 	s.closeMu.Unlock()
-	return s.engine.Close()
+	return s.Engine.Close()
 }
 
 // NormalizeForFixtureSave flushes and compacts the single sync, then
@@ -337,16 +334,16 @@ func (s *pebbleStore) CloseEngineOnly() error {
 // syncID arg is accepted for signature parity but ignored — the file
 // holds one sync and CompactAllRanges covers the whole keyspace.
 func (s *pebbleStore) NormalizeForFixtureSave(ctx context.Context, syncID string) error {
-	if s == nil || s.engine == nil {
+	if s == nil || s.Engine == nil {
 		return nil
 	}
 	if s.readOnly {
 		return errors.New("pebble NormalizeForFixtureSave: store is read-only")
 	}
-	if err := s.engine.Flush(ctx); err != nil {
+	if err := s.Flush(ctx); err != nil {
 		return err
 	}
-	if err := s.engine.CompactAllRanges(ctx); err != nil {
+	if err := s.CompactAllRanges(ctx); err != nil {
 		return err
 	}
 	s.closeMu.Lock()
@@ -398,7 +395,7 @@ func (s *pebbleStore) markDirty(err error) error {
 // StartNewSync after the first would discard the previous sync's records.
 // Future engine authors relying on this contract should preserve it here.
 func (s *pebbleStore) StartNewSync(ctx context.Context, syncType connectorstore.SyncType, parentSyncID string) (string, error) {
-	syncID, err := s.Adapter.StartNewSync(ctx, syncType, parentSyncID)
+	syncID, err := s.Engine.StartNewSync(ctx, syncType, parentSyncID)
 	if err == nil {
 		s.closeMu.Lock()
 		s.dirty = true
@@ -408,7 +405,7 @@ func (s *pebbleStore) StartNewSync(ctx context.Context, syncType connectorstore.
 }
 
 func (s *pebbleStore) StartOrResumeSync(ctx context.Context, syncType connectorstore.SyncType, syncID string) (string, bool, error) {
-	id, started, err := s.Adapter.StartOrResumeSync(ctx, syncType, syncID)
+	id, started, err := s.Engine.StartOrResumeSync(ctx, syncType, syncID)
 	if err == nil && started {
 		s.closeMu.Lock()
 		s.dirty = true
@@ -418,11 +415,11 @@ func (s *pebbleStore) StartOrResumeSync(ctx context.Context, syncType connectors
 }
 
 func (s *pebbleStore) CheckpointSync(ctx context.Context, syncToken string) error {
-	return s.markDirty(s.Adapter.CheckpointSync(ctx, syncToken))
+	return s.markDirty(s.Engine.CheckpointSync(ctx, syncToken))
 }
 
 func (s *pebbleStore) EndSync(ctx context.Context) error {
-	return s.markDirty(s.Adapter.EndSync(ctx))
+	return s.markDirty(s.Engine.EndSync(ctx))
 }
 
 // Cleanup is a no-op for the Pebble v3 engine. A c1z holds exactly one
@@ -437,7 +434,7 @@ func (s *pebbleStore) Cleanup(ctx context.Context) error {
 }
 
 func (s *pebbleStore) PutAsset(ctx context.Context, assetRef *v2.AssetRef, contentType string, data []byte) error {
-	return s.markDirty(s.Adapter.PutAsset(ctx, assetRef, contentType, data))
+	return s.markDirty(s.Engine.PutAsset(ctx, assetRef, contentType, data))
 }
 
 // SetSupportsDiff marks the given sync as diff-capable, matching the
@@ -461,19 +458,19 @@ func (s *pebbleStore) SetSyncLink(ctx context.Context, syncID string, linkedSync
 	if syncID == "" {
 		return fmt.Errorf("SetSyncLink: empty syncID")
 	}
-	r, err := s.engine.GetSyncRunRecord(ctx, syncID)
+	r, err := s.GetSyncRunRecord(ctx, syncID)
 	if err != nil {
 		return fmt.Errorf("SetSyncLink: get: %w", err)
 	}
 	r.SetLinkedSyncId(linkedSyncID)
-	if err := s.engine.PutSyncRunRecord(ctx, r); err != nil {
+	if err := s.PutSyncRunRecord(ctx, r); err != nil {
 		return fmt.Errorf("SetSyncLink: put: %w", err)
 	}
 	return s.markDirty(nil)
 }
 
 func (s *pebbleStore) PutGrants(ctx context.Context, grants ...*v2.Grant) error {
-	return s.markDirty(s.Adapter.PutGrants(ctx, grants...))
+	return s.markDirty(s.Engine.PutGrants(ctx, grants...))
 }
 
 // UnsafePutUniqueGrants is the trusted-import write path (no
@@ -481,30 +478,30 @@ func (s *pebbleStore) PutGrants(ctx context.Context, grants ...*v2.Grant) error 
 // connector output. Caller must guarantee unique external_ids across the whole
 // destination sync. See pebble.Adapter.UnsafePutUniqueGrants.
 func (s *pebbleStore) UnsafePutUniqueGrants(ctx context.Context, grants ...*v2.Grant) error {
-	return s.markDirty(s.Adapter.UnsafePutUniqueGrants(ctx, grants...))
+	return s.markDirty(s.Engine.UnsafePutUniqueGrants(ctx, grants...))
 }
 
 func (s *pebbleStore) PutResourceTypes(ctx context.Context, resourceTypes ...*v2.ResourceType) error {
-	return s.markDirty(s.Adapter.PutResourceTypes(ctx, resourceTypes...))
+	return s.markDirty(s.Engine.PutResourceTypes(ctx, resourceTypes...))
 }
 
 func (s *pebbleStore) PutResources(ctx context.Context, resources ...*v2.Resource) error {
-	return s.markDirty(s.Adapter.PutResources(ctx, resources...))
+	return s.markDirty(s.Engine.PutResources(ctx, resources...))
 }
 
 func (s *pebbleStore) PutEntitlements(ctx context.Context, entitlements ...*v2.Entitlement) error {
-	return s.markDirty(s.Adapter.PutEntitlements(ctx, entitlements...))
+	return s.markDirty(s.Engine.PutEntitlements(ctx, entitlements...))
 }
 
 func (s *pebbleStore) DeleteGrant(ctx context.Context, grantID string) error {
-	return s.markDirty(s.Adapter.DeleteGrant(ctx, grantID))
+	return s.markDirty(s.Engine.DeleteGrant(ctx, grantID))
 }
 
 // DeleteGrantByRefs is the exact grant delete for callers holding the full
 // grant: identity derives from the structured refs, never the lossy id
 // string. The syncer prefers this when available.
 func (s *pebbleStore) DeleteGrantByRefs(ctx context.Context, grant *v2.Grant) error {
-	return s.markDirty(s.Adapter.DeleteGrantByRefs(ctx, grant))
+	return s.markDirty(s.Engine.DeleteGrantByRefs(ctx, grant))
 }
 
 // Grants overrides Adapter.Grants() so the returned GrantStore
@@ -512,7 +509,7 @@ func (s *pebbleStore) DeleteGrantByRefs(ctx context.Context, grant *v2.Grant) er
 // path. The Adapter-level wrapper calls Adapter.PutGrants directly,
 // which skips the dirty flag.
 func (s *pebbleStore) Grants() c1zstore.GrantStore {
-	return pebbleStoreGrants{inner: s.Adapter.Grants(), store: s}
+	return pebbleStoreGrants{inner: s.Engine.Grants(), store: s}
 }
 
 // pebbleStoreGrants wraps the Adapter-level grant store and overrides
@@ -696,7 +693,7 @@ func (s *pebbleStore) Close(ctx context.Context) (retErr error) {
 		}
 	}()
 
-	if err := s.engine.Close(); err != nil {
+	if err := s.Engine.Close(); err != nil {
 		retErr = errors.Join(retErr, err)
 	}
 	return retErr
@@ -715,7 +712,7 @@ func (s *pebbleStore) save(ctx context.Context) error {
 	if err := os.RemoveAll(checkpointDir); err != nil {
 		return fmt.Errorf("pebble save: clear stale checkpoint dir: %w", err)
 	}
-	if err := s.engine.CheckpointTo(ctx, checkpointDir); err != nil {
+	if err := s.CheckpointTo(ctx, checkpointDir); err != nil {
 		return err
 	}
 	checkpointDur := time.Since(saveStart)
@@ -735,7 +732,7 @@ func (s *pebbleStore) save(ctx context.Context) error {
 		}
 	}()
 
-	manifest, err := pebble.BuildManifestWithSyncRuns(ctx, s.engine, s.payloadEncoding)
+	manifest, err := pebble.BuildManifestWithSyncRuns(ctx, s.Engine, s.payloadEncoding)
 	if err != nil {
 		return err
 	}

--- a/pkg/dotc1z/pebble_store_cleanup_test.go
+++ b/pkg/dotc1z/pebble_store_cleanup_test.go
@@ -74,7 +74,7 @@ func TestPebbleSingleSyncReplaces(t *testing.T) {
 	}
 
 	rs := store.(*pebbleStore)
-	ids := listSyncIDs(t, ctx, rs.engine)
+	ids := listSyncIDs(t, ctx, rs.Engine)
 	require.Len(t, ids, 1, "sync_run count = %d, want 1 (single-sync contract); ids=%v", len(ids), ids)
 	require.Equal(t, lastID, ids[0], "retained sync_id = %q, want most recent %q", ids[0], lastID)
 }
@@ -94,20 +94,20 @@ func TestPebbleSecondSyncWipesPriorData(t *testing.T) {
 	newSyncID := runOneSync(t, ctx, store, "new")
 
 	rs := store.(*pebbleStore)
-	ids := listSyncIDs(t, ctx, rs.engine)
+	ids := listSyncIDs(t, ctx, rs.Engine)
 	require.Len(t, ids, 1)
 	require.Equal(t, newSyncID, ids[0], "post-replace sync IDs = %v, want [%s]", ids, newSyncID)
 
 	// Old sync's grants must be gone from the primary keyspace.
 	for _, ext := range []string{"old-g1", "old-g2"} {
-		_, err := rs.engine.GetGrantRecord(ctx, ext)
+		_, err := rs.GetGrantRecord(ctx, ext)
 		require.Error(t, err, "grant %s from the replaced sync still present", ext)
 	}
 
 	// Old sync's by-principal index entries must be gone too — a missing
 	// wipe range would leak index keys the primary delete caught.
 	count := 0
-	err := rs.engine.IterateGrantsByPrincipal(ctx, "user", "old-alice", func(*v3.GrantRecord) bool {
+	err := rs.IterateGrantsByPrincipal(ctx, "user", "old-alice", func(*v3.GrantRecord) bool {
 		count++
 		return true
 	})
@@ -115,7 +115,7 @@ func TestPebbleSecondSyncWipesPriorData(t *testing.T) {
 	require.Zero(t, count, "by-principal index still has %d entries from the replaced sync", count)
 
 	// New sync's grants must remain readable.
-	_, err = rs.engine.GetGrantRecord(ctx, mkV2GrantID("ent", "user", "new-alice"))
+	_, err = rs.GetGrantRecord(ctx, mkV2GrantID("ent", "user", "new-alice"))
 	require.NoError(t, err, "GetGrantRecord on current sync: %v", err)
 }
 
@@ -136,7 +136,7 @@ func TestPebbleCleanupIsNoOp(t *testing.T) {
 	err := rs.Cleanup(ctx)
 	require.NoError(t, err, "Cleanup: %v", err)
 	require.False(t, rs.dirty, "Cleanup marked the store dirty; expected a no-op")
-	ids := listSyncIDs(t, ctx, rs.engine)
+	ids := listSyncIDs(t, ctx, rs.Engine)
 	require.Len(t, ids, 1)
 	require.Equal(t, syncID, ids[0], "post-Cleanup sync IDs = %v, want [%s]", ids, syncID)
 }

--- a/pkg/dotc1z/pebble_store_session.go
+++ b/pkg/dotc1z/pebble_store_session.go
@@ -15,29 +15,29 @@ type pebbleStoreSessionStore struct {
 }
 
 func (s pebbleStoreSessionStore) Get(ctx context.Context, key string, opt ...sessions.SessionStoreOption) ([]byte, bool, error) {
-	return s.store.engine.SessionGet(ctx, key, opt...)
+	return s.store.SessionGet(ctx, key, opt...)
 }
 
 func (s pebbleStoreSessionStore) Set(ctx context.Context, key string, value []byte, opt ...sessions.SessionStoreOption) error {
-	return s.store.markDirty(s.store.engine.SessionSet(ctx, key, value, opt...))
+	return s.store.markDirty(s.store.SessionSet(ctx, key, value, opt...))
 }
 
 func (s pebbleStoreSessionStore) GetMany(ctx context.Context, keys []string, opt ...sessions.SessionStoreOption) (map[string][]byte, []string, error) {
-	return s.store.engine.SessionGetMany(ctx, keys, opt...)
+	return s.store.SessionGetMany(ctx, keys, opt...)
 }
 
 func (s pebbleStoreSessionStore) GetAll(ctx context.Context, pageToken string, opt ...sessions.SessionStoreOption) (map[string][]byte, string, error) {
-	return s.store.engine.SessionGetAll(ctx, pageToken, opt...)
+	return s.store.SessionGetAll(ctx, pageToken, opt...)
 }
 
 func (s pebbleStoreSessionStore) SetMany(ctx context.Context, values map[string][]byte, opt ...sessions.SessionStoreOption) error {
-	return s.store.markDirty(s.store.engine.SessionSetMany(ctx, values, opt...))
+	return s.store.markDirty(s.store.SessionSetMany(ctx, values, opt...))
 }
 
 func (s pebbleStoreSessionStore) Delete(ctx context.Context, key string, opt ...sessions.SessionStoreOption) error {
-	return s.store.markDirty(s.store.engine.SessionDelete(ctx, key, opt...))
+	return s.store.markDirty(s.store.SessionDelete(ctx, key, opt...))
 }
 
 func (s pebbleStoreSessionStore) Clear(ctx context.Context, opt ...sessions.SessionStoreOption) error {
-	return s.store.markDirty(s.store.engine.SessionClear(ctx, opt...))
+	return s.store.markDirty(s.store.SessionClear(ctx, opt...))
 }

--- a/pkg/dotc1z/to_pebble_discovered_at_test.go
+++ b/pkg/dotc1z/to_pebble_discovered_at_test.go
@@ -64,7 +64,7 @@ func TestToPebblePreservesDiscoveredAt(t *testing.T) {
 	eng, ok := pebble.AsEngine(dest)
 	require.True(t, ok)
 
-	iter, err := eng.DB().NewIter(nil)
+	iter, err := eng.NewIter(nil)
 	require.NoError(t, err)
 	defer iter.Close()
 

--- a/pkg/dotc1z/to_pebble_equivalence_test.go
+++ b/pkg/dotc1z/to_pebble_equivalence_test.go
@@ -182,7 +182,7 @@ func dumpSyncKeyspace(ctx context.Context, t *testing.T, path, tmpDir string) ma
 	eng, ok := enginepkg.AsEngine(store)
 	require.True(t, ok)
 
-	iter, err := eng.DB().NewIter(nil)
+	iter, err := eng.NewIter(nil)
 	require.NoError(t, err)
 	defer iter.Close()
 

--- a/pkg/synccompactor/compactor_grant_digest_test.go
+++ b/pkg/synccompactor/compactor_grant_digest_test.go
@@ -314,7 +314,7 @@ func TestCompactPebbleFoldRepairsOnlyTouchedEntitlements(t *testing.T) {
 // in [lo, hi).
 func requireEmptyKeyRange(t testing.TB, eng *enginepkg.Engine, lo, hi []byte, what string) {
 	t.Helper()
-	iter, err := eng.DB().NewIter(&pebble.IterOptions{LowerBound: lo, UpperBound: hi})
+	iter, err := eng.NewIter(&pebble.IterOptions{LowerBound: lo, UpperBound: hi})
 	require.NoError(t, err)
 	defer iter.Close()
 	require.False(t, iter.First(), "%s keyspace must be empty, found key %x", what, iter.Key())

--- a/pkg/synccompactor/compactor_pebble.go
+++ b/pkg/synccompactor/compactor_pebble.go
@@ -1014,7 +1014,7 @@ func (c *Compactor) compactPebble(ctx context.Context, newSyncId string) error {
 	// along as consequences (see Engine.SetCurrentSync / Engine.seal). An
 	// exported ResumeCompactions-style escape hatch would let callers write
 	// on a sealed engine again, recreating the very hang this fixes.
-	if err := destEng.SetCurrentSync(newSyncId); err != nil {
+	if err := destEng.SetCurrentSync(ctx, newSyncId); err != nil {
 		return fmt.Errorf("compactPebble: bind dest sync: %w", err)
 	}
 

--- a/pkg/synccompactor/compactor_pebble_test.go
+++ b/pkg/synccompactor/compactor_pebble_test.go
@@ -94,7 +94,7 @@ func countPebbleAssets(t *testing.T, ctx context.Context, path string) int {
 	defer w.Close(ctx)
 	eng, ok := enginepkg.AsEngine(w)
 	require.True(t, ok, "store at %s is not a pebble engine", path)
-	it, err := eng.DB().NewIter(&pebble.IterOptions{
+	it, err := eng.NewIter(&pebble.IterOptions{
 		LowerBound: enginepkg.AssetLowerBound(),
 		UpperBound: enginepkg.AssetUpperBound(),
 	})
@@ -1253,7 +1253,7 @@ func deletePebbleStatsSidecar(t testing.TB, ctx context.Context, path string) {
 	require.NoError(t, err)
 	eng, ok := enginepkg.AsEngine(w)
 	require.True(t, ok)
-	iter, err := eng.DB().NewIter(&pebble.IterOptions{
+	iter, err := eng.NewIter(&pebble.IterOptions{
 		LowerBound: enginepkg.SyncStatsSidecarLowerBound(),
 		UpperBound: enginepkg.SyncStatsSidecarUpperBound(),
 	})
@@ -1265,7 +1265,7 @@ func deletePebbleStatsSidecar(t testing.TB, ctx context.Context, path string) {
 	require.NoError(t, iter.Error())
 	require.NoError(t, iter.Close())
 	for _, key := range keys {
-		require.NoError(t, eng.DB().UnsafeForTesting().Delete(key, nil))
+		require.NoError(t, eng.UnsafeForTesting().Delete(key, nil))
 	}
 	require.NoError(t, w.Close(ctx))
 }

--- a/pkg/synccompactor/pebble/compactor.go
+++ b/pkg/synccompactor/pebble/compactor.go
@@ -88,15 +88,8 @@ func (c *Compactor) Compact(ctx context.Context, source *enginepkg.Engine, syncI
 		return errors.New("synccompactor/pebble.Compact: syncID is required")
 	}
 
-	srcDB := source.DB()
-	if srcDB == nil {
-		return errors.New("synccompactor/pebble.Compact: source engine has no DB (closed?)")
-	}
-	dstDB := c.base.DB()
-	if dstDB == nil {
-		return errors.New("synccompactor/pebble.Compact: base engine has no DB (closed?)")
-	}
-	// This function writes the base keyspace through the raw DB handle;
+	// This function writes the base keyspace through the engine's merge
+	// surface (a closed engine surfaces ErrEngineClosing per call);
 	// invalidate the engine's bare-id lookup state on the way out (even on
 	// error — earlier buckets may already have been replaced).
 	defer c.base.InvalidateBareIDLookups()
@@ -128,7 +121,7 @@ func (c *Compactor) Compact(ctx context.Context, source *enginepkg.Engine, syncI
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		iter, err := srcDB.NewIter(&pebble.IterOptions{
+		iter, err := source.NewIter(&pebble.IterOptions{
 			LowerBound: plan.lower,
 			UpperBound: plan.upper,
 		})
@@ -154,7 +147,7 @@ func (c *Compactor) Compact(ctx context.Context, source *enginepkg.Engine, syncI
 			// with zero SSTs (the ingest must reference at least one
 			// file), so we fall back to a RangeDelete + Flush.
 			_ = os.Remove(sstPath)
-			if err := dstDB.DropKeyRange(plan.lower, plan.upper, pebble.Sync); err != nil {
+			if err := c.base.DropKeyRange(plan.lower, plan.upper, pebble.Sync); err != nil {
 				return fmt.Errorf("compact: excise-only DeleteRange for %s: %w", plan.name, err)
 			}
 			continue
@@ -186,7 +179,7 @@ func (c *Compactor) Compact(ctx context.Context, source *enginepkg.Engine, syncI
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		if err := dstDB.ReplaceRangeWithSSTs(ctx, []string{p.sstPath}, p.exciseSpan); err != nil {
+		if err := c.base.ReplaceRangeWithSSTs(ctx, []string{p.sstPath}, p.exciseSpan); err != nil {
 			return fmt.Errorf("compact: IngestAndExcise: %w", err)
 		}
 	}

--- a/pkg/synccompactor/pebble/compactor.go
+++ b/pkg/synccompactor/pebble/compactor.go
@@ -89,7 +89,8 @@ func (c *Compactor) Compact(ctx context.Context, source *enginepkg.Engine, syncI
 	}
 
 	// This function writes the base keyspace through the engine's merge
-	// surface (a closed engine surfaces ErrEngineClosing per call);
+	// surface (a closed engine surfaces ErrEngineClosing from the
+	// error-returning ops, and an explicit panic from NewFoldBatch);
 	// invalidate the engine's bare-id lookup state on the way out (even on
 	// error — earlier buckets may already have been replaced).
 	defer c.base.InvalidateBareIDLookups()

--- a/pkg/synccompactor/pebble/compactor_test.go
+++ b/pkg/synccompactor/pebble/compactor_test.go
@@ -59,8 +59,8 @@ func TestCompactBasicRoundtrip(t *testing.T) {
 	dst, _ := newEngine(t, "dst")
 
 	syncID := ksuid.New().String()
-	require.NoError(t, src.SetCurrentSync(syncID))
-	require.NoError(t, dst.SetCurrentSync(syncID))
+	require.NoError(t, src.SetCurrentSync(ctx, syncID))
+	require.NoError(t, dst.SetCurrentSync(ctx, syncID))
 
 	// 200 grants in source under syncID.
 	for i := 0; i < 200; i++ {
@@ -82,8 +82,8 @@ func TestCompactReplacesExisting(t *testing.T) {
 	dst, _ := newEngine(t, "dst")
 
 	syncID := ksuid.New().String()
-	require.NoError(t, src.SetCurrentSync(syncID))
-	require.NoError(t, dst.SetCurrentSync(syncID))
+	require.NoError(t, src.SetCurrentSync(ctx, syncID))
+	require.NoError(t, dst.SetCurrentSync(ctx, syncID))
 
 	// Seed dst with 500 stale grants under syncID.
 	for i := 0; i < 500; i++ {
@@ -131,7 +131,7 @@ func TestCompactReplacesAllImplementedBuckets(t *testing.T) {
 
 	syncID := ksuid.New().String()
 	for _, e := range []*enginepkg.Engine{src, dst} {
-		require.NoError(t, e.SetCurrentSync(syncID))
+		require.NoError(t, e.SetCurrentSync(ctx, syncID))
 	}
 
 	require.NoError(t, dst.PutResourceTypeRecord(ctx, v3.ResourceTypeRecord_builder{
@@ -230,14 +230,14 @@ func TestCompactReplacesDestData(t *testing.T) {
 	syncID := ksuid.New().String()
 
 	// dst starts with 100 grants that the compaction must replace.
-	require.NoError(t, dst.SetCurrentSync(syncID))
+	require.NoError(t, dst.SetCurrentSync(ctx, syncID))
 	for i := 0; i < 100; i++ {
 		r := grant(syncID, ksuid.New().String(), "ent-old", ksuid.New().String())
 		require.NoError(t, dst.PutGrantRecord(ctx, r))
 	}
 
 	// src has 25 (different) grants.
-	require.NoError(t, src.SetCurrentSync(syncID))
+	require.NoError(t, src.SetCurrentSync(ctx, syncID))
 	for i := 0; i < 25; i++ {
 		r := grant(syncID, ksuid.New().String(), "ent-new", ksuid.New().String())
 		require.NoError(t, src.PutGrantRecord(ctx, r))
@@ -258,7 +258,7 @@ func TestCompactEmptySource(t *testing.T) {
 	dst, _ := newEngine(t, "dst")
 
 	syncID := ksuid.New().String()
-	require.NoError(t, dst.SetCurrentSync(syncID))
+	require.NoError(t, dst.SetCurrentSync(ctx, syncID))
 	// Seed dst with grants we expect to be wiped.
 	for i := 0; i < 20; i++ {
 		r := grant(syncID, ksuid.New().String(), "ent", ksuid.New().String())

--- a/pkg/synccompactor/pebble/kway.go
+++ b/pkg/synccompactor/pebble/kway.go
@@ -595,7 +595,7 @@ func mergeSourceBucketToRunSection(
 	lower, upper := bucket.syncRange()
 	h := &directHeap{}
 	for i, source := range sources {
-		iter, err := source.engine.DB().NewIter(&cpebble.IterOptions{LowerBound: lower, UpperBound: upper})
+		iter, err := source.engine.NewIter(&cpebble.IterOptions{LowerBound: lower, UpperBound: upper})
 		if err != nil {
 			return err
 		}
@@ -681,7 +681,7 @@ func materializeSourceBucketToPebble(
 	lower, upper := bucket.syncRange()
 	h := &directHeap{}
 	for i, source := range sources {
-		iter, err := source.engine.DB().NewIter(&cpebble.IterOptions{LowerBound: lower, UpperBound: upper})
+		iter, err := source.engine.NewIter(&cpebble.IterOptions{LowerBound: lower, UpperBound: upper})
 		if err != nil {
 			return err
 		}
@@ -752,7 +752,7 @@ func materializeSourceBucketToPebble(
 	}
 	primarySuccess = true
 	defer func() { _ = os.Remove(primaryPath) }()
-	if err := dest.DB().IngestSSTs(ctx, []string{primaryPath}); err != nil {
+	if err := dest.IngestSSTs(ctx, []string{primaryPath}); err != nil {
 		return fmt.Errorf("ingest direct primary %s: %w", bucket.name, err)
 	}
 	dest.InvalidateBareIDLookups()
@@ -1260,7 +1260,7 @@ func materializeRunFileBucket(ctx context.Context, dest *enginepkg.Engine, tmpDi
 	}
 	primarySuccess = true
 	defer func() { _ = os.Remove(primaryPath) }()
-	if err := dest.DB().IngestSSTs(ctx, []string{primaryPath}); err != nil {
+	if err := dest.IngestSSTs(ctx, []string{primaryPath}); err != nil {
 		return fmt.Errorf("ingest primary %s: %w", bucket.name, err)
 	}
 	dest.InvalidateBareIDLookups()
@@ -1381,7 +1381,7 @@ func (w *indexRunWriter) closeSortAndIngest(ctx context.Context, dest *enginepkg
 		return err
 	}
 	defer func() { _ = os.Remove(sstPath) }()
-	if err := dest.DB().IngestSSTs(ctx, []string{sstPath}); err != nil {
+	if err := dest.IngestSSTs(ctx, []string{sstPath}); err != nil {
 		return fmt.Errorf("ingest index %s: %w", w.name, err)
 	}
 	dest.InvalidateBareIDLookups()

--- a/pkg/synccompactor/pebble/kway_bench_test.go
+++ b/pkg/synccompactor/pebble/kway_bench_test.go
@@ -148,7 +148,7 @@ func BenchmarkMergeFilesIntoKWayWithGrantDigests(b *testing.B) {
 		if err := os.MkdirAll(tmpDir, 0o755); err != nil {
 			b.Fatal(err)
 		}
-		if err := dest.SetCurrentSync(destSyncID); err != nil {
+		if err := dest.SetCurrentSync(ctx, destSyncID); err != nil {
 			b.Fatal(err)
 		}
 		if _, err := MergeFilesInto(ctx, dest, sources, destSyncID, tmpDir); err != nil {

--- a/pkg/synccompactor/pebble/merge.go
+++ b/pkg/synccompactor/pebble/merge.go
@@ -192,12 +192,8 @@ const mergeRawFlushRecords = 32768
 //     ordering ("never overwrite an incumbent, always fill a hole").
 func mergeOneSource(ctx context.Context, dest *enginepkg.Engine, s SourceSync, destSyncID string) (FoldStats, error) {
 	var stats FoldStats
-	srcDB := s.Engine.DB()
-	if srcDB == nil {
-		return stats, errors.New("source engine has no DB (closed?)")
-	}
 	for _, bucket := range allBuckets() {
-		bucketStats, err := mergeBucketRawIfNewer(ctx, dest, srcDB, bucket)
+		bucketStats, err := mergeBucketRawIfNewer(ctx, dest, s.Engine, bucket)
 		stats.Add(bucketStats)
 		if err != nil {
 			return stats, fmt.Errorf("merge %s: %w", bucket.name, err)
@@ -206,7 +202,7 @@ func mergeOneSource(ctx context.Context, dest *enginepkg.Engine, s SourceSync, d
 	return stats, nil
 }
 
-func mergeBucketRawIfNewer(ctx context.Context, dest *enginepkg.Engine, src *enginepkg.MergeDB, bucket bucketSpec) (FoldStats, error) {
+func mergeBucketRawIfNewer(ctx context.Context, dest *enginepkg.Engine, src *enginepkg.Engine, bucket bucketSpec) (FoldStats, error) {
 	var stats FoldStats
 	lower, upper := bucket.syncRange()
 	iter, err := src.NewIter(&pebble.IterOptions{LowerBound: lower, UpperBound: upper})
@@ -215,8 +211,7 @@ func mergeBucketRawIfNewer(ctx context.Context, dest *enginepkg.Engine, src *eng
 	}
 	defer func() { _ = iter.Close() }()
 
-	destDB := dest.DB()
-	batch := destDB.NewFoldBatch()
+	batch := dest.NewFoldBatch()
 	defer func() { _ = batch.Close() }()
 	pending := 0
 	var scratch rawIndexScratch
@@ -239,7 +234,7 @@ func mergeBucketRawIfNewer(ctx context.Context, dest *enginepkg.Engine, src *eng
 			return err
 		}
 		_ = batch.Close()
-		batch = destDB.NewFoldBatch()
+		batch = dest.NewFoldBatch()
 		pending = 0
 		return nil
 	}
@@ -252,7 +247,7 @@ func mergeBucketRawIfNewer(ctx context.Context, dest *enginepkg.Engine, src *eng
 		// Point-read the committed incumbent. Safe against the pending
 		// batch: a sync holds one record per key, so no key repeats
 		// within this loop, and earlier sources were fully flushed.
-		oldVal, closer, getErr := destDB.Get(key)
+		oldVal, closer, getErr := dest.Get(key)
 		switch {
 		case getErr == nil:
 			if bytes.Equal(oldVal, value) {

--- a/pkg/synccompactor/pebble/merge.go
+++ b/pkg/synccompactor/pebble/merge.go
@@ -144,7 +144,7 @@ func MergeInto(ctx context.Context, dest *enginepkg.Engine, sources []SourceSync
 	if destSyncID == "" {
 		return stats, errors.New("synccompactor/pebble.MergeInto: destSyncID is required")
 	}
-	if err := dest.SetCurrentSync(destSyncID); err != nil {
+	if err := dest.SetCurrentSync(ctx, destSyncID); err != nil {
 		return stats, fmt.Errorf("synccompactor/pebble.MergeInto: bind dest sync: %w", err)
 	}
 	// Folds write the dest keyspace through the raw DB handle; invalidate

--- a/pkg/synccompactor/pebble/merge_test.go
+++ b/pkg/synccompactor/pebble/merge_test.go
@@ -46,10 +46,10 @@ func TestMergeIntoUnionNewerWins(t *testing.T) {
 	newer := time.Unix(2000, 0).UTC()
 
 	// src1 (applied first): shared key @older + a unique key.
-	require.NoError(t, src1.SetCurrentSync(syncA))
+	require.NoError(t, src1.SetCurrentSync(ctx, syncA))
 	require.NoError(t, src1.PutGrantRecords(ctx, grantAt(syncA, "g-shared", older), grantAt(syncA, "g-only1", older)))
 	// src2 (applied second): shared key @newer (must win) + a unique key.
-	require.NoError(t, src2.SetCurrentSync(syncB))
+	require.NoError(t, src2.SetCurrentSync(ctx, syncB))
 	require.NoError(t, src2.PutGrantRecords(ctx, grantAt(syncB, "g-shared", newer), grantAt(syncB, "g-only2", newer)))
 
 	// No SetCurrentSync here: MergeInto must bind the dest engine to
@@ -103,7 +103,7 @@ func TestMergeIntoGrantWritesTracksActualChanges(t *testing.T) {
 	destSync := ksuid.New().String()
 	at := time.Unix(1000, 0).UTC()
 
-	require.NoError(t, src.SetCurrentSync(syncID))
+	require.NoError(t, src.SetCurrentSync(ctx, syncID))
 	require.NoError(t, src.PutGrantRecords(ctx, grantAt(syncID, "g1", at)))
 
 	// First merge: a genuinely new grant is admitted.
@@ -122,7 +122,7 @@ func TestMergeIntoGrantWritesTracksActualChanges(t *testing.T) {
 	// A source with no grants at all contributes zero grant writes.
 	empty, _ := newEngine(t, "gw-empty-src")
 	emptySyncID := ksuid.New().String()
-	require.NoError(t, empty.SetCurrentSync(emptySyncID))
+	require.NoError(t, empty.SetCurrentSync(ctx, emptySyncID))
 	stats3, err := MergeInto(ctx, dst, []SourceSync{{Engine: empty, SyncID: emptySyncID}}, destSync)
 	require.NoError(t, err)
 	require.Zero(t, stats3.GrantWrites, "a source with no grants contributes zero grant writes")
@@ -130,7 +130,7 @@ func TestMergeIntoGrantWritesTracksActualChanges(t *testing.T) {
 	// A genuinely newer record on the same identity DOES count.
 	newer := time.Unix(2000, 0).UTC()
 	src2, _ := newEngine(t, "gw-src2")
-	require.NoError(t, src2.SetCurrentSync(syncID))
+	require.NoError(t, src2.SetCurrentSync(ctx, syncID))
 	require.NoError(t, src2.PutGrantRecords(ctx, grantAt(syncID, "g1", newer)))
 	stats4, err := MergeInto(ctx, dst, []SourceSync{{Engine: src2, SyncID: syncID}}, destSync)
 	require.NoError(t, err)
@@ -157,9 +157,9 @@ func TestMergeIntoTieKeepsIncumbent(t *testing.T) {
 	g2 := grantAt(syncB, "g-tie", tie)
 	g2.SetExternalId("from-src2")
 
-	_ = src1.SetCurrentSync(syncA)
+	_ = src1.SetCurrentSync(ctx, syncA)
 	require.NoError(t, src1.PutGrantRecords(ctx, g1))
-	_ = src2.SetCurrentSync(syncB)
+	_ = src2.SetCurrentSync(ctx, syncB)
 	require.NoError(t, src2.PutGrantRecords(ctx, g2))
 	// src1 applied first → incumbent wins the tie. MergeInto binds the
 	// dest sync itself.
@@ -203,7 +203,7 @@ func seedBase(t *testing.T, ctx context.Context, name string, rs recordSet) (*en
 	t.Helper()
 	dest, _ := newEngine(t, name)
 	destSync := ksuid.New().String()
-	require.NoError(t, dest.SetCurrentSync(destSync))
+	require.NoError(t, dest.SetCurrentSync(ctx, destSync))
 	populateEngine(t, ctx, dest, rs)
 	return dest, destSync
 }

--- a/pkg/synccompactor/pebble/merge_test.go
+++ b/pkg/synccompactor/pebble/merge_test.go
@@ -296,7 +296,7 @@ func sumBucketRawBytes(t *testing.T, eng *enginepkg.Engine, bucket bucketSpec) i
 	ranges := append([][2][]byte{{lo, hi}}, bucketIndexRanges(bucket)...)
 	var total int64
 	for _, r := range ranges {
-		iter, err := eng.DB().NewIter(&cpebble.IterOptions{LowerBound: r[0], UpperBound: r[1]})
+		iter, err := eng.NewIter(&cpebble.IterOptions{LowerBound: r[0], UpperBound: r[1]})
 		require.NoError(t, err)
 		for iter.First(); iter.Valid(); iter.Next() {
 			total += int64(len(iter.Key())) + int64(len(iter.Value()))

--- a/pkg/synccompactor/pebble/overlay.go
+++ b/pkg/synccompactor/pebble/overlay.go
@@ -355,7 +355,7 @@ func overlayRestartBucket(ctx context.Context, dest *enginepkg.Engine, bucket bu
 		return err
 	}
 	writer.discard()
-	b := dest.DB().NewFoldBatch()
+	b := dest.NewFoldBatch()
 	defer func() { _ = b.Close() }()
 	lo, hi := bucket.syncRange()
 	if err := b.DeleteRange(lo, hi); err != nil {
@@ -943,7 +943,7 @@ func overlaySinglePassBucket(
 	hardLimit int64,
 ) error {
 	lower, upper := bucket.syncRange()
-	iter, err := source.DB().NewIter(&cpebble.IterOptions{LowerBound: lower, UpperBound: upper})
+	iter, err := source.NewIter(&cpebble.IterOptions{LowerBound: lower, UpperBound: upper})
 	if err != nil {
 		return err
 	}
@@ -1021,7 +1021,7 @@ func overlayWholeSourceWorthIt(ctx context.Context, source sourceHandle, bucket 
 		}
 	}
 	lower, upper := bucket.syncRange()
-	iter, err := source.engine.DB().NewIter(&cpebble.IterOptions{LowerBound: lower, UpperBound: upper})
+	iter, err := source.engine.NewIter(&cpebble.IterOptions{LowerBound: lower, UpperBound: upper})
 	if err != nil {
 		return false, err
 	}
@@ -1069,7 +1069,7 @@ func overlayMaterializeWholeSourceBucketSST(
 	stats *mergeStatsAccumulator,
 ) error {
 	lower, upper := bucket.syncRange()
-	iter, err := source.DB().NewIter(&cpebble.IterOptions{LowerBound: lower, UpperBound: upper})
+	iter, err := source.NewIter(&cpebble.IterOptions{LowerBound: lower, UpperBound: upper})
 	if err != nil {
 		return err
 	}
@@ -1141,7 +1141,7 @@ func overlayMaterializeWholeSourceBucketSST(
 	primarySuccess = true
 	defer func() { _ = os.Remove(primaryPath) }()
 	if wrotePrimary {
-		if err := dest.DB().IngestSSTs(ctx, []string{primaryPath}); err != nil {
+		if err := dest.IngestSSTs(ctx, []string{primaryPath}); err != nil {
 			return fmt.Errorf("overlay merge: ingest whole primary %s: %w", bucket.name, err)
 		}
 		dest.InvalidateBareIDLookups()
@@ -1234,7 +1234,7 @@ func overlayCopySourceIndexesSST(
 	if !wrote {
 		return nil
 	}
-	if err := dest.DB().IngestSSTs(ctx, []string{sstPath}); err != nil {
+	if err := dest.IngestSSTs(ctx, []string{sstPath}); err != nil {
 		return fmt.Errorf("overlay merge: ingest whole index %s: %w", bucket.name, err)
 	}
 	dest.InvalidateBareIDLookups()
@@ -1251,7 +1251,7 @@ func copyIndexRangeFiltered(
 	w *sstBuilder,
 	wrote *bool,
 ) error {
-	iter, err := source.DB().NewIter(&cpebble.IterOptions{LowerBound: lower, UpperBound: upper})
+	iter, err := source.NewIter(&cpebble.IterOptions{LowerBound: lower, UpperBound: upper})
 	if err != nil {
 		return err
 	}
@@ -1634,8 +1634,8 @@ func newOverlayBucketRawWriter(dest *enginepkg.Engine, bucket bucketSpec, stats 
 		dest:      dest,
 		bucket:    bucket,
 		chunkSize: chunkSize,
-		primary:   dest.DB().NewFoldBatch(),
-		index:     dest.DB().NewFoldBatch(),
+		primary:   dest.NewFoldBatch(),
+		index:     dest.NewFoldBatch(),
 		stats:     stats,
 	}
 }
@@ -1684,7 +1684,7 @@ func (w *overlayBucketRawWriter) replaceRaw(ctx context.Context, bucket bucketSp
 	if err := w.flush(ctx); err != nil {
 		return err
 	}
-	oldVal, closer, err := w.dest.DB().Get(destKey)
+	oldVal, closer, err := w.dest.Get(destKey)
 	if err != nil {
 		if errors.Is(err, cpebble.ErrNotFound) {
 			// Seen-set hash collision: the admitted record was a different
@@ -1764,8 +1764,8 @@ func (w *overlayBucketRawWriter) flush(ctx context.Context) error {
 	if err := w.index.Commit(opts); err != nil {
 		return err
 	}
-	w.primary = w.dest.DB().NewFoldBatch()
-	w.index = w.dest.DB().NewFoldBatch()
+	w.primary = w.dest.NewFoldBatch()
+	w.index = w.dest.NewFoldBatch()
 	w.count = 0
 	return nil
 }
@@ -1797,7 +1797,7 @@ func (w *overlayBucketRawWriter) discard() {
 	if w.index != nil {
 		_ = w.index.Close()
 	}
-	w.primary = w.dest.DB().NewFoldBatch()
-	w.index = w.dest.DB().NewFoldBatch()
+	w.primary = w.dest.NewFoldBatch()
+	w.index = w.dest.NewFoldBatch()
 	w.count = 0
 }

--- a/pkg/synccompactor/pebble/overlay_degradation_test.go
+++ b/pkg/synccompactor/pebble/overlay_degradation_test.go
@@ -92,7 +92,7 @@ func dumpDestSyncContents(t *testing.T, e *enginepkg.Engine) map[string]string {
 		lo, hi := bucket.syncRange()
 		ranges := append([][2][]byte{{lo, hi}}, bucketIndexRanges(bucket)...)
 		for _, r := range ranges {
-			iter, err := e.DB().NewIter(&cpebble.IterOptions{LowerBound: r[0], UpperBound: r[1]})
+			iter, err := e.NewIter(&cpebble.IterOptions{LowerBound: r[0], UpperBound: r[1]})
 			require.NoError(t, err)
 			for iter.First(); iter.Valid(); iter.Next() {
 				out[string(iter.Key())] = string(iter.Value())

--- a/pkg/synccompactor/pebble/overlay_index_copy_test.go
+++ b/pkg/synccompactor/pebble/overlay_index_copy_test.go
@@ -242,7 +242,7 @@ func assertIndexesMatchDerived(t *testing.T, ctx context.Context, dest *enginepk
 	var stored [][]byte
 	for _, bucket := range allBuckets() {
 		for _, r := range bucketIndexRanges(bucket) {
-			iter, err := dest.DB().NewIter(&cpebble.IterOptions{LowerBound: r[0], UpperBound: r[1]})
+			iter, err := dest.NewIter(&cpebble.IterOptions{LowerBound: r[0], UpperBound: r[1]})
 			require.NoError(t, err)
 			for iter.First(); iter.Valid(); iter.Next() {
 				stored = append(stored, append([]byte(nil), iter.Key()...))

--- a/pkg/synccompactor/pebble/winner_equivalence_test.go
+++ b/pkg/synccompactor/pebble/winner_equivalence_test.go
@@ -104,7 +104,7 @@ func buildEngineSource(t *testing.T, ctx context.Context, name string, rs record
 	t.Helper()
 	eng, _ := newEngine(t, name)
 	syncID := ksuid.New().String()
-	require.NoError(t, eng.SetCurrentSync(syncID))
+	require.NoError(t, eng.SetCurrentSync(ctx, syncID))
 	populateEngine(t, ctx, eng, rs)
 	return SourceSync{Engine: eng, SyncID: syncID}
 }

--- a/pkg/synccompactor/prodscale_scan_test.go
+++ b/pkg/synccompactor/prodscale_scan_test.go
@@ -70,7 +70,7 @@ func TestProdScaleScanVsFoldDebt(t *testing.T) {
 		// files present; TablesCount is accurate in both modes. (The
 		// fold's production debt gate reads metrics from a writable
 		// open, where Sublevels is correct.)
-		l0Files := eng.DB().Metrics().Levels[0].TablesCount
+		l0Files := eng.Metrics().Levels[0].TablesCount
 
 		start := time.Now()
 		count := 0


### PR DESCRIPTION
## Simplify the pebble storage stack: fewer layers, one sync-lifecycle state, same guarantees

Refactor only — no behavior change (two small, deliberate exceptions listed below).

### Problem

Writing a record traversed five layers, with glue between them that existed for
structural reasons rather than functional ones:

```
pebbleStore → Adapter → Engine → rawdb → pebble
```

- `internal/rawdb` (the write choke point) couldn't import its parent package, so the
  engine injected nine derivation closures into it at Open, plus an adapter struct to
  carry them.
- The compactor reached the DB through a separate handle type (`Engine.DB()` returning a
  narrowed view struct, with type aliases so other packages could name it).
- The `Adapter` type existed as a separate layer even though only `pebbleStore`
  constructed one, and it kept its own copy of "which sync is open" (id, type, step
  token, …) shadowing the engine's binding — with rehydration logic to keep the two in
  agreement, and real bugs when they drifted (a stale cached step token silently
  restarted the syncer's FSM from scratch).

### Change

```
pebbleStore → Engine → rawdb → pebble
```

- **rawdb owns the key formats it enforces.** The keyspace ABI (key splices, value
  scanners, digest-invalidation key builders, type/index discriminator bytes) moved into
  rawdb (`keyspace.go`). Its typed staging ops now derive their obligations with direct
  function calls; the injected-closure machinery (`RecordDerivers`, `SetRecordDerivers`,
  `recordStager`) is deleted.
- **rawdb owns the write-side crash state.** The deferred-index marker (in-memory flag +
  durable key, with the arm/clear ordering contracts) and the digests-present gate moved
  onto `rawdb.DB`, next to the staging ops that consume them.
- **The compactor handle is gone.** The operations the compactor uses are `Engine`
  methods now (`merge_surface.go`), each checking engine lifecycle per call — using a
  retained reference after Close yields a clean `ErrEngineClosing` (or an explicit,
  messaged panic for the two ops with no error path) instead of a nil dereference.
  A meta-test fences these ops' production use to the compactor package
  (mutation-verified: planting a call in engine production code fails CI).
- **The Adapter layer is dissolved into the Engine.** Same files, same method bodies —
  the receiver changed. `type Adapter = Engine` and `NewAdapter` remain as aliases so
  existing code and tests compile. `pebbleStore` embeds `*pebble.Engine` directly.
- **One sync-lifecycle state.** The engine's sync binding is the only in-memory
  lifecycle state; everything else (step token, type, parent) is read from the durable
  `SyncRunRecord` on demand — the same model the SQLite engine has always used, which is
  why it never needed the cache-rehydration logic this deletes.

### What did not change

The compile-time fence around the raw `*pebble.DB`, the typed staging API and its
obligation derivation, write barriers and seal semantics, all on-disk key formats
(byte-identical), and performance (allocation counts identical before/after; the deleted
indirection was compile-time-inlined all along).

### Deliberate behavior deltas

- `CurrentDBSizeBytes` walks the engine's VFS instead of the host filesystem (required
  for VFS-injected engines), tolerates files deleted mid-walk by compaction, and does
  not follow symlinks.
- `Engine.SetCurrentSync` gained a `ctx` parameter (the validating store-facing form);
  the bare binding is now unexported.

### Testing

Full engine/store/compactor/equivalence suites green (sqlite paths included); fault-
injection sweeps and soak green; `-race` battery green across every touched package
(the one failure, `TestC1ZConcurrentClose`, is a pre-existing sqlite race that
reproduces on main and is tracked separately); lint clean. Two independent adversarial
model reviews on the rawdb half confirmed key-format byte-fidelity and invalidation
equivalence; their findings (symlink traversal, a weakened meta-test, closed-engine nil
panics) are fixed in this branch.