### PR TITLE
Sync lambda deadline preservable

### DIFF
--- a/pkg/lambda/grpc/client.go
+++ b/pkg/lambda/grpc/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
@@ -121,9 +122,18 @@ func (c *clientConn) Invoke(ctx context.Context, method string, args any, reply 
 		return status.Errorf(codes.Unknown, "args and reply must satisfy proto.Message")
 	}
 
-	// TODO(morgabra): Should we do some of this stuff? (e.g. detect ctx deadline and set grpc-timeout, etc?)
-	// https://github.com/grpc/grpc-go/blob/9dc22c029c2592b5b6235d9ef6f14d62ecd6a509/internal/transport/http2_client.go#L541
 	md, _ := metadata.FromOutgoingContext(ctx)
+
+	// Propagate the context deadline to the server via the grpc-timeout header,
+	// mirroring grpc-go's HTTP/2 transport behavior.
+	if deadline, ok := ctx.Deadline(); ok {
+		timeout := time.Until(deadline)
+		if timeout <= 0 {
+			return status.Errorf(codes.DeadlineExceeded, "context deadline exceeded before invoking method %s", method)
+		}
+		md = md.Copy()
+		md.Set("grpc-timeout", encodeTimeout(timeout))
+	}
 
 	treq, err := NewRequest(method, req, md)
 	if err != nil {

--- a/pkg/lambda/grpc/server.go
+++ b/pkg/lambda/grpc/server.go
@@ -226,7 +226,7 @@ func PeerForRequest(req *Request) *peer.Peer {
 
 func TimeoutForRequest(req *Request) (time.Duration, bool, error) {
 	v := req.Headers().Get("grpc-timeout")
-	if len(v) > 1 {
+	if len(v) > 0 {
 		to, err := decodeTimeout(v[0])
 		if err != nil {
 			return 0, false, status.Errorf(codes.Internal, "malformed grpc-timeout: %v", err)

--- a/pkg/lambda/grpc/timeout_test.go
+++ b/pkg/lambda/grpc/timeout_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -149,4 +150,75 @@ func TestInvokeExpiredDeadlineReturnsDeadlineExceeded(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, codes.DeadlineExceeded, status.Code(err))
 	require.False(t, transport.called)
+}
+
+// TestServerHandlerAppliesGrpcTimeoutEndToEnd locks in the full server timeout
+// path, which was dead code before the len(v) > 0 fix in TimeoutForRequest: a
+// request carrying a grpc-timeout header must yield a handler context with a
+// deadline, and a handler that blocks past it must produce a DeadlineExceeded
+// status response.
+func TestServerHandlerAppliesGrpcTimeoutEndToEnd(t *testing.T) {
+	s := NewServer(nil)
+
+	var handlerHadDeadline bool
+	var handlerDeadline time.Time
+
+	// The handler returns immediately when no deadline is set. When a deadline
+	// is present it blocks until cancellation, so a completed response proves
+	// the timeout was never applied.
+	sd := &grpc.ServiceDesc{
+		ServiceName: "test.TimeoutService",
+		HandlerType: (*any)(nil),
+		Methods: []grpc.MethodDesc{{
+			MethodName: "Wait",
+			Handler: func(_ any, ctx context.Context, dec func(any) error, _ grpc.UnaryServerInterceptor) (any, error) {
+				if err := dec(&structpb.Struct{}); err != nil {
+					return nil, err
+				}
+				handlerDeadline, handlerHadDeadline = ctx.Deadline()
+				if !handlerHadDeadline {
+					return &structpb.Struct{}, nil
+				}
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-time.After(10 * time.Second):
+					return nil, status.Error(codes.Internal, "handler context was never cancelled")
+				}
+			},
+		}},
+	}
+	s.RegisterService(sd, &struct{}{})
+
+	t.Run("grpc-timeout cancels the handler and returns DeadlineExceeded", func(t *testing.T) {
+		handlerHadDeadline = false
+		req, err := NewRequest("/test.TimeoutService/Wait", &structpb.Struct{}, metadata.Pairs("grpc-timeout", "50m")) // 50ms
+		require.NoError(t, err)
+
+		start := time.Now()
+		resp, err := s.Handler(context.Background(), req)
+		require.NoError(t, err)
+
+		st, err := resp.Status()
+		require.NoError(t, err)
+		require.Equal(t, codes.DeadlineExceeded, st.Code())
+
+		require.True(t, handlerHadDeadline, "handler context must carry the propagated deadline")
+		require.WithinDuration(t, start.Add(50*time.Millisecond), handlerDeadline, time.Second)
+		require.Less(t, time.Since(start), 5*time.Second, "handler must be cancelled by the timeout, not run to completion")
+	})
+
+	t.Run("no grpc-timeout leaves the handler context without a deadline", func(t *testing.T) {
+		handlerHadDeadline = false
+		req, err := NewRequest("/test.TimeoutService/Wait", &structpb.Struct{}, metadata.MD{})
+		require.NoError(t, err)
+
+		resp, err := s.Handler(context.Background(), req)
+		require.NoError(t, err)
+
+		st, err := resp.Status()
+		require.NoError(t, err)
+		require.Equal(t, codes.OK, st.Code())
+		require.False(t, handlerHadDeadline)
+	})
 }

--- a/pkg/lambda/grpc/timeout_test.go
+++ b/pkg/lambda/grpc/timeout_test.go
@@ -1,0 +1,152 @@
+package grpc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	pbtransport "github.com/conductorone/baton-sdk/pb/c1/transport/v1"
+)
+
+func TestEncodeDecodeTimeoutRoundTrip(t *testing.T) {
+	tests := []struct {
+		name     string
+		duration time.Duration
+		encoded  string
+	}{
+		{name: "1ns", duration: time.Nanosecond, encoded: "1n"},
+		{name: "100ms", duration: 100 * time.Millisecond, encoded: "100000u"},
+		{name: "5s", duration: 5 * time.Second, encoded: "5000000u"},
+		{name: "90m", duration: 90 * time.Minute, encoded: "5400000m"},
+		{name: "24h", duration: 24 * time.Hour, encoded: "86400000m"},
+		{name: "3000h", duration: 3000 * time.Hour, encoded: "10800000S"},
+		{name: "2000000h requires H unit", duration: 2000000 * time.Hour, encoded: "2000000H"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			encoded := encodeTimeout(tt.duration)
+			require.Equal(t, tt.encoded, encoded)
+			decoded, err := decodeTimeout(encoded)
+			require.NoError(t, err)
+			require.Equal(t, tt.duration, decoded)
+		})
+	}
+}
+
+func TestEncodeTimeoutNonPositive(t *testing.T) {
+	require.Equal(t, "0n", encodeTimeout(0))
+	require.Equal(t, "0n", encodeTimeout(-time.Second))
+}
+
+func TestTimeoutForRequest(t *testing.T) {
+	t.Run("single grpc-timeout header is honored", func(t *testing.T) {
+		req, err := NewRequest("/test.Service/Method", &structpb.Struct{}, metadata.Pairs("grpc-timeout", "5S"))
+		require.NoError(t, err)
+
+		timeout, ok, err := TimeoutForRequest(req)
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Equal(t, 5*time.Second, timeout)
+	})
+
+	t.Run("no header yields no timeout", func(t *testing.T) {
+		req, err := NewRequest("/test.Service/Method", &structpb.Struct{}, metadata.MD{})
+		require.NoError(t, err)
+
+		timeout, ok, err := TimeoutForRequest(req)
+		require.NoError(t, err)
+		require.False(t, ok)
+		require.Equal(t, time.Duration(0), timeout)
+	})
+
+	t.Run("malformed value yields error", func(t *testing.T) {
+		req, err := NewRequest("/test.Service/Method", &structpb.Struct{}, metadata.Pairs("grpc-timeout", "bogus"))
+		require.NoError(t, err)
+
+		_, _, err = TimeoutForRequest(req)
+		require.Error(t, err)
+		require.Equal(t, codes.Internal, status.Code(err))
+	})
+}
+
+// fakeClientTransport captures the request and returns a canned OK response.
+type fakeClientTransport struct {
+	req    *Request
+	called bool
+}
+
+func (f *fakeClientTransport) RoundTrip(ctx context.Context, req *Request) (*Response, error) {
+	f.called = true
+	f.req = req
+	respAny, err := anypb.New(&structpb.Struct{})
+	if err != nil {
+		return nil, err
+	}
+	stAny, err := anypb.New(status.New(codes.OK, "OK").Proto())
+	if err != nil {
+		return nil, err
+	}
+	return &Response{
+		msg: pbtransport.Response_builder{
+			Resp:   respAny,
+			Status: stAny,
+		}.Build(),
+	}, nil
+}
+
+func TestInvokeSetsGrpcTimeoutFromDeadline(t *testing.T) {
+	transport := &fakeClientTransport{}
+	cc := NewClientConn(transport)
+
+	callerMD := metadata.Pairs("some-key", "some-value")
+	ctx := metadata.NewOutgoingContext(context.Background(), callerMD)
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	err := cc.Invoke(ctx, "/test.Service/Method", &structpb.Struct{}, &structpb.Struct{})
+	require.NoError(t, err)
+	require.True(t, transport.called)
+
+	values := transport.req.Headers().Get("grpc-timeout")
+	require.Len(t, values, 1)
+	timeout, err := decodeTimeout(values[0])
+	require.NoError(t, err)
+	require.Greater(t, timeout, time.Duration(0))
+	require.LessOrEqual(t, timeout, 5*time.Second)
+
+	// The caller's metadata must not be mutated.
+	require.Empty(t, callerMD.Get("grpc-timeout"))
+	// Other caller metadata is preserved on the request.
+	require.Equal(t, []string{"some-value"}, transport.req.Headers().Get("some-key"))
+}
+
+func TestInvokeWithoutDeadlineDoesNotSetGrpcTimeout(t *testing.T) {
+	transport := &fakeClientTransport{}
+	cc := NewClientConn(transport)
+
+	err := cc.Invoke(context.Background(), "/test.Service/Method", &structpb.Struct{}, &structpb.Struct{})
+	require.NoError(t, err)
+	require.True(t, transport.called)
+	require.Empty(t, transport.req.Headers().Get("grpc-timeout"))
+}
+
+func TestInvokeExpiredDeadlineReturnsDeadlineExceeded(t *testing.T) {
+	transport := &fakeClientTransport{}
+	cc := NewClientConn(transport)
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+
+	err := cc.Invoke(ctx, "/test.Service/Method", &structpb.Struct{}, &structpb.Struct{})
+	require.Error(t, err)
+	require.Equal(t, codes.DeadlineExceeded, status.Code(err))
+	require.False(t, transport.called)
+}

--- a/pkg/lambda/grpc/util.go
+++ b/pkg/lambda/grpc/util.go
@@ -79,6 +79,44 @@ func decodeTimeout(s string) (time.Duration, error) {
 	return d * time.Duration(t), nil
 }
 
+const maxTimeoutValue int64 = 100000000 - 1
+
+// div does integer division and round-up the result. Note that this is
+// equivalent to (d+r-1)/r but has less chance to overflow.
+func div(d, r time.Duration) int64 {
+	if d%r > 0 {
+		return int64(d/r + 1)
+	}
+	return int64(d / r)
+}
+
+// encodeTimeout encodes the duration to the format the grpc-timeout header
+// accepts. Ported from grpc-go's internal/grpcutil.EncodeDuration.
+//
+// https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests
+func encodeTimeout(t time.Duration) string {
+	if t <= 0 {
+		return "0n"
+	}
+	if d := div(t, time.Nanosecond); d <= maxTimeoutValue {
+		return strconv.FormatInt(d, 10) + "n"
+	}
+	if d := div(t, time.Microsecond); d <= maxTimeoutValue {
+		return strconv.FormatInt(d, 10) + "u"
+	}
+	if d := div(t, time.Millisecond); d <= maxTimeoutValue {
+		return strconv.FormatInt(d, 10) + "m"
+	}
+	if d := div(t, time.Second); d <= maxTimeoutValue {
+		return strconv.FormatInt(d, 10) + "S"
+	}
+	if d := div(t, time.Minute); d <= maxTimeoutValue {
+		return strconv.FormatInt(d, 10) + "M"
+	}
+	// Note that maxTimeoutValue * time.Hour > MaxInt64.
+	return strconv.FormatInt(div(t, time.Hour), 10) + "H"
+}
+
 func parseMethod(method string) (string, string, error) {
 	if method != "" && method[0] == '/' {
 		method = method[1:]

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -79,6 +79,8 @@ var connectorCallMethods = []string{
 
 // IsSyncPreservable returns true if the error returned by Sync() means that the sync artifact is useful.
 // This either means that there was no error, or that the error is recoverable (we can resume the sync and possibly succeed next time).
+// Timeouts (context.DeadlineExceeded or codes.DeadlineExceeded, e.g. an AWS Lambda hard timeout) are
+// preservable because the sync can resume from the checkpoint.
 func IsSyncPreservable(err error) bool {
 	if err == nil {
 		return true
@@ -87,6 +89,11 @@ func IsSyncPreservable(err error) bool {
 	// ErrTooManyWarnings means we hit too many warnings.
 	// Both are recoverable errors.
 	if errors.Is(err, ErrSyncNotComplete) || errors.Is(err, ErrTooManyWarnings) {
+		return true
+	}
+	// A wrapped bare context deadline error carries no gRPC status
+	// (status.FromError does not map context.DeadlineExceeded), so check it explicitly.
+	if errors.Is(err, context.DeadlineExceeded) {
 		return true
 	}
 	statusErr, ok := status.FromError(err)
@@ -101,7 +108,8 @@ func IsSyncPreservable(err error) bool {
 		codes.FailedPrecondition,
 		codes.Aborted,
 		codes.Unavailable,
-		codes.Unauthenticated:
+		codes.Unauthenticated,
+		codes.DeadlineExceeded:
 		return true
 	default:
 		return false

--- a/pkg/sync/syncer_preservable_test.go
+++ b/pkg/sync/syncer_preservable_test.go
@@ -1,0 +1,37 @@
+package sync //nolint:revive,nolintlint // we can't change the package name for backwards compatibility
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestIsSyncPreservable(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil error", err: nil, want: true},
+		{name: "ErrSyncNotComplete", err: ErrSyncNotComplete, want: true},
+		{name: "ErrTooManyWarnings", err: ErrTooManyWarnings, want: true},
+		{name: "wrapped ErrSyncNotComplete", err: fmt.Errorf("wrapped: %w", ErrSyncNotComplete), want: true},
+		{name: "status Unavailable", err: status.Error(codes.Unavailable, "server unavailable"), want: true},
+		{name: "status DeadlineExceeded", err: status.Error(codes.DeadlineExceeded, "lambda_transport: function timed out"), want: true},
+		{name: "bare context.DeadlineExceeded", err: context.DeadlineExceeded, want: true},
+		{name: "wrapped context.DeadlineExceeded", err: fmt.Errorf("wrapped: %w", context.DeadlineExceeded), want: true},
+		{name: "status Internal", err: status.Error(codes.Internal, "internal error"), want: false},
+		{name: "plain error", err: errors.New("plain"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, IsSyncPreservable(tt.err))
+		})
+	}
+}


### PR DESCRIPTION
## Treat DeadlineExceeded as preservable and fix grpc-timeout propagation

Execution timeouts (e.g. a serverless connector hitting its platform's hard execution limit) currently cause syncs to throw away all checkpointed progress, and the lambda gRPC transport's deadline-propagation path doesn't actually work. This PR fixes both, so timed-out syncs resume from their checkpoint instead of restarting from zero.

### Changes

**1. `pkg/sync`: `IsSyncPreservable` now treats timeouts as preservable**

The lambda transport already maps function timeouts to `codes.DeadlineExceeded` (a retryable, resumable condition), but `IsSyncPreservable` omitted it from the allowlist, so the c1z checkpoint was discarded on timeout. This adds:

- `codes.DeadlineExceeded` to the gRPC status allowlist.
- An `errors.Is(err, context.DeadlineExceeded)` check for wrapped bare context deadline errors, which carry no gRPC status (`status.FromError` does not map `context.DeadlineExceeded`; only `status.FromContextError` does).

**2. `pkg/lambda/grpc`: fix dead `grpc-timeout` check in the server**

`TimeoutForRequest` read the header with `metadata.MD.Get`, which returns `[]string`, then gated on `len(v) > 1` — requiring *two* header values. A single `grpc-timeout` header (the only realistic case) never applied, making the server-side timeout path dead code. Now `len(v) > 0`.

**3. `pkg/lambda/grpc`: client propagates the caller's deadline**

`clientConn.Invoke` now resolves the long-standing TODO: if the context has a deadline, it sets the `grpc-timeout` header (on a copy of the caller's metadata) so the server can bound the handler context; if the deadline has already expired it returns `codes.DeadlineExceeded` without invoking the function. Adds `encodeTimeout` (ported from grpc-go's `internal/grpcutil`, mirroring the existing `decodeTimeout`).

### Tests

- `IsSyncPreservable` unit tests: nil, `ErrSyncNotComplete`, `ErrTooManyWarnings`, `Unavailable`, `DeadlineExceeded` status, wrapped `context.DeadlineExceeded`, `Internal` (false), plain error (false).
- `TimeoutForRequest` regression tests: single header applies, no header, malformed value errors.
- `encodeTimeout`/`decodeTimeout` round-trips across unit ranges (1ns through 2,000,000h).
- `clientConn.Invoke`: header set when deadline present, absent otherwise, expired deadline short-circuits without calling the transport; caller metadata is not mutated.

`go build ./...`, `go test ./pkg/sync/... ./pkg/lambda/...`, and `make lint` all pass.

### Notes for reviewers

- This is the SDK half of the fix; the host-side error handling (preserving the `DeadlineExceeded` status through the invoker and persisting the c1z on timeout) lands separately.
- Deadline propagation is a correctness fix for