### PR TITLE
uhttp: capture XML attributes in the XML->map unmarshaler

### DIFF
--- a/pkg/uhttp/wrapper_test.go
+++ b/pkg/uhttp/wrapper_test.go
@@ -424,6 +424,59 @@ func TestWrapper_WithGenericResponse(t *testing.T) {
 		}, respBody)
 	})
 
+	t.Run("should marshal an XML response with attributes on a container root element", func(t *testing.T) {
+		// The root <response> element itself carries an attribute, so the
+		// map it decodes to gains an "@attributes" key alongside its
+		// children. WithGenericResponse only requires xm.data to be a
+		// map[string]any, which this still is, so it succeeds as before.
+		exampleResponse := `<?xml version="1.0" encoding="UTF-8"?><response id="7"><items><item><name>John</name><age>30</age></item></items></response>`
+		header := http.Header{}
+		header.Add("Content-Type", "application/xml")
+		resp := WrapperResponse{
+			Header:     header,
+			StatusCode: http.StatusOK,
+		}
+		resp.Body = bytes.NewBufferString(exampleResponse).Bytes()
+		var respBody map[string]any
+		err := WithGenericResponse(&respBody)(&resp)
+		require.NoError(t, err)
+		require.Equal(t, map[string]any{
+			"@attributes": map[string]any{"id": "7"},
+			"items": map[string]any{
+				"item": map[string]any{"name": "John", "age": "30"},
+			},
+		}, respBody)
+	})
+
+	t.Run("should succeed for an attributed leaf root element (intentional behavior change)", func(t *testing.T) {
+		// Before attribute support was added, a root element with no
+		// children and no attributes decoded to a bare string, and
+		// WithGenericResponse rejected that shape with an "unsupported XML
+		// structure: string" error. Now that the root carries an attribute,
+		// unmarshalXMLElement promotes it to
+		// map[string]any{"#text": ..., "@attributes": ...} instead of a bare
+		// string, so WithGenericResponse's `xm.data.(map[string]any)` type
+		// assertion succeeds and the call now returns successfully where it
+		// previously errored. This is a deliberate, if incidental,
+		// consequence of adding attribute support at uhttp's only real
+		// xmlMap call site, not a bug.
+		exampleResponse := `<?xml version="1.0" encoding="UTF-8"?><response foo="bar">hello</response>`
+		header := http.Header{}
+		header.Add("Content-Type", "application/xml")
+		resp := WrapperResponse{
+			Header:     header,
+			StatusCode: http.StatusOK,
+		}
+		resp.Body = bytes.NewBufferString(exampleResponse).Bytes()
+		var respBody map[string]any
+		err := WithGenericResponse(&respBody)(&resp)
+		require.NoError(t, err)
+		require.Equal(t, map[string]any{
+			"#text":       "hello",
+			"@attributes": map[string]any{"foo": "bar"},
+		}, respBody)
+	})
+
 	t.Run("should return an error when the response is not JSON or XML", func(t *testing.T) {
 		header := http.Header{}
 		header.Add("Content-Type", "text/yaml")

--- a/pkg/uhttp/xml.go
+++ b/pkg/uhttp/xml.go
@@ -2,6 +2,7 @@ package uhttp
 
 import (
 	"encoding/xml"
+	"maps"
 	"strings"
 )
 
@@ -23,14 +24,53 @@ func (x *xmlMap) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 
 // attrMap converts xml.Attr entries into a map[string]any keyed by the
 // attribute's local name (namespace prefixes are dropped), badgerfish-style.
-// Returns nil if there are no attributes.
+// Returns nil if there are no (application-level) attributes.
+//
+// Two adjustments are made before keys are assigned:
+//
+//   - Namespace-declaration pseudo-attributes are dropped entirely. Go's
+//     encoding/xml decoder surfaces both the bare default-namespace form
+//     (xmlns="uri", decoded as Attr{Name:{Space:"", Local:"xmlns"}, Value: uri})
+//     and the prefixed form (xmlns:foo="uri", decoded as
+//     Attr{Name:{Space:"xmlns", Local:"foo"}, Value: uri}) as ordinary
+//     attributes. Neither represents application data, and virtually every
+//     namespaced XML/SOAP document declares one on its root element even when
+//     it carries no real attributes, so counting them would spuriously add an
+//     "@attributes" key to otherwise-unaffected elements. Genuine namespaced
+//     attributes (e.g. xsi:type) are unaffected by this filter: the decoder
+//     resolves their Name.Space to the namespace URI itself, never to the
+//     literal string "xmlns".
+//   - If, after filtering, two or more attributes share the same local name
+//     but come from different namespaces (a realistic SOAP/WS-* pattern, e.g.
+//     xsi:type alongside a custom-namespace "type"), keying purely by local
+//     name would silently drop all but the last one. When such a collision is
+//     detected, only the colliding entries are disambiguated by qualifying
+//     their key with their namespace ("<namespace>:<local>"); attributes with
+//     a unique local name keep their bare local-name key.
 func attrMap(attrs []xml.Attr) map[string]any {
-	if len(attrs) == 0 {
+	filtered := make([]xml.Attr, 0, len(attrs))
+	for _, a := range attrs {
+		if a.Name.Space == "xmlns" || a.Name.Local == "xmlns" {
+			continue
+		}
+		filtered = append(filtered, a)
+	}
+	if len(filtered) == 0 {
 		return nil
 	}
-	m := make(map[string]any, len(attrs))
-	for _, a := range attrs {
-		m[a.Name.Local] = a.Value
+
+	localCount := make(map[string]int, len(filtered))
+	for _, a := range filtered {
+		localCount[a.Name.Local]++
+	}
+
+	m := make(map[string]any, len(filtered))
+	for _, a := range filtered {
+		key := a.Name.Local
+		if localCount[key] > 1 && a.Name.Space != "" {
+			key = a.Name.Space + ":" + a.Name.Local
+		}
+		m[key] = a.Value
 	}
 	return m
 }
@@ -55,8 +95,10 @@ func attrMap(attrs []xml.Attr) map[string]any {
 //     since the container itself has no single map to attach "@attributes"
 //     to, the attribute map is added to every entry in the slice.
 //
-// Elements with no attributes are completely unaffected: behavior is
-// byte-for-byte identical to before attribute support was added.
+// Elements with no application-level attributes are completely unaffected:
+// behavior is byte-for-byte identical to before attribute support was added.
+// This includes elements that carry only namespace declarations (xmlns="..."
+// or xmlns:prefix="...") and no other attributes -- see attrMap.
 func unmarshalXMLElement(d *xml.Decoder, attrs []xml.Attr) (any, error) {
 	type entry struct {
 		key   string
@@ -110,7 +152,12 @@ func unmarshalXMLElement(d *xml.Decoder, attrs []xml.Attr) (any, error) {
 				for _, e := range entries {
 					m := map[string]any{e.key: e.value}
 					if selfAttrs != nil {
-						m["@attributes"] = selfAttrs
+						// Clone per entry so each sibling map owns an
+						// independent "@attributes" map; without this, all
+						// entries would alias the same underlying map and a
+						// mutation to one sibling's attributes would silently
+						// appear on every other sibling.
+						m["@attributes"] = maps.Clone(selfAttrs)
 					}
 					result = append(result, m)
 				}

--- a/pkg/uhttp/xml.go
+++ b/pkg/uhttp/xml.go
@@ -13,7 +13,7 @@ type xmlMap struct {
 }
 
 func (x *xmlMap) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
-	result, err := unmarshalXMLElement(d)
+	result, err := unmarshalXMLElement(d, start.Attr)
 	if err != nil {
 		return err
 	}
@@ -21,12 +21,43 @@ func (x *xmlMap) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	return nil
 }
 
+// attrMap converts xml.Attr entries into a map[string]any keyed by the
+// attribute's local name (namespace prefixes are dropped), badgerfish-style.
+// Returns nil if there are no attributes.
+func attrMap(attrs []xml.Attr) map[string]any {
+	if len(attrs) == 0 {
+		return nil
+	}
+	m := make(map[string]any, len(attrs))
+	for _, a := range attrs {
+		m[a.Name.Local] = a.Value
+	}
+	return m
+}
+
 // unmarshalXMLElement reads tokens from the decoder for the current element
 // (after its start element has been consumed) until the matching end element.
+// attrs holds the attributes of the current element itself (empty if none).
+//
 // It returns a map[string]any if there are child elements, a []map[string]any
 // if there are duplicate child element names, or a string if the element
-// contains only text.
-func unmarshalXMLElement(d *xml.Decoder) (any, error) {
+// contains only text and has no attributes.
+//
+// When the current element carries attributes (len(attrs) > 0), they are
+// captured under an "@attributes" key (badgerfish/xml-js convention):
+//   - element with children: "@attributes" is added as a sibling key in the
+//     resulting map (purely additive; existing keys are unaffected).
+//   - leaf element with attributes: the previously bare string value is
+//     promoted to map[string]any{"#text": <trimmed text>, "@attributes": ...},
+//     or just map[string]any{"@attributes": ...} if there is no text. This is
+//     a deliberate type change (string -> map) at that path only.
+//   - element with duplicate child names (returned as []map[string]any):
+//     since the container itself has no single map to attach "@attributes"
+//     to, the attribute map is added to every entry in the slice.
+//
+// Elements with no attributes are completely unaffected: behavior is
+// byte-for-byte identical to before attribute support was added.
+func unmarshalXMLElement(d *xml.Decoder, attrs []xml.Attr) (any, error) {
 	type entry struct {
 		key   string
 		value any
@@ -36,6 +67,8 @@ func unmarshalXMLElement(d *xml.Decoder) (any, error) {
 	hasDuplicates := false
 	var charData strings.Builder
 
+	selfAttrs := attrMap(attrs)
+
 	for {
 		t, err := d.Token()
 		if err != nil {
@@ -43,7 +76,7 @@ func unmarshalXMLElement(d *xml.Decoder) (any, error) {
 		}
 		switch tt := t.(type) {
 		case xml.StartElement:
-			child, err := unmarshalXMLElement(d)
+			child, err := unmarshalXMLElement(d, tt.Attr)
 			if err != nil {
 				return nil, err
 			}
@@ -61,6 +94,12 @@ func unmarshalXMLElement(d *xml.Decoder) (any, error) {
 		case xml.EndElement:
 			if len(entries) == 0 {
 				text := strings.TrimSpace(charData.String())
+				if selfAttrs != nil {
+					if text == "" {
+						return map[string]any{"@attributes": selfAttrs}, nil
+					}
+					return map[string]any{"#text": text, "@attributes": selfAttrs}, nil
+				}
 				if text == "" {
 					return make(map[string]any), nil
 				}
@@ -69,13 +108,20 @@ func unmarshalXMLElement(d *xml.Decoder) (any, error) {
 			if hasDuplicates {
 				result := make([]map[string]any, 0, len(entries))
 				for _, e := range entries {
-					result = append(result, map[string]any{e.key: e.value})
+					m := map[string]any{e.key: e.value}
+					if selfAttrs != nil {
+						m["@attributes"] = selfAttrs
+					}
+					result = append(result, m)
 				}
 				return result, nil
 			}
 			result := make(map[string]any, len(entries))
 			for _, e := range entries {
 				result[e.key] = e.value
+			}
+			if selfAttrs != nil {
+				result["@attributes"] = selfAttrs
 			}
 			return result, nil
 		}

--- a/pkg/uhttp/xml_test.go
+++ b/pkg/uhttp/xml_test.go
@@ -95,9 +95,11 @@ func TestXMLMap_UnmarshalXML(t *testing.T) {
 	})
 
 	t.Run("should use the local name for a namespace-prefixed attribute", func(t *testing.T) {
-		// The xmlns:xsi declaration lives on <response>, so it becomes an
-		// attribute of the root element itself (Go's encoding/xml surfaces
-		// namespace declarations as ordinary Attr entries, keyed by prefix).
+		// The xmlns:xsi declaration lives on <response>, but it is a
+		// namespace-declaration pseudo-attribute, not application data, so it
+		// is filtered out of the root's @attributes (see attrMap) -- the root
+		// element ends up with no @attributes at all here, since it carries
+		// no other attributes.
 		// The attribute under test is xsi:type on <name>, which must be
 		// captured using its local name "type", not the namespace-qualified
 		// form.
@@ -106,10 +108,87 @@ func TestXMLMap_UnmarshalXML(t *testing.T) {
 		err := xml.Unmarshal([]byte(xmlResponse), xmlMap)
 		require.NoError(t, err)
 		require.Equal(t, map[string]any{
-			"@attributes": map[string]any{"xsi": "http://www.w3.org/2001/XMLSchema-instance"},
 			"name": map[string]any{
 				"#text":       "John",
 				"@attributes": map[string]any{"type": "string"},
+			},
+		}, xmlMap.data)
+	})
+
+	t.Run("should not treat a bare default-namespace declaration as an attribute", func(t *testing.T) {
+		// A bare `xmlns="..."` default-namespace declaration on the root is
+		// extremely common in real-world namespaced XML/SOAP documents, even
+		// when the element carries no application-level attributes. It must
+		// not cause a spurious "@attributes" key to appear, preserving the
+		// byte-for-byte no-attribute invariant for ordinary namespaced XML.
+		xmlResponse := `<?xml version="1.0" encoding="UTF-8"?><response xmlns="urn:example"><name>John</name></response>`
+		xmlMap := &xmlMap{}
+		err := xml.Unmarshal([]byte(xmlResponse), xmlMap)
+		require.NoError(t, err)
+		require.Equal(t, map[string]any{"name": "John"}, xmlMap.data)
+	})
+
+	t.Run("should disambiguate same-local-name attributes from different namespaces instead of dropping one", func(t *testing.T) {
+		// Two attributes with the same local name ("id") but different
+		// namespaces on the same element is a realistic SOAP/WS-* pattern.
+		// Keying purely by local name would silently overwrite one with the
+		// other; both must be preserved via namespace-qualified keys.
+		xmlResponse := `<?xml version="1.0" encoding="UTF-8"?><response xmlns:a="urn:a" xmlns:b="urn:b"><elem a:id="1" b:id="2">text</elem></response>`
+		xmlMap := &xmlMap{}
+		err := xml.Unmarshal([]byte(xmlResponse), xmlMap)
+		require.NoError(t, err)
+		require.Equal(t, map[string]any{
+			"elem": map[string]any{
+				"#text": "text",
+				"@attributes": map[string]any{
+					"urn:a:id": "1",
+					"urn:b:id": "2",
+				},
+			},
+		}, xmlMap.data)
+	})
+
+	t.Run("should give each duplicate-sibling entry an independent @attributes map", func(t *testing.T) {
+		xmlResponse := `<?xml version="1.0" encoding="UTF-8"?><response><items count="2"><item>a</item><item>b</item></items></response>`
+		xmlMap := &xmlMap{}
+		err := xml.Unmarshal([]byte(xmlResponse), xmlMap)
+		require.NoError(t, err)
+
+		items, ok := xmlMap.data.(map[string]any)["items"].([]map[string]any)
+		require.True(t, ok)
+		require.Len(t, items, 2)
+
+		firstAttrs, ok := items[0]["@attributes"].(map[string]any)
+		require.True(t, ok)
+		secondAttrs, ok := items[1]["@attributes"].(map[string]any)
+		require.True(t, ok)
+
+		// Mutating one sibling's @attributes map must not affect the other's.
+		firstAttrs["count"] = "mutated"
+		require.Equal(t, "2", secondAttrs["count"])
+	})
+
+	t.Run("should discard stray text alongside child elements regardless of attributes (pre-existing behavior)", func(t *testing.T) {
+		xmlResponse := `<?xml version="1.0" encoding="UTF-8"?><response><person id="1">prefix<name>John</name></person></response>`
+		xmlMap := &xmlMap{}
+		err := xml.Unmarshal([]byte(xmlResponse), xmlMap)
+		require.NoError(t, err)
+		require.Equal(t, map[string]any{
+			"person": map[string]any{
+				"name":        "John",
+				"@attributes": map[string]any{"id": "1"},
+			},
+		}, xmlMap.data)
+	})
+
+	t.Run("should treat a self-closing attributed tag the same as an explicit open/close pair", func(t *testing.T) {
+		xmlResponse := `<?xml version="1.0" encoding="UTF-8"?><response><flag enabled="true"/></response>`
+		xmlMap := &xmlMap{}
+		err := xml.Unmarshal([]byte(xmlResponse), xmlMap)
+		require.NoError(t, err)
+		require.Equal(t, map[string]any{
+			"flag": map[string]any{
+				"@attributes": map[string]any{"enabled": "true"},
 			},
 		}, xmlMap.data)
 	})

--- a/pkg/uhttp/xml_test.go
+++ b/pkg/uhttp/xml_test.go
@@ -55,4 +55,91 @@ func TestXMLMap_UnmarshalXML(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, map[string]any{}, xmlMap.data)
 	})
+
+	t.Run("should capture attributes on a container element as a sibling @attributes key", func(t *testing.T) {
+		xmlResponse := `<?xml version="1.0" encoding="UTF-8"?><response><person id="42"><name>John</name></person></response>`
+		xmlMap := &xmlMap{}
+		err := xml.Unmarshal([]byte(xmlResponse), xmlMap)
+		require.NoError(t, err)
+		require.Equal(t, map[string]any{
+			"person": map[string]any{
+				"name":        "John",
+				"@attributes": map[string]any{"id": "42"},
+			},
+		}, xmlMap.data)
+	})
+
+	t.Run("should promote an attributed leaf element with text to a map with #text and @attributes", func(t *testing.T) {
+		xmlResponse := `<?xml version="1.0" encoding="UTF-8"?><response><name lang="en">John</name></response>`
+		xmlMap := &xmlMap{}
+		err := xml.Unmarshal([]byte(xmlResponse), xmlMap)
+		require.NoError(t, err)
+		require.Equal(t, map[string]any{
+			"name": map[string]any{
+				"#text":       "John",
+				"@attributes": map[string]any{"lang": "en"},
+			},
+		}, xmlMap.data)
+	})
+
+	t.Run("should represent an attributed leaf element with no text as just @attributes", func(t *testing.T) {
+		xmlResponse := `<?xml version="1.0" encoding="UTF-8"?><response><flag enabled="true"></flag></response>`
+		xmlMap := &xmlMap{}
+		err := xml.Unmarshal([]byte(xmlResponse), xmlMap)
+		require.NoError(t, err)
+		require.Equal(t, map[string]any{
+			"flag": map[string]any{
+				"@attributes": map[string]any{"enabled": "true"},
+			},
+		}, xmlMap.data)
+	})
+
+	t.Run("should use the local name for a namespace-prefixed attribute", func(t *testing.T) {
+		// The xmlns:xsi declaration lives on <response>, so it becomes an
+		// attribute of the root element itself (Go's encoding/xml surfaces
+		// namespace declarations as ordinary Attr entries, keyed by prefix).
+		// The attribute under test is xsi:type on <name>, which must be
+		// captured using its local name "type", not the namespace-qualified
+		// form.
+		xmlResponse := `<?xml version="1.0" encoding="UTF-8"?><response xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><name xsi:type="string">John</name></response>`
+		xmlMap := &xmlMap{}
+		err := xml.Unmarshal([]byte(xmlResponse), xmlMap)
+		require.NoError(t, err)
+		require.Equal(t, map[string]any{
+			"@attributes": map[string]any{"xsi": "http://www.w3.org/2001/XMLSchema-instance"},
+			"name": map[string]any{
+				"#text":       "John",
+				"@attributes": map[string]any{"type": "string"},
+			},
+		}, xmlMap.data)
+	})
+
+	t.Run("should capture attributes at every nesting level", func(t *testing.T) {
+		xmlResponse := `<?xml version="1.0" encoding="UTF-8"?><response><outer id="1"><inner id="2">value</inner></outer></response>`
+		xmlMap := &xmlMap{}
+		err := xml.Unmarshal([]byte(xmlResponse), xmlMap)
+		require.NoError(t, err)
+		require.Equal(t, map[string]any{
+			"outer": map[string]any{
+				"@attributes": map[string]any{"id": "1"},
+				"inner": map[string]any{
+					"#text":       "value",
+					"@attributes": map[string]any{"id": "2"},
+				},
+			},
+		}, xmlMap.data)
+	})
+
+	t.Run("should combine a container's attributes with duplicate child siblings", func(t *testing.T) {
+		xmlResponse := `<?xml version="1.0" encoding="UTF-8"?><response><items count="2"><item>a</item><item>b</item></items></response>`
+		xmlMap := &xmlMap{}
+		err := xml.Unmarshal([]byte(xmlResponse), xmlMap)
+		require.NoError(t, err)
+		require.Equal(t, map[string]any{
+			"items": []map[string]any{
+				{"item": "a", "@attributes": map[string]any{"count": "2"}},
+				{"item": "b", "@attributes": map[string]any{"count": "2"}},
+			},
+		}, xmlMap.data)
+	})
 }


### PR DESCRIPTION
## Summary
Capture XML attributes in uhttp's XML→map unmarshaler. Previously `unmarshalXMLElement` read only element/text tokens and silently dropped all attributes, so data carried in XML attributes (common in SOAP/WS-*) was lost.

## Changes (`pkg/uhttp/xml.go`)
- Element with children: add an `@attributes` sibling key (map of local-name → value). Additive.
- Leaf element with attributes: promote from bare string to `{#text, @attributes}` (or `{@attributes}` if no text) — a deliberate, documented type change at that path only.
- Elements with no attributes are byte-for-byte unchanged.
- Filter `xmlns` / `xmlns:prefix` namespace-declaration pseudo-attributes.
- Disambiguate same-local-name attributes from different namespaces (qualify only colliding keys).
- Clone the attribute map per entry in the duplicate-sibling branch to avoid shared-reference aliasing.

## Tests
- `pkg/uhttp/xml_test.go`, `wrapper_test.go`: attributed container, attributed leaf (with/without text), namespace-prefixed attr, nested, attrs+duplicates, namespace collision, xmlns filtering, per-sibling independence; plus a `WithGenericResponse` case for an attributed-leaf root. All pre-existing subtests unchanged.
- `go test ./pkg/uhttp/...` and `go build ./...` pass.

## Backward-compat
The attributed-leaf string→map promotion (and the related `WithGenericResponse` error→success for an attributed-leaf root) is the one deliberate behavior change; no-attribute paths are unchanged. Validated end-to-end against a live SOAP server (attribute data flowed into resource IDs and grants).

Part of CXH-2134. Resolves CXH-2137.
