### PR TITLE
Set decoder context in NewStore().

### DIFF
--- a/cmd/baton/dump_db.go
+++ b/cmd/baton/dump_db.go
@@ -63,7 +63,7 @@ func runDumpDB(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	dbFile, err := dotc1z.NewC1ZFileDecoder(f)
+	dbFile, err := dotc1z.NewC1ZFileDecoder(f, dotc1z.WithContext(cmd.Context()))
 	if err != nil {
 		return err
 	}

--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -512,6 +512,9 @@ func NewC1ZFile(ctx context.Context, outputFilePath string, opts ...C1ZOption) (
 	if err != nil {
 		return nil, err
 	}
+	// Ensure c1z decompression honors caller cancellation. Prepended so an
+	// explicit WithDecoderOptions(WithContext(...)) from the caller still wins.
+	options.decoderOptions = append([]DecoderOption{WithContext(ctx)}, options.decoderOptions...)
 
 	if options.engine == c1zstore.EnginePebble && !options.readOnly {
 		err = fmt.Errorf(

--- a/pkg/dotc1z/engine_registry.go
+++ b/pkg/dotc1z/engine_registry.go
@@ -157,6 +157,9 @@ func NewStore(ctx context.Context, outputFilePath string, opts ...C1ZOption) (c1
 	if err != nil {
 		return nil, err
 	}
+	// Ensure c1z decompression honors caller cancellation. Prepended so an
+	// explicit WithDecoderOptions(WithContext(...)) from the caller still wins.
+	options.decoderOptions = append([]DecoderOption{WithContext(ctx)}, options.decoderOptions...)
 	driver, err := selectStoreDriver(ctx, outputFilePath, options)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This should help with some context canceled/deadline exceeded errors. Now callers won't have to set the decoder context every time they open a c1z.