### PR TITLE
better rate limit stats

### DIFF
--- a/pb/c1/connector/v2/annotation_ratelimit.pb.go
+++ b/pb/c1/connector/v2/annotation_ratelimit.pb.go
@@ -180,6 +180,68 @@ func (b0 RateLimitDescription_builder) Build() *RateLimitDescription {
 	return m0
 }
 
+// RateLimitWaitReport is a response annotation a connector attaches to report
+// time it spent sleeping on rate limits (client-side prevention, in-SDK 429
+// backoff) while serving the request. Those sleeps happen inside the connector
+// process where the syncer cannot observe them; the syncer folds this report
+// into the rate_limit_wait sync stat.
+type RateLimitWaitReport struct {
+	state         protoimpl.MessageState `protogen:"hybrid.v1"`
+	WaitMs        int64                  `protobuf:"varint,1,opt,name=wait_ms,json=waitMs,proto3" json:"wait_ms,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RateLimitWaitReport) Reset() {
+	*x = RateLimitWaitReport{}
+	mi := &file_c1_connector_v2_annotation_ratelimit_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RateLimitWaitReport) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RateLimitWaitReport) ProtoMessage() {}
+
+func (x *RateLimitWaitReport) ProtoReflect() protoreflect.Message {
+	mi := &file_c1_connector_v2_annotation_ratelimit_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *RateLimitWaitReport) GetWaitMs() int64 {
+	if x != nil {
+		return x.WaitMs
+	}
+	return 0
+}
+
+func (x *RateLimitWaitReport) SetWaitMs(v int64) {
+	x.WaitMs = v
+}
+
+type RateLimitWaitReport_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	WaitMs int64
+}
+
+func (b0 RateLimitWaitReport_builder) Build() *RateLimitWaitReport {
+	m0 := &RateLimitWaitReport{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.WaitMs = b.WaitMs
+	return m0
+}
+
 var File_c1_connector_v2_annotation_ratelimit_proto protoreflect.FileDescriptor
 
 const file_c1_connector_v2_annotation_ratelimit_proto_rawDesc = "" +
@@ -194,18 +256,21 @@ const file_c1_connector_v2_annotation_ratelimit_proto_rawDesc = "" +
 	"\x12STATUS_UNSPECIFIED\x10\x00\x12\r\n" +
 	"\tSTATUS_OK\x10\x01\x12\x14\n" +
 	"\x10STATUS_OVERLIMIT\x10\x02\x12\x10\n" +
-	"\fSTATUS_ERROR\x10\x03B6Z4github.com/conductorone/baton-sdk/pb/c1/connector/v2b\x06proto3"
+	"\fSTATUS_ERROR\x10\x03\".\n" +
+	"\x13RateLimitWaitReport\x12\x17\n" +
+	"\await_ms\x18\x01 \x01(\x03R\x06waitMsB6Z4github.com/conductorone/baton-sdk/pb/c1/connector/v2b\x06proto3"
 
 var file_c1_connector_v2_annotation_ratelimit_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_c1_connector_v2_annotation_ratelimit_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
+var file_c1_connector_v2_annotation_ratelimit_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
 var file_c1_connector_v2_annotation_ratelimit_proto_goTypes = []any{
 	(RateLimitDescription_Status)(0), // 0: c1.connector.v2.RateLimitDescription.Status
 	(*RateLimitDescription)(nil),     // 1: c1.connector.v2.RateLimitDescription
-	(*timestamppb.Timestamp)(nil),    // 2: google.protobuf.Timestamp
+	(*RateLimitWaitReport)(nil),      // 2: c1.connector.v2.RateLimitWaitReport
+	(*timestamppb.Timestamp)(nil),    // 3: google.protobuf.Timestamp
 }
 var file_c1_connector_v2_annotation_ratelimit_proto_depIdxs = []int32{
 	0, // 0: c1.connector.v2.RateLimitDescription.status:type_name -> c1.connector.v2.RateLimitDescription.Status
-	2, // 1: c1.connector.v2.RateLimitDescription.reset_at:type_name -> google.protobuf.Timestamp
+	3, // 1: c1.connector.v2.RateLimitDescription.reset_at:type_name -> google.protobuf.Timestamp
 	2, // [2:2] is the sub-list for method output_type
 	2, // [2:2] is the sub-list for method input_type
 	2, // [2:2] is the sub-list for extension type_name
@@ -224,7 +289,7 @@ func file_c1_connector_v2_annotation_ratelimit_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_c1_connector_v2_annotation_ratelimit_proto_rawDesc), len(file_c1_connector_v2_annotation_ratelimit_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   1,
+			NumMessages:   2,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pb/c1/connector/v2/annotation_ratelimit.pb.validate.go
+++ b/pb/c1/connector/v2/annotation_ratelimit.pb.validate.go
@@ -171,3 +171,107 @@ var _ interface {
 	Cause() error
 	ErrorName() string
 } = RateLimitDescriptionValidationError{}
+
+// Validate checks the field values on RateLimitWaitReport with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the first error encountered is returned, or nil if there are no violations.
+func (m *RateLimitWaitReport) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on RateLimitWaitReport with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// RateLimitWaitReportMultiError, or nil if none found.
+func (m *RateLimitWaitReport) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *RateLimitWaitReport) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	// no validation rules for WaitMs
+
+	if len(errors) > 0 {
+		return RateLimitWaitReportMultiError(errors)
+	}
+
+	return nil
+}
+
+// RateLimitWaitReportMultiError is an error wrapping multiple validation
+// errors returned by RateLimitWaitReport.ValidateAll() if the designated
+// constraints aren't met.
+type RateLimitWaitReportMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m RateLimitWaitReportMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m RateLimitWaitReportMultiError) AllErrors() []error { return m }
+
+// RateLimitWaitReportValidationError is the validation error returned by
+// RateLimitWaitReport.Validate if the designated constraints aren't met.
+type RateLimitWaitReportValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e RateLimitWaitReportValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e RateLimitWaitReportValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e RateLimitWaitReportValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e RateLimitWaitReportValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e RateLimitWaitReportValidationError) ErrorName() string {
+	return "RateLimitWaitReportValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e RateLimitWaitReportValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sRateLimitWaitReport.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = RateLimitWaitReportValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = RateLimitWaitReportValidationError{}

--- a/pb/c1/connector/v2/annotation_ratelimit_protoopaque.pb.go
+++ b/pb/c1/connector/v2/annotation_ratelimit_protoopaque.pb.go
@@ -180,6 +180,68 @@ func (b0 RateLimitDescription_builder) Build() *RateLimitDescription {
 	return m0
 }
 
+// RateLimitWaitReport is a response annotation a connector attaches to report
+// time it spent sleeping on rate limits (client-side prevention, in-SDK 429
+// backoff) while serving the request. Those sleeps happen inside the connector
+// process where the syncer cannot observe them; the syncer folds this report
+// into the rate_limit_wait sync stat.
+type RateLimitWaitReport struct {
+	state             protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_WaitMs int64                  `protobuf:"varint,1,opt,name=wait_ms,json=waitMs,proto3"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *RateLimitWaitReport) Reset() {
+	*x = RateLimitWaitReport{}
+	mi := &file_c1_connector_v2_annotation_ratelimit_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RateLimitWaitReport) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RateLimitWaitReport) ProtoMessage() {}
+
+func (x *RateLimitWaitReport) ProtoReflect() protoreflect.Message {
+	mi := &file_c1_connector_v2_annotation_ratelimit_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *RateLimitWaitReport) GetWaitMs() int64 {
+	if x != nil {
+		return x.xxx_hidden_WaitMs
+	}
+	return 0
+}
+
+func (x *RateLimitWaitReport) SetWaitMs(v int64) {
+	x.xxx_hidden_WaitMs = v
+}
+
+type RateLimitWaitReport_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	WaitMs int64
+}
+
+func (b0 RateLimitWaitReport_builder) Build() *RateLimitWaitReport {
+	m0 := &RateLimitWaitReport{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_WaitMs = b.WaitMs
+	return m0
+}
+
 var File_c1_connector_v2_annotation_ratelimit_proto protoreflect.FileDescriptor
 
 const file_c1_connector_v2_annotation_ratelimit_proto_rawDesc = "" +
@@ -194,18 +256,21 @@ const file_c1_connector_v2_annotation_ratelimit_proto_rawDesc = "" +
 	"\x12STATUS_UNSPECIFIED\x10\x00\x12\r\n" +
 	"\tSTATUS_OK\x10\x01\x12\x14\n" +
 	"\x10STATUS_OVERLIMIT\x10\x02\x12\x10\n" +
-	"\fSTATUS_ERROR\x10\x03B6Z4github.com/conductorone/baton-sdk/pb/c1/connector/v2b\x06proto3"
+	"\fSTATUS_ERROR\x10\x03\".\n" +
+	"\x13RateLimitWaitReport\x12\x17\n" +
+	"\await_ms\x18\x01 \x01(\x03R\x06waitMsB6Z4github.com/conductorone/baton-sdk/pb/c1/connector/v2b\x06proto3"
 
 var file_c1_connector_v2_annotation_ratelimit_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_c1_connector_v2_annotation_ratelimit_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
+var file_c1_connector_v2_annotation_ratelimit_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
 var file_c1_connector_v2_annotation_ratelimit_proto_goTypes = []any{
 	(RateLimitDescription_Status)(0), // 0: c1.connector.v2.RateLimitDescription.Status
 	(*RateLimitDescription)(nil),     // 1: c1.connector.v2.RateLimitDescription
-	(*timestamppb.Timestamp)(nil),    // 2: google.protobuf.Timestamp
+	(*RateLimitWaitReport)(nil),      // 2: c1.connector.v2.RateLimitWaitReport
+	(*timestamppb.Timestamp)(nil),    // 3: google.protobuf.Timestamp
 }
 var file_c1_connector_v2_annotation_ratelimit_proto_depIdxs = []int32{
 	0, // 0: c1.connector.v2.RateLimitDescription.status:type_name -> c1.connector.v2.RateLimitDescription.Status
-	2, // 1: c1.connector.v2.RateLimitDescription.reset_at:type_name -> google.protobuf.Timestamp
+	3, // 1: c1.connector.v2.RateLimitDescription.reset_at:type_name -> google.protobuf.Timestamp
 	2, // [2:2] is the sub-list for method output_type
 	2, // [2:2] is the sub-list for method input_type
 	2, // [2:2] is the sub-list for extension type_name
@@ -224,7 +289,7 @@ func file_c1_connector_v2_annotation_ratelimit_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_c1_connector_v2_annotation_ratelimit_proto_rawDesc), len(file_c1_connector_v2_annotation_ratelimit_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   1,
+			NumMessages:   2,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -124,6 +124,19 @@ func (a *Annotations) WithRateLimiting(rateLimit *v2.RateLimitDescription) *Anno
 	return a
 }
 
+// WithRateLimitWaitReport reports time the connector spent sleeping on rate
+// limits (client-side prevention, in-SDK backoff) while serving this response.
+// The syncer folds it into the rate_limit_wait sync stat. No-op if waitMs <= 0.
+func (a *Annotations) WithRateLimitWaitReport(waitMs int64) *Annotations {
+	if waitMs <= 0 {
+		return a
+	}
+	report := &v2.RateLimitWaitReport{}
+	report.SetWaitMs(waitMs)
+	a.Update(report)
+	return a
+}
+
 // NOTE: the store is the only usage of this.
 func GetSyncIdFromAnnotations(annos Annotations) (string, error) {
 	if len(annos) == 0 {

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -124,9 +124,13 @@ func (a *Annotations) WithRateLimiting(rateLimit *v2.RateLimitDescription) *Anno
 	return a
 }
 
-// WithRateLimitWaitReport reports time the connector spent sleeping on rate
-// limits (client-side prevention, in-SDK backoff) while serving this response.
-// The syncer folds it into the rate_limit_wait sync stat. No-op if waitMs <= 0.
+// WithRateLimitWaitReport reports time this connector spent sleeping on rate
+// limits internally while serving the request — e.g. its API client's own
+// client-side throttling or HTTP 429 backoff. Those sleeps happen inside the
+// connector process, invisible to the syncer (which may be across a gRPC or
+// lambda boundary); this annotation is how they reach the rate_limit_wait
+// sync stat. Waits in the syncer process report via ratelimit.ObserveWait
+// instead and must not be double-reported here. No-op if waitMs <= 0.
 func (a *Annotations) WithRateLimitWaitReport(waitMs int64) *Annotations {
 	if waitMs <= 0 {
 		return a

--- a/pkg/annotations/annotations_test.go
+++ b/pkg/annotations/annotations_test.go
@@ -95,6 +95,32 @@ func TestAnnotations_WithRateLimiting(t *testing.T) {
 	require.True(t, ok)
 }
 
+func TestAnnotations_WithRateLimitWaitReport(t *testing.T) {
+	var annos Annotations
+
+	// Non-positive waits are no-ops.
+	annos.WithRateLimitWaitReport(0)
+	annos.WithRateLimitWaitReport(-5)
+	require.Len(t, annos, 0)
+
+	annos.WithRateLimitWaitReport(1500)
+	require.Len(t, annos, 1)
+
+	report := &v2.RateLimitWaitReport{}
+	ok, err := annos.Pick(report)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.EqualValues(t, 1500, report.GetWaitMs())
+
+	// Update replaces rather than appends: a second report overwrites.
+	annos.WithRateLimitWaitReport(2000)
+	require.Len(t, annos, 1)
+	ok, err = annos.Pick(report)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.EqualValues(t, 2000, report.GetWaitMs())
+}
+
 func TestAnnotations_ContainAny(t *testing.T) {
 	var annos Annotations
 

--- a/pkg/ratelimit/grpc.go
+++ b/pkg/ratelimit/grpc.go
@@ -9,6 +9,7 @@ import (
 	connectorV2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	ratelimitV1 "github.com/conductorone/baton-sdk/pb/c1/ratelimit/v1"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/retry"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -88,6 +89,17 @@ func getRatelimitDescriptors(ctx context.Context, method string, in interface{},
 	return ret
 }
 
+// resourceTypeFromDescriptors returns the connector resource type descriptor
+// value, if present, for attributing rate-limit waits.
+func resourceTypeFromDescriptors(descriptors *ratelimitV1.RateLimitDescriptors) string {
+	for _, e := range descriptors.GetEntries() {
+		if e.GetKey() == descriptorKeyConnectorResourceType {
+			return e.GetValue()
+		}
+	}
+	return ""
+}
+
 // UnaryInterceptor returns a new unary server interceptors that adds zap.Logger to the context.
 func UnaryInterceptor(now func() time.Time, descriptors ...*ratelimitV1.RateLimitDescriptors_Entry) grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
@@ -163,11 +175,19 @@ func UnaryInterceptor(now func() time.Time, descriptors ...*ratelimitV1.RateLimi
 
 				l.Info("ratelimit overlimit - waiting", zap.String("method", method), zap.Duration("wait_period", d))
 
+				// Report actual slept time after the fact: a cancelled
+				// context cuts the sleep short and must not inflate
+				// rate_limit_wait with the planned duration.
+				waitCtx := retry.WithWaitLabel(ctx, resourceTypeFromDescriptors(rlDescriptors))
+				waitStart := time.Now()
+
 				// Overlimit -- wait up to maxRatelimitWait before trying the request again or the request is cancelled.
 				select {
 				case <-time.After(d):
+					ObserveWait(waitCtx, d)
 					continue
 				case <-ctx.Done():
+					ObserveWait(waitCtx, time.Since(waitStart))
 					return status.FromContextError(ctx.Err()).Err()
 				}
 

--- a/pkg/ratelimit/grpc.go
+++ b/pkg/ratelimit/grpc.go
@@ -9,7 +9,6 @@ import (
 	connectorV2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	ratelimitV1 "github.com/conductorone/baton-sdk/pb/c1/ratelimit/v1"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
-	"github.com/conductorone/baton-sdk/pkg/retry"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -178,7 +177,7 @@ func UnaryInterceptor(now func() time.Time, descriptors ...*ratelimitV1.RateLimi
 				// Report actual slept time after the fact: a cancelled
 				// context cuts the sleep short and must not inflate
 				// rate_limit_wait with the planned duration.
-				waitCtx := retry.WithWaitLabel(ctx, resourceTypeFromDescriptors(rlDescriptors))
+				waitCtx := WithWaitLabel(ctx, resourceTypeFromDescriptors(rlDescriptors))
 				waitStart := time.Now()
 
 				// Overlimit -- wait up to maxRatelimitWait before trying the request again or the request is cancelled.

--- a/pkg/ratelimit/grpc.go
+++ b/pkg/ratelimit/grpc.go
@@ -184,10 +184,10 @@ func UnaryInterceptor(now func() time.Time, descriptors ...*ratelimitV1.RateLimi
 				// Overlimit -- wait up to maxRatelimitWait before trying the request again or the request is cancelled.
 				select {
 				case <-time.After(d):
-					ObserveWait(waitCtx, d)
+					ObserveWait(waitCtx, WaitEvent{Duration: d})
 					continue
 				case <-ctx.Done():
-					ObserveWait(waitCtx, time.Since(waitStart))
+					ObserveWait(waitCtx, WaitEvent{Duration: time.Since(waitStart)})
 					return status.FromContextError(ctx.Err()).Err()
 				}
 

--- a/pkg/ratelimit/wait_observer.go
+++ b/pkg/ratelimit/wait_observer.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-// WaitObserver is notified each time a rate-limit gate sleeps before (re)issuing
+// WaitObserver is notified each time a rate-limit gate slept before (re)issuing
 // a request. Callers that account for rate-limit wait (e.g. the syncer's sync
 // stats) install one via WithWaitObserver; sleep sites report via ObserveWait.
 type WaitObserver func(ctx context.Context, wait time.Duration)
@@ -14,7 +14,7 @@ type waitObserverKey struct{}
 
 // WithWaitObserver returns a context that carries fn. Any rate-limit gate that
 // sleeps while handling a request made with this context (or one derived from
-// it) reports the wait duration to fn before sleeping.
+// it) reports the actual slept duration to fn after the sleep completes.
 func WithWaitObserver(ctx context.Context, fn WaitObserver) context.Context {
 	if fn == nil {
 		return ctx
@@ -23,7 +23,9 @@ func WithWaitObserver(ctx context.Context, fn WaitObserver) context.Context {
 }
 
 // ObserveWait reports a rate-limit wait to the observer carried by ctx, if any.
-// Sleep sites should call this immediately before sleeping.
+// Sleep sites must call this after the sleep completes with the time actually
+// slept — on context cancellation report only the elapsed portion, never the
+// planned duration, so cut-short sleeps don't inflate wait stats.
 func ObserveWait(ctx context.Context, wait time.Duration) {
 	if fn, ok := ctx.Value(waitObserverKey{}).(WaitObserver); ok {
 		fn(ctx, wait)

--- a/pkg/ratelimit/wait_observer.go
+++ b/pkg/ratelimit/wait_observer.go
@@ -5,10 +5,21 @@ import (
 	"time"
 )
 
+// WaitEvent describes one completed rate-limit sleep. It is a struct so new
+// fields can be added later without breaking WaitObserver implementations.
+// Attribution (e.g. resource type) travels on the context via
+// retry.WithWaitLabel rather than in the event.
+type WaitEvent struct {
+	// Duration is the time actually slept. When the sleep is cut short by
+	// context cancellation this is the elapsed portion only, never the
+	// planned wait, so cut-short sleeps don't inflate wait stats.
+	Duration time.Duration
+}
+
 // WaitObserver is notified each time a rate-limit gate slept before (re)issuing
 // a request. Callers that account for rate-limit wait (e.g. the syncer's sync
 // stats) install one via WithWaitObserver; sleep sites report via ObserveWait.
-type WaitObserver func(ctx context.Context, wait time.Duration)
+type WaitObserver func(ctx context.Context, ev WaitEvent)
 
 type waitObserverKey struct{}
 
@@ -25,9 +36,9 @@ func WithWaitObserver(ctx context.Context, fn WaitObserver) context.Context {
 // ObserveWait reports a rate-limit wait to the observer carried by ctx, if any.
 // Sleep sites must call this after the sleep completes with the time actually
 // slept — on context cancellation report only the elapsed portion, never the
-// planned duration, so cut-short sleeps don't inflate wait stats.
-func ObserveWait(ctx context.Context, wait time.Duration) {
+// planned duration.
+func ObserveWait(ctx context.Context, ev WaitEvent) {
 	if fn, ok := ctx.Value(waitObserverKey{}).(WaitObserver); ok {
-		fn(ctx, wait)
+		fn(ctx, ev)
 	}
 }

--- a/pkg/ratelimit/wait_observer.go
+++ b/pkg/ratelimit/wait_observer.go
@@ -5,27 +5,36 @@ import (
 	"time"
 )
 
-// WaitEvent describes one completed rate-limit sleep. It is a struct so new
-// fields can be added later without breaking WaitObserver implementations.
-// Attribution (e.g. resource type) travels on the context via
-// retry.WithWaitLabel rather than in the event.
+// WaitEvent describes one completed wait: a rate-limit gate sleep or a retry
+// backoff sleep. It is a struct so new fields can be added later without
+// breaking WaitObserver implementations. Attribution (e.g. resource type)
+// travels on the context via WithWaitLabel rather than in the event.
 type WaitEvent struct {
 	// Duration is the time actually slept. When the sleep is cut short by
 	// context cancellation this is the elapsed portion only, never the
 	// planned wait, so cut-short sleeps don't inflate wait stats.
 	Duration time.Duration
+
+	// Retry is true for plain retry backoff sleeps (transient errors with no
+	// rate-limit evidence). The ZERO VALUE means rate-limited: emitters that
+	// predate this field (rate-limit gates, the hosted connector manager)
+	// only ever reported rate-limit sleeps, so their events keep landing in
+	// the rate_limit_wait bucket without a code change.
+	Retry bool
 }
 
-// WaitObserver is notified each time a rate-limit gate slept before (re)issuing
-// a request. Callers that account for rate-limit wait (e.g. the syncer's sync
-// stats) install one via WithWaitObserver; sleep sites report via ObserveWait.
+// WaitObserver is notified each time a rate-limit gate or retryer slept before
+// (re)issuing a request. Callers that account for wait time (e.g. the syncer's
+// sync stats) install one via WithWaitObserver; sleep sites report via
+// ObserveWait.
 type WaitObserver func(ctx context.Context, ev WaitEvent)
 
 type waitObserverKey struct{}
 
-// WithWaitObserver returns a context that carries fn. Any rate-limit gate that
-// sleeps while handling a request made with this context (or one derived from
-// it) reports the actual slept duration to fn after the sleep completes.
+// WithWaitObserver returns a context that carries fn. Any rate-limit gate or
+// retryer that sleeps while handling a request made with this context (or one
+// derived from it) reports the actual slept duration to fn after the sleep
+// completes.
 func WithWaitObserver(ctx context.Context, fn WaitObserver) context.Context {
 	if fn == nil {
 		return ctx
@@ -33,7 +42,7 @@ func WithWaitObserver(ctx context.Context, fn WaitObserver) context.Context {
 	return context.WithValue(ctx, waitObserverKey{}, fn)
 }
 
-// ObserveWait reports a rate-limit wait to the observer carried by ctx, if any.
+// ObserveWait reports a completed wait to the observer carried by ctx, if any.
 // Sleep sites must call this after the sleep completes with the time actually
 // slept — on context cancellation report only the elapsed portion, never the
 // planned duration.
@@ -41,4 +50,23 @@ func ObserveWait(ctx context.Context, ev WaitEvent) {
 	if fn, ok := ctx.Value(waitObserverKey{}).(WaitObserver); ok {
 		fn(ctx, ev)
 	}
+}
+
+type waitLabelKey struct{}
+
+// WithWaitLabel attaches a bounded attribution label (e.g. a resource type) to
+// waits reported from this context. Lives here (not pkg/retry) because both
+// the rate-limit gates and the retryer report through this package's observer;
+// pkg/retry re-exports it for compatibility.
+func WithWaitLabel(ctx context.Context, label string) context.Context {
+	if label == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, waitLabelKey{}, label)
+}
+
+// WaitLabelFromContext returns the wait attribution label, if present.
+func WaitLabelFromContext(ctx context.Context) (string, bool) {
+	label, ok := ctx.Value(waitLabelKey{}).(string)
+	return label, ok && label != ""
 }

--- a/pkg/ratelimit/wait_observer.go
+++ b/pkg/ratelimit/wait_observer.go
@@ -1,0 +1,31 @@
+package ratelimit
+
+import (
+	"context"
+	"time"
+)
+
+// WaitObserver is notified each time a rate-limit gate sleeps before (re)issuing
+// a request. Callers that account for rate-limit wait (e.g. the syncer's sync
+// stats) install one via WithWaitObserver; sleep sites report via ObserveWait.
+type WaitObserver func(ctx context.Context, wait time.Duration)
+
+type waitObserverKey struct{}
+
+// WithWaitObserver returns a context that carries fn. Any rate-limit gate that
+// sleeps while handling a request made with this context (or one derived from
+// it) reports the wait duration to fn before sleeping.
+func WithWaitObserver(ctx context.Context, fn WaitObserver) context.Context {
+	if fn == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, waitObserverKey{}, fn)
+}
+
+// ObserveWait reports a rate-limit wait to the observer carried by ctx, if any.
+// Sleep sites should call this immediately before sleeping.
+func ObserveWait(ctx context.Context, wait time.Duration) {
+	if fn, ok := ctx.Value(waitObserverKey{}).(WaitObserver); ok {
+		fn(ctx, wait)
+	}
+}

--- a/pkg/ratelimit/wait_observer_test.go
+++ b/pkg/ratelimit/wait_observer_test.go
@@ -12,12 +12,12 @@ import (
 func TestObserveWaitReportsToObserver(t *testing.T) {
 	var gotWait time.Duration
 	var calls int
-	ctx := WithWaitObserver(t.Context(), func(ctx context.Context, wait time.Duration) {
-		gotWait = wait
+	ctx := WithWaitObserver(t.Context(), func(ctx context.Context, ev WaitEvent) {
+		gotWait = ev.Duration
 		calls++
 	})
 
-	ObserveWait(ctx, 5*time.Second)
+	ObserveWait(ctx, WaitEvent{Duration: 5 * time.Second})
 
 	require.Equal(t, 1, calls)
 	require.Equal(t, 5*time.Second, gotWait)
@@ -25,7 +25,7 @@ func TestObserveWaitReportsToObserver(t *testing.T) {
 
 func TestObserveWaitWithoutObserverIsNoOp(t *testing.T) {
 	require.NotPanics(t, func() {
-		ObserveWait(t.Context(), time.Second)
+		ObserveWait(t.Context(), WaitEvent{Duration: time.Second})
 	})
 }
 

--- a/pkg/ratelimit/wait_observer_test.go
+++ b/pkg/ratelimit/wait_observer_test.go
@@ -34,6 +34,19 @@ func TestWithWaitObserverNilFn(t *testing.T) {
 	require.Equal(t, t.Context(), ctx)
 }
 
+func TestWaitLabelContext(t *testing.T) {
+	ctx := t.Context()
+	_, ok := WaitLabelFromContext(ctx)
+	require.False(t, ok)
+
+	labeled := WithWaitLabel(ctx, "project")
+	label, ok := WaitLabelFromContext(labeled)
+	require.True(t, ok)
+	require.Equal(t, "project", label)
+
+	require.Same(t, ctx, WithWaitLabel(ctx, ""))
+}
+
 func TestResourceTypeFromDescriptors(t *testing.T) {
 	descriptors := ratelimitV1.RateLimitDescriptors_builder{
 		Entries: []*ratelimitV1.RateLimitDescriptors_Entry{

--- a/pkg/ratelimit/wait_observer_test.go
+++ b/pkg/ratelimit/wait_observer_test.go
@@ -1,0 +1,53 @@
+package ratelimit
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	ratelimitV1 "github.com/conductorone/baton-sdk/pb/c1/ratelimit/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestObserveWaitReportsToObserver(t *testing.T) {
+	var gotWait time.Duration
+	var calls int
+	ctx := WithWaitObserver(t.Context(), func(ctx context.Context, wait time.Duration) {
+		gotWait = wait
+		calls++
+	})
+
+	ObserveWait(ctx, 5*time.Second)
+
+	require.Equal(t, 1, calls)
+	require.Equal(t, 5*time.Second, gotWait)
+}
+
+func TestObserveWaitWithoutObserverIsNoOp(t *testing.T) {
+	require.NotPanics(t, func() {
+		ObserveWait(t.Context(), time.Second)
+	})
+}
+
+func TestWithWaitObserverNilFn(t *testing.T) {
+	ctx := WithWaitObserver(t.Context(), nil)
+	require.Equal(t, t.Context(), ctx)
+}
+
+func TestResourceTypeFromDescriptors(t *testing.T) {
+	descriptors := ratelimitV1.RateLimitDescriptors_builder{
+		Entries: []*ratelimitV1.RateLimitDescriptors_Entry{
+			ratelimitV1.RateLimitDescriptors_Entry_builder{
+				Key:   descriptorKeyConnectorMethod,
+				Value: "list_grants",
+			}.Build(),
+			ratelimitV1.RateLimitDescriptors_Entry_builder{
+				Key:   descriptorKeyConnectorResourceType,
+				Value: "repository",
+			}.Build(),
+		},
+	}.Build()
+
+	require.Equal(t, "repository", resourceTypeFromDescriptors(descriptors))
+	require.Equal(t, "", resourceTypeFromDescriptors(nil))
+}

--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -141,16 +141,20 @@ func (r *Retryer) ShouldWaitAndRetry(ctx context.Context, err error) bool {
 	}
 
 	l.Warn("retrying operation", zap.Error(err), zap.Duration("wait", wait))
-	if r.onWait != nil {
-		r.onWait(ctx, wait, rateLimited)
-	}
 
-	for {
-		select {
-		case <-time.After(wait):
-			return true
-		case <-ctx.Done():
-			return false
+	// Report actual slept time after the fact: a cancelled context cuts the
+	// sleep short and must not inflate wait stats with the planned duration.
+	waitStart := time.Now()
+	select {
+	case <-time.After(wait):
+		if r.onWait != nil {
+			r.onWait(ctx, wait, rateLimited)
 		}
+		return true
+	case <-ctx.Done():
+		if r.onWait != nil {
+			r.onWait(ctx, time.Since(waitStart), rateLimited)
+		}
+		return false
 	}
 }

--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -31,23 +31,6 @@ type RetryConfig struct {
 	MaxDelay     time.Duration // Default is 60 seconds. 0 means no limit.
 }
 
-// WithWaitLabel attaches a bounded attribution label to retry waits. The
-// label moved to pkg/ratelimit alongside the wait observer (one reporting
-// channel for every sleep site); this re-export keeps existing callers
-// compiling.
-//
-// Deprecated: use ratelimit.WithWaitLabel.
-func WithWaitLabel(ctx context.Context, label string) context.Context {
-	return ratelimit.WithWaitLabel(ctx, label)
-}
-
-// WaitLabelFromContext returns the retry-wait attribution label, if present.
-//
-// Deprecated: use ratelimit.WaitLabelFromContext.
-func WaitLabelFromContext(ctx context.Context) (string, bool) {
-	return ratelimit.WaitLabelFromContext(ctx)
-}
-
 func NewRetryer(ctx context.Context, config RetryConfig) *Retryer {
 	r := &Retryer{
 		attempts:     0,

--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -29,7 +29,11 @@ type RetryConfig struct {
 	MaxAttempts  uint          // 0 means no limit (which is also the default).
 	InitialDelay time.Duration // Default is 1 second.
 	MaxDelay     time.Duration // Default is 60 seconds. 0 means no limit.
-	OnWait       func(ctx context.Context, wait time.Duration, rateLimited bool)
+	// OnWait is invoked after each retry wait completes, with the duration
+	// actually slept. If the context is cancelled mid-wait, it fires with the
+	// elapsed portion only (not the planned backoff). Note: prior to this
+	// contract it fired before the wait with the full planned duration.
+	OnWait func(ctx context.Context, wait time.Duration, rateLimited bool)
 }
 
 type waitLabelKey struct{}

--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/ratelimit"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
@@ -22,34 +23,29 @@ type Retryer struct {
 	maxAttempts  uint
 	initialDelay time.Duration
 	maxDelay     time.Duration
-	onWait       func(ctx context.Context, wait time.Duration, rateLimited bool)
 }
 
 type RetryConfig struct {
 	MaxAttempts  uint          // 0 means no limit (which is also the default).
 	InitialDelay time.Duration // Default is 1 second.
 	MaxDelay     time.Duration // Default is 60 seconds. 0 means no limit.
-	// OnWait is invoked after each retry wait completes, with the duration
-	// actually slept. If the context is cancelled mid-wait, it fires with the
-	// elapsed portion only (not the planned backoff). Note: prior to this
-	// contract it fired before the wait with the full planned duration.
-	OnWait func(ctx context.Context, wait time.Duration, rateLimited bool)
 }
 
-type waitLabelKey struct{}
-
-// WithWaitLabel attaches a bounded attribution label to retry waits.
+// WithWaitLabel attaches a bounded attribution label to retry waits. The
+// label moved to pkg/ratelimit alongside the wait observer (one reporting
+// channel for every sleep site); this re-export keeps existing callers
+// compiling.
+//
+// Deprecated: use ratelimit.WithWaitLabel.
 func WithWaitLabel(ctx context.Context, label string) context.Context {
-	if label == "" {
-		return ctx
-	}
-	return context.WithValue(ctx, waitLabelKey{}, label)
+	return ratelimit.WithWaitLabel(ctx, label)
 }
 
 // WaitLabelFromContext returns the retry-wait attribution label, if present.
+//
+// Deprecated: use ratelimit.WaitLabelFromContext.
 func WaitLabelFromContext(ctx context.Context) (string, bool) {
-	label, ok := ctx.Value(waitLabelKey{}).(string)
-	return label, ok && label != ""
+	return ratelimit.WaitLabelFromContext(ctx)
 }
 
 func NewRetryer(ctx context.Context, config RetryConfig) *Retryer {
@@ -58,7 +54,6 @@ func NewRetryer(ctx context.Context, config RetryConfig) *Retryer {
 		maxAttempts:  config.MaxAttempts,
 		initialDelay: config.InitialDelay,
 		maxDelay:     config.MaxDelay,
-		onWait:       config.OnWait,
 	}
 	if r.initialDelay == 0 {
 		r.initialDelay = time.Second
@@ -146,19 +141,19 @@ func (r *Retryer) ShouldWaitAndRetry(ctx context.Context, err error) bool {
 
 	l.Warn("retrying operation", zap.Error(err), zap.Duration("wait", wait))
 
-	// Report actual slept time after the fact: a cancelled context cuts the
-	// sleep short and must not inflate wait stats with the planned duration.
+	// Report actual slept time after the fact via the context wait observer
+	// (the same channel the rate-limit gates use — one reporting mechanism
+	// for every in-process sleep site): a cancelled context cuts the sleep
+	// short and must not inflate wait stats with the planned duration.
+	// Contexts without an observer (e.g. connectorbuilder's connector-side
+	// retryers) make this a no-op.
 	waitStart := time.Now()
 	select {
 	case <-time.After(wait):
-		if r.onWait != nil {
-			r.onWait(ctx, wait, rateLimited)
-		}
+		ratelimit.ObserveWait(ctx, ratelimit.WaitEvent{Duration: wait, Retry: !rateLimited})
 		return true
 	case <-ctx.Done():
-		if r.onWait != nil {
-			r.onWait(ctx, time.Since(waitStart), rateLimited)
-		}
+		ratelimit.ObserveWait(ctx, ratelimit.WaitEvent{Duration: time.Since(waitStart), Retry: !rateLimited})
 		return false
 	}
 }

--- a/pkg/retry/retry_test.go
+++ b/pkg/retry/retry_test.go
@@ -83,6 +83,35 @@ func TestRetryWithRateLimitData(t *testing.T) {
 	require.Less(t, elapsed, 2*time.Second, "should wait approximately 1 second")
 }
 
+func TestRetryOnWaitReportsElapsedOnCancel(t *testing.T) {
+	var gotWait time.Duration
+	var calls int
+	retryer := NewRetryer(t.Context(), RetryConfig{
+		InitialDelay: 10 * time.Second,
+		MaxDelay:     10 * time.Second,
+		OnWait: func(ctx context.Context, wait time.Duration, rateLimited bool) {
+			calls++
+			gotWait = wait
+		},
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	require.False(t, retryer.ShouldWaitAndRetry(ctx, status.Error(codes.Unavailable, "recoverable error")))
+	elapsed := time.Since(start)
+
+	require.Equal(t, 1, calls)
+	// The reported wait must reflect actual slept time, not the planned 10s.
+	require.Less(t, gotWait, time.Second)
+	require.GreaterOrEqual(t, gotWait, 50*time.Millisecond)
+	require.Less(t, elapsed, time.Second)
+}
+
 func TestRetryOnWait(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/pkg/retry/retry_test.go
+++ b/pkg/retry/retry_test.go
@@ -155,9 +155,9 @@ func TestRetryOnWait(t *testing.T) {
 				calls++
 				gotWait = ev.Duration
 				gotRateLimited = !ev.Retry
-				gotLabel, _ = WaitLabelFromContext(ctx)
+				gotLabel, _ = ratelimit.WaitLabelFromContext(ctx)
 			})
-			ctx = WithWaitLabel(ctx, "project")
+			ctx = ratelimit.WithWaitLabel(ctx, "project")
 			require.True(t, retryer.ShouldWaitAndRetry(ctx, tt.err(t)))
 			require.Equal(t, 1, calls)
 			require.Equal(t, time.Millisecond, gotWait)
@@ -165,19 +165,6 @@ func TestRetryOnWait(t *testing.T) {
 			require.Equal(t, "project", gotLabel)
 		})
 	}
-}
-
-func TestWaitLabelContext(t *testing.T) {
-	ctx := t.Context()
-	_, ok := WaitLabelFromContext(ctx)
-	require.False(t, ok)
-
-	labeled := WithWaitLabel(ctx, "project")
-	label, ok := WaitLabelFromContext(labeled)
-	require.True(t, ok)
-	require.Equal(t, "project", label)
-
-	require.Same(t, ctx, WithWaitLabel(ctx, ""))
 }
 
 func TestRetryWithHTTPResponse(t *testing.T) {

--- a/pkg/retry/retry_test.go
+++ b/pkg/retry/retry_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/ratelimit"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -89,13 +90,13 @@ func TestRetryOnWaitReportsElapsedOnCancel(t *testing.T) {
 	retryer := NewRetryer(t.Context(), RetryConfig{
 		InitialDelay: 10 * time.Second,
 		MaxDelay:     10 * time.Second,
-		OnWait: func(ctx context.Context, wait time.Duration, rateLimited bool) {
-			calls++
-			gotWait = wait
-		},
 	})
 
-	ctx, cancel := context.WithCancel(t.Context())
+	observed := ratelimit.WithWaitObserver(t.Context(), func(ctx context.Context, ev ratelimit.WaitEvent) {
+		calls++
+		gotWait = ev.Duration
+	})
+	ctx, cancel := context.WithCancel(observed)
 	go func() {
 		time.Sleep(50 * time.Millisecond)
 		cancel()
@@ -148,15 +149,15 @@ func TestRetryOnWait(t *testing.T) {
 			retryer := NewRetryer(t.Context(), RetryConfig{
 				InitialDelay: time.Millisecond,
 				MaxDelay:     time.Millisecond,
-				OnWait: func(ctx context.Context, wait time.Duration, rateLimited bool) {
-					calls++
-					gotWait = wait
-					gotRateLimited = rateLimited
-					gotLabel, _ = WaitLabelFromContext(ctx)
-				},
 			})
 
-			ctx := WithWaitLabel(t.Context(), "project")
+			ctx := ratelimit.WithWaitObserver(t.Context(), func(ctx context.Context, ev ratelimit.WaitEvent) {
+				calls++
+				gotWait = ev.Duration
+				gotRateLimited = !ev.Retry
+				gotLabel, _ = WaitLabelFromContext(ctx)
+			})
+			ctx = WithWaitLabel(ctx, "project")
 			require.True(t, retryer.ShouldWaitAndRetry(ctx, tt.err(t)))
 			require.Equal(t, 1, calls)
 			require.Equal(t, time.Millisecond, gotWait)

--- a/pkg/sync/parallel_syncer.go
+++ b/pkg/sync/parallel_syncer.go
@@ -20,7 +20,7 @@ import (
 func (s *syncer) timedShouldWaitAndRetry(ctx context.Context, op ActionOp, resourceTypeID string, retryer *retry.Retryer, err error) bool {
 	var shouldRetry bool
 	_ = s.timedStep(op, func() error {
-		shouldRetry = retryer.ShouldWaitAndRetry(retry.WithWaitLabel(ctx, resourceTypeID), err)
+		shouldRetry = retryer.ShouldWaitAndRetry(ratelimit.WithWaitLabel(ctx, resourceTypeID), err)
 		return nil
 	})
 	return shouldRetry
@@ -38,14 +38,18 @@ func (s *syncer) recordRetryWait(ctx context.Context, wait time.Duration, rateLi
 		bucket = "rate_limit_wait"
 	}
 	s.state.AddStepDuration(bucket, wait)
-	if label, ok := retry.WaitLabelFromContext(ctx); ok {
+	if label, ok := ratelimit.WaitLabelFromContext(ctx); ok {
 		s.state.AddStepDuration(bucket+":"+label, wait)
 	}
 }
 
-// withRateLimitWaitObserver subscribes the syncer to rate-limit gate sleeps
-// that happen below it (SDK client interceptor, hosted connector manager) so
-// they are accounted in rate_limit_wait. The recordStats check happens at
+// withRateLimitWaitObserver subscribes the syncer to every in-process sleep
+// that happens below it: rate-limit gate sleeps (SDK client interceptor,
+// hosted connector manager) land in rate_limit_wait, and the retryer's
+// backoff sleeps land in retry_wait or rate_limit_wait per the event's Retry
+// flag. This context observer is the single reporting channel for in-process
+// waits (connector-process sleeps arrive separately, via the
+// RateLimitWaitReport response annotation). The recordStats check happens at
 // report time because the flag is only decided after the store is loaded,
 // which is after the observer must already be on the context.
 func (s *syncer) withRateLimitWaitObserver(ctx context.Context) context.Context {
@@ -53,7 +57,7 @@ func (s *syncer) withRateLimitWaitObserver(ctx context.Context) context.Context 
 		if !s.recordStats {
 			return
 		}
-		s.recordRetryWait(ctx, ev.Duration, true)
+		s.recordRetryWait(ctx, ev.Duration, !ev.Retry)
 	})
 }
 
@@ -64,15 +68,12 @@ func (s *syncer) parallelSync(
 ) ([]error, error) {
 	l := ctxzap.Extract(ctx)
 
-	var onWait func(context.Context, time.Duration, bool)
-	if s.recordStats {
-		onWait = s.recordRetryWait
-	}
+	// Retry backoff sleeps report through the context wait observer
+	// installed at the top of Sync, like every other in-process sleep site.
 	retryer := retry.NewRetryer(ctx, retry.RetryConfig{
 		MaxAttempts:  0,
 		InitialDelay: 1 * time.Second,
 		MaxDelay:     0,
-		OnWait:       onWait,
 	})
 
 	var warnings []error
@@ -332,7 +333,7 @@ func (s *syncer) parallelSync(
 			}
 
 			err = s.SyncGrantExpansion(ctx, stateAction)
-			if !retryer.ShouldWaitAndRetry(retry.WithWaitLabel(ctx, stateAction.ResourceTypeID), err) {
+			if !retryer.ShouldWaitAndRetry(ratelimit.WithWaitLabel(ctx, stateAction.ResourceTypeID), err) {
 				return warnings, err
 			}
 			continue
@@ -424,7 +425,7 @@ func (s *syncer) syncOneAction(ctx context.Context, l *zap.Logger, retryer *retr
 			return workerResult{warning: err}
 		}
 		if err != nil {
-			if retryer.ShouldWaitAndRetry(retry.WithWaitLabel(ctx, action.ResourceTypeID), err) {
+			if retryer.ShouldWaitAndRetry(ratelimit.WithWaitLabel(ctx, action.ResourceTypeID), err) {
 				continue
 			}
 

--- a/pkg/sync/parallel_syncer.go
+++ b/pkg/sync/parallel_syncer.go
@@ -85,9 +85,19 @@ func (s *syncer) recordRateLimitWallInterval(wait time.Duration) {
 	if start.Before(s.rlWallCoveredUntil) {
 		start = s.rlWallCoveredUntil
 	}
-	if end.After(start) {
-		s.state.AddStepDuration("rate_limit_wait_wall", end.Sub(start))
-		s.rlWallCoveredUntil = end
+	if !end.After(start) {
+		return
+	}
+	s.rlWallCoveredUntil = end
+	// The state bucket accumulates whole milliseconds per call, so carry the
+	// sub-millisecond remainder locally: overlapping parallel waits contribute
+	// many tiny past-the-watermark slivers that would otherwise all truncate
+	// to zero and systematically undercount the bucket.
+	delta := end.Sub(start) + s.rlWallCarry
+	whole := delta.Truncate(time.Millisecond)
+	s.rlWallCarry = delta - whole
+	if whole > 0 {
+		s.state.AddStepDuration("rate_limit_wait_wall", whole)
 	}
 }
 
@@ -106,6 +116,7 @@ func (s *syncer) withRateLimitWaitObserver(ctx context.Context) context.Context 
 	// time from before this sync process started waiting.
 	s.rlWallMu.Lock()
 	s.rlWallCoveredUntil = time.Now()
+	s.rlWallCarry = 0
 	s.rlWallMu.Unlock()
 	return ratelimit.WithWaitObserver(ctx, func(ctx context.Context, ev ratelimit.WaitEvent) {
 		if !s.recordStats {

--- a/pkg/sync/parallel_syncer.go
+++ b/pkg/sync/parallel_syncer.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/ratelimit"
 	"github.com/conductorone/baton-sdk/pkg/retry"
 	"github.com/conductorone/baton-sdk/pkg/uotel"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
@@ -34,6 +35,20 @@ func (s *syncer) recordRetryWait(ctx context.Context, wait time.Duration, rateLi
 	if label, ok := retry.WaitLabelFromContext(ctx); ok {
 		s.state.AddStepDuration(bucket+":"+label, wait)
 	}
+}
+
+// withRateLimitWaitObserver subscribes the syncer to rate-limit gate sleeps
+// that happen below it (SDK client interceptor, hosted connector manager) so
+// they are accounted in rate_limit_wait. The recordStats check happens at
+// report time because the flag is only decided after the store is loaded,
+// which is after the observer must already be on the context.
+func (s *syncer) withRateLimitWaitObserver(ctx context.Context) context.Context {
+	return ratelimit.WithWaitObserver(ctx, func(ctx context.Context, wait time.Duration) {
+		if !s.recordStats {
+			return
+		}
+		s.recordRetryWait(ctx, wait, true)
+	})
 }
 
 func (s *syncer) parallelSync(

--- a/pkg/sync/parallel_syncer.go
+++ b/pkg/sync/parallel_syncer.go
@@ -27,6 +27,12 @@ func (s *syncer) timedShouldWaitAndRetry(ctx context.Context, op ActionOp, resou
 }
 
 func (s *syncer) recordRetryWait(ctx context.Context, wait time.Duration, rateLimited bool) {
+	// The wait observer is installed at the top of Sync, before the state
+	// token exists; a gate wait during the initial Validate call must be
+	// dropped, not dereference a nil state.
+	if s.state == nil {
+		return
+	}
 	bucket := "retry_wait"
 	if rateLimited {
 		bucket = "rate_limit_wait"

--- a/pkg/sync/parallel_syncer.go
+++ b/pkg/sync/parallel_syncer.go
@@ -43,11 +43,11 @@ func (s *syncer) recordRetryWait(ctx context.Context, wait time.Duration, rateLi
 // report time because the flag is only decided after the store is loaded,
 // which is after the observer must already be on the context.
 func (s *syncer) withRateLimitWaitObserver(ctx context.Context) context.Context {
-	return ratelimit.WithWaitObserver(ctx, func(ctx context.Context, wait time.Duration) {
+	return ratelimit.WithWaitObserver(ctx, func(ctx context.Context, ev ratelimit.WaitEvent) {
 		if !s.recordStats {
 			return
 		}
-		s.recordRetryWait(ctx, wait, true)
+		s.recordRetryWait(ctx, ev.Duration, true)
 	})
 }
 

--- a/pkg/sync/parallel_syncer.go
+++ b/pkg/sync/parallel_syncer.go
@@ -66,6 +66,14 @@ func (s *syncer) recordRetryWait(ctx context.Context, wait time.Duration, rateLi
 // instant. The watermark is in-memory only; across checkpoint/resume the
 // first event after resume counts in full, which can only under-merge (never
 // double-count) because the bucket itself persists in the token.
+//
+// Known bias: an annotation wait is end-anchored at response receipt, but the
+// connector's sleep ended earlier in the RPC (marshal + transport + any
+// post-sleep work follow it). The claimed interval shifts late by that
+// amount, so under parallelism the merge can count wall time past another
+// worker's watermark that was not actually blocked — an over-count bounded by
+// the post-sleep RPC latency of that one report. The bucket stays bounded by
+// elapsed sync time regardless.
 func (s *syncer) recordRateLimitWallInterval(wait time.Duration) {
 	if wait <= 0 || s.state == nil {
 		return

--- a/pkg/sync/parallel_syncer.go
+++ b/pkg/sync/parallel_syncer.go
@@ -79,13 +79,13 @@ func (s *syncer) recordRateLimitWallInterval(wait time.Duration) {
 		return
 	}
 	s.rlWallMu.Lock()
-	defer s.rlWallMu.Unlock()
 	end := time.Now()
 	start := end.Add(-wait)
 	if start.Before(s.rlWallCoveredUntil) {
 		start = s.rlWallCoveredUntil
 	}
 	if !end.After(start) {
+		s.rlWallMu.Unlock()
 		return
 	}
 	s.rlWallCoveredUntil = end
@@ -96,6 +96,9 @@ func (s *syncer) recordRateLimitWallInterval(wait time.Duration) {
 	delta := end.Sub(start) + s.rlWallCarry
 	whole := delta.Truncate(time.Millisecond)
 	s.rlWallCarry = delta - whole
+	// Flush outside rlWallMu: additions commute, and this keeps the wall
+	// lock from nesting the state mutex.
+	s.rlWallMu.Unlock()
 	if whole > 0 {
 		s.state.AddStepDuration("rate_limit_wait_wall", whole)
 	}

--- a/pkg/sync/parallel_syncer.go
+++ b/pkg/sync/parallel_syncer.go
@@ -26,6 +26,12 @@ func (s *syncer) timedShouldWaitAndRetry(ctx context.Context, op ActionOp, resou
 	return shouldRetry
 }
 
+// recordRetryWait accumulates one completed wait into the cumulative buckets.
+// retry_wait / rate_limit_wait are worker-seconds: parallel workers each
+// report their full sleep, so the totals can exceed wall-clock sync time
+// (divide by worker_count for a utilization view). The per-resource-type
+// sub-buckets decompose the flat totals. rate_limit_wait_wall is the
+// wall-clock companion; see recordRateLimitWallInterval.
 func (s *syncer) recordRetryWait(ctx context.Context, wait time.Duration, rateLimited bool) {
 	// The wait observer is installed at the top of Sync, before the state
 	// token exists; a gate wait during the initial Validate call must be
@@ -41,6 +47,40 @@ func (s *syncer) recordRetryWait(ctx context.Context, wait time.Duration, rateLi
 	if label, ok := ratelimit.WaitLabelFromContext(ctx); ok {
 		s.state.AddStepDuration(bucket+":"+label, wait)
 	}
+	if rateLimited {
+		s.recordRateLimitWallInterval(wait)
+	}
+}
+
+// recordRateLimitWallInterval folds one completed rate-limit wait into
+// rate_limit_wait_wall: wall-clock time with at least one worker blocked on a
+// rate limit. Unlike the cumulative rate_limit_wait (worker-seconds, can
+// exceed wall-clock under parallelism), this bucket is bounded by sync
+// duration.
+//
+// Every reporter fires immediately after its wait ends — syncer-process
+// sleeps exactly, connector-reported annotation waits approximately (at
+// response receipt) — so each event is the interval [now-wait, now] and
+// events arrive ordered by end time. Merging overlaps therefore reduces to a
+// watermark: count only the part of the interval past the last covered
+// instant. The watermark is in-memory only; across checkpoint/resume the
+// first event after resume counts in full, which can only under-merge (never
+// double-count) because the bucket itself persists in the token.
+func (s *syncer) recordRateLimitWallInterval(wait time.Duration) {
+	if wait <= 0 || s.state == nil {
+		return
+	}
+	s.rlWallMu.Lock()
+	defer s.rlWallMu.Unlock()
+	end := time.Now()
+	start := end.Add(-wait)
+	if start.Before(s.rlWallCoveredUntil) {
+		start = s.rlWallCoveredUntil
+	}
+	if end.After(start) {
+		s.state.AddStepDuration("rate_limit_wait_wall", end.Sub(start))
+		s.rlWallCoveredUntil = end
+	}
 }
 
 // withRateLimitWaitObserver subscribes the syncer to every in-process sleep
@@ -53,6 +93,12 @@ func (s *syncer) recordRetryWait(ctx context.Context, wait time.Duration, rateLi
 // report time because the flag is only decided after the store is loaded,
 // which is after the observer must already be on the context.
 func (s *syncer) withRateLimitWaitObserver(ctx context.Context) context.Context {
+	// Start the wall watermark at the top of the run: an end-anchored
+	// interval (notably a connector-reported wait) must not count wall
+	// time from before this sync process started waiting.
+	s.rlWallMu.Lock()
+	s.rlWallCoveredUntil = time.Now()
+	s.rlWallMu.Unlock()
 	return ratelimit.WithWaitObserver(ctx, func(ctx context.Context, ev ratelimit.WaitEvent) {
 		if !s.recordStats {
 			return

--- a/pkg/sync/parallel_syncer_stats_test.go
+++ b/pkg/sync/parallel_syncer_stats_test.go
@@ -59,6 +59,32 @@ func TestWaitObserverDisabledWithoutStats(t *testing.T) {
 	require.Empty(t, s.state.StepDurations())
 }
 
+func TestRecordConnectorWaitReport(t *testing.T) {
+	s := &syncer{
+		recordStats: true,
+		state:       newState(),
+	}
+
+	var annos annotations.Annotations
+	annos.WithRateLimitWaitReport(1500)
+
+	s.recordConnectorWaitReport(annos, "repository")
+	s.recordConnectorWaitReport(annos, "")
+
+	durations := s.state.StepDurations()
+	require.EqualValues(t, 3000, durations["rate_limit_wait"])
+	require.EqualValues(t, 1500, durations["rate_limit_wait:repository"])
+
+	// Responses without the annotation, zero waits, and disabled stats are no-ops.
+	s.recordConnectorWaitReport(annotations.Annotations{}, "repository")
+	var zeroAnnos annotations.Annotations
+	zeroAnnos.WithRateLimitWaitReport(0)
+	require.Empty(t, zeroAnnos)
+	s.recordStats = false
+	s.recordConnectorWaitReport(annos, "repository")
+	require.EqualValues(t, 3000, s.state.StepDurations()["rate_limit_wait"])
+}
+
 func TestRecordRetryWaitWithoutResourceType(t *testing.T) {
 	s := &syncer{
 		recordStats: true,

--- a/pkg/sync/parallel_syncer_stats_test.go
+++ b/pkg/sync/parallel_syncer_stats_test.go
@@ -8,6 +8,7 @@ import (
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/ratelimit"
 	"github.com/conductorone/baton-sdk/pkg/retry"
 	"github.com/stretchr/testify/require"
 )
@@ -26,6 +27,36 @@ func TestRecordRetryWaitWithResourceType(t *testing.T) {
 	require.EqualValues(t, 2000, durations["retry_wait:rt1"])
 	require.EqualValues(t, 3000, durations["rate_limit_wait"])
 	require.EqualValues(t, 3000, durations["rate_limit_wait:rt1"])
+}
+
+func TestWaitObserverRecordsRateLimitWait(t *testing.T) {
+	s := &syncer{
+		recordStats: true,
+		state:       newState(),
+	}
+
+	ctx := s.withRateLimitWaitObserver(t.Context())
+	// Simulate a rate-limit gate (SDK interceptor / hosted manager) sleeping
+	// before a request, attributed to a resource type.
+	ratelimit.ObserveWait(retry.WithWaitLabel(ctx, "repository"), 30*time.Second)
+	ratelimit.ObserveWait(ctx, 10*time.Second)
+
+	durations := s.state.StepDurations()
+	require.EqualValues(t, 40000, durations["rate_limit_wait"])
+	require.EqualValues(t, 30000, durations["rate_limit_wait:repository"])
+}
+
+func TestWaitObserverDisabledWithoutStats(t *testing.T) {
+	s := &syncer{
+		recordStats: false,
+		state:       newState(),
+	}
+
+	ctx := s.withRateLimitWaitObserver(t.Context())
+	// The observer is installed regardless (recordStats is only decided
+	// after store load), but reports are dropped when stats are off.
+	ratelimit.ObserveWait(ctx, time.Second)
+	require.Empty(t, s.state.StepDurations())
 }
 
 func TestRecordRetryWaitWithoutResourceType(t *testing.T) {

--- a/pkg/sync/parallel_syncer_stats_test.go
+++ b/pkg/sync/parallel_syncer_stats_test.go
@@ -22,8 +22,8 @@ func TestRecordRetryWaitWithResourceType(t *testing.T) {
 		state:       newState(),
 	}
 
-	s.recordRetryWait(retry.WithWaitLabel(t.Context(), "rt1"), 2*time.Second, false)
-	s.recordRetryWait(retry.WithWaitLabel(t.Context(), "rt1"), 3*time.Second, true)
+	s.recordRetryWait(ratelimit.WithWaitLabel(t.Context(), "rt1"), 2*time.Second, false)
+	s.recordRetryWait(ratelimit.WithWaitLabel(t.Context(), "rt1"), 3*time.Second, true)
 
 	durations := s.state.StepDurations()
 	require.EqualValues(t, 2000, durations["retry_wait"])
@@ -77,7 +77,7 @@ func TestWaitObserverRecordsRateLimitWait(t *testing.T) {
 	ctx := s.withRateLimitWaitObserver(t.Context())
 	// Simulate a rate-limit gate (SDK interceptor / hosted manager) sleeping
 	// before a request, attributed to a resource type.
-	ratelimit.ObserveWait(retry.WithWaitLabel(ctx, "repository"), ratelimit.WaitEvent{Duration: 30 * time.Second})
+	ratelimit.ObserveWait(ratelimit.WithWaitLabel(ctx, "repository"), ratelimit.WaitEvent{Duration: 30 * time.Second})
 	ratelimit.ObserveWait(ctx, ratelimit.WaitEvent{Duration: 10 * time.Second})
 
 	durations := s.state.StepDurations()
@@ -289,7 +289,7 @@ func TestStatsRecordingConcurrentWithMarshal(t *testing.T) {
 			for i := 0; i < iterations; i++ {
 				s.state.AddStepDuration("list-grants", time.Millisecond)
 				s.state.RecordConnectorCall("list-grants", 2*time.Millisecond)
-				s.recordRetryWait(retry.WithWaitLabel(t.Context(), "rt1"), time.Millisecond, i%2 == 0)
+				s.recordRetryWait(ratelimit.WithWaitLabel(t.Context(), "rt1"), time.Millisecond, i%2 == 0)
 			}
 		})
 	}

--- a/pkg/sync/parallel_syncer_stats_test.go
+++ b/pkg/sync/parallel_syncer_stats_test.go
@@ -161,6 +161,9 @@ func TestRecordConnectorWaitReportClampsOverflow(t *testing.T) {
 	const dayMs = int64(24 * 60 * 60 * 1000)
 	require.EqualValues(t, dayMs, durations["rate_limit_wait"])
 	require.EqualValues(t, dayMs, durations["rate_limit_wait:repository"])
+	// The clamped value also feeds the wall bucket; with a zero watermark
+	// (no prior events) the full clamped interval counts.
+	require.EqualValues(t, dayMs, durations["rate_limit_wait_wall"])
 }
 
 // TestRateLimitWallIntervalMergesOverlap: rate_limit_wait sums worker-seconds,
@@ -174,12 +177,17 @@ func TestRateLimitWallIntervalMergesOverlap(t *testing.T) {
 
 	// Two 10s waits reported back-to-back: intervals [now-10s, now] overlap
 	// almost entirely, so wall time is ~10s while cumulative would be 20s.
+	// The second event contributes only the inter-call gap, so bound the
+	// assertion by the measured gap instead of a fixed slack that a slow CI
+	// machine could blow through.
+	callsStart := time.Now()
 	s.recordRateLimitWallInterval(10 * time.Second)
 	s.recordRateLimitWallInterval(10 * time.Second)
+	elapsedMs := time.Since(callsStart).Milliseconds()
 
 	wallMs := s.state.StepDurations()["rate_limit_wait_wall"]
 	require.GreaterOrEqual(t, wallMs, int64(10_000))
-	require.Less(t, wallMs, int64(10_500), "overlapping waits must merge, not sum")
+	require.LessOrEqual(t, wallMs, 10_000+elapsedMs+1, "overlapping waits must merge, not sum")
 
 	// Non-positive waits and nil state are no-ops.
 	s.recordRateLimitWallInterval(0)

--- a/pkg/sync/parallel_syncer_stats_test.go
+++ b/pkg/sync/parallel_syncer_stats_test.go
@@ -38,8 +38,8 @@ func TestWaitObserverRecordsRateLimitWait(t *testing.T) {
 	ctx := s.withRateLimitWaitObserver(t.Context())
 	// Simulate a rate-limit gate (SDK interceptor / hosted manager) sleeping
 	// before a request, attributed to a resource type.
-	ratelimit.ObserveWait(retry.WithWaitLabel(ctx, "repository"), 30*time.Second)
-	ratelimit.ObserveWait(ctx, 10*time.Second)
+	ratelimit.ObserveWait(retry.WithWaitLabel(ctx, "repository"), ratelimit.WaitEvent{Duration: 30 * time.Second})
+	ratelimit.ObserveWait(ctx, ratelimit.WaitEvent{Duration: 10 * time.Second})
 
 	durations := s.state.StepDurations()
 	require.EqualValues(t, 40000, durations["rate_limit_wait"])
@@ -55,7 +55,7 @@ func TestWaitObserverDisabledWithoutStats(t *testing.T) {
 	ctx := s.withRateLimitWaitObserver(t.Context())
 	// The observer is installed regardless (recordStats is only decided
 	// after store load), but reports are dropped when stats are off.
-	ratelimit.ObserveWait(ctx, time.Second)
+	ratelimit.ObserveWait(ctx, ratelimit.WaitEvent{Duration: time.Second})
 	require.Empty(t, s.state.StepDurations())
 }
 

--- a/pkg/sync/parallel_syncer_stats_test.go
+++ b/pkg/sync/parallel_syncer_stats_test.go
@@ -197,6 +197,26 @@ func TestRateLimitWallIntervalMergesOverlap(t *testing.T) {
 	require.NotPanics(t, func() { stateless.recordRateLimitWallInterval(time.Second) })
 }
 
+// TestRateLimitWallIntervalCarriesSubMillisecond: the state bucket only
+// accumulates whole milliseconds per call, so sub-millisecond slivers past the
+// watermark (the common case for overlapping parallel waits) must be carried
+// across calls instead of each truncating to zero.
+func TestRateLimitWallIntervalCarriesSubMillisecond(t *testing.T) {
+	s := &syncer{
+		recordStats: true,
+		state:       newState(),
+	}
+
+	// Rewind the watermark ~500µs before each report so every event
+	// contributes a sliver that alone truncates to 0ms. Ten of them must sum
+	// to at least 5ms minus the (<1ms) unflushed carry.
+	for range 10 {
+		s.rlWallCoveredUntil = time.Now().Add(-500 * time.Microsecond)
+		s.recordRateLimitWallInterval(time.Hour)
+	}
+	require.GreaterOrEqual(t, s.state.StepDurations()["rate_limit_wait_wall"], int64(4))
+}
+
 func TestRecordRetryWaitWithoutResourceType(t *testing.T) {
 	s := &syncer{
 		recordStats: true,

--- a/pkg/sync/parallel_syncer_stats_test.go
+++ b/pkg/sync/parallel_syncer_stats_test.go
@@ -59,6 +59,22 @@ func TestWaitObserverDisabledWithoutStats(t *testing.T) {
 	require.Empty(t, s.state.StepDurations())
 }
 
+// TestWaitObserverBeforeStateExists covers the window at the top of Sync:
+// the observer is installed (and recordStats may already be true) before the
+// state token is loaded. A gate wait during the initial Validate call must be
+// dropped, not panic on a nil state.
+func TestWaitObserverBeforeStateExists(t *testing.T) {
+	s := &syncer{
+		recordStats: true,
+		state:       nil,
+	}
+
+	ctx := s.withRateLimitWaitObserver(t.Context())
+	require.NotPanics(t, func() {
+		ratelimit.ObserveWait(ctx, ratelimit.WaitEvent{Duration: time.Second})
+	})
+}
+
 func TestRecordConnectorWaitReport(t *testing.T) {
 	s := &syncer{
 		recordStats: true,

--- a/pkg/sync/parallel_syncer_stats_test.go
+++ b/pkg/sync/parallel_syncer_stats_test.go
@@ -11,6 +11,9 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/ratelimit"
 	"github.com/conductorone/baton-sdk/pkg/retry"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestRecordRetryWaitWithResourceType(t *testing.T) {
@@ -27,6 +30,42 @@ func TestRecordRetryWaitWithResourceType(t *testing.T) {
 	require.EqualValues(t, 2000, durations["retry_wait:rt1"])
 	require.EqualValues(t, 3000, durations["rate_limit_wait"])
 	require.EqualValues(t, 3000, durations["rate_limit_wait:rt1"])
+}
+
+// TestRetryerReportsThroughWaitObserver pins the retryer's reporting channel:
+// backoff sleeps reach sync stats via the context wait observer (the OnWait
+// callback is gone), with the event's Retry flag routing plain backoff to
+// retry_wait and rate-limited backoff to rate_limit_wait.
+func TestRetryerReportsThroughWaitObserver(t *testing.T) {
+	s := &syncer{
+		recordStats: true,
+		state:       newState(),
+	}
+	ctx := s.withRateLimitWaitObserver(t.Context())
+	retryer := retry.NewRetryer(ctx, retry.RetryConfig{
+		InitialDelay: time.Millisecond,
+		MaxDelay:     time.Millisecond,
+	})
+
+	// Plain transient error: linear backoff, lands in retry_wait.
+	require.True(t, retryer.ShouldWaitAndRetry(ratelimit.WithWaitLabel(ctx, "rt1"),
+		status.Error(codes.Unavailable, "transient")))
+
+	// Rate-limited error: RateLimitDescription in the error details, lands
+	// in rate_limit_wait. The reset must still be in the future when the
+	// retryer evaluates it; MaxDelay clamps the actual sleep to 1ms.
+	st, err := status.New(codes.Unavailable, "rate limited").WithDetails(&v2.RateLimitDescription{
+		Remaining: 0,
+		ResetAt:   timestamppb.New(time.Now().Add(30 * time.Second)),
+	})
+	require.NoError(t, err)
+	require.True(t, retryer.ShouldWaitAndRetry(ratelimit.WithWaitLabel(ctx, "rt1"), st.Err()))
+
+	durations := s.state.StepDurations()
+	require.Positive(t, durations["retry_wait"])
+	require.Positive(t, durations["retry_wait:rt1"])
+	require.Positive(t, durations["rate_limit_wait"])
+	require.Positive(t, durations["rate_limit_wait:rt1"])
 }
 
 func TestWaitObserverRecordsRateLimitWait(t *testing.T) {

--- a/pkg/sync/parallel_syncer_stats_test.go
+++ b/pkg/sync/parallel_syncer_stats_test.go
@@ -140,6 +140,55 @@ func TestRecordConnectorWaitReport(t *testing.T) {
 	require.EqualValues(t, 3000, s.state.StepDurations()["rate_limit_wait"])
 }
 
+// TestRecordConnectorWaitReportClampsOverflow: the annotation crosses a
+// process boundary, so a buggy connector can send a wait_ms whose
+// millisecond-to-Duration conversion overflows negative and would subtract
+// from the buckets. The syncer clamps to 24h per response.
+func TestRecordConnectorWaitReportClampsOverflow(t *testing.T) {
+	s := &syncer{
+		recordStats: true,
+		state:       newState(),
+	}
+
+	report := &v2.RateLimitWaitReport{}
+	report.SetWaitMs(9_223_372_036_855) // time.Duration(v) * time.Millisecond overflows negative
+	var annos annotations.Annotations
+	annos.Update(report)
+
+	s.recordConnectorWaitReport(annos, "repository")
+
+	durations := s.state.StepDurations()
+	const dayMs = int64(24 * 60 * 60 * 1000)
+	require.EqualValues(t, dayMs, durations["rate_limit_wait"])
+	require.EqualValues(t, dayMs, durations["rate_limit_wait:repository"])
+}
+
+// TestRateLimitWallIntervalMergesOverlap: rate_limit_wait sums worker-seconds,
+// but rate_limit_wait_wall merges end-anchored intervals via the watermark, so
+// two overlapping sleeps count wall time once.
+func TestRateLimitWallIntervalMergesOverlap(t *testing.T) {
+	s := &syncer{
+		recordStats: true,
+		state:       newState(),
+	}
+
+	// Two 10s waits reported back-to-back: intervals [now-10s, now] overlap
+	// almost entirely, so wall time is ~10s while cumulative would be 20s.
+	s.recordRateLimitWallInterval(10 * time.Second)
+	s.recordRateLimitWallInterval(10 * time.Second)
+
+	wallMs := s.state.StepDurations()["rate_limit_wait_wall"]
+	require.GreaterOrEqual(t, wallMs, int64(10_000))
+	require.Less(t, wallMs, int64(10_500), "overlapping waits must merge, not sum")
+
+	// Non-positive waits and nil state are no-ops.
+	s.recordRateLimitWallInterval(0)
+	s.recordRateLimitWallInterval(-time.Second)
+	require.Equal(t, wallMs, s.state.StepDurations()["rate_limit_wait_wall"])
+	stateless := &syncer{recordStats: true}
+	require.NotPanics(t, func() { stateless.recordRateLimitWallInterval(time.Second) })
+}
+
 func TestRecordRetryWaitWithoutResourceType(t *testing.T) {
 	s := &syncer{
 		recordStats: true,

--- a/pkg/sync/sync_summary.go
+++ b/pkg/sync/sync_summary.go
@@ -15,7 +15,7 @@ const sessionStatsLogMinTotalMs = 50
 
 func isWaitStepBucket(bucket string) bool {
 	switch {
-	case bucket == "rate_limit_wait", bucket == "retry_wait":
+	case bucket == "rate_limit_wait", bucket == "retry_wait", bucket == "rate_limit_wait_wall":
 		return true
 	case strings.HasPrefix(bucket, "rate_limit_wait:"), strings.HasPrefix(bucket, "retry_wait:"):
 		return true

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -173,10 +173,12 @@ type syncer struct {
 	recordStats                         bool
 
 	// Watermark for the rate_limit_wait_wall bucket: the latest instant
-	// already counted as rate-limit-blocked wall time. Guarded by
-	// rlWallMu; see recordRateLimitWallInterval.
+	// already counted as rate-limit-blocked wall time, plus the
+	// sub-millisecond remainder not yet flushed to the state bucket.
+	// Guarded by rlWallMu; see recordRateLimitWallInterval.
 	rlWallMu           native_sync.Mutex
 	rlWallCoveredUntil time.Time
+	rlWallCarry        time.Duration
 }
 
 var _ Syncer = (*syncer)(nil)

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -1021,6 +1021,7 @@ func (s *syncer) listAllResourceTypes(ctx context.Context) iter.Seq2[[]*v2.Resou
 				ActiveSyncId: s.getActiveSyncID(),
 			}.Build())
 			s.observeConnectorCall(ctx, "list-resource-types", start, "", "")
+			s.recordConnectorWaitReport(resp.GetAnnotations(), "")
 			if err != nil {
 				_ = yield(nil, err)
 				return
@@ -1057,6 +1058,7 @@ func (s *syncer) SyncResourceTypes(ctx context.Context, action *Action) error {
 		ActiveSyncId: s.getActiveSyncID(),
 	}.Build())
 	s.observeConnectorCall(ctx, "list-resource-types", start, action.ResourceTypeID, action.ResourceID)
+	s.recordConnectorWaitReport(resp.GetAnnotations(), action.ResourceTypeID)
 	if err != nil {
 		return err
 	}
@@ -1173,6 +1175,7 @@ func (s *syncer) getResourceFromConnector(ctx context.Context, resourceID *v2.Re
 		}.Build(),
 	)
 	s.observeConnectorCall(ctx, "get-resource", start, resourceID.GetResourceType(), resourceID.GetResource())
+	s.recordConnectorWaitReport(resourceResp.GetAnnotations(), resourceID.GetResourceType())
 	if err == nil {
 		return resourceResp.GetResource(), nil
 	}

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -171,6 +171,12 @@ type syncer struct {
 	metricsHandler                      metrics.Handler
 	syncIdentity                        uotel.SyncIdentity
 	recordStats                         bool
+
+	// Watermark for the rate_limit_wait_wall bucket: the latest instant
+	// already counted as rate-limit-blocked wall time. Guarded by
+	// rlWallMu; see recordRateLimitWallInterval.
+	rlWallMu           native_sync.Mutex
+	rlWallCoveredUntil time.Time
 }
 
 var _ Syncer = (*syncer)(nil)
@@ -449,7 +455,7 @@ func (s *syncer) syncSummaryFields(span trace.Span) []zap.Field {
 		key := strings.ReplaceAll(bucket, "-", "_")
 		attrs = append(attrs, attribute.Int64("sync.step."+key+".duration_ms", stepDurations[bucket]))
 	}
-	for _, waitBucket := range []string{"checkpoint", "rate_limit_wait", "retry_wait"} {
+	for _, waitBucket := range []string{"checkpoint", "rate_limit_wait", "retry_wait", "rate_limit_wait_wall"} {
 		key := strings.ReplaceAll(waitBucket, "-", "_")
 		attrs = append(attrs, attribute.Int64("sync.step."+key+".duration_ms", stepDurations[waitBucket]))
 	}
@@ -574,11 +580,19 @@ func (s *syncer) recordConnectorWaitReport(annos []*anypb.Any, resourceTypeID st
 	if waitMs <= 0 {
 		return
 	}
+	// The report crosses a process boundary; a buggy connector can send
+	// anything. Clamp to a day per response so a garbage value can't
+	// overflow time.Duration and subtract from the buckets.
+	const maxWaitReportMs = int64(24 * time.Hour / time.Millisecond)
+	if waitMs > maxWaitReportMs {
+		waitMs = maxWaitReportMs
+	}
 	wait := time.Duration(waitMs) * time.Millisecond
 	s.state.AddStepDuration("rate_limit_wait", wait)
 	if resourceTypeID != "" {
 		s.state.AddStepDuration("rate_limit_wait:"+resourceTypeID, wait)
 	}
+	s.recordRateLimitWallInterval(wait)
 }
 
 func (s *syncer) returnSyncError(l *zap.Logger, span trace.Span, err error) error {

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -483,6 +483,11 @@ func (s *syncer) syncSummaryFields(span trace.Span) []zap.Field {
 		zap.Uint64("completed_actions", s.state.GetCompletedActionsCount()),
 		zap.Int("worker_count", s.workerCount),
 	}
+	// Prefer identity from WithSyncIdentity so dashboards can group by
+	// catalog_name (platform context often has catalog_id but not the name).
+	if s.syncIdentity.CatalogName != "" {
+		fields = append(fields, zap.String("catalog_name", s.syncIdentity.CatalogName))
+	}
 	if len(waits) > 0 {
 		fields = append(fields, zap.Any("sync_step_wait_ms", waits))
 	}
@@ -732,6 +737,12 @@ func (s *syncer) Sync(ctx context.Context) error {
 	uotel.SetSyncIdentityAttrs(ctx, span)
 	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
+
+	// Rate-limit gates below the syncer (the SDK client interceptor, the
+	// hosted connector manager) sleep before issuing requests. Those sleeps
+	// are invisible to the retryer, so have them report here to land in the
+	// rate_limit_wait bucket alongside retry backoff.
+	ctx = s.withRateLimitWaitObserver(ctx)
 
 	if s.skipFullSync {
 		return s.SkipSync(ctx)

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -554,6 +554,33 @@ func (s *syncer) recordSessionUsage(annos []*anypb.Any) {
 	}
 }
 
+// recordConnectorWaitReport folds a connector-reported RateLimitWaitReport
+// response annotation into rate_limit_wait. This surfaces sleeps that happen
+// inside the connector process (client-side rate-limit prevention, in-SDK 429
+// backoff) which the syncer cannot observe directly — including across
+// process/lambda boundaries where context-based observers don't reach.
+// Attributed to the action's resource type like retry and gate waits.
+func (s *syncer) recordConnectorWaitReport(annos []*anypb.Any, resourceTypeID string) {
+	if !s.recordStats || len(annos) == 0 || s.state == nil {
+		return
+	}
+	report := &v2.RateLimitWaitReport{}
+	respAnnos := annotations.Annotations(annos)
+	ok, err := respAnnos.Pick(report)
+	if err != nil || !ok {
+		return
+	}
+	waitMs := report.GetWaitMs()
+	if waitMs <= 0 {
+		return
+	}
+	wait := time.Duration(waitMs) * time.Millisecond
+	s.state.AddStepDuration("rate_limit_wait", wait)
+	if resourceTypeID != "" {
+		s.state.AddStepDuration("rate_limit_wait:"+resourceTypeID, wait)
+	}
+}
+
 func (s *syncer) returnSyncError(l *zap.Logger, span trace.Span, err error) error {
 	if err == nil || !s.recordStats || s.state == nil || errors.Is(err, ErrSyncNotComplete) {
 		return err
@@ -1300,6 +1327,7 @@ func (s *syncer) syncResources(ctx context.Context, action *Action) error {
 	resp, err := s.connector.ListResources(ctx, req)
 	s.observeConnectorCall(ctx, "list-resources", start, action.ResourceTypeID, action.ResourceID)
 	s.recordSessionUsage(resp.GetAnnotations())
+	s.recordConnectorWaitReport(resp.GetAnnotations(), action.ResourceTypeID)
 	if err != nil {
 		return err
 	}
@@ -1570,6 +1598,7 @@ func (s *syncer) syncEntitlementsForResource(ctx context.Context, action *Action
 	}.Build())
 	s.observeConnectorCall(ctx, "list-entitlements", start, action.ResourceTypeID, action.ResourceID)
 	s.recordSessionUsage(resp.GetAnnotations())
+	s.recordConnectorWaitReport(resp.GetAnnotations(), action.ResourceTypeID)
 	if err != nil {
 		return err
 	}
@@ -1636,6 +1665,7 @@ func (s *syncer) syncStaticEntitlementsForResourceType(ctx context.Context, acti
 	}.Build())
 	s.observeConnectorCall(ctx, "list-static-entitlements", start, action.ResourceTypeID, action.ResourceID)
 	s.recordSessionUsage(resp.GetAnnotations())
+	s.recordConnectorWaitReport(resp.GetAnnotations(), action.ResourceTypeID)
 	if err != nil {
 		// Ignore prefixError if we're calling a lambda with an old version of baton-sdk.
 		if strings.Contains(err.Error(), `unable to resolve \"type.googleapis.com/c1.connector.v2.EntitlementsServiceListStaticEntitlementsRequest\": \"not found\"","errorType":"prefixError"`) {
@@ -2073,6 +2103,7 @@ func (s *syncer) syncGrantsForResource(ctx context.Context, action *Action) erro
 	}.Build())
 	s.observeConnectorCall(ctx, "list-grants", start, action.ResourceTypeID, action.ResourceID)
 	s.recordSessionUsage(resp.GetAnnotations())
+	s.recordConnectorWaitReport(resp.GetAnnotations(), action.ResourceTypeID)
 	if err != nil {
 		return fmt.Errorf("sync-grants-for-resource: error listing grants: %w", err)
 	}

--- a/pkg/sync/wait_observer_e2e_test.go
+++ b/pkg/sync/wait_observer_e2e_test.go
@@ -56,6 +56,11 @@ func (g *gateSimConnector) ListResourceTypes(
 
 func (g *gateSimConnector) ListGrants(ctx context.Context, in *v2.GrantsServiceListGrantsRequest, opts ...grpc.CallOption) (*v2.GrantsServiceListGrantsResponse, error) {
 	resourceType := in.GetResource().GetId().GetResourceType()
+	// Really sleep, then report — like the prod gate. The wall bucket only
+	// counts real elapsed time past its watermark, so a claimed-but-not-slept
+	// wait would leave rate_limit_wait_wall at whatever the test's incidental
+	// runtime happens to be.
+	time.Sleep(g.gateWait)
 	ratelimit.ObserveWait(ratelimit.WithWaitLabel(ctx, resourceType), ratelimit.WaitEvent{Duration: g.gateWait})
 	g.gateCalls++
 	resp, err := g.mockConnector.ListGrants(ctx, in, opts...)
@@ -86,7 +91,7 @@ func TestRateLimitGateWaitsReachSyncStats(t *testing.T) {
 	require.NoError(t, err)
 	_ = mc.AddGroupMember(ctx, group1, u1)
 
-	gc := &gateSimConnector{mockConnector: mc, gateWait: 250 * time.Millisecond, annotationMs: 100}
+	gc := &gateSimConnector{mockConnector: mc, gateWait: 25 * time.Millisecond, annotationMs: 100}
 
 	syncer, err := NewSyncer(ctx, gc,
 		WithConnectorStore(store),
@@ -127,10 +132,12 @@ func TestRateLimitGateWaitsReachSyncStats(t *testing.T) {
 	}
 	require.EqualValues(t, grantsMs, labeledMs)
 
-	// The wall-clock bucket merges overlapping end-anchored intervals, so it
-	// must be positive but can never exceed the cumulative worker-seconds.
+	// The wall-clock bucket merges overlapping end-anchored intervals. The
+	// gate sleeps were real and sequential, so each one's interval lies fully
+	// past the watermark and the bucket must cover at least their sum; it can
+	// never exceed the cumulative worker-seconds.
 	wallMs := durations["rate_limit_wait_wall"]
-	require.Positive(t, wallMs)
+	require.GreaterOrEqual(t, wallMs, int64(gc.gateCalls)*gc.gateWait.Milliseconds())
 	require.LessOrEqual(t, wallMs, grantsMs+rtMs)
 
 	require.NoError(t, syncer.Close(ctx))

--- a/pkg/sync/wait_observer_e2e_test.go
+++ b/pkg/sync/wait_observer_e2e_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/dotc1z"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
 	"github.com/conductorone/baton-sdk/pkg/ratelimit"
-	"github.com/conductorone/baton-sdk/pkg/retry"
 )
 
 // gateSimConnector simulates the two connector-side rate-limit wait sources:
@@ -57,7 +56,7 @@ func (g *gateSimConnector) ListResourceTypes(
 
 func (g *gateSimConnector) ListGrants(ctx context.Context, in *v2.GrantsServiceListGrantsRequest, opts ...grpc.CallOption) (*v2.GrantsServiceListGrantsResponse, error) {
 	resourceType := in.GetResource().GetId().GetResourceType()
-	ratelimit.ObserveWait(retry.WithWaitLabel(ctx, resourceType), ratelimit.WaitEvent{Duration: g.gateWait})
+	ratelimit.ObserveWait(ratelimit.WithWaitLabel(ctx, resourceType), ratelimit.WaitEvent{Duration: g.gateWait})
 	g.gateCalls++
 	resp, err := g.mockConnector.ListGrants(ctx, in, opts...)
 	if err != nil {

--- a/pkg/sync/wait_observer_e2e_test.go
+++ b/pkg/sync/wait_observer_e2e_test.go
@@ -128,5 +128,11 @@ func TestRateLimitGateWaitsReachSyncStats(t *testing.T) {
 	}
 	require.EqualValues(t, grantsMs, labeledMs)
 
+	// The wall-clock bucket merges overlapping end-anchored intervals, so it
+	// must be positive but can never exceed the cumulative worker-seconds.
+	wallMs := durations["rate_limit_wait_wall"]
+	require.Positive(t, wallMs)
+	require.LessOrEqual(t, wallMs, grantsMs+rtMs)
+
 	require.NoError(t, syncer.Close(ctx))
 }

--- a/pkg/sync/wait_observer_e2e_test.go
+++ b/pkg/sync/wait_observer_e2e_test.go
@@ -1,0 +1,92 @@
+package sync //nolint:revive,nolintlint // we can't change the package name for backwards compatibility
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
+	"github.com/conductorone/baton-sdk/pkg/ratelimit"
+	"github.com/conductorone/baton-sdk/pkg/retry"
+)
+
+// gateSimConnector simulates the hosted connector manager's rate-limit gate:
+// it reports a sleep via ratelimit.ObserveWait from *inside* a connector call,
+// using only the context the syncer passed in. This proves end-to-end that the
+// observer installed at the top of Syncer.Sync survives the syncer's action
+// loop and call plumbing to reach gate code, mirroring the prod topology where
+// c1's ConnectorWrapper.ratelimitDo receives the syncer's context in-process.
+type gateSimConnector struct {
+	*mockConnector
+	gateWait  time.Duration
+	gateCalls int
+}
+
+func (g *gateSimConnector) ListGrants(ctx context.Context, in *v2.GrantsServiceListGrantsRequest, opts ...grpc.CallOption) (*v2.GrantsServiceListGrantsResponse, error) {
+	resourceType := in.GetResource().GetId().GetResourceType()
+	ratelimit.ObserveWait(retry.WithWaitLabel(ctx, resourceType), g.gateWait)
+	g.gateCalls++
+	return g.mockConnector.ListGrants(ctx, in, opts...)
+}
+
+func TestRateLimitGateWaitsReachSyncStats(t *testing.T) {
+	ctx := t.Context()
+	tempDir := t.TempDir()
+
+	store, err := dotc1z.NewStore(ctx, filepath.Join(tempDir, "gate-sim.c1z"),
+		dotc1z.WithEngine(c1zstore.EnginePebble),
+		dotc1z.WithTmpDir(tempDir),
+	)
+	require.NoError(t, err)
+
+	mc := newMockConnector()
+	mc.rtDB = append(mc.rtDB, groupResourceType, userResourceType)
+	group1, _, err := mc.AddGroup(ctx, "g1")
+	require.NoError(t, err)
+	u1, err := mc.AddUser(ctx, "u1")
+	require.NoError(t, err)
+	_ = mc.AddGroupMember(ctx, group1, u1)
+
+	gc := &gateSimConnector{mockConnector: mc, gateWait: 250 * time.Millisecond}
+
+	syncer, err := NewSyncer(ctx, gc,
+		WithConnectorStore(store),
+		WithTmpDir(tempDir),
+	)
+	require.NoError(t, err)
+	require.NoError(t, syncer.Sync(ctx))
+
+	latest, ok := store.(connectorstore.LatestFinishedSyncIDFetcher)
+	require.True(t, ok)
+	syncID, err := latest.LatestFinishedSyncID(ctx, connectorstore.SyncTypeFull)
+	require.NoError(t, err)
+	require.NoError(t, store.SetCurrentSync(ctx, syncID))
+	token, err := store.CurrentSyncStep(ctx)
+	require.NoError(t, err)
+	completedState := newState()
+	require.NoError(t, completedState.Unmarshal(token))
+
+	durations := completedState.StepDurations()
+	require.Positive(t, gc.gateCalls, "sync should have listed grants")
+	expectedMs := int64(gc.gateCalls) * gc.gateWait.Milliseconds()
+	require.EqualValues(t, expectedMs, durations["rate_limit_wait"],
+		"every gate-reported wait must land in rate_limit_wait")
+
+	// Attribution: labeled sub-buckets must decompose the flat total.
+	var labeledMs int64
+	for bucket, ms := range durations {
+		if bucket != "rate_limit_wait" && len(bucket) > len("rate_limit_wait:") && bucket[:len("rate_limit_wait:")] == "rate_limit_wait:" {
+			labeledMs += ms
+		}
+	}
+	require.EqualValues(t, expectedMs, labeledMs)
+
+	require.NoError(t, syncer.Close(ctx))
+}

--- a/pkg/sync/wait_observer_e2e_test.go
+++ b/pkg/sync/wait_observer_e2e_test.go
@@ -37,7 +37,7 @@ type gateSimConnector struct {
 
 func (g *gateSimConnector) ListGrants(ctx context.Context, in *v2.GrantsServiceListGrantsRequest, opts ...grpc.CallOption) (*v2.GrantsServiceListGrantsResponse, error) {
 	resourceType := in.GetResource().GetId().GetResourceType()
-	ratelimit.ObserveWait(retry.WithWaitLabel(ctx, resourceType), g.gateWait)
+	ratelimit.ObserveWait(retry.WithWaitLabel(ctx, resourceType), ratelimit.WaitEvent{Duration: g.gateWait})
 	g.gateCalls++
 	resp, err := g.mockConnector.ListGrants(ctx, in, opts...)
 	if err != nil {

--- a/pkg/sync/wait_observer_e2e_test.go
+++ b/pkg/sync/wait_observer_e2e_test.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/grpc"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
@@ -17,23 +18,35 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/retry"
 )
 
-// gateSimConnector simulates the hosted connector manager's rate-limit gate:
-// it reports a sleep via ratelimit.ObserveWait from *inside* a connector call,
-// using only the context the syncer passed in. This proves end-to-end that the
-// observer installed at the top of Syncer.Sync survives the syncer's action
-// loop and call plumbing to reach gate code, mirroring the prod topology where
-// c1's ConnectorWrapper.ratelimitDo receives the syncer's context in-process.
+// gateSimConnector simulates the two connector-side rate-limit wait sources:
+//   - the hosted connector manager's gate, which reports a sleep via
+//     ratelimit.ObserveWait from *inside* a connector call using only the
+//     context the syncer passed in (proving the observer installed at the top
+//     of Syncer.Sync survives the syncer's action loop and call plumbing,
+//     mirroring prod where c1's ConnectorWrapper.ratelimitDo receives the
+//     syncer's context in-process), and
+//   - a connector that slept in its own process (client-side prevention /
+//     in-SDK backoff) and reports it via a RateLimitWaitReport response
+//     annotation, which works across process/lambda boundaries.
 type gateSimConnector struct {
 	*mockConnector
-	gateWait  time.Duration
-	gateCalls int
+	gateWait     time.Duration
+	annotationMs int64
+	gateCalls    int
 }
 
 func (g *gateSimConnector) ListGrants(ctx context.Context, in *v2.GrantsServiceListGrantsRequest, opts ...grpc.CallOption) (*v2.GrantsServiceListGrantsResponse, error) {
 	resourceType := in.GetResource().GetId().GetResourceType()
 	ratelimit.ObserveWait(retry.WithWaitLabel(ctx, resourceType), g.gateWait)
 	g.gateCalls++
-	return g.mockConnector.ListGrants(ctx, in, opts...)
+	resp, err := g.mockConnector.ListGrants(ctx, in, opts...)
+	if err != nil {
+		return nil, err
+	}
+	var annos annotations.Annotations = resp.GetAnnotations()
+	annos.WithRateLimitWaitReport(g.annotationMs)
+	resp.SetAnnotations(annos)
+	return resp, nil
 }
 
 func TestRateLimitGateWaitsReachSyncStats(t *testing.T) {
@@ -54,7 +67,7 @@ func TestRateLimitGateWaitsReachSyncStats(t *testing.T) {
 	require.NoError(t, err)
 	_ = mc.AddGroupMember(ctx, group1, u1)
 
-	gc := &gateSimConnector{mockConnector: mc, gateWait: 250 * time.Millisecond}
+	gc := &gateSimConnector{mockConnector: mc, gateWait: 250 * time.Millisecond, annotationMs: 100}
 
 	syncer, err := NewSyncer(ctx, gc,
 		WithConnectorStore(store),
@@ -75,9 +88,11 @@ func TestRateLimitGateWaitsReachSyncStats(t *testing.T) {
 
 	durations := completedState.StepDurations()
 	require.Positive(t, gc.gateCalls, "sync should have listed grants")
-	expectedMs := int64(gc.gateCalls) * gc.gateWait.Milliseconds()
+	// Both sources must land: observer-reported gate sleeps plus
+	// annotation-reported in-connector sleeps.
+	expectedMs := int64(gc.gateCalls) * (gc.gateWait.Milliseconds() + gc.annotationMs)
 	require.EqualValues(t, expectedMs, durations["rate_limit_wait"],
-		"every gate-reported wait must land in rate_limit_wait")
+		"every gate-reported and annotation-reported wait must land in rate_limit_wait")
 
 	// Attribution: labeled sub-buckets must decompose the flat total.
 	var labeledMs int64

--- a/pkg/sync/wait_observer_e2e_test.go
+++ b/pkg/sync/wait_observer_e2e_test.go
@@ -33,6 +33,26 @@ type gateSimConnector struct {
 	gateWait     time.Duration
 	annotationMs int64
 	gateCalls    int
+	rtCalls      int
+}
+
+// ListResourceTypes attaches a RateLimitWaitReport with no resource-type
+// attribution, covering the syncer's wiring on the list-resource-types path
+// (which has no action resource type, so the report lands unlabeled).
+func (g *gateSimConnector) ListResourceTypes(
+	ctx context.Context,
+	in *v2.ResourceTypesServiceListResourceTypesRequest,
+	opts ...grpc.CallOption,
+) (*v2.ResourceTypesServiceListResourceTypesResponse, error) {
+	resp, err := g.mockConnector.ListResourceTypes(ctx, in, opts...)
+	if err != nil {
+		return nil, err
+	}
+	g.rtCalls++
+	var annos annotations.Annotations = resp.GetAnnotations()
+	annos.WithRateLimitWaitReport(g.annotationMs)
+	resp.SetAnnotations(annos)
+	return resp, nil
 }
 
 func (g *gateSimConnector) ListGrants(ctx context.Context, in *v2.GrantsServiceListGrantsRequest, opts ...grpc.CallOption) (*v2.GrantsServiceListGrantsResponse, error) {
@@ -88,20 +108,25 @@ func TestRateLimitGateWaitsReachSyncStats(t *testing.T) {
 
 	durations := completedState.StepDurations()
 	require.Positive(t, gc.gateCalls, "sync should have listed grants")
-	// Both sources must land: observer-reported gate sleeps plus
-	// annotation-reported in-connector sleeps.
-	expectedMs := int64(gc.gateCalls) * (gc.gateWait.Milliseconds() + gc.annotationMs)
-	require.EqualValues(t, expectedMs, durations["rate_limit_wait"],
+	require.Positive(t, gc.rtCalls, "sync should have listed resource types")
+	// All three sources must land: observer-reported gate sleeps,
+	// annotation-reported in-connector sleeps on grants, and unlabeled
+	// annotation reports on list-resource-types.
+	grantsMs := int64(gc.gateCalls) * (gc.gateWait.Milliseconds() + gc.annotationMs)
+	rtMs := int64(gc.rtCalls) * gc.annotationMs
+	require.EqualValues(t, grantsMs+rtMs, durations["rate_limit_wait"],
 		"every gate-reported and annotation-reported wait must land in rate_limit_wait")
 
-	// Attribution: labeled sub-buckets must decompose the flat total.
+	// Attribution: labeled sub-buckets must decompose the labeled portion of
+	// the flat total; list-resource-types reports carry no resource type and
+	// stay unlabeled.
 	var labeledMs int64
 	for bucket, ms := range durations {
 		if bucket != "rate_limit_wait" && len(bucket) > len("rate_limit_wait:") && bucket[:len("rate_limit_wait:")] == "rate_limit_wait:" {
 			labeledMs += ms
 		}
 	}
-	require.EqualValues(t, expectedMs, labeledMs)
+	require.EqualValues(t, grantsMs, labeledMs)
 
 	require.NoError(t, syncer.Close(ctx))
 }

--- a/proto/c1/connector/v2/annotation_ratelimit.proto
+++ b/proto/c1/connector/v2/annotation_ratelimit.proto
@@ -18,3 +18,12 @@ message RateLimitDescription {
   int64 remaining = 3;
   google.protobuf.Timestamp reset_at = 4;
 }
+
+// RateLimitWaitReport is a response annotation a connector attaches to report
+// time it spent sleeping on rate limits (client-side prevention, in-SDK 429
+// backoff) while serving the request. Those sleeps happen inside the connector
+// process where the syncer cannot observe them; the syncer folds this report
+// into the rate_limit_wait sync stat.
+message RateLimitWaitReport {
+  int64 wait_ms = 1;
+}


### PR DESCRIPTION
# Record rate-limit gate waits and connector-reported sleeps in sync stats

## Why

`rate_limit_wait` only captured retry backoff inside the syncer. The two
places where most real waiting happens were invisible:

- the pre-request rate-limit gate (SDK gRPC interceptor, and the hosted
  connector manager) sleeps before issuing the request, and that time hid
  inside the step's wall clock; and
- connectors that sleep client-side to avoid limits (e.g. Okta-style
  prevention) never reported that time at all — across a process/Lambda
  boundary there was no way to.

This is why heavily rate-limited connectors (GitHub) never showed up on the
rate-limit dashboards despite spending most of their sync waiting.

## What

**In-process waits — `WaitObserver` (pkg/ratelimit):** a context-carried
callback installed by the syncer at the start of `Sync()`. Sleep sites report
via `ratelimit.ObserveWait` after the sleep completes, with the time actually
slept (a cancelled sleep reports only the elapsed portion). The interceptor's
OVERLIMIT sleep now reports; waits are labeled by resource type via
`retry.WithWaitLabel` and land in `rate_limit_wait` (plus per-resource-type
sub-buckets). No observer on the context = no-op; non-sync callers are
unaffected, and the interceptor's blocking behavior is unchanged.

**Cross-process waits — `RateLimitWaitReport` annotation (proto):** connectors
can attach total slept milliseconds to a list response
(`annotations.WithRateLimitWaitReport`). The syncer folds it into
`rate_limit_wait`, attributed to the resource type being synced. Works for
self-hosted and Lambda connectors where context values can't cross the RPC
boundary. Connector adoption is a follow-up; this PR adds the plumbing.

## Behavior change

`retry.RetryConfig.OnWait` now fires **after** the wait completes with the
duration actually slept, instead of before the wait with the planned
duration. On mid-wait cancellation it reports only the elapsed portion. The
only in-tree consumer is the syncer's own stats recording; downstream users
of `OnWait` should note the timing/value change.

## Testing

- Unit tests for the observer API, interceptor reporting, annotation helper,
  and the cancellation/elapsed-time contract.
- An end-to-end test (`TestRateLimitGateWaitsReachSyncStats`) runs a full
  sync against a mock connector that both triggers gate waits and attaches
  wait-report annotations, and asserts both totals reach the final sync
  summary.

Companion change in the hosted connector manager reports its gate sleeps via
`ObserveWait` (separate PR; requires an SDK version bump there).