### PR TITLE
feat(dotc1z): surface discovered_at through reader

### DIFF
--- a/pkg/connectorstore/connectorstore.go
+++ b/pkg/connectorstore/connectorstore.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"io"
 
+	"google.golang.org/protobuf/types/known/timestamppb"
+
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	reader_v2 "github.com/conductorone/baton-sdk/pb/c1/reader/v2"
 )
@@ -234,6 +236,41 @@ type DBSizeProvider interface {
 // Pebble adapter, whose ListGrants already carries it) need not implement it.
 type ExpansionGrantLister interface {
 	ListGrantsWithExpansion(ctx context.Context, request *v2.GrantsServiceListGrantsRequest) (*v2.GrantsServiceListGrantsResponse, error)
+}
+
+// GrantDiscoveredAtReader is an optional Reader capability that returns
+// a grant's stored discovered_at — the time the connector actually
+// observed the grant. It is stamped once when the grant is first
+// written and carried forward unchanged across re-syncs and expander
+// rewrites (never refreshed to now()), so it is a durable per-entry
+// observation timestamp, not a freshness signal recomputed on read.
+//
+// The value is stored in the c1z but stripped by the v2.Grant
+// translation (V3GrantToV2 populates only identity/annotations/sources),
+// so v2.Grant has no field to carry it. This capability is the
+// additive, contract-preserving way to read it back without touching
+// the connector API.
+//
+// It is engine-specific: only the Pebble (v3) engine records and
+// serves discovered_at through this surface, so callers MUST type-assert
+// and fall back when the assertion fails. Other readers (the legacy
+// SQLite engine, gRPC-backed readers) do not implement it — a failed
+// assertion means "discovered_at unavailable from this store", which
+// callers must treat as "unknown", never as an error.
+//
+// Grants are addressed by the same id GetGrant accepts — the stored
+// external id, or the legacy reconstructed principal/entitlement concat;
+// see reader_v2.GrantsReaderServiceGetGrantRequest.GrantId.
+//
+// found is false when no grant resolves for grantID under the reader's
+// active sync (an unknown or unresolvable id). A nil error with
+// found=false means "no such grant", not an error; an AMBIGUOUS id
+// (a lossy concat that could match more than one grant) is an error,
+// never a guess. found can be true with a nil timestamp for a grant
+// whose discovered_at was never stamped (legacy data) — callers must
+// treat a nil timestamp as "unknown", not epoch zero.
+type GrantDiscoveredAtReader interface {
+	GetGrantDiscoveredAt(ctx context.Context, grantID string) (discoveredAt *timestamppb.Timestamp, found bool, err error)
 }
 
 // GrantUpsertMode controls how grant conflicts are resolved during upsert.

--- a/pkg/dotc1z/engine/pebble/adapter.go
+++ b/pkg/dotc1z/engine/pebble/adapter.go
@@ -65,6 +65,7 @@ var (
 	_ connectorstore.LatestFinishedSyncIDFetcher  = (*Engine)(nil)
 	_ connectorstore.DBSizeProvider               = (*Engine)(nil)
 	_ connectorstore.EntitlementGrantDigestReader = (*Engine)(nil)
+	_ connectorstore.GrantDiscoveredAtReader      = (*Engine)(nil)
 )
 
 // === sync lifecycle ===

--- a/pkg/dotc1z/engine/pebble/adapter_reader.go
+++ b/pkg/dotc1z/engine/pebble/adapter_reader.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/cockroachdb/pebble/v2"
 	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	reader_v2 "github.com/conductorone/baton-sdk/pb/c1/reader/v2"
@@ -683,6 +684,33 @@ func (e *Engine) digestEntitlementIdentity(ctx context.Context, ent *v2.Entitlem
 		return entitlementIdentity{}, false, err
 	}
 	return id, true, nil
+}
+
+// GetGrantDiscoveredAt implements connectorstore.GrantDiscoveredAtReader.
+// It returns the discovered_at stored on the grant addressed by grantID
+// — the value stamped when the grant was first written and preserved
+// across re-syncs and expander rewrites, NEVER a fresh now(). It reads
+// the same GrantRecord GetGrant serves (grant keys carry no sync scope,
+// so no active-sync binding is required) and returns the record's
+// DiscoveredAt verbatim.
+//
+// found is false when no grant resolves for grantID (unknown or
+// unresolvable id); an ambiguous concat id stays an error, matching the
+// GetGrant resolution contract — a lossy string never guesses which
+// grant to answer with. A found grant that was never stamped returns a
+// nil timestamp with found=true.
+func (e *Engine) GetGrantDiscoveredAt(ctx context.Context, grantID string) (*timestamppb.Timestamp, bool, error) {
+	rec, err := e.GetGrantRecord(ctx, grantID)
+	if err != nil {
+		if errors.Is(err, pebble.ErrNotFound) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	if rec == nil {
+		return nil, false, nil
+	}
+	return rec.GetDiscoveredAt(), true, nil
 }
 
 // GetEntitlementGrantDigest implements connectorstore.EntitlementGrantDigestReader.

--- a/pkg/dotc1z/engine/pebble/grant_discovered_at_reader_test.go
+++ b/pkg/dotc1z/engine/pebble/grant_discovered_at_reader_test.go
@@ -1,0 +1,102 @@
+package pebble
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+)
+
+// TestGetGrantDiscoveredAtRoundTrip proves the stored per-grant
+// discovered_at survives to the new GrantDiscoveredAtReader surface
+// verbatim — the reader returns the value on disk, never a fresh
+// now(). It seeds a record with a deterministic, clearly-past timestamp
+// directly via the engine (bypassing the adapter's now() stamp), the
+// same technique the StoreExpandedGrants discovered_at tests use.
+func TestGetGrantDiscoveredAtRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	e, err := Open(ctx, filepath.Join(t.TempDir(), "engine"))
+	require.NoError(t, err)
+	defer func() { _ = e.Close() }()
+
+	// Compile-time contract is asserted in adapter.go; assert here too so
+	// this test fails loudly if the capability is ever dropped.
+	var _ connectorstore.GrantDiscoveredAtReader = e
+
+	_, err = e.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+
+	seeded := timestamppb.New(time.Date(2021, 6, 7, 8, 9, 10, 0, time.UTC))
+	seed := v3.GrantRecord_builder{
+		ExternalId: "g-1",
+		Entitlement: v3.EntitlementRef_builder{
+			ResourceTypeId: "app", ResourceId: "github", EntitlementId: canonicalTestEntID("ent-A"),
+		}.Build(),
+		Principal: v3.PrincipalRef_builder{
+			ResourceTypeId: "user", ResourceId: "alice",
+		}.Build(),
+		DiscoveredAt: seeded,
+	}.Build()
+	require.NoError(t, e.PutGrantRecord(ctx, seed))
+
+	got, found, err := e.GetGrantDiscoveredAt(ctx, "g-1")
+	require.NoError(t, err)
+	require.True(t, found, "seeded grant must be found")
+	require.NotNil(t, got, "discovered_at must survive to the reader surface")
+	require.Equal(t, seeded.AsTime(), got.AsTime(),
+		"GetGrantDiscoveredAt must return the STORED discovered_at, not a fresh now()")
+}
+
+// TestGetGrantDiscoveredAtUnknownID confirms an unresolvable id is
+// reported as found=false with a nil error and nil timestamp — "no such
+// grant", not an error.
+func TestGetGrantDiscoveredAtUnknownID(t *testing.T) {
+	ctx := context.Background()
+	e, err := Open(ctx, filepath.Join(t.TempDir(), "engine"))
+	require.NoError(t, err)
+	defer func() { _ = e.Close() }()
+
+	_, err = e.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+
+	got, found, err := e.GetGrantDiscoveredAt(ctx, "does-not-exist")
+	require.NoError(t, err)
+	require.False(t, found)
+	require.Nil(t, got)
+}
+
+// TestGetGrantDiscoveredAtNilStamp confirms a grant stored without a
+// discovered_at reports found=true with a nil timestamp — the caller's
+// signal to treat it as "unknown", distinct from "no such grant".
+func TestGetGrantDiscoveredAtNilStamp(t *testing.T) {
+	ctx := context.Background()
+	e, err := Open(ctx, filepath.Join(t.TempDir(), "engine"))
+	require.NoError(t, err)
+	defer func() { _ = e.Close() }()
+
+	_, err = e.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+
+	seed := v3.GrantRecord_builder{
+		ExternalId: "g-no-stamp",
+		Entitlement: v3.EntitlementRef_builder{
+			ResourceTypeId: "app", ResourceId: "github", EntitlementId: canonicalTestEntID("ent-A"),
+		}.Build(),
+		Principal: v3.PrincipalRef_builder{
+			ResourceTypeId: "user", ResourceId: "bob",
+		}.Build(),
+	}.Build()
+	require.Nil(t, seed.GetDiscoveredAt())
+	require.NoError(t, e.PutGrantRecord(ctx, seed))
+
+	got, found, err := e.GetGrantDiscoveredAt(ctx, "g-no-stamp")
+	require.NoError(t, err)
+	require.True(t, found, "a stored grant is found even with no discovered_at")
+	require.Nil(t, got, "an unstamped grant returns a nil timestamp, not epoch zero")
+}

--- a/pkg/dotc1z/grant_discovered_at_reader_test.go
+++ b/pkg/dotc1z/grant_discovered_at_reader_test.go
@@ -1,0 +1,102 @@
+package dotc1z_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
+)
+
+// TestGrantDiscoveredAtReaderAcrossEngines proves the additive
+// GrantDiscoveredAtReader capability behaves correctly on BOTH engines
+// through the public store surface:
+//
+//   - Pebble implements the capability and returns the grant's stored
+//     discovered_at. The value is stamped once at write and is stable
+//     across reads (a fresh now() on every call would not be), and it is
+//     surfaced even though the v2.Grant translation drops the field.
+//   - SQLite (deprecated) does not implement the capability: the type
+//     assertion fails, which callers must treat as "discovered_at
+//     unavailable from this store" and fall back — never an error.
+func TestGrantDiscoveredAtReaderAcrossEngines(t *testing.T) {
+	ctx := context.Background()
+
+	const grantID = "grant-alice-member"
+
+	seed := func(t *testing.T, store connectorstore.Writer) {
+		t.Helper()
+		_, err := store.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+		require.NoError(t, err)
+		require.NoError(t, store.PutResourceTypes(ctx,
+			v2.ResourceType_builder{Id: "user", DisplayName: "User", Traits: []v2.ResourceType_Trait{v2.ResourceType_TRAIT_USER}}.Build(),
+			v2.ResourceType_builder{Id: "app", DisplayName: "App", Traits: []v2.ResourceType_Trait{v2.ResourceType_TRAIT_APP}}.Build(),
+		))
+		appRes := v2.Resource_builder{
+			Id: v2.ResourceId_builder{ResourceType: "app", Resource: "gh"}.Build(),
+		}.Build()
+		alice := v2.Resource_builder{
+			Id: v2.ResourceId_builder{ResourceType: "user", Resource: "alice"}.Build(),
+		}.Build()
+		require.NoError(t, store.PutResources(ctx, appRes, alice))
+		ent := v2.Entitlement_builder{Id: "ent-A", Resource: appRes, Purpose: v2.Entitlement_PURPOSE_VALUE_PERMISSION, Slug: "A"}.Build()
+		require.NoError(t, store.PutEntitlements(ctx, ent))
+		grant := v2.Grant_builder{
+			Id:          grantID,
+			Entitlement: ent,
+			Principal:   alice,
+		}.Build()
+		require.NoError(t, store.PutGrants(ctx, grant))
+		require.NoError(t, store.EndSync(ctx))
+	}
+
+	openStore := func(t *testing.T, engine c1zstore.Engine) connectorstore.Writer {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), string(engine)+".c1z")
+		store, err := dotc1z.NewStore(ctx, path, dotc1z.WithEngine(engine))
+		require.NoError(t, err)
+		seed(t, store)
+		return store
+	}
+
+	t.Run("pebble returns stored discovered_at", func(t *testing.T) {
+		store := openStore(t, c1zstore.EnginePebble)
+		defer func() { _ = store.Close(ctx) }()
+
+		reader, ok := store.(connectorstore.GrantDiscoveredAtReader)
+		require.True(t, ok, "Pebble store must implement GrantDiscoveredAtReader")
+
+		got, found, err := reader.GetGrantDiscoveredAt(ctx, grantID)
+		require.NoError(t, err)
+		require.True(t, found, "the seeded grant must be found")
+		require.NotNil(t, got, "Pebble must surface a stored discovered_at")
+
+		// Stable across reads: a stored value round-trips identically,
+		// whereas a fabricated now() would differ between calls.
+		again, found2, err := reader.GetGrantDiscoveredAt(ctx, grantID)
+		require.NoError(t, err)
+		require.True(t, found2)
+		require.Equal(t, got.AsTime(), again.AsTime(),
+			"discovered_at must be the STORED value, stable across reads, not a fresh now()")
+
+		// Unknown id is a clean not-found, never an error.
+		_, found3, err := reader.GetGrantDiscoveredAt(ctx, "no-such-grant")
+		require.NoError(t, err)
+		require.False(t, found3)
+	})
+
+	t.Run("sqlite cleanly reports unavailable", func(t *testing.T) {
+		store := openStore(t, c1zstore.EngineSQLite)
+		defer func() { _ = store.Close(ctx) }()
+
+		_, ok := store.(connectorstore.GrantDiscoveredAtReader)
+		require.False(t, ok,
+			"deprecated SQLite store must NOT implement GrantDiscoveredAtReader; "+
+				"callers fall back to 'discovered_at unavailable'")
+	})
+}


### PR DESCRIPTION
## What & why

c1z entries store a per-entry `discovered_at` — the time the connector actually observed a grant. It's persisted in the storage layer but **stripped when storage records convert to `c1.connector.v2` protos**: `pebble.V3GrantToV2` never copies `r.GetDiscoveredAt()`, and `v2.Grant` has no field to carry it. So c1 can't read it.

c1 needs it: its uplift deletes optimistic "overlay" grant records by comparing `overlay.created_at` against a single coarse per-sync timestamp, which can delete an overlay before the connector has actually re-observed the grant (→ a user loses access). The real fix compares against the per-entry `discovered_at`. This PR stops dropping it — it surfaces it through the reader.

## Mechanism chosen: **A — additive optional reader capability**

New interface `connectorstore.GrantDiscoveredAtReader`, in the **exact mold** of the existing `EntitlementGrantDigestReader` / `ExpansionGrantLister`:

```go
type GrantDiscoveredAtReader interface {
    GetGrantDiscoveredAt(ctx context.Context, grantID string) (discoveredAt *timestamppb.Timestamp, found bool, err error)
}
```

- **Type-asserted, Pebble-implemented.** Only the Pebble (v3) engine implements it; callers type-assert and fall back on failure.
- **Addressed by the same `grantID` `GetGrant` accepts** (stored external id, or the legacy reconstructed concat). The Pebble impl reuses `GetGrantRecord` and returns `rec.GetDiscoveredAt()`.
- **`v2.Grant` is untouched** → the `c1.connector.v2` API contract is unchanged, keeping the review surface narrow.

**Why A over B (adding a field to `v2.Grant`):** B is simpler for c1 to consume but mutates the connector API contract (proto field on a wire type shared by every connector) — a much wider blast radius for a value only c1's uplift needs. A is fully additive and mirrors how every other engine-specific read capability in this package is already exposed.

### Semantics
- Value is the **STORED** `discovered_at`, stamped once at first write and carried forward across re-syncs / expander rewrites — **never a fresh `time.Now()`**.
- `found=false` (nil error) = "no such grant"; an **ambiguous** concat id stays an error (never a guess), matching `GetGrant`.
- `found=true` with a **nil** timestamp = a grant stored without a stamp (legacy) → caller treats as "unknown", not epoch zero.

### Scope
- **Grants only** (the must-have). Entitlements also carry `discovered_at` in storage — a parallel `GetEntitlementDiscoveredAt` is a cheap follow-up if the "absence/coverage" signal ever needs it, deliberately left out here to keep the surface minimal.
- **SQLite (deprecated) is intentionally not implemented** — a failed type assertion is the caller's "unavailable, fall back" signal, exactly like `EntitlementGrantDigestReader`.

## Files touched
- `pkg/connectorstore/connectorstore.go` — new `GrantDiscoveredAtReader` interface + doc.
- `pkg/dotc1z/engine/pebble/adapter_reader.go` — Pebble `GetGrantDiscoveredAt` impl.
- `pkg/dotc1z/engine/pebble/adapter.go` — compile-time interface assertion.
- `pkg/dotc1z/engine/pebble/grant_discovered_at_reader_test.go` — exact-seed round-trip, unknown-id, nil-stamp.
- `pkg/dotc1z/grant_discovered_at_reader_test.go` — cross-engine: Pebble returns stored value (stable across reads); SQLite cleanly reports unavailable.

## Tests
```
go test ./pkg/connectorstore/... ./pkg/dotc1z/ ./pkg/dotc1z/engine/pebble/   # ok
```
All new tests pass; full `pkg/dotc1z` + Pebble suites green. Changed files are lint-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)