### PR TITLE
Persist ingest invariant verification metadata

### DIFF
--- a/pb/c1/storage/v3/records.pb.go
+++ b/pb/c1/storage/v3/records.pb.go
@@ -1470,9 +1470,21 @@ type SyncRunRecord struct {
 	// (full-fetch) sync. Orchestrators deciding which artifact to
 	// materialize as the previous sync should apply the same predicate
 	// instead of guessing from provenance.
-	Compacted     bool `protobuf:"varint,9,opt,name=compacted,proto3" json:"compacted,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Compacted bool `protobuf:"varint,9,opt,name=compacted,proto3" json:"compacted,omitempty"`
+	// Persisted proof that the post-collection ingestion-invariant pass
+	// completed successfully before this sync was sealed. Empty generation
+	// means the artifact predates verification metadata (or was produced by a
+	// path that did not run the pass). Coverage names only checks that actually
+	// ran; engines without the inspection surface therefore record a subset
+	// rather than claiming full verification.
+	IngestInvariantGeneration string   `protobuf:"bytes,10,opt,name=ingest_invariant_generation,json=ingestInvariantGeneration,proto3" json:"ingest_invariant_generation,omitempty"`
+	IngestInvariantCoverage   []string `protobuf:"bytes,11,rep,name=ingest_invariant_coverage,json=ingestInvariantCoverage,proto3" json:"ingest_invariant_coverage,omitempty"`
+	// "connector" applies the ordinary connector-ingest verdict policy;
+	// "compaction_merge" applies the policy for a pre-sealed keep-newer merge.
+	// Empty when ingest_invariant_generation is empty.
+	IngestInvariantMode string `protobuf:"bytes,12,opt,name=ingest_invariant_mode,json=ingestInvariantMode,proto3" json:"ingest_invariant_mode,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
 }
 
 func (x *SyncRunRecord) Reset() {
@@ -1563,6 +1575,27 @@ func (x *SyncRunRecord) GetCompacted() bool {
 	return false
 }
 
+func (x *SyncRunRecord) GetIngestInvariantGeneration() string {
+	if x != nil {
+		return x.IngestInvariantGeneration
+	}
+	return ""
+}
+
+func (x *SyncRunRecord) GetIngestInvariantCoverage() []string {
+	if x != nil {
+		return x.IngestInvariantCoverage
+	}
+	return nil
+}
+
+func (x *SyncRunRecord) GetIngestInvariantMode() string {
+	if x != nil {
+		return x.IngestInvariantMode
+	}
+	return ""
+}
+
 func (x *SyncRunRecord) SetSyncId(v string) {
 	x.SyncId = v
 }
@@ -1597,6 +1630,18 @@ func (x *SyncRunRecord) SetLinkedSyncId(v string) {
 
 func (x *SyncRunRecord) SetCompacted(v bool) {
 	x.Compacted = v
+}
+
+func (x *SyncRunRecord) SetIngestInvariantGeneration(v string) {
+	x.IngestInvariantGeneration = v
+}
+
+func (x *SyncRunRecord) SetIngestInvariantCoverage(v []string) {
+	x.IngestInvariantCoverage = v
+}
+
+func (x *SyncRunRecord) SetIngestInvariantMode(v string) {
+	x.IngestInvariantMode = v
 }
 
 func (x *SyncRunRecord) HasStartedAt() bool {
@@ -1646,6 +1691,18 @@ type SyncRunRecord_builder struct {
 	// materialize as the previous sync should apply the same predicate
 	// instead of guessing from provenance.
 	Compacted bool
+	// Persisted proof that the post-collection ingestion-invariant pass
+	// completed successfully before this sync was sealed. Empty generation
+	// means the artifact predates verification metadata (or was produced by a
+	// path that did not run the pass). Coverage names only checks that actually
+	// ran; engines without the inspection surface therefore record a subset
+	// rather than claiming full verification.
+	IngestInvariantGeneration string
+	IngestInvariantCoverage   []string
+	// "connector" applies the ordinary connector-ingest verdict policy;
+	// "compaction_merge" applies the policy for a pre-sealed keep-newer merge.
+	// Empty when ingest_invariant_generation is empty.
+	IngestInvariantMode string
 }
 
 func (b0 SyncRunRecord_builder) Build() *SyncRunRecord {
@@ -1661,6 +1718,9 @@ func (b0 SyncRunRecord_builder) Build() *SyncRunRecord {
 	x.SupportsDiff = b.SupportsDiff
 	x.LinkedSyncId = b.LinkedSyncId
 	x.Compacted = b.Compacted
+	x.IngestInvariantGeneration = b.IngestInvariantGeneration
+	x.IngestInvariantCoverage = b.IngestInvariantCoverage
+	x.IngestInvariantMode = b.IngestInvariantMode
 	return m0
 }
 
@@ -2522,7 +2582,7 @@ const file_c1_storage_v3_records_proto_rawDesc = "" +
 	"\fcontent_type\x18\x03 \x01(\tR\vcontentType\x12\x12\n" +
 	"\x04data\x18\x04 \x01(\fR\x04data\x12?\n" +
 	"\rdiscovered_at\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\fdiscoveredAt:\"\x82\xf9+\x1e\n" +
-	"\x06assets\x12\async_id\x12\vexternal_id\"\x8f\x03\n" +
+	"\x06assets\x12\async_id\x12\vexternal_id\"\xbf\x04\n" +
 	"\rSyncRunRecord\x12\x17\n" +
 	"\async_id\x18\x01 \x01(\tR\x06syncId\x12+\n" +
 	"\x04type\x18\x02 \x01(\x0e2\x17.c1.storage.v3.SyncTypeR\x04type\x12$\n" +
@@ -2534,7 +2594,11 @@ const file_c1_storage_v3_records_proto_rawDesc = "" +
 	"sync_token\x18\x06 \x01(\tR\tsyncToken\x12#\n" +
 	"\rsupports_diff\x18\a \x01(\bR\fsupportsDiff\x12$\n" +
 	"\x0elinked_sync_id\x18\b \x01(\tR\flinkedSyncId\x12\x1c\n" +
-	"\tcompacted\x18\t \x01(\bR\tcompacted:\x18\x82\xf9+\x14\n" +
+	"\tcompacted\x18\t \x01(\bR\tcompacted\x12>\n" +
+	"\x1bingest_invariant_generation\x18\n" +
+	" \x01(\tR\x19ingestInvariantGeneration\x12:\n" +
+	"\x19ingest_invariant_coverage\x18\v \x03(\tR\x17ingestInvariantCoverage\x122\n" +
+	"\x15ingest_invariant_mode\x18\f \x01(\tR\x13ingestInvariantMode:\x18\x82\xf9+\x14\n" +
 	"\tsync_runs\x12\async_id\"\xb4\v\n" +
 	"\x0fSyncStatsRecord\x12\x17\n" +
 	"\async_id\x18\x01 \x01(\tR\x06syncId\x12%\n" +

--- a/pb/c1/storage/v3/records.pb.validate.go
+++ b/pb/c1/storage/v3/records.pb.validate.go
@@ -1551,6 +1551,10 @@ func (m *SyncRunRecord) validate(all bool) error {
 
 	// no validation rules for Compacted
 
+	// no validation rules for IngestInvariantGeneration
+
+	// no validation rules for IngestInvariantMode
+
 	if len(errors) > 0 {
 		return SyncRunRecordMultiError(errors)
 	}

--- a/pb/c1/storage/v3/records_protoopaque.pb.go
+++ b/pb/c1/storage/v3/records_protoopaque.pb.go
@@ -1407,18 +1407,21 @@ func (b0 AssetRecord_builder) Build() *AssetRecord {
 }
 
 type SyncRunRecord struct {
-	state                   protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_SyncId       string                 `protobuf:"bytes,1,opt,name=sync_id,json=syncId,proto3"`
-	xxx_hidden_Type         SyncType               `protobuf:"varint,2,opt,name=type,proto3,enum=c1.storage.v3.SyncType"`
-	xxx_hidden_ParentSyncId string                 `protobuf:"bytes,3,opt,name=parent_sync_id,json=parentSyncId,proto3"`
-	xxx_hidden_StartedAt    *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=started_at,json=startedAt,proto3"`
-	xxx_hidden_EndedAt      *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=ended_at,json=endedAt,proto3"`
-	xxx_hidden_SyncToken    string                 `protobuf:"bytes,6,opt,name=sync_token,json=syncToken,proto3"`
-	xxx_hidden_SupportsDiff bool                   `protobuf:"varint,7,opt,name=supports_diff,json=supportsDiff,proto3"`
-	xxx_hidden_LinkedSyncId string                 `protobuf:"bytes,8,opt,name=linked_sync_id,json=linkedSyncId,proto3"`
-	xxx_hidden_Compacted    bool                   `protobuf:"varint,9,opt,name=compacted,proto3"`
-	unknownFields           protoimpl.UnknownFields
-	sizeCache               protoimpl.SizeCache
+	state                                protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_SyncId                    string                 `protobuf:"bytes,1,opt,name=sync_id,json=syncId,proto3"`
+	xxx_hidden_Type                      SyncType               `protobuf:"varint,2,opt,name=type,proto3,enum=c1.storage.v3.SyncType"`
+	xxx_hidden_ParentSyncId              string                 `protobuf:"bytes,3,opt,name=parent_sync_id,json=parentSyncId,proto3"`
+	xxx_hidden_StartedAt                 *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=started_at,json=startedAt,proto3"`
+	xxx_hidden_EndedAt                   *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=ended_at,json=endedAt,proto3"`
+	xxx_hidden_SyncToken                 string                 `protobuf:"bytes,6,opt,name=sync_token,json=syncToken,proto3"`
+	xxx_hidden_SupportsDiff              bool                   `protobuf:"varint,7,opt,name=supports_diff,json=supportsDiff,proto3"`
+	xxx_hidden_LinkedSyncId              string                 `protobuf:"bytes,8,opt,name=linked_sync_id,json=linkedSyncId,proto3"`
+	xxx_hidden_Compacted                 bool                   `protobuf:"varint,9,opt,name=compacted,proto3"`
+	xxx_hidden_IngestInvariantGeneration string                 `protobuf:"bytes,10,opt,name=ingest_invariant_generation,json=ingestInvariantGeneration,proto3"`
+	xxx_hidden_IngestInvariantCoverage   []string               `protobuf:"bytes,11,rep,name=ingest_invariant_coverage,json=ingestInvariantCoverage,proto3"`
+	xxx_hidden_IngestInvariantMode       string                 `protobuf:"bytes,12,opt,name=ingest_invariant_mode,json=ingestInvariantMode,proto3"`
+	unknownFields                        protoimpl.UnknownFields
+	sizeCache                            protoimpl.SizeCache
 }
 
 func (x *SyncRunRecord) Reset() {
@@ -1509,6 +1512,27 @@ func (x *SyncRunRecord) GetCompacted() bool {
 	return false
 }
 
+func (x *SyncRunRecord) GetIngestInvariantGeneration() string {
+	if x != nil {
+		return x.xxx_hidden_IngestInvariantGeneration
+	}
+	return ""
+}
+
+func (x *SyncRunRecord) GetIngestInvariantCoverage() []string {
+	if x != nil {
+		return x.xxx_hidden_IngestInvariantCoverage
+	}
+	return nil
+}
+
+func (x *SyncRunRecord) GetIngestInvariantMode() string {
+	if x != nil {
+		return x.xxx_hidden_IngestInvariantMode
+	}
+	return ""
+}
+
 func (x *SyncRunRecord) SetSyncId(v string) {
 	x.xxx_hidden_SyncId = v
 }
@@ -1543,6 +1567,18 @@ func (x *SyncRunRecord) SetLinkedSyncId(v string) {
 
 func (x *SyncRunRecord) SetCompacted(v bool) {
 	x.xxx_hidden_Compacted = v
+}
+
+func (x *SyncRunRecord) SetIngestInvariantGeneration(v string) {
+	x.xxx_hidden_IngestInvariantGeneration = v
+}
+
+func (x *SyncRunRecord) SetIngestInvariantCoverage(v []string) {
+	x.xxx_hidden_IngestInvariantCoverage = v
+}
+
+func (x *SyncRunRecord) SetIngestInvariantMode(v string) {
+	x.xxx_hidden_IngestInvariantMode = v
 }
 
 func (x *SyncRunRecord) HasStartedAt() bool {
@@ -1592,6 +1628,18 @@ type SyncRunRecord_builder struct {
 	// materialize as the previous sync should apply the same predicate
 	// instead of guessing from provenance.
 	Compacted bool
+	// Persisted proof that the post-collection ingestion-invariant pass
+	// completed successfully before this sync was sealed. Empty generation
+	// means the artifact predates verification metadata (or was produced by a
+	// path that did not run the pass). Coverage names only checks that actually
+	// ran; engines without the inspection surface therefore record a subset
+	// rather than claiming full verification.
+	IngestInvariantGeneration string
+	IngestInvariantCoverage   []string
+	// "connector" applies the ordinary connector-ingest verdict policy;
+	// "compaction_merge" applies the policy for a pre-sealed keep-newer merge.
+	// Empty when ingest_invariant_generation is empty.
+	IngestInvariantMode string
 }
 
 func (b0 SyncRunRecord_builder) Build() *SyncRunRecord {
@@ -1607,6 +1655,9 @@ func (b0 SyncRunRecord_builder) Build() *SyncRunRecord {
 	x.xxx_hidden_SupportsDiff = b.SupportsDiff
 	x.xxx_hidden_LinkedSyncId = b.LinkedSyncId
 	x.xxx_hidden_Compacted = b.Compacted
+	x.xxx_hidden_IngestInvariantGeneration = b.IngestInvariantGeneration
+	x.xxx_hidden_IngestInvariantCoverage = b.IngestInvariantCoverage
+	x.xxx_hidden_IngestInvariantMode = b.IngestInvariantMode
 	return m0
 }
 
@@ -2435,7 +2486,7 @@ const file_c1_storage_v3_records_proto_rawDesc = "" +
 	"\fcontent_type\x18\x03 \x01(\tR\vcontentType\x12\x12\n" +
 	"\x04data\x18\x04 \x01(\fR\x04data\x12?\n" +
 	"\rdiscovered_at\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\fdiscoveredAt:\"\x82\xf9+\x1e\n" +
-	"\x06assets\x12\async_id\x12\vexternal_id\"\x8f\x03\n" +
+	"\x06assets\x12\async_id\x12\vexternal_id\"\xbf\x04\n" +
 	"\rSyncRunRecord\x12\x17\n" +
 	"\async_id\x18\x01 \x01(\tR\x06syncId\x12+\n" +
 	"\x04type\x18\x02 \x01(\x0e2\x17.c1.storage.v3.SyncTypeR\x04type\x12$\n" +
@@ -2447,7 +2498,11 @@ const file_c1_storage_v3_records_proto_rawDesc = "" +
 	"sync_token\x18\x06 \x01(\tR\tsyncToken\x12#\n" +
 	"\rsupports_diff\x18\a \x01(\bR\fsupportsDiff\x12$\n" +
 	"\x0elinked_sync_id\x18\b \x01(\tR\flinkedSyncId\x12\x1c\n" +
-	"\tcompacted\x18\t \x01(\bR\tcompacted:\x18\x82\xf9+\x14\n" +
+	"\tcompacted\x18\t \x01(\bR\tcompacted\x12>\n" +
+	"\x1bingest_invariant_generation\x18\n" +
+	" \x01(\tR\x19ingestInvariantGeneration\x12:\n" +
+	"\x19ingest_invariant_coverage\x18\v \x03(\tR\x17ingestInvariantCoverage\x122\n" +
+	"\x15ingest_invariant_mode\x18\f \x01(\tR\x13ingestInvariantMode:\x18\x82\xf9+\x14\n" +
 	"\tsync_runs\x12\async_id\"\xb4\v\n" +
 	"\x0fSyncStatsRecord\x12\x17\n" +
 	"\async_id\x18\x01 \x01(\tR\x06syncId\x12%\n" +

--- a/pkg/dotc1z/c1file_store.go
+++ b/pkg/dotc1z/c1file_store.go
@@ -18,11 +18,12 @@ import (
 // wrapper structs satisfy each sub-interface. These assertions catch
 // signature drift at build time rather than at the first runtime call.
 var (
-	_ c1zstore.Store      = (*C1File)(nil)
-	_ c1zstore.GrantStore = c1FileGrantStore{}
-	_ c1zstore.SyncMeta   = c1FileSyncMeta{}
-	_ c1zstore.FileOps    = c1FileFileOps{}
-	_ SessionStore        = c1FileSessionStore{}
+	_ c1zstore.Store                             = (*C1File)(nil)
+	_ c1zstore.GrantStore                        = c1FileGrantStore{}
+	_ c1zstore.SyncMeta                          = c1FileSyncMeta{}
+	_ c1zstore.IngestInvariantVerificationWriter = c1FileSyncMeta{}
+	_ c1zstore.FileOps                           = c1FileFileOps{}
+	_ SessionStore                               = c1FileSessionStore{}
 )
 
 // Grants returns the grant-store slice of this c1z.
@@ -273,6 +274,18 @@ type c1FileSyncMeta struct{ c *C1File }
 // MarkSyncSupportsDiff implements SyncMeta. Thin rename over SetSupportsDiff.
 func (s c1FileSyncMeta) MarkSyncSupportsDiff(ctx context.Context, syncID string) error {
 	return s.c.SetSupportsDiff(ctx, syncID)
+}
+
+func (s c1FileSyncMeta) MarkIngestInvariantsVerified(
+	ctx context.Context,
+	syncID string,
+	verification c1zstore.IngestInvariantVerification,
+) error {
+	return s.c.markIngestInvariantsVerified(ctx, syncID, verification)
+}
+
+func (s c1FileSyncMeta) ClearIngestInvariantVerification(ctx context.Context, syncID string) error {
+	return s.c.clearIngestInvariantVerification(ctx, syncID)
 }
 
 // LatestFullSync implements SyncMeta. Returns the most-recent finished

--- a/pkg/dotc1z/c1zstore/sync_meta.go
+++ b/pkg/dotc1z/c1zstore/sync_meta.go
@@ -53,6 +53,15 @@ type SyncMeta interface {
 	RecalculateStats(ctx context.Context, syncID string) error
 }
 
+// IngestInvariantVerificationWriter is the additive sync-metadata capability
+// implemented by stores that can persist invariant provenance. It is separate
+// from SyncMeta so adding the marker does not break third-party SyncMeta
+// implementations at compile time.
+type IngestInvariantVerificationWriter interface {
+	MarkIngestInvariantsVerified(ctx context.Context, syncID string, verification IngestInvariantVerification) error
+	ClearIngestInvariantVerification(ctx context.Context, syncID string) error
+}
+
 // SyncRun is the exported shape of a sync run. The fields match the
 // sync_runs schema.
 //
@@ -69,4 +78,42 @@ type SyncRun struct {
 	LinkedSyncID string
 	SupportsDiff bool
 	Stats        *reader_v2.SyncStats
+	IngestInvariantVerification
 }
+
+// IngestInvariantVerification is persisted provenance for a successful
+// post-collection invariant pass. Generation identifies the verifier
+// contract, Coverage lists the invariant IDs that actually ran, and Mode
+// identifies the verdict policy used. Generation == "" means unverified.
+type IngestInvariantVerification struct {
+	Generation string
+	Coverage   []string
+	Mode       IngestInvariantVerificationMode
+}
+
+// IsVerified reports whether the provenance marker is complete and uses a
+// known verdict mode. It says the recorded pass completed; callers must still
+// compare Generation and required Coverage with their own contract.
+func (v IngestInvariantVerification) IsVerified() bool {
+	if v.Generation == "" || len(v.Coverage) == 0 {
+		return false
+	}
+	switch v.Mode {
+	case IngestInvariantVerificationModeConnector,
+		IngestInvariantVerificationModeConnectorFailFast,
+		IngestInvariantVerificationModeCompactionMerge,
+		IngestInvariantVerificationModeCompactionMergeFailFast:
+		return true
+	default:
+		return false
+	}
+}
+
+type IngestInvariantVerificationMode string
+
+const (
+	IngestInvariantVerificationModeConnector               IngestInvariantVerificationMode = "connector"
+	IngestInvariantVerificationModeConnectorFailFast       IngestInvariantVerificationMode = "connector_fail_fast"
+	IngestInvariantVerificationModeCompactionMerge         IngestInvariantVerificationMode = "compaction_merge"
+	IngestInvariantVerificationModeCompactionMergeFailFast IngestInvariantVerificationMode = "compaction_merge_fail_fast"
+)

--- a/pkg/dotc1z/engine/pebble/adapter.go
+++ b/pkg/dotc1z/engine/pebble/adapter.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"github.com/segmentio/ksuid"
 	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"google.golang.org/protobuf/types/known/anypb"
@@ -243,14 +244,10 @@ func (e *Engine) CheckpointSync(ctx context.Context, syncToken string) error {
 	if err != nil {
 		return err
 	}
-	updated := v3.SyncRunRecord_builder{
-		SyncId:       existing.GetSyncId(),
-		Type:         existing.GetType(),
-		ParentSyncId: existing.GetParentSyncId(),
-		StartedAt:    existing.GetStartedAt(),
-		EndedAt:      existing.GetEndedAt(),
-		SyncToken:    syncToken,
-	}.Build()
+	// Clone-and-mutate so lifecycle updates preserve every metadata field,
+	// including fields introduced after this code was written.
+	updated := proto.Clone(existing).(*v3.SyncRunRecord)
+	updated.SetSyncToken(syncToken)
 	return e.PutSyncRunRecord(ctx, updated)
 }
 
@@ -336,14 +333,9 @@ func (e *Engine) endSyncFinalize(ctx context.Context, existing *v3.SyncRunRecord
 			return fmt.Errorf("EndSync: repair grant digests: %w", err)
 		}
 	}
-	updated := v3.SyncRunRecord_builder{
-		SyncId:       existing.GetSyncId(),
-		Type:         existing.GetType(),
-		ParentSyncId: existing.GetParentSyncId(),
-		StartedAt:    existing.GetStartedAt(),
-		EndedAt:      timestamppb.Now(),
-		SyncToken:    existing.GetSyncToken(),
-	}.Build()
+	// Preserve all provenance fields while adding the lifecycle stamp.
+	updated := proto.Clone(existing).(*v3.SyncRunRecord)
+	updated.SetEndedAt(timestamppb.Now())
 	if e.test.endSyncStampHook != nil {
 		if err := e.test.endSyncStampHook(); err != nil {
 			return err

--- a/pkg/dotc1z/engine/pebble/adapter_sync_meta.go
+++ b/pkg/dotc1z/engine/pebble/adapter_sync_meta.go
@@ -26,6 +26,8 @@ type pebbleSyncMeta struct {
 	e *Engine
 }
 
+var _ c1zstore.IngestInvariantVerificationWriter = pebbleSyncMeta{}
+
 // MarkSyncSupportsDiff sets supports_diff = true on the named sync's
 // run record. Used by pkg/sync.parallelSyncer after graph
 // construction to signal that the sync has SQL-layer grant metadata
@@ -47,6 +49,49 @@ func (s pebbleSyncMeta) MarkSyncSupportsDiff(ctx context.Context, syncID string)
 	r.SetSupportsDiff(true)
 	if err := s.e.PutSyncRunRecord(ctx, r); err != nil {
 		return fmt.Errorf("MarkSyncSupportsDiff: put: %w", err)
+	}
+	return nil
+}
+
+// MarkIngestInvariantsVerified persists the successful invariant pass on the
+// sync-run record. Rewriting the same marker after crash/resume is idempotent.
+func (s pebbleSyncMeta) MarkIngestInvariantsVerified(
+	ctx context.Context,
+	syncID string,
+	verification c1zstore.IngestInvariantVerification,
+) error {
+	if syncID == "" {
+		return errors.New("MarkIngestInvariantsVerified: empty syncID")
+	}
+	if !verification.IsVerified() {
+		return errors.New("MarkIngestInvariantsVerified: incomplete verification")
+	}
+	r, err := s.e.GetSyncRunRecord(ctx, syncID)
+	if err != nil {
+		return c1zstore.AdaptNotFound(fmt.Errorf("MarkIngestInvariantsVerified: get: %w", err), pebble.ErrNotFound)
+	}
+	r.SetIngestInvariantGeneration(verification.Generation)
+	r.SetIngestInvariantCoverage(append([]string(nil), verification.Coverage...))
+	r.SetIngestInvariantMode(string(verification.Mode))
+	if err := s.e.PutSyncRunRecord(ctx, r); err != nil {
+		return fmt.Errorf("MarkIngestInvariantsVerified: put: %w", err)
+	}
+	return nil
+}
+
+func (s pebbleSyncMeta) ClearIngestInvariantVerification(ctx context.Context, syncID string) error {
+	if syncID == "" {
+		return errors.New("ClearIngestInvariantVerification: empty syncID")
+	}
+	r, err := s.e.GetSyncRunRecord(ctx, syncID)
+	if err != nil {
+		return c1zstore.AdaptNotFound(fmt.Errorf("ClearIngestInvariantVerification: get: %w", err), pebble.ErrNotFound)
+	}
+	r.SetIngestInvariantGeneration("")
+	r.SetIngestInvariantCoverage(nil)
+	r.SetIngestInvariantMode("")
+	if err := s.e.PutSyncRunRecord(ctx, r); err != nil {
+		return fmt.Errorf("ClearIngestInvariantVerification: put: %w", err)
 	}
 	return nil
 }
@@ -114,13 +159,22 @@ func syncRunRecordToExported(r *v3.SyncRunRecord) *c1zstore.SyncRun {
 	if r == nil {
 		return nil
 	}
+	verification := c1zstore.IngestInvariantVerification{
+		Generation: r.GetIngestInvariantGeneration(),
+		Coverage:   append([]string(nil), r.GetIngestInvariantCoverage()...),
+		Mode:       c1zstore.IngestInvariantVerificationMode(r.GetIngestInvariantMode()),
+	}
+	if !verification.IsVerified() {
+		verification = c1zstore.IngestInvariantVerification{}
+	}
 	out := &c1zstore.SyncRun{
-		ID:           r.GetSyncId(),
-		Type:         syncTypeV3ToConnectorstore(r.GetType()),
-		SyncToken:    r.GetSyncToken(),
-		ParentSyncID: r.GetParentSyncId(),
-		LinkedSyncID: r.GetLinkedSyncId(),
-		SupportsDiff: r.GetSupportsDiff(),
+		ID:                          r.GetSyncId(),
+		Type:                        syncTypeV3ToConnectorstore(r.GetType()),
+		SyncToken:                   r.GetSyncToken(),
+		ParentSyncID:                r.GetParentSyncId(),
+		LinkedSyncID:                r.GetLinkedSyncId(),
+		SupportsDiff:                r.GetSupportsDiff(),
+		IngestInvariantVerification: verification,
 	}
 	if t := r.GetStartedAt(); t != nil {
 		tt := t.AsTime()
@@ -148,13 +202,22 @@ func syncRunRecordToExported(r *v3.SyncRunRecord) *c1zstore.SyncRun {
 func (e *Engine) sortedSyncRuns(ctx context.Context) ([]c1zstore.SyncRun, error) {
 	var out []c1zstore.SyncRun
 	err := e.IterateAllSyncRuns(ctx, func(r *v3.SyncRunRecord) bool {
+		verification := c1zstore.IngestInvariantVerification{
+			Generation: r.GetIngestInvariantGeneration(),
+			Coverage:   append([]string(nil), r.GetIngestInvariantCoverage()...),
+			Mode:       c1zstore.IngestInvariantVerificationMode(r.GetIngestInvariantMode()),
+		}
+		if !verification.IsVerified() {
+			verification = c1zstore.IngestInvariantVerification{}
+		}
 		cand := c1zstore.SyncRun{
-			ID:           r.GetSyncId(),
-			Type:         syncTypeV3ToConnectorstore(r.GetType()),
-			SyncToken:    r.GetSyncToken(),
-			ParentSyncID: r.GetParentSyncId(),
-			SupportsDiff: r.GetSupportsDiff(),
-			LinkedSyncID: r.GetLinkedSyncId(),
+			ID:                          r.GetSyncId(),
+			Type:                        syncTypeV3ToConnectorstore(r.GetType()),
+			SyncToken:                   r.GetSyncToken(),
+			ParentSyncID:                r.GetParentSyncId(),
+			SupportsDiff:                r.GetSupportsDiff(),
+			LinkedSyncID:                r.GetLinkedSyncId(),
+			IngestInvariantVerification: verification,
 		}
 		if t := r.GetStartedAt(); t != nil {
 			tt := t.AsTime()

--- a/pkg/dotc1z/engine/pebble/adapter_sync_meta.go
+++ b/pkg/dotc1z/engine/pebble/adapter_sync_meta.go
@@ -70,6 +70,12 @@ func (s pebbleSyncMeta) MarkIngestInvariantsVerified(
 	if err != nil {
 		return c1zstore.AdaptNotFound(fmt.Errorf("MarkIngestInvariantsVerified: get: %w", err), pebble.ErrNotFound)
 	}
+	// The marker is only ever valid on a sealed sync: an unfinished sync's
+	// data is still mutable, so a verified-but-unfinished record would be a
+	// lie the moment the next write lands. Callers mark AFTER EndSync.
+	if r.GetEndedAt() == nil {
+		return fmt.Errorf("MarkIngestInvariantsVerified: sync %s is not finished", syncID)
+	}
 	r.SetIngestInvariantGeneration(verification.Generation)
 	r.SetIngestInvariantCoverage(append([]string(nil), verification.Coverage...))
 	r.SetIngestInvariantMode(string(verification.Mode))

--- a/pkg/dotc1z/pebble_store.go
+++ b/pkg/dotc1z/pebble_store.go
@@ -16,6 +16,7 @@ import (
 
 	c1zv3 "github.com/conductorone/baton-sdk/pb/c1/c1z/v3"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	reader_v2 "github.com/conductorone/baton-sdk/pb/c1/reader/v2"
 	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
@@ -273,6 +274,66 @@ func (f pebbleStoreFileOps) GenerateSyncDiff(ctx context.Context, baseSyncID, ap
 		return "", err
 	}
 	return diffSyncID, f.store.markDirty(nil)
+}
+
+// SyncMeta overrides the Adapter-level SyncMeta so the MUTATING
+// metadata methods flip the store's dirty bit — Close only saves the
+// envelope when dirty, so a standalone metadata stamp on a reopened
+// c1z (e.g. MarkIngestInvariantsVerified after the engine sealed)
+// would otherwise be silently dropped with the discarded temp dir.
+// Same pattern as Grants() and FileOps(); the production Sync() path
+// never noticed because EndSync sets dirty right before the stamps.
+func (s *pebbleStore) SyncMeta() c1zstore.SyncMeta {
+	return pebbleStoreSyncMeta{inner: s.Engine.SyncMeta(), store: s}
+}
+
+type pebbleStoreSyncMeta struct {
+	inner c1zstore.SyncMeta
+	store *pebbleStore
+}
+
+// The engine-level SyncMeta implements the verification writer; the
+// dirty-marking wrapper must keep exposing it.
+var _ c1zstore.IngestInvariantVerificationWriter = pebbleStoreSyncMeta{}
+
+func (m pebbleStoreSyncMeta) MarkSyncSupportsDiff(ctx context.Context, syncID string) error {
+	return m.store.markDirty(m.inner.MarkSyncSupportsDiff(ctx, syncID))
+}
+
+func (m pebbleStoreSyncMeta) MarkIngestInvariantsVerified(ctx context.Context, syncID string, verification c1zstore.IngestInvariantVerification) error {
+	w, ok := m.inner.(c1zstore.IngestInvariantVerificationWriter)
+	if !ok {
+		return errors.New("pebble sync meta: engine SyncMeta does not implement IngestInvariantVerificationWriter")
+	}
+	return m.store.markDirty(w.MarkIngestInvariantsVerified(ctx, syncID, verification))
+}
+
+func (m pebbleStoreSyncMeta) ClearIngestInvariantVerification(ctx context.Context, syncID string) error {
+	w, ok := m.inner.(c1zstore.IngestInvariantVerificationWriter)
+	if !ok {
+		return errors.New("pebble sync meta: engine SyncMeta does not implement IngestInvariantVerificationWriter")
+	}
+	return m.store.markDirty(w.ClearIngestInvariantVerification(ctx, syncID))
+}
+
+func (m pebbleStoreSyncMeta) RecalculateStats(ctx context.Context, syncID string) error {
+	return m.store.markDirty(m.inner.RecalculateStats(ctx, syncID))
+}
+
+func (m pebbleStoreSyncMeta) LatestFullSync(ctx context.Context) (*c1zstore.SyncRun, error) {
+	return m.inner.LatestFullSync(ctx)
+}
+
+func (m pebbleStoreSyncMeta) LatestFinishedSyncOfAnyType(ctx context.Context) (*c1zstore.SyncRun, error) {
+	return m.inner.LatestFinishedSyncOfAnyType(ctx)
+}
+
+func (m pebbleStoreSyncMeta) Stats(ctx context.Context, syncType connectorstore.SyncType, syncID string) (map[string]int64, error) {
+	return m.inner.Stats(ctx, syncType, syncID)
+}
+
+func (m pebbleStoreSyncMeta) StatsV2(ctx context.Context, syncType connectorstore.SyncType, syncID string) (*reader_v2.SyncStats, error) {
+	return m.inner.StatsV2(ctx, syncType, syncID)
 }
 
 // Metadata extends the embedded Adapter's Metadata with this store's

--- a/pkg/dotc1z/pebble_store_dirty_test.go
+++ b/pkg/dotc1z/pebble_store_dirty_test.go
@@ -40,3 +40,52 @@ func TestPebbleStoreGrantsStoreExpandedGrantsMarksDirty(t *testing.T) {
 	require.NoError(t, err, "clone stat: %v", err)
 	require.NotZero(t, fi.Size(), "c1z size = 0; pebble store didn't flush after StoreExpandedGrants")
 }
+
+// TestPebbleStoreSyncMetaMarksDirty pins the same dirty-flag escape for
+// the SyncMeta mutators: a standalone metadata stamp on a REOPENED c1z
+// (nothing else set the dirty flag in the session) must survive Close.
+// Before pebbleStore overrode SyncMeta(), MarkIngestInvariantsVerified
+// wrote to the engine but Close skipped the envelope save and the
+// marker vanished with the temp dir.
+func TestPebbleStoreSyncMetaMarksDirty(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "meta-dirty.c1z")
+
+	store, err := NewStore(ctx, path, WithEngine(c1zstore.EnginePebble))
+	require.NoError(t, err)
+	syncID, err := store.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+
+	verification := c1zstore.IngestInvariantVerification{
+		Generation: "test-generation",
+		Coverage:   []string{"I5"},
+		Mode:       c1zstore.IngestInvariantVerificationModeConnector,
+	}
+	writer, ok := store.SyncMeta().(c1zstore.IngestInvariantVerificationWriter)
+	require.True(t, ok)
+	// The marker is only writable on a sealed sync.
+	require.Error(t, writer.MarkIngestInvariantsVerified(ctx, syncID, verification),
+		"marking an unfinished sync must be refused")
+	require.NoError(t, store.EndSync(ctx))
+	require.NoError(t, store.Close(ctx))
+
+	// Reopen CLEAN (no sync started, nothing dirties the store) and stamp
+	// only the marker.
+	store, err = NewStore(ctx, path, WithEngine(c1zstore.EnginePebble))
+	require.NoError(t, err)
+	writer, ok = store.SyncMeta().(c1zstore.IngestInvariantVerificationWriter)
+	require.True(t, ok)
+	require.NoError(t, writer.MarkIngestInvariantsVerified(ctx, syncID, verification))
+	require.NoError(t, store.Close(ctx))
+
+	// The stamp-only session must have saved the envelope.
+	store, err = NewStore(ctx, path, WithEngine(c1zstore.EnginePebble), WithReadOnly(true))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, store.Close(ctx)) }()
+	run, err := store.SyncMeta().LatestFinishedSyncOfAnyType(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, run)
+	require.Equal(t, verification, run.IngestInvariantVerification,
+		"a standalone SyncMeta stamp must survive close/reopen")
+}

--- a/pkg/dotc1z/store_conformance_test.go
+++ b/pkg/dotc1z/store_conformance_test.go
@@ -258,8 +258,12 @@ func testIngestInvariantVerificationMigratesAndPersists(t *testing.T) {
 	}
 	verificationWriter, ok := c1f.SyncMeta().(c1zstore.IngestInvariantVerificationWriter)
 	require.True(t, ok)
-	require.NoError(t, verificationWriter.MarkIngestInvariantsVerified(ctx, syncID, want))
+	// The marker is only writable on a sealed sync: marking the open sync
+	// must be refused, and succeed once EndSync stamps ended_at.
+	require.Error(t, verificationWriter.MarkIngestInvariantsVerified(ctx, syncID, want),
+		"marking an unfinished sync must be refused")
 	require.NoError(t, c1f.EndSync(ctx))
+	require.NoError(t, verificationWriter.MarkIngestInvariantsVerified(ctx, syncID, want))
 	require.NoError(t, c1f.Close(ctx))
 
 	c1f, err = NewC1ZFile(ctx, path)

--- a/pkg/dotc1z/store_conformance_test.go
+++ b/pkg/dotc1z/store_conformance_test.go
@@ -27,6 +27,7 @@ func TestC1ZStoreConformance(t *testing.T) {
 	t.Run("Grants/ListWithAnnotations yields nil for non-expandable", testListWithAnnotationsNilForNonExpandable)
 	t.Run("Grants/ListWithAnnotations yields annotation for expandable", testListWithAnnotationsAnnotationPopulated)
 	t.Run("SyncMeta/MarkSyncSupportsDiff persists across reopen", testMarkSyncSupportsDiffPersists)
+	t.Run("SyncMeta/invariant verification migrates and persists", testIngestInvariantVerificationMigratesAndPersists)
 	t.Run("SyncMeta/LatestFullSync returns nil when no runs", testLatestFullSyncEmptyReturnsNil)
 	t.Run("SyncMeta/LatestFullSync ignores in-progress and non-full", testLatestFullSyncIgnoresInProgressAndPartial)
 	t.Run("SyncMeta/LatestFinishedSyncOfAnyType includes diff types", testLatestFinishedSyncOfAnyTypeIncludesDiff)
@@ -222,6 +223,52 @@ func testMarkSyncSupportsDiffPersists(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, run)
 	require.True(t, run.SupportsDiff)
+}
+
+func testIngestInvariantVerificationMigratesAndPersists(t *testing.T) {
+	ctx := context.Background()
+	tmp, err := os.CreateTemp("", "test-invariant-verification-*.c1z")
+	require.NoError(t, err)
+	require.NoError(t, tmp.Close())
+	path := tmp.Name()
+	defer func() { _ = os.Remove(path) }()
+
+	c1f, err := NewC1ZFile(ctx, path)
+	require.NoError(t, err)
+	// Simulate a file created before verification metadata existed. Reopen
+	// must add every column before the marker can be written.
+	for _, column := range []string{
+		"ingest_invariant_generation",
+		"ingest_invariant_coverage",
+		"ingest_invariant_mode",
+	} {
+		_, err = c1f.db.ExecContext(ctx, "ALTER TABLE v1_sync_runs DROP COLUMN "+column)
+		require.NoError(t, err)
+	}
+	require.NoError(t, c1f.Close(ctx))
+
+	c1f, err = NewC1ZFile(ctx, path)
+	require.NoError(t, err)
+	syncID, err := c1f.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	want := c1zstore.IngestInvariantVerification{
+		Generation: "test-generation",
+		Coverage:   []string{"I5"},
+		Mode:       c1zstore.IngestInvariantVerificationModeConnector,
+	}
+	verificationWriter, ok := c1f.SyncMeta().(c1zstore.IngestInvariantVerificationWriter)
+	require.True(t, ok)
+	require.NoError(t, verificationWriter.MarkIngestInvariantsVerified(ctx, syncID, want))
+	require.NoError(t, c1f.EndSync(ctx))
+	require.NoError(t, c1f.Close(ctx))
+
+	c1f, err = NewC1ZFile(ctx, path)
+	require.NoError(t, err)
+	defer func() { _ = c1f.Close(ctx) }()
+	run, err := c1f.SyncMeta().LatestFullSync(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, run)
+	require.Equal(t, want, run.IngestInvariantVerification)
 }
 
 func testLatestFullSyncEmptyReturnsNil(t *testing.T) {

--- a/pkg/dotc1z/sync_runs.go
+++ b/pkg/dotc1z/sync_runs.go
@@ -924,6 +924,10 @@ func (c *C1File) markIngestInvariantsVerified(
 		"ingest_invariant_mode":       string(verification.Mode),
 	})
 	q = q.Where(goqu.C("sync_id").Eq(syncID))
+	// The marker is only ever valid on a sealed sync: an unfinished sync's
+	// data is still mutable, so a verified-but-unfinished row would be a
+	// lie the moment the next write lands. Callers mark AFTER EndSync.
+	q = q.Where(goqu.C("ended_at").IsNotNull())
 
 	query, args, err := q.ToSQL()
 	if err != nil {
@@ -938,7 +942,8 @@ func (c *C1File) markIngestInvariantsVerified(
 		return err
 	}
 	if rows == 0 {
-		return c1zstore.AdaptNotFound(sql.ErrNoRows)
+		return status.Errorf(codes.FailedPrecondition,
+			"mark ingest invariants verified: sync %s not found or not finished", syncID)
 	}
 	c.dbUpdated = true
 	c.invalidateCachedViewSyncRun()

--- a/pkg/dotc1z/sync_runs.go
+++ b/pkg/dotc1z/sync_runs.go
@@ -49,7 +49,10 @@ create table if not exists %s (
     linked_sync_id text not null default '',
     supports_diff integer not null default 0,
     grants_backfilled integer not null default 0,
-		stats text
+		stats text,
+    ingest_invariant_generation text not null default '',
+    ingest_invariant_coverage text not null default '',
+    ingest_invariant_mode text not null default ''
 );
 create unique index if not exists %s on %s (sync_id);`
 
@@ -148,7 +151,50 @@ func (r *syncRunsTable) Migrations(ctx context.Context, db *goqu.Database) (bool
 		migrated = true
 	}
 
+	for _, column := range []struct {
+		name string
+		ddl  string
+	}{
+		{name: "ingest_invariant_generation", ddl: "text not null default ''"},
+		{name: "ingest_invariant_coverage", ddl: "text not null default ''"},
+		{name: "ingest_invariant_mode", ddl: "text not null default ''"},
+	} {
+		_, err = db.ExecContext(ctx, fmt.Sprintf("alter table %s add column %s %s", r.Name(), column.name, column.ddl))
+		if err != nil {
+			if !isAlreadyExistsError(err) {
+				return false, err
+			}
+		} else {
+			migrated = true
+		}
+	}
+
 	return migrated, nil
+}
+
+func parseIngestInvariantVerification(
+	generation string,
+	coverageJSON string,
+	mode string,
+) c1zstore.IngestInvariantVerification {
+	if generation == "" {
+		return c1zstore.IngestInvariantVerification{}
+	}
+	var coverage []string
+	if err := json.Unmarshal([]byte(coverageJSON), &coverage); err != nil {
+		// Malformed provenance must fail closed: expose it as unverified so a
+		// future compaction consumer cannot trust a partial/corrupt marker.
+		return c1zstore.IngestInvariantVerification{}
+	}
+	verification := c1zstore.IngestInvariantVerification{
+		Generation: generation,
+		Coverage:   coverage,
+		Mode:       c1zstore.IngestInvariantVerificationMode(mode),
+	}
+	if !verification.IsVerified() {
+		return c1zstore.IngestInvariantVerification{}
+	}
+	return verification
 }
 
 // getCachedViewSyncRun returns the cached sync run for read operations.
@@ -202,7 +248,12 @@ func (c *C1File) getLatestUnfinishedSync(ctx context.Context, syncType connector
 	oneWeekAgo := time.Now().AddDate(0, 0, -7)
 	ret := &c1zstore.SyncRun{}
 	q := c.db.From(syncRuns.Name())
-	q = q.Select("sync_id", "started_at", "ended_at", "sync_token", "sync_type", "parent_sync_id", "linked_sync_id", "supports_diff", "stats")
+	q = q.Select(
+		"sync_id", "started_at", "ended_at", "sync_token", "sync_type",
+		"parent_sync_id", "linked_sync_id", "supports_diff",
+		"ingest_invariant_generation", "ingest_invariant_coverage", "ingest_invariant_mode",
+		"stats",
+	)
 	q = q.Where(goqu.C("ended_at").IsNull())
 	q = q.Where(goqu.C("started_at").Gte(oneWeekAgo))
 	q = q.Order(goqu.C("started_at").Desc())
@@ -218,7 +269,12 @@ func (c *C1File) getLatestUnfinishedSync(ctx context.Context, syncType connector
 
 	row := c.db.QueryRowContext(ctx, query, args...)
 	statsBytes := &[]byte{}
-	err = row.Scan(&ret.ID, &ret.StartedAt, &ret.EndedAt, &ret.SyncToken, &ret.Type, &ret.ParentSyncID, &ret.LinkedSyncID, &ret.SupportsDiff, &statsBytes)
+	var generation, coverageJSON, mode string
+	err = row.Scan(
+		&ret.ID, &ret.StartedAt, &ret.EndedAt, &ret.SyncToken, &ret.Type,
+		&ret.ParentSyncID, &ret.LinkedSyncID, &ret.SupportsDiff,
+		&generation, &coverageJSON, &mode, &statsBytes,
+	)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
@@ -227,6 +283,7 @@ func (c *C1File) getLatestUnfinishedSync(ctx context.Context, syncType connector
 	}
 
 	ret.Stats = parseStats(ctx, statsBytes)
+	ret.IngestInvariantVerification = parseIngestInvariantVerification(generation, coverageJSON, mode)
 
 	return ret, nil
 }
@@ -248,7 +305,12 @@ func (c *C1File) getFinishedSync(ctx context.Context, offset uint, syncType conn
 
 	ret := &c1zstore.SyncRun{}
 	q := c.db.From(syncRuns.Name())
-	q = q.Select("sync_id", "started_at", "ended_at", "sync_token", "sync_type", "parent_sync_id", "linked_sync_id", "supports_diff", "stats")
+	q = q.Select(
+		"sync_id", "started_at", "ended_at", "sync_token", "sync_type",
+		"parent_sync_id", "linked_sync_id", "supports_diff",
+		"ingest_invariant_generation", "ingest_invariant_coverage", "ingest_invariant_mode",
+		"stats",
+	)
 	q = q.Where(goqu.C("ended_at").IsNotNull())
 	if syncType != connectorstore.SyncTypeAny {
 		q = q.Where(goqu.C("sync_type").Eq(syncType))
@@ -271,7 +333,12 @@ func (c *C1File) getFinishedSync(ctx context.Context, offset uint, syncType conn
 
 	row := c.db.QueryRowContext(ctx, query, args...)
 	statsBytes := &[]byte{}
-	err = row.Scan(&ret.ID, &ret.StartedAt, &ret.EndedAt, &ret.SyncToken, &ret.Type, &ret.ParentSyncID, &ret.LinkedSyncID, &ret.SupportsDiff, &statsBytes)
+	var generation, coverageJSON, mode string
+	err = row.Scan(
+		&ret.ID, &ret.StartedAt, &ret.EndedAt, &ret.SyncToken, &ret.Type,
+		&ret.ParentSyncID, &ret.LinkedSyncID, &ret.SupportsDiff,
+		&generation, &coverageJSON, &mode, &statsBytes,
+	)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
@@ -280,6 +347,7 @@ func (c *C1File) getFinishedSync(ctx context.Context, offset uint, syncType conn
 	}
 
 	ret.Stats = parseStats(ctx, statsBytes)
+	ret.IngestInvariantVerification = parseIngestInvariantVerification(generation, coverageJSON, mode)
 
 	return ret, nil
 }
@@ -312,7 +380,12 @@ func (c *C1File) ListSyncRuns(ctx context.Context, pageToken string, pageSize ui
 	}
 
 	q := c.db.From(syncRuns.Name()).Prepared(true)
-	q = q.Select("id", "sync_id", "started_at", "ended_at", "sync_token", "sync_type", "parent_sync_id", "linked_sync_id", "supports_diff", "stats")
+	q = q.Select(
+		"id", "sync_id", "started_at", "ended_at", "sync_token", "sync_type",
+		"parent_sync_id", "linked_sync_id", "supports_diff",
+		"ingest_invariant_generation", "ingest_invariant_coverage", "ingest_invariant_mode",
+		"stats",
+	)
 
 	if pageToken != "" {
 		q = q.Where(goqu.C("id").Gte(pageToken))
@@ -348,12 +421,18 @@ func (c *C1File) ListSyncRuns(ctx context.Context, pageToken string, pageSize ui
 		statsBytes := &[]byte{}
 		rowId := 0
 		data := &c1zstore.SyncRun{}
-		err := rows.Scan(&rowId, &data.ID, &data.StartedAt, &data.EndedAt, &data.SyncToken, &data.Type, &data.ParentSyncID, &data.LinkedSyncID, &data.SupportsDiff, &statsBytes)
+		var generation, coverageJSON, mode string
+		err := rows.Scan(
+			&rowId, &data.ID, &data.StartedAt, &data.EndedAt, &data.SyncToken, &data.Type,
+			&data.ParentSyncID, &data.LinkedSyncID, &data.SupportsDiff,
+			&generation, &coverageJSON, &mode, &statsBytes,
+		)
 		if err != nil {
 			return nil, "", err
 		}
 
 		data.Stats = parseStats(ctx, statsBytes)
+		data.IngestInvariantVerification = parseIngestInvariantVerification(generation, coverageJSON, mode)
 		lastRow = rowId
 		ret = append(ret, data)
 	}
@@ -445,7 +524,12 @@ func (c *C1File) getSync(ctx context.Context, syncID string) (*c1zstore.SyncRun,
 	ret := &c1zstore.SyncRun{}
 
 	q := c.db.From(syncRuns.Name())
-	q = q.Select("sync_id", "started_at", "ended_at", "sync_token", "sync_type", "parent_sync_id", "linked_sync_id", "supports_diff", "stats")
+	q = q.Select(
+		"sync_id", "started_at", "ended_at", "sync_token", "sync_type",
+		"parent_sync_id", "linked_sync_id", "supports_diff",
+		"ingest_invariant_generation", "ingest_invariant_coverage", "ingest_invariant_mode",
+		"stats",
+	)
 	q = q.Where(goqu.C("sync_id").Eq(syncID))
 
 	query, args, err := q.ToSQL()
@@ -454,12 +538,18 @@ func (c *C1File) getSync(ctx context.Context, syncID string) (*c1zstore.SyncRun,
 	}
 	row := c.db.QueryRowContext(ctx, query, args...)
 	var statsBytes *[]byte
-	err = row.Scan(&ret.ID, &ret.StartedAt, &ret.EndedAt, &ret.SyncToken, &ret.Type, &ret.ParentSyncID, &ret.LinkedSyncID, &ret.SupportsDiff, &statsBytes)
+	var generation, coverageJSON, mode string
+	err = row.Scan(
+		&ret.ID, &ret.StartedAt, &ret.EndedAt, &ret.SyncToken, &ret.Type,
+		&ret.ParentSyncID, &ret.LinkedSyncID, &ret.SupportsDiff,
+		&generation, &coverageJSON, &mode, &statsBytes,
+	)
 	if err != nil {
 		return nil, c1zstore.AdaptNotFound(err)
 	}
 
 	ret.Stats = parseStats(ctx, statsBytes)
+	ret.IngestInvariantVerification = parseIngestInvariantVerification(generation, coverageJSON, mode)
 
 	return ret, nil
 }
@@ -805,6 +895,87 @@ func (c *C1File) SetSupportsDiff(ctx context.Context, syncID string) error {
 	}
 	c.dbUpdated = true
 
+	return nil
+}
+
+func (c *C1File) markIngestInvariantsVerified(
+	ctx context.Context,
+	syncID string,
+	verification c1zstore.IngestInvariantVerification,
+) error {
+	if c.readOnly {
+		return ErrReadOnly
+	}
+	if syncID == "" {
+		return status.Error(codes.InvalidArgument, "sync id is required")
+	}
+	if !verification.IsVerified() {
+		return status.Error(codes.InvalidArgument, "ingest invariant verification is incomplete")
+	}
+	coverage, err := json.Marshal(verification.Coverage)
+	if err != nil {
+		return fmt.Errorf("marshal ingest invariant coverage: %w", err)
+	}
+
+	q := c.db.Update(syncRuns.Name())
+	q = q.Set(goqu.Record{
+		"ingest_invariant_generation": verification.Generation,
+		"ingest_invariant_coverage":   string(coverage),
+		"ingest_invariant_mode":       string(verification.Mode),
+	})
+	q = q.Where(goqu.C("sync_id").Eq(syncID))
+
+	query, args, err := q.ToSQL()
+	if err != nil {
+		return err
+	}
+	result, err := c.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return c1zstore.AdaptNotFound(sql.ErrNoRows)
+	}
+	c.dbUpdated = true
+	c.invalidateCachedViewSyncRun()
+	return nil
+}
+
+func (c *C1File) clearIngestInvariantVerification(ctx context.Context, syncID string) error {
+	if c.readOnly {
+		return ErrReadOnly
+	}
+	if syncID == "" {
+		return status.Error(codes.InvalidArgument, "sync id is required")
+	}
+	q := c.db.Update(syncRuns.Name())
+	q = q.Set(goqu.Record{
+		"ingest_invariant_generation": "",
+		"ingest_invariant_coverage":   "",
+		"ingest_invariant_mode":       "",
+	})
+	q = q.Where(goqu.C("sync_id").Eq(syncID))
+	query, args, err := q.ToSQL()
+	if err != nil {
+		return err
+	}
+	result, err := c.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return c1zstore.AdaptNotFound(sql.ErrNoRows)
+	}
+	c.dbUpdated = true
+	c.invalidateCachedViewSyncRun()
 	return nil
 }
 

--- a/pkg/dotc1z/to_pebble.go
+++ b/pkg/dotc1z/to_pebble.go
@@ -246,14 +246,16 @@ func (c *C1File) ToPebble(ctx context.Context, outPath string, syncID string, op
 	if err = dest.EndSync(ctx); err != nil {
 		return nil, fmt.Errorf("to-pebble: end destination sync: %w", err)
 	}
-	if sync.EndedAt != nil || sync.IsVerified() {
+	if sync.EndedAt != nil {
 		rec, err := destEng.GetSyncRunRecord(ctx, destSyncID)
 		if err != nil {
 			return nil, fmt.Errorf("to-pebble: load destination sync metadata: %w", err)
 		}
-		if sync.EndedAt != nil {
-			rec.SetEndedAt(timestamppb.New(*sync.EndedAt))
-		}
+		rec.SetEndedAt(timestamppb.New(*sync.EndedAt))
+		// Verification provenance only rides along with a FINISHED source:
+		// a marker on an unfinished source (impossible through the writer
+		// API, but representable in a hand-edited file) must not convert
+		// into a sealed, verified destination.
 		if sync.IsVerified() {
 			rec.SetIngestInvariantGeneration(sync.Generation)
 			rec.SetIngestInvariantCoverage(append([]string(nil), sync.Coverage...))

--- a/pkg/dotc1z/to_pebble.go
+++ b/pkg/dotc1z/to_pebble.go
@@ -246,14 +246,21 @@ func (c *C1File) ToPebble(ctx context.Context, outPath string, syncID string, op
 	if err = dest.EndSync(ctx); err != nil {
 		return nil, fmt.Errorf("to-pebble: end destination sync: %w", err)
 	}
-	if sync.EndedAt != nil {
+	if sync.EndedAt != nil || sync.IsVerified() {
 		rec, err := destEng.GetSyncRunRecord(ctx, destSyncID)
 		if err != nil {
 			return nil, fmt.Errorf("to-pebble: load destination sync metadata: %w", err)
 		}
-		rec.SetEndedAt(timestamppb.New(*sync.EndedAt))
+		if sync.EndedAt != nil {
+			rec.SetEndedAt(timestamppb.New(*sync.EndedAt))
+		}
+		if sync.IsVerified() {
+			rec.SetIngestInvariantGeneration(sync.Generation)
+			rec.SetIngestInvariantCoverage(append([]string(nil), sync.Coverage...))
+			rec.SetIngestInvariantMode(string(sync.Mode))
+		}
 		if err := destEng.PutSyncRunRecord(ctx, rec); err != nil {
-			return nil, fmt.Errorf("to-pebble: preserve source ended_at: %w", err)
+			return nil, fmt.Errorf("to-pebble: preserve source sync metadata: %w", err)
 		}
 	}
 	endSyncDur := time.Since(endSyncStart)

--- a/pkg/dotc1z/to_pebble_test.go
+++ b/pkg/dotc1z/to_pebble_test.go
@@ -67,6 +67,14 @@ func TestToPebbleRoundTrip(t *testing.T) {
 	assetData := []byte("hello-asset-bytes")
 	require.NoError(t, src.PutAsset(ctx, v2.AssetRef_builder{Id: "asset-1"}.Build(), "text/plain", assetData))
 
+	wantVerification := c1zstore.IngestInvariantVerification{
+		Generation: "test-generation",
+		Coverage:   []string{"I5"},
+		Mode:       c1zstore.IngestInvariantVerificationModeConnector,
+	}
+	verificationWriter, ok := src.SyncMeta().(c1zstore.IngestInvariantVerificationWriter)
+	require.True(t, ok)
+	require.NoError(t, verificationWriter.MarkIngestInvariantsVerified(ctx, syncID, wantVerification))
 	require.NoError(t, src.EndSync(ctx))
 
 	// Convert the finished sync into a new Pebble .c1z.
@@ -88,6 +96,10 @@ func TestToPebbleRoundTrip(t *testing.T) {
 	dst, err := dotc1z.NewStore(ctx, outPath, dotc1z.WithEngine(c1zstore.EnginePebble), dotc1z.WithTmpDir(dir))
 	require.NoError(t, err)
 	defer func() { require.NoError(t, dst.Close(ctx)) }()
+	dstRun, err := dst.SyncMeta().LatestFullSync(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, dstRun)
+	require.Equal(t, wantVerification, dstRun.IngestInvariantVerification)
 	require.NoError(t, dst.SetCurrentSync(ctx, stats.DestSyncID))
 
 	rtResp, err := dst.ListResourceTypes(ctx, v2.ResourceTypesServiceListResourceTypesRequest_builder{}.Build())

--- a/pkg/dotc1z/to_pebble_test.go
+++ b/pkg/dotc1z/to_pebble_test.go
@@ -74,8 +74,9 @@ func TestToPebbleRoundTrip(t *testing.T) {
 	}
 	verificationWriter, ok := src.SyncMeta().(c1zstore.IngestInvariantVerificationWriter)
 	require.True(t, ok)
-	require.NoError(t, verificationWriter.MarkIngestInvariantsVerified(ctx, syncID, wantVerification))
+	// Production ordering: the marker is only writable on a sealed sync.
 	require.NoError(t, src.EndSync(ctx))
+	require.NoError(t, verificationWriter.MarkIngestInvariantsVerified(ctx, syncID, wantVerification))
 
 	// Convert the finished sync into a new Pebble .c1z.
 	outPath := filepath.Join(dir, "out.c1z")

--- a/pkg/sync/ingest_invariant_verification_test.go
+++ b/pkg/sync/ingest_invariant_verification_test.go
@@ -2,6 +2,7 @@ package sync //nolint:revive,nolintlint // we can't change the package name for 
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"testing"
 
@@ -92,6 +93,9 @@ func TestIngestInvariantVerificationCoverageByEngine(t *testing.T) {
 			// preserve provenance while updating the sync token.
 			require.NoError(t, store.CheckpointSync(ctx, "after-verification"))
 			require.NoError(t, store.EndSync(ctx))
+			// Production ordering: the marker is persisted only after the
+			// seal, so a crash before EndSync leaves the sync unverified.
+			require.NoError(t, s.persistIngestInvariantVerification(ctx))
 			require.NoError(t, store.Close(ctx))
 
 			store, err = dotc1z.NewStore(ctx, path,
@@ -106,6 +110,86 @@ func TestIngestInvariantVerificationCoverageByEngine(t *testing.T) {
 			require.Equal(t, IngestInvariantGeneration, run.Generation)
 			require.Equal(t, tc.want, run.Coverage)
 			require.Equal(t, tc.wantMode, run.Mode)
+		})
+	}
+}
+
+// TestCrashBetweenInvariantPassAndSealLeavesNoMarker pins the marker's core
+// promise: verification provenance must never be readable on an UNFINISHED
+// sync. The seam between the invariant pass and the final checkpoint/EndSync
+// is a real crash window (haltStageInvariantsComplete). A marker persisted
+// before the seal would claim "verified" over a sync the resume machinery is
+// about to rewrite wholesale (resume pushes InitOp and re-collects), and any
+// consumer reading the crash image meanwhile would trust data that never
+// sealed. The marker must therefore be written only after EndSync: a crash
+// anywhere before the seal leaves the sync unverified (fail-closed).
+func TestCrashBetweenInvariantPassAndSealLeavesNoMarker(t *testing.T) {
+	for _, engine := range []c1zstore.Engine{c1zstore.EngineSQLite, c1zstore.EnginePebble} {
+		t.Run(string(engine), func(t *testing.T) {
+			ctx := context.Background()
+			tempDir := t.TempDir()
+			c1zPath := filepath.Join(tempDir, "marker-crash.c1z")
+
+			mc := newMockConnector()
+			mc.rtDB = append(mc.rtDB, userResourceType, groupResourceType)
+			user, err := rs.NewUserResource("user1", userResourceType, "user1", nil)
+			require.NoError(t, err)
+			mc.AddResource(ctx, user)
+			group, _, err := mc.AddGroup(ctx, "group1")
+			require.NoError(t, err)
+			mc.AddGroupMember(ctx, group, user)
+
+			errCrash := errors.New("injected crash after invariant pass, before seal")
+			crashed, err := NewSyncer(ctx, mc,
+				WithC1ZPath(c1zPath),
+				WithTmpDir(tempDir),
+				WithStorageEngine(engine),
+			)
+			require.NoError(t, err)
+			crashed.(*syncer).testIngestHaltHook = func(stage string) error {
+				if stage == haltStageInvariantsComplete {
+					return errCrash
+				}
+				return nil
+			}
+			require.ErrorIs(t, crashed.Sync(ctx), errCrash)
+			require.NoError(t, crashed.Close(ctx))
+
+			// The crash image: exactly one unfinished sync, and it must
+			// read as UNVERIFIED.
+			store, err := dotc1z.NewStore(ctx, c1zPath, dotc1z.WithEngine(engine), dotc1z.WithTmpDir(tempDir))
+			require.NoError(t, err)
+			lister, ok := store.(interface {
+				ListSyncRuns(ctx context.Context, pageToken string, pageSize uint32) ([]*c1zstore.SyncRun, string, error)
+			})
+			require.True(t, ok)
+			runs, _, err := lister.ListSyncRuns(ctx, "", 100)
+			require.NoError(t, err)
+			require.Len(t, runs, 1, "the crash image must hold exactly the one aborted sync")
+			require.Nil(t, runs[0].EndedAt, "the aborted sync must be unfinished")
+			require.False(t, runs[0].IsVerified(),
+				"an unfinished sync must never carry verification provenance")
+			require.NoError(t, store.Close(ctx))
+
+			// The resume seals the sync and the marker lands with it —
+			// the production mark point still fires end to end.
+			resumed, err := NewSyncer(ctx, mc,
+				WithC1ZPath(c1zPath),
+				WithTmpDir(tempDir),
+				WithStorageEngine(engine),
+			)
+			require.NoError(t, err)
+			require.NoError(t, resumed.Sync(ctx))
+			require.NoError(t, resumed.Close(ctx))
+
+			store, err = dotc1z.NewStore(ctx, c1zPath, dotc1z.WithEngine(engine), dotc1z.WithTmpDir(tempDir))
+			require.NoError(t, err)
+			defer func() { require.NoError(t, store.Close(ctx)) }()
+			run, err := store.SyncMeta().LatestFinishedSyncOfAnyType(ctx)
+			require.NoError(t, err)
+			require.NotNil(t, run, "the resumed sync must have sealed")
+			require.True(t, run.IsVerified(), "the sealed sync must carry the verification marker")
+			require.Equal(t, IngestInvariantGeneration, run.Generation)
 		})
 	}
 }

--- a/pkg/sync/ingest_invariant_verification_test.go
+++ b/pkg/sync/ingest_invariant_verification_test.go
@@ -7,7 +7,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
@@ -194,6 +196,96 @@ func TestCrashBetweenInvariantPassAndSealLeavesNoMarker(t *testing.T) {
 	}
 }
 
+// grantFailingConnector fails ListGrants on demand so a re-collection
+// can be aborted mid-flight, after resource/entitlement writes have
+// already mutated the store.
+type grantFailingConnector struct {
+	*mockConnector
+	failGrants bool
+}
+
+func (c *grantFailingConnector) ListGrants(ctx context.Context, in *v2.GrantsServiceListGrantsRequest, opts ...grpc.CallOption) (*v2.GrantsServiceListGrantsResponse, error) {
+	if c.failGrants {
+		return nil, errors.New("injected connector failure during re-collection")
+	}
+	return c.mockConnector.ListGrants(ctx, in, opts...)
+}
+
+// TestRebindingSealedSyncClearsStaleVerification pins the rebind
+// hazard: WithSyncID can bind an already-sealed, VERIFIED sync (the
+// compactor's expansion pass does exactly this; a reused syncer can
+// too) and re-collection then rewrites the data the marker vouched
+// for. The stale proof must be invalidated at sync start, before any
+// collection write — a run that aborts mid-collection must leave the
+// sync unverified, not verified-over-rewritten-data.
+func TestRebindingSealedSyncClearsStaleVerification(t *testing.T) {
+	for _, engine := range []c1zstore.Engine{c1zstore.EngineSQLite, c1zstore.EnginePebble} {
+		t.Run(string(engine), func(t *testing.T) {
+			ctx := context.Background()
+			tempDir := t.TempDir()
+			c1zPath := filepath.Join(tempDir, "rebind.c1z")
+
+			mc := newMockConnector()
+			mc.rtDB = append(mc.rtDB, userResourceType, groupResourceType)
+			user, err := rs.NewUserResource("user1", userResourceType, "user1", nil)
+			require.NoError(t, err)
+			mc.AddResource(ctx, user)
+			group, _, err := mc.AddGroup(ctx, "group1")
+			require.NoError(t, err)
+			mc.AddGroupMember(ctx, group, user)
+			conn := &grantFailingConnector{mockConnector: mc}
+
+			// Run 1: a clean sync seals and marks.
+			first, err := NewSyncer(ctx, conn,
+				WithC1ZPath(c1zPath), WithTmpDir(tempDir), WithStorageEngine(engine))
+			require.NoError(t, err)
+			require.NoError(t, first.Sync(ctx))
+			require.NoError(t, first.Close(ctx))
+
+			sealedID := func() string {
+				store, err := dotc1z.NewStore(ctx, c1zPath,
+					dotc1z.WithEngine(engine), dotc1z.WithTmpDir(tempDir))
+				require.NoError(t, err)
+				defer func() { require.NoError(t, store.Close(ctx)) }()
+				run, err := store.SyncMeta().LatestFinishedSyncOfAnyType(ctx)
+				require.NoError(t, err)
+				require.NotNil(t, run)
+				require.True(t, run.IsVerified(), "run 1 must have sealed verified (precondition)")
+				return run.ID
+			}()
+
+			// Run 2: rebind the sealed sync and abort mid-collection,
+			// after the store has already been rewritten under the marker.
+			conn.failGrants = true
+			second, err := NewSyncer(ctx, conn,
+				WithC1ZPath(c1zPath), WithTmpDir(tempDir), WithStorageEngine(engine),
+				WithSyncID(sealedID))
+			require.NoError(t, err)
+			require.Error(t, second.Sync(ctx), "the rebound run must abort at the injected failure")
+			require.NoError(t, second.Close(ctx))
+
+			store, err := dotc1z.NewStore(ctx, c1zPath,
+				dotc1z.WithEngine(engine), dotc1z.WithTmpDir(tempDir))
+			require.NoError(t, err)
+			defer func() { require.NoError(t, store.Close(ctx)) }()
+			lister, ok := store.(interface {
+				ListSyncRuns(ctx context.Context, pageToken string, pageSize uint32) ([]*c1zstore.SyncRun, string, error)
+			})
+			require.True(t, ok)
+			runs, _, err := lister.ListSyncRuns(ctx, "", 100)
+			require.NoError(t, err)
+			require.NotEmpty(t, runs)
+			for _, run := range runs {
+				if run.ID != sealedID {
+					continue
+				}
+				require.False(t, run.IsVerified(),
+					"a sealed sync whose data was rewritten by a rebound run must not still read as verified")
+			}
+		})
+	}
+}
+
 func TestFailedIngestInvariantPassDoesNotWriteVerification(t *testing.T) {
 	ctx := context.Background()
 	store, syncID := newInvariantTestStore(ctx, t)
@@ -207,7 +299,10 @@ func TestFailedIngestInvariantPassDoesNotWriteVerification(t *testing.T) {
 		et.NewPermissionEntitlement(r2, "admin", et.WithExclusionGroupDefault("role", 2)),
 	))
 
-	s := &syncer{store: store, syncID: syncID, syncType: connectorstore.SyncTypeFull}
+	// The stale-marker shape the pass-start clear exists for: a sealed,
+	// MARKED sync rebound for a re-run (the writer refuses unfinished
+	// syncs, so this is the only way a marker can pre-exist the pass).
+	require.NoError(t, store.EndSync(ctx))
 	verificationWriter, ok := store.SyncMeta().(c1zstore.IngestInvariantVerificationWriter)
 	require.True(t, ok)
 	require.NoError(t, verificationWriter.MarkIngestInvariantsVerified(ctx, syncID, c1zstore.IngestInvariantVerification{
@@ -215,11 +310,14 @@ func TestFailedIngestInvariantPassDoesNotWriteVerification(t *testing.T) {
 		Coverage:   []string{"I5"},
 		Mode:       c1zstore.IngestInvariantVerificationModeConnector,
 	}))
+	require.NoError(t, store.SetCurrentSync(ctx, syncID))
+
+	s := &syncer{store: store, syncID: syncID, syncType: connectorstore.SyncTypeFull}
 	require.Error(t, s.runIngestionInvariants(ctx))
 
-	// Seal manually to make the absence observable. Production returns before
-	// EndSync on this error, so a violating run is never published.
-	require.NoError(t, store.EndSync(ctx))
+	// The failed pass must have invalidated the inherited proof, and no
+	// new verification may have been staged.
+	require.Nil(t, s.pendingInvariantVerification)
 	run, err := store.SyncMeta().LatestFullSync(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, run)

--- a/pkg/sync/ingest_invariant_verification_test.go
+++ b/pkg/sync/ingest_invariant_verification_test.go
@@ -1,0 +1,145 @@
+package sync //nolint:revive,nolintlint // we can't change the package name for backwards compatibility
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
+	et "github.com/conductorone/baton-sdk/pkg/types/entitlement"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+)
+
+func TestIngestInvariantVerificationCoverageByEngine(t *testing.T) {
+	ctx := context.Background()
+	cases := []struct {
+		name       string
+		engine     c1zstore.Engine
+		syncType   connectorstore.SyncType
+		compaction bool
+		failFast   bool
+		resources  bool
+		want       []string
+		wantMode   c1zstore.IngestInvariantVerificationMode
+	}{
+		{
+			name:     "SQLite records its engine-independent I5 coverage",
+			engine:   c1zstore.EngineSQLite,
+			syncType: connectorstore.SyncTypeFull,
+			want:     []string{"I5"},
+			wantMode: c1zstore.IngestInvariantVerificationModeConnector,
+		},
+		{
+			name:     "Pebble full records the referential family",
+			engine:   c1zstore.EnginePebble,
+			syncType: connectorstore.SyncTypeFull,
+			want:     []string{"I5", "I7", "I3", "I8", "I9"},
+			wantMode: c1zstore.IngestInvariantVerificationModeConnector,
+		},
+		{
+			name:     "Pebble partial records only all-sync-type checks",
+			engine:   c1zstore.EnginePebble,
+			syncType: connectorstore.SyncTypePartial,
+			want:     []string{"I5"},
+			wantMode: c1zstore.IngestInvariantVerificationModeConnector,
+		},
+		{
+			name:      "fail-fast records I4 when schedule evidence exists",
+			engine:    c1zstore.EngineSQLite,
+			syncType:  connectorstore.SyncTypeFull,
+			failFast:  true,
+			resources: true,
+			want:      []string{"I5", "I4"},
+			wantMode:  c1zstore.IngestInvariantVerificationModeConnectorFailFast,
+		},
+		{
+			name:       "compaction mode is explicit",
+			engine:     c1zstore.EnginePebble,
+			syncType:   connectorstore.SyncTypeFull,
+			compaction: true,
+			want:       []string{"I5", "I7", "I3", "I8", "I9"},
+			wantMode:   c1zstore.IngestInvariantVerificationModeCompactionMerge,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			path := filepath.Join(tmpDir, "verification.c1z")
+			store, err := dotc1z.NewStore(ctx, path,
+				dotc1z.WithEngine(tc.engine),
+				dotc1z.WithTmpDir(tmpDir),
+			)
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = store.Close(ctx) })
+
+			syncID, err := store.StartNewSync(ctx, tc.syncType, "")
+			require.NoError(t, err)
+			s := &syncer{
+				store:                 store,
+				syncID:                syncID,
+				syncType:              tc.syncType,
+				compactionMergedStore: tc.compaction,
+				failFastInvariants:    tc.failFast,
+				resourcesPhaseRanHere: tc.resources,
+			}
+			require.NoError(t, s.runIngestionInvariants(ctx))
+			// The production seam checkpoints after validation. Pebble must
+			// preserve provenance while updating the sync token.
+			require.NoError(t, store.CheckpointSync(ctx, "after-verification"))
+			require.NoError(t, store.EndSync(ctx))
+			require.NoError(t, store.Close(ctx))
+
+			store, err = dotc1z.NewStore(ctx, path,
+				dotc1z.WithEngine(tc.engine),
+				dotc1z.WithTmpDir(tmpDir),
+			)
+			require.NoError(t, err)
+
+			run, err := store.SyncMeta().LatestFinishedSyncOfAnyType(ctx)
+			require.NoError(t, err)
+			require.NotNil(t, run)
+			require.Equal(t, IngestInvariantGeneration, run.Generation)
+			require.Equal(t, tc.want, run.Coverage)
+			require.Equal(t, tc.wantMode, run.Mode)
+		})
+	}
+}
+
+func TestFailedIngestInvariantPassDoesNotWriteVerification(t *testing.T) {
+	ctx := context.Background()
+	store, syncID := newInvariantTestStore(ctx, t)
+
+	r1, err := rs.NewResource("user1", userResourceType, "user1")
+	require.NoError(t, err)
+	r2, err := rs.NewResource("user2", userResourceType, "user2")
+	require.NoError(t, err)
+	require.NoError(t, store.PutEntitlements(ctx,
+		et.NewPermissionEntitlement(r1, "viewer", et.WithExclusionGroupDefault("role", 1)),
+		et.NewPermissionEntitlement(r2, "admin", et.WithExclusionGroupDefault("role", 2)),
+	))
+
+	s := &syncer{store: store, syncID: syncID, syncType: connectorstore.SyncTypeFull}
+	verificationWriter, ok := store.SyncMeta().(c1zstore.IngestInvariantVerificationWriter)
+	require.True(t, ok)
+	require.NoError(t, verificationWriter.MarkIngestInvariantsVerified(ctx, syncID, c1zstore.IngestInvariantVerification{
+		Generation: "old-generation",
+		Coverage:   []string{"I5"},
+		Mode:       c1zstore.IngestInvariantVerificationModeConnector,
+	}))
+	require.Error(t, s.runIngestionInvariants(ctx))
+
+	// Seal manually to make the absence observable. Production returns before
+	// EndSync on this error, so a violating run is never published.
+	require.NoError(t, store.EndSync(ctx))
+	run, err := store.SyncMeta().LatestFullSync(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, run)
+	require.Empty(t, run.Generation)
+	require.Empty(t, run.Coverage)
+	require.Empty(t, run.Mode)
+}

--- a/pkg/sync/ingest_invariants.go
+++ b/pkg/sync/ingest_invariants.go
@@ -475,9 +475,16 @@ func runIngestInvariants(
 // runIngestionInvariants is the syncer's call into the pass: policy
 // from syncer state, evidence from the in-memory schedule set, halt
 // hook from the test seam.
+//
+// A successful pass does NOT write the verification marker here — it
+// only records the pending verification on the syncer. The marker is
+// persisted by persistIngestInvariantVerification AFTER EndSync, so a
+// crash anywhere between this pass and the seal leaves the sync
+// unverified (fail-closed) instead of claiming verification over an
+// unfinished artifact the resume machinery will rewrite.
 func (s *syncer) runIngestionInvariants(ctx context.Context) error {
-	verificationWriter, canPersistVerification := s.store.SyncMeta().(c1zstore.IngestInvariantVerificationWriter)
-	if canPersistVerification {
+	s.pendingInvariantVerification = nil
+	if verificationWriter, ok := s.store.SyncMeta().(c1zstore.IngestInvariantVerificationWriter); ok {
 		// Invalidate any proof inherited from an earlier pass before
 		// re-evaluating. A failed rerun must leave the sync unverified.
 		if err := verificationWriter.ClearIngestInvariantVerification(ctx, s.syncID); err != nil {
@@ -509,18 +516,37 @@ func (s *syncer) runIngestionInvariants(ctx context.Context) error {
 	case policy.FailFast:
 		mode = c1zstore.IngestInvariantVerificationModeConnectorFailFast
 	}
-	if !canPersistVerification {
+	s.pendingInvariantVerification = &c1zstore.IngestInvariantVerification{
+		Generation: IngestInvariantGeneration,
+		Coverage:   coverage,
+		Mode:       mode,
+	}
+	return nil
+}
+
+// persistIngestInvariantVerification writes the verification marker the last
+// successful runIngestionInvariants staged. Called AFTER EndSync: the marker
+// must only ever be readable on a sealed sync, so a crash before the seal
+// leaves the artifact unverified rather than claiming verification over data
+// a resume is free to rewrite. Both built-in writers accept metadata stamps
+// on a sealed sync (SQLite updates by sync_id; Pebble's PutSyncRunRecord is
+// an AllowSealed path). The inverse crash window — sealed but not yet marked
+// — reads as an unverified legacy artifact: fail-closed.
+func (s *syncer) persistIngestInvariantVerification(ctx context.Context) error {
+	if s.pendingInvariantVerification == nil {
+		return errors.New("ingest invariants: no staged verification to persist")
+	}
+	verification := *s.pendingInvariantVerification
+	s.pendingInvariantVerification = nil
+	verificationWriter, ok := s.store.SyncMeta().(c1zstore.IngestInvariantVerificationWriter)
+	if !ok {
 		// SyncMeta predates verification metadata and is implemented outside
 		// this repository. Preserve its established behavior; the absent
 		// marker truthfully distinguishes it from built-in verified stores.
 		ctxzap.Extract(ctx).Warn("ingest invariants: store cannot persist verification metadata")
 		return nil
 	}
-	return verificationWriter.MarkIngestInvariantsVerified(ctx, s.syncID, c1zstore.IngestInvariantVerification{
-		Generation: IngestInvariantGeneration,
-		Coverage:   coverage,
-		Mode:       mode,
-	})
+	return verificationWriter.MarkIngestInvariantsVerified(ctx, s.syncID, verification)
 }
 
 // exclusionGroupTracker is the pure validation core behind invariant I5:

--- a/pkg/sync/ingest_invariants.go
+++ b/pkg/sync/ingest_invariants.go
@@ -106,6 +106,7 @@ import (
 	reader_v2 "github.com/conductorone/baton-sdk/pb/c1/reader/v2"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
 )
 
 // ErrIngestInvariantViolated classifies DATA VERDICTS — the store's
@@ -281,6 +282,10 @@ type ingestInvariant struct {
 	// full-resource-scan cost is a bad trade for a default-mode
 	// warning).
 	failFastOnly bool
+	// requiresScheduleEvidence: the check only runs when this process
+	// retained evidence from the resources phase. Keeping this applicability
+	// gate here makes persisted coverage reflect checks that truly ran.
+	requiresScheduleEvidence bool
 	// failFastPromotes: under FailFast the check's tolerated
 	// warn-verdicts become hard failures. Enforced by the fail-fast
 	// test suite; documented here so the matrix is one artifact.
@@ -321,10 +326,11 @@ var ingestInvariants = []ingestInvariant{
 		check:            (*ingestInvariantsPass).checkStoredExclusionGroups,
 	},
 	{
-		id:               "I4",
-		failFastOnly:     true,
-		failFastPromotes: true, // the whole check exists only under fail-fast
-		check:            (*ingestInvariantsPass).checkChildScheduling,
+		id:                       "I4",
+		failFastOnly:             true,
+		requiresScheduleEvidence: true,
+		failFastPromotes:         true, // the whole check exists only under fail-fast
+		check:                    (*ingestInvariantsPass).checkChildScheduling,
 	},
 	{
 		id:               "I7",
@@ -366,6 +372,12 @@ const haltStageI9IndexesEnsured = "invariants-I9-indexes-ensured"
 // entire pass over the same state, so every check must be idempotent.
 const haltStageInvariantsComplete = "ingest-invariants-complete"
 
+// IngestInvariantGeneration identifies the verification contract persisted in
+// sync metadata. Increment it whenever the meaning of a covered invariant
+// changes such that an older successful pass is not equivalent to the current
+// one.
+const IngestInvariantGeneration = "1"
+
 // ingestInvariantHaltStages enumerates every halt seam the pass can
 // fire, in firing order — the halt sweep iterates this list, so a new
 // stage is swept by construction, and the meta-test pins
@@ -394,21 +406,34 @@ func ingestInvariantHaltStages() []string {
 // store-level function so store-producing pipelines without a syncer
 // (the compactor's expand pass) can enforce the same contract.
 func RunIngestInvariants(ctx context.Context, store connectorstore.Reader, policy IngestInvariantsPolicy) error {
+	_, err := runIngestInvariants(ctx, store, policy)
+	return err
+}
+
+// runIngestInvariants returns the IDs of checks that actually completed. The
+// public wrapper intentionally retains its existing error-only API; the syncer
+// consumes the coverage to persist verification provenance.
+func runIngestInvariants(
+	ctx context.Context,
+	store connectorstore.Reader,
+	policy IngestInvariantsPolicy,
+) ([]string, error) {
 	if store == nil {
-		return fmt.Errorf("ingest invariants: store is required")
+		return nil, fmt.Errorf("ingest invariants: store is required")
 	}
 	// Fail closed on a zero SyncType: connectorstore's zero value is
 	// SyncTypeAny (""), which is not SyncTypeFull — a caller omitting
 	// the field would silently skip every full-keyspace invariant and
 	// read a green pass that validated almost nothing.
 	if policy.SyncType == "" {
-		return fmt.Errorf("ingest invariants: policy.SyncType is required (the zero value would silently skip the full-keyspace invariants; pass the sync's actual type)")
+		return nil, fmt.Errorf("ingest invariants: policy.SyncType is required (the zero value would silently skip the full-keyspace invariants; pass the sync's actual type)")
 	}
 	pass := &ingestInvariantsPass{store: store, p: &policy}
 	if facts, ok := store.(dotc1z.IngestInvariantStore); ok {
 		pass.facts = facts
 	}
 	var skippedNoStore []string
+	coverage := make([]string, 0, len(ingestInvariants))
 	for i := range ingestInvariants {
 		inv := &ingestInvariants[i]
 		if !inv.runsOnAllSyncTypes && policy.SyncType != connectorstore.SyncTypeFull {
@@ -426,27 +451,39 @@ func RunIngestInvariants(ctx context.Context, store connectorstore.Reader, polic
 		if inv.failFastOnly && !policy.FailFast {
 			continue
 		}
+		if inv.requiresScheduleEvidence && (!policy.resourcesPhaseRan || policy.childSchedule == nil) {
+			continue
+		}
 		if err := inv.check(pass, ctx); err != nil {
-			return err
+			return nil, err
 		}
 		if inv.haltStage != "" {
 			if err := pass.haltAt(inv.haltStage); err != nil {
-				return err
+				return nil, err
 			}
 		}
+		coverage = append(coverage, inv.id)
 	}
 	if len(skippedNoStore) > 0 {
 		ctxzap.Extract(ctx).Info("ingest invariants: store engine lacks the inspection surface; referential invariants were not evaluated",
 			zap.Strings("skipped_invariants", skippedNoStore),
 		)
 	}
-	return nil
+	return coverage, nil
 }
 
 // runIngestionInvariants is the syncer's call into the pass: policy
 // from syncer state, evidence from the in-memory schedule set, halt
 // hook from the test seam.
 func (s *syncer) runIngestionInvariants(ctx context.Context) error {
+	verificationWriter, canPersistVerification := s.store.SyncMeta().(c1zstore.IngestInvariantVerificationWriter)
+	if canPersistVerification {
+		// Invalidate any proof inherited from an earlier pass before
+		// re-evaluating. A failed rerun must leave the sync unverified.
+		if err := verificationWriter.ClearIngestInvariantVerification(ctx, s.syncID); err != nil {
+			return fmt.Errorf("ingest invariants: clear prior verification: %w", err)
+		}
+	}
 	policy := IngestInvariantsPolicy{
 		ActiveSyncID:      s.getActiveSyncID(),
 		SyncType:          s.syncType,
@@ -459,7 +496,31 @@ func (s *syncer) runIngestionInvariants(ctx context.Context) error {
 	if s.testIngestHaltHook != nil {
 		policy.halt = s.testIngestHaltHook
 	}
-	return RunIngestInvariants(ctx, s.store, policy)
+	coverage, err := runIngestInvariants(ctx, s.store, policy)
+	if err != nil {
+		return err
+	}
+	mode := c1zstore.IngestInvariantVerificationModeConnector
+	switch {
+	case policy.CompactionMerge && policy.FailFast:
+		mode = c1zstore.IngestInvariantVerificationModeCompactionMergeFailFast
+	case policy.CompactionMerge:
+		mode = c1zstore.IngestInvariantVerificationModeCompactionMerge
+	case policy.FailFast:
+		mode = c1zstore.IngestInvariantVerificationModeConnectorFailFast
+	}
+	if !canPersistVerification {
+		// SyncMeta predates verification metadata and is implemented outside
+		// this repository. Preserve its established behavior; the absent
+		// marker truthfully distinguishes it from built-in verified stores.
+		ctxzap.Extract(ctx).Warn("ingest invariants: store cannot persist verification metadata")
+		return nil
+	}
+	return verificationWriter.MarkIngestInvariantsVerified(ctx, s.syncID, c1zstore.IngestInvariantVerification{
+		Generation: IngestInvariantGeneration,
+		Coverage:   coverage,
+		Mode:       mode,
+	})
 }
 
 // exclusionGroupTracker is the pure validation core behind invariant I5:

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -163,19 +163,26 @@ type syncer struct {
 	// returning an error fails the sync at exactly that boundary. The
 	// halt sweep uses it to prove crash/resume equivalence at every
 	// ordering-sensitive point. Nil in production: one pointer check.
-	testIngestHaltHook    func(stage string) error
-	connector             types.ConnectorClient
-	state                 State
-	runDuration           time.Duration
-	transitionHandler     func(s Action)
-	progressHandler       func(p *Progress)
-	tmpDir                string
-	storageEngine         c1zstore.Engine
-	skipFullSync          bool
-	lastCheckPointTime    time.Time
-	counts                *progresslog.ProgressLog
-	targetedSyncResources []*v2.Resource
-	onlyExpandGrants      bool
+	testIngestHaltHook func(stage string) error
+	// pendingInvariantVerification is the verification a successful
+	// runIngestionInvariants staged, awaiting persistence by
+	// persistIngestInvariantVerification AFTER EndSync. Deferring the
+	// write keeps the marker off unfinished syncs: a crash before the
+	// seal leaves the artifact unverified instead of claiming
+	// verification over data a resume will rewrite.
+	pendingInvariantVerification *c1zstore.IngestInvariantVerification
+	connector                    types.ConnectorClient
+	state                        State
+	runDuration                  time.Duration
+	transitionHandler            func(s Action)
+	progressHandler              func(p *Progress)
+	tmpDir                       string
+	storageEngine                c1zstore.Engine
+	skipFullSync                 bool
+	lastCheckPointTime           time.Time
+	counts                       *progresslog.ProgressLog
+	targetedSyncResources        []*v2.Resource
+	onlyExpandGrants             bool
 	// compactionMergedStore marks the store as a pre-sealed artifact
 	// this process did not collect (WithCompactionMergedStore — the
 	// compactor's keep-newer merge and rollback-expansion's replay):
@@ -945,6 +952,14 @@ func (s *syncer) Sync(ctx context.Context) error {
 
 	err = s.store.EndSync(ctx)
 	if err != nil {
+		return s.returnSyncError(l, span, err)
+	}
+
+	// The sync is sealed: publish the verification the invariant pass
+	// staged. Marking only after EndSync keeps the marker off unfinished
+	// syncs; a crash in the sealed-but-unmarked window reads as an
+	// unverified legacy artifact (fail-closed).
+	if err := s.persistIngestInvariantVerification(ctx); err != nil {
 		return s.returnSyncError(l, span, err)
 	}
 

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -852,6 +852,20 @@ func (s *syncer) Sync(ctx context.Context) error {
 		l.Debug("resuming previous sync", zap.String("sync_id", syncID))
 	}
 
+	// Every run that reaches collection rewrites sync-scoped data, so no
+	// prior verification may survive into the window where the store is
+	// being mutated. New syncs carry no marker (no-op); the case that
+	// matters is a rebound, already-sealed sync (WithSyncID — e.g. the
+	// compactor's expansion pass, or a reused syncer): without this, its
+	// stale marker would read as verified while collection rewrites the
+	// data underneath it. The invariant pass re-stages and the marker is
+	// re-persisted after EndSync.
+	if w, ok := s.store.SyncMeta().(c1zstore.IngestInvariantVerificationWriter); ok {
+		if err := w.ClearIngestInvariantVerification(ctx, syncID); err != nil {
+			return s.returnSyncError(l, span, fmt.Errorf("clear prior ingest invariant verification: %w", err))
+		}
+	}
+
 	currentStep, err := s.store.CurrentSyncStep(ctx)
 	if err != nil {
 		return err
@@ -959,8 +973,14 @@ func (s *syncer) Sync(ctx context.Context) error {
 	// staged. Marking only after EndSync keeps the marker off unfinished
 	// syncs; a crash in the sealed-but-unmarked window reads as an
 	// unverified legacy artifact (fail-closed).
+	//
+	// Log-only on failure: EndSync was the last mutation allowed to fail
+	// the sync. The artifact is complete and an absent marker is safe by
+	// design, while a returned error here would read as a FAILED sync —
+	// IsSyncPreservable callers would discard a finished artifact and a
+	// retry would re-collect from scratch over it.
 	if err := s.persistIngestInvariantVerification(ctx); err != nil {
-		return s.returnSyncError(l, span, err)
+		l.Warn("failed to persist ingest invariant verification; the sealed sync remains unverified", zap.Error(err))
 	}
 
 	if s.recordStats {

--- a/pkg/synccompactor/compactor_fold_test.go
+++ b/pkg/synccompactor/compactor_fold_test.go
@@ -38,6 +38,20 @@ func grantDiscoveredAt(t *testing.T, ctx context.Context, path, syncID, grantID 
 	return rec.GetDiscoveredAt().AsTime()
 }
 
+func markFoldInputVerified(t *testing.T, ctx context.Context, path, syncID string) {
+	t.Helper()
+	store, err := dotc1z.NewStore(ctx, path, dotc1z.WithTmpDir(t.TempDir()))
+	require.NoError(t, err)
+	writer, ok := store.SyncMeta().(c1zstore.IngestInvariantVerificationWriter)
+	require.True(t, ok)
+	require.NoError(t, writer.MarkIngestInvariantsVerified(ctx, syncID, c1zstore.IngestInvariantVerification{
+		Generation: "test-generation",
+		Coverage:   []string{"I5", "I7", "I3", "I8", "I9"},
+		Mode:       c1zstore.IngestInvariantVerificationModeConnector,
+	}))
+	require.NoError(t, store.Close(ctx))
+}
+
 // TestCompactPebbleFoldMintsFreshSync covers the in-place fold strategy
 // (BATON_EXPERIMENTAL_PEBBLE_COMPACTOR=fold): the compacted output is a
 // copy of the base input into which the partials' winners are folded
@@ -55,6 +69,7 @@ func TestCompactPebbleFoldMintsFreshSync(t *testing.T) {
 	// strictly newer discovered_at and must win the fold.
 	baseSyncID := buildPebbleInput(t, ctx, basePath, connectorstore.SyncTypeFull, "g-shared", "g-base-only")
 	partialSyncID := buildPebbleInput(t, ctx, partialPath, connectorstore.SyncTypePartial, "g-shared", "g-partial-only")
+	markFoldInputVerified(t, ctx, basePath, baseSyncID)
 
 	t.Setenv("BATON_EXPERIMENTAL_PEBBLE_COMPACTOR", "fold")
 	c, cleanup, err := NewCompactor(ctx, t.TempDir(), []*CompactableSync{
@@ -110,6 +125,9 @@ func TestCompactPebbleFoldMintsFreshSync(t *testing.T) {
 	rec, err := statsEng.GetSyncRunRecord(ctx, out.SyncID)
 	require.NoError(t, err)
 	require.Empty(t, rec.GetParentSyncId(), "folded sync must not carry a parent link to the overwritten base sync")
+	require.Empty(t, rec.GetIngestInvariantGeneration(), "folded sync must not inherit the base verification generation")
+	require.Empty(t, rec.GetIngestInvariantCoverage(), "folded sync must not inherit the base verification coverage")
+	require.Empty(t, rec.GetIngestInvariantMode(), "folded sync must not inherit the base verification mode")
 	stats, err := enginepkg.ReadSyncStatsRecord(ctx, statsEng, out.SyncID)
 	require.NoError(t, err)
 	require.NotNil(t, stats)

--- a/pkg/synccompactor/compactor_fold_test.go
+++ b/pkg/synccompactor/compactor_fold_test.go
@@ -50,6 +50,19 @@ func markFoldInputVerified(t *testing.T, ctx context.Context, path, syncID strin
 		Mode:       c1zstore.IngestInvariantVerificationModeConnector,
 	}))
 	require.NoError(t, store.Close(ctx))
+
+	// Reopen and prove the marker actually landed in the saved file —
+	// without this, the fold's "must not inherit" assertions would pass
+	// vacuously against an input that was never marked (a standalone
+	// metadata stamp used to miss the pebble store's dirty bit and be
+	// dropped at Close).
+	store, err = dotc1z.NewStore(ctx, path, dotc1z.WithTmpDir(t.TempDir()), dotc1z.WithReadOnly(true))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, store.Close(ctx)) }()
+	run, err := store.SyncMeta().LatestFinishedSyncOfAnyType(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, run)
+	require.True(t, run.IsVerified(), "the fold input's marker must persist across close/reopen")
 }
 
 // TestCompactPebbleFoldMintsFreshSync covers the in-place fold strategy

--- a/pkg/synccompactor/compactor_pebble.go
+++ b/pkg/synccompactor/compactor_pebble.go
@@ -680,6 +680,12 @@ func (c *Compactor) compactPebbleFold(ctx context.Context) (string, error) {
 	baseRec.SetSyncId(newSyncID)
 	baseRec.SetParentSyncId("")
 	baseRec.SetType(unionType)
+	// The fold mutated the inherited base keyspace. Never publish the base
+	// artifact's pre-fold verification as proof of the merged output; a later
+	// expansion/invariant pass will write a fresh marker when one runs.
+	baseRec.SetIngestInvariantGeneration("")
+	baseRec.SetIngestInvariantCoverage(nil)
+	baseRec.SetIngestInvariantMode("")
 	if !maxEnded.IsZero() {
 		baseRec.SetEndedAt(timestamppb.New(maxEnded))
 	}

--- a/proto/c1/storage/v3/records.proto
+++ b/proto/c1/storage/v3/records.proto
@@ -285,6 +285,20 @@ message SyncRunRecord {
   // materialize as the previous sync should apply the same predicate
   // instead of guessing from provenance.
   bool compacted = 9;
+
+  // Persisted proof that the post-collection ingestion-invariant pass
+  // completed successfully before this sync was sealed. Empty generation
+  // means the artifact predates verification metadata (or was produced by a
+  // path that did not run the pass). Coverage names only checks that actually
+  // ran; engines without the inspection surface therefore record a subset
+  // rather than claiming full verification.
+  string ingest_invariant_generation = 10;
+  repeated string ingest_invariant_coverage = 11;
+
+  // "connector" applies the ordinary connector-ingest verdict policy;
+  // "compaction_merge" applies the policy for a pre-sealed keep-newer merge.
+  // Empty when ingest_invariant_generation is empty.
+  string ingest_invariant_mode = 12;
 }
 
 // SyncStatsRecord is the engine-internal sidecar populated at


### PR DESCRIPTION
## Persist ingest invariant verification metadata

Adds a durable verification marker to sync-run metadata recording that a sync
passed the post-collection ingestion invariants: which contract generation ran
(`ingest_invariant_generation`), which invariant IDs actually executed
(`ingest_invariant_coverage`), and under which verdict policy
(`ingest_invariant_mode`: `connector`/`compaction_merge`, with `_fail_fast`
variants). Downstream consumers (e.g. compaction choosing a base sync) can now
distinguish "validated" from "predates validation" instead of assuming.

### Semantics

- The marker is **only ever readable on a sealed sync**. The syncer stages the
  verification after a successful invariant pass and persists it only after
  `EndSync` succeeds — a crash anywhere before the seal leaves the artifact
  unverified (fail-closed). Both engines' writers refuse to mark an unfinished
  sync.
- Marker persistence failure after a successful seal is log-only: the artifact
  is complete and an absent marker is safe, while a returned error would make
  `IsSyncPreservable` callers discard a finished sync.
- Any run that reaches collection clears prior verification up front, so a
  rebound sealed sync (`WithSyncID` — the compactor's expansion pass, a reused
  syncer) can't read as verified while collection rewrites its data.
- SQLite records its engine-independent coverage (I5, plus I4 under
  fail-fast); Pebble full syncs record the referential family (I5, I7, I3,
  I8, I9). Partial syncs record only all-sync-type checks.
- Coverage is what RAN, not what passed-by-skipping: consumers compare
  generation + required coverage against their own contract.
- Fold compaction clears inherited markers (merged output ≠ verified base);
  the post-fold expansion sync re-verifies and re-marks. The c1z sanitizer
  intentionally does not carry the marker (it rewrites record contents).
- SQLite→Pebble conversion preserves the marker for finished, verified
  sources (byte-identical data).
- Third-party `SyncMeta` implementations are untouched: the writer is a
  separate optional interface (`IngestInvariantVerificationWriter`); stores
  without it just produce unmarked (truthfully unverified) syncs.

### Pre-existing bugs fixed along the way

- **Pebble sync-run metadata was silently dropped across lifecycle updates**:
  `CheckpointSync`/`EndSync` rebuilt the record from a partial field list;
  they now clone-and-mutate, preserving all fields.
- **Pebble `SyncMeta` mutations skipped the store dirty bit**: a standalone
  metadata stamp on a reopened c1z was dropped at `Close` (the envelope save
  is dirty-gated). `pebbleStore` now wraps `SyncMeta()` in the same
  dirty-marking pattern as `Grants()`/`FileOps()` — this also covers the
  pre-existing `MarkSyncSupportsDiff`/`RecalculateStats`.

### Testing

- Crash seam: `TestCrashBetweenInvariantPassAndSealLeavesNoMarker` aborts a
  real sync between the invariant pass and the seal on both engines and
  asserts the unfinished sync reads unverified; the resume then seals and
  marks.
- Rebind: `TestRebindingSealedSyncClearsStaleVerification` rebinds a sealed
  verified sync, aborts mid-collection, and asserts the marker is gone
  (fails without the clear, both engines).
- Coverage/mode by engine and sync type; failed-pass-writes-nothing;
  SQLite column migration from pre-marker files; conversion round-trip;
  fold non-inheritance (the marking helper now proves the marker persisted
  into the input file — it previously didn't, making the assertion vacuous);
  standalone Pebble stamp persistence (`TestPebbleStoreSyncMetaMarksDirty`).
- Two adversarial review rounds (independent models); all confirmed findings
  fixed: post-seal error semantics, dirty-bit escape, unfinished-sync
  marking, rebind staleness.