### PR TITLE
fix(pebble): hydrate entitlement resource annotations on read

### DIFF
--- a/pkg/dotc1z/engine/pebble/adapter.go
+++ b/pkg/dotc1z/engine/pebble/adapter.go
@@ -888,8 +888,11 @@ func (e *Engine) ListEntitlements(ctx context.Context, req *v2.EntitlementsServi
 		return nil, c1zstore.AdaptNotFound(err, pebble.ErrNotFound)
 	}
 	out := make([]*v2.Entitlement, 0, len(records))
+	resCache := make(map[string]*v2.Resource)
 	for _, rec := range records {
-		out = append(out, V3EntitlementToV2(rec))
+		ent := V3EntitlementToV2(rec)
+		e.hydrateEntitlementResource(ctx, ent, resCache)
+		out = append(out, ent)
 	}
 	return v2.EntitlementsServiceListEntitlementsResponse_builder{
 		List:          out,

--- a/pkg/dotc1z/engine/pebble/adapter_reader.go
+++ b/pkg/dotc1z/engine/pebble/adapter_reader.go
@@ -30,6 +30,60 @@ var _ reader_v2.GrantsReaderServiceServer = (*Adapter)(nil)
 // the engine, then returns a v2-shaped response (via the translation
 // layer in translate_v2.go).
 
+// hydrateEntitlementResource swaps the identity-only Resource stub that
+// V3EntitlementToV2 produces for the full resource stored under the same
+// sync, so the Pebble reader returns entitlements shaped exactly like the
+// SQLite engine does.
+//
+// Connectors emit an entitlement carrying its full Resource (id +
+// annotations + profile). The SQLite engine round-tripped that whole proto,
+// so readers saw entitlement.Resource.Annotations intact. The Pebble engine
+// normalizes the entitlement's resource to an id-only ref on write
+// (V2EntitlementToV3) and rebuilds only the id on read, so downstream
+// consumers that read connector metadata off entitlement.Resource — most
+// importantly the connector RawId annotation, which uplift uses to populate
+// raw_baton_id and to merge match_baton_id placeholder entitlements — get
+// nothing once a connector switches from SQLite to Pebble. Rehydrating here
+// keeps the two engines' reader output identical.
+//
+// A resource not present under this sync (targeted/partial syncs can
+// reference resources they didn't write) leaves the id-only stub in place
+// rather than failing the entitlement read. The optional cache dedupes
+// lookups when many entitlements share one resource.
+func (e *Engine) hydrateEntitlementResource(ctx context.Context, ent *v2.Entitlement, cache map[string]*v2.Resource) {
+	if ent == nil {
+		return
+	}
+	rid := ent.GetResource().GetId()
+	rt, id := rid.GetResourceType(), rid.GetResource()
+	if rt == "" || id == "" {
+		return
+	}
+	cacheKey := rt + "\x00" + id
+	if cache != nil {
+		if full, ok := cache[cacheKey]; ok {
+			if full != nil {
+				ent.SetResource(full)
+			}
+			return
+		}
+	}
+	rec, err := e.GetResourceRecord(ctx, rt, id)
+	if err != nil {
+		// Not found under this sync: keep the id-only stub. A missing
+		// resource must never turn into a failed entitlement read.
+		if cache != nil {
+			cache[cacheKey] = nil
+		}
+		return
+	}
+	full := V3ResourceToV2(rec)
+	ent.SetResource(full)
+	if cache != nil {
+		cache[cacheKey] = full
+	}
+}
+
 // GetEntitlement fetches a single entitlement by ID. Implements
 // reader_v2.EntitlementsReaderServiceServer.
 func (e *Engine) GetEntitlement(ctx context.Context, req *reader_v2.EntitlementsReaderServiceGetEntitlementRequest) (*reader_v2.EntitlementsReaderServiceGetEntitlementResponse, error) {
@@ -45,8 +99,10 @@ func (e *Engine) GetEntitlement(ctx context.Context, req *reader_v2.Entitlements
 	if err != nil {
 		return nil, err
 	}
+	ent := V3EntitlementToV2(rec)
+	e.hydrateEntitlementResource(ctx, ent, nil)
 	return reader_v2.EntitlementsReaderServiceGetEntitlementResponse_builder{
-		Entitlement: V3EntitlementToV2(rec),
+		Entitlement: ent,
 	}.Build(), nil
 }
 
@@ -150,6 +206,7 @@ func (e *Engine) ListEntitlementsByIds(
 	}
 	ids := req.GetEntitlementIds()
 	out := make([]*v2.Entitlement, 0, len(ids))
+	resCache := make(map[string]*v2.Resource)
 	for _, id := range ids {
 		if err := ctx.Err(); err != nil {
 			return nil, err
@@ -164,7 +221,9 @@ func (e *Engine) ListEntitlementsByIds(
 			}
 			return nil, err
 		}
-		out = append(out, V3EntitlementToV2(rec))
+		ent := V3EntitlementToV2(rec)
+		e.hydrateEntitlementResource(ctx, ent, resCache)
+		out = append(out, ent)
 	}
 	return reader_v2.EntitlementsReaderServiceListEntitlementsByIdsResponse_builder{
 		List: out,

--- a/pkg/dotc1z/engine/pebble/adapter_streaming.go
+++ b/pkg/dotc1z/engine/pebble/adapter_streaming.go
@@ -129,12 +129,15 @@ func (e *Engine) StreamEntitlements(
 			return
 		}
 		var iterErr error
+		resCache := make(map[string]*v2.Resource)
 		err := e.IterateEntitlements(ctx, func(rec *v3.EntitlementRecord) bool {
 			if err := ctx.Err(); err != nil {
 				iterErr = err
 				return false
 			}
-			return yield(V3EntitlementToV2(rec), nil)
+			ent := V3EntitlementToV2(rec)
+			e.hydrateEntitlementResource(ctx, ent, resCache)
+			return yield(ent, nil)
 		})
 		if iterErr != nil {
 			yield(nil, iterErr)

--- a/pkg/dotc1z/engine/pebble/entitlement_resource_hydrate_test.go
+++ b/pkg/dotc1z/engine/pebble/entitlement_resource_hydrate_test.go
@@ -1,0 +1,101 @@
+package pebble
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	reader_v2 "github.com/conductorone/baton-sdk/pb/c1/reader/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+)
+
+// TestEntitlementResourceAnnotationsHydrated locks in that every reader path
+// returns an entitlement whose embedded Resource carries the full resource's
+// annotations (here a connector RawId), matching the SQLite engine.
+//
+// The Pebble engine stores an entitlement's resource as an id-only ref, so
+// without read-side hydration the resource annotations are dropped. That
+// silently broke uplift's raw_baton_id derivation and match_baton_id
+// placeholder merging, which both read the connector RawId off
+// entitlement.Resource.GetAnnotations().
+func TestEntitlementResourceAnnotationsHydrated(t *testing.T) {
+	ctx := context.Background()
+	a := newAdapter(t)
+	_, err := a.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+
+	require.NoError(t, a.PutResourceTypes(ctx, v2.ResourceType_builder{
+		Id:          "group",
+		DisplayName: "Group",
+		Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_GROUP},
+	}.Build()))
+
+	resAnnos := annotations.Annotations{}
+	resAnnos.Update(&v2.RawId{Id: "00gRAWID"})
+	res := v2.Resource_builder{
+		Id:          v2.ResourceId_builder{ResourceType: "group", Resource: "00gRAWID"}.Build(),
+		DisplayName: "Engineering",
+		Annotations: resAnnos,
+	}.Build()
+	require.NoError(t, a.PutResources(ctx, res))
+
+	// Connectors emit the entitlement carrying its full resource; the engine
+	// normalizes that to an id-only ref on write.
+	const entID = "group:00gRAWID:member"
+	require.NoError(t, a.PutEntitlements(ctx, v2.Entitlement_builder{
+		Id:          entID,
+		Slug:        "member",
+		DisplayName: "Group Member",
+		Purpose:     v2.Entitlement_PURPOSE_VALUE_ASSIGNMENT,
+		Resource:    res,
+	}.Build()))
+
+	requireRawID := func(t *testing.T, ent *v2.Entitlement) {
+		t.Helper()
+		require.NotNil(t, ent)
+		require.NotNil(t, ent.GetResource(), "embedded resource present")
+		gotAnnos := annotations.Annotations(ent.GetResource().GetAnnotations())
+		rawID := &v2.RawId{}
+		ok, err := gotAnnos.Pick(rawID)
+		require.NoError(t, err)
+		require.True(t, ok, "embedded resource must carry the RawId annotation")
+		require.Equal(t, "00gRAWID", rawID.GetId())
+	}
+
+	t.Run("GetEntitlement", func(t *testing.T) {
+		resp, err := a.GetEntitlement(ctx, reader_v2.EntitlementsReaderServiceGetEntitlementRequest_builder{
+			EntitlementId: entID,
+		}.Build())
+		require.NoError(t, err)
+		requireRawID(t, resp.GetEntitlement())
+	})
+
+	t.Run("ListEntitlements", func(t *testing.T) {
+		resp, err := a.ListEntitlements(ctx, v2.EntitlementsServiceListEntitlementsRequest_builder{}.Build())
+		require.NoError(t, err)
+		require.Len(t, resp.GetList(), 1)
+		requireRawID(t, resp.GetList()[0])
+	})
+
+	t.Run("ListEntitlementsByIds", func(t *testing.T) {
+		resp, err := a.ListEntitlementsByIds(ctx, reader_v2.EntitlementsReaderServiceListEntitlementsByIdsRequest_builder{
+			EntitlementIds: []string{entID},
+		}.Build())
+		require.NoError(t, err)
+		require.Len(t, resp.GetList(), 1)
+		requireRawID(t, resp.GetList()[0])
+	})
+
+	t.Run("StreamEntitlements", func(t *testing.T) {
+		var got []*v2.Entitlement
+		for ent, err := range a.StreamEntitlements(ctx, "") {
+			require.NoError(t, err)
+			got = append(got, ent)
+		}
+		require.Len(t, got, 1)
+		requireRawID(t, got[0])
+	})
+}


### PR DESCRIPTION
## Summary

The Pebble c1z storage engine drops **resource-level annotations from the resource embedded in an entitlement** on read. Anything that reads connector metadata off `entitlement.Resource` — most importantly the `RawId` annotation — silently breaks when a connector moves from the SQLite engine to Pebble. This PR rehydrates the embedded resource in all four entitlement reader paths so the two engines return identical shapes.

## Background: how the two engines differ

Connectors emit an `Entitlement` carrying its **full** `Resource` (id **+ annotations** + profile). For example baton-okta builds the group member entitlement from the fully-annotated group resource, which carries `RawId{Id: <group id>}`.

- **SQLite engine**: stores the entire `v2.Entitlement` proto as a blob and unmarshals it verbatim on read → `entitlement.Resource.Annotations` (incl. `RawId`) is intact.
- **Pebble engine**: normalizes storage. On write (`V2EntitlementToV3`) the embedded resource is reduced to an id-only `v3.ResourceRef{ResourceTypeId, ResourceId}`; on read (`V3EntitlementToV2`) it is rebuilt as an **identity-only stub** — id present, **annotations gone**. This is called out in `V3EntitlementToV2`'s own doc comment ("The Resource side is hydrated as a stub (identity only); callers that need the full v2 Resource must hydrate via the engine's GetResourceRecord.").

Both types implement the same `reader_v2` service interface (`type Adapter = Engine`), so consumers written against the SQLite behavior — which never required separate hydration — get a silently degraded object from Pebble.

## Impact (how this surfaced)

In ConductorOne's uplift, the entitlement's embedded-resource `RawId` is the source for two things:

1. **`raw_baton_id`** on connector-sourced entitlements — derived from `source.Entitlement.GetResource().GetAnnotations()`.
2. **`match_baton_id` placeholder merging** — a manually-created "waiting to be merged" entitlement is matched to its connector entitlement by comparing `match_baton_id` against the same embedded-resource `RawId`.

When a tenant's connector was switched to the Pebble engine (rollout gated by a feature flag), that `RawId` disappeared from entitlements. Observed symptoms:

- `raw_baton_id` empty on newly-synced connector entitlements.
- `match_baton_id` placeholders never merged — every sync created a **duplicate** connector-sourced entitlement alongside the orphaned placeholder.
- **Resource-level** `match_baton_id` merges kept working, because standalone `ResourceRecord`s retain their annotations (`V3ResourceToV2` copies `Annotations`) — which is exactly the asymmetry that made this confusing to diagnose.
- `entitlement.Resource.GetId()` still resolved (id survives), so the entitlement was still processed — it just missed the merge and got created fresh.

## Fix

Add `(*Engine).hydrateEntitlementResource`, which replaces the identity-only stub with the full resource loaded from the resource record (via `GetResourceRecord` + `V3ResourceToV2`), and call it from every reader path that returns entitlements:

- `GetEntitlement`
- `ListEntitlements`
- `ListEntitlementsByIds`
- `StreamEntitlements`

Behavior:

- A resource **not present** under the sync (targeted/partial syncs can reference resources they didn't write) leaves the id-only stub in place — a missing resource must never turn into a failed entitlement read.
- The list/stream paths pass a per-call cache so entitlements sharing a resource incur a single lookup.

This restores parity with the SQLite engine: readers again see the full embedded resource (annotations included).

## Alternative considered

Persist the resource's annotations on the `EntitlementRecord` at write time (`V2EntitlementToV3`) so reads stay self-contained with no per-read lookup. That avoids the read-side `GetResourceRecord` cost but requires a storage-proto change and duplicates data. Read-side hydration was chosen as the smaller, engine-local fix that exactly matches SQLite semantics; happy to switch to the write-side approach if maintainers prefer it for the hot list/stream paths.

## Testing

- New `TestEntitlementResourceAnnotationsHydrated` writes a resource carrying a `RawId` annotation plus an entitlement on it, then asserts the `RawId` is present on the embedded resource returned by all four reader paths. (Without the fix, all four fail.)
- `go test ./pkg/dotc1z/engine/pebble/ -count=1` passes (incl. the SQLite-parity/differential suites).
- `go build ./...` clean.

## Note for downstream (c1)

A defense-in-depth guard on the consumer side is also worth doing: derive `RawId`/`raw_baton_id` and the match key from the standalone app resource that uplift already resolves, rather than the entitlement's embedded copy — so the merge is robust regardless of storage engine.
