### PR TITLE
Phase 5: type-scoped grants & ents and connector spawned cursors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,14 @@ protofmt:
 test:
 	go test -tags=baton_lambda_support -v ./...
 
+# Two-artifact checkpoint compatibility matrix: builds the harness against
+# HEAD and a pinned past release, and exchanges mid-flight checkpoints in
+# both directions. See cmd/baton-compat-harness. Override the old release
+# with BATON_COMPAT_OLD_REF=<tag>.
+.PHONY: compat-check
+compat-check:
+	BATON_COMPAT=1 go test -v -count=1 -run TestCheckpointCompatAcrossSDKVersions ./cmd/baton-compat-harness
+
 .PHONY: pkg/sdk/version.go
 pkg/sdk/version.go:
 	echo $(VERSION)

--- a/cmd/baton-compat-harness/driver_test.go
+++ b/cmd/baton-compat-harness/driver_test.go
@@ -1,0 +1,191 @@
+// Driver for the two-artifact checkpoint compatibility harness (main.go).
+//
+// TestCompatHarnessBuildsAgainstHead always runs: it is the compile gate
+// that keeps the tag-gated harness from rotting against HEAD.
+//
+// TestCheckpointCompatAcrossSDKVersions is the instrument itself and needs
+// a second SDK checkout, so it is gated behind BATON_COMPAT=1 (run it via
+// `make compat-check`). It materializes a pinned past release with `git
+// worktree`, compiles the SAME harness source against both trees, and runs
+// every (gen version × resume version) cell:
+//
+//	new→new  self-equivalence baseline
+//	old→old  old-binary baseline (also validates the harness under old)
+//	old→new  backward: HEAD must resume an old checkpoint to a complete store
+//	new→old  forward: the old release meets a version-stamped type-scoped
+//	         checkpoint; whatever it does (refuse, restart), the sealed
+//	         store must be content-complete — silently sealing the
+//	         incomplete resume is the worst bug on this repo's record
+//
+// The oracle is counted rows against the connector's known topology, in
+// every cell — not error strings.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The connector topology in main.go: numGroups groups + 1 user, one
+// entitlement and one grant per group.
+const (
+	wantResources = numGroupsForDriver + 1
+	wantEnts      = numGroupsForDriver
+	wantGrants    = numGroupsForDriver
+	// Kept in lockstep with numGroups in main.go; main.go is excluded from
+	// this compilation by its build tag, so the constant is restated here.
+	numGroupsForDriver = 12
+)
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	require.NoError(t, err)
+	return root
+}
+
+func buildHarness(t *testing.T, tree, out string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "go", "build", "-tags", "compatharness", "-o", out, "./cmd/baton-compat-harness")
+	cmd.Dir = tree
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "build harness in %s:\n%s", tree, output)
+}
+
+// TestCompatHarnessBuildsAgainstHead is the ungated compile gate: the
+// harness source must always build against the current tree.
+func TestCompatHarnessBuildsAgainstHead(t *testing.T) {
+	buildHarness(t, repoRoot(t), filepath.Join(t.TempDir(), "harness"))
+}
+
+func runHarness(t *testing.T, bin, mode, c1zPath string) compatDriverResult {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin, "-mode", mode, "-c1z", c1zPath)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "%s -mode %s:\n%s", bin, mode, output)
+
+	var line string
+	for _, l := range strings.Split(string(output), "\n") {
+		if strings.HasPrefix(l, "COMPAT_RESULT ") {
+			line = strings.TrimPrefix(l, "COMPAT_RESULT ")
+		}
+	}
+	require.NotEmpty(t, line, "no COMPAT_RESULT line in output:\n%s", output)
+	var result compatDriverResult
+	require.NoError(t, json.Unmarshal([]byte(line), &result))
+	return result
+}
+
+// compatDriverResult mirrors compatResult in main.go (excluded from this
+// compilation by its build tag).
+type compatDriverResult struct {
+	Mode            string `json:"mode"`
+	SyncErr         string `json:"sync_err"`
+	NotComplete     bool   `json:"not_complete"`
+	Resources       int    `json:"resources"`
+	Ents            int    `json:"entitlements"`
+	Grants          int    `json:"grants"`
+	CountErr        string `json:"count_err"`
+	UnfinishedRuns  int    `json:"unfinished_runs"`
+	TokenLen        int    `json:"token_len"`
+	TokenSpawned    bool   `json:"token_spawned"`
+	TokenTypeScoped bool   `json:"token_type_scoped"`
+}
+
+func TestCheckpointCompatAcrossSDKVersions(t *testing.T) {
+	if os.Getenv("BATON_COMPAT") == "" {
+		t.Skip("two-artifact compatibility matrix; set BATON_COMPAT=1 (or run `make compat-check`)")
+	}
+	oldRef := os.Getenv("BATON_COMPAT_OLD_REF")
+	if oldRef == "" {
+		// The last release before the type-scoped/fan-out branch.
+		oldRef = "v0.20.2"
+	}
+	root := repoRoot(t)
+	tmp := t.TempDir()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	// Materialize the old tree. worktree (vs. clone) shares objects and
+	// works offline; --detach avoids claiming the ref.
+	oldTree := filepath.Join(tmp, "old-tree")
+	//nolint:gosec // the ref comes from the developer's own environment; this is a local test driver
+	wtAdd := exec.CommandContext(ctx, "git", "-C", root, "worktree", "add", "--detach", oldTree, oldRef)
+	output, err := wtAdd.CombinedOutput()
+	require.NoError(t, err, "git worktree add %s:\n%s", oldRef, output)
+	t.Cleanup(func() {
+		rmCtx, rmCancel := context.WithTimeout(context.Background(), time.Minute)
+		defer rmCancel()
+		out, rmErr := exec.CommandContext(rmCtx, "git", "-C", root, "worktree", "remove", "--force", oldTree).CombinedOutput()
+		if rmErr != nil {
+			t.Logf("git worktree remove: %v\n%s", rmErr, out)
+		}
+	})
+
+	// The same source compiles against both trees: copy it into the old
+	// checkout (the old release predates the harness).
+	src, err := os.ReadFile(filepath.Join(root, "cmd", "baton-compat-harness", "main.go"))
+	require.NoError(t, err)
+	oldHarnessDir := filepath.Join(oldTree, "cmd", "baton-compat-harness")
+	require.NoError(t, os.MkdirAll(oldHarnessDir, 0o755))
+	//nolint:gosec // the path is rooted in this test's own TempDir worktree
+	require.NoError(t, os.WriteFile(filepath.Join(oldHarnessDir, "main.go"), src, 0o600))
+
+	newBin := filepath.Join(tmp, "harness-new")
+	oldBin := filepath.Join(tmp, "harness-old")
+	buildHarness(t, root, newBin)
+	buildHarness(t, oldTree, oldBin)
+
+	cells := []struct {
+		name       string
+		gen        string
+		resumeWith string
+	}{
+		{"new_gen_new_resume", newBin, newBin},
+		{"old_gen_old_resume", oldBin, oldBin},
+		{"old_gen_new_resume", oldBin, newBin},
+		{"new_gen_old_resume", newBin, oldBin},
+	}
+	for _, cell := range cells {
+		t.Run(cell.name, func(t *testing.T) {
+			c1zPath := filepath.Join(t.TempDir(), "compat.c1z")
+
+			gen := runHarness(t, cell.gen, "gen", c1zPath)
+			require.True(t, gen.NotComplete,
+				"gen must be interrupted mid-flight (got sync_err=%q)", gen.SyncErr)
+			require.GreaterOrEqual(t, gen.UnfinishedRuns, 1,
+				"gen must leave an unfinished sync run")
+			require.Positive(t, gen.TokenLen, "gen checkpoint token must be non-empty")
+			if cell.gen == newBin {
+				// Meta-assertion against a vacuous harness: the new
+				// binary's checkpoint must actually carry the adversarial
+				// state the exchange exists to test.
+				require.True(t, gen.TokenSpawned,
+					"new-binary gen checkpoint must hold spawned cursors")
+				require.True(t, gen.TokenTypeScoped,
+					"new-binary gen checkpoint must hold type-scoped actions")
+			}
+
+			resume := runHarness(t, cell.resumeWith, "resume", c1zPath)
+			require.Empty(t, resume.SyncErr, "resume must complete")
+			require.Empty(t, resume.CountErr)
+			require.Zero(t, resume.UnfinishedRuns, "resume must seal the sync")
+			require.Equal(t, wantResources, resume.Resources, "resource count")
+			require.Equal(t, wantEnts, resume.Ents, "entitlement count")
+			require.Equal(t, wantGrants, resume.Grants, "grant count")
+		})
+	}
+}

--- a/cmd/baton-compat-harness/main.go
+++ b/cmd/baton-compat-harness/main.go
@@ -1,0 +1,456 @@
+//go:build compatharness
+
+// Command baton-compat-harness is one half of the two-artifact checkpoint
+// compatibility instrument (docs/BUG_CATCHING.md §2: multi-artifact
+// properties are review-blind — the property under test is a function of
+// TWO SDK versions, so a test that only executes HEAD can check at most
+// half of it).
+//
+// The same source compiles against two checkouts of baton-sdk — HEAD
+// ("new") and a pinned past release ("old", see driver_test.go) — and the
+// two binaries exchange a real c1z containing a mid-flight checkpoint:
+//
+//	-mode gen    start a sync and interrupt it via run-duration expiry,
+//	             leaving an unfinished sync run + checkpoint in the c1z.
+//	             Under the new binary the checkpoint holds type-scoped and
+//	             spawned cursor actions; under the old binary it holds a
+//	             mid-pagination per-resource grants root.
+//	-mode resume resume the same c1z to completion (no delays, no fan-out)
+//	             and report the final resource/entitlement/grant counts.
+//
+// The oracle is counted rows, not error text: whatever a resumer does with
+// a foreign-version checkpoint (resume it, refuse it, or restart the sync),
+// the sealed store must end content-complete. The bug this instrument
+// exists for — an old SDK zero-filling a newer token and silently sealing
+// an incomplete sync — is invisible to everything except the count.
+//
+// The connector is version-skew realistic: its resource type always carries
+// TypeScopedEntitlements/TypeScopedGrants annotations (like a connector
+// built against the new SDK), and it serves both the per-resource calls an
+// old syncer makes and the type-scoped calls a new syncer makes.
+//
+// The final stdout line is COMPAT_RESULT <json> for the driver to parse.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
+	sdksync "github.com/conductorone/baton-sdk/pkg/sync"
+	et "github.com/conductorone/baton-sdk/pkg/types/entitlement"
+	gt "github.com/conductorone/baton-sdk/pkg/types/grant"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+)
+
+const (
+	numGroups        = 12
+	resourcePageSize = 4
+)
+
+type compatConnector struct {
+	// gen-mode behavior knobs.
+	slowPerResourceGrants time.Duration // old-binary gen: stall per-resource grant calls
+	fanoutAndBlock        bool          // new-binary gen: spawn sibling cursors, block all but the first
+
+	groupType *v2.ResourceType
+	userType  *v2.ResourceType
+	groups    []*v2.Resource
+	user      *v2.Resource
+	entsByRes map[string]*v2.Entitlement
+	grantsBy  map[string]*v2.Grant
+
+	v2.AssetServiceClient
+	v2.GrantManagerServiceClient
+	v2.ResourceManagerServiceClient
+	v2.AccountManagerServiceClient
+	v2.ResourceDeleterServiceClient
+	v2.CredentialManagerServiceClient
+	v2.EventServiceClient
+	v2.TicketsServiceClient
+	v2.ActionServiceClient
+	v2.ResourceGetterServiceClient
+	v2.EntitlementsServiceClient
+}
+
+func newCompatConnector() (*compatConnector, error) {
+	c := &compatConnector{
+		entsByRes: make(map[string]*v2.Entitlement),
+		grantsBy:  make(map[string]*v2.Grant),
+	}
+	c.groupType = v2.ResourceType_builder{
+		Id:          "group",
+		DisplayName: "Group",
+		Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_GROUP},
+		Annotations: annotations.New(&v2.TypeScopedEntitlements{}, &v2.TypeScopedGrants{}),
+	}.Build()
+	c.userType = v2.ResourceType_builder{
+		Id:          "user",
+		DisplayName: "User",
+		Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_USER},
+		Annotations: annotations.New(&v2.SkipEntitlementsAndGrants{}),
+	}.Build()
+	user, err := rs.NewUserResource("user-1", c.userType, "User 1", nil)
+	if err != nil {
+		return nil, err
+	}
+	c.user = user
+	for i := 0; i < numGroups; i++ {
+		id := fmt.Sprintf("g%02d", i)
+		group, err := rs.NewGroupResource(id, c.groupType, "Group "+id, nil)
+		if err != nil {
+			return nil, err
+		}
+		c.groups = append(c.groups, group)
+		ent := et.NewAssignmentEntitlement(group, "member", et.WithGrantableTo(c.userType))
+		// Key by the resource's actual stored ID (NewGroupResource derives
+		// it from the objectID argument, not the name).
+		key := group.GetId().GetResource()
+		c.entsByRes[key] = ent
+		c.grantsBy[key] = gt.NewGrant(group, "member", user.GetId())
+	}
+	return c, nil
+}
+
+func (c *compatConnector) ListResourceTypes(
+	_ context.Context, _ *v2.ResourceTypesServiceListResourceTypesRequest, _ ...grpc.CallOption,
+) (*v2.ResourceTypesServiceListResourceTypesResponse, error) {
+	return v2.ResourceTypesServiceListResourceTypesResponse_builder{
+		List: []*v2.ResourceType{c.groupType, c.userType},
+	}.Build(), nil
+}
+
+func (c *compatConnector) ListResources(
+	_ context.Context, in *v2.ResourcesServiceListResourcesRequest, _ ...grpc.CallOption,
+) (*v2.ResourcesServiceListResourcesResponse, error) {
+	if in.GetResourceTypeId() == "user" {
+		return v2.ResourcesServiceListResourcesResponse_builder{
+			List: []*v2.Resource{c.user},
+		}.Build(), nil
+	}
+	// Paginate groups so a grants root planner is mid-pagination when a
+	// gen-mode run expires.
+	start := 0
+	if in.GetPageToken() != "" {
+		if _, err := fmt.Sscanf(in.GetPageToken(), "page-%d", &start); err != nil {
+			return nil, fmt.Errorf("compat: bad resource page token %q", in.GetPageToken())
+		}
+	}
+	end := start + resourcePageSize
+	next := ""
+	if end < len(c.groups) {
+		next = fmt.Sprintf("page-%d", end)
+	} else {
+		end = len(c.groups)
+	}
+	return v2.ResourcesServiceListResourcesResponse_builder{
+		List:          c.groups[start:end],
+		NextPageToken: next,
+	}.Build(), nil
+}
+
+func (c *compatConnector) ListEntitlements(
+	_ context.Context, in *v2.EntitlementsServiceListEntitlementsRequest, _ ...grpc.CallOption,
+) (*v2.EntitlementsServiceListEntitlementsResponse, error) {
+	reqAnnos := annotations.Annotations(in.GetAnnotations())
+	if reqAnnos.Contains(&v2.TypeScopedEntitlements{}) {
+		// New syncer, whole type in one page.
+		ents := make([]*v2.Entitlement, 0, len(c.groups))
+		for _, g := range c.groups {
+			ents = append(ents, c.entsByRes[g.GetId().GetResource()])
+		}
+		return v2.EntitlementsServiceListEntitlementsResponse_builder{List: ents}.Build(), nil
+	}
+	// Old syncer, per resource.
+	ent, ok := c.entsByRes[in.GetResource().GetId().GetResource()]
+	if !ok {
+		return v2.EntitlementsServiceListEntitlementsResponse_builder{}.Build(), nil
+	}
+	return v2.EntitlementsServiceListEntitlementsResponse_builder{
+		List: []*v2.Entitlement{ent},
+	}.Build(), nil
+}
+
+func (c *compatConnector) ListStaticEntitlements(
+	_ context.Context, _ *v2.EntitlementsServiceListStaticEntitlementsRequest, _ ...grpc.CallOption,
+) (*v2.EntitlementsServiceListStaticEntitlementsResponse, error) {
+	return v2.EntitlementsServiceListStaticEntitlementsResponse_builder{}.Build(), nil
+}
+
+func (c *compatConnector) ListGrants(
+	ctx context.Context, in *v2.GrantsServiceListGrantsRequest, _ ...grpc.CallOption,
+) (*v2.GrantsServiceListGrantsResponse, error) {
+	reqAnnos := annotations.Annotations(in.GetAnnotations())
+	if reqAnnos.Contains(&v2.TypeScopedGrants{}) {
+		return c.listGrantsTypeScoped(ctx, in)
+	}
+	// Per-resource path (old syncer).
+	resourceID := in.GetResource().GetId().GetResource()
+	if c.slowPerResourceGrants > 0 {
+		select {
+		case <-ctx.Done():
+			return nil, context.Cause(ctx)
+		case <-time.After(c.slowPerResourceGrants):
+		}
+	}
+	grant, ok := c.grantsBy[resourceID]
+	if !ok {
+		return v2.GrantsServiceListGrantsResponse_builder{}.Build(), nil
+	}
+	return v2.GrantsServiceListGrantsResponse_builder{List: []*v2.Grant{grant}}.Build(), nil
+}
+
+func (c *compatConnector) listGrantsTypeScoped(
+	ctx context.Context, in *v2.GrantsServiceListGrantsRequest,
+) (*v2.GrantsServiceListGrantsResponse, error) {
+	if !c.fanoutAndBlock {
+		// Resume mode: whole type in one page, whatever the cursor. A
+		// resumed spawned cursor re-fetches the full type; duplicate
+		// upserts are idempotent by identity.
+		grants := make([]*v2.Grant, 0, len(c.groups))
+		for _, g := range c.groups {
+			grants = append(grants, c.grantsBy[g.GetId().GetResource()])
+		}
+		return v2.GrantsServiceListGrantsResponse_builder{List: grants}.Build(), nil
+	}
+	// Gen mode: planner spawns sibling cursors; only the first returns,
+	// the rest block until the run duration cancels them, stranding
+	// spawned+type-scoped actions in the checkpoint.
+	switch tok := in.GetPageToken(); {
+	case tok == "":
+		return v2.GrantsServiceListGrantsResponse_builder{
+			Annotations: annotations.New(v2.EnqueuePageTokens_builder{
+				PageTokens: []string{"ts-0", "ts-1", "ts-2", "ts-3"},
+			}.Build()),
+		}.Build(), nil
+	case tok == "ts-0":
+		return v2.GrantsServiceListGrantsResponse_builder{
+			List: []*v2.Grant{
+				c.grantsBy[c.groups[0].GetId().GetResource()],
+				c.grantsBy[c.groups[1].GetId().GetResource()],
+				c.grantsBy[c.groups[2].GetId().GetResource()],
+			},
+		}.Build(), nil
+	case strings.HasPrefix(tok, "ts-"):
+		select {
+		case <-ctx.Done():
+			return nil, context.Cause(ctx)
+		case <-time.After(30 * time.Second):
+			return nil, fmt.Errorf("compat: blocked cursor %s was never cancelled", tok)
+		}
+	default:
+		return nil, fmt.Errorf("compat: unexpected type-scoped grants token %q", in.GetPageToken())
+	}
+}
+
+func (c *compatConnector) GetMetadata(
+	_ context.Context, _ *v2.ConnectorServiceGetMetadataRequest, _ ...grpc.CallOption,
+) (*v2.ConnectorServiceGetMetadataResponse, error) {
+	return v2.ConnectorServiceGetMetadataResponse_builder{
+		Metadata: v2.ConnectorMetadata_builder{DisplayName: "compat-harness"}.Build(),
+	}.Build(), nil
+}
+
+func (c *compatConnector) Validate(
+	_ context.Context, _ *v2.ConnectorServiceValidateRequest, _ ...grpc.CallOption,
+) (*v2.ConnectorServiceValidateResponse, error) {
+	return v2.ConnectorServiceValidateResponse_builder{}.Build(), nil
+}
+
+func (c *compatConnector) Cleanup(
+	_ context.Context, _ *v2.ConnectorServiceCleanupRequest, _ ...grpc.CallOption,
+) (*v2.ConnectorServiceCleanupResponse, error) {
+	return v2.ConnectorServiceCleanupResponse_builder{}.Build(), nil
+}
+
+func countList(ctx context.Context, store c1zstore.Store) (int, int, int, error) {
+	resources := 0
+	pageToken := ""
+	for {
+		resp, err := store.ListResources(ctx, v2.ResourcesServiceListResourcesRequest_builder{
+			PageToken: pageToken,
+		}.Build())
+		if err != nil {
+			return 0, 0, 0, fmt.Errorf("list resources: %w", err)
+		}
+		resources += len(resp.GetList())
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			break
+		}
+	}
+	ents := 0
+	pageToken = ""
+	for {
+		resp, err := store.ListEntitlements(ctx, v2.EntitlementsServiceListEntitlementsRequest_builder{
+			PageToken: pageToken,
+		}.Build())
+		if err != nil {
+			return 0, 0, 0, fmt.Errorf("list entitlements: %w", err)
+		}
+		ents += len(resp.GetList())
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			break
+		}
+	}
+	grants := 0
+	pageToken = ""
+	for {
+		resp, err := store.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{
+			PageToken: pageToken,
+		}.Build())
+		if err != nil {
+			return 0, 0, 0, fmt.Errorf("list grants: %w", err)
+		}
+		grants += len(resp.GetList())
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			break
+		}
+	}
+	return resources, ents, grants, nil
+}
+
+// syncRunLister is the store surface the run inspection needs; asserted
+// dynamically because the harness compiles against two SDK versions.
+type syncRunLister interface {
+	ListSyncRuns(ctx context.Context, pageToken string, pageSize uint32) ([]*c1zstore.SyncRun, string, error)
+}
+
+// inspectRuns records checkpoint evidence for the driver's meta-assertions:
+// a gen run must leave an UNFINISHED sync whose token actually carries the
+// adversarial state (spawned/type-scoped actions under the new binary) —
+// otherwise the exchange tests a conveniently quiet checkpoint and the
+// harness is vacuous for the bug class it exists for.
+func inspectRuns(ctx context.Context, store c1zstore.Store, result *compatResult) {
+	lister, ok := store.(syncRunLister)
+	if !ok {
+		return
+	}
+	runs, _, err := lister.ListSyncRuns(ctx, "", 100)
+	if err != nil {
+		return
+	}
+	for _, run := range runs {
+		if run.EndedAt != nil {
+			continue
+		}
+		result.UnfinishedRuns++
+		result.TokenLen += len(run.SyncToken)
+		if strings.Contains(run.SyncToken, "spawned") {
+			result.TokenSpawned = true
+		}
+		if strings.Contains(run.SyncToken, "type_scoped") {
+			result.TokenTypeScoped = true
+		}
+	}
+}
+
+func countRows(ctx context.Context, c1zPath, tmpDir string, result *compatResult) (int, int, int, error) {
+	store, err := dotc1z.NewStore(ctx, c1zPath, dotc1z.WithTmpDir(tmpDir))
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	defer func() { _ = store.Close(ctx) }()
+	inspectRuns(ctx, store, result)
+	return countList(ctx, store)
+}
+
+// compatResult is the machine-readable summary the driver parses from the
+// final COMPAT_RESULT stdout line.
+type compatResult struct {
+	Mode        string `json:"mode"`
+	SyncErr     string `json:"sync_err,omitempty"`
+	NotComplete bool   `json:"not_complete"`
+	Resources   int    `json:"resources"`
+	Ents        int    `json:"entitlements"`
+	Grants      int    `json:"grants"`
+	CountErr    string `json:"count_err,omitempty"`
+	// Checkpoint evidence (see inspectRuns).
+	UnfinishedRuns  int  `json:"unfinished_runs"`
+	TokenLen        int  `json:"token_len"`
+	TokenSpawned    bool `json:"token_spawned"`
+	TokenTypeScoped bool `json:"token_type_scoped"`
+}
+
+func run() error {
+	mode := flag.String("mode", "", "gen or resume")
+	c1zPath := flag.String("c1z", "", "path to c1z file")
+	runDuration := flag.Duration("run-duration", 2*time.Second, "gen-mode run duration")
+	flag.Parse()
+	if *mode == "" || *c1zPath == "" {
+		return fmt.Errorf("usage: -mode gen|resume -c1z path")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+	logger, err := zap.NewDevelopment()
+	if err != nil {
+		return err
+	}
+	ctx = ctxzap.ToContext(ctx, logger)
+
+	connector, err := newCompatConnector()
+	if err != nil {
+		return err
+	}
+	store, err := dotc1z.NewStore(ctx, *c1zPath, dotc1z.WithTmpDir(os.TempDir()))
+	if err != nil {
+		return fmt.Errorf("new store: %w", err)
+	}
+	opts := []sdksync.SyncOpt{
+		sdksync.WithConnectorStore(store),
+		sdksync.WithTmpDir(os.TempDir()),
+		sdksync.WithWorkerCount(2),
+	}
+	if *mode == "gen" {
+		connector.fanoutAndBlock = true
+		connector.slowPerResourceGrants = 400 * time.Millisecond
+		opts = append(opts, sdksync.WithRunDuration(*runDuration))
+	}
+
+	s, err := sdksync.NewSyncer(ctx, connector, opts...)
+	if err != nil {
+		return fmt.Errorf("new syncer: %w", err)
+	}
+	syncErr := s.Sync(ctx)
+	if closeErr := s.Close(ctx); closeErr != nil {
+		return fmt.Errorf("close: %w", closeErr)
+	}
+
+	result := compatResult{Mode: *mode}
+	if syncErr != nil {
+		result.SyncErr = syncErr.Error()
+		result.NotComplete = strings.Contains(syncErr.Error(), sdksync.ErrSyncNotComplete.Error())
+	}
+	var countErr error
+	result.Resources, result.Ents, result.Grants, countErr = countRows(ctx, *c1zPath, os.TempDir(), &result)
+	if countErr != nil {
+		result.CountErr = countErr.Error()
+	}
+	encoded, err := json.Marshal(result)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("COMPAT_RESULT %s\n", encoded)
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "FATAL: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/pkg/connectorbuilder/connectorbuilder.go
+++ b/pkg/connectorbuilder/connectorbuilder.go
@@ -202,6 +202,9 @@ func NewConnector(ctx context.Context, in interface{}, opts ...Opt) (types.Conne
 	if cb, ok := in.(ConnectorBuilder); ok {
 		for _, rb := range cb.ResourceSyncers(ctx) {
 			rType := rb.ResourceType(ctx)
+			if err := validateTypeScopedRegistration(rType, rb); err != nil {
+				return nil, err
+			}
 			if err := addResourceType(ctx, rType.GetId(), rb); err != nil {
 				return nil, err
 			}
@@ -212,6 +215,9 @@ func NewConnector(ctx context.Context, in interface{}, opts ...Opt) (types.Conne
 	if cb2, ok := in.(ConnectorBuilderV2); ok {
 		for _, rb := range cb2.ResourceSyncers(ctx) {
 			rType := rb.ResourceType(ctx)
+			if err := validateTypeScopedRegistration(rType, rb); err != nil {
+				return nil, err
+			}
 			if err := addResourceType(ctx, rType.GetId(), rb); err != nil {
 				return nil, err
 			}

--- a/pkg/connectorbuilder/resource_syncer.go
+++ b/pkg/connectorbuilder/resource_syncer.go
@@ -61,6 +61,14 @@ type ResourceSyncerV2Limited interface {
 	Grants(ctx context.Context, resource *v2.Resource, opts resource.SyncOpAttrs) ([]*v2.Grant, *resource.SyncOpResults, error)
 }
 
+type TypeScopedGrantsSyncer interface {
+	GrantsForResourceType(ctx context.Context, resourceTypeID string, opts resource.SyncOpAttrs) ([]*v2.Grant, *resource.SyncOpResults, error)
+}
+
+type TypeScopedEntitlementsSyncer interface {
+	EntitlementsForResourceType(ctx context.Context, resourceTypeID string, opts resource.SyncOpAttrs) ([]*v2.Entitlement, *resource.SyncOpResults, error)
+}
+
 type StaticEntitlementSyncerV2 interface {
 	StaticEntitlements(ctx context.Context, opts resource.SyncOpAttrs) ([]*v2.Entitlement, *resource.SyncOpResults, error)
 }
@@ -258,9 +266,15 @@ func (b *builder) ListEntitlements(ctx context.Context, request *v2.Entitlements
 
 	start := b.nowFunc()
 	tt := tasks.ListEntitlementsType
-	rb, ok := b.resourceSyncers[request.GetResource().GetId().GetResourceType()]
+	if request.GetResource() == nil {
+		err = status.Error(codes.InvalidArgument, "error: list entitlements requires a resource")
+		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
+		return nil, err
+	}
+	rid := request.GetResource().GetId()
+	rb, ok := b.resourceSyncers[rid.GetResourceType()]
 	if !ok {
-		err = status.Errorf(codes.NotFound, "error: list entitlements with unknown resource type %s", request.GetResource().GetId().GetResourceType())
+		err = status.Errorf(codes.NotFound, "error: list entitlements with unknown resource type %s", rid.GetResourceType())
 		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
 		return nil, err
 	}
@@ -270,7 +284,21 @@ func (b *builder) ListEntitlements(ctx context.Context, request *v2.Entitlements
 		Token: request.GetPageToken(),
 	}
 	opts := resource.SyncOpAttrs{SyncID: request.GetActiveSyncId(), PageToken: token, Session: WithSyncId(b.sessionStore, request.GetActiveSyncId())}
-	out, retOptions, err := rb.Entitlements(ctx, request.GetResource(), opts)
+	var out []*v2.Entitlement
+	var retOptions *resource.SyncOpResults
+	reqAnnos := annotations.Annotations(request.GetAnnotations())
+	if reqAnnos.Contains(&v2.TypeScopedEntitlements{}) {
+		ts, ok := rb.(TypeScopedEntitlementsSyncer)
+		if !ok {
+			err = status.Errorf(codes.InvalidArgument,
+				"error: type-scoped list entitlements for resource type %s, but its syncer does not implement TypeScopedEntitlementsSyncer", rid.GetResourceType())
+			b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
+			return nil, err
+		}
+		out, retOptions, err = ts.EntitlementsForResourceType(ctx, rid.GetResourceType(), opts)
+	} else {
+		out, retOptions, err = rb.Entitlements(ctx, request.GetResource(), opts)
+	}
 	if retOptions == nil {
 		retOptions = &resource.SyncOpResults{}
 	}
@@ -328,7 +356,21 @@ func (b *builder) ListGrants(ctx context.Context, request *v2.GrantsServiceListG
 		Token: request.GetPageToken(),
 	}
 	opts := resource.SyncOpAttrs{SyncID: request.GetActiveSyncId(), PageToken: token, Session: WithSyncId(b.sessionStore, request.GetActiveSyncId())}
-	out, retOptions, err := rb.Grants(ctx, request.GetResource(), opts)
+	var out []*v2.Grant
+	var retOptions *resource.SyncOpResults
+	reqAnnos := annotations.Annotations(request.GetAnnotations())
+	if reqAnnos.Contains(&v2.TypeScopedGrants{}) {
+		ts, ok := rb.(TypeScopedGrantsSyncer)
+		if !ok {
+			err = status.Errorf(codes.InvalidArgument,
+				"error: type-scoped list grants for resource type %s, but its syncer does not implement TypeScopedGrantsSyncer", rid.GetResourceType())
+			b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
+			return nil, err
+		}
+		out, retOptions, err = ts.GrantsForResourceType(ctx, rid.GetResourceType(), opts)
+	} else {
+		out, retOptions, err = rb.Grants(ctx, request.GetResource(), opts)
+	}
 	if retOptions == nil {
 		retOptions = &resource.SyncOpResults{}
 	}
@@ -356,7 +398,29 @@ func (b *builder) ListGrants(ctx context.Context, request *v2.GrantsServiceListG
 }
 
 func newResourceSyncerV1toV2(rb ResourceSyncer) ResourceSyncerV2 {
-	return &resourceSyncerV1toV2{rb: rb}
+	base := &resourceSyncerV1toV2{rb: rb}
+	tsg, hasTSG := rb.(TypeScopedGrantsSyncer)
+	tse, hasTSE := rb.(TypeScopedEntitlementsSyncer)
+	switch {
+	case hasTSG && hasTSE:
+		return &struct {
+			*resourceSyncerV1toV2
+			TypeScopedGrantsSyncer
+			TypeScopedEntitlementsSyncer
+		}{base, tsg, tse}
+	case hasTSG:
+		return &struct {
+			*resourceSyncerV1toV2
+			TypeScopedGrantsSyncer
+		}{base, tsg}
+	case hasTSE:
+		return &struct {
+			*resourceSyncerV1toV2
+			TypeScopedEntitlementsSyncer
+		}{base, tse}
+	default:
+		return base
+	}
 }
 
 type resourceSyncerV1toV2 struct {
@@ -397,6 +461,25 @@ func (rw *resourceSyncerV1toV2) Grants(ctx context.Context, r *v2.Resource, opts
 	grants, pageToken, annos, err := rw.rb.Grants(ctx, r, &opts.PageToken)
 	ret := &resource.SyncOpResults{NextPageToken: pageToken, Annotations: annos}
 	return grants, ret, err
+}
+
+func validateTypeScopedRegistration(rType *v2.ResourceType, in any) error {
+	rtAnnos := annotations.Annotations(rType.GetAnnotations())
+	if rtAnnos.Contains(&v2.TypeScopedGrants{}) {
+		if _, ok := in.(TypeScopedGrantsSyncer); !ok {
+			return fmt.Errorf(
+				"resource type %s carries the TypeScopedGrants annotation but its syncer does not implement TypeScopedGrantsSyncer",
+				rType.GetId())
+		}
+	}
+	if rtAnnos.Contains(&v2.TypeScopedEntitlements{}) {
+		if _, ok := in.(TypeScopedEntitlementsSyncer); !ok {
+			return fmt.Errorf(
+				"resource type %s carries the TypeScopedEntitlements annotation but its syncer does not implement TypeScopedEntitlementsSyncer",
+				rType.GetId())
+		}
+	}
+	return nil
 }
 
 func (b *builder) addTargetedSyncer(_ context.Context, typeId string, in any) error {

--- a/pkg/connectorbuilder/type_scoped_test.go
+++ b/pkg/connectorbuilder/type_scoped_test.go
@@ -1,0 +1,250 @@
+package connectorbuilder
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/pagination"
+	"github.com/conductorone/baton-sdk/pkg/types/resource"
+)
+
+type testTypeScopedSyncer struct {
+	testResourceSyncerV2Simple
+	entitlementCalls         int
+	grantCalls               int
+	ordinaryEntitlementCalls int
+	ordinaryGrantCalls       int
+	lastEntitlementType      string
+	lastGrantType            string
+	lastEntitlementOpts      resource.SyncOpAttrs
+	lastGrantOpts            resource.SyncOpAttrs
+}
+
+func (s *testTypeScopedSyncer) Entitlements(ctx context.Context, r *v2.Resource, opts resource.SyncOpAttrs) ([]*v2.Entitlement, *resource.SyncOpResults, error) {
+	s.ordinaryEntitlementCalls++
+	return s.testResourceSyncerV2Simple.Entitlements(ctx, r, opts)
+}
+
+func (s *testTypeScopedSyncer) Grants(ctx context.Context, r *v2.Resource, opts resource.SyncOpAttrs) ([]*v2.Grant, *resource.SyncOpResults, error) {
+	s.ordinaryGrantCalls++
+	return s.testResourceSyncerV2Simple.Grants(ctx, r, opts)
+}
+
+func (s *testTypeScopedSyncer) EntitlementsForResourceType(_ context.Context, resourceTypeID string, opts resource.SyncOpAttrs) ([]*v2.Entitlement, *resource.SyncOpResults, error) {
+	s.entitlementCalls++
+	s.lastEntitlementType = resourceTypeID
+	s.lastEntitlementOpts = opts
+	return []*v2.Entitlement{v2.Entitlement_builder{Id: "type-entitlement"}.Build()}, &resource.SyncOpResults{
+		NextPageToken: "ent-next",
+		Annotations:   annotations.New(v2.EnqueuePageTokens_builder{PageTokens: []string{"ent-sibling"}}.Build()),
+	}, nil
+}
+
+func (s *testTypeScopedSyncer) GrantsForResourceType(_ context.Context, resourceTypeID string, opts resource.SyncOpAttrs) ([]*v2.Grant, *resource.SyncOpResults, error) {
+	s.grantCalls++
+	s.lastGrantType = resourceTypeID
+	s.lastGrantOpts = opts
+	return []*v2.Grant{v2.Grant_builder{Id: "type-grant"}.Build()}, &resource.SyncOpResults{
+		NextPageToken: "grant-next",
+		Annotations:   annotations.New(v2.EnqueuePageTokens_builder{PageTokens: []string{"grant-sibling"}}.Build()),
+	}, nil
+}
+
+func typeScopedResource(resourceTypeID string) *v2.Resource {
+	return v2.Resource_builder{
+		Id: v2.ResourceId_builder{ResourceType: resourceTypeID, Resource: resourceTypeID}.Build(),
+	}.Build()
+}
+
+func TestTypeScopedRequestsRouteToOptionalInterfaces(t *testing.T) {
+	ctx := context.Background()
+	s := &testTypeScopedSyncer{testResourceSyncerV2Simple: testResourceSyncerV2Simple{resourceType: "group"}}
+	conn, err := NewConnector(ctx, &testConnectorV2{resourceSyncers: []ResourceSyncerV2{s}})
+	require.NoError(t, err)
+
+	entResp, err := conn.ListEntitlements(ctx, v2.EntitlementsServiceListEntitlementsRequest_builder{
+		Resource:     typeScopedResource("group"),
+		Annotations:  annotations.New(&v2.TypeScopedEntitlements{}),
+		ActiveSyncId: "sync-1",
+		PageToken:    "ent-page",
+	}.Build())
+	require.NoError(t, err)
+	require.Len(t, entResp.GetList(), 1)
+	require.Equal(t, 1, s.entitlementCalls)
+	require.Equal(t, "group", s.lastEntitlementType)
+	require.Equal(t, "sync-1", s.lastEntitlementOpts.SyncID)
+	require.Equal(t, "ent-page", s.lastEntitlementOpts.PageToken.Token)
+	require.Equal(t, "ent-next", entResp.GetNextPageToken())
+	entRespAnnos := annotations.Annotations(entResp.GetAnnotations())
+	require.True(t, entRespAnnos.Contains(&v2.EnqueuePageTokens{}))
+
+	grantResp, err := conn.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{
+		Resource:     typeScopedResource("group"),
+		Annotations:  annotations.New(&v2.TypeScopedGrants{}),
+		ActiveSyncId: "sync-1",
+		PageToken:    "grant-page",
+	}.Build())
+	require.NoError(t, err)
+	require.Len(t, grantResp.GetList(), 1)
+	require.Equal(t, 1, s.grantCalls)
+	require.Equal(t, "group", s.lastGrantType)
+	require.Equal(t, "sync-1", s.lastGrantOpts.SyncID)
+	require.Equal(t, "grant-page", s.lastGrantOpts.PageToken.Token)
+	require.Equal(t, "grant-next", grantResp.GetNextPageToken())
+	grantRespAnnos := annotations.Annotations(grantResp.GetAnnotations())
+	require.True(t, grantRespAnnos.Contains(&v2.EnqueuePageTokens{}))
+	require.Zero(t, s.ordinaryEntitlementCalls)
+	require.Zero(t, s.ordinaryGrantCalls)
+}
+
+type annotatedWithoutTypeScopedInterface struct {
+	testResourceSyncerV2Simple
+	annotation annotations.Annotations
+}
+
+func (s *annotatedWithoutTypeScopedInterface) ResourceType(context.Context) *v2.ResourceType {
+	return v2.ResourceType_builder{
+		Id:          "group",
+		DisplayName: "Group",
+		Annotations: s.annotation,
+	}.Build()
+}
+
+func TestTypeScopedAnnotationRequiresMatchingInterface(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		annotation annotations.Annotations
+		want       string
+	}{
+		{"grants", annotations.New(&v2.TypeScopedGrants{}), "does not implement TypeScopedGrantsSyncer"},
+		{"entitlements", annotations.New(&v2.TypeScopedEntitlements{}), "does not implement TypeScopedEntitlementsSyncer"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &annotatedWithoutTypeScopedInterface{
+				testResourceSyncerV2Simple: testResourceSyncerV2Simple{resourceType: "group"},
+				annotation:                 tc.annotation,
+			}
+			_, err := NewConnector(context.Background(), &testConnectorV2{resourceSyncers: []ResourceSyncerV2{s}})
+			require.ErrorContains(t, err, tc.want)
+		})
+	}
+}
+
+func TestTypeScopedMarkerRequiresMatchingInterfaceAtRuntime(t *testing.T) {
+	ctx := context.Background()
+	s := &testResourceSyncerV2Simple{resourceType: "group"}
+	conn, err := NewConnector(ctx, &testConnectorV2{resourceSyncers: []ResourceSyncerV2{s}})
+	require.NoError(t, err)
+
+	_, err = conn.ListEntitlements(ctx, v2.EntitlementsServiceListEntitlementsRequest_builder{
+		Resource:    typeScopedResource("group"),
+		Annotations: annotations.New(&v2.TypeScopedEntitlements{}),
+	}.Build())
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+
+	_, err = conn.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{
+		Resource:    typeScopedResource("group"),
+		Annotations: annotations.New(&v2.TypeScopedGrants{}),
+	}.Build())
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+func TestTypeScopedInterfacesDoNotChangeUnmarkedRouting(t *testing.T) {
+	ctx := context.Background()
+	s := &testTypeScopedSyncer{testResourceSyncerV2Simple: testResourceSyncerV2Simple{resourceType: "group"}}
+	conn, err := NewConnector(ctx, &testConnectorV2{resourceSyncers: []ResourceSyncerV2{s}})
+	require.NoError(t, err)
+
+	_, err = conn.ListEntitlements(ctx, v2.EntitlementsServiceListEntitlementsRequest_builder{
+		Resource: typeScopedResource("group"),
+	}.Build())
+	require.NoError(t, err)
+	_, err = conn.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{
+		Resource: typeScopedResource("group"),
+	}.Build())
+	require.NoError(t, err)
+
+	require.Equal(t, 1, s.ordinaryEntitlementCalls)
+	require.Equal(t, 1, s.ordinaryGrantCalls)
+	require.Zero(t, s.entitlementCalls)
+	require.Zero(t, s.grantCalls)
+}
+
+func TestListEntitlementsRejectsNilResource(t *testing.T) {
+	ctx := context.Background()
+	s := &testResourceSyncerV2Simple{resourceType: "group"}
+	conn, err := NewConnector(ctx, &testConnectorV2{resourceSyncers: []ResourceSyncerV2{s}})
+	require.NoError(t, err)
+
+	_, err = conn.ListEntitlements(ctx, v2.EntitlementsServiceListEntitlementsRequest_builder{}.Build())
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+type typeScopedV1Syncer struct {
+	grantCalls int
+	entCalls   int
+}
+
+func (s *typeScopedV1Syncer) ResourceType(context.Context) *v2.ResourceType {
+	return v2.ResourceType_builder{
+		Id:          "group",
+		DisplayName: "Group",
+		Annotations: annotations.New(&v2.TypeScopedGrants{}, &v2.TypeScopedEntitlements{}),
+	}.Build()
+}
+
+func (s *typeScopedV1Syncer) List(context.Context, *v2.ResourceId, *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+	return nil, "", nil, nil
+}
+
+func (s *typeScopedV1Syncer) Entitlements(context.Context, *v2.Resource, *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
+	return nil, "", nil, nil
+}
+
+func (s *typeScopedV1Syncer) Grants(context.Context, *v2.Resource, *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
+	return nil, "", nil, nil
+}
+
+func (s *typeScopedV1Syncer) GrantsForResourceType(_ context.Context, resourceTypeID string, _ resource.SyncOpAttrs) ([]*v2.Grant, *resource.SyncOpResults, error) {
+	s.grantCalls++
+	return []*v2.Grant{v2.Grant_builder{Id: "type-grant"}.Build()}, &resource.SyncOpResults{}, nil
+}
+
+func (s *typeScopedV1Syncer) EntitlementsForResourceType(_ context.Context, resourceTypeID string, _ resource.SyncOpAttrs) ([]*v2.Entitlement, *resource.SyncOpResults, error) {
+	s.entCalls++
+	return []*v2.Entitlement{v2.Entitlement_builder{Id: "type-entitlement"}.Build()}, &resource.SyncOpResults{}, nil
+}
+
+func TestTypeScopedV1AdapterForwardsOptionalInterfaces(t *testing.T) {
+	ctx := context.Background()
+	s := &typeScopedV1Syncer{}
+	conn, err := NewConnector(ctx, newTestConnector([]ResourceSyncer{s}))
+	require.NoError(t, err)
+
+	_, err = conn.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{
+		Resource:    typeScopedResource("group"),
+		Annotations: annotations.New(&v2.TypeScopedGrants{}),
+	}.Build())
+	require.NoError(t, err)
+	_, err = conn.ListEntitlements(ctx, v2.EntitlementsServiceListEntitlementsRequest_builder{
+		Resource:    typeScopedResource("group"),
+		Annotations: annotations.New(&v2.TypeScopedEntitlements{}),
+	}.Build())
+	require.NoError(t, err)
+	require.Equal(t, 1, s.grantCalls)
+	require.Equal(t, 1, s.entCalls)
+}
+
+func TestTypeScopedV1AdapterDoesNotOverclaim(t *testing.T) {
+	adapted := newResourceSyncerV1toV2(newTestResourceSyncer("group"))
+	_, grants := adapted.(TypeScopedGrantsSyncer)
+	_, entitlements := adapted.(TypeScopedEntitlementsSyncer)
+	require.False(t, grants)
+	require.False(t, entitlements)
+}

--- a/pkg/dotc1z/assets.go
+++ b/pkg/dotc1z/assets.go
@@ -104,7 +104,7 @@ func (c *C1File) PutAsset(ctx context.Context, assetRef *v2.AssetRef, contentTyp
 		return err
 	}
 
-	c.dbUpdated = true
+	c.dbUpdated.Store(true)
 
 	return nil
 }

--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/doug-martin/goqu/v9"
@@ -49,7 +50,7 @@ type C1File struct {
 	viewSyncID         string
 	outputFilePath     string
 	dbFilePath         string
-	dbUpdated          bool
+	dbUpdated          atomic.Bool
 	tempDir            string
 	pragmas            []pragma
 	readOnly           bool
@@ -627,7 +628,7 @@ func (c *C1File) Close(ctx context.Context) (retErr error) {
 
 	span.SetAttributes(
 		attribute.Bool("read_only", c.readOnly),
-		attribute.Bool("db_updated", c.dbUpdated),
+		attribute.Bool("db_updated", c.dbUpdated.Load()),
 		attribute.String("db_path", c.dbFilePath),
 	)
 
@@ -638,13 +639,13 @@ func (c *C1File) Close(ctx context.Context) (retErr error) {
 	// open) before returning so a misuse like opening read-only and
 	// then dirtying via an attached-db mutation still releases the
 	// SQLite handle and any FDs/goroutines it owns.
-	if !c.dbUpdated || c.readOnly {
+	if !c.dbUpdated.Load() || c.readOnly {
 		if c.rawDb != nil {
 			if err := c.closeRawDB(ctx); err != nil {
 				return cleanupDbDir(c.dbFilePath, err)
 			}
 		}
-		if c.dbUpdated && c.readOnly {
+		if c.dbUpdated.Load() && c.readOnly {
 			c.closed = true
 			return cleanupDbDir(c.dbFilePath, ErrReadOnly)
 		}
@@ -1363,7 +1364,7 @@ func (c *C1File) stats(ctx context.Context, syncType connectorstore.SyncType, sy
 		if err != nil {
 			return nil, nil, fmt.Errorf("c1file-stats: error saving stats: %w", err)
 		}
-		c.dbUpdated = true
+		c.dbUpdated.Store(true)
 	}
 
 	return &reader_v2.SyncRun{

--- a/pkg/dotc1z/c1file_attached.go
+++ b/pkg/dotc1z/c1file_attached.go
@@ -346,7 +346,7 @@ func (c *C1FileAttached) GenerateSyncDiffFromFile(ctx context.Context, oldSyncID
 		return "", "", fmt.Errorf("failed to commit transaction: %w", err)
 	}
 	committed = true
-	c.file.dbUpdated = true
+	c.file.dbUpdated.Store(true)
 
 	return upsertsSyncID, deletionsSyncID, nil
 }

--- a/pkg/dotc1z/c1file_close_cancel_test.go
+++ b/pkg/dotc1z/c1file_close_cancel_test.go
@@ -138,7 +138,7 @@ func TestC1FileCloseReadOnlyButDirtyClosesRawDb(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, f2.rawDb)
 	// Force the readonly+dbUpdated cheap-path branch.
-	f2.dbUpdated = true
+	f2.dbUpdated.Store(true)
 
 	err = f2.Close(openCtx)
 	require.ErrorIs(t, err, ErrReadOnly)

--- a/pkg/dotc1z/clone_sync.go
+++ b/pkg/dotc1z/clone_sync.go
@@ -357,7 +357,7 @@ func (c *C1File) cloneCopy(ctx context.Context, outPath string, syncID string, s
 	if err != nil {
 		return err
 	}
-	outFile.dbUpdated = true
+	outFile.dbUpdated.Store(true)
 	outFile.outputFilePath = outPath
 	err = outFile.Close(ctx)
 	if err != nil {

--- a/pkg/dotc1z/copy_isolate_sync.go
+++ b/pkg/dotc1z/copy_isolate_sync.go
@@ -233,7 +233,7 @@ func (c *C1File) CopyIsolateSync(ctx context.Context, outPath string, syncID str
 	// Step 4 — recompress the isolated copy to outPath. Mirrors cloneCopy's
 	// finalize: dbUpdated + outputFilePath + Close() runs the
 	// WAL-checkpoint -> close-raw-db -> saveC1z sequence.
-	copyFile.dbUpdated = true
+	copyFile.dbUpdated.Store(true)
 	copyFile.outputFilePath = outPath
 	finalized = true
 	if err = copyFile.Close(ctx); err != nil {

--- a/pkg/dotc1z/diff.go
+++ b/pkg/dotc1z/diff.go
@@ -55,7 +55,7 @@ func (c *C1File) GenerateSyncDiff(ctx context.Context, baseSyncID string, applie
 		if err != nil {
 			return "", err
 		}
-		c.dbUpdated = true
+		c.dbUpdated.Store(true)
 	}
 
 	if err := c.endSyncRun(ctx, diffSyncID); err != nil {

--- a/pkg/dotc1z/entitlements.go
+++ b/pkg/dotc1z/entitlements.go
@@ -127,6 +127,6 @@ func (c *C1File) putEntitlementsInternal(ctx context.Context, f entitlementPutFu
 	if err != nil {
 		return err
 	}
-	c.dbUpdated = true
+	c.dbUpdated.Store(true)
 	return nil
 }

--- a/pkg/dotc1z/grants.go
+++ b/pkg/dotc1z/grants.go
@@ -514,7 +514,7 @@ func (c *C1File) upsertGrants(ctx context.Context, opts grantUpsertOptions, bulk
 		return err
 	}
 
-	c.dbUpdated = true
+	c.dbUpdated.Store(true)
 	return nil
 }
 

--- a/pkg/dotc1z/resouce_types.go
+++ b/pkg/dotc1z/resouce_types.go
@@ -115,6 +115,6 @@ func (c *C1File) putResourceTypesInternal(ctx context.Context, f resourceTypePut
 	if err != nil {
 		return err
 	}
-	c.dbUpdated = true
+	c.dbUpdated.Store(true)
 	return nil
 }

--- a/pkg/dotc1z/resources.go
+++ b/pkg/dotc1z/resources.go
@@ -131,6 +131,6 @@ func (c *C1File) putResourcesInternal(ctx context.Context, f resourcePutFunc, re
 	if err != nil {
 		return err
 	}
-	c.dbUpdated = true
+	c.dbUpdated.Store(true)
 	return nil
 }

--- a/pkg/dotc1z/rollback_expansion.go
+++ b/pkg/dotc1z/rollback_expansion.go
@@ -231,7 +231,7 @@ func (c *C1File) RollbackExpansion(ctx context.Context, syncID string, dryRun bo
 		return nil, err
 	}
 
-	c.dbUpdated = true
+	c.dbUpdated.Store(true)
 	// The cached view sync run carries the now-stale stats; drop it so the
 	// next Stats()/GetSync recomputes against the rolled-back rows.
 	c.invalidateCachedViewSyncRun()

--- a/pkg/dotc1z/sync_runs.go
+++ b/pkg/dotc1z/sync_runs.go
@@ -608,7 +608,7 @@ func (c *C1File) CheckpointSync(ctx context.Context, syncToken string) error {
 		return err
 	}
 
-	c.dbUpdated = true
+	c.dbUpdated.Store(true)
 
 	return nil
 }
@@ -797,7 +797,7 @@ func (c *C1File) insertSyncRunWithLink(ctx context.Context, syncID string, syncT
 	if err != nil {
 		return err
 	}
-	c.dbUpdated = true
+	c.dbUpdated.Store(true)
 	return nil
 }
 
@@ -852,7 +852,7 @@ func (c *C1File) endSyncRun(ctx context.Context, syncID string) error {
 	if err != nil {
 		return err
 	}
-	c.dbUpdated = true
+	c.dbUpdated.Store(true)
 
 	// Run stats to generate and save the cached stats.
 	_, _, statsErr := c.stats(ctx, connectorstore.SyncTypeAny, syncID, true)
@@ -893,7 +893,7 @@ func (c *C1File) SetSupportsDiff(ctx context.Context, syncID string) error {
 	if err != nil {
 		return err
 	}
-	c.dbUpdated = true
+	c.dbUpdated.Store(true)
 
 	return nil
 }
@@ -1016,7 +1016,7 @@ func (c *C1File) SetSyncLink(ctx context.Context, syncID string, linkedSyncID st
 	if err != nil {
 		return err
 	}
-	c.dbUpdated = true
+	c.dbUpdated.Store(true)
 
 	return nil
 }
@@ -1106,7 +1106,7 @@ func (c *C1File) Cleanup(ctx context.Context) error {
 		l.Debug("vacuum complete")
 	}
 
-	c.dbUpdated = true
+	c.dbUpdated.Store(true)
 
 	// If DB is open in WAL mode, truncate the WAL.
 	var journalMode string
@@ -1201,7 +1201,7 @@ func (c *C1File) DeleteSyncRun(ctx context.Context, syncID string) error {
 	deleted += rowsDeleted
 
 	l.Debug("deleted sync run", zap.String("sync_id", syncID), zap.Int64("rows", deleted))
-	c.dbUpdated = true
+	c.dbUpdated.Store(true)
 
 	return nil
 }
@@ -1239,7 +1239,7 @@ func (c *C1File) Vacuum(ctx context.Context) error {
 		}
 	}
 
-	c.dbUpdated = true
+	c.dbUpdated.Store(true)
 
 	return nil
 }

--- a/pkg/dotc1z/sync_runs.go
+++ b/pkg/dotc1z/sync_runs.go
@@ -945,7 +945,7 @@ func (c *C1File) markIngestInvariantsVerified(
 		return status.Errorf(codes.FailedPrecondition,
 			"mark ingest invariants verified: sync %s not found or not finished", syncID)
 	}
-	c.dbUpdated = true
+	c.dbUpdated.Store(true)
 	c.invalidateCachedViewSyncRun()
 	return nil
 }
@@ -979,7 +979,7 @@ func (c *C1File) clearIngestInvariantVerification(ctx context.Context, syncID st
 	if rows == 0 {
 		return c1zstore.AdaptNotFound(sql.ErrNoRows)
 	}
-	c.dbUpdated = true
+	c.dbUpdated.Store(true)
 	c.invalidateCachedViewSyncRun()
 	return nil
 }

--- a/pkg/sync/checkpoint_cost_bench_test.go
+++ b/pkg/sync/checkpoint_cost_bench_test.go
@@ -1,0 +1,122 @@
+package sync //nolint:revive,nolintlint // we can't change the package name for backwards compatibility
+
+// Cost contract for the per-checkpoint loop under spawned-cursor fan-out
+// (docs/BUG_CATCHING.md §2 "cost contracts": the per-checkpoint loop is a
+// declared hot path — performance there is a correctness property, and the
+// reviewable object is the cost CURVE, stated and benchmarked, not "fine at
+// fixture scale").
+//
+// What this branch added to that loop, and the curves these benchmarks pin:
+//
+//   - Every in-flight spawned cursor is an Action in state.actions, and
+//     Marshal re-serializes the whole map on EVERY checkpoint (default
+//     every ~10s for the sync's lifetime). Cost is O(width) in time and
+//     token bytes, where width is bounded only by maxSpawnedCursorsPerBatch
+//     (100k) — and each cursor's page token may itself be up to ~1 MiB, so
+//     the constant is connector-controlled. The benchmark reports
+//     token-bytes alongside ns/op so a regression in either is visible.
+//   - Marshal also version-stamps by scanning every action for
+//     type-scoped/spawned markers: a second O(width) pass that exists only
+//     on this branch. It is measured by the same benchmark.
+//   - Each admission permanently retains a spawnedAdmitted entry (32-byte
+//     identity digest + action-ID string) for the process lifetime BY
+//     DESIGN (re-mention termination guard; see state.go). Admission cost,
+//     including that never-pruned entry, is pinned per-op below.
+//
+// Ratchet these against main when touching the checkpoint loop, state
+// serialization, or the scheduler's admission path:
+//
+//	go test ./pkg/sync/ -run '^$' -bench BenchmarkCheckpoint -benchmem
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+// buildFanoutState models the checkpoint-visible state of a sync holding
+// `width` in-flight spawned type-scoped cursors (the worst case the batch
+// cap admits), plus the parent action that spawned them.
+func buildFanoutState(b *testing.B, width int) *state {
+	b.Helper()
+	ctx := context.Background()
+	st := newState()
+	st.pushAction(ctx, Action{Op: SyncGrantsOp, ResourceTypeID: "group", TypeScoped: true})
+	for i := 0; i < width; i++ {
+		st.pushAction(ctx, Action{
+			Op:             SyncGrantsOp,
+			ResourceTypeID: "group",
+			PageToken:      fmt.Sprintf("spawned-cursor-page-token-%08d", i),
+			Spawned:        true,
+			TypeScoped:     true,
+		})
+	}
+	return st
+}
+
+var checkpointFanoutWidths = []int{100, 1_000, 10_000, maxSpawnedCursorsPerBatch}
+
+// BenchmarkCheckpointTokenMarshalFanout is the per-checkpoint serialization
+// cost at fan-out width: O(width) time and token bytes, paid every ~10s.
+func BenchmarkCheckpointTokenMarshalFanout(b *testing.B) {
+	for _, width := range checkpointFanoutWidths {
+		b.Run(fmt.Sprintf("width-%d", width), func(b *testing.B) {
+			st := buildFanoutState(b, width)
+			token, err := st.Marshal()
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.ReportMetric(float64(len(token)), "token-bytes")
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := st.Marshal(); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkCheckpointTokenUnmarshalFanout is the resume-side cost of the
+// same token: parse plus the spawnedInFlight/spawnedAdmitted evidence
+// rebuild, paid once per process start.
+func BenchmarkCheckpointTokenUnmarshalFanout(b *testing.B) {
+	for _, width := range checkpointFanoutWidths {
+		b.Run(fmt.Sprintf("width-%d", width), func(b *testing.B) {
+			token, err := buildFanoutState(b, width).Marshal()
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if err := newState().Unmarshal(token); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkSpawnedCursorAdmission is the steady-state cost of admitting and
+// draining one spawned cursor, INCLUDING the process-lifetime spawnedAdmitted
+// entry the drain deliberately does not free: B/op here is the memory the
+// process permanently retains per admission (the map grows monotonically
+// across the loop, so amortized growth is in the number).
+func BenchmarkSpawnedCursorAdmission(b *testing.B) {
+	ctx := context.Background()
+	st := newState()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		admitted := st.pushAction(ctx, Action{
+			Op:             SyncGrantsOp,
+			ResourceTypeID: "group",
+			PageToken:      fmt.Sprintf("admission-cursor-%012d", i),
+			Spawned:        true,
+			TypeScoped:     true,
+		})
+		st.FinishAction(ctx, admitted)
+	}
+}

--- a/pkg/sync/checkpoint_cut_test.go
+++ b/pkg/sync/checkpoint_cut_test.go
@@ -1,0 +1,558 @@
+package sync //nolint:revive,nolintlint // backwards-compatible package name
+
+// Checkpoint-cut enumeration harness (Option B of the verification plan).
+//
+// The crash-cut contract — from ANY durable checkpoint plus whatever store
+// state exists, a cold resume completes to exactly the right sealed store —
+// was previously tested at a handful of hand-picked cut points. This
+// harness mechanizes the sweep over a stated space:
+//
+//   - CHECKPOINT cuts: the sync is killed immediately after its Nth durable
+//     checkpoint, for every N the sync produces (checkpointInterval is
+//     zeroed so every loop-top checkpoint commits — each one is a cut
+//     point). These are quiet-point crashes: token and store agree.
+//   - RESPONSE cuts: the sync is killed right after the Mth connector
+//     response, for every M — mid-batch, workers in flight, store writes
+//     landed PAST the last checkpointed token. These are the adversarial
+//     crashes: the resumer must tolerate a store ahead of its token and
+//     redo in-flight fan-out work exactly once.
+//
+// Each cut is followed by a cold resume (fresh store handle, fresh syncer —
+// the distributed-execution assumption) under a DIFFERENT worker count than
+// the generator, and every third cut gets a double-cut: the first resume is
+// itself killed at its first checkpoint before a second resume completes,
+// exercising the restored-state re-checkpoint path. The oracle is derived
+// ground truth: the topology makes the exact entitlement/grant sets
+// computable, so any lost, duplicated, or misrouted cursor is a set
+// mismatch. Every attempt also runs the queue-contract audit
+// (verifyQueueAudit).
+//
+// The default sweep is strided to cap runtime; BATON_CUT_SWEEP=full covers
+// every cut point.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	native_sync "sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
+	et "github.com/conductorone/baton-sdk/pkg/types/entitlement"
+	gt "github.com/conductorone/baton-sdk/pkg/types/grant"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+)
+
+// errInjectedCut is the cancellation cause for a simulated crash; the
+// harness accepts a failed sync only when this cause is present, so a
+// genuine bug error cannot masquerade as a cut.
+var errInjectedCut = errors.New("checkpoint-cut: injected crash")
+
+// errInjectedExpiry simulates a run-duration expiry: it wraps
+// context.DeadlineExceeded so the syncer takes the REAL expiry path —
+// which force-writes a checkpoint mid-batch. Those tokens carry spawned
+// in-flight actions, the state shape hard cuts never persist (their last
+// durable token predates the batch), and historically the shape resume
+// bugs hid in.
+var errInjectedExpiry = fmt.Errorf("checkpoint-cut: injected expiry: %w", context.DeadlineExceeded)
+
+// cutConnector wraps the deterministic soak connector, counting successful
+// list responses and simulating a crash (context cancellation) right after
+// the configured one — mid-batch, with in-flight workers and store writes
+// ahead of the last checkpoint.
+type cutConnector struct {
+	*soakConnector
+	mu              native_sync.Mutex
+	responses       int
+	grantsResponses int
+	cutAfter        int
+	// cutAfterGrants triggers on the Nth type-scoped ListGrants response
+	// only — pinning the cut inside the grants phase, the one phase where
+	// a topology change across resume cannot manufacture a referential
+	// violation (entitlements are complete before grants start).
+	cutAfterGrants int
+	cut            bool
+	cutCause       error
+	cancel         context.CancelCauseFunc
+}
+
+func (c *cutConnector) observe(grants bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.responses++
+	if grants {
+		c.grantsResponses++
+	}
+	hit := (c.cutAfter > 0 && c.responses == c.cutAfter) ||
+		(c.cutAfterGrants > 0 && grants && c.grantsResponses == c.cutAfterGrants)
+	if hit && c.cancel != nil {
+		c.cut = true
+		c.cancel(c.cutCause)
+	}
+}
+
+// stall blocks a call issued after the cut fired until the attempt context
+// dies, then fails it — a crashed process's in-flight calls never return.
+// This keeps sibling workers in flight at the moment of the crash, so the
+// expiry path's forced checkpoint captures a mid-batch stack (spawned
+// cursors unfinished) instead of a conveniently drained one.
+func (c *cutConnector) stall(ctx context.Context) error {
+	c.mu.Lock()
+	cut := c.cut
+	c.mu.Unlock()
+	if !cut {
+		return nil
+	}
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (c *cutConnector) responseCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.responses
+}
+
+func (c *cutConnector) grantsResponseCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.grantsResponses
+}
+
+func (c *cutConnector) ListResourceTypes(
+	ctx context.Context,
+	in *v2.ResourceTypesServiceListResourceTypesRequest,
+	opts ...grpc.CallOption,
+) (*v2.ResourceTypesServiceListResourceTypesResponse, error) {
+	if err := c.stall(ctx); err != nil {
+		return nil, err
+	}
+	resp, err := c.soakConnector.ListResourceTypes(ctx, in, opts...)
+	if err == nil {
+		c.observe(false)
+	}
+	return resp, err
+}
+
+func (c *cutConnector) ListResources(
+	ctx context.Context,
+	in *v2.ResourcesServiceListResourcesRequest,
+	opts ...grpc.CallOption,
+) (*v2.ResourcesServiceListResourcesResponse, error) {
+	if err := c.stall(ctx); err != nil {
+		return nil, err
+	}
+	resp, err := c.soakConnector.ListResources(ctx, in, opts...)
+	if err == nil {
+		c.observe(false)
+	}
+	return resp, err
+}
+
+func (c *cutConnector) ListEntitlements(
+	ctx context.Context,
+	in *v2.EntitlementsServiceListEntitlementsRequest,
+	opts ...grpc.CallOption,
+) (*v2.EntitlementsServiceListEntitlementsResponse, error) {
+	if err := c.stall(ctx); err != nil {
+		return nil, err
+	}
+	resp, err := c.soakConnector.ListEntitlements(ctx, in, opts...)
+	if err == nil {
+		c.observe(false)
+	}
+	return resp, err
+}
+
+func (c *cutConnector) ListGrants(
+	ctx context.Context,
+	in *v2.GrantsServiceListGrantsRequest,
+	opts ...grpc.CallOption,
+) (*v2.GrantsServiceListGrantsResponse, error) {
+	if err := c.stall(ctx); err != nil {
+		return nil, err
+	}
+	resp, err := c.soakConnector.ListGrants(ctx, in, opts...)
+	if err == nil {
+		reqAnnos := annotations.Annotations(in.GetAnnotations())
+		c.observe(reqAnnos.Contains(&v2.TypeScopedGrants{}))
+	}
+	return resp, err
+}
+
+// buildTopoFixture builds a deterministic connector serving the given
+// type topologies (no failure injection), plus the exact expected
+// entitlement-ID set and the principal user ID — the derived oracle.
+func buildTopoFixture(t *testing.T, topos map[string]*soakTypeTopology) (*soakConnector, map[string]struct{}, string) {
+	t.Helper()
+
+	userType := v2.ResourceType_builder{
+		Id:          "user",
+		DisplayName: "User",
+		Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_USER},
+		Annotations: annotations.New(&v2.SkipEntitlementsAndGrants{}),
+	}.Build()
+	user, err := rs.NewUserResource("user-1", userType, "User 1", nil)
+	require.NoError(t, err)
+
+	connector := &soakConnector{
+		mockConnector: newMockConnector(),
+		topos:         make(map[string]*soakTypeTopology),
+		entsByToken:   make(map[string]map[string]*v2.Entitlement),
+		grantsByTok:   make(map[string]map[string]*v2.Grant),
+		failedOnce:    make(map[string]struct{}),
+	}
+	connector.rtDB = append(connector.rtDB, userType)
+	connector.resourceDB["user"] = append(connector.resourceDB["user"], user)
+
+	expectedEntIDs := make(map[string]struct{})
+	for typeID, topo := range topos {
+		groupType := v2.ResourceType_builder{
+			Id:          typeID,
+			DisplayName: typeID,
+			Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_GROUP},
+			Annotations: annotations.New(&v2.TypeScopedEntitlements{}, &v2.TypeScopedGrants{}),
+		}.Build()
+		connector.rtDB = append(connector.rtDB, groupType)
+		connector.topos[typeID] = topo
+
+		resources := make([]*v2.Resource, 0, 2)
+		for ri := 0; ri < 2; ri++ {
+			res, err := rs.NewGroupResource(fmt.Sprintf("%s-res%d", typeID, ri), groupType, fmt.Sprintf("%s res %d", typeID, ri), nil)
+			require.NoError(t, err)
+			resources = append(resources, res)
+			connector.resourceDB[typeID] = append(connector.resourceDB[typeID], res)
+		}
+
+		connector.entsByToken[typeID] = make(map[string]*v2.Entitlement, len(topo.tokens))
+		connector.grantsByTok[typeID] = make(map[string]*v2.Grant, len(topo.tokens))
+		for i, token := range topo.tokens {
+			res := resources[i%len(resources)]
+			slug := "m-" + token
+			ent := et.NewAssignmentEntitlement(res, slug, et.WithGrantableTo(userType))
+			grant := gt.NewGrant(res, slug, user.GetId())
+			connector.entsByToken[typeID][token] = ent
+			connector.grantsByTok[typeID][token] = grant
+			expectedEntIDs[ent.GetId()] = struct{}{}
+		}
+	}
+	return connector, expectedEntIDs, user.GetId().GetResource()
+}
+
+// withTopos clones the connector with alternate topologies over the same
+// token universe (shared payload maps) — "the API's answers changed".
+func withTopos(base *soakConnector, topos map[string]*soakTypeTopology) *soakConnector {
+	return &soakConnector{
+		mockConnector: base.mockConnector,
+		topos:         topos,
+		entsByToken:   base.entsByToken,
+		grantsByTok:   base.grantsByTok,
+		failedOnce:    make(map[string]struct{}),
+	}
+}
+
+// buildCutFixture hand-builds a deterministic two-type fan-out topology
+// covering the interesting shapes: planner-spawned siblings, a planner
+// continuation, chained continuations, spawns from spawned cursors, and a
+// deep chain. Every token is reachable exactly once, so the expected
+// payload sets are exact. No failure injection — cuts are the only
+// disturbance under test.
+func buildCutFixture(t *testing.T) (*soakConnector, map[string]struct{}, string) {
+	t.Helper()
+	return buildTopoFixture(t, map[string]*soakTypeTopology{
+		// Type A: wide — planner spawns two siblings and continues;
+		// spawned cursors spawn and continue in turn.
+		"groupA": {
+			plannerChildren: []string{"a0", "a1"},
+			plannerNext:     "a2",
+			nodes: map[string]*soakNode{
+				"a0": {children: []string{"a3", "a4"}, next: "a5"},
+				"a1": {next: "a6"},
+				"a2": {children: []string{"a7"}},
+				"a3": {}, "a4": {},
+				"a5": {children: []string{"a8"}},
+				"a6": {next: "a9"},
+				"a7": {}, "a8": {}, "a9": {},
+			},
+			tokens:         []string{"a0", "a1", "a2", "a3", "a4", "a5", "a6", "a7", "a8", "a9"},
+			poisonedEnts:   map[string]bool{},
+			poisonedGrants: map[string]bool{},
+		},
+		// Type B: deep — a single spawned cursor heads a continuation
+		// chain that fans out near the bottom.
+		"groupB": {
+			plannerChildren: []string{"b0"},
+			nodes: map[string]*soakNode{
+				"b0": {next: "b1"},
+				"b1": {next: "b2"},
+				"b2": {children: []string{"b3", "b4", "b5"}},
+				"b3": {next: "b6"},
+				"b4": {children: []string{"b7"}},
+				"b5": {}, "b6": {}, "b7": {},
+			},
+			tokens:         []string{"b0", "b1", "b2", "b3", "b4", "b5", "b6", "b7"},
+			poisonedEnts:   map[string]bool{},
+			poisonedGrants: map[string]bool{},
+		},
+	})
+}
+
+type cutAttemptResult struct {
+	completed       bool
+	checkpoints     int
+	responses       int
+	grantsResponses int
+	// spawnedTokens counts durable checkpoint tokens that carried a
+	// spawned in-flight action — the state shape resume bugs hide in.
+	// The sweep meta-asserts it reaches that shape at least once, so the
+	// harness cannot silently degrade into sweeping only trivial cuts.
+	spawnedTokens int
+}
+
+// cutSpec configures one attempt: which cut trigger fires (checkpoint
+// count, total response count, or grants-phase response count; zero =
+// disabled) and the crash flavor. cause selects a hard cut
+// (errInjectedCut — nothing further is written) or an expiry
+// (errInjectedExpiry — the syncer's deadline path force-checkpoints the
+// mid-batch stack before exiting). cause must be non-nil even for no-cut
+// attempts so a genuine failure can never be mistaken for an injected one.
+type cutSpec struct {
+	workers        int
+	checkpoint     int
+	response       int
+	grantsResponse int
+	cause          error
+}
+
+// runCutAttempt runs one sync attempt against the shared fixture on the
+// c1z at path, simulating a crash per spec. A fresh store handle and
+// syncer per attempt simulate the cold restart of a different process.
+func runCutAttempt(
+	t *testing.T,
+	base *soakConnector,
+	c1zPath string,
+	tmpDir string,
+	spec cutSpec,
+) cutAttemptResult {
+	t.Helper()
+	require.NotNil(t, spec.cause, "cutSpec.cause must always be set")
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+
+	connector := &cutConnector{
+		soakConnector:  base,
+		cutAfter:       spec.response,
+		cutAfterGrants: spec.grantsResponse,
+		cutCause:       spec.cause,
+		cancel:         cancel,
+	}
+
+	store, err := dotc1z.NewStore(ctx, c1zPath,
+		dotc1z.WithEngine(c1zstore.EnginePebble),
+		dotc1z.WithTmpDir(tmpDir),
+	)
+	require.NoError(t, err)
+
+	s, err := NewSyncer(ctx, connector,
+		WithConnectorStore(store),
+		WithTmpDir(tmpDir),
+		WithWorkerCount(spec.workers),
+	)
+	require.NoError(t, err)
+	sc, ok := s.(*syncer)
+	require.True(t, ok)
+	// Every loop-top checkpoint commits durably: each one is a cut point.
+	sc.checkpointInterval = 0
+	checkpoints := 0
+	spawnedTokens := 0
+	sc.testCheckpointHook = func(token string) {
+		checkpoints++
+		if strings.Contains(token, `"spawned":true`) {
+			spawnedTokens++
+		}
+		if spec.checkpoint > 0 && checkpoints == spec.checkpoint {
+			cancel(spec.cause)
+		}
+	}
+	audit := attachQueueAudit(t, s)
+
+	syncErr := s.Sync(ctx)
+	require.NoError(t, s.Close(context.Background()))
+	verifyQueueAudit(t, audit)
+
+	if syncErr != nil {
+		// A failed attempt is only acceptable when WE crashed it; any
+		// other failure is a real bug the harness must not absorb.
+		require.ErrorIs(t, context.Cause(ctx), spec.cause,
+			"sync failed without an injected cut (spec %+v): %v", spec, syncErr)
+	}
+	return cutAttemptResult{
+		completed:       syncErr == nil,
+		checkpoints:     checkpoints,
+		responses:       connector.responseCount(),
+		grantsResponses: connector.grantsResponseCount(),
+		spawnedTokens:   spawnedTokens,
+	}
+}
+
+// verifyCutStore opens the sealed c1z read-only and asserts the stored
+// entitlement and grant sets match the topology-derived expectation
+// exactly — the derived-ground-truth oracle.
+func verifyCutStore(t *testing.T, c1zPath, tmpDir string, expectedEntIDs map[string]struct{}, userID string) {
+	t.Helper()
+	ctx := context.Background()
+	store, err := dotc1z.NewStore(ctx, c1zPath,
+		dotc1z.WithEngine(c1zstore.EnginePebble),
+		dotc1z.WithTmpDir(tmpDir),
+		dotc1z.WithReadOnly(true),
+	)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, store.Close(ctx)) }()
+
+	gotEntIDs := make(map[string]struct{})
+	pageToken := ""
+	for {
+		resp, err := store.ListEntitlements(ctx, v2.EntitlementsServiceListEntitlementsRequest_builder{
+			PageToken: pageToken,
+		}.Build())
+		require.NoError(t, err)
+		for _, ent := range resp.GetList() {
+			gotEntIDs[ent.GetId()] = struct{}{}
+		}
+		if pageToken = resp.GetNextPageToken(); pageToken == "" {
+			break
+		}
+	}
+	require.Equal(t, expectedEntIDs, gotEntIDs, "stored entitlement set diverged from topology")
+
+	gotGrantEnts := make(map[string]struct{})
+	grantCount := 0
+	pageToken = ""
+	for {
+		resp, err := store.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{
+			PageToken: pageToken,
+		}.Build())
+		require.NoError(t, err)
+		for _, grant := range resp.GetList() {
+			grantCount++
+			gotGrantEnts[grant.GetEntitlement().GetId()] = struct{}{}
+			require.Equal(t, userID, grant.GetPrincipal().GetId().GetResource())
+		}
+		if pageToken = resp.GetNextPageToken(); pageToken == "" {
+			break
+		}
+	}
+	require.Equal(t, expectedEntIDs, gotGrantEnts, "stored grant set diverged from topology")
+	require.Equal(t, len(expectedEntIDs), grantCount, "duplicate grants stored")
+}
+
+// enumerateCutPoints strides a 1..total sweep down to at most limit points
+// (always including 1 and total). BATON_CUT_SWEEP=full disables the cap.
+func enumerateCutPoints(total, limit int) []int {
+	if total <= 0 {
+		return nil
+	}
+	if os.Getenv("BATON_CUT_SWEEP") == "full" || total <= limit {
+		out := make([]int, 0, total)
+		for i := 1; i <= total; i++ {
+			out = append(out, i)
+		}
+		return out
+	}
+	out := make([]int, 0, limit)
+	seen := map[int]bool{}
+	for i := 0; i < limit; i++ {
+		// Even spread over [1, total], endpoints included.
+		p := 1 + i*(total-1)/(limit-1)
+		if !seen[p] {
+			seen[p] = true
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func TestCheckpointCutEnumeration(t *testing.T) {
+	tmpDir := t.TempDir()
+	base, expectedEntIDs, userID := buildCutFixture(t)
+
+	// Baseline: an uninterrupted run measures the cut space (K durable
+	// checkpoints, M connector responses) and sanity-checks the oracle.
+	baselinePath := filepath.Join(tmpDir, "baseline.c1z")
+	baseline := runCutAttempt(t, base, baselinePath, tmpDir, cutSpec{workers: 4, cause: errInjectedCut})
+	require.True(t, baseline.completed, "baseline sync must complete")
+	verifyCutStore(t, baselinePath, tmpDir, expectedEntIDs, userID)
+	t.Logf("cut space: %d durable checkpoints, %d connector responses (BATON_CUT_SWEEP=full for the whole space)",
+		baseline.checkpoints, baseline.responses)
+
+	type cut struct {
+		name       string
+		checkpoint int
+		response   int
+		cause      error
+	}
+	var cuts []cut
+	for _, n := range enumerateCutPoints(baseline.checkpoints, 16) {
+		cuts = append(cuts, cut{name: fmt.Sprintf("checkpoint-%02d", n), checkpoint: n, cause: errInjectedCut})
+	}
+	for _, m := range enumerateCutPoints(baseline.responses, 16) {
+		cuts = append(cuts, cut{name: fmt.Sprintf("response-%02d", m), response: m, cause: errInjectedCut})
+	}
+	// Expiry cuts take the run-duration deadline path, which force-writes
+	// a checkpoint of the MID-BATCH stack (spawned cursors in flight)
+	// before exiting — the token shape hard cuts never persist, and the
+	// one resume bugs have historically hidden in.
+	for _, m := range enumerateCutPoints(baseline.responses, 12) {
+		cuts = append(cuts, cut{name: fmt.Sprintf("expire-%02d", m), response: m, cause: errInjectedExpiry})
+	}
+
+	// midBatchTokens counts, across the sweep, the durable tokens that
+	// carried spawned in-flight actions. If it stays zero the sweep never
+	// reached the state shape the expire mode exists for, and the harness
+	// is vacuous — fail loudly instead of passing quietly.
+	midBatchTokens := 0
+	for i, c := range cuts {
+		t.Run(c.name, func(t *testing.T) {
+			path := filepath.Join(tmpDir, fmt.Sprintf("cut-%s.c1z", c.name))
+			r := runCutAttempt(t, base, path, tmpDir, cutSpec{workers: 4, checkpoint: c.checkpoint, response: c.response, cause: c.cause})
+			midBatchTokens += r.spawnedTokens
+			if r.completed {
+				// The cut landed past the end of this run's schedule
+				// (parallel timing varies run to run); the completed
+				// store must still be exactly right.
+				verifyCutStore(t, path, tmpDir, expectedEntIDs, userID)
+				return
+			}
+
+			// Cold resume under a different worker count than the
+			// generator. Every third cut double-cuts: the first resume
+			// is itself crashed at its first checkpoint, exercising the
+			// restored-state re-checkpoint path before a final resume.
+			resumeWorkers := []int{1, 7}[i%2]
+			if i%3 == 0 {
+				rr := runCutAttempt(t, base, path, tmpDir, cutSpec{workers: resumeWorkers, checkpoint: 1, cause: errInjectedCut})
+				if rr.completed {
+					verifyCutStore(t, path, tmpDir, expectedEntIDs, userID)
+					return
+				}
+			}
+			final := runCutAttempt(t, base, path, tmpDir, cutSpec{workers: resumeWorkers, cause: errInjectedCut})
+			require.True(t, final.completed, "resume after cut %s did not complete", c.name)
+			midBatchTokens += final.spawnedTokens
+			verifyCutStore(t, path, tmpDir, expectedEntIDs, userID)
+		})
+	}
+
+	require.Positive(t, midBatchTokens,
+		"no durable token in the whole sweep carried a spawned in-flight action; the expire mode is not reaching mid-batch state and the harness has gone vacuous")
+	require.Zero(t, base.perResourceCalls, "type-scoped types must never receive per-resource calls")
+}

--- a/pkg/sync/ingest_invariant_verification_test.go
+++ b/pkg/sync/ingest_invariant_verification_test.go
@@ -33,21 +33,21 @@ func TestIngestInvariantVerificationCoverageByEngine(t *testing.T) {
 			name:     "SQLite records its engine-independent I5 coverage",
 			engine:   c1zstore.EngineSQLite,
 			syncType: connectorstore.SyncTypeFull,
-			want:     []string{"I5"},
+			want:     []string{"I5", "I10"},
 			wantMode: c1zstore.IngestInvariantVerificationModeConnector,
 		},
 		{
 			name:     "Pebble full records the referential family",
 			engine:   c1zstore.EnginePebble,
 			syncType: connectorstore.SyncTypeFull,
-			want:     []string{"I5", "I7", "I3", "I8", "I9"},
+			want:     []string{"I5", "I10", "I7", "I3", "I8", "I9"},
 			wantMode: c1zstore.IngestInvariantVerificationModeConnector,
 		},
 		{
 			name:     "Pebble partial records only all-sync-type checks",
 			engine:   c1zstore.EnginePebble,
 			syncType: connectorstore.SyncTypePartial,
-			want:     []string{"I5"},
+			want:     []string{"I5", "I10"},
 			wantMode: c1zstore.IngestInvariantVerificationModeConnector,
 		},
 		{
@@ -56,7 +56,7 @@ func TestIngestInvariantVerificationCoverageByEngine(t *testing.T) {
 			syncType:  connectorstore.SyncTypeFull,
 			failFast:  true,
 			resources: true,
-			want:      []string{"I5", "I4"},
+			want:      []string{"I5", "I10", "I4"},
 			wantMode:  c1zstore.IngestInvariantVerificationModeConnectorFailFast,
 		},
 		{
@@ -64,7 +64,7 @@ func TestIngestInvariantVerificationCoverageByEngine(t *testing.T) {
 			engine:     c1zstore.EnginePebble,
 			syncType:   connectorstore.SyncTypeFull,
 			compaction: true,
-			want:       []string{"I5", "I7", "I3", "I8", "I9"},
+			want:       []string{"I5", "I10", "I7", "I3", "I8", "I9"},
 			wantMode:   c1zstore.IngestInvariantVerificationModeCompactionMerge,
 		},
 	}

--- a/pkg/sync/ingest_invariants.go
+++ b/pkg/sync/ingest_invariants.go
@@ -56,6 +56,20 @@ package sync //nolint:revive,nolintlint // we can't change the package name for 
 //     ExternalResourceMatch* annotations — unprocessed match carriers
 //     are evidence that no external resource file was configured, not
 //     bad data (the match op deletes carriers when it runs).
+//   - I10 spawned-cursor drain completeness: every sibling cursor a
+//     connector enqueued via EnqueuePageTokens that was admitted to
+//     the action schedule must complete through a legitimate finish
+//     path before the sync quiesces. A dropped cursor is the failure
+//     mode the referential family CANNOT see — it produces ABSENCE
+//     (missing rows with perfect referential integrity), i.e. silent
+//     data loss. Evidence is the state's spawned-in-flight set,
+//     maintained at the state-mutation funnels (admission records,
+//     finish deletes) and rebuilt from the checkpoint on resume, so
+//     the check survives crash/resume. Hard failure in every mode
+//     (a residual entry at quiesce is definitionally a scheduler bug,
+//     never connector data); costs one in-memory map read. Skipped
+//     only for callers with no scheduler evidence (store-level
+//     pipelines like the compactor, which never schedule cursors).
 //
 // I7/I8/I9 verdicts are aggregated warnings in default mode, split by
 // whether the referent's resource TYPE was synced:
@@ -149,6 +163,8 @@ func invariantVerdict(err error) error { return &invariantVerdictError{err: err}
 // TypeScopedGrants) land, they register here against I7 and I8
 // respectively — type-granularity scopes are exactly the shapes those
 // referential checks exist for.
+//
+//nolint:gosec // G101 false positive: "PageTokens" is an annotation name, not a credential.
 var sideEffectAnnotationCoverage = map[string]string{
 	"c1.connector.v2.GrantExpandable":           "I1: response-loop expansion arming (SetNeedsExpansion) + needs_expansion column persistence; store-derived probe arrives with replay",
 	"c1.connector.v2.ExternalResourceMatch":     "I2: response-loop match arming (SetHasExternalResourcesGrants); store-derived existence-bit repair arrives with replay",
@@ -159,6 +175,7 @@ var sideEffectAnnotationCoverage = map[string]string{
 	"c1.connector.v2.EntitlementExclusionGroup": "I5: stored-keyspace validation post-collection",
 	"c1.connector.v2.TypeScopedEntitlements":    "I7: entitlement→resource referential check post-collection",
 	"c1.connector.v2.TypeScopedGrants":          "I8: grant→entitlement referential check post-collection",
+	"c1.connector.v2.EnqueuePageTokens":         "I10: spawned-cursor drain completeness check at sync quiesce",
 }
 
 // childScheduleSet is the monotone record of scheduled child-resource
@@ -239,6 +256,13 @@ type IngestInvariantsPolicy struct {
 	childSchedule     *childScheduleSet
 	resourcesPhaseRan bool
 	syncResourceTypes []string
+
+	// I10 evidence: the sync state's spawned-cursor drain read
+	// (state.UndrainedSpawnedCursors), evaluated at check time. Only a
+	// caller that runs the scheduler can supply it; nil skips the check
+	// (a store-level pipeline never schedules cursors, so the predicate
+	// has no subject).
+	undrainedSpawned func() []string
 
 	// halt, when non-nil, fires at named seams of the pass (see
 	// ingestInvariantHaltStages); returning an error fails the sync at
@@ -326,6 +350,18 @@ var ingestInvariants = []ingestInvariant{
 		failFastPromotes: true,
 		haltStage:        "invariants-I5-complete",
 		check:            (*ingestInvariantsPass).checkStoredExclusionGroups,
+	},
+	{
+		// I10 sits early: it is the cheapest check here (one in-memory
+		// map read) and its verdict is hard-fail class — a scheduler
+		// that lost an admitted cursor must block the seal before the
+		// expensive referential scans spend their seeks. Runs on every
+		// sync type: targeted and partial syncs schedule spawned
+		// cursors too, and the evidence is engine-independent.
+		id:                 "I10",
+		runsOnAllSyncTypes: true,
+		failFastPromotes:   true,
+		check:              (*ingestInvariantsPass).checkSpawnedCursorDrain,
 	},
 	{
 		id:                       "I4",
@@ -467,11 +503,64 @@ func runIngestInvariants(
 		coverage = append(coverage, inv.id)
 	}
 	if len(skippedNoStore) > 0 {
-		ctxzap.Extract(ctx).Info("ingest invariants: store engine lacks the inspection surface; referential invariants were not evaluated",
-			zap.Strings("skipped_invariants", skippedNoStore),
-		)
+		logSkippedReferentialInvariants(ctx, store, policy.ActiveSyncID, skippedNoStore)
 	}
 	return coverage, nil
+}
+
+// logSkippedReferentialInvariants makes the SQLite degradation visible.
+// The level depends on exposure: when the store carries TYPE-SCOPED
+// listing annotations, the skipped checks include exactly the ones the
+// annotation registry promises for that feature (I7/I8 — whole-type
+// listings are the shape referential mistakes hide in), so the line
+// escalates to a warning. Plain stores keep the informational line.
+// A failed probe also warns: unknown exposure must not read quieter
+// than known-benign.
+func logSkippedReferentialInvariants(ctx context.Context, store connectorstore.Reader, activeSyncID string, skipped []string) {
+	l := ctxzap.Extract(ctx)
+	typeScoped, err := storeCarriesTypeScopedTypes(ctx, store, activeSyncID)
+	switch {
+	case err != nil:
+		l.Warn("ingest invariants: store engine lacks the inspection surface; referential invariants were not evaluated (type-scoped exposure unknown: probe failed)",
+			zap.Strings("skipped_invariants", skipped),
+			zap.Error(err),
+		)
+	case typeScoped:
+		l.Warn("ingest invariants: store engine lacks the inspection surface; referential invariants were not evaluated, "+
+			"and the store carries TYPE-SCOPED listing annotations whose registered checks (I7/I8) are among them",
+			zap.Strings("skipped_invariants", skipped),
+		)
+	default:
+		l.Info("ingest invariants: store engine lacks the inspection surface; referential invariants were not evaluated",
+			zap.Strings("skipped_invariants", skipped),
+		)
+	}
+}
+
+// storeCarriesTypeScopedTypes reports whether any stored resource type
+// carries a type-scoped listing annotation (TypeScopedEntitlements or
+// TypeScopedGrants).
+func storeCarriesTypeScopedTypes(ctx context.Context, store connectorstore.Reader, activeSyncID string) (bool, error) {
+	pageToken := ""
+	for {
+		resp, err := store.ListResourceTypes(ctx, v2.ResourceTypesServiceListResourceTypesRequest_builder{
+			PageToken:    pageToken,
+			ActiveSyncId: activeSyncID,
+		}.Build())
+		if err != nil {
+			return false, fmt.Errorf("listing resource types: %w", err)
+		}
+		for _, rt := range resp.GetList() {
+			for _, a := range rt.GetAnnotations() {
+				if a.MessageIs((*v2.TypeScopedEntitlements)(nil)) || a.MessageIs((*v2.TypeScopedGrants)(nil)) {
+					return true, nil
+				}
+			}
+		}
+		if pageToken = resp.GetNextPageToken(); pageToken == "" {
+			return false, nil
+		}
+	}
 }
 
 // runIngestionInvariants is the syncer's call into the pass: policy
@@ -501,6 +590,9 @@ func (s *syncer) runIngestionInvariants(ctx context.Context) error {
 		childSchedule:     &s.childSchedule,
 		resourcesPhaseRan: s.resourcesPhaseRanHere,
 		syncResourceTypes: s.syncResourceTypes,
+	}
+	if st, ok := s.state.(*state); ok {
+		policy.undrainedSpawned = st.UndrainedSpawnedCursors
 	}
 	if s.testIngestHaltHook != nil {
 		policy.halt = s.testIngestHaltHook
@@ -826,6 +918,31 @@ func (pass *ingestInvariantsPass) checkChildScheduling(ctx context.Context) erro
 			len(violations), violations))
 	}
 	return nil
+}
+
+// checkSpawnedCursorDrain is invariant I10: every spawned sibling
+// cursor (EnqueuePageTokens) admitted to the action schedule must have
+// completed through a legitimate finish path by the time the sync
+// quiesces. A residual entry is definitionally a scheduler bug — an
+// admitted cursor was lost without doing its work — and its consequence
+// is silent data loss the referential invariants cannot see (missing
+// rows dangle nothing). Hard failure in every mode; the check reads one
+// in-memory map. Callers with no scheduler evidence (the compactor's
+// expand pass) skip: they never schedule cursors, so the predicate has
+// no subject.
+func (pass *ingestInvariantsPass) checkSpawnedCursorDrain(ctx context.Context) error {
+	if pass.p.undrainedSpawned == nil {
+		return nil
+	}
+	undrained := pass.p.undrainedSpawned()
+	if len(undrained) == 0 {
+		return nil
+	}
+	// Already sorted by action ID (state.UndrainedSpawnedCursors); the
+	// verdict text is byte-stable.
+	return invariantVerdict(fmt.Errorf(
+		"ingest invariant I10 violated: %d spawned page-token cursor(s) were admitted to the schedule but never drained (scheduler bug — the sync is missing their data): %v",
+		len(undrained), undrained))
 }
 
 // maxDanglingIDExamples caps the id samples carried on the aggregated

--- a/pkg/sync/ingest_invariants.go
+++ b/pkg/sync/ingest_invariants.go
@@ -157,6 +157,8 @@ var sideEffectAnnotationCoverage = map[string]string{
 	"c1.connector.v2.InsertResourceGrants":      "I3: grant→resource referential check post-collection",
 	"c1.connector.v2.ChildResourceType":         "I4: scheduled-set completeness check post-collection",
 	"c1.connector.v2.EntitlementExclusionGroup": "I5: stored-keyspace validation post-collection",
+	"c1.connector.v2.TypeScopedEntitlements":    "I7: entitlement→resource referential check post-collection",
+	"c1.connector.v2.TypeScopedGrants":          "I8: grant→entitlement referential check post-collection",
 }
 
 // childScheduleSet is the monotone record of scheduled child-resource

--- a/pkg/sync/ingest_invariants_telemetry_test.go
+++ b/pkg/sync/ingest_invariants_telemetry_test.go
@@ -19,6 +19,7 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
 	et "github.com/conductorone/baton-sdk/pkg/types/entitlement"
 	"github.com/conductorone/baton-sdk/pkg/types/grant"
@@ -200,4 +201,45 @@ func TestIngestInvariantSkipLogTelemetry(t *testing.T) {
 		}
 	}
 	require.True(t, hasField, "the skip line must name the invariants that did not run")
+	require.Nil(t, findEntry(entries(), zapcore.WarnLevel, "referential invariants were not evaluated"),
+		"a store with no type-scoped exposure keeps the informational level")
+}
+
+// TestIngestInvariantSkipLogEscalatesForTypeScopedStores pins the
+// exposure-dependent level of the degradation line: the annotation
+// registry promises I7/I8 for the type-scoped listing annotations, and
+// on an engine without the inspection surface those exact checks are
+// the ones skipped — a connector relying on the promised guard must see
+// a WARNING, not an info line indistinguishable from benign downgrade.
+func TestIngestInvariantSkipLogEscalatesForTypeScopedStores(t *testing.T) {
+	ctx := context.Background()
+	store, syncID := newInvariantTestStore(ctx, t) // SQLite-backed
+
+	scoped := v2.ResourceType_builder{
+		Id:          "group",
+		DisplayName: "Group",
+		Annotations: annotations.New(&v2.TypeScopedGrants{}),
+	}.Build()
+	require.NoError(t, store.PutResourceTypes(ctx, scoped))
+
+	core, entries := newCaptureCore()
+	lctx := ctxzap.ToContext(ctx, zap.New(core))
+
+	require.NoError(t, RunIngestInvariants(lctx, store, IngestInvariantsPolicy{
+		ActiveSyncID: syncID,
+		SyncType:     connectorstore.SyncTypeFull,
+	}))
+
+	warn := findEntry(entries(), zapcore.WarnLevel, "TYPE-SCOPED listing annotations")
+	require.NotNil(t, warn,
+		"skipping I7/I8 on a store that carries the annotations they were promised for must escalate to a warning")
+	var skipped bool
+	for _, f := range warn.fields {
+		if f.Key == "skipped_invariants" {
+			skipped = true
+		}
+	}
+	require.True(t, skipped, "the escalated line must still name the invariants that did not run")
+	require.Nil(t, findEntry(entries(), zapcore.InfoLevel, "referential invariants were not evaluated"),
+		"the verdict is one line at one level, not both")
 }

--- a/pkg/sync/ingest_invariants_test.go
+++ b/pkg/sync/ingest_invariants_test.go
@@ -635,12 +635,14 @@ func TestIngestInvariantI10SpawnedCursorDrain(t *testing.T) {
 // drops it.
 func TestSyncerWiresSpawnDrainEvidenceIntoInvariants(t *testing.T) {
 	ctx := context.Background()
-	store, _ := newInvariantTestStore(ctx, t)
+	// The syncer needs the active sync's ID: runIngestionInvariants clears
+	// any prior verification marker for that sync before re-evaluating.
+	store, syncID := newInvariantTestStore(ctx, t)
 
 	st := newEmptySchedulerState(t)
 	st.PushAction(ctx, Action{Op: SyncGrantsOp, ResourceTypeID: "group", PageToken: "wired", Spawned: true, TypeScoped: true})
 
-	s := &syncer{state: st, store: store, syncType: connectorstore.SyncTypeFull}
+	s := &syncer{state: st, store: store, syncID: syncID, syncType: connectorstore.SyncTypeFull}
 	err := s.runIngestionInvariants(ctx)
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrIngestInvariantViolated)

--- a/pkg/sync/ingest_invariants_test.go
+++ b/pkg/sync/ingest_invariants_test.go
@@ -70,6 +70,7 @@ func TestIngestInvariantAnnotationCoverage(t *testing.T) {
 		&v2.EntitlementExclusionGroup{},
 		&v2.TypeScopedEntitlements{},
 		&v2.TypeScopedGrants{},
+		&v2.EnqueuePageTokens{},
 	}
 	for _, msg := range sideEffectAnnotations {
 		name := string(msg.ProtoReflect().Descriptor().FullName())
@@ -90,7 +91,7 @@ func TestIngestInvariantAnnotationCoverage(t *testing.T) {
 var ingestInvariantExclusions = map[string]string{
 	"I1": "expansion arming rides the response loop (SetNeedsExpansion) + needs_expansion persistence; store-derived probe arrives with replay",
 	"I2": "external-match arming rides the response loop (SetHasExternalResourcesGrants); store-derived existence-bit repair arrives with replay",
-	"I6": "source-cache scope consistency has no subject until replay state exists; arrives with replay",
+	"I6": "source-cache scope consistency has no subject until replay state exists; arrives with replay (type-scoped listings' whole-type scopes join its subject then)",
 }
 
 // TestIngestInvariantVerdictTable is the completeness meta-test for the
@@ -483,6 +484,170 @@ func TestIngestInvariantI4ChildScheduling(t *testing.T) {
 	// A process that resumed past the resources phase cannot verify the
 	// predicate; the check declines instead of false-positives.
 	require.NoError(t, RunIngestInvariants(ctx, store, policy(&childScheduleSet{}, true, false)))
+}
+
+// TestSpawnedCursorDrainEvidence pins the I10 evidence mechanics at
+// every state-mutation funnel: admission enrolls (PushAction and
+// transitionAction children), only the two legitimate finish paths
+// drain (FinishAction and transitionAction's finish branch), and the
+// set is rebuilt from the checkpoint on resume. The last subtest is the
+// point of the invariant: a cursor dropped from the stack WITHOUT
+// finishing stays on the evidence — silent omission becomes observable.
+func TestSpawnedCursorDrainEvidence(t *testing.T) {
+	ctx := t.Context()
+
+	t.Run("admission and FinishAction drain", func(t *testing.T) {
+		st := newEmptySchedulerState(t)
+		require.Empty(t, st.UndrainedSpawnedCursors())
+
+		st.PushAction(ctx, Action{Op: SyncGrantsOp, ResourceTypeID: "group", PageToken: "spawn-a", Spawned: true, TypeScoped: true})
+		require.Len(t, st.UndrainedSpawnedCursors(), 1)
+
+		// Non-spawned actions never enroll.
+		st.PushAction(ctx, Action{Op: SyncGrantsOp, ResourceTypeID: "group", ResourceID: "g1"})
+		require.Len(t, st.UndrainedSpawnedCursors(), 1)
+
+		// Finishing the plain action leaves the spawned evidence alone;
+		// finishing the spawned cursor drains it.
+		st.FinishAction(ctx, st.Current())
+		require.Len(t, st.UndrainedSpawnedCursors(), 1)
+		st.FinishAction(ctx, st.Current())
+		require.Empty(t, st.UndrainedSpawnedCursors())
+	})
+
+	t.Run("transitionAction commit and finish branch", func(t *testing.T) {
+		st := newEmptySchedulerState(t)
+		parent := st.pushAction(ctx, Action{Op: SyncGrantsOp, ResourceTypeID: "group", TypeScoped: true, PageToken: "p1"})
+
+		pushed, err := st.transitionAction(ctx, parent, "p2", []Action{
+			{Op: SyncGrantsOp, ResourceTypeID: "group", PageToken: "spawn-1", Spawned: true, TypeScoped: true},
+			{Op: SyncGrantsOp, ResourceTypeID: "group", PageToken: "spawn-2", Spawned: true, TypeScoped: true},
+		})
+		require.NoError(t, err)
+		require.Len(t, pushed, 2)
+		require.Len(t, st.UndrainedSpawnedCursors(), 2)
+
+		// A spawned cursor advancing its own pagination stays enrolled
+		// (it has not completed); finishing it drains it.
+		_, err = st.transitionAction(ctx, pushed[0], "spawn-1-page-2", nil)
+		require.NoError(t, err)
+		require.Len(t, st.UndrainedSpawnedCursors(), 2)
+		_, err = st.transitionAction(ctx, pushed[0], "", nil)
+		require.NoError(t, err)
+		require.Len(t, st.UndrainedSpawnedCursors(), 1)
+		_, err = st.transitionAction(ctx, pushed[1], "", nil)
+		require.NoError(t, err)
+		require.Empty(t, st.UndrainedSpawnedCursors())
+	})
+
+	t.Run("evidence survives checkpoint resume", func(t *testing.T) {
+		st := newEmptySchedulerState(t)
+		st.PushAction(ctx, Action{Op: SyncEntitlementsOp, ResourceTypeID: "group", PageToken: "spawn-resume", Spawned: true, TypeScoped: true})
+		token, err := st.Marshal()
+		require.NoError(t, err)
+
+		resumed := newState()
+		require.NoError(t, resumed.Unmarshal(token))
+		undrained := resumed.UndrainedSpawnedCursors()
+		require.Len(t, undrained, 1,
+			"a spawned cursor admitted by a previous process must still drain in the process that completes the sync")
+		require.Contains(t, undrained[0], "spawn-resume")
+
+		resumed.FinishAction(ctx, resumed.Current())
+		require.Empty(t, resumed.UndrainedSpawnedCursors())
+	})
+
+	t.Run("a silent drop stays on the evidence", func(t *testing.T) {
+		st := newEmptySchedulerState(t)
+		spawned := st.pushAction(ctx, Action{Op: SyncGrantsOp, ResourceTypeID: "group", PageToken: "dropped", Spawned: true, TypeScoped: true})
+
+		// Simulate the bug class I10 exists for: the action vanishes
+		// from the stack without going through a finish path. The
+		// stack looks clean; the evidence does not.
+		st.mtx.Lock()
+		delete(st.actions, spawned.ID)
+		st.actionOrder = st.actionOrder[:len(st.actionOrder)-1]
+		st.mtx.Unlock()
+		require.Nil(t, st.Current(), "the stack is empty — structurally indistinguishable from a completed sync")
+
+		undrained := st.UndrainedSpawnedCursors()
+		require.Len(t, undrained, 1)
+		require.Contains(t, undrained[0], `token="dropped"`)
+	})
+
+	t.Run("oversized tokens are excerpted on the verdict", func(t *testing.T) {
+		st := newEmptySchedulerState(t)
+		big := strings.Repeat("x", 4096)
+		st.PushAction(ctx, Action{Op: SyncGrantsOp, ResourceTypeID: "group", PageToken: big, Spawned: true, TypeScoped: true})
+		undrained := st.UndrainedSpawnedCursors()
+		require.Len(t, undrained, 1)
+		require.Less(t, len(undrained[0]), 512, "verdict lines must not carry megabyte tokens")
+		require.Contains(t, undrained[0], "(4096 bytes)")
+	})
+}
+
+// TestIngestInvariantI10SpawnedCursorDrain drives I10 through
+// RunIngestInvariants: an undrained spawned cursor is a hard,
+// non-retryable verdict in EVERY mode (silent data loss must not seal),
+// draining satisfies it, and callers with no scheduler evidence (the
+// compactor's expand pass) skip instead of false-positiving.
+func TestIngestInvariantI10SpawnedCursorDrain(t *testing.T) {
+	ctx := context.Background()
+	store, syncID := newInvariantTestStore(ctx, t)
+
+	st := newEmptySchedulerState(t)
+	st.PushAction(ctx, Action{Op: SyncGrantsOp, ResourceTypeID: "group", PageToken: "lost-cursor", Spawned: true, TypeScoped: true})
+
+	policy := IngestInvariantsPolicy{
+		ActiveSyncID:     syncID,
+		SyncType:         connectorstore.SyncTypeFull,
+		undrainedSpawned: st.UndrainedSpawnedCursors,
+	}
+
+	// Default mode: hard failure carrying the non-retryable sentinel and
+	// naming the lost cursor.
+	err := RunIngestInvariants(ctx, store, policy)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrIngestInvariantViolated)
+	require.Contains(t, err.Error(), "ingest invariant I10 violated")
+	require.Contains(t, err.Error(), "lost-cursor")
+
+	// Partial syncs run I10 too: targeted syncs schedule spawned
+	// cursors as well, and the evidence is engine- and type-independent.
+	partialPolicy := policy
+	partialPolicy.SyncType = connectorstore.SyncTypePartial
+	err = RunIngestInvariants(ctx, store, partialPolicy)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ingest invariant I10 violated")
+
+	// Draining the cursor satisfies the invariant.
+	st.FinishAction(ctx, st.Current())
+	require.NoError(t, RunIngestInvariants(ctx, store, policy))
+
+	// No scheduler evidence: the predicate has no subject; skip.
+	policy.undrainedSpawned = nil
+	require.NoError(t, RunIngestInvariants(ctx, store, policy))
+}
+
+// TestSyncerWiresSpawnDrainEvidenceIntoInvariants pins the syncer seam
+// for I10: runIngestionInvariants must hand the live state's evidence
+// to the pass — the check existing means nothing if the policy plumbing
+// drops it.
+func TestSyncerWiresSpawnDrainEvidenceIntoInvariants(t *testing.T) {
+	ctx := context.Background()
+	store, _ := newInvariantTestStore(ctx, t)
+
+	st := newEmptySchedulerState(t)
+	st.PushAction(ctx, Action{Op: SyncGrantsOp, ResourceTypeID: "group", PageToken: "wired", Spawned: true, TypeScoped: true})
+
+	s := &syncer{state: st, store: store, syncType: connectorstore.SyncTypeFull}
+	err := s.runIngestionInvariants(ctx)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrIngestInvariantViolated)
+	require.Contains(t, err.Error(), "ingest invariant I10 violated")
+
+	st.FinishAction(ctx, st.Current())
+	require.NoError(t, s.runIngestionInvariants(ctx))
 }
 
 // TestSyncFailsOnStoredExclusionGroupConflict pins the syncer seam:

--- a/pkg/sync/ingest_invariants_test.go
+++ b/pkg/sync/ingest_invariants_test.go
@@ -60,8 +60,6 @@ func TestPushChildResourceActionsDedupesPerSync(t *testing.T) {
 // sideEffectAnnotationCoverage — and the invariant behind it — fails
 // here instead of in review round eleven.
 func TestIngestInvariantAnnotationCoverage(t *testing.T) {
-	// TypeScopedEntitlements and TypeScopedGrants join this list (mapped
-	// to I7/I8) when the type-scoped listing protos land.
 	sideEffectAnnotations := []proto.Message{
 		&v2.GrantExpandable{},
 		&v2.ExternalResourceMatch{},
@@ -70,6 +68,8 @@ func TestIngestInvariantAnnotationCoverage(t *testing.T) {
 		&v2.InsertResourceGrants{},
 		&v2.ChildResourceType{},
 		&v2.EntitlementExclusionGroup{},
+		&v2.TypeScopedEntitlements{},
+		&v2.TypeScopedGrants{},
 	}
 	for _, msg := range sideEffectAnnotations {
 		name := string(msg.ProtoReflect().Descriptor().FullName())

--- a/pkg/sync/parallel_audit_test.go
+++ b/pkg/sync/parallel_audit_test.go
@@ -1,0 +1,157 @@
+package sync //nolint:revive,nolintlint // backwards-compatible package name
+
+// Post-hoc contract checker for the parallel scheduler (Option D of the
+// verification plan; see docs/BUG_CATCHING.md §2 in the overview repo).
+//
+// The queue's failure modes are silent: a dropped action produces absent
+// data, a double execution produces duplicates, a post-abort commit
+// produces state the checkpoint never admitted — none of them log. The
+// queueAudit records every queue event at its mutation site (under q.mu,
+// so recorded order is real order), and verifyQueueAudit replays the log
+// against the contract:
+//
+//   C1  exactly-once: every seeded/admitted action is dequeued at most
+//       once, and — on a clean batch — exactly once (full drain).
+//   C2  admission before execution: nothing is dequeued that was never
+//       seeded or committed.
+//   C3  no commits after abort: an aborted batch admits nothing further.
+//   C4  dedup soundness: no two actions in one batch share an identity
+//       digest (re-verified from the recorded keys, independent of the
+//       queue's own seen set).
+//   C5  accounting: dones never exceed dequeues, and on any batch end
+//       they match (every taken action was returned).
+//
+// Any heavy test that runs the scheduler gets these checks for free by
+// attaching an audit (syncer.testQueueAudit) and calling verifyQueueAudit.
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type auditBatchState struct {
+	op        ActionOp
+	admitted  map[string]bool // actionID -> dequeued yet?
+	keys      map[parallelActionKey]string
+	dequeues  int
+	dones     int
+	aborted   bool
+	ended     bool
+	clean     bool
+	violation []string
+}
+
+func (b *auditBatchState) violatef(format string, args ...any) {
+	b.violation = append(b.violation, fmt.Sprintf(format, args...))
+}
+
+// verifyQueueAudit checks every recorded batch segment against the queue
+// contract. Call after the sync attempts under test have finished.
+func verifyQueueAudit(t *testing.T, audit *queueAudit) {
+	t.Helper()
+	batches := map[int]*auditBatchState{}
+
+	admit := func(b *auditBatchState, batch int, ids []string, keys []parallelActionKey) {
+		for i, id := range ids {
+			if _, ok := b.admitted[id]; ok {
+				b.violatef("action %s admitted twice", id)
+			}
+			b.admitted[id] = false
+			key := keys[i]
+			if prev, ok := b.keys[key]; ok {
+				b.violatef("actions %s and %s share identity digest in batch %d (dedup unsound)", prev, id, batch)
+			}
+			b.keys[key] = id
+		}
+	}
+
+	for _, ev := range audit.snapshot() {
+		b := batches[ev.batch]
+		if b == nil {
+			require.Equal(t, auditBatchStart, ev.kind,
+				"audit: batch %d's first event must be batch-start, got kind %d", ev.batch, ev.kind)
+			b = &auditBatchState{
+				op:       ev.op,
+				admitted: map[string]bool{},
+				keys:     map[parallelActionKey]string{},
+			}
+			batches[ev.batch] = b
+			admit(b, ev.batch, ev.actionIDs, ev.keys)
+			continue
+		}
+		if b.ended {
+			b.violatef("event kind %d after batch end", ev.kind)
+			continue
+		}
+		switch ev.kind {
+		case auditBatchStart:
+			b.violatef("duplicate batch-start")
+		case auditDequeue:
+			id := ev.actionIDs[0]
+			dequeued, ok := b.admitted[id]
+			switch {
+			case !ok:
+				b.violatef("action %s dequeued but never admitted (C2)", id)
+			case dequeued:
+				b.violatef("action %s dequeued twice (C1)", id)
+			default:
+				b.admitted[id] = true
+			}
+			b.dequeues++
+			if b.aborted {
+				b.violatef("dequeue of %s after abort", id)
+			}
+		case auditCommit:
+			if b.aborted {
+				b.violatef("transition committed after abort (C3)")
+			}
+			admit(b, ev.batch, ev.actionIDs, ev.keys)
+		case auditReject:
+			// Rejections mutate nothing; post-abort rejections are the
+			// REQUIRED behavior (the abort path returning cancellation
+			// instead of committing), so nothing to check.
+		case auditDone:
+			b.dones++
+			if b.dones > b.dequeues {
+				b.violatef("done count %d exceeds dequeue count %d (C5)", b.dones, b.dequeues)
+			}
+		case auditAbort:
+			b.aborted = true
+		case auditBatchEnd:
+			b.ended = true
+			b.clean = ev.clean
+			if b.dones != b.dequeues {
+				b.violatef("batch ended with %d dequeues but %d dones (C5)", b.dequeues, b.dones)
+			}
+			if ev.clean {
+				if b.aborted {
+					b.violatef("batch reported clean but recorded an abort")
+				}
+				for id, dequeued := range b.admitted {
+					if !dequeued {
+						b.violatef("clean batch ended with admitted action %s never dequeued (C1 drain)", id)
+					}
+				}
+			}
+		}
+	}
+
+	for batch, b := range batches {
+		require.Truef(t, b.ended, "audit: batch %d (op %s) never recorded batch-end", batch, b.op.String())
+		require.Emptyf(t, b.violation,
+			"audit: queue contract violations in batch %d (op %s):\n%v", batch, b.op.String(), b.violation)
+	}
+}
+
+// attachQueueAudit installs a fresh audit on the syncer under test and
+// returns it. Same-package tests only.
+func attachQueueAudit(t *testing.T, s Syncer) *queueAudit {
+	t.Helper()
+	sc, ok := s.(*syncer)
+	require.True(t, ok, "syncer under test is not *syncer")
+	audit := &queueAudit{}
+	sc.testQueueAudit = audit
+	return audit
+}

--- a/pkg/sync/parallel_scheduler_test.go
+++ b/pkg/sync/parallel_scheduler_test.go
@@ -4,15 +4,47 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"sync"
 	"testing"
 	"time"
 
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
 	"github.com/conductorone/baton-sdk/pkg/retry"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+type legacyPaginatedCheckpointStore struct {
+	c1zstore.Store
+	resourceType     *v2.ResourceType
+	nextPageToken    string
+	listResourcesErr error
+}
+
+func (s *legacyPaginatedCheckpointStore) ListResourceTypes(
+	context.Context,
+	*v2.ResourceTypesServiceListResourceTypesRequest,
+) (*v2.ResourceTypesServiceListResourceTypesResponse, error) {
+	return v2.ResourceTypesServiceListResourceTypesResponse_builder{
+		List: []*v2.ResourceType{s.resourceType},
+	}.Build(), nil
+}
+
+func (s *legacyPaginatedCheckpointStore) ListResources(
+	context.Context,
+	*v2.ResourcesServiceListResourcesRequest,
+) (*v2.ResourcesServiceListResourcesResponse, error) {
+	if s.listResourcesErr != nil {
+		return nil, s.listResourcesErr
+	}
+	return v2.ResourcesServiceListResourcesResponse_builder{
+		NextPageToken: s.nextPageToken,
+	}.Build(), nil
+}
 
 func newEmptySchedulerState(t *testing.T) *state {
 	t.Helper()
@@ -121,6 +153,352 @@ func TestSyncParallelDrainsMultipleSpawnedCursors(t *testing.T) {
 	require.Empty(t, warnings)
 	require.Equal(t, map[string]int{"": 1, "a": 1, "b": 1, "c": 1}, processed)
 	require.Nil(t, st.Current())
+}
+
+func TestSyncParallelRejectsCyclicSpawnedCursor(t *testing.T) {
+	ctx := t.Context()
+	st := newEmptySchedulerState(t)
+	origin := st.pushAction(ctx, Action{
+		Op:             SyncGrantsOp,
+		ResourceTypeID: "group",
+		ResourceID:     "group-1",
+		PageToken:      "loop",
+	})
+	s := &syncer{state: st, workerCount: 1}
+
+	calls := 0
+	f := func(ctx context.Context, action *Action) error {
+		calls++
+		if calls > 3 {
+			return errors.New("test safety stop: cyclic cursor was accepted")
+		}
+		return s.nextPageOrFinishAction(ctx, action, "", Action{
+			Op:             SyncGrantsOp,
+			ResourceTypeID: action.ResourceTypeID,
+			ResourceID:     action.ResourceID,
+			PageToken:      "loop",
+			Spawned:        true,
+		})
+	}
+
+	_, err := s.syncParallel(ctx, newTestRetryer(ctx), []*Action{origin}, f)
+	require.ErrorContains(t, err, "duplicate or cyclic spawned cursor")
+	require.LessOrEqual(t, calls, 2)
+}
+
+func TestParallelActionKeyDoesNotRetainCursorStrings(t *testing.T) {
+	key := makeParallelActionKey(&Action{
+		Op:             SyncGrantsOp,
+		ResourceTypeID: "group",
+		ResourceID:     "group-1",
+		PageToken:      string(make([]byte, maxEnqueuedPageTokenBytes)),
+	})
+	require.LessOrEqual(t, reflect.TypeOf(key).Size(), uintptr(32))
+}
+
+func TestFailedSiblingAdmissionDoesNotAdvanceParentCursor(t *testing.T) {
+	ctx := t.Context()
+	st := newEmptySchedulerState(t)
+	origin := st.pushAction(ctx, Action{
+		Op:             SyncGrantsOp,
+		ResourceTypeID: "group",
+		ResourceID:     "group-1",
+		PageToken:      "origin",
+	})
+	s := &syncer{state: st, workerCount: 1}
+
+	f := func(ctx context.Context, action *Action) error {
+		return s.nextPageOrFinishAction(
+			ctx,
+			action,
+			"next",
+			Action{
+				Op:             SyncGrantsOp,
+				ResourceTypeID: action.ResourceTypeID,
+				ResourceID:     action.ResourceID,
+				PageToken:      "unique-child",
+				Spawned:        true,
+			},
+			Action{
+				Op:             SyncGrantsOp,
+				ResourceTypeID: action.ResourceTypeID,
+				ResourceID:     action.ResourceID,
+				PageToken:      "origin",
+				Spawned:        true,
+			},
+		)
+	}
+
+	_, err := s.syncParallel(ctx, newTestRetryer(ctx), []*Action{origin}, f)
+	require.ErrorContains(t, err, "duplicate or cyclic spawned cursor")
+	persisted := st.GetAction(origin.ID)
+	require.NotNil(t, persisted)
+	require.Equal(t, "origin", persisted.PageToken)
+	require.Equal(t, []string{origin.ID}, st.actionOrder)
+	require.Len(t, st.PeekMatchingActions(ctx, SyncGrantsOp), 1)
+}
+
+func TestSpawnedCursorCannotCollideWithParentContinuation(t *testing.T) {
+	ctx := t.Context()
+	st := newEmptySchedulerState(t)
+	origin := st.pushAction(ctx, Action{
+		Op:             SyncGrantsOp,
+		ResourceTypeID: "group",
+		ResourceID:     "group-1",
+		PageToken:      "current",
+	})
+	s := &syncer{state: st, workerCount: 1}
+
+	calls := 0
+	f := func(ctx context.Context, action *Action) error {
+		calls++
+		if calls > 1 {
+			return errors.New("test safety stop: parent/spawn collision was accepted")
+		}
+		return s.nextPageOrFinishAction(ctx, action, "same-next-token", Action{
+			Op:             SyncGrantsOp,
+			ResourceTypeID: action.ResourceTypeID,
+			ResourceID:     action.ResourceID,
+			PageToken:      "same-next-token",
+			Spawned:        true,
+		})
+	}
+
+	_, err := s.syncParallel(ctx, newTestRetryer(ctx), []*Action{origin}, f)
+	require.ErrorContains(t, err, "duplicate or cyclic spawned cursor")
+	require.Equal(t, 1, calls)
+	require.Equal(t, "current", st.GetAction(origin.ID).PageToken)
+	require.Equal(t, []string{origin.ID}, st.actionOrder)
+}
+
+func TestAbortedQueueRejectsInFlightTransitionWithoutStateMutation(t *testing.T) {
+	queue := newParallelActionQueue(nil)
+	queue.abort()
+	committed := false
+
+	err := queue.transition(SyncGrantsOp, nil, "", []Action{{
+		Op:        SyncGrantsOp,
+		PageToken: "child",
+	}}, func() ([]*Action, error) {
+		committed = true
+		return []*Action{{Op: SyncGrantsOp, PageToken: "child"}}, nil
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	require.False(t, committed)
+	require.Zero(t, queue.outstanding)
+	require.Empty(t, queue.actions)
+}
+
+func TestNextPageOrFinishActionStateTransitions(t *testing.T) {
+	child := Action{
+		Op:             SyncGrantsOp,
+		ResourceTypeID: "group",
+		ResourceID:     "group-1",
+		PageToken:      "child",
+		Spawned:        true,
+	}
+	tests := []struct {
+		name             string
+		nextPageToken    string
+		children         []Action
+		wantParent       bool
+		wantParentToken  string
+		wantCurrentToken string
+		wantActions      int
+	}{
+		{
+			name:            "continuation keeps parent",
+			nextPageToken:   "next",
+			wantParent:      true,
+			wantParentToken: "next",
+			wantActions:     1,
+		},
+		{
+			name:             "continuation commits child and keeps parent",
+			nextPageToken:    "next",
+			children:         []Action{child},
+			wantParent:       true,
+			wantParentToken:  "next",
+			wantCurrentToken: "child",
+			wantActions:      2,
+		},
+		{
+			name:        "final page removes parent",
+			wantActions: 0,
+		},
+		{
+			name:             "final page commits child then removes parent",
+			children:         []Action{child},
+			wantCurrentToken: "child",
+			wantActions:      1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			st := newEmptySchedulerState(t)
+			parent := st.pushAction(ctx, Action{
+				Op:             SyncGrantsOp,
+				ResourceTypeID: "group",
+				ResourceID:     "group-1",
+				PageToken:      "current",
+			})
+			s := &syncer{state: st}
+
+			require.NoError(t, s.nextPageOrFinishAction(ctx, parent, tt.nextPageToken, tt.children...))
+			require.Len(t, st.actions, tt.wantActions)
+			persistedParent := st.GetAction(parent.ID)
+			if tt.wantParent {
+				require.NotNil(t, persistedParent)
+				require.Equal(t, tt.wantParentToken, persistedParent.PageToken)
+			} else {
+				require.Nil(t, persistedParent)
+			}
+			if tt.wantCurrentToken == "" {
+				if tt.wantActions == 0 {
+					require.Nil(t, st.Current())
+				} else {
+					require.Equal(t, parent.ID, st.Current().ID)
+				}
+			} else {
+				require.NotNil(t, st.Current())
+				require.Equal(t, tt.wantCurrentToken, st.Current().PageToken)
+				require.NotEqual(t, parent.ID, st.Current().ID)
+			}
+		})
+	}
+}
+
+func TestTransitionActionValidationFailureIsAtomic(t *testing.T) {
+	ctx := t.Context()
+	st := newEmptySchedulerState(t)
+	parent := st.pushAction(ctx, Action{
+		Op:         SyncGrantsOp,
+		ResourceID: "group-1",
+		PageToken:  "current",
+	})
+	beforeOrder := append([]string(nil), st.actionOrder...)
+	beforeCompleted := st.GetCompletedActionsCount()
+
+	_, err := st.transitionAction(ctx, parent, "next", []Action{
+		{Op: SyncGrantsOp, ResourceID: "group-1", PageToken: "valid"},
+		{ID: "already-assigned", Op: SyncGrantsOp, ResourceID: "group-1", PageToken: "invalid"},
+	})
+	require.ErrorContains(t, err, "action ID must be empty")
+	require.Equal(t, beforeOrder, st.actionOrder)
+	require.Equal(t, beforeCompleted, st.GetCompletedActionsCount())
+	require.Len(t, st.actions, 1)
+	persisted := st.GetAction(parent.ID)
+	require.NotNil(t, persisted)
+	require.Equal(t, "current", persisted.PageToken)
+}
+
+func TestLegacyPaginatedCheckpointPlansTypeScopedCollection(t *testing.T) {
+	tests := []struct {
+		name       string
+		op         ActionOp
+		annotation *v2.ResourceType
+		sync       func(*syncer, context.Context, *Action) error
+	}{
+		{
+			name: "entitlements",
+			op:   SyncEntitlementsOp,
+			annotation: v2.ResourceType_builder{
+				Id:          "group",
+				DisplayName: "Group",
+				Annotations: annotations.New(&v2.TypeScopedEntitlements{}),
+			}.Build(),
+			sync: (*syncer).SyncEntitlements,
+		},
+		{
+			name: "grants",
+			op:   SyncGrantsOp,
+			annotation: v2.ResourceType_builder{
+				Id:          "group",
+				DisplayName: "Group",
+				Annotations: annotations.New(&v2.TypeScopedGrants{}),
+			}.Build(),
+			sync: (*syncer).SyncGrants,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			st := newEmptySchedulerState(t)
+			root := st.pushAction(ctx, Action{Op: tt.op, PageToken: "legacy-page-2"})
+			s := &syncer{
+				state: st,
+				store: &legacyPaginatedCheckpointStore{resourceType: tt.annotation},
+			}
+
+			require.NoError(t, tt.sync(s, ctx, root))
+			planned := st.Current()
+			require.NotNil(t, planned)
+			require.Equal(t, tt.op, planned.Op)
+			require.Equal(t, "group", planned.ResourceTypeID)
+			require.True(t, planned.TypeScoped)
+		})
+	}
+}
+
+func TestTypeScopedPlanningFailureDoesNotCommitMarker(t *testing.T) {
+	ctx := t.Context()
+	st := newEmptySchedulerState(t)
+	root := st.pushAction(ctx, Action{Op: SyncGrantsOp, PageToken: "legacy-page-2"})
+	store := &legacyPaginatedCheckpointStore{
+		resourceType: v2.ResourceType_builder{
+			Id:          "group",
+			DisplayName: "Group",
+			Annotations: annotations.New(&v2.TypeScopedGrants{}),
+		}.Build(),
+		listResourcesErr: errors.New("injected list-resources failure"),
+	}
+	s := &syncer{state: st, store: store}
+
+	require.ErrorContains(t, s.SyncGrants(ctx, root), "injected list-resources failure")
+	persisted := st.GetAction(root.ID)
+	require.NotNil(t, persisted)
+	require.False(t, persisted.TypeScopedPlanned)
+
+	store.listResourcesErr = nil
+	require.NoError(t, s.SyncGrants(ctx, persisted))
+	planned := st.Current()
+	require.NotNil(t, planned)
+	require.True(t, planned.TypeScoped)
+	require.Equal(t, "group", planned.ResourceTypeID)
+}
+
+func TestTypeScopedPlanningMarkerSurvivesCheckpoint(t *testing.T) {
+	ctx := t.Context()
+	st := newEmptySchedulerState(t)
+	root := st.pushAction(ctx, Action{Op: SyncGrantsOp, PageToken: "legacy-page-2"})
+	store := &legacyPaginatedCheckpointStore{
+		resourceType: v2.ResourceType_builder{
+			Id:          "group",
+			DisplayName: "Group",
+			Annotations: annotations.New(&v2.TypeScopedGrants{}),
+		}.Build(),
+		nextPageToken: "page-3",
+	}
+	s := &syncer{state: st, store: store}
+
+	require.NoError(t, s.SyncGrants(ctx, root))
+	planned := st.Current()
+	require.NotNil(t, planned)
+	require.True(t, planned.TypeScoped)
+	st.FinishAction(ctx, planned)
+	resumedRoot := st.Current()
+	require.NotNil(t, resumedRoot)
+	require.True(t, resumedRoot.TypeScopedPlanned)
+	require.Equal(t, "page-3", resumedRoot.PageToken)
+
+	token, err := st.Marshal()
+	require.NoError(t, err)
+	resumed := newState()
+	require.NoError(t, resumed.Unmarshal(token))
+	require.True(t, resumed.Current().TypeScopedPlanned)
 }
 
 func TestSyncParallelErrorAbortsQueuedWorkAndCancelsPeer(t *testing.T) {

--- a/pkg/sync/parallel_scheduler_test.go
+++ b/pkg/sync/parallel_scheduler_test.go
@@ -2,6 +2,7 @@ package sync //nolint:revive,nolintlint // backwards-compatible package name
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"reflect"
@@ -287,6 +288,26 @@ func TestAbortedQueueRejectsInFlightTransitionWithoutStateMutation(t *testing.T)
 	require.False(t, committed)
 	require.Zero(t, queue.outstanding)
 	require.Empty(t, queue.actions)
+}
+
+func TestParallelActionQueueRejectsCursorLimitBeforeCommit(t *testing.T) {
+	queue := newParallelActionQueue(nil)
+	for i := 0; i < maxSpawnedCursorsPerBatch; i++ {
+		var key parallelActionKey
+		binary.BigEndian.PutUint64(key[:8], uint64(i))
+		queue.seen[key] = struct{}{}
+	}
+	committed := false
+	err := queue.transition(SyncGrantsOp, nil, "", []Action{{
+		Op:        SyncGrantsOp,
+		PageToken: "over-limit",
+	}}, func() ([]*Action, error) {
+		committed = true
+		return nil, nil
+	})
+	require.ErrorContains(t, err, "exceeded the maximum")
+	require.False(t, committed)
+	require.Len(t, queue.seen, maxSpawnedCursorsPerBatch)
 }
 
 func TestNextPageOrFinishActionStateTransitions(t *testing.T) {
@@ -659,5 +680,44 @@ func TestSpawnedCursorsResumeAfterPartialCompletion(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, warnings)
 	require.ElementsMatch(t, []string{"a", "b"}, processed)
+	require.Nil(t, resumed.Current())
+}
+
+func TestOriginContinuationAndSiblingsResumeExactlyOnce(t *testing.T) {
+	ctx := t.Context()
+	st := newEmptySchedulerState(t)
+	origin := st.pushAction(ctx, Action{
+		Op:             SyncGrantsOp,
+		ResourceTypeID: "group",
+		ResourceID:     "group-1",
+		PageToken:      "origin-current",
+	})
+	_, err := st.transitionAction(ctx, origin, "origin-next", []Action{
+		{Op: SyncGrantsOp, ResourceTypeID: "group", ResourceID: "group-1", PageToken: "sibling-a", Spawned: true},
+		{Op: SyncGrantsOp, ResourceTypeID: "group", ResourceID: "group-1", PageToken: "sibling-b", Spawned: true},
+	})
+	require.NoError(t, err)
+	st.FinishAction(ctx, st.Current())
+
+	token, err := st.Marshal()
+	require.NoError(t, err)
+	resumed := newState()
+	require.NoError(t, resumed.Unmarshal(token))
+	s := &syncer{state: resumed, workerCount: 2}
+
+	var mu sync.Mutex
+	processed := make(map[string]int)
+	f := func(ctx context.Context, action *Action) error {
+		mu.Lock()
+		processed[action.PageToken]++
+		mu.Unlock()
+		s.state.FinishAction(ctx, action)
+		return nil
+	}
+
+	warnings, err := s.syncParallel(ctx, newTestRetryer(ctx), resumed.PeekMatchingActions(ctx, SyncGrantsOp), f)
+	require.NoError(t, err)
+	require.Empty(t, warnings)
+	require.Equal(t, map[string]int{"origin-next": 1, "sibling-a": 1}, processed)
 	require.Nil(t, resumed.Current())
 }

--- a/pkg/sync/parallel_scheduler_test.go
+++ b/pkg/sync/parallel_scheduler_test.go
@@ -156,7 +156,11 @@ func TestSyncParallelDrainsMultipleSpawnedCursors(t *testing.T) {
 	require.Nil(t, st.Current())
 }
 
-func TestSyncParallelRejectsCyclicSpawnedCursor(t *testing.T) {
+func TestSyncParallelBreaksCyclicSpawnedCursorIdempotently(t *testing.T) {
+	// A cursor that re-mentions its own identity (the tightest cycle) is
+	// skipped, not fatal: the identical work is scheduled exactly once,
+	// so failing would wedge the sync deterministically — while skipping
+	// terminates the cycle with the batch fully drained.
 	ctx := t.Context()
 	st := newEmptySchedulerState(t)
 	origin := st.pushAction(ctx, Action{
@@ -171,7 +175,7 @@ func TestSyncParallelRejectsCyclicSpawnedCursor(t *testing.T) {
 	f := func(ctx context.Context, action *Action) error {
 		calls++
 		if calls > 3 {
-			return errors.New("test safety stop: cyclic cursor was accepted")
+			return errors.New("test safety stop: cyclic cursor spawned unbounded copies")
 		}
 		return s.nextPageOrFinishAction(ctx, action, "", Action{
 			Op:             SyncGrantsOp,
@@ -183,8 +187,9 @@ func TestSyncParallelRejectsCyclicSpawnedCursor(t *testing.T) {
 	}
 
 	_, err := s.syncParallel(ctx, newTestRetryer(ctx), []*Action{origin}, f)
-	require.ErrorContains(t, err, "duplicate or cyclic spawned cursor")
-	require.LessOrEqual(t, calls, 2)
+	require.NoError(t, err)
+	require.Equal(t, 1, calls, "the cycle must be broken at admission, not by re-running the cursor")
+	require.Nil(t, st.Current(), "the batch must drain completely")
 }
 
 func TestParallelActionKeyDoesNotRetainCursorStrings(t *testing.T) {
@@ -198,6 +203,10 @@ func TestParallelActionKeyDoesNotRetainCursorStrings(t *testing.T) {
 }
 
 func TestFailedSiblingAdmissionDoesNotAdvanceParentCursor(t *testing.T) {
+	// A WITHIN-CALL duplicate (the same cursor twice in one response) is
+	// a genuine connector protocol violation and stays fatal — and the
+	// rejection must be atomic: the parent's cursor must not advance and
+	// nothing may be admitted.
 	ctx := t.Context()
 	st := newEmptySchedulerState(t)
 	origin := st.pushAction(ctx, Action{
@@ -208,7 +217,12 @@ func TestFailedSiblingAdmissionDoesNotAdvanceParentCursor(t *testing.T) {
 	})
 	s := &syncer{state: st, workerCount: 1}
 
+	calls := 0
 	f := func(ctx context.Context, action *Action) error {
+		calls++
+		if calls > 1 {
+			return errors.New("test safety stop: duplicate within one response was accepted")
+		}
 		return s.nextPageOrFinishAction(
 			ctx,
 			action,
@@ -217,14 +231,14 @@ func TestFailedSiblingAdmissionDoesNotAdvanceParentCursor(t *testing.T) {
 				Op:             SyncGrantsOp,
 				ResourceTypeID: action.ResourceTypeID,
 				ResourceID:     action.ResourceID,
-				PageToken:      "unique-child",
+				PageToken:      "dup-child",
 				Spawned:        true,
 			},
 			Action{
 				Op:             SyncGrantsOp,
 				ResourceTypeID: action.ResourceTypeID,
 				ResourceID:     action.ResourceID,
-				PageToken:      "origin",
+				PageToken:      "dup-child",
 				Spawned:        true,
 			},
 		)
@@ -237,6 +251,52 @@ func TestFailedSiblingAdmissionDoesNotAdvanceParentCursor(t *testing.T) {
 	require.Equal(t, "origin", persisted.PageToken)
 	require.Equal(t, []string{origin.ID}, st.actionOrder)
 	require.Len(t, st.PeekMatchingActions(ctx, SyncGrantsOp), 1)
+}
+
+func TestContinuationReconvergenceFinishesParent(t *testing.T) {
+	// A parent whose NEXT PAGE TOKEN re-converges on an identity already
+	// scheduled in the batch (e.g. a resumed cursor persisted with that
+	// exact token, re-mentioned because the API's answers shifted across
+	// a crash) must FINISH instead of erroring: the action owning that
+	// identity performs exactly the work the continuation would have.
+	// Pre-fix this was fatal, and deterministically so on every retry —
+	// a permanently wedged sync.
+	ctx := t.Context()
+	st := newEmptySchedulerState(t)
+	walker := st.pushAction(ctx, Action{
+		Op:             SyncGrantsOp,
+		ResourceTypeID: "group",
+		ResourceID:     "group-1",
+		PageToken:      "walker",
+	})
+	holder := st.pushAction(ctx, Action{
+		Op:             SyncGrantsOp,
+		ResourceTypeID: "group",
+		ResourceID:     "group-1",
+		PageToken:      "held-token",
+		Spawned:        true,
+	})
+	s := &syncer{state: st, workerCount: 1}
+
+	processed := map[string]int{}
+	f := func(ctx context.Context, action *Action) error {
+		processed[action.PageToken]++
+		if action.PageToken == "walker" {
+			// The connector's answer says "continue at held-token" —
+			// which the sibling seed already owns.
+			return s.nextPageOrFinishAction(ctx, action, "held-token")
+		}
+		s.state.FinishAction(ctx, action)
+		return nil
+	}
+
+	warnings, err := s.syncParallel(ctx, newTestRetryer(ctx), []*Action{walker, holder}, f)
+	require.NoError(t, err)
+	require.Empty(t, warnings)
+	require.Equal(t, map[string]int{"walker": 1, "held-token": 1}, processed,
+		"the held token must be walked exactly once, by its owner")
+	require.Nil(t, st.GetAction(walker.ID), "the re-converged parent must finish, not continue")
+	require.Nil(t, st.Current(), "the batch must drain completely")
 }
 
 func TestSpawnedCursorCannotCollideWithParentContinuation(t *testing.T) {
@@ -277,10 +337,10 @@ func TestAbortedQueueRejectsInFlightTransitionWithoutStateMutation(t *testing.T)
 	queue.abort()
 	committed := false
 
-	err := queue.transition(SyncGrantsOp, nil, "", []Action{{
+	err := queue.transition(t.Context(), SyncGrantsOp, nil, "", []Action{{
 		Op:        SyncGrantsOp,
 		PageToken: "child",
-	}}, func() ([]*Action, error) {
+	}}, func(string, []Action) ([]*Action, error) {
 		committed = true
 		return []*Action{{Op: SyncGrantsOp, PageToken: "child"}}, nil
 	})
@@ -298,10 +358,10 @@ func TestParallelActionQueueRejectsCursorLimitBeforeCommit(t *testing.T) {
 		queue.seen[key] = struct{}{}
 	}
 	committed := false
-	err := queue.transition(SyncGrantsOp, nil, "", []Action{{
+	err := queue.transition(t.Context(), SyncGrantsOp, nil, "", []Action{{
 		Op:        SyncGrantsOp,
 		PageToken: "over-limit",
-	}}, func() ([]*Action, error) {
+	}}, func(string, []Action) ([]*Action, error) {
 		committed = true
 		return nil, nil
 	})

--- a/pkg/sync/parallel_scheduler_test.go
+++ b/pkg/sync/parallel_scheduler_test.go
@@ -1,0 +1,285 @@
+package sync //nolint:revive,nolintlint // backwards-compatible package name
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/conductorone/baton-sdk/pkg/retry"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func newEmptySchedulerState(t *testing.T) *state {
+	t.Helper()
+	st := newState()
+	require.NoError(t, st.Unmarshal(""))
+	st.FinishAction(t.Context(), st.Current())
+	return st
+}
+
+func newTestRetryer(ctx context.Context) *retry.Retryer {
+	return retry.NewRetryer(ctx, retry.RetryConfig{
+		MaxAttempts:  1,
+		InitialDelay: time.Millisecond,
+		MaxDelay:     time.Millisecond,
+	})
+}
+
+func TestTooManyWarningsThreshold(t *testing.T) {
+	require.False(t, tooManyWarnings(10, 1), "requires more than ten warnings")
+	require.False(t, tooManyWarnings(11, 0), "requires completed actions")
+	require.False(t, tooManyWarnings(11, 110), "exactly ten percent is allowed")
+	require.True(t, tooManyWarnings(11, 109), "more than ten percent must stop the sync")
+}
+
+func TestCollectionProgressAccounting(t *testing.T) {
+	tests := []struct {
+		name          string
+		action        *Action
+		itemCount     int
+		hasNextPage   bool
+		wantIncrement int
+		wantCountOnly bool
+	}{
+		{
+			name:          "per-resource origin counts once on final page",
+			action:        &Action{},
+			itemCount:     25,
+			wantIncrement: 1,
+		},
+		{
+			name:        "per-resource origin does not count intermediate page",
+			action:      &Action{},
+			itemCount:   25,
+			hasNextPage: true,
+		},
+		{
+			name:      "spawned cursor does not count resource",
+			action:    &Action{Spawned: true},
+			itemCount: 25,
+		},
+		{
+			name:          "type-scoped cursor counts collected rows",
+			action:        &Action{TypeScoped: true},
+			itemCount:     25,
+			hasNextPage:   true,
+			wantIncrement: 25,
+			wantCountOnly: true,
+		},
+		{
+			name:          "spawned type-scoped cursor still counts collected rows",
+			action:        &Action{Spawned: true, TypeScoped: true},
+			itemCount:     10,
+			wantIncrement: 10,
+			wantCountOnly: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			increment, countOnly := collectionProgressIncrement(tt.action, tt.itemCount, tt.hasNextPage)
+			require.Equal(t, tt.wantIncrement, increment)
+			require.Equal(t, tt.wantCountOnly, countOnly)
+		})
+	}
+}
+
+func TestSyncParallelDrainsMultipleSpawnedCursors(t *testing.T) {
+	ctx := t.Context()
+	st := newEmptySchedulerState(t)
+	origin := st.pushAction(ctx, Action{
+		Op:             SyncGrantsOp,
+		ResourceTypeID: "group",
+		ResourceID:     "group-1",
+	})
+	s := &syncer{state: st, workerCount: 3}
+
+	var mu sync.Mutex
+	processed := make(map[string]int)
+	f := func(ctx context.Context, action *Action) error {
+		mu.Lock()
+		processed[action.PageToken]++
+		mu.Unlock()
+		if action.PageToken == "" {
+			return s.nextPageOrFinishAction(ctx, action, "",
+				Action{Op: SyncGrantsOp, ResourceTypeID: "group", ResourceID: "group-1", PageToken: "a", Spawned: true},
+				Action{Op: SyncGrantsOp, ResourceTypeID: "group", ResourceID: "group-1", PageToken: "b", Spawned: true},
+				Action{Op: SyncGrantsOp, ResourceTypeID: "group", ResourceID: "group-1", PageToken: "c", Spawned: true},
+			)
+		}
+		s.state.FinishAction(ctx, action)
+		return nil
+	}
+
+	warnings, err := s.syncParallel(ctx, newTestRetryer(ctx), []*Action{origin}, f)
+	require.NoError(t, err)
+	require.Empty(t, warnings)
+	require.Equal(t, map[string]int{"": 1, "a": 1, "b": 1, "c": 1}, processed)
+	require.Nil(t, st.Current())
+}
+
+func TestSyncParallelErrorAbortsQueuedWorkAndCancelsPeer(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	st := newEmptySchedulerState(t)
+	fail := st.pushAction(ctx, Action{Op: SyncGrantsOp, ResourceID: "fail"})
+	slow := st.pushAction(ctx, Action{Op: SyncGrantsOp, ResourceID: "slow"})
+	queued := st.pushAction(ctx, Action{Op: SyncGrantsOp, ResourceID: "queued"})
+	s := &syncer{state: st, workerCount: 2}
+
+	slowStarted := make(chan struct{})
+	var queuedRan bool
+	var mu sync.Mutex
+	f := func(ctx context.Context, action *Action) error {
+		switch action.ResourceID {
+		case "fail":
+			select {
+			case <-slowStarted:
+				return errors.New("permanent failure")
+			case <-ctx.Done():
+				return context.Cause(ctx)
+			}
+		case "slow":
+			close(slowStarted)
+			<-ctx.Done()
+			return context.Cause(ctx)
+		case "queued":
+			mu.Lock()
+			queuedRan = true
+			mu.Unlock()
+			return nil
+		default:
+			return fmt.Errorf("unexpected action %q", action.ResourceID)
+		}
+	}
+
+	warnings, err := s.syncParallel(ctx, newTestRetryer(ctx), []*Action{fail, slow, queued}, f)
+	require.ErrorContains(t, err, "permanent failure")
+	require.Empty(t, warnings)
+	mu.Lock()
+	require.False(t, queuedRan)
+	mu.Unlock()
+	require.NotNil(t, st.GetAction(queued.ID))
+}
+
+func TestSyncParallelAggregatesWarningAndContinues(t *testing.T) {
+	ctx := t.Context()
+	st := newEmptySchedulerState(t)
+	warningAction := st.pushAction(ctx, Action{Op: SyncGrantsOp, ResourceID: "missing"})
+	successAction := st.pushAction(ctx, Action{Op: SyncGrantsOp, ResourceID: "present"})
+	s := &syncer{state: st, workerCount: 2}
+
+	f := func(ctx context.Context, action *Action) error {
+		if action.ResourceID == "missing" {
+			return status.Error(codes.NotFound, "resource disappeared")
+		}
+		s.state.FinishAction(ctx, action)
+		return nil
+	}
+
+	warnings, err := s.syncParallel(ctx, newTestRetryer(ctx), []*Action{warningAction, successAction}, f)
+	require.NoError(t, err)
+	require.Len(t, warnings, 1)
+	require.Equal(t, codes.NotFound, status.Code(warnings[0]))
+	require.Nil(t, st.Current())
+}
+
+func TestSyncParallelRetriesActionWithinWorker(t *testing.T) {
+	ctx := t.Context()
+	st := newEmptySchedulerState(t)
+	action := st.pushAction(ctx, Action{Op: SyncGrantsOp, ResourceID: "group-1"})
+	s := &syncer{state: st, workerCount: 1}
+
+	calls := 0
+	f := func(ctx context.Context, action *Action) error {
+		calls++
+		if calls == 1 {
+			return status.Error(codes.Unavailable, "transient")
+		}
+		s.state.FinishAction(ctx, action)
+		return nil
+	}
+
+	warnings, err := s.syncParallel(ctx, newTestRetryer(ctx), []*Action{action}, f)
+	require.NoError(t, err)
+	require.Empty(t, warnings)
+	require.Equal(t, 2, calls)
+	require.Nil(t, st.Current())
+}
+
+func TestSyncParallelFiltersSpawnedActionsFromOtherOperations(t *testing.T) {
+	ctx := t.Context()
+	st := newEmptySchedulerState(t)
+	origin := st.pushAction(ctx, Action{Op: SyncGrantsOp, ResourceID: "group-1"})
+	s := &syncer{state: st, workerCount: 2}
+
+	calls := 0
+	f := func(ctx context.Context, action *Action) error {
+		calls++
+		return s.nextPageOrFinishAction(ctx, action, "", Action{
+			Op:         SyncEntitlementsOp,
+			ResourceID: "group-1",
+		})
+	}
+
+	warnings, err := s.syncParallel(ctx, newTestRetryer(ctx), []*Action{origin}, f)
+	require.NoError(t, err)
+	require.Empty(t, warnings)
+	require.Equal(t, 1, calls)
+	require.NotNil(t, st.Current())
+	require.Equal(t, SyncEntitlementsOp, st.Current().Op)
+}
+
+func TestSyncParallelEmptyBatchWithIdleWorkers(t *testing.T) {
+	ctx := t.Context()
+	st := newEmptySchedulerState(t)
+	s := &syncer{state: st, workerCount: 8}
+
+	warnings, err := s.syncParallel(ctx, newTestRetryer(ctx), nil, func(context.Context, *Action) error {
+		panic("empty batch invoked worker function")
+	})
+	require.NoError(t, err)
+	require.Empty(t, warnings)
+}
+
+func TestSpawnedCursorsResumeAfterPartialCompletion(t *testing.T) {
+	ctx := t.Context()
+	st := newEmptySchedulerState(t)
+	for _, token := range []string{"a", "b", "c"} {
+		st.PushAction(ctx, Action{
+			Op:             SyncGrantsOp,
+			ResourceTypeID: "group",
+			PageToken:      token,
+			Spawned:        true,
+			TypeScoped:     true,
+		})
+	}
+	st.FinishAction(ctx, st.Current())
+
+	token, err := st.Marshal()
+	require.NoError(t, err)
+	resumed := newState()
+	require.NoError(t, resumed.Unmarshal(token))
+	s := &syncer{state: resumed, workerCount: 2}
+
+	var mu sync.Mutex
+	var processed []string
+	f := func(ctx context.Context, action *Action) error {
+		mu.Lock()
+		processed = append(processed, action.PageToken)
+		mu.Unlock()
+		s.state.FinishAction(ctx, action)
+		return nil
+	}
+
+	warnings, err := s.syncParallel(ctx, newTestRetryer(ctx), resumed.PeekMatchingActions(ctx, SyncGrantsOp), f)
+	require.NoError(t, err)
+	require.Empty(t, warnings)
+	require.ElementsMatch(t, []string{"a", "b"}, processed)
+	require.Nil(t, resumed.Current())
+}

--- a/pkg/sync/parallel_scheduler_test.go
+++ b/pkg/sync/parallel_scheduler_test.go
@@ -683,6 +683,56 @@ func TestSpawnedCursorsResumeAfterPartialCompletion(t *testing.T) {
 	require.Nil(t, resumed.Current())
 }
 
+// Checkpoint tokens carrying type-scoped or spawned markers must be stamped
+// with StateTokenVersionTypeScoped: an older SDK's parser silently drops the
+// marker fields and dead-ends the cursors against store pagination, sealing
+// the sync as complete with missing data. The version bump makes the old
+// parser fall back to V0 (empty action state), restarting collection from
+// Init instead — redone work, never silent loss. Plain tokens keep version 1
+// so downgrades resume seamlessly.
+func TestCheckpointVersionStampsTypeScopedTokens(t *testing.T) {
+	ctx := t.Context()
+
+	plain := newEmptySchedulerState(t)
+	plain.PushAction(ctx, Action{Op: SyncGrantsOp, ResourceTypeID: "group", ResourceID: "g1"})
+	plainToken, err := plain.Marshal()
+	require.NoError(t, err)
+	require.Contains(t, plainToken, `"version":1`)
+
+	scoped := newEmptySchedulerState(t)
+	scoped.PushAction(ctx, Action{Op: SyncGrantsOp, ResourceTypeID: "group", TypeScoped: true})
+	scopedToken, err := scoped.Marshal()
+	require.NoError(t, err)
+	require.Contains(t, scopedToken, `"version":2`)
+
+	spawned := newEmptySchedulerState(t)
+	spawned.PushAction(ctx, Action{Op: SyncGrantsOp, ResourceTypeID: "group", ResourceID: "g1", PageToken: "p", Spawned: true})
+	spawnedToken, err := spawned.Marshal()
+	require.NoError(t, err)
+	require.Contains(t, spawnedToken, `"version":2`)
+
+	planned := newEmptySchedulerState(t)
+	planned.PushAction(ctx, Action{Op: SyncGrantsOp, TypeScopedPlanned: true})
+	plannedToken, err := planned.Marshal()
+	require.NoError(t, err)
+	require.Contains(t, plannedToken, `"version":2`)
+
+	// This SDK accepts both versions losslessly.
+	resumedScoped := newState()
+	require.NoError(t, resumedScoped.Unmarshal(scopedToken))
+	require.True(t, resumedScoped.Current().TypeScoped)
+	resumedPlain := newState()
+	require.NoError(t, resumedPlain.Unmarshal(plainToken))
+	require.NotNil(t, resumedPlain.Current())
+
+	// An older SDK rejects version 2 and reparses via the V0 format, which
+	// carries no actions_map — the state comes back empty and the old
+	// syncer restarts collection from Init.
+	v0Fallback, err := unmarshalTokenV0(scopedToken)
+	require.NoError(t, err)
+	require.Empty(t, v0Fallback.ActionsMap)
+}
+
 func TestOriginContinuationAndSiblingsResumeExactlyOnce(t *testing.T) {
 	ctx := t.Context()
 	st := newEmptySchedulerState(t)

--- a/pkg/sync/parallel_stepper_test.go
+++ b/pkg/sync/parallel_stepper_test.go
@@ -1,0 +1,452 @@
+package sync //nolint:revive,nolintlint // backwards-compatible package name
+
+// Bounded-exhaustive interleaving stepper for parallelActionQueue (Option
+// A of the verification plan).
+//
+// Every queue operation executes under one mutex, so a concurrent
+// schedule is exactly an ORDERING of critical sections — and executing
+// enabled operations one at a time against the REAL queue is a faithful
+// execution of that schedule. The stepper explores ALL reachable
+// orderings of a scenario by depth-first search: each tree node is a
+// prefix of operations, each branch an enabled next operation, with
+// visited-state pruning (queue state + worker states; workers are
+// symmetric, so states are sorted) and replay from scratch per node.
+//
+// Worker lifecycle mirrors syncParallel's worker loop exactly:
+//
+//	idle -next()-> holding -transition()xN-> finished -done()-> idle
+//	                  \-(connector failure or transition error)-> failed
+//	                     -done()-> failedDone -abort()-> exited
+//	idle -next()==false-> exited
+//
+// At every node the stepper checks liveness (some operation enabled, or
+// every worker exited — a stuck node is the outstanding-accounting bug
+// class) and queue sanity (outstanding never negative). At every terminal
+// it runs the full Option D audit contract (verifyQueueAudit): exactly-
+// once, admission-before-execution, no-commit-after-abort, dedup
+// soundness, accounting, and full drain on clean completion. Silent
+// violations in ANY schedule of the scenario space fail the test.
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// stepPage is one connector response for a cursor: a continuation token
+// (empty = final page) and spawned sibling tokens.
+type stepPage struct {
+	next     string
+	children []string
+}
+
+// stepBehavior is the deterministic behavior of one cursor. fail models
+// the connector call failing (non-retryable): no transition happens and
+// the worker takes the done→abort→exit path. Tokens without an entry
+// behave as leaves (one final page, no spawns).
+type stepBehavior struct {
+	pages []stepPage
+	fail  bool
+}
+
+type stepScenario struct {
+	name      string
+	seeds     []string
+	workers   int
+	behaviors map[string]stepBehavior
+	// cleanReachable declares whether any schedule can finish without an
+	// abort (false when a seed always fails). Used to sanity-check the
+	// explored space.
+	cleanReachable bool
+}
+
+const (
+	wIdle = iota
+	wHolding
+	wFinished
+	wFailed
+	wFailedDone
+	wExited
+)
+
+type stepWorker struct {
+	phase  int
+	action *Action
+	page   int
+}
+
+// stepRun is one replayed execution: the real queue plus worker states.
+type stepRun struct {
+	sc      *stepScenario
+	queue   *parallelActionQueue
+	audit   *queueAudit
+	workers []*stepWorker
+	nextID  int
+	failed  bool // any worker took the failure path (batchErr != nil)
+}
+
+func newStepRun(sc *stepScenario) *stepRun {
+	r := &stepRun{sc: sc}
+	seeds := make([]*Action, 0, len(sc.seeds))
+	for _, tok := range sc.seeds {
+		r.nextID++
+		seeds = append(seeds, &Action{
+			ID:             fmt.Sprintf("s%03d", r.nextID),
+			Op:             SyncGrantsOp,
+			ResourceTypeID: "group",
+			ResourceID:     "res-1",
+			PageToken:      tok,
+			Spawned:        true,
+			TypeScoped:     true,
+		})
+	}
+	r.queue = newParallelActionQueue(seeds)
+	r.audit = &queueAudit{}
+	r.queue.attachAudit(r.audit, SyncGrantsOp, 1)
+	r.workers = make([]*stepWorker, sc.workers)
+	for i := range r.workers {
+		r.workers[i] = &stepWorker{phase: wIdle}
+	}
+	return r
+}
+
+func (r *stepRun) behavior(tok string) stepBehavior {
+	if b, ok := r.sc.behaviors[tok]; ok {
+		return b
+	}
+	return stepBehavior{pages: []stepPage{{}}}
+}
+
+// enabledOps lists every worker operation that can run without blocking.
+// Op encoding: worker index only — each worker phase has exactly one next
+// operation, so the phase determines what runs.
+func (r *stepRun) enabledOps() []int {
+	var ops []int
+	for i, w := range r.workers {
+		switch w.phase {
+		case wExited:
+			continue
+		case wIdle:
+			// next() blocks while !aborted && drained-head && outstanding>0.
+			q := r.queue
+			q.mu.Lock()
+			blocked := !q.aborted && q.head == len(q.actions) && q.outstanding > 0
+			q.mu.Unlock()
+			if !blocked {
+				ops = append(ops, i)
+			}
+		default:
+			// transition/done/abort never block.
+			ops = append(ops, i)
+		}
+	}
+	return ops
+}
+
+// step executes worker i's next operation against the real queue,
+// mirroring syncParallel's worker loop:
+//
+//	go func() {
+//	    for { action, ok := next(); if !ok return
+//	          r := syncOneAction(...)          // pages: transition per page
+//	          done(); if r.err != nil { abort(); return } }
+//	}()
+func (r *stepRun) step(t *testing.T, i int) {
+	w := r.workers[i]
+	switch w.phase {
+	case wIdle:
+		action, ok := r.queue.next()
+		if !ok {
+			w.phase = wExited
+			return
+		}
+		w.action = action
+		w.page = 0
+		if r.behavior(action.PageToken).fail {
+			// The connector call fails before any transition.
+			w.phase = wFailed
+			return
+		}
+		w.phase = wHolding
+	case wHolding:
+		b := r.behavior(w.action.PageToken)
+		require.Less(t, w.page, len(b.pages), "scenario bug: cursor %q ran out of pages", w.action.PageToken)
+		page := b.pages[w.page]
+		children := make([]Action, 0, len(page.children))
+		for _, tok := range page.children {
+			children = append(children, Action{
+				Op:             SyncGrantsOp,
+				ResourceTypeID: "group",
+				ResourceID:     "res-1",
+				PageToken:      tok,
+				Spawned:        true,
+				TypeScoped:     true,
+			})
+		}
+		var committedNext string
+		err := r.queue.transition(context.Background(), SyncGrantsOp, w.action, page.next, children,
+			func(effectiveNext string, admitted []Action) ([]*Action, error) {
+				committedNext = effectiveNext
+				pushed := make([]*Action, 0, len(admitted))
+				for j := range admitted {
+					child := admitted[j]
+					r.nextID++
+					child.ID = fmt.Sprintf("c%03d", r.nextID)
+					pushed = append(pushed, &child)
+				}
+				return pushed, nil
+			})
+		switch {
+		case err != nil:
+			// Post-abort rejection (or a protocol violation): the real
+			// worker surfaces the error from f and takes the failure
+			// path.
+			w.phase = wFailed
+		case committedNext == "":
+			w.phase = wFinished
+		default:
+			w.page++
+		}
+	case wFinished:
+		r.queue.done()
+		w.phase = wIdle
+		w.action = nil
+	case wFailed:
+		r.queue.done()
+		r.failed = true
+		w.phase = wFailedDone
+	case wFailedDone:
+		r.queue.abort()
+		w.phase = wExited
+	default:
+		t.Fatalf("step on worker in phase %d", w.phase)
+	}
+}
+
+// signature canonicalizes the full future-relevant state: real queue
+// internals plus sorted worker states (workers are symmetric).
+func (r *stepRun) signature() string {
+	q := r.queue
+	q.mu.Lock()
+	head := fmt.Sprintf("o%d|a%v", q.outstanding, q.aborted)
+	pending := make([]string, 0, len(q.actions)-q.head)
+	for _, action := range q.actions[q.head:] {
+		if action != nil {
+			pending = append(pending, action.PageToken)
+		}
+	}
+	seen := make([]string, 0, len(q.seen))
+	for k := range q.seen {
+		seen = append(seen, fmt.Sprintf("%x", k[:8]))
+	}
+	q.mu.Unlock()
+	sort.Strings(seen)
+
+	ws := make([]string, 0, len(r.workers))
+	for _, w := range r.workers {
+		switch w.phase {
+		case wHolding:
+			ws = append(ws, fmt.Sprintf("h:%s:%d", w.action.PageToken, w.page))
+		case wFinished:
+			ws = append(ws, "f:"+w.action.PageToken)
+		case wFailed:
+			ws = append(ws, "x:"+w.action.PageToken)
+		default:
+			ws = append(ws, fmt.Sprintf("p%d", w.phase))
+		}
+	}
+	sort.Strings(ws)
+	return strings.Join([]string{head, strings.Join(pending, ","), strings.Join(seen, ","), strings.Join(ws, ",")}, "|")
+}
+
+func (r *stepRun) sane(t *testing.T) {
+	q := r.queue
+	q.mu.Lock()
+	outstanding, head, actions := q.outstanding, q.head, len(q.actions)
+	q.mu.Unlock()
+	require.GreaterOrEqual(t, outstanding, 0, "outstanding went negative")
+	require.LessOrEqual(t, head, actions, "queue head ran past the buffer")
+}
+
+type stepStats struct {
+	nodes          int
+	terminals      int
+	cleanTerminals int
+}
+
+const stepNodeCap = 500_000
+
+// exploreScenario DFS-explores every schedule of the scenario, replaying
+// the operation prefix from scratch at each node (the queue is rebuilt
+// deterministically), pruning by state signature.
+func exploreScenario(t *testing.T, sc *stepScenario) stepStats {
+	t.Helper()
+	stats := stepStats{}
+	visited := map[string]bool{}
+
+	var dfs func(prefix []int)
+	dfs = func(prefix []int) {
+		stats.nodes++
+		require.Less(t, stats.nodes, stepNodeCap, "scenario state space exceeded the node cap")
+
+		// Replay the prefix on a fresh run.
+		r := newStepRun(sc)
+		for _, op := range prefix {
+			r.step(t, op)
+			r.sane(t)
+		}
+
+		sig := r.signature()
+		if visited[sig] {
+			return
+		}
+		visited[sig] = true
+
+		ops := r.enabledOps()
+		if len(ops) == 0 {
+			// Liveness: a node with no enabled operations must be a
+			// fully exited terminal — anything else is the stuck-batch
+			// bug class (broken outstanding accounting).
+			for _, w := range r.workers {
+				require.Equal(t, wExited, w.phase,
+					"schedule %v deadlocked: worker stuck in phase %d with no enabled operations", prefix, w.phase)
+			}
+			stats.terminals++
+			clean := !r.failed
+			if clean {
+				stats.cleanTerminals++
+				q := r.queue
+				q.mu.Lock()
+				outstanding := q.outstanding
+				q.mu.Unlock()
+				require.Zero(t, outstanding, "clean terminal with nonzero outstanding")
+			}
+			// Full queue-contract audit over this schedule's event log.
+			r.audit.record(queueAuditEvent{kind: auditBatchEnd, batch: 1, clean: clean})
+			verifyQueueAudit(t, r.audit)
+			return
+		}
+		for _, op := range ops {
+			dfs(append(append([]int(nil), prefix...), op))
+		}
+	}
+	dfs(nil)
+	require.Positive(t, stats.terminals, "scenario explored no terminal states")
+	if sc.cleanReachable {
+		require.Positive(t, stats.cleanTerminals, "scenario declared clean-reachable but no clean terminal was found")
+	}
+	return stats
+}
+
+func TestParallelQueueExhaustiveInterleavings(t *testing.T) {
+	scenarios := []*stepScenario{
+		{
+			// Fan-out chain: the planner-ish seed spawns two, one spawns
+			// a grandchild. Exactly-once and full drain across every
+			// dequeue/commit/done ordering.
+			name:    "fanout-chain",
+			seeds:   []string{"A"},
+			workers: 2,
+			behaviors: map[string]stepBehavior{
+				"A": {pages: []stepPage{{children: []string{"B", "C"}}}},
+				"B": {pages: []stepPage{{children: []string{"D"}}}},
+			},
+			cleanReachable: true,
+		},
+		{
+			// Pagination interleaved with spawns: A pages twice,
+			// spawning on both pages, while B runs alongside.
+			name:    "pagination-with-spawns",
+			seeds:   []string{"A", "B"},
+			workers: 2,
+			behaviors: map[string]stepBehavior{
+				"A": {pages: []stepPage{
+					{next: "A#2", children: []string{"C"}},
+					{children: []string{"E"}},
+				}},
+			},
+			cleanReachable: true,
+		},
+		{
+			// Failure mid-fan-out: B always fails, aborting the batch at
+			// every possible point relative to A's spawning — the
+			// no-commit-after-abort and accounting-on-abort space.
+			name:    "failure-aborts-batch",
+			seeds:   []string{"A", "B", "C"},
+			workers: 2,
+			behaviors: map[string]stepBehavior{
+				"A": {pages: []stepPage{{children: []string{"D"}}}},
+				"B": {fail: true},
+			},
+			cleanReachable: false,
+		},
+		{
+			// Both workers fail concurrently: done/abort/exit windows of
+			// the two failure paths interleave; abort must be idempotent
+			// and accounting exact.
+			name:    "double-failure",
+			seeds:   []string{"A", "B"},
+			workers: 2,
+			behaviors: map[string]stepBehavior{
+				"A": {fail: true},
+				"B": {fail: true},
+			},
+			cleanReachable: false,
+		},
+		{
+			// Re-mention: A re-mentions seed B (skip, admitted once) and
+			// spawns fresh C; the mutual pair B<->C also re-mention each
+			// other — the cycle must terminate in every schedule.
+			name:    "re-mention-and-cycle",
+			seeds:   []string{"A", "B"},
+			workers: 2,
+			behaviors: map[string]stepBehavior{
+				"A": {pages: []stepPage{{children: []string{"B", "C"}}}},
+				"B": {pages: []stepPage{{children: []string{"C"}}}},
+				"C": {pages: []stepPage{{children: []string{"B"}}}},
+			},
+			cleanReachable: true,
+		},
+		{
+			// Continuation re-convergence: A's next page token is seed
+			// H's identity. In every schedule A must finish (not error,
+			// not walk H's pages itself) and H must run exactly once.
+			name:    "continuation-reconvergence",
+			seeds:   []string{"A", "H"},
+			workers: 2,
+			behaviors: map[string]stepBehavior{
+				"A": {pages: []stepPage{{next: "H", children: []string{"C"}}}},
+				"H": {pages: []stepPage{{children: []string{"D"}}}},
+			},
+			cleanReachable: true,
+		},
+		{
+			// Three workers over the widest scenario: more concurrent
+			// windows between dequeue, commit, done, and abort.
+			name:    "three-workers-wide",
+			seeds:   []string{"A", "B"},
+			workers: 3,
+			behaviors: map[string]stepBehavior{
+				"A": {pages: []stepPage{{next: "A#2", children: []string{"C", "D"}}, {}}},
+				"B": {pages: []stepPage{{children: []string{"E"}}}},
+				"E": {fail: true},
+			},
+			cleanReachable: false,
+		},
+	}
+
+	for _, sc := range scenarios {
+		t.Run(sc.name, func(t *testing.T) {
+			stats := exploreScenario(t, sc)
+			t.Logf("explored %d nodes, %d distinct terminal states (%d clean)", stats.nodes, stats.terminals, stats.cleanTerminals)
+			// Non-vacuity: the space must be genuinely combinatorial.
+			// (The smallest scenario, double-failure, legitimately has a
+			// 19-node space: two seeds, both failing, two workers.)
+			require.Greater(t, stats.nodes, 15, "suspiciously small schedule space — stepper may have gone vacuous")
+		})
+	}
+}

--- a/pkg/sync/parallel_syncer.go
+++ b/pkg/sync/parallel_syncer.go
@@ -159,7 +159,7 @@ func (s *syncer) parallelSync(
 		// If we have more than 10 warnings and more than 10% of actions ended in a warning, exit the sync.
 		if len(warnings) > 10 {
 			completedActionsCount := s.state.GetCompletedActionsCount()
-			if completedActionsCount > 0 && float64(len(warnings))/float64(completedActionsCount) > 0.1 {
+			if tooManyWarnings(len(warnings), completedActionsCount) {
 				return warnings, fmt.Errorf("%w: warnings: %v completed actions: %d", ErrTooManyWarnings, warnings, completedActionsCount)
 			}
 		}
@@ -412,9 +412,105 @@ func (s *syncer) parallelSync(
 	return warnings, nil
 }
 
+func tooManyWarnings(warningCount int, completedActionsCount uint64) bool {
+	return warningCount > 10 &&
+		completedActionsCount > 0 &&
+		float64(warningCount)/float64(completedActionsCount) > 0.1
+}
+
 type workerResult struct {
 	warning error
 	err     error
+}
+
+// parallelActionQueue is a dynamically extensible worker queue. outstanding
+// counts queued plus in-flight actions, so workers stop only after the whole
+// fan-out drains. An in-flight action may enqueue siblings before completing;
+// therefore outstanding cannot transiently reach zero between parent and child.
+type parallelActionQueue struct {
+	mu          native_sync.Mutex
+	cond        *native_sync.Cond
+	actions     []*Action
+	head        int
+	outstanding int
+	aborted     bool
+}
+
+func newParallelActionQueue(actions []*Action) *parallelActionQueue {
+	q := &parallelActionQueue{
+		actions:     append([]*Action(nil), actions...),
+		outstanding: len(actions),
+	}
+	q.cond = native_sync.NewCond(&q.mu)
+	return q
+}
+
+func (q *parallelActionQueue) enqueue(action *Action) {
+	if action == nil {
+		return
+	}
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.aborted {
+		return
+	}
+	q.actions = append(q.actions, action)
+	q.outstanding++
+	q.cond.Signal()
+}
+
+func (q *parallelActionQueue) next() (*Action, bool) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	for !q.aborted && q.head == len(q.actions) && q.outstanding > 0 {
+		q.cond.Wait()
+	}
+	if q.aborted || q.outstanding == 0 {
+		return nil, false
+	}
+	action := q.actions[q.head]
+	q.actions[q.head] = nil
+	q.head++
+	if q.head == len(q.actions) {
+		q.actions = nil
+		q.head = 0
+	} else if q.head >= 1024 && q.head*2 >= len(q.actions) {
+		copy(q.actions, q.actions[q.head:])
+		q.actions = q.actions[:len(q.actions)-q.head]
+		q.head = 0
+	}
+	return action, true
+}
+
+func (q *parallelActionQueue) done() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.outstanding--
+	if q.outstanding == 0 {
+		q.cond.Broadcast()
+	}
+}
+
+func (q *parallelActionQueue) abort() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.aborted = true
+	q.cond.Broadcast()
+}
+
+func (s *syncer) setParallelActionEnqueuer(enqueue func(*Action)) {
+	s.parallelEnqueueMu.Lock()
+	defer s.parallelEnqueueMu.Unlock()
+	s.parallelActionEnqueuer = enqueue
+}
+
+func (s *syncer) enqueueParallelAction(action *Action) {
+	s.parallelEnqueueMu.RLock()
+	enqueue := s.parallelActionEnqueuer
+	s.parallelEnqueueMu.RUnlock()
+	if enqueue != nil {
+		enqueue(action)
+	}
 }
 
 func (s *syncer) syncParallel(ctx context.Context, retryer *retry.Retryer, actions []*Action, f func(ctx context.Context, action *Action) error) ([]error, error) {
@@ -425,8 +521,10 @@ func (s *syncer) syncParallel(ctx context.Context, retryer *retry.Retryer, actio
 	// its own linked-root span, so this stays a handful of spans per sync rather
 	// than one per resource/grant.
 	op := ""
+	batchOp := UnknownOp
 	if len(actions) > 0 {
-		op = actions[0].Op.String()
+		batchOp = actions[0].Op
+		op = batchOp.String()
 	}
 	ctx, span := tracer.Start(ctx, "syncer.syncParallel")
 	span.SetAttributes(
@@ -441,23 +539,40 @@ func (s *syncer) syncParallel(ctx context.Context, retryer *retry.Retryer, actio
 	ctx, cancel := context.WithCancelCause(ctx)
 	defer cancel(nil)
 
-	actionCh := make(chan *Action, len(actions))
-	for _, a := range actions {
-		actionCh <- a
-	}
-	close(actionCh)
+	queue := newParallelActionQueue(actions)
+	s.setParallelActionEnqueuer(func(action *Action) {
+		if action.Op == batchOp {
+			queue.enqueue(action)
+		}
+	})
+	defer s.setParallelActionEnqueuer(nil)
 
-	resultCh := make(chan workerResult, len(actions))
+	var resultsMu native_sync.Mutex
+	var warnings []error
+	var errs []error
 
 	var wg native_sync.WaitGroup
 	for i := 0; i < s.workerCount; i++ {
 		wg.Go(func() {
-			for action := range actionCh {
+			for {
+				action, ok := queue.next()
+				if !ok {
+					return
+				}
 				r := s.syncOneAction(ctx, l, retryer, action, f)
-				resultCh <- r
+				resultsMu.Lock()
+				if r.warning != nil {
+					warnings = append(warnings, r.warning)
+				}
+				if r.err != nil {
+					errs = append(errs, r.err)
+				}
+				resultsMu.Unlock()
+				queue.done()
 				if r.err != nil {
 					l.Error("cancelling context due to error in action", zap.Any("action", action), zap.Error(r.err))
 					cancel(fmt.Errorf("cancelling context due to error in action %v: %w", action, r.err))
+					queue.abort()
 					return
 				}
 			}
@@ -465,18 +580,6 @@ func (s *syncer) syncParallel(ctx context.Context, retryer *retry.Retryer, actio
 	}
 
 	wg.Wait()
-	close(resultCh)
-
-	var warnings []error
-	var errs []error
-	for r := range resultCh {
-		if r.warning != nil {
-			warnings = append(warnings, r.warning)
-		}
-		if r.err != nil {
-			errs = append(errs, r.err)
-		}
-	}
 
 	batchErr = errors.Join(errs...)
 	return warnings, batchErr

--- a/pkg/sync/parallel_syncer.go
+++ b/pkg/sync/parallel_syncer.go
@@ -2,6 +2,8 @@ package sync //nolint:revive,nolintlint // we can't change the package name for 
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	native_sync "sync"
@@ -135,6 +137,14 @@ func (s *syncer) parallelSync(
 	targetedResources []*v2.Resource,
 ) ([]error, error) {
 	l := ctxzap.Extract(ctx)
+	workerCtx, cancelWorkers := context.WithCancelCause(ctx)
+	stopWorkers := context.AfterFunc(runCtx, func() {
+		cancelWorkers(context.Cause(runCtx))
+	})
+	defer func() {
+		stopWorkers()
+		cancelWorkers(nil)
+	}()
 
 	// Retry backoff sleeps report through the context wait observer
 	// installed at the top of Sync, like every other in-process sleep site.
@@ -252,49 +262,49 @@ func (s *syncer) parallelSync(
 
 		case SyncResourceTypesOp:
 			err = s.timedStep(SyncResourceTypesOp, func() error {
-				return s.SyncResourceTypes(ctx, stateAction)
+				return s.SyncResourceTypes(workerCtx, stateAction)
 			})
-			if !s.timedShouldWaitAndRetry(ctx, SyncResourceTypesOp, stateAction.ResourceTypeID, retryer, err) {
-				return warnings, err
+			if !s.timedShouldWaitAndRetry(workerCtx, SyncResourceTypesOp, stateAction.ResourceTypeID, retryer, err) {
+				return s.handleOperationError(ctx, runCtx, warnings, err)
 			}
 			continue
 
 		case SyncResourcesOp:
 			if stateAction.ResourceTypeID == "" && stateAction.ResourceID == "" {
 				err = s.timedStep(SyncResourcesOp, func() error {
-					return s.SyncResources(ctx, stateAction)
+					return s.SyncResources(workerCtx, stateAction)
 				})
-				if !s.timedShouldWaitAndRetry(ctx, SyncResourcesOp, stateAction.ResourceTypeID, retryer, err) {
-					return warnings, err
+				if !s.timedShouldWaitAndRetry(workerCtx, SyncResourcesOp, stateAction.ResourceTypeID, retryer, err) {
+					return s.handleOperationError(ctx, runCtx, warnings, err)
 				}
 				continue
 			}
 			resourceActions := s.state.PeekMatchingActions(ctx, SyncResourcesOp)
 			err = s.timedStep(SyncResourcesOp, func() error {
-				w, syncErr := s.syncParallel(ctx, retryer, resourceActions, s.SyncResources)
+				w, syncErr := s.syncParallel(workerCtx, retryer, resourceActions, s.SyncResources)
 				warnings = append(warnings, w...)
 				return syncErr
 			})
 			if err != nil {
-				return warnings, err
+				return s.handleOperationError(ctx, runCtx, warnings, err)
 			}
 			continue
 
 		case SyncTargetedResourceOp:
 			targetedResourceActions := s.state.PeekMatchingActions(ctx, SyncTargetedResourceOp)
 			err = s.timedStep(SyncTargetedResourceOp, func() error {
-				w, syncErr := s.syncParallel(ctx, retryer, targetedResourceActions, s.SyncTargetedResource)
+				w, syncErr := s.syncParallel(workerCtx, retryer, targetedResourceActions, s.SyncTargetedResource)
 				warnings = append(warnings, w...)
 				return syncErr
 			})
 			if err != nil {
-				return warnings, err
+				return s.handleOperationError(ctx, runCtx, warnings, err)
 			}
 			continue
 
 		case SyncStaticEntitlementsOp:
 			err = s.timedStep(SyncStaticEntitlementsOp, func() error {
-				return s.SyncStaticEntitlements(ctx, stateAction)
+				return s.SyncStaticEntitlements(workerCtx, stateAction)
 			})
 			if isWarning(ctx, err) {
 				l.Warn("skipping sync static entitlements action", zap.Any("stateAction", stateAction), zap.Error(err))
@@ -302,14 +312,14 @@ func (s *syncer) parallelSync(
 				s.state.FinishAction(ctx, stateAction)
 				continue
 			}
-			if !s.timedShouldWaitAndRetry(ctx, SyncStaticEntitlementsOp, stateAction.ResourceTypeID, retryer, err) {
-				return warnings, err
+			if !s.timedShouldWaitAndRetry(workerCtx, SyncStaticEntitlementsOp, stateAction.ResourceTypeID, retryer, err) {
+				return s.handleOperationError(ctx, runCtx, warnings, err)
 			}
 			continue
 		case SyncEntitlementsOp:
 			if stateAction.ResourceTypeID == "" && stateAction.ResourceID == "" {
 				err = s.timedStep(SyncEntitlementsOp, func() error {
-					return s.SyncEntitlements(ctx, stateAction)
+					return s.SyncEntitlements(workerCtx, stateAction)
 				})
 				if isWarning(ctx, err) {
 					l.Warn("skipping sync entitlement action", zap.Any("stateAction", stateAction), zap.Error(err))
@@ -317,26 +327,26 @@ func (s *syncer) parallelSync(
 					s.state.FinishAction(ctx, stateAction)
 					continue
 				}
-				if !s.timedShouldWaitAndRetry(ctx, SyncEntitlementsOp, stateAction.ResourceTypeID, retryer, err) {
-					return warnings, err
+				if !s.timedShouldWaitAndRetry(workerCtx, SyncEntitlementsOp, stateAction.ResourceTypeID, retryer, err) {
+					return s.handleOperationError(ctx, runCtx, warnings, err)
 				}
 				continue
 			}
 			entitlementActions := s.state.PeekMatchingActions(ctx, SyncEntitlementsOp)
 			err = s.timedStep(SyncEntitlementsOp, func() error {
-				w, syncErr := s.syncParallel(ctx, retryer, entitlementActions, s.SyncEntitlements)
+				w, syncErr := s.syncParallel(workerCtx, retryer, entitlementActions, s.SyncEntitlements)
 				warnings = append(warnings, w...)
 				return syncErr
 			})
 			if err != nil {
-				return warnings, err
+				return s.handleOperationError(ctx, runCtx, warnings, err)
 			}
 			continue
 
 		case SyncGrantsOp:
 			if stateAction.ResourceTypeID == "" && stateAction.ResourceID == "" {
 				err = s.timedStep(SyncGrantsOp, func() error {
-					return s.SyncGrants(ctx, stateAction)
+					return s.SyncGrants(workerCtx, stateAction)
 				})
 				if isWarning(ctx, err) {
 					l.Warn("skipping sync grant action", zap.Any("stateAction", stateAction), zap.Error(err))
@@ -344,37 +354,37 @@ func (s *syncer) parallelSync(
 					s.state.FinishAction(ctx, stateAction)
 					continue
 				}
-				if !s.timedShouldWaitAndRetry(ctx, SyncGrantsOp, stateAction.ResourceTypeID, retryer, err) {
-					return warnings, err
+				if !s.timedShouldWaitAndRetry(workerCtx, SyncGrantsOp, stateAction.ResourceTypeID, retryer, err) {
+					return s.handleOperationError(ctx, runCtx, warnings, err)
 				}
 				continue
 			}
 
 			grantActions := s.state.PeekMatchingActions(ctx, SyncGrantsOp)
 			err = s.timedStep(SyncGrantsOp, func() error {
-				w, syncErr := s.syncParallel(ctx, retryer, grantActions, s.SyncGrants)
+				w, syncErr := s.syncParallel(workerCtx, retryer, grantActions, s.SyncGrants)
 				warnings = append(warnings, w...)
 				return syncErr
 			})
 			if err != nil {
-				return warnings, err
+				return s.handleOperationError(ctx, runCtx, warnings, err)
 			}
 			continue
 
 		case SyncExternalResourcesOp:
 			err = s.timedStep(SyncExternalResourcesOp, func() error {
-				return s.SyncExternalResources(ctx, stateAction)
+				return s.SyncExternalResources(workerCtx, stateAction)
 			})
-			if !s.timedShouldWaitAndRetry(ctx, SyncExternalResourcesOp, stateAction.ResourceTypeID, retryer, err) {
-				return warnings, err
+			if !s.timedShouldWaitAndRetry(workerCtx, SyncExternalResourcesOp, stateAction.ResourceTypeID, retryer, err) {
+				return s.handleOperationError(ctx, runCtx, warnings, err)
 			}
 			continue
 		case SyncAssetsOp:
 			err = s.timedStep(SyncAssetsOp, func() error {
-				return s.SyncAssets(ctx, stateAction)
+				return s.SyncAssets(workerCtx, stateAction)
 			})
-			if !s.timedShouldWaitAndRetry(ctx, SyncAssetsOp, stateAction.ResourceTypeID, retryer, err) {
-				return warnings, err
+			if !s.timedShouldWaitAndRetry(workerCtx, SyncAssetsOp, stateAction.ResourceTypeID, retryer, err) {
+				return s.handleOperationError(ctx, runCtx, warnings, err)
 			}
 			continue
 
@@ -400,9 +410,9 @@ func (s *syncer) parallelSync(
 				continue
 			}
 
-			err = s.SyncGrantExpansion(ctx, stateAction)
-			if !retryer.ShouldWaitAndRetry(ratelimit.WithWaitLabel(ctx, stateAction.ResourceTypeID), err) {
-				return warnings, err
+			err = s.SyncGrantExpansion(workerCtx, stateAction)
+			if !retryer.ShouldWaitAndRetry(ratelimit.WithWaitLabel(workerCtx, stateAction.ResourceTypeID), err) {
+				return s.handleOperationError(ctx, runCtx, warnings, err)
 			}
 			continue
 		default:
@@ -410,6 +420,19 @@ func (s *syncer) parallelSync(
 		}
 	}
 	return warnings, nil
+}
+
+func (s *syncer) handleOperationError(
+	ctx context.Context,
+	runCtx context.Context,
+	warnings []error,
+	batchErr error,
+) ([]error, error) {
+	if !errors.Is(context.Cause(runCtx), context.DeadlineExceeded) {
+		return warnings, batchErr
+	}
+	checkpointErr := s.Checkpoint(ctx, true)
+	return warnings, errors.Join(checkpointErr, ErrSyncNotComplete)
 }
 
 func tooManyWarnings(warningCount int, completedActionsCount uint64) bool {
@@ -423,40 +446,138 @@ type workerResult struct {
 	err     error
 }
 
+const maxSpawnedCursorsPerBatch = 100_000
+
 // parallelActionQueue is a dynamically extensible worker queue. outstanding
 // counts queued plus in-flight actions, so workers stop only after the whole
 // fan-out drains. An in-flight action may enqueue siblings before completing;
 // therefore outstanding cannot transiently reach zero between parent and child.
 type parallelActionQueue struct {
+	// mu guards every field below, including the fixed-size cursor digest set.
 	mu          native_sync.Mutex
 	cond        *native_sync.Cond
 	actions     []*Action
 	head        int
 	outstanding int
 	aborted     bool
+	seen        map[parallelActionKey]struct{}
+}
+
+type parallelActionKey [sha256.Size]byte
+
+func makeParallelActionKey(action *Action) parallelActionKey {
+	hasher := sha256.New()
+	header := [2]byte{byte(action.Op)}
+	if action.TypeScoped {
+		header[1] = 1
+	}
+	_, _ = hasher.Write(header[:])
+	for _, value := range []string{
+		action.ResourceTypeID,
+		action.ResourceID,
+		action.ParentResourceTypeID,
+		action.ParentResourceID,
+		action.PageToken,
+	} {
+		var length [8]byte
+		binary.BigEndian.PutUint64(length[:], uint64(len(value)))
+		_, _ = hasher.Write(length[:])
+		_, _ = hasher.Write([]byte(value))
+	}
+	var key parallelActionKey
+	hasher.Sum(key[:0])
+	return key
 }
 
 func newParallelActionQueue(actions []*Action) *parallelActionQueue {
 	q := &parallelActionQueue{
 		actions:     append([]*Action(nil), actions...),
 		outstanding: len(actions),
+		seen:        make(map[parallelActionKey]struct{}, len(actions)),
+	}
+	for _, action := range actions {
+		if action != nil {
+			q.seen[makeParallelActionKey(action)] = struct{}{}
+		}
 	}
 	q.cond = native_sync.NewCond(&q.mu)
 	return q
 }
 
-func (q *parallelActionQueue) enqueue(action *Action) {
-	if action == nil {
-		return
-	}
+func (q *parallelActionQueue) transition(
+	batchOp ActionOp,
+	parent *Action,
+	nextPageToken string,
+	childActions []Action,
+	commit func() ([]*Action, error),
+) error {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	if q.aborted {
-		return
+		return context.Canceled
 	}
-	q.actions = append(q.actions, action)
-	q.outstanding++
-	q.cond.Signal()
+
+	keys := make(map[parallelActionKey]struct{}, len(childActions)+1)
+	if nextPageToken != "" && parent != nil && parent.Op == batchOp {
+		continuedParent := *parent
+		continuedParent.PageToken = nextPageToken
+		key := makeParallelActionKey(&continuedParent)
+		if _, ok := q.seen[key]; ok {
+			return fmt.Errorf(
+				"duplicate or cyclic spawned cursor for op %s, resource type %q, resource %q, page token %q",
+				parent.Op.String(),
+				parent.ResourceTypeID,
+				parent.ResourceID,
+				nextPageToken,
+			)
+		}
+		keys[key] = struct{}{}
+	}
+	for i := range childActions {
+		child := &childActions[i]
+		if child.Op != batchOp {
+			continue
+		}
+		key := makeParallelActionKey(child)
+		if _, ok := q.seen[key]; ok {
+			return fmt.Errorf(
+				"duplicate or cyclic spawned cursor for op %s, resource type %q, resource %q, page token %q",
+				child.Op.String(),
+				child.ResourceTypeID,
+				child.ResourceID,
+				child.PageToken,
+			)
+		}
+		if _, ok := keys[key]; ok {
+			return fmt.Errorf(
+				"duplicate or cyclic spawned cursor for op %s, resource type %q, resource %q, page token %q",
+				child.Op.String(),
+				child.ResourceTypeID,
+				child.ResourceID,
+				child.PageToken,
+			)
+		}
+		keys[key] = struct{}{}
+	}
+	if len(q.seen)+len(keys) > maxSpawnedCursorsPerBatch {
+		return fmt.Errorf("spawned cursor batch exceeded the maximum of %d unique cursors", maxSpawnedCursorsPerBatch)
+	}
+
+	pushed, err := commit()
+	if err != nil {
+		return err
+	}
+	for key := range keys {
+		q.seen[key] = struct{}{}
+	}
+	for _, action := range pushed {
+		if action != nil && action.Op == batchOp {
+			q.actions = append(q.actions, action)
+			q.outstanding++
+		}
+	}
+	q.cond.Broadcast()
+	return nil
 }
 
 func (q *parallelActionQueue) next() (*Action, bool) {
@@ -498,19 +619,12 @@ func (q *parallelActionQueue) abort() {
 	q.cond.Broadcast()
 }
 
-func (s *syncer) setParallelActionEnqueuer(enqueue func(*Action)) {
-	s.parallelEnqueueMu.Lock()
-	defer s.parallelEnqueueMu.Unlock()
-	s.parallelActionEnqueuer = enqueue
-}
-
-func (s *syncer) enqueueParallelAction(action *Action) {
-	s.parallelEnqueueMu.RLock()
-	enqueue := s.parallelActionEnqueuer
-	s.parallelEnqueueMu.RUnlock()
-	if enqueue != nil {
-		enqueue(action)
-	}
+func (s *syncer) setParallelActionTransitioner(
+	transition func(context.Context, *Action, string, []Action) error,
+) {
+	s.parallelTransitionMu.Lock()
+	defer s.parallelTransitionMu.Unlock()
+	s.parallelActionTransitioner = transition
 }
 
 func (s *syncer) syncParallel(ctx context.Context, retryer *retry.Retryer, actions []*Action, f func(ctx context.Context, action *Action) error) ([]error, error) {
@@ -540,12 +654,17 @@ func (s *syncer) syncParallel(ctx context.Context, retryer *retry.Retryer, actio
 	defer cancel(nil)
 
 	queue := newParallelActionQueue(actions)
-	s.setParallelActionEnqueuer(func(action *Action) {
-		if action.Op == batchOp {
-			queue.enqueue(action)
-		}
+	s.setParallelActionTransitioner(func(
+		transitionCtx context.Context,
+		parent *Action,
+		nextPageToken string,
+		childActions []Action,
+	) error {
+		return queue.transition(batchOp, parent, nextPageToken, childActions, func() ([]*Action, error) {
+			return s.transitionActionState(transitionCtx, parent, nextPageToken, childActions)
+		})
 	})
-	defer s.setParallelActionEnqueuer(nil)
+	defer s.setParallelActionTransitioner(nil)
 
 	var resultsMu native_sync.Mutex
 	var warnings []error

--- a/pkg/sync/parallel_syncer.go
+++ b/pkg/sync/parallel_syncer.go
@@ -473,6 +473,10 @@ type parallelActionQueue struct {
 	outstanding int
 	aborted     bool
 	seen        map[parallelActionKey]struct{}
+	// audit, when non-nil, records every queue event for the post-hoc
+	// contract checker (queue_audit.go). Nil in production.
+	audit      *queueAudit
+	auditBatch int
 }
 
 type parallelActionKey [sha256.Size]byte
@@ -516,42 +520,96 @@ func newParallelActionQueue(actions []*Action) *parallelActionQueue {
 	return q
 }
 
+// attachAudit enrolls the queue with the test audit recorder and records
+// the batch-start event with the seeded actions. Called before workers
+// start; no-op when audit is nil (production).
+func (q *parallelActionQueue) attachAudit(audit *queueAudit, batchOp ActionOp, batch int) {
+	if audit == nil {
+		return
+	}
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.audit = audit
+	q.auditBatch = batch
+	ev := queueAuditEvent{kind: auditBatchStart, batch: batch, op: batchOp}
+	for _, action := range q.actions {
+		if action == nil {
+			continue
+		}
+		ev.actionIDs = append(ev.actionIDs, action.ID)
+		ev.keys = append(ev.keys, makeParallelActionKey(action))
+	}
+	audit.record(ev)
+}
+
+// transition atomically validates and commits a parent's pagination plus
+// its spawned children, then admits the same-op children to the queue.
+// commit receives the EFFECTIVE continuation and the ADMITTED children
+// only: an identity already seeded or admitted earlier in this batch is
+// handled idempotently rather than fatally, because connectors
+// legitimately re-converge on a cursor that is already scheduled
+// (DAG-shaped shard discovery, cyclic discovery graphs, or post-crash
+// answers that shifted under a resumed checkpoint) and a hard error here
+// is deterministic on every retry — it would wedge the sync permanently.
+// Concretely:
+//   - a CHILD whose identity is already scheduled is skipped (the
+//     identical work is admitted exactly once);
+//   - a CONTINUATION whose identity is already scheduled finishes the
+//     parent instead (the action owning that identity performs exactly
+//     the work the continuation would have — the tail is not lost);
+//   - the same cursor twice within ONE commit stays a loud failure: same
+//     call, same answer — a genuine connector protocol violation.
 func (q *parallelActionQueue) transition(
+	ctx context.Context,
 	batchOp ActionOp,
 	parent *Action,
 	nextPageToken string,
 	childActions []Action,
-	commit func() ([]*Action, error),
+	commit func(nextPageToken string, children []Action) ([]*Action, error),
 ) error {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	if q.aborted {
+		q.audit.record(queueAuditEvent{kind: auditReject, batch: q.auditBatch, postAbort: true})
 		return context.Canceled
 	}
 
+	effectiveNext := nextPageToken
 	keys := make(map[parallelActionKey]struct{}, len(childActions)+1)
 	if nextPageToken != "" && parent != nil && parent.Op == batchOp {
 		continuedParent := *parent
 		continuedParent.PageToken = nextPageToken
 		key := makeParallelActionKey(&continuedParent)
 		if _, ok := q.seen[key]; ok {
-			return fmt.Errorf(
-				"duplicate or cyclic spawned cursor for op %s, resource type %q, resource %q, page token %q",
-				parent.Op.String(),
-				parent.ResourceTypeID,
-				parent.ResourceID,
-				nextPageToken,
+			// Re-convergence: the continuation's identity is already
+			// scheduled in this batch (a resumed cursor holding this
+			// exact token, or a cyclic continuation that already walked
+			// it). Finish the parent — see the function comment.
+			effectiveNext = ""
+			ctxzap.Extract(ctx).Warn(
+				"parallel scheduler: parent continuation re-converged on an already-scheduled cursor; finishing parent",
+				zap.String("op", batchOp.String()),
+				zap.String("resource_type_id", parent.ResourceTypeID),
+				zap.String("resource_id", parent.ResourceID),
 			)
+		} else {
+			keys[key] = struct{}{}
 		}
-		keys[key] = struct{}{}
 	}
+	admitted := make([]Action, 0, len(childActions))
+	skipped := 0
 	for i := range childActions {
 		child := &childActions[i]
 		if child.Op != batchOp {
+			admitted = append(admitted, *child)
 			continue
 		}
 		key := makeParallelActionKey(child)
-		if _, ok := q.seen[key]; ok {
+		if _, ok := keys[key]; ok {
+			// The same cursor twice within one commit (or a child
+			// identical to the parent's own continuation): a protocol
+			// violation by the connector — fail loudly.
+			q.audit.record(queueAuditEvent{kind: auditReject, batch: q.auditBatch})
 			return fmt.Errorf(
 				"duplicate or cyclic spawned cursor for op %s, resource type %q, resource %q, page token %q",
 				child.Op.String(),
@@ -560,34 +618,48 @@ func (q *parallelActionQueue) transition(
 				child.PageToken,
 			)
 		}
-		if _, ok := keys[key]; ok {
-			return fmt.Errorf(
-				"duplicate or cyclic spawned cursor for op %s, resource type %q, resource %q, page token %q",
-				child.Op.String(),
-				child.ResourceTypeID,
-				child.ResourceID,
-				child.PageToken,
-			)
+		if _, ok := q.seen[key]; ok {
+			// Already seeded or admitted earlier in this batch: the
+			// identical work is scheduled exactly once already. Skip
+			// idempotently — see the function comment for why this must
+			// not be an error.
+			skipped++
+			continue
 		}
 		keys[key] = struct{}{}
+		admitted = append(admitted, *child)
+	}
+	if skipped > 0 {
+		ctxzap.Extract(ctx).Warn("parallel scheduler: skipped re-mentioned spawned cursors already scheduled in this batch",
+			zap.Int("skipped_cursors", skipped),
+			zap.String("op", batchOp.String()),
+		)
 	}
 	if len(q.seen)+len(keys) > maxSpawnedCursorsPerBatch {
+		q.audit.record(queueAuditEvent{kind: auditReject, batch: q.auditBatch})
 		return fmt.Errorf("spawned cursor batch exceeded the maximum of %d unique cursors", maxSpawnedCursorsPerBatch)
 	}
 
-	pushed, err := commit()
+	pushed, err := commit(effectiveNext, admitted)
 	if err != nil {
+		q.audit.record(queueAuditEvent{kind: auditReject, batch: q.auditBatch})
 		return err
 	}
 	for key := range keys {
 		q.seen[key] = struct{}{}
 	}
+	commitEv := queueAuditEvent{kind: auditCommit, batch: q.auditBatch}
 	for _, action := range pushed {
 		if action != nil && action.Op == batchOp {
+			if q.audit != nil {
+				commitEv.actionIDs = append(commitEv.actionIDs, action.ID)
+				commitEv.keys = append(commitEv.keys, makeParallelActionKey(action))
+			}
 			q.actions = append(q.actions, action)
 			q.outstanding++
 		}
 	}
+	q.audit.record(commitEv)
 	q.cond.Broadcast()
 	return nil
 }
@@ -604,6 +676,7 @@ func (q *parallelActionQueue) next() (*Action, bool) {
 	action := q.actions[q.head]
 	q.actions[q.head] = nil
 	q.head++
+	q.audit.record(queueAuditEvent{kind: auditDequeue, batch: q.auditBatch, actionIDs: []string{action.ID}})
 	if q.head == len(q.actions) {
 		q.actions = nil
 		q.head = 0
@@ -619,6 +692,7 @@ func (q *parallelActionQueue) done() {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	q.outstanding--
+	q.audit.record(queueAuditEvent{kind: auditDone, batch: q.auditBatch})
 	if q.outstanding == 0 {
 		q.cond.Broadcast()
 	}
@@ -628,6 +702,7 @@ func (q *parallelActionQueue) abort() {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	q.aborted = true
+	q.audit.record(queueAuditEvent{kind: auditAbort, batch: q.auditBatch})
 	q.cond.Broadcast()
 }
 
@@ -666,14 +741,17 @@ func (s *syncer) syncParallel(ctx context.Context, retryer *retry.Retryer, actio
 	defer cancel(nil)
 
 	queue := newParallelActionQueue(actions)
+	if s.testQueueAudit != nil {
+		queue.attachAudit(s.testQueueAudit, batchOp, s.testQueueAudit.newBatch())
+	}
 	s.setParallelActionTransitioner(func(
 		transitionCtx context.Context,
 		parent *Action,
 		nextPageToken string,
 		childActions []Action,
 	) error {
-		return queue.transition(batchOp, parent, nextPageToken, childActions, func() ([]*Action, error) {
-			return s.transitionActionState(transitionCtx, parent, nextPageToken, childActions)
+		return queue.transition(transitionCtx, batchOp, parent, nextPageToken, childActions, func(effectiveNext string, children []Action) ([]*Action, error) {
+			return s.transitionActionState(transitionCtx, parent, effectiveNext, children)
 		})
 	})
 	defer s.setParallelActionTransitioner(nil)
@@ -713,6 +791,9 @@ func (s *syncer) syncParallel(ctx context.Context, retryer *retry.Retryer, actio
 	wg.Wait()
 
 	batchErr = errors.Join(errs...)
+	if s.testQueueAudit != nil {
+		s.testQueueAudit.record(queueAuditEvent{kind: auditBatchEnd, batch: queue.auditBatch, clean: batchErr == nil})
+	}
 	return warnings, batchErr
 }
 

--- a/pkg/sync/parallel_syncer.go
+++ b/pkg/sync/parallel_syncer.go
@@ -431,6 +431,18 @@ func (s *syncer) handleOperationError(
 	if !errors.Is(context.Cause(runCtx), context.DeadlineExceeded) {
 		return warnings, batchErr
 	}
+	// The run duration expired. The operation error is usually just the
+	// resulting cancellation, but a genuine connector/store failure can
+	// land in the same window — log it so expiry never masks a real bug.
+	// The sync resumes from the checkpoint, so the work is retried either
+	// way; only ErrSyncNotComplete is surfaced to keep the resumable
+	// contract for callers.
+	if batchErr != nil && !errors.Is(batchErr, context.Canceled) && !errors.Is(batchErr, context.DeadlineExceeded) {
+		ctxzap.Extract(ctx).Error(
+			"sync operation failed while run duration expired; exiting early for resume",
+			zap.Error(batchErr),
+		)
+	}
 	checkpointErr := s.Checkpoint(ctx, true)
 	return warnings, errors.Join(checkpointErr, ErrSyncNotComplete)
 }

--- a/pkg/sync/progresslog/progresslog.go
+++ b/pkg/sync/progresslog/progresslog.go
@@ -268,12 +268,6 @@ func (p *ProgressLog) SetEntitlementsCountOnly(resourceType string) {
 	p.entitlementsCountOnly[resourceType] = true
 }
 
-func (p *ProgressLog) EntitlementsProgress(resourceType string) int {
-	p.mu.RLock()
-	defer p.mu.RUnlock()
-	return p.entitlementsProgress[resourceType]
-}
-
 func (p *ProgressLog) LogGrantsProgress(ctx context.Context, resourceType string) {
 	var grantsProgress, resources int
 	var lastLogTime time.Time
@@ -337,12 +331,6 @@ func (p *ProgressLog) SetGrantsCountOnly(resourceType string) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.grantsCountOnly[resourceType] = true
-}
-
-func (p *ProgressLog) GrantsProgress(resourceType string) int {
-	p.mu.RLock()
-	defer p.mu.RUnlock()
-	return p.grantsProgress[resourceType]
 }
 
 // LogExpandProgress emits an Info-level "Expanding grants" log at most once

--- a/pkg/sync/progresslog/progresslog.go
+++ b/pkg/sync/progresslog/progresslog.go
@@ -32,15 +32,17 @@ const (
 )
 
 type ProgressLog struct {
-	resourceTypes        int
-	resources            map[string]int
-	entitlementsProgress map[string]int
-	lastEntitlementLog   map[string]time.Time
-	grantsProgress       map[string]int
-	lastGrantLog         map[string]time.Time
-	mu                   sync.RWMutex
-	l                    *zap.Logger
-	maxLogFrequency      time.Duration
+	resourceTypes         int
+	resources             map[string]int
+	entitlementsProgress  map[string]int
+	lastEntitlementLog    map[string]time.Time
+	entitlementsCountOnly map[string]bool
+	grantsProgress        map[string]int
+	lastGrantLog          map[string]time.Time
+	grantsCountOnly       map[string]bool
+	mu                    sync.RWMutex
+	l                     *zap.Logger
+	maxLogFrequency       time.Duration
 
 	// Optional cross-step db-size tracking for LogExpandProgress. Populated
 	// via WithDBSizeProvider at construction time or SetDBSizeProvider after
@@ -145,15 +147,17 @@ func (p *ProgressLog) SetDBSizeProvider(provider connectorstore.DBSizeProvider) 
 
 func NewProgressCounts(ctx context.Context, opts ...Option) *ProgressLog {
 	p := &ProgressLog{
-		resources:            make(map[string]int),
-		entitlementsProgress: make(map[string]int),
-		lastEntitlementLog:   make(map[string]time.Time),
-		grantsProgress:       make(map[string]int),
-		lastGrantLog:         make(map[string]time.Time),
-		l:                    ctxzap.Extract(ctx),
-		maxLogFrequency:      defaultMaxLogFrequency,
-		mu:                   sync.RWMutex{},
-		metricsHandler:       metrics.NewNoOpHandler(ctx),
+		resources:             make(map[string]int),
+		entitlementsProgress:  make(map[string]int),
+		lastEntitlementLog:    make(map[string]time.Time),
+		entitlementsCountOnly: make(map[string]bool),
+		grantsProgress:        make(map[string]int),
+		lastGrantLog:          make(map[string]time.Time),
+		grantsCountOnly:       make(map[string]bool),
+		l:                     ctxzap.Extract(ctx),
+		maxLogFrequency:       defaultMaxLogFrequency,
+		mu:                    sync.RWMutex{},
+		metricsHandler:        metrics.NewNoOpHandler(ctx),
 	}
 	for _, o := range opts {
 		o(p)
@@ -202,14 +206,16 @@ func (p *ProgressLog) LogResourcesProgress(ctx context.Context, resourceType str
 func (p *ProgressLog) LogEntitlementsProgress(ctx context.Context, resourceType string) {
 	var entitlementsProgress, resources int
 	var lastLogTime time.Time
+	var countOnly bool
 
 	p.mu.RLock()
 	entitlementsProgress = p.entitlementsProgress[resourceType]
 	resources = p.resources[resourceType]
 	lastLogTime = p.lastEntitlementLog[resourceType]
+	countOnly = p.entitlementsCountOnly[resourceType]
 	p.mu.RUnlock()
 
-	if resources == 0 {
+	if resources == 0 || countOnly {
 		// if resuming sync, resource counts will be zero, so don't calculate percentage. just log every 10 seconds.
 		if time.Since(lastLogTime) > p.maxLogFrequency {
 			p.l.Info("Syncing entitlements",
@@ -256,17 +262,31 @@ func (p *ProgressLog) LogEntitlementsProgress(ctx context.Context, resourceType 
 	}
 }
 
+func (p *ProgressLog) SetEntitlementsCountOnly(resourceType string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.entitlementsCountOnly[resourceType] = true
+}
+
+func (p *ProgressLog) EntitlementsProgress(resourceType string) int {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.entitlementsProgress[resourceType]
+}
+
 func (p *ProgressLog) LogGrantsProgress(ctx context.Context, resourceType string) {
 	var grantsProgress, resources int
 	var lastLogTime time.Time
+	var countOnly bool
 
 	p.mu.RLock()
 	grantsProgress = p.grantsProgress[resourceType]
 	resources = p.resources[resourceType]
 	lastLogTime = p.lastGrantLog[resourceType]
+	countOnly = p.grantsCountOnly[resourceType]
 	p.mu.RUnlock()
 
-	if resources == 0 {
+	if resources == 0 || countOnly {
 		// if resuming sync, resource counts will be zero, so don't calculate percentage. just log every 10 seconds.
 		if time.Since(lastLogTime) > p.maxLogFrequency {
 			p.l.Info("Syncing grants",
@@ -311,6 +331,18 @@ func (p *ProgressLog) LogGrantsProgress(ctx context.Context, resourceType string
 		p.lastGrantLog[resourceType] = time.Now()
 		p.mu.Unlock()
 	}
+}
+
+func (p *ProgressLog) SetGrantsCountOnly(resourceType string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.grantsCountOnly[resourceType] = true
+}
+
+func (p *ProgressLog) GrantsProgress(resourceType string) int {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.grantsProgress[resourceType]
 }
 
 // LogExpandProgress emits an Info-level "Expanding grants" log at most once

--- a/pkg/sync/queue_audit.go
+++ b/pkg/sync/queue_audit.go
@@ -1,0 +1,94 @@
+package sync //nolint:revive,nolintlint // we can't change the package name for backwards compatibility
+
+import (
+	native_sync "sync"
+)
+
+// queueAudit is the test-only event recorder behind the parallel-scheduler
+// contract checker (verifyQueueAudit, parallel_audit_test.go). The queue's
+// correctness properties — exactly-once execution, dedup soundness, no
+// commits after abort, exact outstanding accounting, full drain on clean
+// completion — are silent when violated: a dropped action produces absence,
+// not an error. The audit turns every heavy test that runs the scheduler
+// into a checked execution: the queue records each event at its mutation
+// site (already under q.mu, so the recorded order is the real order), and
+// the checker replays the log against the contract post-hoc.
+//
+// Production cost is one nil check per queue operation: the syncer only
+// attaches an audit when a test sets testQueueAudit.
+type queueAudit struct {
+	mu       native_sync.Mutex
+	events   []queueAuditEvent
+	batchSeq int
+}
+
+// newBatch allocates the next batch segment id.
+func (a *queueAudit) newBatch() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.batchSeq++
+	return a.batchSeq
+}
+
+type queueAuditEventKind uint8
+
+const (
+	// auditBatchStart opens a batch segment; carries the batch op and the
+	// seeded action IDs and identity keys.
+	auditBatchStart queueAuditEventKind = iota
+	// auditDequeue: a worker took the action (actionID).
+	auditDequeue
+	// auditCommit: a transition's commit ran and succeeded; carries the
+	// action IDs and identity keys of the same-op children admitted to
+	// this batch's queue.
+	auditCommit
+	// auditReject: a transition was refused before commit (duplicate,
+	// cap, or post-abort refusal); no state was mutated.
+	auditReject
+	// auditDone: a worker finished processing a dequeued action.
+	auditDone
+	// auditAbort: the batch was aborted.
+	auditAbort
+	// auditBatchEnd closes a batch segment; carries whether the batch
+	// drained cleanly (no worker error).
+	auditBatchEnd
+)
+
+type queueAuditEvent struct {
+	kind  queueAuditEventKind
+	batch int
+	op    ActionOp
+	// actionIDs: seeded IDs (auditBatchStart), enqueued child IDs
+	// (auditCommit), or the single dequeued ID (auditDequeue).
+	actionIDs []string
+	// keys are the queue identity digests matching actionIDs
+	// (auditBatchStart, auditCommit); the checker re-verifies dedup
+	// soundness independently of the queue's own seen set.
+	keys []parallelActionKey
+	// clean marks a batch end without worker error (auditBatchEnd).
+	clean bool
+	// postAbort marks a reject that happened after the batch aborted
+	// (auditReject); the checker asserts such transitions never commit.
+	postAbort bool
+}
+
+func (a *queueAudit) record(ev queueAuditEvent) {
+	if a == nil {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.events = append(a.events, ev)
+}
+
+// snapshot returns a copy of the recorded events.
+func (a *queueAudit) snapshot() []queueAuditEvent {
+	if a == nil {
+		return nil
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	out := make([]queueAuditEvent, len(a.events))
+	copy(out, a.events)
+	return out
+}

--- a/pkg/sync/resume_adversary_test.go
+++ b/pkg/sync/resume_adversary_test.go
@@ -1,0 +1,339 @@
+package sync //nolint:revive,nolintlint // backwards-compatible package name
+
+// Adversarial protocol behaviors for the fan-out scheduler (Option C of
+// the verification plan): connectors whose answers are legal but
+// inconvenient — re-mentioning cursors that were already spawned (DAG
+// discovery, or answers that shifted across a crash), and transient
+// failures that must retry in place.
+//
+// The re-mention family pins a specific bug class: treating a re-mention
+// as a fatal duplicate is DETERMINISTIC on every retry, so one shifted
+// answer after a crash would wedge a sync permanently — at every worker
+// count, including the default of one (all batch ops run through the
+// parallel queue; workerCount only sets the worker pool size). The
+// contract under test: identical spawned work is admitted exactly once
+// per process, re-mentions are skipped idempotently and loudly, and
+// syncs always terminate with the exact payload set.
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	native_sync "sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
+)
+
+// mutualMentionTopo is a legal-but-adversarial answer shape: w1 spawns
+// both w2 and w3, and w2/w3 each ALSO mention the other — a DAG-with-a-
+// cycle in the discovery graph. Every payload must land exactly once and
+// the sync must terminate in both scheduler modes.
+func mutualMentionTopo() map[string]*soakTypeTopology {
+	return map[string]*soakTypeTopology{
+		"groupW": {
+			plannerChildren: []string{"w1"},
+			nodes: map[string]*soakNode{
+				"w1": {children: []string{"w2", "w3"}},
+				"w2": {children: []string{"w3"}},
+				"w3": {children: []string{"w2"}},
+			},
+			tokens:         []string{"w1", "w2", "w3"},
+			poisonedEnts:   map[string]bool{},
+			poisonedGrants: map[string]bool{},
+		},
+	}
+}
+
+func TestReMentionedSpawnsTerminateIdempotently(t *testing.T) {
+	// workers=1 is the DEFAULT config (still queue-scheduled, single
+	// worker); workers=4 adds real concurrency. Pre-fix, both treated
+	// the re-mention as a fatal duplicate and failed the sync —
+	// deterministically, on every retry.
+	for _, workers := range []int{1, 4} {
+		t.Run(fmt.Sprintf("workers=%d", workers), func(t *testing.T) {
+			tmpDir := t.TempDir()
+			base, expectedEntIDs, userID := buildTopoFixture(t, mutualMentionTopo())
+			path := filepath.Join(tmpDir, "mutual.c1z")
+			r := runCutAttempt(t, base, path, tmpDir, cutSpec{workers: workers, cause: errInjectedCut})
+			require.True(t, r.completed, "a mutual-mention topology must terminate")
+			verifyCutStore(t, path, tmpDir, expectedEntIDs, userID)
+		})
+	}
+}
+
+// TestStateSkipsReAdmittedSpawnIdentity pins the state-level re-mention
+// guard at its own scope: the parallel queue's dedup set lives for ONE
+// batch, so an identity finished in an earlier batch is invisible to it —
+// the process-lifetime spawnedAdmitted set is what terminates mutual
+// mentions that span batches. The guard must hold across completion
+// (never pruned on finish) and reset with a fresh state (rebuilt from the
+// surviving stack on resume).
+func TestStateSkipsReAdmittedSpawnIdentity(t *testing.T) {
+	ctx := t.Context()
+	st := newEmptySchedulerState(t)
+	spawn := Action{Op: SyncGrantsOp, ResourceTypeID: "group", PageToken: "shard-1", Spawned: true, TypeScoped: true}
+	parent := st.pushAction(ctx, Action{Op: SyncGrantsOp, ResourceTypeID: "group", TypeScoped: true, PageToken: "root"})
+
+	pushed, err := st.transitionAction(ctx, parent, "root-2", []Action{spawn})
+	require.NoError(t, err)
+	require.Len(t, pushed, 1, "first admission goes through")
+
+	// Re-mention while the original is still in flight: skipped.
+	pushed2, err := st.transitionAction(ctx, parent, "root-3", []Action{spawn})
+	require.NoError(t, err)
+	require.Empty(t, pushed2, "re-mentioned in-flight spawn must be skipped")
+
+	// Finish the original, then re-mention again — the batch-scoped queue
+	// would have forgotten it by the next batch; the state must not.
+	st.FinishAction(ctx, pushed[0])
+	pushed3, err := st.transitionAction(ctx, parent, "root-4", []Action{spawn})
+	require.NoError(t, err)
+	require.Empty(t, pushed3, "re-mentioned COMPLETED spawn must stay skipped for the life of the process")
+
+	// A distinct identity is unaffected.
+	other := Action{Op: SyncGrantsOp, ResourceTypeID: "group", PageToken: "shard-2", Spawned: true, TypeScoped: true}
+	pushed4, err := st.transitionAction(ctx, parent, "root-5", []Action{other})
+	require.NoError(t, err)
+	require.Len(t, pushed4, 1)
+
+	// Resume semantics: the guard rebuilds from the SURVIVING stack.
+	// shard-2 is still in flight (survives, stays skippable); shard-1
+	// completed (amnesia — re-doable once, idempotently).
+	token, err := st.Marshal()
+	require.NoError(t, err)
+	resumed := newState()
+	require.NoError(t, resumed.Unmarshal(token))
+	restoredParent := resumed.Current()
+	require.NotNil(t, restoredParent)
+	require.Equal(t, "shard-2", restoredParent.PageToken)
+
+	rePushed, err := resumed.transitionAction(ctx, restoredParent, "", []Action{spawn})
+	require.NoError(t, err)
+	require.Len(t, rePushed, 1, "a spawn completed before the crash is re-doable after resume (idempotent redo, set re-accumulates)")
+	rePushed2, err := resumed.transitionAction(ctx, rePushed[0], "", []Action{spawn})
+	require.NoError(t, err)
+	require.Empty(t, rePushed2, "and the re-accumulated set terminates cycles post-resume")
+}
+
+// rewiredCutTopologies is the changed-answers variant of the cut
+// fixture's graphs: the SAME token universe for both types, reattached
+// along completely different spawn/continuation edges. Any cursor that
+// persisted in a checkpoint can be re-mentioned by the new graph.
+func rewiredCutTopologies() map[string]*soakTypeTopology {
+	return map[string]*soakTypeTopology{
+		"groupA": {
+			plannerChildren: []string{"a9", "a8"},
+			plannerNext:     "a7",
+			nodes: map[string]*soakNode{
+				"a9": {children: []string{"a0", "a1"}},
+				"a8": {next: "a2"},
+				"a7": {children: []string{"a3"}},
+				"a0": {next: "a4"},
+				"a1": {children: []string{"a5"}},
+				"a2": {next: "a6"},
+				"a3": {}, "a4": {}, "a5": {}, "a6": {},
+			},
+			tokens:         []string{"a0", "a1", "a2", "a3", "a4", "a5", "a6", "a7", "a8", "a9"},
+			poisonedEnts:   map[string]bool{},
+			poisonedGrants: map[string]bool{},
+		},
+		"groupB": {
+			plannerChildren: []string{"b7", "b6"},
+			nodes: map[string]*soakNode{
+				"b7": {next: "b5"},
+				"b6": {children: []string{"b4", "b3"}},
+				"b5": {children: []string{"b2"}},
+				"b4": {next: "b1"},
+				"b3": {children: []string{"b0"}},
+				"b2": {}, "b1": {}, "b0": {},
+			},
+			tokens:         []string{"b0", "b1", "b2", "b3", "b4", "b5", "b6", "b7"},
+			poisonedEnts:   map[string]bool{},
+			poisonedGrants: map[string]bool{},
+		},
+	}
+}
+
+// verifyChangedAnswerStore asserts the contract that survives an API
+// whose answers shifted across a crash: the entitlement set is exactly
+// complete (the entitlements phase finished before the first grants-phase
+// cut), and the grant set is duplicate-free and referentially closed —
+// every grant references a stored entitlement and the right principal.
+// Grant COMPLETENESS under changed answers is explicitly not promised:
+// data collected at two moments legitimately mixes.
+func verifyChangedAnswerStore(t *testing.T, c1zPath, tmpDir string, expectedEntIDs map[string]struct{}, userID string) {
+	t.Helper()
+	ctx := context.Background()
+	store, err := dotc1z.NewStore(ctx, c1zPath,
+		dotc1z.WithEngine(c1zstore.EnginePebble),
+		dotc1z.WithTmpDir(tmpDir),
+		dotc1z.WithReadOnly(true),
+	)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, store.Close(ctx)) }()
+
+	gotEntIDs := make(map[string]struct{})
+	pageToken := ""
+	for {
+		resp, err := store.ListEntitlements(ctx, v2.EntitlementsServiceListEntitlementsRequest_builder{
+			PageToken: pageToken,
+		}.Build())
+		require.NoError(t, err)
+		for _, ent := range resp.GetList() {
+			gotEntIDs[ent.GetId()] = struct{}{}
+		}
+		if pageToken = resp.GetNextPageToken(); pageToken == "" {
+			break
+		}
+	}
+	require.Equal(t, expectedEntIDs, gotEntIDs,
+		"entitlements completed before the grants-phase cut and must be exactly complete")
+
+	gotGrantEnts := make(map[string]struct{})
+	grantCount := 0
+	pageToken = ""
+	for {
+		resp, err := store.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{
+			PageToken: pageToken,
+		}.Build())
+		require.NoError(t, err)
+		for _, grant := range resp.GetList() {
+			grantCount++
+			entID := grant.GetEntitlement().GetId()
+			gotGrantEnts[entID] = struct{}{}
+			require.Contains(t, expectedEntIDs, entID, "grant references an entitlement outside the token universe")
+			require.Equal(t, userID, grant.GetPrincipal().GetId().GetResource())
+		}
+		if pageToken = resp.GetNextPageToken(); pageToken == "" {
+			break
+		}
+	}
+	require.Equal(t, len(gotGrantEnts), grantCount, "duplicate grants stored")
+}
+
+// TestResumeAcrossChangedAnswersTerminates sweeps expiry cuts across the
+// grants phase (the forced checkpoint persists mid-batch spawned cursors)
+// and resumes every one against the REWIRED topology — the API's answers
+// changed while the sync was down. Pre-fix, a re-mention of a persisted
+// cursor was a fatal duplicate, deterministic on every retry: the sync
+// could never complete again. The contract: every resume terminates, and
+// the store honors the changed-answer guarantees (see
+// verifyChangedAnswerStore).
+func TestResumeAcrossChangedAnswersTerminates(t *testing.T) {
+	tmpDir := t.TempDir()
+	base, expectedEntIDs, userID := buildCutFixture(t)
+	rewired := withTopos(base, rewiredCutTopologies())
+
+	baselinePath := filepath.Join(tmpDir, "baseline.c1z")
+	baseline := runCutAttempt(t, base, baselinePath, tmpDir, cutSpec{workers: 4, cause: errInjectedCut})
+	require.True(t, baseline.completed, "baseline sync must complete")
+	require.Positive(t, baseline.grantsResponses)
+
+	midBatchTokens := 0
+	for i, m := range enumerateCutPoints(baseline.grantsResponses, 10) {
+		t.Run(fmt.Sprintf("grants-cut-%02d", m), func(t *testing.T) {
+			path := filepath.Join(tmpDir, fmt.Sprintf("changed-%02d.c1z", m))
+			r := runCutAttempt(t, base, path, tmpDir, cutSpec{workers: 4, grantsResponse: m, cause: errInjectedExpiry})
+			midBatchTokens += r.spawnedTokens
+			if r.completed {
+				verifyCutStore(t, path, tmpDir, expectedEntIDs, userID)
+				return
+			}
+			resumeWorkers := []int{1, 5}[i%2]
+			final := runCutAttempt(t, rewired, path, tmpDir, cutSpec{workers: resumeWorkers, cause: errInjectedCut})
+			require.True(t, final.completed,
+				"resume under changed answers must terminate (grants cut %d, workers %d)", m, resumeWorkers)
+			verifyChangedAnswerStore(t, path, tmpDir, expectedEntIDs, userID)
+		})
+	}
+	require.Positive(t, midBatchTokens,
+		"no expiry checkpoint carried a spawned in-flight cursor; the sweep is not reaching the changed-answer state shape")
+}
+
+// flakyOnceConnector fails the FIRST type-scoped grants call for one
+// token with a retryable gRPC code, then serves normally.
+type flakyOnceConnector struct {
+	*soakConnector
+	mu    native_sync.Mutex
+	token string
+	fired bool
+	hits  int
+}
+
+func (c *flakyOnceConnector) ListGrants(
+	ctx context.Context,
+	in *v2.GrantsServiceListGrantsRequest,
+	opts ...grpc.CallOption,
+) (*v2.GrantsServiceListGrantsResponse, error) {
+	reqAnnos := annotations.Annotations(in.GetAnnotations())
+	if reqAnnos.Contains(&v2.TypeScopedGrants{}) && in.GetPageToken() == c.token {
+		c.mu.Lock()
+		fired := c.fired
+		c.fired = true
+		c.hits++
+		c.mu.Unlock()
+		if !fired {
+			return nil, status.Error(codes.Unavailable, "injected transient unavailability")
+		}
+	}
+	return c.soakConnector.ListGrants(ctx, in, opts...)
+}
+
+// TestParallelWorkerRetriesUnavailableInPlace pins the in-batch retry
+// path: a retryable failure (codes.Unavailable) on a spawned cursor must
+// retry IN PLACE — same worker, same action, no batch abort, no resume —
+// and the failed attempt must contribute nothing (its spawns were never
+// committed). One Sync call completes with the exact payload set.
+func TestParallelWorkerRetriesUnavailableInPlace(t *testing.T) {
+	ctx := t.Context()
+	tmpDir := t.TempDir()
+	base, expectedEntIDs, userID := buildTopoFixture(t, map[string]*soakTypeTopology{
+		"groupU": {
+			plannerChildren: []string{"u1", "u2"},
+			nodes: map[string]*soakNode{
+				// u2 — the flaky cursor — spawns u3, so the retry must
+				// also prove the failed attempt admitted nothing.
+				"u1": {},
+				"u2": {children: []string{"u3"}},
+				"u3": {},
+			},
+			tokens:         []string{"u1", "u2", "u3"},
+			poisonedEnts:   map[string]bool{},
+			poisonedGrants: map[string]bool{},
+		},
+	})
+	connector := &flakyOnceConnector{soakConnector: base, token: "u2"}
+
+	path := filepath.Join(tmpDir, "flaky.c1z")
+	store, err := dotc1z.NewStore(ctx, path,
+		dotc1z.WithEngine(c1zstore.EnginePebble),
+		dotc1z.WithTmpDir(tmpDir),
+	)
+	require.NoError(t, err)
+	s, err := NewSyncer(ctx, connector,
+		WithConnectorStore(store),
+		WithTmpDir(tmpDir),
+		WithWorkerCount(3),
+	)
+	require.NoError(t, err)
+	audit := attachQueueAudit(t, s)
+
+	require.NoError(t, s.Sync(ctx), "a retryable failure must be absorbed in place, not fail the sync")
+	require.NoError(t, s.Close(ctx))
+	verifyQueueAudit(t, audit)
+
+	connector.mu.Lock()
+	hits := connector.hits
+	connector.mu.Unlock()
+	require.GreaterOrEqual(t, hits, 2, "the flaky cursor must have been retried after the injected failure")
+	verifyCutStore(t, path, tmpDir, expectedEntIDs, userID)
+}

--- a/pkg/sync/resume_adversary_test.go
+++ b/pkg/sync/resume_adversary_test.go
@@ -259,17 +259,20 @@ func TestResumeAcrossChangedAnswersTerminates(t *testing.T) {
 		"no expiry checkpoint carried a spawned in-flight cursor; the sweep is not reaching the changed-answer state shape")
 }
 
-// flakyOnceConnector fails the FIRST type-scoped grants call for one
-// token with a retryable gRPC code, then serves normally.
-type flakyOnceConnector struct {
+// spawnedErrorOnceConnector fails the FIRST type-scoped grants call for one
+// spawned token with the configured error, then serves normally. It drives
+// the end-to-end error-category matrix below through the real connector,
+// scheduler, state, checkpoint, and store seams.
+type spawnedErrorOnceConnector struct {
 	*soakConnector
 	mu    native_sync.Mutex
 	token string
+	err   error
 	fired bool
 	hits  int
 }
 
-func (c *flakyOnceConnector) ListGrants(
+func (c *spawnedErrorOnceConnector) ListGrants(
 	ctx context.Context,
 	in *v2.GrantsServiceListGrantsRequest,
 	opts ...grpc.CallOption,
@@ -282,58 +285,192 @@ func (c *flakyOnceConnector) ListGrants(
 		c.hits++
 		c.mu.Unlock()
 		if !fired {
-			return nil, status.Error(codes.Unavailable, "injected transient unavailability")
+			return nil, c.err
 		}
 	}
 	return c.soakConnector.ListGrants(ctx, in, opts...)
 }
 
-// TestParallelWorkerRetriesUnavailableInPlace pins the in-batch retry
-// path: a retryable failure (codes.Unavailable) on a spawned cursor must
-// retry IN PLACE — same worker, same action, no batch abort, no resume —
-// and the failed attempt must contribute nothing (its spawns were never
-// committed). One Sync call completes with the exact payload set.
-func TestParallelWorkerRetriesUnavailableInPlace(t *testing.T) {
+// storedGrantEntitlementIDs returns the exact entitlement IDs referenced by
+// grants in the sealed store. It is the category matrix's absence oracle:
+// warning/drop must omit precisely the warned cursor and its undiscovered
+// descendants; retry and resume must produce the complete topology.
+func storedGrantEntitlementIDs(t *testing.T, c1zPath, tmpDir string) map[string]struct{} {
+	t.Helper()
 	ctx := t.Context()
-	tmpDir := t.TempDir()
-	base, expectedEntIDs, userID := buildTopoFixture(t, map[string]*soakTypeTopology{
-		"groupU": {
-			plannerChildren: []string{"u1", "u2"},
-			nodes: map[string]*soakNode{
-				// u2 — the flaky cursor — spawns u3, so the retry must
-				// also prove the failed attempt admitted nothing.
-				"u1": {},
-				"u2": {children: []string{"u3"}},
-				"u3": {},
-			},
-			tokens:         []string{"u1", "u2", "u3"},
-			poisonedEnts:   map[string]bool{},
-			poisonedGrants: map[string]bool{},
-		},
-	})
-	connector := &flakyOnceConnector{soakConnector: base, token: "u2"}
-
-	path := filepath.Join(tmpDir, "flaky.c1z")
-	store, err := dotc1z.NewStore(ctx, path,
+	store, err := dotc1z.NewStore(ctx, c1zPath,
 		dotc1z.WithEngine(c1zstore.EnginePebble),
 		dotc1z.WithTmpDir(tmpDir),
+		dotc1z.WithReadOnly(true),
 	)
 	require.NoError(t, err)
-	s, err := NewSyncer(ctx, connector,
-		WithConnectorStore(store),
-		WithTmpDir(tmpDir),
-		WithWorkerCount(3),
-	)
-	require.NoError(t, err)
-	audit := attachQueueAudit(t, s)
+	defer func() { require.NoError(t, store.Close(ctx)) }()
 
-	require.NoError(t, s.Sync(ctx), "a retryable failure must be absorbed in place, not fail the sync")
-	require.NoError(t, s.Close(ctx))
-	verifyQueueAudit(t, audit)
+	out := make(map[string]struct{})
+	pageToken := ""
+	for {
+		resp, err := store.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{
+			PageToken: pageToken,
+		}.Build())
+		require.NoError(t, err)
+		for _, grant := range resp.GetList() {
+			out[grant.GetEntitlement().GetId()] = struct{}{}
+		}
+		if pageToken = resp.GetNextPageToken(); pageToken == "" {
+			return out
+		}
+	}
+}
 
-	connector.mu.Lock()
-	hits := connector.hits
-	connector.mu.Unlock()
-	require.GreaterOrEqual(t, hits, 2, "the flaky cursor must have been retried after the injected failure")
-	verifyCutStore(t, path, tmpDir, expectedEntIDs, userID)
+// TestSpawnedCursorErrorCategoriesEndToEnd maps every connector-error
+// disposition that changes scheduler behavior to its state and store
+// contract:
+//
+//   - NotFound is warn-and-drop: the action is legitimately finished, its
+//     undiscovered descendants never run, and the sync seals that exact
+//     subset without leaving I10 evidence.
+//   - Unavailable is retryable: the SAME spawned action retries in place;
+//     the failed attempt admits no children and one Sync produces the exact
+//     complete store.
+//   - InvalidArgument is fatal: the first process aborts with the spawned
+//     action still enrolled in I10. A fresh syncer/store handle then resumes
+//     the durable checkpoint and produces the exact complete store.
+//
+// Real context cancellation is a fourth exit category, already exercised at
+// the connector seam by TestRunDurationCancelsActiveSpawnedCursorBatch and
+// across forced-checkpoint resume by TestCheckpointCutEnumeration's expiry
+// cuts; duplicating its multi-second timer here would add runtime, not space.
+func TestSpawnedCursorErrorCategoriesEndToEnd(t *testing.T) {
+	tests := []struct {
+		name            string
+		injected        error
+		wantFirstError  bool
+		wantRetry       bool
+		wantColdResume  bool
+		wantDroppedWork bool
+	}{
+		{
+			name:            "warning drops action and undiscovered descendants",
+			injected:        status.Error(codes.NotFound, "spawned resource disappeared"),
+			wantDroppedWork: true,
+		},
+		{
+			name:      "retryable retries same action in place",
+			injected:  status.Error(codes.Unavailable, "injected transient unavailability"),
+			wantRetry: true,
+		},
+		{
+			name:           "fatal survives cold resume",
+			injected:       status.Error(codes.InvalidArgument, "injected permanent protocol failure"),
+			wantFirstError: true,
+			wantColdResume: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := t.Context()
+			tmpDir := t.TempDir()
+			const typeID = "groupE"
+			base, expectedEntIDs, userID := buildTopoFixture(t, map[string]*soakTypeTopology{
+				typeID: {
+					plannerChildren: []string{"e1", "e2"},
+					nodes: map[string]*soakNode{
+						"e1": {},
+						// The injected e2 call would discover e3 on
+						// success. Its absence proves a failed attempt
+						// never committed children.
+						"e2": {children: []string{"e3"}},
+						"e3": {},
+					},
+					tokens:         []string{"e1", "e2", "e3"},
+					poisonedEnts:   map[string]bool{},
+					poisonedGrants: map[string]bool{},
+				},
+			})
+			connector := &spawnedErrorOnceConnector{
+				soakConnector: base,
+				token:         "e2",
+				err:           tc.injected,
+			}
+			path := filepath.Join(tmpDir, "error-category.c1z")
+			store, err := dotc1z.NewStore(ctx, path,
+				dotc1z.WithEngine(c1zstore.EnginePebble),
+				dotc1z.WithTmpDir(tmpDir),
+			)
+			require.NoError(t, err)
+			s, err := NewSyncer(ctx, connector,
+				WithConnectorStore(store),
+				WithTmpDir(tmpDir),
+				// One worker makes the first-process state
+				// deterministic without bypassing the parallel queue.
+				WithWorkerCount(1),
+			)
+			require.NoError(t, err)
+			audit := attachQueueAudit(t, s)
+
+			firstErr := s.Sync(ctx)
+			if tc.wantFirstError {
+				require.Error(t, firstErr)
+				require.ErrorContains(t, firstErr, "injected permanent protocol failure")
+			} else {
+				require.NoError(t, firstErr)
+			}
+			verifyQueueAudit(t, audit)
+
+			impl, ok := s.(*syncer)
+			require.True(t, ok)
+			state, ok := impl.state.(*state)
+			require.True(t, ok)
+			undrained := state.UndrainedSpawnedCursors()
+			if tc.wantColdResume {
+				require.NotEmpty(t, undrained, "fatal spawned action must remain enrolled for resume")
+				require.Contains(t, fmt.Sprint(undrained), `token="e2"`)
+			} else {
+				require.Empty(t, undrained, "handled spawned action must discharge I10 evidence")
+			}
+
+			connector.mu.Lock()
+			firstProcessHits := connector.hits
+			connector.mu.Unlock()
+			if tc.wantRetry {
+				require.GreaterOrEqual(t, firstProcessHits, 2,
+					"retryable cursor must retry in the first process")
+			} else {
+				require.Equal(t, 1, firstProcessHits,
+					"non-retry category must not retry in the first process")
+			}
+
+			require.NoError(t, s.Close(ctx))
+			if tc.wantColdResume {
+				// New handle + new syncer: no in-memory state from the
+				// failed process can satisfy the assertion.
+				resumeStore, err := dotc1z.NewStore(ctx, path,
+					dotc1z.WithEngine(c1zstore.EnginePebble),
+					dotc1z.WithTmpDir(tmpDir),
+				)
+				require.NoError(t, err)
+				resumed, err := NewSyncer(ctx, connector,
+					WithConnectorStore(resumeStore),
+					WithTmpDir(tmpDir),
+					WithWorkerCount(3),
+				)
+				require.NoError(t, err)
+				resumeAudit := attachQueueAudit(t, resumed)
+				require.NoError(t, resumed.Sync(ctx))
+				require.NoError(t, resumed.Close(ctx))
+				verifyQueueAudit(t, resumeAudit)
+			}
+
+			if tc.wantDroppedWork {
+				want := map[string]struct{}{
+					base.grantsByTok[typeID]["e1"].GetEntitlement().GetId(): {},
+				}
+				require.Equal(t, want, storedGrantEntitlementIDs(t, path, tmpDir),
+					"warn-and-drop must omit exactly the failed cursor and its undiscovered descendants")
+				return
+			}
+			verifyCutStore(t, path, tmpDir, expectedEntIDs, userID)
+		})
+	}
 }

--- a/pkg/sync/scheduler_soak_test.go
+++ b/pkg/sync/scheduler_soak_test.go
@@ -1,0 +1,398 @@
+package sync //nolint:revive,nolintlint // backwards-compatible package name
+
+// Randomized soak test for the parallel scheduler.
+//
+// Each iteration builds a random-but-deterministic (seeded) fan-out topology
+// for several type-scoped resource types: the planner call and every cursor
+// can spawn sibling cursors (EnqueuePageTokens), carry a continuation token
+// (NextPageToken), or both. A random subset of cursors is poisoned to fail
+// exactly once, which aborts the sync mid-batch; the test resumes from the
+// checkpoint until the sync completes. At the end the store must contain
+// exactly the expected entitlement and grant set — any lost, duplicated, or
+// misrouted cursor shows up as a set mismatch.
+//
+// Run with -race. Iterations can be extended with BATON_SOAK_ITERATIONS.
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strconv"
+	native_sync "sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
+	et "github.com/conductorone/baton-sdk/pkg/types/entitlement"
+	gt "github.com/conductorone/baton-sdk/pkg/types/grant"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+)
+
+// soakNode is one cursor in the fan-out topology.
+type soakNode struct {
+	children []string // sibling cursors spawned via EnqueuePageTokens
+	next     string   // continuation cursor via NextPageToken ("" = final page)
+}
+
+// soakTypeTopology is the deterministic cursor graph for one resource type.
+// Every token is reachable exactly once (as a planner child, a node child,
+// or a node continuation), so the expected payload set is exact.
+type soakTypeTopology struct {
+	plannerChildren []string
+	plannerNext     string
+	nodes           map[string]*soakNode
+	tokens          []string // every payload-bearing token
+	poisonedEnts    map[string]bool
+	poisonedGrants  map[string]bool
+}
+
+func buildSoakTopology(r *rand.Rand) *soakTypeTopology {
+	total := 8 + r.Intn(28)
+	topo := &soakTypeTopology{
+		nodes:          make(map[string]*soakNode, total),
+		poisonedEnts:   make(map[string]bool),
+		poisonedGrants: make(map[string]bool),
+	}
+	tokens := make([]string, total)
+	for i := range tokens {
+		tokens[i] = fmt.Sprintf("n%02d", i)
+		topo.nodes[tokens[i]] = &soakNode{}
+	}
+	topo.tokens = tokens
+
+	unattached := append([]string(nil), tokens...)
+	take := func() string {
+		tok := unattached[0]
+		unattached = unattached[1:]
+		return tok
+	}
+
+	// Planner spawns 1..4 siblings and sometimes has its own continuation.
+	k := 1 + r.Intn(4)
+	frontier := make([]string, 0, total)
+	for i := 0; i < k && len(unattached) > 0; i++ {
+		tok := take()
+		topo.plannerChildren = append(topo.plannerChildren, tok)
+		frontier = append(frontier, tok)
+	}
+	if r.Intn(3) == 0 && len(unattached) > 0 {
+		topo.plannerNext = take()
+		frontier = append(frontier, topo.plannerNext)
+	}
+
+	for len(unattached) > 0 {
+		// Pop a random frontier node to attach the next tokens to.
+		var ap string
+		if len(frontier) > 0 {
+			i := r.Intn(len(frontier))
+			ap = frontier[i]
+			frontier = append(frontier[:i], frontier[i+1:]...)
+		} else {
+			// Shouldn't happen (every attached token enters the frontier
+			// exactly once), but guarantee progress regardless.
+			ap = tokens[0]
+		}
+		node := topo.nodes[ap]
+		attached := false
+		if r.Intn(2) == 0 && len(unattached) > 0 {
+			node.next = take()
+			frontier = append(frontier, node.next)
+			attached = true
+		}
+		c := r.Intn(4)
+		for i := 0; i < c && len(unattached) > 0; i++ {
+			tok := take()
+			node.children = append(node.children, tok)
+			frontier = append(frontier, tok)
+			attached = true
+		}
+		if !attached && len(frontier) == 0 && len(unattached) > 0 && node.next == "" {
+			node.next = take()
+			frontier = append(frontier, node.next)
+		}
+	}
+
+	// Poison ~15% of cursors per phase, including the planner call ("").
+	for _, tok := range append([]string{""}, tokens...) {
+		if r.Intn(100) < 15 {
+			topo.poisonedEnts[tok] = true
+		}
+		if r.Intn(100) < 15 {
+			topo.poisonedGrants[tok] = true
+		}
+	}
+	return topo
+}
+
+func (t *soakTypeTopology) poisonCount() int {
+	return len(t.poisonedEnts) + len(t.poisonedGrants)
+}
+
+// soakConnector serves the topology. Poisoned cursors fail exactly once
+// across all sync attempts; state is mutex-guarded because workers call
+// concurrently.
+type soakConnector struct {
+	*mockConnector
+	topos       map[string]*soakTypeTopology
+	entsByToken map[string]map[string]*v2.Entitlement // type -> token -> payload
+	grantsByTok map[string]map[string]*v2.Grant
+
+	mu               native_sync.Mutex
+	failedOnce       map[string]struct{}
+	perResourceCalls int
+}
+
+func (c *soakConnector) failOnce(phase, resourceType, token string, poisoned map[string]bool) error {
+	if !poisoned[token] {
+		return nil
+	}
+	key := phase + "|" + resourceType + "|" + token
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, ok := c.failedOnce[key]; ok {
+		return nil
+	}
+	c.failedOnce[key] = struct{}{}
+	return fmt.Errorf("soak: injected failure for %s", key)
+}
+
+func (c *soakConnector) countPerResourceCall() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.perResourceCalls++
+}
+
+func (c *soakConnector) ListEntitlements(
+	_ context.Context,
+	in *v2.EntitlementsServiceListEntitlementsRequest,
+	_ ...grpc.CallOption,
+) (*v2.EntitlementsServiceListEntitlementsResponse, error) {
+	reqAnnos := annotations.Annotations(in.GetAnnotations())
+	if !reqAnnos.Contains(&v2.TypeScopedEntitlements{}) {
+		c.countPerResourceCall()
+		return v2.EntitlementsServiceListEntitlementsResponse_builder{}.Build(), nil
+	}
+	resourceType := in.GetResource().GetId().GetResourceType()
+	topo := c.topos[resourceType]
+	token := in.GetPageToken()
+	if err := c.failOnce("ent", resourceType, token, topo.poisonedEnts); err != nil {
+		return nil, err
+	}
+	builder := v2.EntitlementsServiceListEntitlementsResponse_builder{}
+	var children []string
+	if token == "" {
+		children = topo.plannerChildren
+		builder.NextPageToken = topo.plannerNext
+	} else {
+		node := topo.nodes[token]
+		children = node.children
+		builder.NextPageToken = node.next
+		builder.List = []*v2.Entitlement{c.entsByToken[resourceType][token]}
+	}
+	if len(children) > 0 {
+		builder.Annotations = annotations.New(v2.EnqueuePageTokens_builder{
+			PageTokens: children,
+		}.Build())
+	}
+	return builder.Build(), nil
+}
+
+func (c *soakConnector) ListGrants(
+	_ context.Context,
+	in *v2.GrantsServiceListGrantsRequest,
+	_ ...grpc.CallOption,
+) (*v2.GrantsServiceListGrantsResponse, error) {
+	reqAnnos := annotations.Annotations(in.GetAnnotations())
+	if !reqAnnos.Contains(&v2.TypeScopedGrants{}) {
+		c.countPerResourceCall()
+		return v2.GrantsServiceListGrantsResponse_builder{}.Build(), nil
+	}
+	resourceType := in.GetResource().GetId().GetResourceType()
+	topo := c.topos[resourceType]
+	token := in.GetPageToken()
+	if err := c.failOnce("grant", resourceType, token, topo.poisonedGrants); err != nil {
+		return nil, err
+	}
+	builder := v2.GrantsServiceListGrantsResponse_builder{}
+	var children []string
+	if token == "" {
+		children = topo.plannerChildren
+		builder.NextPageToken = topo.plannerNext
+	} else {
+		node := topo.nodes[token]
+		children = node.children
+		builder.NextPageToken = node.next
+		builder.List = []*v2.Grant{c.grantsByTok[resourceType][token]}
+	}
+	if len(children) > 0 {
+		builder.Annotations = annotations.New(v2.EnqueuePageTokens_builder{
+			PageTokens: children,
+		}.Build())
+	}
+	return builder.Build(), nil
+}
+
+func soakSeeds(t *testing.T) []int64 {
+	seeds := []int64{1, 2, 3, 4, 5, 6}
+	if extra := os.Getenv("BATON_SOAK_ITERATIONS"); extra != "" {
+		n, err := strconv.Atoi(extra)
+		require.NoError(t, err, "BATON_SOAK_ITERATIONS must be an integer")
+		for i := 0; i < n; i++ {
+			seeds = append(seeds, rand.Int63()) //nolint:gosec // deterministic test topology, not crypto
+		}
+	}
+	return seeds
+}
+
+func TestSchedulerSoakRandomizedFanoutWithFailures(t *testing.T) {
+	for _, seed := range soakSeeds(t) {
+		t.Run(fmt.Sprintf("seed=%d", seed), func(t *testing.T) {
+			runSchedulerSoak(t, seed)
+		})
+	}
+}
+
+func runSchedulerSoak(t *testing.T, seed int64) {
+	t.Logf("scheduler soak seed=%d (re-run with runSchedulerSoak(t, %d))", seed, seed)
+	r := rand.New(rand.NewSource(seed)) //nolint:gosec // deterministic test topology, not crypto
+	ctx := t.Context()
+	tmpDir := t.TempDir()
+
+	userType := v2.ResourceType_builder{
+		Id:          "user",
+		DisplayName: "User",
+		Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_USER},
+		Annotations: annotations.New(&v2.SkipEntitlementsAndGrants{}),
+	}.Build()
+	user, err := rs.NewUserResource("user-1", userType, "User 1", nil)
+	require.NoError(t, err)
+
+	connector := &soakConnector{
+		mockConnector: newMockConnector(),
+		topos:         make(map[string]*soakTypeTopology),
+		entsByToken:   make(map[string]map[string]*v2.Entitlement),
+		grantsByTok:   make(map[string]map[string]*v2.Grant),
+		failedOnce:    make(map[string]struct{}),
+	}
+	connector.rtDB = append(connector.rtDB, userType)
+	connector.resourceDB["user"] = append(connector.resourceDB["user"], user)
+
+	expectedEntIDs := make(map[string]struct{})
+	totalPoisoned := 0
+	numTypes := 2 + r.Intn(3)
+	for ti := 0; ti < numTypes; ti++ {
+		typeID := fmt.Sprintf("group%d", ti)
+		groupType := v2.ResourceType_builder{
+			Id:          typeID,
+			DisplayName: typeID,
+			Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_GROUP},
+			Annotations: annotations.New(&v2.TypeScopedEntitlements{}, &v2.TypeScopedGrants{}),
+		}.Build()
+		connector.rtDB = append(connector.rtDB, groupType)
+
+		numResources := 1 + r.Intn(4)
+		resources := make([]*v2.Resource, 0, numResources)
+		for ri := 0; ri < numResources; ri++ {
+			res, err := rs.NewGroupResource(fmt.Sprintf("%s-res%d", typeID, ri), groupType, fmt.Sprintf("%s res %d", typeID, ri), nil)
+			require.NoError(t, err)
+			resources = append(resources, res)
+			connector.resourceDB[typeID] = append(connector.resourceDB[typeID], res)
+		}
+
+		topo := buildSoakTopology(r)
+		connector.topos[typeID] = topo
+		totalPoisoned += topo.poisonCount()
+		connector.entsByToken[typeID] = make(map[string]*v2.Entitlement, len(topo.tokens))
+		connector.grantsByTok[typeID] = make(map[string]*v2.Grant, len(topo.tokens))
+		for i, token := range topo.tokens {
+			res := resources[i%numResources]
+			slug := "m-" + token
+			ent := et.NewAssignmentEntitlement(res, slug, et.WithGrantableTo(userType))
+			grant := gt.NewGrant(res, slug, user.GetId())
+			connector.entsByToken[typeID][token] = ent
+			connector.grantsByTok[typeID][token] = grant
+			expectedEntIDs[ent.GetId()] = struct{}{}
+		}
+	}
+
+	store, err := dotc1z.NewStore(ctx, filepath.Join(tmpDir, "soak.c1z"),
+		dotc1z.WithEngine(c1zstore.EnginePebble),
+		dotc1z.WithTmpDir(tmpDir),
+	)
+	require.NoError(t, err)
+	workers := 1 + r.Intn(8)
+	t.Logf("soak topology: types=%d expected=%d poisoned=%d workers=%d", numTypes, len(expectedEntIDs), totalPoisoned, workers)
+	s, err := NewSyncer(ctx, connector,
+		WithConnectorStore(store),
+		WithTmpDir(tmpDir),
+		WithWorkerCount(workers),
+	)
+	require.NoError(t, err)
+
+	// Each poisoned cursor fails at most once ever, so the sync needs at
+	// most one resume per poisoned cursor. With workers > 1 a single
+	// attempt can consume several poison pills at once.
+	maxAttempts := totalPoisoned + 3
+	attempts := 0
+	for {
+		attempts++
+		err = s.Sync(ctx)
+		if err == nil {
+			break
+		}
+		require.ErrorContains(t, err, "soak: injected failure",
+			"sync failed with a non-injected error on attempt %d", attempts)
+		require.Less(t, attempts, maxAttempts, "sync did not converge after %d attempts: %v", attempts, err)
+	}
+	t.Logf("soak converged after %d sync attempts", attempts)
+
+	// Completeness: the store must hold exactly the expected entitlement
+	// set, and exactly one grant per entitlement.
+	gotEntIDs := make(map[string]struct{})
+	pageToken := ""
+	for {
+		resp, err := store.ListEntitlements(ctx, v2.EntitlementsServiceListEntitlementsRequest_builder{
+			PageToken: pageToken,
+		}.Build())
+		require.NoError(t, err)
+		for _, ent := range resp.GetList() {
+			gotEntIDs[ent.GetId()] = struct{}{}
+		}
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			break
+		}
+	}
+	require.Equal(t, expectedEntIDs, gotEntIDs, "stored entitlement set diverged from topology")
+
+	gotGrantEnts := make(map[string]struct{})
+	grantCount := 0
+	pageToken = ""
+	for {
+		resp, err := store.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{
+			PageToken: pageToken,
+		}.Build())
+		require.NoError(t, err)
+		for _, grant := range resp.GetList() {
+			grantCount++
+			gotGrantEnts[grant.GetEntitlement().GetId()] = struct{}{}
+			require.Equal(t, user.GetId().GetResource(), grant.GetPrincipal().GetId().GetResource())
+		}
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			break
+		}
+	}
+	require.Equal(t, expectedEntIDs, gotGrantEnts, "stored grant set diverged from topology")
+	require.Equal(t, len(expectedEntIDs), grantCount, "duplicate grants stored")
+
+	require.NoError(t, s.Close(ctx))
+	require.Zero(t, connector.perResourceCalls, "type-scoped types must never receive per-resource calls")
+}

--- a/pkg/sync/scheduler_soak_test.go
+++ b/pkg/sync/scheduler_soak_test.go
@@ -335,6 +335,10 @@ func runSchedulerSoak(t *testing.T, seed int64) {
 		WithWorkerCount(workers),
 	)
 	require.NoError(t, err)
+	// Every soak execution doubles as a queue-contract check: the audit
+	// records each scheduler event and verifyQueueAudit replays the log
+	// against the exactly-once/dedup/abort/accounting properties.
+	audit := attachQueueAudit(t, s)
 
 	// Each poisoned cursor fails at most once ever, so the sync needs at
 	// most one resume per poisoned cursor. With workers > 1 a single
@@ -395,4 +399,5 @@ func runSchedulerSoak(t *testing.T, seed int64) {
 
 	require.NoError(t, s.Close(ctx))
 	require.Zero(t, connector.perResourceCalls, "type-scoped types must never receive per-resource calls")
+	verifyQueueAudit(t, audit)
 }

--- a/pkg/sync/state.go
+++ b/pkg/sync/state.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"sort"
 	"sync"
 	"time"
 
@@ -238,6 +239,18 @@ type state struct {
 	// state so Unmarshal→Marshal round trips (e.g. expansion replay
 	// tokens) preserve it.
 	compaction *CompactionTokenStats
+	// spawnedInFlight is the evidence set behind ingest invariant I10:
+	// every spawned sibling cursor (EnqueuePageTokens) admitted to the
+	// stack, keyed by action ID, removed only by the two legitimate
+	// completion paths (FinishAction and transitionAction's finish
+	// branch). A silent drop — any code path that loses an admitted
+	// action without finishing it — leaves its entry behind, and the
+	// invariant pass names it at sync quiesce. Unmarshal rebuilds the
+	// set from the checkpointed actions, so the evidence survives
+	// resume: a restored spawned cursor must still drain in the process
+	// that completes the sync. Guarded by st.mtx; bounded by the number
+	// of in-flight spawned actions (entries are deleted on finish).
+	spawnedInFlight map[string]Action
 }
 
 // ConnectorCallStat contains cumulative latency statistics for one connector method.
@@ -307,6 +320,7 @@ func newState() *state {
 		stepDurationsMs:    make(map[string]int64),
 		connectorCallStats: make(map[string]*ConnectorCallStat),
 		sessionStoreStats:  make(map[string]*SessionStoreStat),
+		spawnedInFlight:    make(map[string]Action),
 	}
 }
 
@@ -444,6 +458,14 @@ func (st *state) Unmarshal(input string) error {
 			st.sessionStoreStats = make(map[string]*SessionStoreStat)
 		}
 		st.compaction = token.Compaction
+		// Rebuild the I10 drain-evidence set from the checkpointed
+		// actions: a spawned cursor restored from a token was admitted
+		// by a previous process and must still drain in the process
+		// that completes the sync.
+		st.spawnedInFlight = make(map[string]Action)
+		for _, action := range st.actions {
+			st.recordSpawnedAdmissionLocked(action)
+		}
 	} else {
 		st.actions = make(map[string]Action)
 		st.actionOrder = []string{}
@@ -461,9 +483,42 @@ func (st *state) Unmarshal(input string) error {
 		st.connectorCallStats = make(map[string]*ConnectorCallStat)
 		st.sessionStoreStats = make(map[string]*SessionStoreStat)
 		st.compaction = nil
+		st.spawnedInFlight = make(map[string]Action)
 	}
 
 	return nil
+}
+
+// maxUndrainedTokenChars caps the page-token excerpt carried on I10
+// verdict lines (spawned tokens can be up to 1 MiB).
+const maxUndrainedTokenChars = 64
+
+// UndrainedSpawnedCursors describes every spawned cursor that was
+// admitted to the action stack but never completed through a legitimate
+// finish path — the I10 evidence read. Empty on a healthy state. Sorted
+// by action ID so verdicts are byte-stable.
+func (st *state) UndrainedSpawnedCursors() []string {
+	st.mtx.RLock()
+	defer st.mtx.RUnlock()
+	if len(st.spawnedInFlight) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(st.spawnedInFlight))
+	for id := range st.spawnedInFlight {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		action := st.spawnedInFlight[id]
+		token := action.PageToken
+		if len(token) > maxUndrainedTokenChars {
+			token = fmt.Sprintf("%s… (%d bytes)", token[:maxUndrainedTokenChars], len(action.PageToken))
+		}
+		out = append(out, fmt.Sprintf("action %s %s %s/%s token=%q",
+			id, action.Op.String(), action.ResourceTypeID, action.ResourceID, token))
+	}
+	return out
 }
 
 // Marshal returns a string encoding of the state object. This is useful for datastores to checkpoint the current state.
@@ -671,8 +726,21 @@ func (st *state) pushAction(ctx context.Context, action Action) *Action {
 	}
 	st.actions[action.ID] = action
 	st.actionOrder = append(st.actionOrder, action.ID)
+	st.recordSpawnedAdmissionLocked(action)
 	ctxzap.Extract(ctx).Debug("pushed action", zap.Any("action", action))
 	return &action
+}
+
+// recordSpawnedAdmissionLocked enrolls a spawned cursor in the I10
+// drain-evidence set. Caller holds st.mtx.
+func (st *state) recordSpawnedAdmissionLocked(action Action) {
+	if !action.Spawned {
+		return
+	}
+	if st.spawnedInFlight == nil {
+		st.spawnedInFlight = make(map[string]Action)
+	}
+	st.spawnedInFlight[action.ID] = action
 }
 
 func (st *state) markTypeScopedPlanned(actionID string) {
@@ -715,6 +783,7 @@ func (st *state) transitionAction(
 		}
 		st.actions[child.ID] = child
 		st.actionOrder = append(st.actionOrder, child.ID)
+		st.recordSpawnedAdmissionLocked(child)
 		childCopy := child
 		pushed = append(pushed, &childCopy)
 		ctxzap.Extract(ctx).Debug("pushed action", zap.Any("action", child))
@@ -733,6 +802,7 @@ func (st *state) transitionAction(
 	}
 	st.actionOrder = slices.Delete(st.actionOrder, index, index+1)
 	delete(st.actions, parent.ID)
+	delete(st.spawnedInFlight, parent.ID)
 	st.completedActionsCount++
 	ctxzap.Extract(ctx).Debug("finishing action", zap.Any("action", parent))
 	return pushed, nil
@@ -757,6 +827,7 @@ func (st *state) FinishAction(ctx context.Context, action *Action) {
 	}
 	st.actionOrder = slices.Delete(st.actionOrder, index, index+1)
 	delete(st.actions, action.ID)
+	delete(st.spawnedInFlight, action.ID)
 	st.completedActionsCount++
 	ctxzap.Extract(ctx).Debug("finishing action", zap.Any("action", action))
 }

--- a/pkg/sync/state.go
+++ b/pkg/sync/state.go
@@ -3,6 +3,7 @@ package sync //nolint:revive,nolintlint // we can't change the package name for 
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"slices"
 	"sync"
@@ -198,6 +199,10 @@ type Action struct {
 	// malformed connector resources with empty ids can exist in old stores
 	// and must retain the pre-type-scoped per-resource behavior.
 	TypeScoped bool `json:"type_scoped,omitempty"`
+	// TypeScopedPlanned records that a root entitlement/grant action has
+	// already scheduled whole-type collection. Legacy checkpoints omit it,
+	// causing an upgraded syncer to plan type-scoped work once on resume.
+	TypeScopedPlanned bool `json:"type_scoped_planned,omitempty"`
 }
 
 var _ State = &state{}
@@ -647,6 +652,69 @@ func (st *state) pushAction(ctx context.Context, action Action) *Action {
 	st.actionOrder = append(st.actionOrder, action.ID)
 	ctxzap.Extract(ctx).Debug("pushed action", zap.Any("action", action))
 	return &action
+}
+
+func (st *state) markTypeScopedPlanned(actionID string) {
+	st.mtx.Lock()
+	defer st.mtx.Unlock()
+	action, ok := st.actions[actionID]
+	if !ok {
+		return
+	}
+	action.TypeScopedPlanned = true
+	st.actions[actionID] = action
+}
+
+func (st *state) transitionAction(
+	ctx context.Context,
+	parent *Action,
+	nextPageToken string,
+	childActions []Action,
+) ([]*Action, error) {
+	st.mtx.Lock()
+	defer st.mtx.Unlock()
+	if parent == nil {
+		return nil, errors.New("parent action cannot be nil")
+	}
+	if _, ok := st.actions[parent.ID]; !ok {
+		return nil, fmt.Errorf("action ID %s does not exist", parent.ID)
+	}
+	for _, child := range childActions {
+		if child.ID != "" {
+			return nil, errors.New("action ID must be empty for new actions")
+		}
+	}
+
+	pushed := make([]*Action, 0, len(childActions))
+	for _, child := range childActions {
+		child.ID = makeActionID(st.currentActionID)
+		st.currentActionID++
+		if _, ok := st.actions[child.ID]; ok {
+			panic(fmt.Sprintf("action ID for new action %s already exists", child.ID))
+		}
+		st.actions[child.ID] = child
+		st.actionOrder = append(st.actionOrder, child.ID)
+		childCopy := child
+		pushed = append(pushed, &childCopy)
+		ctxzap.Extract(ctx).Debug("pushed action", zap.Any("action", child))
+	}
+
+	if nextPageToken != "" {
+		updated := st.actions[parent.ID]
+		updated.PageToken = nextPageToken
+		st.actions[parent.ID] = updated
+		return pushed, nil
+	}
+
+	index, ok := slices.BinarySearch(st.actionOrder, parent.ID)
+	if !ok {
+		panic(fmt.Sprintf("action ID %s does not exist in action order", parent.ID))
+	}
+	st.actionOrder = slices.Delete(st.actionOrder, index, index+1)
+	delete(st.actions, parent.ID)
+	st.completedActionsCount++
+	ctxzap.Extract(ctx).Debug("finishing action", zap.Any("action", parent))
+	return pushed, nil
 }
 
 // FinishAction pops the current action from the state.

--- a/pkg/sync/state.go
+++ b/pkg/sync/state.go
@@ -193,6 +193,11 @@ type Action struct {
 	// Progress accounting counts only the origin action for per-resource
 	// phases. The marker is checkpointed so resume preserves that rule.
 	Spawned bool `json:"spawned,omitempty"`
+	// TypeScoped distinguishes whole-type grant/entitlement cursors from
+	// per-resource actions. Do not infer this from an empty ResourceID:
+	// malformed connector resources with empty ids can exist in old stores
+	// and must retain the pre-type-scoped per-resource behavior.
+	TypeScoped bool `json:"type_scoped,omitempty"`
 }
 
 var _ State = &state{}
@@ -618,6 +623,13 @@ func makeActionID(id uint64) string {
 
 // PushAction adds a new action to the stack.
 func (st *state) PushAction(ctx context.Context, action Action) {
+	st.pushAction(ctx, action)
+}
+
+// pushAction adds an action and returns the checkpointed copy, including its
+// assigned ID. The scheduler uses that copy to admit spawned work without
+// changing the exported State interface.
+func (st *state) pushAction(ctx context.Context, action Action) *Action {
 	st.mtx.Lock()
 	defer st.mtx.Unlock()
 
@@ -634,6 +646,7 @@ func (st *state) PushAction(ctx context.Context, action Action) {
 	st.actions[action.ID] = action
 	st.actionOrder = append(st.actionOrder, action.ID)
 	ctxzap.Extract(ctx).Debug("pushed action", zap.Any("action", action))
+	return &action
 }
 
 // FinishAction pops the current action from the state.

--- a/pkg/sync/state.go
+++ b/pkg/sync/state.go
@@ -778,43 +778,67 @@ func (st *state) NextPage(ctx context.Context, actionID string, pageToken string
 	return nil
 }
 
+// The boolean flag accessors below take st.mtx because parallel workers set
+// them concurrently mid-batch (e.g. every grant carrying an expandable
+// annotation calls SetNeedsExpansion from its worker goroutine).
+
 func (st *state) NeedsExpansion() bool {
+	st.mtx.RLock()
+	defer st.mtx.RUnlock()
 	return st.needsExpansion
 }
 
 func (st *state) SetNeedsExpansion() {
+	st.mtx.Lock()
+	defer st.mtx.Unlock()
 	st.needsExpansion = true
 }
 
 func (st *state) HasExternalResourcesGrants() bool {
+	st.mtx.RLock()
+	defer st.mtx.RUnlock()
 	return st.hasExternalResourceGrants
 }
 
 func (st *state) SetHasExternalResourcesGrants() {
+	st.mtx.Lock()
+	defer st.mtx.Unlock()
 	st.hasExternalResourceGrants = true
 }
 
 func (st *state) ShouldFetchRelatedResources() bool {
+	st.mtx.RLock()
+	defer st.mtx.RUnlock()
 	return st.shouldFetchRelatedResources
 }
 
 func (st *state) SetShouldFetchRelatedResources() {
+	st.mtx.Lock()
+	defer st.mtx.Unlock()
 	st.shouldFetchRelatedResources = true
 }
 
 func (st *state) ShouldSkipEntitlementsAndGrants() bool {
+	st.mtx.RLock()
+	defer st.mtx.RUnlock()
 	return st.shouldSkipEntitlementsAndGrants
 }
 
 func (st *state) SetShouldSkipEntitlementsAndGrants() {
+	st.mtx.Lock()
+	defer st.mtx.Unlock()
 	st.shouldSkipEntitlementsAndGrants = true
 }
 
 func (st *state) ShouldSkipGrants() bool {
+	st.mtx.RLock()
+	defer st.mtx.RUnlock()
 	return st.shouldSkipGrants
 }
 
 func (st *state) SetShouldSkipGrants() {
+	st.mtx.Lock()
+	defer st.mtx.Unlock()
 	st.shouldSkipGrants = true
 }
 

--- a/pkg/sync/state.go
+++ b/pkg/sync/state.go
@@ -189,6 +189,10 @@ type Action struct {
 	ResourceID           string   `json:"resource_id,omitempty"`
 	ParentResourceTypeID string   `json:"parent_resource_type_id,omitempty"`
 	ParentResourceID     string   `json:"parent_resource_id,omitempty"`
+	// Spawned marks a sibling cursor enqueued by EnqueuePageTokens.
+	// Progress accounting counts only the origin action for per-resource
+	// phases. The marker is checkpointed so resume preserves that rule.
+	Spawned bool `json:"spawned,omitempty"`
 }
 
 var _ State = &state{}

--- a/pkg/sync/state.go
+++ b/pkg/sync/state.go
@@ -251,6 +251,25 @@ type state struct {
 	// that completes the sync. Guarded by st.mtx; bounded by the number
 	// of in-flight spawned actions (entries are deleted on finish).
 	spawnedInFlight map[string]Action
+	// spawnedAdmitted maps the identity digest (op, resource type,
+	// resource, page token, type-scope) of every spawned cursor admitted
+	// in THIS PROCESS to its action ID. It is the termination and
+	// idempotency guard for re-mentioned spawns: connectors legitimately
+	// re-mention a cursor another response already spawned (DAG-shaped
+	// shard discovery, or post-crash answers that shifted under a
+	// resumed checkpoint). The parallel queue's own dedup set is scoped
+	// to ONE batch, so an identity that completed in an earlier batch is
+	// invisible to it — without this process-lifetime set, two cursors
+	// mentioning each other across batch boundaries would re-admit each
+	// other forever. transitionAction skips a spawned child whose
+	// identity is already here. Entries are deliberately NEVER pruned on
+	// finish — a completed spawn must stay skippable or cycles resume.
+	// Not serialized: after a crash the set rebuilds from the surviving
+	// stack (Unmarshal), so a re-mention of work completed before the
+	// crash is redone once, idempotently, and the set re-accumulates —
+	// cycles still terminate. Guarded by st.mtx; bounded by total
+	// spawned admissions in the process (32-byte keys).
+	spawnedAdmitted map[parallelActionKey]string
 }
 
 // ConnectorCallStat contains cumulative latency statistics for one connector method.
@@ -321,6 +340,7 @@ func newState() *state {
 		connectorCallStats: make(map[string]*ConnectorCallStat),
 		sessionStoreStats:  make(map[string]*SessionStoreStat),
 		spawnedInFlight:    make(map[string]Action),
+		spawnedAdmitted:    make(map[parallelActionKey]string),
 	}
 }
 
@@ -461,8 +481,12 @@ func (st *state) Unmarshal(input string) error {
 		// Rebuild the I10 drain-evidence set from the checkpointed
 		// actions: a spawned cursor restored from a token was admitted
 		// by a previous process and must still drain in the process
-		// that completes the sync.
+		// that completes the sync. The re-mention guard set rebuilds
+		// from the same scan: only surviving identities are known —
+		// crash amnesia means completed spawns are re-doable, which is
+		// idempotent and re-accumulates the set.
 		st.spawnedInFlight = make(map[string]Action)
+		st.spawnedAdmitted = make(map[parallelActionKey]string)
 		for _, action := range st.actions {
 			st.recordSpawnedAdmissionLocked(action)
 		}
@@ -484,6 +508,7 @@ func (st *state) Unmarshal(input string) error {
 		st.sessionStoreStats = make(map[string]*SessionStoreStat)
 		st.compaction = nil
 		st.spawnedInFlight = make(map[string]Action)
+		st.spawnedAdmitted = make(map[parallelActionKey]string)
 	}
 
 	return nil
@@ -732,7 +757,7 @@ func (st *state) pushAction(ctx context.Context, action Action) *Action {
 }
 
 // recordSpawnedAdmissionLocked enrolls a spawned cursor in the I10
-// drain-evidence set. Caller holds st.mtx.
+// drain-evidence set and the re-mention guard index. Caller holds st.mtx.
 func (st *state) recordSpawnedAdmissionLocked(action Action) {
 	if !action.Spawned {
 		return
@@ -741,6 +766,10 @@ func (st *state) recordSpawnedAdmissionLocked(action Action) {
 		st.spawnedInFlight = make(map[string]Action)
 	}
 	st.spawnedInFlight[action.ID] = action
+	if st.spawnedAdmitted == nil {
+		st.spawnedAdmitted = make(map[parallelActionKey]string)
+	}
+	st.spawnedAdmitted[makeParallelActionKey(&action)] = action.ID
 }
 
 func (st *state) markTypeScopedPlanned(actionID string) {
@@ -776,6 +805,24 @@ func (st *state) transitionAction(
 
 	pushed := make([]*Action, 0, len(childActions))
 	for _, child := range childActions {
+		// Re-mention guard: a spawned child whose identity was already
+		// admitted in this process is the same work, already scheduled
+		// or done. Re-admitting it duplicates work at best; at worst it
+		// never terminates (mutual mentions re-admitting each other
+		// across batch boundaries, where the queue's per-batch dedup
+		// cannot see them). Skip it, loudly.
+		if child.Spawned {
+			if priorID, dup := st.spawnedAdmitted[makeParallelActionKey(&child)]; dup {
+				ctxzap.Extract(ctx).Warn(
+					"skipping re-mentioned spawned cursor: identical work was already admitted this sync",
+					zap.String("existing_action_id", priorID),
+					zap.String("op", child.Op.String()),
+					zap.String("resource_type_id", child.ResourceTypeID),
+					zap.String("resource_id", child.ResourceID),
+				)
+				continue
+			}
+		}
 		child.ID = makeActionID(st.currentActionID)
 		st.currentActionID++
 		if _, ok := st.actions[child.ID]; ok {

--- a/pkg/sync/state.go
+++ b/pkg/sync/state.go
@@ -18,6 +18,16 @@ import (
 // If you make a breaking change to the state token, you must increment this version.
 const StateTokenVersion = 1
 
+// StateTokenVersionTypeScoped marks checkpoints whose action state carries
+// type-scoped or spawned-cursor markers. Older SDKs cannot interpret those
+// actions: their JSON parser silently drops the marker fields, and the
+// resulting actions dead-end against store pagination, sealing the sync as
+// complete while missing every pending cursor's data. Version 2 defeats
+// that: an older SDK fails the version check, falls back to the V0 parser,
+// gets an empty action state, and restarts collection from Init inside the
+// same sync run — redone work instead of silent data loss.
+const StateTokenVersionTypeScoped = 2
+
 type State interface {
 	PushAction(ctx context.Context, action Action)
 	FinishAction(ctx context.Context, action *Action)
@@ -397,7 +407,7 @@ func (st *state) Unmarshal(input string) error {
 
 	if input != "" {
 		err := json.Unmarshal([]byte(input), &token)
-		if err != nil || token.Version != StateTokenVersion {
+		if err != nil || (token.Version != StateTokenVersion && token.Version != StateTokenVersionTypeScoped) {
 			// Fall back to old serialized token format.
 			token, err = unmarshalTokenV0(input)
 			if err != nil {
@@ -461,6 +471,17 @@ func (st *state) Marshal() (string, error) {
 	st.mtx.RLock()
 	defer st.mtx.RUnlock()
 
+	// Stamp the type-scoped version only when the token actually carries
+	// markers an older parser would misinterpret; plain tokens keep
+	// version 1 so downgrades resume seamlessly.
+	version := uint64(StateTokenVersion)
+	for _, action := range st.actions {
+		if action.TypeScoped || action.Spawned || action.TypeScopedPlanned {
+			version = StateTokenVersionTypeScoped
+			break
+		}
+	}
+
 	data, err := json.Marshal(serializedTokenV1{
 		ActionsMap:                      st.actions,
 		ActionOrder:                     st.actionOrder,
@@ -476,7 +497,7 @@ func (st *state) Marshal() (string, error) {
 		ConnectorCallStats:              st.connectorCallStats,
 		SessionStoreStats:               st.sessionStoreStats,
 		Compaction:                      st.compaction,
-		Version:                         1,
+		Version:                         version,
 	})
 	if err != nil {
 		return "", err

--- a/pkg/sync/state_test.go
+++ b/pkg/sync/state_test.go
@@ -242,6 +242,35 @@ func TestSyncerTokenNextPage(t *testing.T) {
 	compareSyncerState(t, op2, *st.Current())
 }
 
+func TestPeekMatchingActionsCapsBatchesAndDrainsRemainder(t *testing.T) {
+	ctx := t.Context()
+	st := newEmptySchedulerState(t)
+	for range maxPeekActionsCount + 5 {
+		st.PushAction(ctx, Action{Op: SyncGrantsOp})
+	}
+
+	firstBatch := st.PeekMatchingActions(ctx, SyncGrantsOp)
+	require.Len(t, firstBatch, maxPeekActionsCount)
+	for _, action := range firstBatch {
+		st.FinishAction(ctx, action)
+	}
+
+	require.Len(t, st.PeekMatchingActions(ctx, SyncGrantsOp), 5)
+}
+
+func TestPeekMatchingActionsStopsAtDifferentOperation(t *testing.T) {
+	ctx := t.Context()
+	st := newEmptySchedulerState(t)
+	st.PushAction(ctx, Action{Op: SyncEntitlementsOp})
+	st.PushAction(ctx, Action{Op: SyncGrantsOp, ResourceID: "first"})
+	st.PushAction(ctx, Action{Op: SyncGrantsOp, ResourceID: "second"})
+
+	actions := st.PeekMatchingActions(ctx, SyncGrantsOp)
+	require.Len(t, actions, 2)
+	require.Equal(t, "second", actions[0].ResourceID)
+	require.Equal(t, "first", actions[1].ResourceID)
+}
+
 func TestSyncerTokenUnmarshalBackwardsCompatible(t *testing.T) {
 	initOp := Action{Op: InitOp}
 	syncResourcesOp := Action{Op: SyncResourcesOp, PageToken: "", ResourceTypeID: "user", ResourceID: "userID1"}

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -218,11 +218,10 @@ type syncer struct {
 	metricsHandler                        metrics.Handler
 	syncIdentity                          uotel.SyncIdentity
 	recordStats                           bool
-	// parallelActionEnqueuer admits actions spawned by an in-flight list
-	// response into the active worker pool. Access only through the helper
-	// methods in parallel_syncer.go.
-	parallelEnqueueMu      native_sync.RWMutex
-	parallelActionEnqueuer func(*Action)
+	// parallelActionTransitioner atomically commits parent pagination and
+	// spawned work to state and the active worker pool.
+	parallelTransitionMu       native_sync.RWMutex
+	parallelActionTransitioner func(context.Context, *Action, string, []Action) error
 
 	// Watermark for the rate_limit_wait_wall bucket: the latest instant
 	// already counted as rate-limit-blocked wall time, plus the
@@ -681,6 +680,13 @@ func collectionProgressIncrement(action *Action, itemCount int, hasNextPage bool
 	return 0, false
 }
 
+func (s *syncer) markTypeScopedPlanned(action *Action) {
+	action.TypeScopedPlanned = true
+	if st, ok := s.state.(*state); ok {
+		st.markTypeScopedPlanned(action.ID)
+	}
+}
+
 // maxEntitlementsPerExclusionGroup caps how many entitlements may share a
 // single exclusion_group_id. Phase 1 limit. Enforced by ingestion
 // invariant I5 over the STORED entitlement keyspace post-collection
@@ -692,28 +698,38 @@ const maxEntitlementsPerExclusionGroup = 50
 // It also pushes any child actions before updating/finishing the action.
 // This is useful for pagination, and for actions that create other actions.
 func (s *syncer) nextPageOrFinishAction(ctx context.Context, action *Action, nextPageToken string, childActions ...Action) error {
+	s.parallelTransitionMu.RLock()
+	transitioner := s.parallelActionTransitioner
+	s.parallelTransitionMu.RUnlock()
+	if transitioner != nil {
+		return transitioner(ctx, action, nextPageToken, childActions)
+	}
+
+	_, err := s.transitionActionState(ctx, action, nextPageToken, childActions)
+	return err
+}
+
+func (s *syncer) transitionActionState(
+	ctx context.Context,
+	action *Action,
+	nextPageToken string,
+	childActions []Action,
+) ([]*Action, error) {
+	if st, ok := s.state.(*state); ok {
+		return st.transitionAction(ctx, action, nextPageToken, childActions)
+	}
 	if nextPageToken != "" {
-		err := s.state.NextPage(ctx, action.ID, nextPageToken)
-		if err != nil {
-			return err
+		if err := s.state.NextPage(ctx, action.ID, nextPageToken); err != nil {
+			return nil, err
 		}
 	}
-
-	for _, a := range childActions {
-		var pushed *Action
-		if st, ok := s.state.(*state); ok {
-			pushed = st.pushAction(ctx, a)
-		} else {
-			s.state.PushAction(ctx, a)
-		}
-		s.enqueueParallelAction(pushed)
+	for _, child := range childActions {
+		s.state.PushAction(ctx, child)
 	}
-
 	if nextPageToken == "" {
 		s.state.FinishAction(ctx, action)
 	}
-
-	return nil
+	return nil, nil
 }
 
 func isWarning(ctx context.Context, err error) bool {
@@ -1208,19 +1224,37 @@ func (s *syncer) hasChildResources(resource *v2.Resource) bool {
 // At sync scale (100k+ resources per trace) the span overhead and trace bloat
 // outweighed any debugging value.
 func (s *syncer) getSubResources(ctx context.Context, parent *v2.Resource) error {
+	actions, err := s.subResourceActions(parent)
+	if err != nil {
+		return err
+	}
+	for _, action := range actions {
+		s.state.PushAction(ctx, action)
+	}
+	return nil
+}
+
+func (s *syncer) subResourceActions(parent *v2.Resource) ([]Action, error) {
+	childTypeIDs, err := childResourceTypeIDs(parent)
+	if err != nil {
+		return nil, err
+	}
+	return s.childResourceActions(childTypeIDs, parent.GetId().GetResourceType(), parent.GetId().GetResource()), nil
+}
+
+func childResourceTypeIDs(parent *v2.Resource) ([]string, error) {
 	var childTypeIDs []string
 	for _, a := range parent.GetAnnotations() {
 		if a.MessageIs((*v2.ChildResourceType)(nil)) {
 			crt := &v2.ChildResourceType{}
 			err := a.UnmarshalTo(crt)
 			if err != nil {
-				return err
+				return nil, err
 			}
 			childTypeIDs = append(childTypeIDs, crt.GetResourceTypeId())
 		}
 	}
-	s.pushChildResourceActions(ctx, childTypeIDs, parent.GetId().GetResourceType(), parent.GetId().GetResource())
-	return nil
+	return childTypeIDs, nil
 }
 
 // pushChildResourceActions queues child resource syncs for one parent,
@@ -1229,6 +1263,13 @@ func (s *syncer) getSubResources(ctx context.Context, parent *v2.Resource) error
 // resource can schedule its children through the same evidence-recorded
 // seam.
 func (s *syncer) pushChildResourceActions(ctx context.Context, childTypeIDs []string, parentTypeID, parentID string) {
+	for _, action := range s.childResourceActions(childTypeIDs, parentTypeID, parentID) {
+		s.state.PushAction(ctx, action)
+	}
+}
+
+func (s *syncer) childResourceActions(childTypeIDs []string, parentTypeID, parentID string) []Action {
+	var actions []Action
 	for _, childTypeID := range childTypeIDs {
 		if len(s.syncResourceTypes) > 0 && !slices.Contains(s.syncResourceTypes, childTypeID) {
 			continue
@@ -1242,13 +1283,33 @@ func (s *syncer) pushChildResourceActions(ctx context.Context, childTypeIDs []st
 		if !s.childSchedule.recordIfNew(childTypeID, parentTypeID, parentID) {
 			continue
 		}
-		s.state.PushAction(ctx, Action{
+		actions = append(actions, Action{
 			Op:                   SyncResourcesOp,
 			ResourceTypeID:       childTypeID,
 			ParentResourceID:     parentID,
 			ParentResourceTypeID: parentTypeID,
 		})
 	}
+	return actions
+}
+
+func (s *syncer) pendingChildResourceActions(childTypeIDs []string, parentTypeID, parentID string) []Action {
+	var actions []Action
+	for _, childTypeID := range childTypeIDs {
+		if len(s.syncResourceTypes) > 0 && !slices.Contains(s.syncResourceTypes, childTypeID) {
+			continue
+		}
+		if s.childSchedule.has(childTypeID, parentTypeID, parentID) {
+			continue
+		}
+		actions = append(actions, Action{
+			Op:                   SyncResourcesOp,
+			ResourceTypeID:       childTypeID,
+			ParentResourceID:     parentID,
+			ParentResourceTypeID: parentTypeID,
+		})
+	}
+	return actions
 }
 
 func (s *syncer) getResourceFromConnector(ctx context.Context, resourceID *v2.ResourceId, parentResourceID *v2.ResourceId) (*v2.Resource, error) {
@@ -1313,8 +1374,7 @@ func (s *syncer) SyncTargetedResource(ctx context.Context, action *Action) error
 
 	// If getResource encounters not found or unimplemented, it returns a nil resource and nil error.
 	if resource == nil {
-		s.state.FinishAction(ctx, action)
-		return nil
+		return s.nextPageOrFinishAction(ctx, action, "")
 	}
 
 	// Save our resource in the DB
@@ -1322,9 +1382,8 @@ func (s *syncer) SyncTargetedResource(ctx context.Context, action *Action) error
 		return err
 	}
 
-	s.state.FinishAction(ctx, action)
-
 	// Actions happen in reverse order. We want to sync child resources, then entitlements, then grants
+	var followupActions []Action
 
 	shouldSkipGrants, err := s.shouldSkipGrants(ctx, resource)
 	if err != nil {
@@ -1336,7 +1395,7 @@ func (s *syncer) SyncTargetedResource(ctx context.Context, action *Action) error
 			return err
 		}
 		if !typeScopedGrants {
-			s.state.PushAction(ctx, Action{
+			followupActions = append(followupActions, Action{
 				Op:             SyncGrantsOp,
 				ResourceTypeID: resourceTypeID,
 				ResourceID:     resourceID,
@@ -1355,7 +1414,7 @@ func (s *syncer) SyncTargetedResource(ctx context.Context, action *Action) error
 			return err
 		}
 		if !typeScopedEnts {
-			s.state.PushAction(ctx, Action{
+			followupActions = append(followupActions, Action{
 				Op:             SyncEntitlementsOp,
 				ResourceTypeID: resourceTypeID,
 				ResourceID:     resourceID,
@@ -1363,11 +1422,19 @@ func (s *syncer) SyncTargetedResource(ctx context.Context, action *Action) error
 		}
 	}
 
-	err = s.getSubResources(ctx, resource)
+	childTypeIDs, err := childResourceTypeIDs(resource)
 	if err != nil {
 		return err
 	}
+	childActions := s.pendingChildResourceActions(childTypeIDs, resourceTypeID, resourceID)
+	followupActions = append(followupActions, childActions...)
 
+	if err := s.nextPageOrFinishAction(ctx, action, "", followupActions...); err != nil {
+		return err
+	}
+	for _, childAction := range childActions {
+		s.childSchedule.recordIfNew(childAction.ResourceTypeID, childAction.ParentResourceTypeID, childAction.ParentResourceID)
+	}
 	return nil
 }
 
@@ -1647,11 +1714,14 @@ func (s *syncer) SyncEntitlements(ctx context.Context, action *Action) error {
 	if action.ResourceTypeID == "" && action.ResourceID == "" {
 		actions := make([]Action, 0)
 		pageToken := action.PageToken
+		plannedTypeScoped := false
 
 		if pageToken == "" {
 			ctxzap.Extract(ctx).Info("Syncing entitlements...")
 			s.handleInitialActionForStep(ctx, *action)
+		}
 
+		if !action.TypeScopedPlanned {
 			typeScoped, err := s.typeScopedEntitlementsResourceTypes(ctx)
 			if err != nil {
 				return fmt.Errorf("sync-entitlements: error listing type-scoped resource types: %w", err)
@@ -1659,6 +1729,7 @@ func (s *syncer) SyncEntitlements(ctx context.Context, action *Action) error {
 			for _, rtID := range typeScoped {
 				actions = append(actions, Action{Op: SyncEntitlementsOp, ResourceTypeID: rtID, TypeScoped: true})
 			}
+			plannedTypeScoped = true
 		}
 
 		resp, err := s.store.ListResources(ctx, v2.ResourcesServiceListResourcesRequest_builder{
@@ -1687,7 +1758,13 @@ func (s *syncer) SyncEntitlements(ctx context.Context, action *Action) error {
 			actions = append(actions, Action{Op: SyncEntitlementsOp, ResourceID: r.GetId().GetResource(), ResourceTypeID: r.GetId().GetResourceType()})
 		}
 
-		return s.nextPageOrFinishAction(ctx, action, resp.GetNextPageToken(), actions...)
+		if err := s.nextPageOrFinishAction(ctx, action, resp.GetNextPageToken(), actions...); err != nil {
+			return err
+		}
+		if plannedTypeScoped {
+			s.markTypeScopedPlanned(action)
+		}
+		return nil
 	}
 
 	err = s.syncEntitlementsForResource(ctx, action)
@@ -2193,10 +2270,13 @@ func (s *syncer) SyncGrants(ctx context.Context, action *Action) error {
 
 	if action.ResourceTypeID == "" && action.ResourceID == "" {
 		actions := make([]Action, 0)
+		plannedTypeScoped := false
 		if action.PageToken == "" {
 			ctxzap.Extract(ctx).Info("Syncing grants...")
 			s.handleInitialActionForStep(ctx, *action)
+		}
 
+		if !action.TypeScopedPlanned {
 			typeScoped, err := s.typeScopedGrantsResourceTypes(ctx)
 			if err != nil {
 				return fmt.Errorf("sync-grants: error listing type-scoped resource types: %w", err)
@@ -2204,6 +2284,7 @@ func (s *syncer) SyncGrants(ctx context.Context, action *Action) error {
 			for _, rtID := range typeScoped {
 				actions = append(actions, Action{Op: SyncGrantsOp, ResourceTypeID: rtID, TypeScoped: true})
 			}
+			plannedTypeScoped = true
 		}
 
 		resp, err := s.store.ListResources(ctx, v2.ResourcesServiceListResourcesRequest_builder{
@@ -2233,7 +2314,13 @@ func (s *syncer) SyncGrants(ctx context.Context, action *Action) error {
 			actions = append(actions, Action{Op: SyncGrantsOp, ResourceID: r.GetId().GetResource(), ResourceTypeID: r.GetId().GetResourceType()})
 		}
 
-		return s.nextPageOrFinishAction(ctx, action, resp.GetNextPageToken(), actions...)
+		if err := s.nextPageOrFinishAction(ctx, action, resp.GetNextPageToken(), actions...); err != nil {
+			return err
+		}
+		if plannedTypeScoped {
+			s.markTypeScopedPlanned(action)
+		}
+		return nil
 	}
 	err = s.syncGrantsForResource(ctx, action)
 	if err != nil {

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -868,6 +868,13 @@ func (s *syncer) Sync(ctx context.Context) error {
 
 	// Validate any targeted resource IDs before starting a sync.
 	targetedResources := []*v2.Resource{}
+	type targetedResourceKey struct {
+		resourceTypeID       string
+		resourceID           string
+		parentResourceTypeID string
+		parentResourceID     string
+	}
+	seenTargetedResources := make(map[targetedResourceKey]struct{}, len(s.targetedSyncResources))
 	for _, r := range s.targetedSyncResources {
 		if len(s.syncResourceTypes) > 0 {
 			if _, ok := syncResourceTypeMap[r.GetId().GetResourceType()]; !ok {
@@ -875,6 +882,16 @@ func (s *syncer) Sync(ctx context.Context) error {
 			}
 		}
 
+		key := targetedResourceKey{
+			resourceTypeID:       r.GetId().GetResourceType(),
+			resourceID:           r.GetId().GetResource(),
+			parentResourceTypeID: r.GetParentResourceId().GetResourceType(),
+			parentResourceID:     r.GetParentResourceId().GetResource(),
+		}
+		if _, ok := seenTargetedResources[key]; ok {
+			continue
+		}
+		seenTargetedResources[key] = struct{}{}
 		targetedResources = append(targetedResources, r)
 	}
 
@@ -1058,45 +1075,50 @@ func (s *syncer) Sync(ctx context.Context) error {
 	return nil
 }
 
-func (s *syncer) SkipSync(ctx context.Context) error {
+func (s *syncer) SkipSync(ctx context.Context) (err error) {
 	ctx, span := tracer.Start(ctx, "syncer.SkipSync")
 	uotel.SetSyncIdentityAttrs(ctx, span)
-	var err error
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
 	l := ctxzap.Extract(ctx)
 	l.Info("skipping sync")
 
+	runCtx := ctx
 	var runCanc context.CancelFunc
 	if s.runDuration > 0 {
-		_, runCanc = context.WithTimeout(ctx, s.runDuration)
+		runCtx, runCanc = context.WithTimeout(ctx, s.runDuration)
 	}
 	if runCanc != nil {
 		defer runCanc()
 	}
+	defer func() {
+		if errors.Is(context.Cause(runCtx), context.DeadlineExceeded) {
+			err = errors.Join(err, ErrSyncNotComplete)
+		}
+	}()
 
-	err = s.loadStore(ctx)
+	err = s.loadStore(runCtx)
 	if err != nil {
 		return err
 	}
 
-	_, err = s.connector.Validate(ctx, &v2.ConnectorServiceValidateRequest{})
+	_, err = s.connector.Validate(runCtx, &v2.ConnectorServiceValidateRequest{})
 	if err != nil {
 		return err
 	}
 
 	// TODO: Create a new sync type for empty syncs.
-	_, err = s.store.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	_, err = s.store.StartNewSync(runCtx, connectorstore.SyncTypeFull, "")
 	if err != nil {
 		return err
 	}
 
-	err = s.store.EndSync(ctx)
+	err = s.store.EndSync(runCtx)
 	if err != nil {
 		return err
 	}
 
-	err = s.store.Cleanup(ctx)
+	err = s.store.Cleanup(runCtx)
 	if err != nil {
 		return err
 	}
@@ -1390,6 +1412,11 @@ func (s *syncer) SyncTargetedResource(ctx context.Context, action *Action) error
 		return err
 	}
 	if !shouldSkipGrants {
+		// INTENTIONAL: no per-resource grants action for type-scoped
+		// types, and no type-scoped replacement either. Targeted sync
+		// syncs the resource (and children) only; whole-type grant
+		// enumeration is left to a full grants phase. See the TARGETED
+		// SYNC contract in annotation_type_scoped_grants.proto.
 		typeScopedGrants, err := s.resourceTypeHasTypeScopedGrants(ctx, resourceTypeID)
 		if err != nil {
 			return err
@@ -1409,6 +1436,10 @@ func (s *syncer) SyncTargetedResource(ctx context.Context, action *Action) error
 	}
 
 	if !shouldSkipEnts {
+		// INTENTIONAL: same as grants above — type-scoped entitlement
+		// enumeration is deferred to a full entitlements phase. See the
+		// TARGETED SYNC contract in
+		// annotation_type_scoped_entitlements.proto.
 		typeScopedEnts, err := s.resourceTypeHasTypeScopedEntitlements(ctx, resourceTypeID)
 		if err != nil {
 			return err

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -179,18 +179,33 @@ type syncer struct {
 	// seal leaves the artifact unverified instead of claiming
 	// verification over data a resume will rewrite.
 	pendingInvariantVerification *c1zstore.IngestInvariantVerification
-	connector                    types.ConnectorClient
-	state                        State
-	runDuration                  time.Duration
-	transitionHandler            func(s Action)
-	progressHandler              func(p *Progress)
-	tmpDir                       string
-	storageEngine                c1zstore.Engine
-	skipFullSync                 bool
-	lastCheckPointTime           time.Time
-	counts                       *progresslog.ProgressLog
-	targetedSyncResources        []*v2.Resource
-	onlyExpandGrants             bool
+	// checkpointInterval throttles non-forced checkpoints (default
+	// minCheckpointInterval). The checkpoint-cut verification harness
+	// sets it to zero so every loop-top checkpoint durably commits,
+	// making each one an enumerable crash-cut point.
+	checkpointInterval time.Duration
+	// testCheckpointHook, when non-nil, observes every durably written
+	// checkpoint token. The cut harness uses it to count checkpoints
+	// and to simulate a crash immediately after a chosen one. Nil in
+	// production: one pointer check.
+	testCheckpointHook func(token string)
+	// testQueueAudit, when non-nil, records every parallelActionQueue
+	// event (seed/dequeue/commit/abort/done) for post-hoc verification
+	// of the queue contract. Nil in production: one pointer check per
+	// queue operation.
+	testQueueAudit        *queueAudit
+	connector             types.ConnectorClient
+	state                 State
+	runDuration           time.Duration
+	transitionHandler     func(s Action)
+	progressHandler       func(p *Progress)
+	tmpDir                string
+	storageEngine         c1zstore.Engine
+	skipFullSync          bool
+	lastCheckPointTime    time.Time
+	counts                *progresslog.ProgressLog
+	targetedSyncResources []*v2.Resource
+	onlyExpandGrants      bool
 	// compactionMergedStore marks the store as a pre-sealed artifact
 	// this process did not collect (WithCompactionMergedStore — the
 	// compactor's keep-newer merge and rollback-expansion's replay):
@@ -413,7 +428,7 @@ const minCheckpointInterval = 10 * time.Second
 
 // Checkpoint marshals the current state and stores it.
 func (s *syncer) Checkpoint(ctx context.Context, force bool) error {
-	if !force && !s.lastCheckPointTime.IsZero() && time.Since(s.lastCheckPointTime) < minCheckpointInterval {
+	if !force && !s.lastCheckPointTime.IsZero() && time.Since(s.lastCheckPointTime) < s.checkpointInterval {
 		return nil
 	}
 	start := time.Now()
@@ -434,6 +449,9 @@ func (s *syncer) Checkpoint(ctx context.Context, force bool) error {
 	err = s.store.CheckpointSync(ctx, checkpoint)
 	if err != nil {
 		return err
+	}
+	if s.testCheckpointHook != nil {
+		s.testCheckpointHook(checkpoint)
 	}
 
 	return nil
@@ -3652,9 +3670,10 @@ func WithSyncIdentity(id uotel.SyncIdentity) SyncOpt {
 // NewSyncer returns a new syncer object.
 func NewSyncer(ctx context.Context, c types.ConnectorClient, opts ...SyncOpt) (Syncer, error) {
 	s := &syncer{
-		connector:   c,
-		syncType:    connectorstore.SyncTypeFull,
-		workerCount: 1,
+		connector:          c,
+		syncType:           connectorstore.SyncTypeFull,
+		workerCount:        1,
+		checkpointInterval: minCheckpointInterval,
 	}
 
 	for _, o := range opts {

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -198,24 +198,26 @@ type syncer struct {
 	// merge and soften hard arms to aggregated warnings. Distinct from
 	// onlyExpandGrants, which changes WHAT syncs and carries no
 	// invariant policy on its own.
-	compactionMergedStore           bool
-	dontExpandGrants                bool
-	syncID                          string
-	skipEGForResourceType           syncMap[string, bool]
-	skipEntitlementsForResourceType syncMap[string, bool]
-	scheduledResourceTypes          syncMap[string, bool]
-	ingestFilterStats               ingestFilterStats
-	skipEntitlementsAndGrants       bool
-	skipGrants                      bool
-	resourceTypeTraits              syncMap[string, []v2.ResourceType_Trait]
-	syncType                        connectorstore.SyncType
-	injectSyncIDAnnotation          bool
-	setSessionStore                 sessions.SetSessionStore
-	syncResourceTypes               []string
-	workerCount                     int // If 1, sync is sequential (default). If > 1, sync operations are done in parallel.
-	metricsHandler                  metrics.Handler
-	syncIdentity                    uotel.SyncIdentity
-	recordStats                     bool
+	compactionMergedStore                 bool
+	dontExpandGrants                      bool
+	syncID                                string
+	skipEGForResourceType                 syncMap[string, bool]
+	skipEntitlementsForResourceType       syncMap[string, bool]
+	typeScopedGrantsForResourceType       syncMap[string, bool]
+	typeScopedEntitlementsForResourceType syncMap[string, bool]
+	scheduledResourceTypes                syncMap[string, bool]
+	ingestFilterStats                     ingestFilterStats
+	skipEntitlementsAndGrants             bool
+	skipGrants                            bool
+	resourceTypeTraits                    syncMap[string, []v2.ResourceType_Trait]
+	syncType                              connectorstore.SyncType
+	injectSyncIDAnnotation                bool
+	setSessionStore                       sessions.SetSessionStore
+	syncResourceTypes                     []string
+	workerCount                           int // If 1, sync is sequential (default). If > 1, sync operations are done in parallel.
+	metricsHandler                        metrics.Handler
+	syncIdentity                          uotel.SyncIdentity
+	recordStats                           bool
 
 	// Watermark for the rate_limit_wait_wall bucket: the latest instant
 	// already counted as rate-limit-blocked wall time, plus the
@@ -1308,11 +1310,17 @@ func (s *syncer) SyncTargetedResource(ctx context.Context, action *Action) error
 		return err
 	}
 	if !shouldSkipGrants {
-		s.state.PushAction(ctx, Action{
-			Op:             SyncGrantsOp,
-			ResourceTypeID: resourceTypeID,
-			ResourceID:     resourceID,
-		})
+		typeScopedGrants, err := s.resourceTypeHasTypeScopedGrants(ctx, resourceTypeID)
+		if err != nil {
+			return err
+		}
+		if !typeScopedGrants {
+			s.state.PushAction(ctx, Action{
+				Op:             SyncGrantsOp,
+				ResourceTypeID: resourceTypeID,
+				ResourceID:     resourceID,
+			})
+		}
 	}
 
 	shouldSkipEnts, err := s.shouldSkipEntitlements(ctx, resource)
@@ -1321,11 +1329,17 @@ func (s *syncer) SyncTargetedResource(ctx context.Context, action *Action) error
 	}
 
 	if !shouldSkipEnts {
-		s.state.PushAction(ctx, Action{
-			Op:             SyncEntitlementsOp,
-			ResourceTypeID: resourceTypeID,
-			ResourceID:     resourceID,
-		})
+		typeScopedEnts, err := s.resourceTypeHasTypeScopedEntitlements(ctx, resourceTypeID)
+		if err != nil {
+			return err
+		}
+		if !typeScopedEnts {
+			s.state.PushAction(ctx, Action{
+				Op:             SyncEntitlementsOp,
+				ResourceTypeID: resourceTypeID,
+				ResourceID:     resourceID,
+			})
+		}
 	}
 
 	err = s.getSubResources(ctx, resource)
@@ -1601,8 +1615,8 @@ func (s *syncer) shouldSkipEntitlements(ctx context.Context, r *v2.Resource) (bo
 	return skipEntitlements, nil
 }
 
-// SyncEntitlements fetches the entitlements from the connector. It first lists each resource from the datastore,
-// and pushes an action to fetch the entitlements for each resource.
+// SyncEntitlements fetches entitlements. Annotated resource types receive one
+// type-scoped action instead of a per-resource fan-out.
 func (s *syncer) SyncEntitlements(ctx context.Context, action *Action) error {
 	ctx, span := uotel.StartWithLink(ctx, tracer, "syncer.SyncEntitlements")
 	uotel.SetSyncIdentityAttrs(ctx, span)
@@ -1610,11 +1624,20 @@ func (s *syncer) SyncEntitlements(ctx context.Context, action *Action) error {
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
 	if action.ResourceTypeID == "" && action.ResourceID == "" {
+		actions := make([]Action, 0)
 		pageToken := action.PageToken
 
 		if pageToken == "" {
 			ctxzap.Extract(ctx).Info("Syncing entitlements...")
 			s.handleInitialActionForStep(ctx, *action)
+
+			typeScoped, err := s.typeScopedEntitlementsResourceTypes(ctx)
+			if err != nil {
+				return fmt.Errorf("sync-entitlements: error listing type-scoped resource types: %w", err)
+			}
+			for _, rtID := range typeScoped {
+				actions = append(actions, Action{Op: SyncEntitlementsOp, ResourceTypeID: rtID})
+			}
 		}
 
 		resp, err := s.store.ListResources(ctx, v2.ResourcesServiceListResourcesRequest_builder{
@@ -1625,13 +1648,19 @@ func (s *syncer) SyncEntitlements(ctx context.Context, action *Action) error {
 			return err
 		}
 
-		actions := make([]Action, 0)
 		for _, r := range resp.GetList() {
 			shouldSkipEntitlements, err := s.shouldSkipEntitlements(ctx, r)
 			if err != nil {
 				return err
 			}
 			if shouldSkipEntitlements {
+				continue
+			}
+			typeScoped, err := s.resourceTypeHasTypeScopedEntitlements(ctx, r.GetId().GetResourceType())
+			if err != nil {
+				return err
+			}
+			if typeScoped {
 				continue
 			}
 			actions = append(actions, Action{Op: SyncEntitlementsOp, ResourceID: r.GetId().GetResource(), ResourceTypeID: r.GetId().GetResourceType()})
@@ -1648,27 +1677,43 @@ func (s *syncer) SyncEntitlements(ctx context.Context, action *Action) error {
 	return nil
 }
 
+func (s *syncer) resourceTypeHasTypeScopedEntitlements(ctx context.Context, resourceTypeID string) (bool, error) {
+	return s.resourceTypeCarries(ctx, resourceTypeID, &v2.TypeScopedEntitlements{}, &s.typeScopedEntitlementsForResourceType)
+}
+
+func (s *syncer) typeScopedEntitlementsResourceTypes(ctx context.Context) ([]string, error) {
+	return s.resourceTypesCarrying(ctx, &v2.TypeScopedEntitlements{}, &s.typeScopedEntitlementsForResourceType)
+}
+
 // syncEntitlementsForResource fetches the entitlements for a specific resource from the connector.
 // No span here: only call site is SyncEntitlements, which already owns a span.
 func (s *syncer) syncEntitlementsForResource(ctx context.Context, action *Action) error {
+	typeScoped := action.ResourceID == ""
 	resourceID := v2.ResourceId_builder{
 		ResourceType: action.ResourceTypeID,
 		Resource:     action.ResourceID,
 	}.Build()
-	resourceResponse, err := s.store.GetResource(ctx, reader_v2.ResourcesReaderServiceGetResourceRequest_builder{
-		ResourceId: resourceID,
-	}.Build())
-	if err != nil {
-		return err
-	}
 
-	resource := resourceResponse.GetResource()
+	var resource *v2.Resource
+	var reqAnnos annotations.Annotations
+	if typeScoped {
+		resource, reqAnnos = typeScopedRequestStub(action.ResourceTypeID, &v2.TypeScopedEntitlements{})
+	} else {
+		resourceResponse, err := s.store.GetResource(ctx, reader_v2.ResourcesReaderServiceGetResourceRequest_builder{
+			ResourceId: resourceID,
+		}.Build())
+		if err != nil {
+			return err
+		}
+		resource = resourceResponse.GetResource()
+	}
 
 	start := time.Now()
 	resp, err := s.connector.ListEntitlements(ctx, v2.EntitlementsServiceListEntitlementsRequest_builder{
 		Resource:     resource,
 		PageToken:    action.PageToken,
 		ActiveSyncId: s.getActiveSyncID(),
+		Annotations:  reqAnnos,
 	}.Build())
 	s.observeConnectorCall(ctx, "list-entitlements", start, action.ResourceTypeID, action.ResourceID)
 	s.recordSessionUsage(resp.GetAnnotations())
@@ -1690,12 +1735,20 @@ func (s *syncer) syncEntitlementsForResource(ctx context.Context, action *Action
 	}
 
 	s.handleProgress(ctx, action, len(entitlements))
-	if resp.GetNextPageToken() == "" {
+	if typeScoped {
+		s.counts.SetEntitlementsCountOnly(resourceID.GetResourceType())
+		s.counts.AddEntitlementsProgress(resourceID.GetResourceType(), len(entitlements))
+		s.counts.LogEntitlementsProgress(ctx, resourceID.GetResourceType())
+	} else if resp.GetNextPageToken() == "" && !action.Spawned {
 		s.counts.AddEntitlementsProgress(resourceID.ResourceType, 1)
 		s.counts.LogEntitlementsProgress(ctx, resourceID.GetResourceType())
 	}
 
-	return s.nextPageOrFinishAction(ctx, action, resp.GetNextPageToken())
+	spawned, err := s.collectEnqueuedPageTokens(ctx, "sync-entitlements", SyncEntitlementsOp, action, annotations.Annotations(resp.GetAnnotations()))
+	if err != nil {
+		return err
+	}
+	return s.nextPageOrFinishAction(ctx, action, resp.GetNextPageToken(), spawned...)
 }
 
 func (s *syncer) SyncStaticEntitlements(ctx context.Context, action *Action) error {
@@ -2109,8 +2162,8 @@ func (s *syncer) fixEntitlementGraphCycles(ctx context.Context, graph *expand.En
 	return graph.FixCyclesFromComponents(ctx, comps)
 }
 
-// SyncGrants fetches the grants for each resource from the connector. It iterates each resource
-// from the datastore, and pushes a new action to sync the grants for each individual resource.
+// SyncGrants fetches grants. Annotated resource types receive one type-scoped
+// action instead of a per-resource fan-out.
 func (s *syncer) SyncGrants(ctx context.Context, action *Action) error {
 	ctx, span := uotel.StartWithLink(ctx, tracer, "syncer.SyncGrants")
 	uotel.SetSyncIdentityAttrs(ctx, span)
@@ -2118,9 +2171,18 @@ func (s *syncer) SyncGrants(ctx context.Context, action *Action) error {
 	defer func() { uotel.EndSpanWithError(span, err) }()
 
 	if action.ResourceTypeID == "" && action.ResourceID == "" {
+		actions := make([]Action, 0)
 		if action.PageToken == "" {
 			ctxzap.Extract(ctx).Info("Syncing grants...")
 			s.handleInitialActionForStep(ctx, *action)
+
+			typeScoped, err := s.typeScopedGrantsResourceTypes(ctx)
+			if err != nil {
+				return fmt.Errorf("sync-grants: error listing type-scoped resource types: %w", err)
+			}
+			for _, rtID := range typeScoped {
+				actions = append(actions, Action{Op: SyncGrantsOp, ResourceTypeID: rtID})
+			}
 		}
 
 		resp, err := s.store.ListResources(ctx, v2.ResourcesServiceListResourcesRequest_builder{
@@ -2131,7 +2193,6 @@ func (s *syncer) SyncGrants(ctx context.Context, action *Action) error {
 			return fmt.Errorf("sync-grants: error listing resources: %w", err)
 		}
 
-		actions := make([]Action, 0)
 		for _, r := range resp.GetList() {
 			shouldSkip, err := s.shouldSkipGrants(ctx, r)
 			if err != nil {
@@ -2139,6 +2200,13 @@ func (s *syncer) SyncGrants(ctx context.Context, action *Action) error {
 			}
 
 			if shouldSkip {
+				continue
+			}
+			typeScoped, err := s.resourceTypeHasTypeScopedGrants(ctx, r.GetId().GetResourceType())
+			if err != nil {
+				return err
+			}
+			if typeScoped {
 				continue
 			}
 			actions = append(actions, Action{Op: SyncGrantsOp, ResourceID: r.GetId().GetResource(), ResourceTypeID: r.GetId().GetResourceType()})
@@ -2154,27 +2222,43 @@ func (s *syncer) SyncGrants(ctx context.Context, action *Action) error {
 	return nil
 }
 
+func (s *syncer) resourceTypeHasTypeScopedGrants(ctx context.Context, resourceTypeID string) (bool, error) {
+	return s.resourceTypeCarries(ctx, resourceTypeID, &v2.TypeScopedGrants{}, &s.typeScopedGrantsForResourceType)
+}
+
+func (s *syncer) typeScopedGrantsResourceTypes(ctx context.Context) ([]string, error) {
+	return s.resourceTypesCarrying(ctx, &v2.TypeScopedGrants{}, &s.typeScopedGrantsForResourceType)
+}
+
 // syncGrantsForResource fetches the grants for a specific resource from the connector.
 // No span here: only call site is SyncGrants, which already owns a span.
 func (s *syncer) syncGrantsForResource(ctx context.Context, action *Action) error {
+	typeScoped := action.ResourceID == ""
 	resourceID := v2.ResourceId_builder{
 		ResourceType: action.ResourceTypeID,
 		Resource:     action.ResourceID,
 	}.Build()
-	resourceResponse, err := s.store.GetResource(ctx, reader_v2.ResourcesReaderServiceGetResourceRequest_builder{
-		ResourceId: resourceID,
-	}.Build())
-	if err != nil {
-		return fmt.Errorf("sync-grants-for-resource: error getting resource: %w", err)
-	}
 
-	resource := resourceResponse.GetResource()
+	var resource *v2.Resource
+	var reqAnnos annotations.Annotations
+	if typeScoped {
+		resource, reqAnnos = typeScopedRequestStub(action.ResourceTypeID, &v2.TypeScopedGrants{})
+	} else {
+		resourceResponse, err := s.store.GetResource(ctx, reader_v2.ResourcesReaderServiceGetResourceRequest_builder{
+			ResourceId: resourceID,
+		}.Build())
+		if err != nil {
+			return fmt.Errorf("sync-grants-for-resource: error getting resource: %w", err)
+		}
+		resource = resourceResponse.GetResource()
+	}
 
 	start := time.Now()
 	resp, err := s.connector.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{
 		Resource:     resource,
 		PageToken:    action.PageToken,
 		ActiveSyncId: s.getActiveSyncID(),
+		Annotations:  reqAnnos,
 	}.Build())
 	s.observeConnectorCall(ctx, "list-grants", start, action.ResourceTypeID, action.ResourceID)
 	s.recordSessionUsage(resp.GetAnnotations())
@@ -2297,12 +2381,20 @@ func (s *syncer) syncGrantsForResource(ctx context.Context, action *Action) erro
 
 	s.handleProgress(ctx, action, len(grants))
 
-	if resp.GetNextPageToken() == "" {
+	if typeScoped {
+		s.counts.SetGrantsCountOnly(resourceID.GetResourceType())
+		s.counts.AddGrantsProgress(resourceID.GetResourceType(), len(grants))
+		s.counts.LogGrantsProgress(ctx, resourceID.GetResourceType())
+	} else if resp.GetNextPageToken() == "" && !action.Spawned {
 		s.counts.AddGrantsProgress(resourceID.GetResourceType(), 1)
 		s.counts.LogGrantsProgress(ctx, resourceID.GetResourceType())
 	}
 
-	return s.nextPageOrFinishAction(ctx, action, resp.GetNextPageToken())
+	spawned, err := s.collectEnqueuedPageTokens(ctx, "sync-grants-for-resource", SyncGrantsOp, action, respAnnos)
+	if err != nil {
+		return err
+	}
+	return s.nextPageOrFinishAction(ctx, action, resp.GetNextPageToken(), spawned...)
 }
 
 func (s *syncer) SyncExternalResources(ctx context.Context, action *Action) error {

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -218,6 +218,11 @@ type syncer struct {
 	metricsHandler                        metrics.Handler
 	syncIdentity                          uotel.SyncIdentity
 	recordStats                           bool
+	// parallelActionEnqueuer admits actions spawned by an in-flight list
+	// response into the active worker pool. Access only through the helper
+	// methods in parallel_syncer.go.
+	parallelEnqueueMu      native_sync.RWMutex
+	parallelActionEnqueuer func(*Action)
 
 	// Watermark for the rate_limit_wait_wall bucket: the latest instant
 	// already counted as rate-limit-blocked wall time, plus the
@@ -666,6 +671,16 @@ func (s *syncer) handleProgress(ctx context.Context, a *Action, c int) {
 	}
 }
 
+func collectionProgressIncrement(action *Action, itemCount int, hasNextPage bool) (int, bool) {
+	if action.TypeScoped {
+		return itemCount, true
+	}
+	if !hasNextPage && !action.Spawned {
+		return 1, false
+	}
+	return 0, false
+}
+
 // maxEntitlementsPerExclusionGroup caps how many entitlements may share a
 // single exclusion_group_id. Phase 1 limit. Enforced by ingestion
 // invariant I5 over the STORED entitlement keyspace post-collection
@@ -685,7 +700,13 @@ func (s *syncer) nextPageOrFinishAction(ctx context.Context, action *Action, nex
 	}
 
 	for _, a := range childActions {
-		s.state.PushAction(ctx, a)
+		var pushed *Action
+		if st, ok := s.state.(*state); ok {
+			pushed = st.pushAction(ctx, a)
+		} else {
+			s.state.PushAction(ctx, a)
+		}
+		s.enqueueParallelAction(pushed)
 	}
 
 	if nextPageToken == "" {
@@ -1636,7 +1657,7 @@ func (s *syncer) SyncEntitlements(ctx context.Context, action *Action) error {
 				return fmt.Errorf("sync-entitlements: error listing type-scoped resource types: %w", err)
 			}
 			for _, rtID := range typeScoped {
-				actions = append(actions, Action{Op: SyncEntitlementsOp, ResourceTypeID: rtID})
+				actions = append(actions, Action{Op: SyncEntitlementsOp, ResourceTypeID: rtID, TypeScoped: true})
 			}
 		}
 
@@ -1688,7 +1709,7 @@ func (s *syncer) typeScopedEntitlementsResourceTypes(ctx context.Context) ([]str
 // syncEntitlementsForResource fetches the entitlements for a specific resource from the connector.
 // No span here: only call site is SyncEntitlements, which already owns a span.
 func (s *syncer) syncEntitlementsForResource(ctx context.Context, action *Action) error {
-	typeScoped := action.ResourceID == ""
+	typeScoped := action.TypeScoped
 	resourceID := v2.ResourceId_builder{
 		ResourceType: action.ResourceTypeID,
 		Resource:     action.ResourceID,
@@ -1735,12 +1756,12 @@ func (s *syncer) syncEntitlementsForResource(ctx context.Context, action *Action
 	}
 
 	s.handleProgress(ctx, action, len(entitlements))
-	if typeScoped {
+	progressIncrement, countOnly := collectionProgressIncrement(action, len(entitlements), resp.GetNextPageToken() != "")
+	if countOnly {
 		s.counts.SetEntitlementsCountOnly(resourceID.GetResourceType())
-		s.counts.AddEntitlementsProgress(resourceID.GetResourceType(), len(entitlements))
-		s.counts.LogEntitlementsProgress(ctx, resourceID.GetResourceType())
-	} else if resp.GetNextPageToken() == "" && !action.Spawned {
-		s.counts.AddEntitlementsProgress(resourceID.ResourceType, 1)
+	}
+	if progressIncrement > 0 || countOnly {
+		s.counts.AddEntitlementsProgress(resourceID.GetResourceType(), progressIncrement)
 		s.counts.LogEntitlementsProgress(ctx, resourceID.GetResourceType())
 	}
 
@@ -2181,7 +2202,7 @@ func (s *syncer) SyncGrants(ctx context.Context, action *Action) error {
 				return fmt.Errorf("sync-grants: error listing type-scoped resource types: %w", err)
 			}
 			for _, rtID := range typeScoped {
-				actions = append(actions, Action{Op: SyncGrantsOp, ResourceTypeID: rtID})
+				actions = append(actions, Action{Op: SyncGrantsOp, ResourceTypeID: rtID, TypeScoped: true})
 			}
 		}
 
@@ -2233,7 +2254,7 @@ func (s *syncer) typeScopedGrantsResourceTypes(ctx context.Context) ([]string, e
 // syncGrantsForResource fetches the grants for a specific resource from the connector.
 // No span here: only call site is SyncGrants, which already owns a span.
 func (s *syncer) syncGrantsForResource(ctx context.Context, action *Action) error {
-	typeScoped := action.ResourceID == ""
+	typeScoped := action.TypeScoped
 	resourceID := v2.ResourceId_builder{
 		ResourceType: action.ResourceTypeID,
 		Resource:     action.ResourceID,
@@ -2381,12 +2402,12 @@ func (s *syncer) syncGrantsForResource(ctx context.Context, action *Action) erro
 
 	s.handleProgress(ctx, action, len(grants))
 
-	if typeScoped {
+	progressIncrement, countOnly := collectionProgressIncrement(action, len(grants), resp.GetNextPageToken() != "")
+	if countOnly {
 		s.counts.SetGrantsCountOnly(resourceID.GetResourceType())
-		s.counts.AddGrantsProgress(resourceID.GetResourceType(), len(grants))
-		s.counts.LogGrantsProgress(ctx, resourceID.GetResourceType())
-	} else if resp.GetNextPageToken() == "" && !action.Spawned {
-		s.counts.AddGrantsProgress(resourceID.GetResourceType(), 1)
+	}
+	if progressIncrement > 0 || countOnly {
+		s.counts.AddGrantsProgress(resourceID.GetResourceType(), progressIncrement)
 		s.counts.LogGrantsProgress(ctx, resourceID.GetResourceType())
 	}
 

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -1771,9 +1771,10 @@ func (s *syncer) SyncEntitlements(ctx context.Context, action *Action) error {
 		}
 
 		if !action.TypeScopedPlanned {
-			typeScoped, err := s.typeScopedEntitlementsResourceTypes(ctx)
-			if err != nil {
-				return fmt.Errorf("sync-entitlements: error listing type-scoped resource types: %w", err)
+			typeScoped, typeScopedErr := s.typeScopedEntitlementsResourceTypes(ctx)
+			if typeScopedErr != nil {
+				err = fmt.Errorf("sync-entitlements: error listing type-scoped resource types: %w", typeScopedErr)
+				return err
 			}
 			for _, rtID := range typeScoped {
 				actions = append(actions, Action{Op: SyncEntitlementsOp, ResourceTypeID: rtID, TypeScoped: true})
@@ -1781,24 +1782,27 @@ func (s *syncer) SyncEntitlements(ctx context.Context, action *Action) error {
 			plannedTypeScoped = true
 		}
 
-		resp, err := s.store.ListResources(ctx, v2.ResourcesServiceListResourcesRequest_builder{
+		resp, listResourcesErr := s.store.ListResources(ctx, v2.ResourcesServiceListResourcesRequest_builder{
 			PageToken:    pageToken,
 			ActiveSyncId: s.getActiveSyncID(),
 		}.Build())
-		if err != nil {
+		if listResourcesErr != nil {
+			err = listResourcesErr
 			return err
 		}
 
 		for _, r := range resp.GetList() {
-			shouldSkipEntitlements, err := s.shouldSkipEntitlements(ctx, r)
-			if err != nil {
+			shouldSkipEntitlements, shouldSkipErr := s.shouldSkipEntitlements(ctx, r)
+			if shouldSkipErr != nil {
+				err = shouldSkipErr
 				return err
 			}
 			if shouldSkipEntitlements {
 				continue
 			}
-			typeScoped, err := s.resourceTypeHasTypeScopedEntitlements(ctx, r.GetId().GetResourceType())
-			if err != nil {
+			typeScoped, typeScopedErr := s.resourceTypeHasTypeScopedEntitlements(ctx, r.GetId().GetResourceType())
+			if typeScopedErr != nil {
+				err = typeScopedErr
 				return err
 			}
 			if typeScoped {
@@ -1807,7 +1811,8 @@ func (s *syncer) SyncEntitlements(ctx context.Context, action *Action) error {
 			actions = append(actions, Action{Op: SyncEntitlementsOp, ResourceID: r.GetId().GetResource(), ResourceTypeID: r.GetId().GetResourceType()})
 		}
 
-		if err := s.nextPageOrFinishAction(ctx, action, resp.GetNextPageToken(), actions...); err != nil {
+		if nextPageErr := s.nextPageOrFinishAction(ctx, action, resp.GetNextPageToken(), actions...); nextPageErr != nil {
+			err = nextPageErr
 			return err
 		}
 		if plannedTypeScoped {
@@ -2326,9 +2331,10 @@ func (s *syncer) SyncGrants(ctx context.Context, action *Action) error {
 		}
 
 		if !action.TypeScopedPlanned {
-			typeScoped, err := s.typeScopedGrantsResourceTypes(ctx)
-			if err != nil {
-				return fmt.Errorf("sync-grants: error listing type-scoped resource types: %w", err)
+			typeScoped, typeScopedErr := s.typeScopedGrantsResourceTypes(ctx)
+			if typeScopedErr != nil {
+				err = fmt.Errorf("sync-grants: error listing type-scoped resource types: %w", typeScopedErr)
+				return err
 			}
 			for _, rtID := range typeScoped {
 				actions = append(actions, Action{Op: SyncGrantsOp, ResourceTypeID: rtID, TypeScoped: true})
@@ -2336,25 +2342,28 @@ func (s *syncer) SyncGrants(ctx context.Context, action *Action) error {
 			plannedTypeScoped = true
 		}
 
-		resp, err := s.store.ListResources(ctx, v2.ResourcesServiceListResourcesRequest_builder{
+		resp, listResourcesErr := s.store.ListResources(ctx, v2.ResourcesServiceListResourcesRequest_builder{
 			PageToken:    action.PageToken,
 			ActiveSyncId: s.getActiveSyncID(),
 		}.Build())
-		if err != nil {
-			return fmt.Errorf("sync-grants: error listing resources: %w", err)
+		if listResourcesErr != nil {
+			err = fmt.Errorf("sync-grants: error listing resources: %w", listResourcesErr)
+			return err
 		}
 
 		for _, r := range resp.GetList() {
-			shouldSkip, err := s.shouldSkipGrants(ctx, r)
-			if err != nil {
+			shouldSkip, shouldSkipErr := s.shouldSkipGrants(ctx, r)
+			if shouldSkipErr != nil {
+				err = shouldSkipErr
 				return err
 			}
 
 			if shouldSkip {
 				continue
 			}
-			typeScoped, err := s.resourceTypeHasTypeScopedGrants(ctx, r.GetId().GetResourceType())
-			if err != nil {
+			typeScoped, typeScopedErr := s.resourceTypeHasTypeScopedGrants(ctx, r.GetId().GetResourceType())
+			if typeScopedErr != nil {
+				err = typeScopedErr
 				return err
 			}
 			if typeScoped {
@@ -2363,7 +2372,8 @@ func (s *syncer) SyncGrants(ctx context.Context, action *Action) error {
 			actions = append(actions, Action{Op: SyncGrantsOp, ResourceID: r.GetId().GetResource(), ResourceTypeID: r.GetId().GetResourceType()})
 		}
 
-		if err := s.nextPageOrFinishAction(ctx, action, resp.GetNextPageToken(), actions...); err != nil {
+		if nextPageErr := s.nextPageOrFinishAction(ctx, action, resp.GetNextPageToken(), actions...); nextPageErr != nil {
+			err = nextPageErr
 			return err
 		}
 		if plannedTypeScoped {

--- a/pkg/sync/type_scoped.go
+++ b/pkg/sync/type_scoped.go
@@ -1,0 +1,130 @@
+package sync //nolint:revive,nolintlint // we can't change the package name for backwards compatibility
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	reader_v2 "github.com/conductorone/baton-sdk/pb/c1/reader/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+)
+
+const (
+	maxEnqueuePageTokensPerResponse = 1024
+	maxEnqueuedPageTokenBytes       = 1 << 20
+	maxEnqueuedPageTokenTotalBytes  = 16 << 20
+)
+
+// resourceTypeCarries reports (cached per sync in cache) whether the
+// resource type's stored annotations contain marker.
+func (s *syncer) resourceTypeCarries(ctx context.Context, resourceTypeID string, marker proto.Message, cache *syncMap[string, bool]) (bool, error) {
+	if v, ok := cache.Load(resourceTypeID); ok {
+		return v, nil
+	}
+	rt, err := s.store.GetResourceType(ctx, reader_v2.ResourceTypesReaderServiceGetResourceTypeRequest_builder{
+		ResourceTypeId: resourceTypeID,
+	}.Build())
+	if err != nil {
+		return false, err
+	}
+	rtAnnos := annotations.Annotations(rt.GetResourceType().GetAnnotations())
+	carries := rtAnnos.Contains(marker)
+	cache.Store(resourceTypeID, carries)
+	return carries, nil
+}
+
+// resourceTypesCarrying lists every synced resource type whose stored
+// annotations contain marker, warming cache for every type seen.
+func (s *syncer) resourceTypesCarrying(ctx context.Context, marker proto.Message, cache *syncMap[string, bool]) ([]string, error) {
+	var out []string
+	pageToken := ""
+	for {
+		resp, err := s.store.ListResourceTypes(ctx, v2.ResourceTypesServiceListResourceTypesRequest_builder{
+			PageToken: pageToken,
+		}.Build())
+		if err != nil {
+			return nil, err
+		}
+		for _, rt := range resp.GetList() {
+			rtAnnos := annotations.Annotations(rt.GetAnnotations())
+			carries := rtAnnos.Contains(marker)
+			cache.Store(rt.GetId(), carries)
+			if carries {
+				out = append(out, rt.GetId())
+			}
+		}
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			return out, nil
+		}
+	}
+}
+
+// typeScopedRequestStub builds the wire shape of a type-scoped list request.
+func typeScopedRequestStub(resourceTypeID string, marker proto.Message) (*v2.Resource, annotations.Annotations) {
+	stub := v2.Resource_builder{
+		Id: v2.ResourceId_builder{
+			ResourceType: resourceTypeID,
+			Resource:     resourceTypeID,
+		}.Build(),
+	}.Build()
+	var reqAnnos annotations.Annotations
+	reqAnnos.Update(marker)
+	return stub, reqAnnos
+}
+
+// collectEnqueuedPageTokens turns connector-supplied sibling cursors into
+// ordinary checkpointed actions. Empty and oversized tokens fail loudly.
+func (s *syncer) collectEnqueuedPageTokens(ctx context.Context, phase string, op ActionOp, action *Action, respAnnos annotations.Annotations) ([]Action, error) {
+	spawn := &v2.EnqueuePageTokens{}
+	hasSpawn, err := respAnnos.Pick(spawn)
+	if err != nil {
+		return nil, fmt.Errorf("%s: error parsing enqueue-page-tokens annotation: %w", phase, err)
+	}
+	if !hasSpawn {
+		return nil, nil
+	}
+	if len(spawn.GetPageTokens()) > maxEnqueuePageTokensPerResponse {
+		return nil, fmt.Errorf(
+			"%s: EnqueuePageTokens carried %d page tokens (max %d per response); chain additional spawns across pages instead",
+			phase, len(spawn.GetPageTokens()), maxEnqueuePageTokensPerResponse)
+	}
+
+	spawned := make([]Action, 0, len(spawn.GetPageTokens()))
+	totalTokenBytes := 0
+	for _, tok := range spawn.GetPageTokens() {
+		if tok == "" {
+			return nil, fmt.Errorf("%s: EnqueuePageTokens carried an empty page token", phase)
+		}
+		if len(tok) > maxEnqueuedPageTokenBytes {
+			return nil, fmt.Errorf(
+				"%s: EnqueuePageTokens page token is %d bytes (max %d)",
+				phase, len(tok), maxEnqueuedPageTokenBytes)
+		}
+		totalTokenBytes += len(tok)
+		if totalTokenBytes > maxEnqueuedPageTokenTotalBytes {
+			return nil, fmt.Errorf(
+				"%s: EnqueuePageTokens carries more than %d total page-token bytes; shrink the tokens or chain additional spawns across pages",
+				phase, maxEnqueuedPageTokenTotalBytes)
+		}
+		spawned = append(spawned, Action{
+			Op:             op,
+			ResourceTypeID: action.ResourceTypeID,
+			ResourceID:     action.ResourceID,
+			PageToken:      tok,
+			Spawned:        true,
+		})
+	}
+
+	ctxzap.Extract(ctx).Debug(phase+": enqueued sibling page-token cursors",
+		zap.String("resource_type_id", action.ResourceTypeID),
+		zap.String("resource_id", action.ResourceID),
+		zap.Int("cursors", len(spawned)),
+		zap.Int64("estimated_total", spawn.GetEstimatedTotal()))
+	return spawned, nil
+}

--- a/pkg/sync/type_scoped.go
+++ b/pkg/sync/type_scoped.go
@@ -82,6 +82,15 @@ func typeScopedRequestStub(resourceTypeID string, marker proto.Message) (*v2.Res
 // ordinary checkpointed actions. Empty and oversized tokens fail loudly.
 func (s *syncer) collectEnqueuedPageTokens(ctx context.Context, phase string, op ActionOp, action *Action, respAnnos annotations.Annotations) ([]Action, error) {
 	spawn := &v2.EnqueuePageTokens{}
+	spawnAnnotations := 0
+	for _, annotation := range respAnnos {
+		if annotation.MessageIs(spawn) {
+			spawnAnnotations++
+		}
+	}
+	if spawnAnnotations > 1 {
+		return nil, fmt.Errorf("%s: response carried multiple EnqueuePageTokens annotations", phase)
+	}
 	hasSpawn, err := respAnnos.Pick(spawn)
 	if err != nil {
 		return nil, fmt.Errorf("%s: error parsing enqueue-page-tokens annotation: %w", phase, err)
@@ -118,6 +127,7 @@ func (s *syncer) collectEnqueuedPageTokens(ctx context.Context, phase string, op
 			ResourceID:     action.ResourceID,
 			PageToken:      tok,
 			Spawned:        true,
+			TypeScoped:     action.TypeScoped,
 		})
 	}
 

--- a/pkg/sync/type_scoped_test.go
+++ b/pkg/sync/type_scoped_test.go
@@ -98,6 +98,39 @@ type blockingRootListResourcesStore struct {
 	blocked atomic.Bool
 }
 
+type countingTargetConnector struct {
+	*mockConnector
+	getResourceCalls atomic.Int64
+}
+
+func (c *countingTargetConnector) GetResource(
+	ctx context.Context,
+	in *v2.ResourceGetterServiceGetResourceRequest,
+	opts ...grpc.CallOption,
+) (*v2.ResourceGetterServiceGetResourceResponse, error) {
+	c.getResourceCalls.Add(1)
+	return c.mockConnector.GetResource(ctx, in, opts...)
+}
+
+type blockingValidateConnector struct {
+	*mockConnector
+	blocked atomic.Bool
+}
+
+func (c *blockingValidateConnector) Validate(
+	ctx context.Context,
+	_ *v2.ConnectorServiceValidateRequest,
+	_ ...grpc.CallOption,
+) (*v2.ConnectorServiceValidateResponse, error) {
+	c.blocked.Store(true)
+	select {
+	case <-ctx.Done():
+		return nil, context.Cause(ctx)
+	case <-time.After(time.Second):
+		return nil, errors.New("test safety stop: SkipSync ignored run duration")
+	}
+}
+
 func (s *blockingRootListResourcesStore) ListResources(
 	ctx context.Context,
 	_ *v2.ResourcesServiceListResourcesRequest,
@@ -517,11 +550,42 @@ func TestTargetedResourceSchedulingFailureLeavesParentAndNoFollowups(t *testing.
 			require.Equal(t, "group-1", action.ResourceID)
 		case SyncEntitlementsOp, SyncGrantsOp, SyncResourcesOp:
 			followupActions++
+		default:
 		}
 	}
 	require.Equal(t, 1, targetedActions)
 	require.Zero(t, followupActions)
 	require.NoError(t, s.Close(ctx))
+}
+
+func TestDuplicateTargetedResourcesAreScheduledOnce(t *testing.T) {
+	ctx := t.Context()
+	tmpDir := t.TempDir()
+	resourceType := v2.ResourceType_builder{
+		Id:          "group",
+		DisplayName: "Group",
+	}.Build()
+	resource := v2.Resource_builder{
+		Id: v2.ResourceId_builder{
+			ResourceType: "group",
+			Resource:     "group-1",
+		}.Build(),
+		DisplayName: "Group 1",
+	}.Build()
+	connector := &countingTargetConnector{mockConnector: newMockConnector()}
+	connector.rtDB = append(connector.rtDB, resourceType)
+	connector.resourceDB["group"] = append(connector.resourceDB["group"], resource)
+
+	s, err := NewSyncer(ctx, connector,
+		WithC1ZPath(filepath.Join(tmpDir, "duplicate-targets.c1z")),
+		WithTmpDir(tmpDir),
+		WithTargetedSyncResources([]*v2.Resource{resource, resource}),
+		WithWorkerCount(2),
+	)
+	require.NoError(t, err)
+	require.NoError(t, s.Sync(ctx))
+	require.NoError(t, s.Close(ctx))
+	require.EqualValues(t, 1, connector.getResourceCalls.Load())
 }
 
 func TestTypeScopedColdCollectionEndToEnd(t *testing.T) {
@@ -743,5 +807,25 @@ func TestRunDurationCancelsRootPlannerIO(t *testing.T) {
 	require.ErrorIs(t, err, ErrSyncNotComplete)
 	require.True(t, store.blocked.Load())
 	require.Less(t, time.Since(started), time.Second)
+	require.NoError(t, s.Close(ctx))
+}
+
+func TestSkipSyncHonorsRunDuration(t *testing.T) {
+	ctx := t.Context()
+	tmpDir := t.TempDir()
+	connector := &blockingValidateConnector{mockConnector: newMockConnector()}
+	s, err := NewSyncer(ctx, connector,
+		WithC1ZPath(filepath.Join(tmpDir, "skip-run-duration.c1z")),
+		WithTmpDir(tmpDir),
+		WithSkipFullSync(),
+		WithRunDuration(50*time.Millisecond),
+	)
+	require.NoError(t, err)
+
+	started := time.Now()
+	err = s.Sync(ctx)
+	require.ErrorIs(t, err, ErrSyncNotComplete)
+	require.True(t, connector.blocked.Load())
+	require.Less(t, time.Since(started), 500*time.Millisecond)
 	require.NoError(t, s.Close(ctx))
 }

--- a/pkg/sync/type_scoped_test.go
+++ b/pkg/sync/type_scoped_test.go
@@ -2,6 +2,7 @@ package sync //nolint:revive,nolintlint // backwards-compatible package name
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -86,6 +87,54 @@ type resumableTypeScopedConnector struct {
 	*coldTypeScopedConnector
 	failGrantToken string
 	failedOnce     bool
+}
+
+type blockingTypeScopedGrantConnector struct {
+	*mockConnector
+}
+
+type blockingRootListResourcesStore struct {
+	c1zstore.Store
+	blocked atomic.Bool
+}
+
+func (s *blockingRootListResourcesStore) ListResources(
+	ctx context.Context,
+	_ *v2.ResourcesServiceListResourcesRequest,
+) (*v2.ResourcesServiceListResourcesResponse, error) {
+	if s.blocked.CompareAndSwap(false, true) {
+		select {
+		case <-ctx.Done():
+			return nil, context.Cause(ctx)
+		case <-time.After(2 * time.Second):
+			return nil, errors.New("test safety stop: root planner ignored run duration")
+		}
+	}
+	return v2.ResourcesServiceListResourcesResponse_builder{}.Build(), nil
+}
+
+func (c *blockingTypeScopedGrantConnector) ListGrants(
+	ctx context.Context,
+	in *v2.GrantsServiceListGrantsRequest,
+	_ ...grpc.CallOption,
+) (*v2.GrantsServiceListGrantsResponse, error) {
+	reqAnnos := annotations.Annotations(in.GetAnnotations())
+	if !reqAnnos.Contains(&v2.TypeScopedGrants{}) {
+		return v2.GrantsServiceListGrantsResponse_builder{}.Build(), nil
+	}
+	if in.GetPageToken() == "" {
+		return v2.GrantsServiceListGrantsResponse_builder{
+			Annotations: annotations.New(v2.EnqueuePageTokens_builder{
+				PageTokens: []string{"slow"},
+			}.Build()),
+		}.Build(), nil
+	}
+	select {
+	case <-ctx.Done():
+		return nil, context.Cause(ctx)
+	case <-time.After(time.Second):
+		return nil, errors.New("test safety stop: active batch ignored run duration")
+	}
 }
 
 func (c *resumableTypeScopedConnector) ListGrants(
@@ -428,6 +477,53 @@ func TestTargetedSyncSkipsPerResourceCallsForTypeScopedType(t *testing.T) {
 	require.Zero(t, connector.grantCalls)
 }
 
+func TestTargetedResourceSchedulingFailureLeavesParentAndNoFollowups(t *testing.T) {
+	ctx := t.Context()
+	tmpDir := t.TempDir()
+	resourceType := v2.ResourceType_builder{
+		Id:          "group",
+		DisplayName: "Group",
+	}.Build()
+	malformedChildType, err := anypb.New(&v2.ChildResourceType{})
+	require.NoError(t, err)
+	malformedChildType.Value = []byte{0xff}
+	resource := v2.Resource_builder{
+		Id: v2.ResourceId_builder{
+			ResourceType: "group",
+			Resource:     "group-1",
+		}.Build(),
+		DisplayName: "Group 1",
+		Annotations: []*anypb.Any{malformedChildType},
+	}.Build()
+	connector := newMockConnector()
+	connector.rtDB = append(connector.rtDB, resourceType)
+	connector.resourceDB["group"] = append(connector.resourceDB["group"], resource)
+
+	s, err := NewSyncer(ctx, connector,
+		WithC1ZPath(filepath.Join(tmpDir, "targeted-transition.c1z")),
+		WithTmpDir(tmpDir),
+		WithTargetedSyncResources([]*v2.Resource{resource}),
+		WithWorkerCount(2),
+	)
+	require.NoError(t, err)
+	require.Error(t, s.Sync(ctx))
+
+	internalState := s.(*syncer).state.(*state)
+	var targetedActions, followupActions int
+	for _, action := range internalState.actions {
+		switch action.Op {
+		case SyncTargetedResourceOp:
+			targetedActions++
+			require.Equal(t, "group-1", action.ResourceID)
+		case SyncEntitlementsOp, SyncGrantsOp, SyncResourcesOp:
+			followupActions++
+		}
+	}
+	require.Equal(t, 1, targetedActions)
+	require.Zero(t, followupActions)
+	require.NoError(t, s.Close(ctx))
+}
+
 func TestTypeScopedColdCollectionEndToEnd(t *testing.T) {
 	for _, workers := range []int{1, 4} {
 		t.Run(fmt.Sprintf("workers=%d", workers), func(t *testing.T) {
@@ -584,4 +680,68 @@ func TestTypeScopedFanoutResumesAfterStoredCursorFailure(t *testing.T) {
 	require.Len(t, grantResp.GetList(), 2)
 	require.NoError(t, s.Close(ctx))
 	require.True(t, connector.failedOnce)
+}
+
+func TestRunDurationCancelsActiveSpawnedCursorBatch(t *testing.T) {
+	ctx := t.Context()
+	tmpDir := t.TempDir()
+	resourceType := v2.ResourceType_builder{
+		Id:          "group",
+		DisplayName: "Group",
+		Annotations: annotations.New(&v2.TypeScopedGrants{}),
+	}.Build()
+	connector := &blockingTypeScopedGrantConnector{mockConnector: newMockConnector()}
+	connector.rtDB = append(connector.rtDB, resourceType)
+
+	s, err := NewSyncer(ctx, connector,
+		WithC1ZPath(filepath.Join(tmpDir, "run-duration.c1z")),
+		WithTmpDir(tmpDir),
+		WithWorkerCount(2),
+		WithRunDuration(50*time.Millisecond),
+	)
+	require.NoError(t, err)
+	started := time.Now()
+	err = s.Sync(ctx)
+	require.ErrorIs(t, err, ErrSyncNotComplete)
+	require.Less(t, time.Since(started), 500*time.Millisecond)
+	require.NoError(t, s.Close(ctx))
+}
+
+func TestRunDurationCancelsRootPlannerIO(t *testing.T) {
+	ctx := t.Context()
+	tmpDir := t.TempDir()
+	resourceType := v2.ResourceType_builder{
+		Id:          "group",
+		DisplayName: "Group",
+	}.Build()
+	resource := v2.Resource_builder{
+		Id: v2.ResourceId_builder{
+			ResourceType: "group",
+			Resource:     "group-1",
+		}.Build(),
+		DisplayName: "Group 1",
+	}.Build()
+	connector := newMockConnector()
+	connector.rtDB = append(connector.rtDB, resourceType)
+	connector.resourceDB["group"] = append(connector.resourceDB["group"], resource)
+
+	baseStore, err := dotc1z.NewStore(ctx, filepath.Join(tmpDir, "root-run-duration.c1z"),
+		dotc1z.WithTmpDir(tmpDir),
+	)
+	require.NoError(t, err)
+	store := &blockingRootListResourcesStore{Store: baseStore}
+	s, err := NewSyncer(ctx, connector,
+		WithConnectorStore(store),
+		WithTmpDir(tmpDir),
+		WithWorkerCount(2),
+		WithRunDuration(300*time.Millisecond),
+	)
+	require.NoError(t, err)
+
+	started := time.Now()
+	err = s.Sync(ctx)
+	require.ErrorIs(t, err, ErrSyncNotComplete)
+	require.True(t, store.blocked.Load())
+	require.Less(t, time.Since(started), time.Second)
+	require.NoError(t, s.Close(ctx))
 }

--- a/pkg/sync/type_scoped_test.go
+++ b/pkg/sync/type_scoped_test.go
@@ -126,7 +126,7 @@ func (c *blockingValidateConnector) Validate(
 	select {
 	case <-ctx.Done():
 		return nil, context.Cause(ctx)
-	case <-time.After(time.Second):
+	case <-time.After(5 * time.Second):
 		return nil, errors.New("test safety stop: SkipSync ignored run duration")
 	}
 }
@@ -818,7 +818,10 @@ func TestSkipSyncHonorsRunDuration(t *testing.T) {
 		WithC1ZPath(filepath.Join(tmpDir, "skip-run-duration.c1z")),
 		WithTmpDir(tmpDir),
 		WithSkipFullSync(),
-		WithRunDuration(50*time.Millisecond),
+		// Generous enough that store setup finishes before expiry even
+		// under -race slowdown; the blocked Validate is what must be
+		// cancelled by the run duration.
+		WithRunDuration(500*time.Millisecond),
 	)
 	require.NoError(t, err)
 
@@ -826,6 +829,6 @@ func TestSkipSyncHonorsRunDuration(t *testing.T) {
 	err = s.Sync(ctx)
 	require.ErrorIs(t, err, ErrSyncNotComplete)
 	require.True(t, connector.blocked.Load())
-	require.Less(t, time.Since(started), 500*time.Millisecond)
+	require.Less(t, time.Since(started), 3*time.Second)
 	require.NoError(t, s.Close(ctx))
 }

--- a/pkg/sync/type_scoped_test.go
+++ b/pkg/sync/type_scoped_test.go
@@ -91,11 +91,20 @@ type resumableTypeScopedConnector struct {
 
 type blockingTypeScopedGrantConnector struct {
 	*mockConnector
+	reached   atomic.Bool
+	cancelled atomic.Bool
 }
 
+// blockingRootListResourcesStore blocks the FIRST root ListResources call
+// until its context dies. Deadline-presence on the context is NOT a valid
+// oracle here: parallelSync deliberately derives workerCtx from the
+// parent (no deadline) and propagates expiry manually via
+// context.AfterFunc(runCtx), preserving the DeadlineExceeded cause. The
+// proof that expiry can interrupt root planner IO is cancellation itself.
 type blockingRootListResourcesStore struct {
 	c1zstore.Store
-	blocked atomic.Bool
+	reached   atomic.Bool
+	cancelled atomic.Bool
 }
 
 type countingTargetConnector struct {
@@ -114,7 +123,8 @@ func (c *countingTargetConnector) GetResource(
 
 type blockingValidateConnector struct {
 	*mockConnector
-	blocked atomic.Bool
+	blocked   atomic.Bool
+	cancelled atomic.Bool
 }
 
 func (c *blockingValidateConnector) Validate(
@@ -125,25 +135,33 @@ func (c *blockingValidateConnector) Validate(
 	c.blocked.Store(true)
 	select {
 	case <-ctx.Done():
+		c.cancelled.Store(true)
 		return nil, context.Cause(ctx)
-	case <-time.After(5 * time.Second):
+	case <-time.After(30 * time.Second):
+		// Only guards an outright hang if cancellation is broken; must
+		// exceed the test's run duration by a wide margin so slow CI
+		// runners never race it.
 		return nil, errors.New("test safety stop: SkipSync ignored run duration")
 	}
 }
 
 func (s *blockingRootListResourcesStore) ListResources(
 	ctx context.Context,
-	_ *v2.ResourcesServiceListResourcesRequest,
+	req *v2.ResourcesServiceListResourcesRequest,
 ) (*v2.ResourcesServiceListResourcesResponse, error) {
-	if s.blocked.CompareAndSwap(false, true) {
+	if s.reached.CompareAndSwap(false, true) {
 		select {
 		case <-ctx.Done():
+			s.cancelled.Store(true)
 			return nil, context.Cause(ctx)
-		case <-time.After(2 * time.Second):
+		case <-time.After(30 * time.Second):
+			// Only guards an outright hang if cancellation is broken;
+			// must exceed the test's run duration by a wide margin so
+			// slow CI runners never race it.
 			return nil, errors.New("test safety stop: root planner ignored run duration")
 		}
 	}
-	return v2.ResourcesServiceListResourcesResponse_builder{}.Build(), nil
+	return s.Store.ListResources(ctx, req)
 }
 
 func (c *blockingTypeScopedGrantConnector) ListGrants(
@@ -162,10 +180,15 @@ func (c *blockingTypeScopedGrantConnector) ListGrants(
 			}.Build()),
 		}.Build(), nil
 	}
+	c.reached.Store(true)
 	select {
 	case <-ctx.Done():
+		c.cancelled.Store(true)
 		return nil, context.Cause(ctx)
-	case <-time.After(time.Second):
+	case <-time.After(30 * time.Second):
+		// Only guards an outright hang if cancellation is broken; must
+		// exceed the test's run duration by a wide margin so slow CI
+		// runners never race it.
 		return nil, errors.New("test safety stop: active batch ignored run duration")
 	}
 }
@@ -747,6 +770,15 @@ func TestTypeScopedFanoutResumesAfterStoredCursorFailure(t *testing.T) {
 }
 
 func TestRunDurationCancelsActiveSpawnedCursorBatch(t *testing.T) {
+	// The REAL run-duration timer must fire while a spawned cursor's
+	// connector call is in flight, cancel that call via its context (not
+	// wait it out), and surface ErrSyncNotComplete. The duration is
+	// deliberately generous: it must not expire before setup reaches the
+	// grants batch on a slow CI runner, or the test never exercises the
+	// in-flight call at all — the previous 50ms raced setup and was
+	// vacuous whenever it lost (and its 500ms wall bound failed on
+	// Windows FS latency). reached/cancelled make the claim mechanical;
+	// the wall bound only guards outright hangs.
 	ctx := t.Context()
 	tmpDir := t.TempDir()
 	resourceType := v2.ResourceType_builder{
@@ -761,17 +793,31 @@ func TestRunDurationCancelsActiveSpawnedCursorBatch(t *testing.T) {
 		WithC1ZPath(filepath.Join(tmpDir, "run-duration.c1z")),
 		WithTmpDir(tmpDir),
 		WithWorkerCount(2),
-		WithRunDuration(50*time.Millisecond),
+		WithRunDuration(8*time.Second),
 	)
 	require.NoError(t, err)
 	started := time.Now()
 	err = s.Sync(ctx)
 	require.ErrorIs(t, err, ErrSyncNotComplete)
-	require.Less(t, time.Since(started), 500*time.Millisecond)
+	require.True(t, connector.reached.Load(),
+		"run duration expired before the spawned-cursor batch was reached; the duration must comfortably exceed setup time")
+	require.True(t, connector.cancelled.Load(),
+		"the in-flight spawned cursor call was not cancelled by the run-duration deadline")
+	require.Less(t, time.Since(started), time.Minute)
 	require.NoError(t, s.Close(ctx))
 }
 
 func TestRunDurationCancelsRootPlannerIO(t *testing.T) {
+	// Root planning steps (entitlements/grants planning, not the
+	// parallel batch workers) are a separate call-site family: both
+	// receive workerCtx today, but a regression could rewire one family
+	// without the other. The real run-duration timer must expire while
+	// the first root store ListResources is blocked and cancel it via
+	// context.AfterFunc propagation (workerCtx carries no deadline by
+	// design, so cancellation is the only valid oracle). The duration is
+	// deliberately generous: it must not expire before setup reaches the
+	// root call on a slow CI runner — the previous 300ms raced setup and
+	// failed on Windows, where setup was slower than the whole deadline.
 	ctx := t.Context()
 	tmpDir := t.TempDir()
 	resourceType := v2.ResourceType_builder{
@@ -798,19 +844,28 @@ func TestRunDurationCancelsRootPlannerIO(t *testing.T) {
 		WithConnectorStore(store),
 		WithTmpDir(tmpDir),
 		WithWorkerCount(2),
-		WithRunDuration(300*time.Millisecond),
+		WithRunDuration(8*time.Second),
 	)
 	require.NoError(t, err)
 
 	started := time.Now()
 	err = s.Sync(ctx)
 	require.ErrorIs(t, err, ErrSyncNotComplete)
-	require.True(t, store.blocked.Load())
-	require.Less(t, time.Since(started), time.Second)
+	require.True(t, store.reached.Load(),
+		"run duration expired before root planner IO was reached; the duration must comfortably exceed setup time")
+	require.True(t, store.cancelled.Load(),
+		"the blocked root planner IO was not cancelled by the run-duration expiry")
+	require.Less(t, time.Since(started), time.Minute)
 	require.NoError(t, s.Close(ctx))
 }
 
 func TestSkipSyncHonorsRunDuration(t *testing.T) {
+	// Same shape as the spawned-cursor test above, for the SkipFullSync
+	// path: the real timer must expire while Validate is blocked and
+	// cancel it via context. The duration must comfortably exceed store
+	// setup on slow CI runners or the deadline fires before Validate is
+	// reached and the test asserts nothing; the wall bound only guards
+	// outright hangs.
 	ctx := t.Context()
 	tmpDir := t.TempDir()
 	connector := &blockingValidateConnector{mockConnector: newMockConnector()}
@@ -818,17 +873,17 @@ func TestSkipSyncHonorsRunDuration(t *testing.T) {
 		WithC1ZPath(filepath.Join(tmpDir, "skip-run-duration.c1z")),
 		WithTmpDir(tmpDir),
 		WithSkipFullSync(),
-		// Generous enough that store setup finishes before expiry even
-		// under -race slowdown; the blocked Validate is what must be
-		// cancelled by the run duration.
-		WithRunDuration(500*time.Millisecond),
+		WithRunDuration(5*time.Second),
 	)
 	require.NoError(t, err)
 
 	started := time.Now()
 	err = s.Sync(ctx)
 	require.ErrorIs(t, err, ErrSyncNotComplete)
-	require.True(t, connector.blocked.Load())
-	require.Less(t, time.Since(started), 3*time.Second)
+	require.True(t, connector.blocked.Load(),
+		"run duration expired before Validate was reached; the duration must comfortably exceed setup time")
+	require.True(t, connector.cancelled.Load(),
+		"the blocked Validate call was not cancelled by the run-duration deadline")
+	require.Less(t, time.Since(started), time.Minute)
 	require.NoError(t, s.Close(ctx))
 }

--- a/pkg/sync/type_scoped_test.go
+++ b/pkg/sync/type_scoped_test.go
@@ -1,0 +1,314 @@
+package sync //nolint:revive,nolintlint // backwards-compatible package name
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
+	et "github.com/conductorone/baton-sdk/pkg/types/entitlement"
+	gt "github.com/conductorone/baton-sdk/pkg/types/grant"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+)
+
+type targetedTypeScopedConnector struct {
+	*mockConnector
+	entitlementCalls int
+	grantCalls       int
+}
+
+type coldTypeScopedConnector struct {
+	*mockConnector
+	entitlementsByToken         map[string]*v2.Entitlement
+	grantsByToken               map[string]*v2.Grant
+	entitlementPlannerCalls     int
+	grantPlannerCalls           int
+	perResourceEntitlementCalls int
+	perResourceGrantCalls       int
+}
+
+func (c *coldTypeScopedConnector) ListEntitlements(
+	_ context.Context,
+	in *v2.EntitlementsServiceListEntitlementsRequest,
+	_ ...grpc.CallOption,
+) (*v2.EntitlementsServiceListEntitlementsResponse, error) {
+	reqAnnos := annotations.Annotations(in.GetAnnotations())
+	if !reqAnnos.Contains(&v2.TypeScopedEntitlements{}) {
+		c.perResourceEntitlementCalls++
+		return v2.EntitlementsServiceListEntitlementsResponse_builder{}.Build(), nil
+	}
+	if in.GetPageToken() == "" {
+		c.entitlementPlannerCalls++
+		return v2.EntitlementsServiceListEntitlementsResponse_builder{
+			Annotations: annotations.New(v2.EnqueuePageTokens_builder{
+				PageTokens: []string{"ent-1", "ent-2"},
+			}.Build()),
+		}.Build(), nil
+	}
+	return v2.EntitlementsServiceListEntitlementsResponse_builder{
+		List: []*v2.Entitlement{c.entitlementsByToken[in.GetPageToken()]},
+	}.Build(), nil
+}
+
+func (c *coldTypeScopedConnector) ListGrants(_ context.Context, in *v2.GrantsServiceListGrantsRequest, _ ...grpc.CallOption) (*v2.GrantsServiceListGrantsResponse, error) {
+	reqAnnos := annotations.Annotations(in.GetAnnotations())
+	if !reqAnnos.Contains(&v2.TypeScopedGrants{}) {
+		c.perResourceGrantCalls++
+		return v2.GrantsServiceListGrantsResponse_builder{}.Build(), nil
+	}
+	if in.GetPageToken() == "" {
+		c.grantPlannerCalls++
+		return v2.GrantsServiceListGrantsResponse_builder{
+			Annotations: annotations.New(v2.EnqueuePageTokens_builder{
+				PageTokens: []string{"grant-1", "grant-2"},
+			}.Build()),
+		}.Build(), nil
+	}
+	return v2.GrantsServiceListGrantsResponse_builder{
+		List: []*v2.Grant{c.grantsByToken[in.GetPageToken()]},
+	}.Build(), nil
+}
+
+func (c *targetedTypeScopedConnector) ListEntitlements(
+	ctx context.Context,
+	in *v2.EntitlementsServiceListEntitlementsRequest,
+	opts ...grpc.CallOption,
+) (*v2.EntitlementsServiceListEntitlementsResponse, error) {
+	c.entitlementCalls++
+	return c.mockConnector.ListEntitlements(ctx, in, opts...)
+}
+
+func (c *targetedTypeScopedConnector) ListGrants(ctx context.Context, in *v2.GrantsServiceListGrantsRequest, opts ...grpc.CallOption) (*v2.GrantsServiceListGrantsResponse, error) {
+	c.grantCalls++
+	return c.mockConnector.ListGrants(ctx, in, opts...)
+}
+
+func TestCollectEnqueuedPageTokens(t *testing.T) {
+	s := &syncer{}
+	origin := &Action{
+		Op:             SyncGrantsOp,
+		ResourceTypeID: "group",
+		ResourceID:     "group-1",
+	}
+	spawned, err := s.collectEnqueuedPageTokens(
+		context.Background(),
+		"sync-grants-for-resource",
+		SyncGrantsOp,
+		origin,
+		annotations.New(v2.EnqueuePageTokens_builder{
+			PageTokens: []string{"page-2", "page-3"},
+		}.Build()),
+	)
+	require.NoError(t, err)
+	require.Equal(t, []Action{
+		{Op: SyncGrantsOp, ResourceTypeID: "group", ResourceID: "group-1", PageToken: "page-2", Spawned: true},
+		{Op: SyncGrantsOp, ResourceTypeID: "group", ResourceID: "group-1", PageToken: "page-3", Spawned: true},
+	}, spawned)
+}
+
+func TestCollectEnqueuedPageTokensRejectsInvalidFanout(t *testing.T) {
+	s := &syncer{}
+	action := &Action{ResourceTypeID: "group"}
+
+	_, err := s.collectEnqueuedPageTokens(context.Background(), "sync-grants", SyncGrantsOp, action,
+		annotations.New(v2.EnqueuePageTokens_builder{PageTokens: []string{""}}.Build()))
+	require.ErrorContains(t, err, "empty page token")
+
+	_, err = s.collectEnqueuedPageTokens(context.Background(), "sync-grants", SyncGrantsOp, action,
+		annotations.New(v2.EnqueuePageTokens_builder{PageTokens: []string{strings.Repeat("x", maxEnqueuedPageTokenBytes+1)}}.Build()))
+	require.ErrorContains(t, err, "page token is")
+
+	tooMany := make([]string, maxEnqueuePageTokensPerResponse+1)
+	for i := range tooMany {
+		tooMany[i] = "token"
+	}
+	_, err = s.collectEnqueuedPageTokens(context.Background(), "sync-grants", SyncGrantsOp, action,
+		annotations.New(v2.EnqueuePageTokens_builder{PageTokens: tooMany}.Build()))
+	require.ErrorContains(t, err, "max 1024")
+
+	tooLargeInAggregate := make([]string, maxEnqueuedPageTokenTotalBytes/maxEnqueuedPageTokenBytes+1)
+	for i := range tooLargeInAggregate {
+		tooLargeInAggregate[i] = strings.Repeat("x", maxEnqueuedPageTokenBytes)
+	}
+	_, err = s.collectEnqueuedPageTokens(context.Background(), "sync-grants", SyncGrantsOp, action,
+		annotations.New(v2.EnqueuePageTokens_builder{PageTokens: tooLargeInAggregate}.Build()))
+	require.ErrorContains(t, err, "total page-token bytes")
+
+	malformed, err := anypb.New(&v2.EnqueuePageTokens{})
+	require.NoError(t, err)
+	malformed.Value = []byte{0xff}
+	_, err = s.collectEnqueuedPageTokens(context.Background(), "sync-grants", SyncGrantsOp, action,
+		annotations.Annotations{malformed})
+	require.ErrorContains(t, err, "error parsing enqueue-page-tokens annotation")
+}
+
+func TestCollectEnqueuedPageTokensAcceptsMaximumCount(t *testing.T) {
+	tokens := make([]string, maxEnqueuePageTokensPerResponse)
+	for i := range tokens {
+		tokens[i] = fmt.Sprintf("token-%d", i)
+	}
+	spawned, err := (&syncer{}).collectEnqueuedPageTokens(
+		context.Background(),
+		"sync-entitlements",
+		SyncEntitlementsOp,
+		&Action{ResourceTypeID: "group"},
+		annotations.New(v2.EnqueuePageTokens_builder{PageTokens: tokens}.Build()),
+	)
+	require.NoError(t, err)
+	require.Len(t, spawned, maxEnqueuePageTokensPerResponse)
+}
+
+func TestSpawnedActionsCoexistWithOriginContinuation(t *testing.T) {
+	ctx := context.Background()
+	st := newState()
+	require.NoError(t, st.Unmarshal(""))
+	st.FinishAction(ctx, st.Current())
+	st.PushAction(ctx, Action{Op: SyncGrantsOp, ResourceTypeID: "group", ResourceID: "group-1"})
+	origin := st.Current()
+	s := &syncer{state: st}
+	require.NoError(t, s.nextPageOrFinishAction(ctx, origin, "origin-next",
+		Action{Op: SyncGrantsOp, ResourceTypeID: "group", ResourceID: "group-1", PageToken: "sibling-1", Spawned: true},
+		Action{Op: SyncGrantsOp, ResourceTypeID: "group", ResourceID: "group-1", PageToken: "sibling-2", Spawned: true},
+	))
+
+	token, err := st.Marshal()
+	require.NoError(t, err)
+	resumed := newState()
+	require.NoError(t, resumed.Unmarshal(token))
+
+	seen := map[string]Action{}
+	for resumed.Current() != nil {
+		action := *resumed.Current()
+		seen[action.PageToken] = action
+		resumed.FinishAction(ctx, &action)
+	}
+	require.Len(t, seen, 3)
+	require.False(t, seen["origin-next"].Spawned)
+	require.True(t, seen["sibling-1"].Spawned)
+	require.True(t, seen["sibling-2"].Spawned)
+}
+
+func TestSpawnedActionsSurviveCheckpoint(t *testing.T) {
+	ctx := context.Background()
+	st := newState()
+	require.NoError(t, st.Unmarshal(""))
+	st.FinishAction(ctx, st.Current())
+	st.PushAction(ctx, Action{
+		Op:             SyncEntitlementsOp,
+		ResourceTypeID: "group",
+		PageToken:      "chunk-1",
+		Spawned:        true,
+	})
+
+	token, err := st.Marshal()
+	require.NoError(t, err)
+	resumed := newState()
+	require.NoError(t, resumed.Unmarshal(token))
+	require.NotNil(t, resumed.Current())
+	require.True(t, resumed.Current().Spawned)
+	require.Equal(t, "chunk-1", resumed.Current().PageToken)
+}
+
+func TestTargetedSyncSkipsPerResourceCallsForTypeScopedType(t *testing.T) {
+	ctx := t.Context()
+	tmpDir := t.TempDir()
+	resourceType := v2.ResourceType_builder{
+		Id:          "group",
+		DisplayName: "Group",
+		Annotations: annotations.New(&v2.TypeScopedEntitlements{}, &v2.TypeScopedGrants{}),
+	}.Build()
+	resource := v2.Resource_builder{
+		Id:          v2.ResourceId_builder{ResourceType: "group", Resource: "group-1"}.Build(),
+		DisplayName: "Group 1",
+	}.Build()
+	connector := &targetedTypeScopedConnector{mockConnector: newMockConnector()}
+	connector.rtDB = append(connector.rtDB, resourceType)
+	connector.resourceDB["group"] = append(connector.resourceDB["group"], resource)
+
+	s, err := NewSyncer(ctx, connector,
+		WithC1ZPath(filepath.Join(tmpDir, "targeted.c1z")),
+		WithTmpDir(tmpDir),
+		WithTargetedSyncResources([]*v2.Resource{resource}),
+	)
+	require.NoError(t, err)
+	require.NoError(t, s.Sync(ctx))
+	require.NoError(t, s.Close(ctx))
+
+	require.Zero(t, connector.entitlementCalls)
+	require.Zero(t, connector.grantCalls)
+}
+
+func TestTypeScopedColdCollectionEndToEnd(t *testing.T) {
+	for _, workers := range []int{1, 4} {
+		t.Run(fmt.Sprintf("workers=%d", workers), func(t *testing.T) {
+			ctx := t.Context()
+			tmpDir := t.TempDir()
+			groupType := v2.ResourceType_builder{
+				Id:          "group",
+				DisplayName: "Group",
+				Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_GROUP},
+				Annotations: annotations.New(&v2.TypeScopedEntitlements{}, &v2.TypeScopedGrants{}),
+			}.Build()
+			userType := v2.ResourceType_builder{
+				Id:          "user",
+				DisplayName: "User",
+				Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_USER},
+				Annotations: annotations.New(&v2.SkipEntitlementsAndGrants{}),
+			}.Build()
+			group1, err := rs.NewGroupResource("group-1", groupType, "Group 1", nil)
+			require.NoError(t, err)
+			group2, err := rs.NewGroupResource("group-2", groupType, "Group 2", nil)
+			require.NoError(t, err)
+			user, err := rs.NewUserResource("user-1", userType, "User 1", nil)
+			require.NoError(t, err)
+			ent1 := et.NewAssignmentEntitlement(group1, "member", et.WithGrantableTo(userType))
+			ent2 := et.NewAssignmentEntitlement(group2, "member", et.WithGrantableTo(userType))
+			grant1 := gt.NewGrant(group1, "member", user.GetId())
+			grant2 := gt.NewGrant(group2, "member", user.GetId())
+
+			connector := &coldTypeScopedConnector{
+				mockConnector:       newMockConnector(),
+				entitlementsByToken: map[string]*v2.Entitlement{"ent-1": ent1, "ent-2": ent2},
+				grantsByToken:       map[string]*v2.Grant{"grant-1": grant1, "grant-2": grant2},
+			}
+			connector.rtDB = append(connector.rtDB, groupType, userType)
+			connector.resourceDB["group"] = append(connector.resourceDB["group"], group1, group2)
+			connector.resourceDB["user"] = append(connector.resourceDB["user"], user)
+
+			store, err := dotc1z.NewStore(ctx, filepath.Join(tmpDir, "type-scoped.c1z"),
+				dotc1z.WithEngine(c1zstore.EnginePebble),
+				dotc1z.WithTmpDir(tmpDir),
+			)
+			require.NoError(t, err)
+			s, err := NewSyncer(ctx, connector,
+				WithConnectorStore(store),
+				WithTmpDir(tmpDir),
+				WithWorkerCount(workers),
+			)
+			require.NoError(t, err)
+			require.NoError(t, s.Sync(ctx))
+
+			entResp, err := store.ListEntitlements(ctx, v2.EntitlementsServiceListEntitlementsRequest_builder{}.Build())
+			require.NoError(t, err)
+			require.Len(t, entResp.GetList(), 2)
+			grantResp, err := store.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{}.Build())
+			require.NoError(t, err)
+			require.Len(t, grantResp.GetList(), 2)
+			require.NoError(t, s.Close(ctx))
+
+			require.Equal(t, 1, connector.entitlementPlannerCalls)
+			require.Equal(t, 1, connector.grantPlannerCalls)
+			require.Zero(t, connector.perResourceEntitlementCalls)
+			require.Zero(t, connector.perResourceGrantCalls)
+		})
+	}
+}

--- a/pkg/sync/type_scoped_test.go
+++ b/pkg/sync/type_scoped_test.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -15,6 +17,7 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
+	"github.com/conductorone/baton-sdk/pkg/retry"
 	et "github.com/conductorone/baton-sdk/pkg/types/entitlement"
 	gt "github.com/conductorone/baton-sdk/pkg/types/grant"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
@@ -26,6 +29,35 @@ type targetedTypeScopedConnector struct {
 	grantCalls       int
 }
 
+type emptyIDConnector struct {
+	*mockConnector
+	entitlementCalls int
+	grantCalls       int
+	sawTypeMarker    bool
+}
+
+func (c *emptyIDConnector) ListEntitlements(
+	_ context.Context,
+	in *v2.EntitlementsServiceListEntitlementsRequest,
+	_ ...grpc.CallOption,
+) (*v2.EntitlementsServiceListEntitlementsResponse, error) {
+	c.entitlementCalls++
+	reqAnnos := annotations.Annotations(in.GetAnnotations())
+	c.sawTypeMarker = c.sawTypeMarker || reqAnnos.Contains(&v2.TypeScopedEntitlements{})
+	return v2.EntitlementsServiceListEntitlementsResponse_builder{}.Build(), nil
+}
+
+func (c *emptyIDConnector) ListGrants(
+	_ context.Context,
+	in *v2.GrantsServiceListGrantsRequest,
+	_ ...grpc.CallOption,
+) (*v2.GrantsServiceListGrantsResponse, error) {
+	c.grantCalls++
+	reqAnnos := annotations.Annotations(in.GetAnnotations())
+	c.sawTypeMarker = c.sawTypeMarker || reqAnnos.Contains(&v2.TypeScopedGrants{})
+	return v2.GrantsServiceListGrantsResponse_builder{}.Build(), nil
+}
+
 type coldTypeScopedConnector struct {
 	*mockConnector
 	entitlementsByToken         map[string]*v2.Entitlement
@@ -34,6 +66,38 @@ type coldTypeScopedConnector struct {
 	grantPlannerCalls           int
 	perResourceEntitlementCalls int
 	perResourceGrantCalls       int
+}
+
+type countingEntitlementsConnector struct {
+	*mockConnector
+	calls atomic.Int64
+}
+
+func (c *countingEntitlementsConnector) ListEntitlements(
+	_ context.Context,
+	_ *v2.EntitlementsServiceListEntitlementsRequest,
+	_ ...grpc.CallOption,
+) (*v2.EntitlementsServiceListEntitlementsResponse, error) {
+	c.calls.Add(1)
+	return v2.EntitlementsServiceListEntitlementsResponse_builder{}.Build(), nil
+}
+
+type resumableTypeScopedConnector struct {
+	*coldTypeScopedConnector
+	failGrantToken string
+	failedOnce     bool
+}
+
+func (c *resumableTypeScopedConnector) ListGrants(
+	ctx context.Context,
+	in *v2.GrantsServiceListGrantsRequest,
+	opts ...grpc.CallOption,
+) (*v2.GrantsServiceListGrantsResponse, error) {
+	if in.GetPageToken() == c.failGrantToken && !c.failedOnce {
+		c.failedOnce = true
+		return nil, fmt.Errorf("injected grant cursor failure")
+	}
+	return c.coldTypeScopedConnector.ListGrants(ctx, in, opts...)
 }
 
 func (c *coldTypeScopedConnector) ListEntitlements(
@@ -115,6 +179,22 @@ func TestCollectEnqueuedPageTokens(t *testing.T) {
 	}, spawned)
 }
 
+func TestCollectEnqueuedPageTokensPreservesTypeScopedMarker(t *testing.T) {
+	spawned, err := (&syncer{}).collectEnqueuedPageTokens(
+		t.Context(),
+		"sync-grants-for-type",
+		SyncGrantsOp,
+		&Action{ResourceTypeID: "group", TypeScoped: true},
+		annotations.New(v2.EnqueuePageTokens_builder{
+			PageTokens: []string{"page-2"},
+		}.Build()),
+	)
+	require.NoError(t, err)
+	require.Len(t, spawned, 1)
+	require.True(t, spawned[0].TypeScoped)
+	require.True(t, spawned[0].Spawned)
+}
+
 func TestCollectEnqueuedPageTokensRejectsInvalidFanout(t *testing.T) {
 	s := &syncer{}
 	action := &Action{ResourceTypeID: "group"}
@@ -149,6 +229,14 @@ func TestCollectEnqueuedPageTokensRejectsInvalidFanout(t *testing.T) {
 	_, err = s.collectEnqueuedPageTokens(context.Background(), "sync-grants", SyncGrantsOp, action,
 		annotations.Annotations{malformed})
 	require.ErrorContains(t, err, "error parsing enqueue-page-tokens annotation")
+
+	first, err := anypb.New(v2.EnqueuePageTokens_builder{PageTokens: []string{"page-1"}}.Build())
+	require.NoError(t, err)
+	second, err := anypb.New(v2.EnqueuePageTokens_builder{PageTokens: []string{"page-2"}}.Build())
+	require.NoError(t, err)
+	_, err = s.collectEnqueuedPageTokens(context.Background(), "sync-grants", SyncGrantsOp, action,
+		annotations.Annotations{first, second})
+	require.ErrorContains(t, err, "multiple EnqueuePageTokens annotations")
 }
 
 func TestCollectEnqueuedPageTokensAcceptsMaximumCount(t *testing.T) {
@@ -207,6 +295,7 @@ func TestSpawnedActionsSurviveCheckpoint(t *testing.T) {
 		ResourceTypeID: "group",
 		PageToken:      "chunk-1",
 		Spawned:        true,
+		TypeScoped:     true,
 	})
 
 	token, err := st.Marshal()
@@ -215,7 +304,99 @@ func TestSpawnedActionsSurviveCheckpoint(t *testing.T) {
 	require.NoError(t, resumed.Unmarshal(token))
 	require.NotNil(t, resumed.Current())
 	require.True(t, resumed.Current().Spawned)
+	require.True(t, resumed.Current().TypeScoped)
 	require.Equal(t, "chunk-1", resumed.Current().PageToken)
+}
+
+func TestSpawnedCursorJoinsActiveParallelBatch(t *testing.T) {
+	ctx := t.Context()
+	st := newState()
+	require.NoError(t, st.Unmarshal(""))
+	st.FinishAction(ctx, st.Current())
+	origin := st.pushAction(ctx, Action{
+		Op:             SyncGrantsOp,
+		ResourceTypeID: "group",
+		ResourceID:     "group-1",
+	})
+	s := &syncer{state: st, workerCount: 2}
+	childStarted := make(chan struct{})
+
+	f := func(ctx context.Context, action *Action) error {
+		switch action.PageToken {
+		case "":
+			return s.nextPageOrFinishAction(ctx, action, "origin-next", Action{
+				Op:             SyncGrantsOp,
+				ResourceTypeID: "group",
+				ResourceID:     "group-1",
+				PageToken:      "sibling",
+				Spawned:        true,
+			})
+		case "sibling":
+			close(childStarted)
+			s.state.FinishAction(ctx, action)
+			return nil
+		case "origin-next":
+			select {
+			case <-childStarted:
+				s.state.FinishAction(ctx, action)
+				return nil
+			case <-time.After(2 * time.Second):
+				return fmt.Errorf("spawned cursor did not join the active worker batch")
+			}
+		default:
+			return fmt.Errorf("unexpected page token %q", action.PageToken)
+		}
+	}
+
+	_, err := s.syncParallel(ctx, retry.NewRetryer(ctx, retry.RetryConfig{}), []*Action{origin}, f)
+	require.NoError(t, err)
+	require.Nil(t, st.Current())
+}
+
+func TestParallelActionQueueReleasesDequeuedStorage(t *testing.T) {
+	actions := make([]*Action, 2048)
+	for i := range actions {
+		actions[i] = &Action{ID: fmt.Sprintf("action-%d", i)}
+	}
+	queue := newParallelActionQueue(actions)
+
+	for range actions {
+		action, ok := queue.next()
+		require.True(t, ok)
+		require.NotNil(t, action)
+		queue.done()
+	}
+
+	require.Empty(t, queue.actions)
+	require.Zero(t, queue.head)
+	require.Zero(t, queue.outstanding)
+}
+
+func TestEmptyResourceIDRemainsPerResource(t *testing.T) {
+	ctx := t.Context()
+	tmpDir := t.TempDir()
+	resourceType := v2.ResourceType_builder{
+		Id:          "untyped",
+		DisplayName: "Untyped",
+	}.Build()
+	resource := v2.Resource_builder{
+		Id:          v2.ResourceId_builder{ResourceType: "untyped"}.Build(),
+		DisplayName: "Malformed but historically tolerated",
+	}.Build()
+	connector := &emptyIDConnector{mockConnector: newMockConnector()}
+	connector.rtDB = append(connector.rtDB, resourceType)
+	connector.resourceDB["untyped"] = append(connector.resourceDB["untyped"], resource)
+
+	s, err := NewSyncer(ctx, connector,
+		WithC1ZPath(filepath.Join(tmpDir, "empty-id.c1z")),
+		WithTmpDir(tmpDir),
+	)
+	require.NoError(t, err)
+	require.NoError(t, s.Sync(ctx))
+	require.NoError(t, s.Close(ctx))
+	require.Equal(t, 1, connector.entitlementCalls)
+	require.Equal(t, 1, connector.grantCalls)
+	require.False(t, connector.sawTypeMarker)
 }
 
 func TestTargetedSyncSkipsPerResourceCallsForTypeScopedType(t *testing.T) {
@@ -311,4 +492,96 @@ func TestTypeScopedColdCollectionEndToEnd(t *testing.T) {
 			require.Zero(t, connector.perResourceGrantCalls)
 		})
 	}
+}
+
+func TestSyncDrainsMoreThanOneSchedulerBatch(t *testing.T) {
+	ctx := t.Context()
+	tmpDir := t.TempDir()
+	resourceType := v2.ResourceType_builder{
+		Id:          "item",
+		DisplayName: "Item",
+	}.Build()
+	connector := &countingEntitlementsConnector{mockConnector: newMockConnector()}
+	connector.rtDB = append(connector.rtDB, resourceType)
+	for i := 0; i < maxPeekActionsCount+5; i++ {
+		connector.resourceDB["item"] = append(connector.resourceDB["item"], v2.Resource_builder{
+			Id: v2.ResourceId_builder{
+				ResourceType: "item",
+				Resource:     fmt.Sprintf("item-%03d", i),
+			}.Build(),
+			DisplayName: fmt.Sprintf("Item %03d", i),
+		}.Build())
+	}
+
+	s, err := NewSyncer(ctx, connector,
+		WithC1ZPath(filepath.Join(tmpDir, "multi-batch.c1z")),
+		WithTmpDir(tmpDir),
+		WithWorkerCount(4),
+		WithSkipGrants(true),
+	)
+	require.NoError(t, err)
+	require.NoError(t, s.Sync(ctx))
+	require.NoError(t, s.Close(ctx))
+	require.EqualValues(t, maxPeekActionsCount+5, connector.calls.Load())
+}
+
+func TestTypeScopedFanoutResumesAfterStoredCursorFailure(t *testing.T) {
+	ctx := t.Context()
+	tmpDir := t.TempDir()
+	groupType := v2.ResourceType_builder{
+		Id:          "group",
+		DisplayName: "Group",
+		Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_GROUP},
+		Annotations: annotations.New(&v2.TypeScopedEntitlements{}, &v2.TypeScopedGrants{}),
+	}.Build()
+	userType := v2.ResourceType_builder{
+		Id:          "user",
+		DisplayName: "User",
+		Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_USER},
+		Annotations: annotations.New(&v2.SkipEntitlementsAndGrants{}),
+	}.Build()
+	group1, err := rs.NewGroupResource("group-1", groupType, "Group 1", nil)
+	require.NoError(t, err)
+	group2, err := rs.NewGroupResource("group-2", groupType, "Group 2", nil)
+	require.NoError(t, err)
+	user, err := rs.NewUserResource("user-1", userType, "User 1", nil)
+	require.NoError(t, err)
+	entitlement1 := et.NewAssignmentEntitlement(group1, "member", et.WithGrantableTo(userType))
+	entitlement2 := et.NewAssignmentEntitlement(group2, "member", et.WithGrantableTo(userType))
+	grant1 := gt.NewGrant(group1, "member", user.GetId())
+	grant2 := gt.NewGrant(group2, "member", user.GetId())
+
+	baseConnector := &coldTypeScopedConnector{
+		mockConnector:       newMockConnector(),
+		entitlementsByToken: map[string]*v2.Entitlement{"ent-1": entitlement1, "ent-2": entitlement2},
+		grantsByToken:       map[string]*v2.Grant{"grant-1": grant1, "grant-2": grant2},
+	}
+	baseConnector.rtDB = append(baseConnector.rtDB, groupType, userType)
+	baseConnector.resourceDB["group"] = append(baseConnector.resourceDB["group"], group1, group2)
+	baseConnector.resourceDB["user"] = append(baseConnector.resourceDB["user"], user)
+	connector := &resumableTypeScopedConnector{
+		coldTypeScopedConnector: baseConnector,
+		failGrantToken:          "grant-2",
+	}
+
+	store, err := dotc1z.NewStore(ctx, filepath.Join(tmpDir, "resume-fanout.c1z"),
+		dotc1z.WithEngine(c1zstore.EnginePebble),
+		dotc1z.WithTmpDir(tmpDir),
+	)
+	require.NoError(t, err)
+	s, err := NewSyncer(ctx, connector,
+		WithConnectorStore(store),
+		WithTmpDir(tmpDir),
+		WithWorkerCount(1),
+	)
+	require.NoError(t, err)
+
+	require.ErrorContains(t, s.Sync(ctx), "injected grant cursor failure")
+	require.NoError(t, s.Sync(ctx))
+
+	grantResp, err := store.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{}.Build())
+	require.NoError(t, err)
+	require.Len(t, grantResp.GetList(), 2)
+	require.NoError(t, s.Close(ctx))
+	require.True(t, connector.failedOnce)
 }


### PR DESCRIPTION
## Summary

Implements Phase 5 of the source-cache replay stack: type-scoped grant and entitlement collection.

Resource types can now opt out of per-resource fan-out using `TypeScopedGrants` or `TypeScopedEntitlements`. The syncer instead issues one type-scoped planner action, and connectors can enqueue checkpointed sibling cursors with `EnqueuePageTokens`.

## Changes

- Add shared type-scoped collection plumbing.
- Route type-scoped requests through connectorbuilder optional interfaces.
- Preserve those interfaces through the V1-to-V2 adapter.
- Validate annotation/interface coherence during connector construction.
- Persist spawned cursor state across checkpoints.
- Bound cursor count and token sizes.
- Avoid per-resource collection for type-scoped types, including targeted syncs.
- Add count-only progress reporting for type-scoped phases.
- Register type-scoped annotations with ingestion invariants I7 and I8.
- Add focused routing, validation, fan-out, and checkpoint tests.

## Scope

This PR contains collection and routing behavior only. Source-cache replay, continuation lookup, and warm/cold equivalence tests remain in Phase 6.

## Testing

- `go test ./pkg/sync ./pkg/sync/progresslog ./pkg/connectorbuilder`