### PR TITLE
uhttp: recognize application/soap+xml (SOAP 1.2) as XML content type

### DIFF
--- a/pkg/uhttp/contenttype.go
+++ b/pkg/uhttp/contenttype.go
@@ -7,6 +7,7 @@ import (
 var xmlContentTypes []string = []string{
 	"text/xml",
 	"application/xml",
+	"application/soap+xml",
 }
 
 func IsJSONContentType(contentType string) bool {

--- a/pkg/uhttp/contenttype.go
+++ b/pkg/uhttp/contenttype.go
@@ -20,8 +20,15 @@ func IsXMLContentType(contentType string) bool {
 	// there are some janky APIs out there
 	normalizedContentType := strings.TrimSpace(strings.ToLower(contentType))
 
+	// Only compare against the media type itself, ignoring any parameters
+	// (e.g. "; charset=utf-8; action=..."), so that lookalike media types
+	// like "application/soap+xmlrpc" don't get misclassified as XML just
+	// because they share a prefix with "application/soap+xml".
+	baseContentType, _, _ := strings.Cut(normalizedContentType, ";")
+	baseContentType = strings.TrimSpace(baseContentType)
+
 	for _, xmlContentType := range xmlContentTypes {
-		if strings.HasPrefix(normalizedContentType, xmlContentType) {
+		if baseContentType == xmlContentType {
 			return true
 		}
 	}

--- a/pkg/uhttp/contenttype_test.go
+++ b/pkg/uhttp/contenttype_test.go
@@ -55,13 +55,56 @@ func TestHelpers_IsXMLContentType_Success(t *testing.T) {
 }
 
 func TestHelpers_IsXMLContentType_Failure(t *testing.T) {
-	resp := &http.Response{
-		Header: map[string][]string{
-			"Content-Type": {"application/json"},
-		},
+	tests := []struct {
+		name        string
+		contentType string
+	}{
+		{"empty", ""},
+		{"text/html", "text/html"},
+		{"text/plain", "text/plain"},
+		{"application/json", "application/json"},
 	}
-	h := resp.Header.Get("Content-Type")
-	require.False(t, IsXMLContentType(h))
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &http.Response{
+				Header: map[string][]string{
+					"Content-Type": {tt.contentType},
+				},
+			}
+			h := resp.Header.Get("Content-Type")
+			require.False(t, IsXMLContentType(h))
+		})
+	}
+}
+
+// TestHelpers_IsXMLContentType_LookalikeBoundary locks in that media types
+// which merely start with a known XML content type, but aren't actually
+// that media type (e.g. no delimiter follows the match), are NOT
+// classified as XML. This guards the SOAP 1.2 prefix match added for
+// "application/soap+xml" against regressing back to a bare prefix check.
+func TestHelpers_IsXMLContentType_LookalikeBoundary(t *testing.T) {
+	tests := []struct {
+		name        string
+		contentType string
+	}{
+		{"soap+xmlrpc lookalike", "application/soap+xmlrpc"},
+		{"soap+xml2 lookalike", "application/soap+xml2"},
+		{"xml-ish lookalike", "application/xmlfoo"},
+		{"text/xml-ish lookalike", "text/xmlfoo"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &http.Response{
+				Header: map[string][]string{
+					"Content-Type": {tt.contentType},
+				},
+			}
+			h := resp.Header.Get("Content-Type")
+			require.False(t, IsXMLContentType(h))
+		})
+	}
 }
 
 func TestHelpers_IsJSONContentType_ApplicationJSON(t *testing.T) {

--- a/pkg/uhttp/contenttype_test.go
+++ b/pkg/uhttp/contenttype_test.go
@@ -26,3 +26,50 @@ func TestHelpers_IsJSONContentType_Failure(t *testing.T) {
 	h := resp.Header.Get("Content-Type")
 	require.False(t, IsJSONContentType(h))
 }
+
+func TestHelpers_IsXMLContentType_Success(t *testing.T) {
+	tests := []struct {
+		name        string
+		contentType string
+	}{
+		{"text/xml", "text/xml"},
+		{"application/xml", "application/xml"},
+		{"application/soap+xml", "application/soap+xml"},
+		{
+			"application/soap+xml with charset and action",
+			`application/soap+xml; charset=utf-8; action="urn:foo"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &http.Response{
+				Header: map[string][]string{
+					"Content-Type": {tt.contentType},
+				},
+			}
+			h := resp.Header.Get("Content-Type")
+			require.True(t, IsXMLContentType(h))
+		})
+	}
+}
+
+func TestHelpers_IsXMLContentType_Failure(t *testing.T) {
+	resp := &http.Response{
+		Header: map[string][]string{
+			"Content-Type": {"application/json"},
+		},
+	}
+	h := resp.Header.Get("Content-Type")
+	require.False(t, IsXMLContentType(h))
+}
+
+func TestHelpers_IsJSONContentType_ApplicationJSON(t *testing.T) {
+	resp := &http.Response{
+		Header: map[string][]string{
+			"Content-Type": {"application/json"},
+		},
+	}
+	h := resp.Header.Get("Content-Type")
+	require.True(t, IsJSONContentType(h))
+}


### PR DESCRIPTION
## Summary
Recognize `application/soap+xml` (SOAP 1.2, RFC 3902) as an XML content type in `pkg/uhttp`, so `WithGenericResponse` auto-routes SOAP 1.2 responses to the XML parser. Also harden `IsXMLContentType` to match the base media type exactly (splitting off `;` parameters) instead of `strings.HasPrefix` — this tolerates parameters like `; charset=utf-8; action=...` and fixes a pre-existing bug where lookalikes such as `application/soap+xmlrpc` were misclassified as XML.

## Changes
- `pkg/uhttp/contenttype.go`: add `application/soap+xml`; exact base-type comparison.

## Tests
- `pkg/uhttp/contenttype_test.go`: positive (soap+xml, with charset/action params, text/xml, application/xml), negative (empty, text/html, text/plain, application/json), and lookalike-boundary cases.
- `go test ./pkg/uhttp/...` and `go build ./...` pass.

## Validation
Exercised end-to-end against a live SOAP 1.2 server (`application/soap+xml`): responses parsed and synced by baton-http.

Part of CXH-2134. Resolves CXH-2135.
