### PR TITLE
fix: checkpoint sync progress on SIGTERM before exit

### DIFF
--- a/pkg/connectorrunner/runner.go
+++ b/pkg/connectorrunner/runner.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/conductorone/baton-sdk/pkg/bid"
@@ -138,7 +139,7 @@ func (c *connectorRunner) Run(ctx context.Context) error {
 	}
 
 	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, os.Interrupt)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		for range sigChan {
 			cancel(ErrSigTerm)

--- a/pkg/connectorrunner/runner.go
+++ b/pkg/connectorrunner/runner.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -72,9 +73,16 @@ const shutdownDrainTimeout = 25 * time.Second
 // drainInFlightTasks waits for every currently-held semaphore slot to be
 // released — i.e. every dispatched task goroutine (see the `go func(t
 // *v1.Task)` dispatch below) to return — bounded by shutdownDrainTimeout.
-// Called right before run() returns on cancellation, so the caller's
-// deferred Close() (which tears down the connector client) doesn't race an
-// in-flight sync that's still writing its forced checkpoint.
+// Deferred once, right after sem is created, so it runs on every exit from
+// run() — including the cancellation-driven returns below, and the
+// stopForLoop exit further down, which falls out of the loop with no select
+// case involved at all. Covering every return this way, rather than one
+// call per return site, is deliberate: this loop has already had a return
+// path added without a matching drain call once (a task goroutine setting
+// stopForLoop bypassed it entirely), and a per-site call is exactly the
+// shape of bug that keeps recurring. Whichever return runs, the caller's
+// deferred Close() (which tears down the connector client) must not race
+// an in-flight sync that's still writing its forced checkpoint.
 func (c *connectorRunner) drainInFlightTasks(ctx context.Context, sem *semaphore.Weighted, l *zap.Logger) {
 	drainCtx, cancelDrain := context.WithTimeout(context.WithoutCancel(ctx), shutdownDrainTimeout)
 	defer cancelDrain()
@@ -247,15 +255,22 @@ func (c *connectorRunner) run(ctx context.Context) error {
 	}
 
 	sem := semaphore.NewWeighted(int64(c.taskConcurrency))
+	// Drain unconditionally on every exit from this function, not just the
+	// two cancellation-driven returns below: a dispatched task goroutine can
+	// also end this loop by setting stopForLoop (see the "grpc: the client
+	// connection is closing" check further down), which falls through to the
+	// post-loop return with no select case involved at all. A per-return-site
+	// call is exactly the shape of bug this already was once -- a defer here
+	// covers every current and future exit path from run() by construction.
+	defer c.drainInFlightTasks(ctx, sem, l)
 
 	nextCheckAfter := time.Second * 0
 	errCount := 0
-	stopForLoop := false
+	var stopForLoop atomic.Bool
 	var err error
-	for !stopForLoop {
+	for !stopForLoop.Load() {
 		select {
 		case <-ctx.Done():
-			c.drainInFlightTasks(ctx, sem, l)
 			return c.handleContextCancel(ctx)
 		case <-time.After(nextCheckAfter):
 			l.Debug("runner: claiming worker")
@@ -263,7 +278,6 @@ func (c *connectorRunner) run(ctx context.Context) error {
 			err = sem.Acquire(ctx, 1)
 			if err != nil {
 				l.Error("runner: error acquiring semaphore to claim worker", zap.Error(err))
-				c.drainInFlightTasks(ctx, sem, l)
 				return c.handleContextCancel(ctx)
 			}
 			l.Debug("runner: worker claimed, checking for next task")
@@ -320,7 +334,7 @@ func (c *connectorRunner) run(ctx context.Context) error {
 				err := c.processTask(ctx, t)
 				if err != nil {
 					if strings.Contains(err.Error(), "grpc: the client connection is closing") {
-						stopForLoop = true
+						stopForLoop.Store(true)
 					}
 					l.Error("runner: error processing task", zap.Error(err), zap.String("task_id", t.GetId()), zap.String("task_type", tasks.GetType(t).String()))
 					return
@@ -332,7 +346,7 @@ func (c *connectorRunner) run(ctx context.Context) error {
 		}
 	}
 
-	if stopForLoop {
+	if stopForLoop.Load() {
 		return fmt.Errorf("unable to communicate with gRPC server")
 	}
 

--- a/pkg/connectorrunner/runner.go
+++ b/pkg/connectorrunner/runner.go
@@ -49,6 +49,42 @@ type connectorRunner struct {
 
 var ErrSigTerm = errors.New("context cancelled by process shutdown")
 
+// shutdownDrainTimeout bounds how long run() waits, on cancellation, for
+// in-flight task goroutines to finish before returning. Each task goroutine
+// is untracked (dispatched via a bare `go func`) and Close() — called
+// immediately after Run() returns by every caller of this runner — tears
+// down the connector client via c.cw.Close() with no synchronization against
+// those goroutines. Without a drain, a SIGTERM can still race the very
+// checkpoint this package exists to protect: Run() returns as soon as ctx is
+// Done, Close() runs, and the in-flight sync's forced checkpoint write (see
+// sync/parallel_syncer.go's handleOperationError, bounded to 15s) can be torn
+// out from under it.
+//
+// This budget intentionally only targets that checkpoint write, not a full
+// c1z finalize: syncer.Close() (called by the task handler on every path,
+// including sync failure) bounds its own detached finalize by
+// dotc1z.FinalizeTimeout, which defaults to 1 hour — no realistic
+// termination grace period can wait that out, and this drain does not try
+// to. It only aims to let the smaller, higher-priority checkpoint write
+// complete before the connector client is torn down.
+const shutdownDrainTimeout = 25 * time.Second
+
+// drainInFlightTasks waits for every currently-held semaphore slot to be
+// released — i.e. every dispatched task goroutine (see the `go func(t
+// *v1.Task)` dispatch below) to return — bounded by shutdownDrainTimeout.
+// Called right before run() returns on cancellation, so the caller's
+// deferred Close() (which tears down the connector client) doesn't race an
+// in-flight sync that's still writing its forced checkpoint.
+func (c *connectorRunner) drainInFlightTasks(ctx context.Context, sem *semaphore.Weighted, l *zap.Logger) {
+	drainCtx, cancelDrain := context.WithTimeout(context.WithoutCancel(ctx), shutdownDrainTimeout)
+	defer cancelDrain()
+	if err := sem.Acquire(drainCtx, int64(c.taskConcurrency)); err != nil {
+		l.Warn("runner: shutdown drain timed out; in-flight tasks may not have finished checkpointing", zap.Error(err))
+		return
+	}
+	sem.Release(int64(c.taskConcurrency))
+}
+
 // setupPersistentLog ensures that a log file on disk is created,
 // when required by either the stored Manager or by a Task.
 // A log file created by a stored Manager persists for our entire run,
@@ -219,6 +255,7 @@ func (c *connectorRunner) run(ctx context.Context) error {
 	for !stopForLoop {
 		select {
 		case <-ctx.Done():
+			c.drainInFlightTasks(ctx, sem, l)
 			return c.handleContextCancel(ctx)
 		case <-time.After(nextCheckAfter):
 			l.Debug("runner: claiming worker")
@@ -226,6 +263,7 @@ func (c *connectorRunner) run(ctx context.Context) error {
 			err = sem.Acquire(ctx, 1)
 			if err != nil {
 				l.Error("runner: error acquiring semaphore to claim worker", zap.Error(err))
+				c.drainInFlightTasks(ctx, sem, l)
 				return c.handleContextCancel(ctx)
 			}
 			l.Debug("runner: worker claimed, checking for next task")

--- a/pkg/connectorrunner/runner_test.go
+++ b/pkg/connectorrunner/runner_test.go
@@ -101,6 +101,58 @@ func TestRun_TaskConcurrencyCapsProcessing(t *testing.T) {
 	}
 }
 
+// TestRun_DrainsInFlightTaskBeforeReturningOnCancellation covers the gap
+// between catching SIGTERM and actually protecting an in-flight sync's
+// forced checkpoint: every task is dispatched to an untracked goroutine
+// (`go func(t *v1.Task)` in run()), and every caller of this runner closes
+// the connector client (Close -> c.cw.Close()) immediately after Run()
+// returns. Without draining, run() returns as soon as ctx is Done
+// regardless of what that goroutine is still doing -- including a
+// checkpoint write deliberately running on a context.WithoutCancel(ctx)
+// scope specifically so cancellation doesn't cut it off.
+//
+// detachedTaskManager's Process ignores ctx.Done() (mirroring that
+// detached-context write) and only returns when explicitly released, so
+// this test can assert run() actually waits for it instead of just
+// hoping the timing works out.
+func TestRun_DrainsInFlightTaskBeforeReturningOnCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(ErrSigTerm)
+
+	tm := newDetachedTaskManager()
+	runner := &connectorRunner{
+		cw:              noopClientWrapper{},
+		tasks:           tm,
+		taskConcurrency: 1,
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- runner.run(ctx)
+	}()
+
+	waitForStartedTasks(t, tm.started, 1)
+
+	cancel(ErrSigTerm)
+
+	select {
+	case <-errCh:
+		require.Fail(t, "run() returned before the in-flight task finished; the shutdown drain did not wait for it")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(tm.release)
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		require.Fail(t, "timed out waiting for runner to stop after releasing the in-flight task")
+	}
+}
+
 func waitForStartedTasks(t *testing.T, started <-chan struct{}, count int) {
 	t.Helper()
 	for range count {
@@ -230,6 +282,51 @@ func (m *blockingTaskManager) ShouldDebug() bool {
 }
 
 func (m *blockingTaskManager) GetTempDir() string {
+	return ""
+}
+
+// detachedTaskManager's Process deliberately does not select on ctx.Done()
+// -- it mirrors a sync's forced checkpoint write, which runs on a
+// context.WithoutCancel(ctx) scope specifically so the caller's cancellation
+// doesn't cut it off. It only returns once explicitly released.
+type detachedTaskManager struct {
+	nextCalls atomic.Int64
+	started   chan struct{}
+	release   chan struct{}
+}
+
+func newDetachedTaskManager() *detachedTaskManager {
+	return &detachedTaskManager{
+		started: make(chan struct{}, 1),
+		release: make(chan struct{}),
+	}
+}
+
+func (m *detachedTaskManager) Next(ctx context.Context) (*v1.Task, time.Duration, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, 0, err
+	}
+	if m.nextCalls.Add(1) > 1 {
+		return nil, time.Hour, nil
+	}
+	return v1.Task_builder{
+		Id:     "task-1",
+		Status: v1.Task_STATUS_PENDING,
+		Hello:  &v1.Task_HelloTask{},
+	}.Build(), 0, nil
+}
+
+func (m *detachedTaskManager) Process(ctx context.Context, task *v1.Task, cc types.ConnectorClient) error {
+	m.started <- struct{}{}
+	<-m.release
+	return nil
+}
+
+func (m *detachedTaskManager) ShouldDebug() bool {
+	return false
+}
+
+func (m *detachedTaskManager) GetTempDir() string {
 	return ""
 }
 

--- a/pkg/connectorrunner/runner_test.go
+++ b/pkg/connectorrunner/runner_test.go
@@ -153,6 +153,52 @@ func TestRun_DrainsInFlightTaskBeforeReturningOnCancellation(t *testing.T) {
 	}
 }
 
+// TestRun_DrainsInFlightTaskOnStopForLoopExit covers a second, distinct exit
+// path from run()'s loop: a dispatched task goroutine can set stopForLoop
+// (on a "grpc: the client connection is closing" error), which the loop only
+// notices at its next `for !stopForLoop` check -- falling straight to the
+// post-loop return with no select case, and therefore no drain call,
+// involved at all. The two `<-ctx.Done()`/semaphore-acquire-error returns
+// each called drainInFlightTasks directly; this third path did not, so with
+// taskConcurrency > 1 another task could still be mid-checkpoint-write when
+// run() returned. Now covered by a single deferred drain instead of a call
+// per return site.
+func TestRun_DrainsInFlightTaskOnStopForLoopExit(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(ErrSigTerm)
+
+	tm := newGRPCCloseTriggeringTaskManager()
+	runner := &connectorRunner{
+		cw:              noopClientWrapper{},
+		tasks:           tm,
+		taskConcurrency: 2,
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- runner.run(ctx)
+	}()
+
+	waitForStartedTasks(t, tm.started, 1)
+
+	select {
+	case <-errCh:
+		require.Fail(t, "run() returned before the blocking task finished; the stopForLoop exit bypassed the drain")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	close(tm.release)
+
+	select {
+	case err := <-errCh:
+		require.ErrorContains(t, err, "unable to communicate with gRPC server")
+	case <-time.After(time.Second):
+		require.Fail(t, "timed out waiting for runner to stop after releasing the blocking task")
+	}
+}
+
 func waitForStartedTasks(t *testing.T, started <-chan struct{}, count int) {
 	t.Helper()
 	for range count {
@@ -327,6 +373,58 @@ func (m *detachedTaskManager) ShouldDebug() bool {
 }
 
 func (m *detachedTaskManager) GetTempDir() string {
+	return ""
+}
+
+// grpcCloseTriggeringTaskManager dispatches two tasks: "blocking-task" mimics
+// an in-flight checkpoint write (blocks until released, ignoring ctx.Done()
+// same as detachedTaskManager), and "failing-task" returns immediately with
+// a "grpc: the client connection is closing" error -- the OTHER way run()'s
+// loop can exit besides context cancellation (see the stopForLoop check in
+// run()). Both are dispatched to their own goroutine when taskConcurrency
+// >= 2, so the failing task can trigger stopForLoop while the blocking task
+// is still in flight.
+type grpcCloseTriggeringTaskManager struct {
+	nextCalls atomic.Int64
+	started   chan struct{}
+	release   chan struct{}
+}
+
+func newGRPCCloseTriggeringTaskManager() *grpcCloseTriggeringTaskManager {
+	return &grpcCloseTriggeringTaskManager{
+		started: make(chan struct{}, 1),
+		release: make(chan struct{}),
+	}
+}
+
+func (m *grpcCloseTriggeringTaskManager) Next(ctx context.Context) (*v1.Task, time.Duration, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, 0, err
+	}
+	switch m.nextCalls.Add(1) {
+	case 1:
+		return v1.Task_builder{Id: "blocking-task", Status: v1.Task_STATUS_PENDING, Hello: &v1.Task_HelloTask{}}.Build(), 0, nil
+	case 2:
+		return v1.Task_builder{Id: "failing-task", Status: v1.Task_STATUS_PENDING, Hello: &v1.Task_HelloTask{}}.Build(), 0, nil
+	default:
+		return nil, time.Hour, nil
+	}
+}
+
+func (m *grpcCloseTriggeringTaskManager) Process(ctx context.Context, task *v1.Task, cc types.ConnectorClient) error {
+	if task.GetId() == "failing-task" {
+		return errors.New("rpc error: grpc: the client connection is closing")
+	}
+	m.started <- struct{}{}
+	<-m.release
+	return nil
+}
+
+func (m *grpcCloseTriggeringTaskManager) ShouldDebug() bool {
+	return false
+}
+
+func (m *grpcCloseTriggeringTaskManager) GetTempDir() string {
 	return ""
 }
 

--- a/pkg/sync/parallel_syncer.go
+++ b/pkg/sync/parallel_syncer.go
@@ -176,23 +176,28 @@ func (s *syncer) parallelSync(
 		select {
 		case <-runCtx.Done():
 			err = context.Cause(runCtx)
-			switch {
-			case errors.Is(err, context.DeadlineExceeded):
+			if errors.Is(err, context.DeadlineExceeded) {
 				if s.recordStats {
 					l.Info("sync run duration has expired, exiting sync early", s.syncSummaryFields(trace.SpanFromContext(ctx))...)
 				} else {
 					l.Info("sync run duration has expired, exiting sync early", zap.String("sync_id", s.syncID))
 				}
-				// It would be nice to remove this once we're more confident in the checkpointing logic.
-				checkpointErr := s.Checkpoint(ctx, true)
-				if checkpointErr != nil {
-					l.Error("error checkpointing before exiting sync", zap.Error(checkpointErr))
-				}
-				return warnings, errors.Join(checkpointErr, ErrSyncNotComplete)
-			default:
-				l.Error("sync context cancelled", zap.String("sync_id", s.syncID), zap.Error(err))
-				return warnings, err
+			} else {
+				// Any other cancellation (e.g. SIGTERM/SIGINT via connectorrunner.ErrSigTerm) is just as
+				// resumable as a deadline timeout, so it gets the same forced checkpoint and treatment below.
+				l.Info("sync context cancelled, exiting sync early", zap.String("sync_id", s.syncID), zap.Error(err))
 			}
+			// ctx itself may already be Done here (e.g. a SIGTERM-driven cancellation
+			// cancels ctx directly, not just runCtx's derived deadline), so this
+			// checkpoint must run on a context that survives that cancellation —
+			// same pattern as the other finalize/cleanup writes in this codebase
+			// (c1file.go, clone_sync.go, syncer.go) that must complete after ctx is done.
+			// It would be nice to remove this once we're more confident in the checkpointing logic.
+			checkpointErr := s.Checkpoint(context.WithoutCancel(ctx), true)
+			if checkpointErr != nil {
+				l.Error("error checkpointing before exiting sync", zap.Error(checkpointErr))
+			}
+			return warnings, errors.Join(checkpointErr, ErrSyncNotComplete)
 		default:
 		}
 

--- a/pkg/sync/parallel_syncer.go
+++ b/pkg/sync/parallel_syncer.go
@@ -161,6 +161,19 @@ func (s *syncer) parallelSync(
 			break
 		}
 
+		// Checked before the throttled checkpoint below: that checkpoint runs
+		// on the raw ctx, which may already be Done (a SIGTERM-driven
+		// cancellation cancels ctx itself, not just runCtx's derived
+		// deadline) -- checking cancellation first means a cancelled ctx
+		// never gets a chance to fail that write and return a raw,
+		// non-resumable error before this iteration reaches
+		// handleOperationError.
+		select {
+		case <-runCtx.Done():
+			return s.handleOperationError(ctx, runCtx, warnings, nil)
+		default:
+		}
+
 		err := s.Checkpoint(ctx, false)
 		if err != nil {
 			return warnings, err
@@ -172,33 +185,6 @@ func (s *syncer) parallelSync(
 			if tooManyWarnings(len(warnings), completedActionsCount) {
 				return warnings, fmt.Errorf("%w: warnings: %v completed actions: %d", ErrTooManyWarnings, warnings, completedActionsCount)
 			}
-		}
-		select {
-		case <-runCtx.Done():
-			err = context.Cause(runCtx)
-			if errors.Is(err, context.DeadlineExceeded) {
-				if s.recordStats {
-					l.Info("sync run duration has expired, exiting sync early", s.syncSummaryFields(trace.SpanFromContext(ctx))...)
-				} else {
-					l.Info("sync run duration has expired, exiting sync early", zap.String("sync_id", s.syncID))
-				}
-			} else {
-				// Any other cancellation (e.g. SIGTERM/SIGINT via connectorrunner.ErrSigTerm) is just as
-				// resumable as a deadline timeout, so it gets the same forced checkpoint and treatment below.
-				l.Info("sync context cancelled, exiting sync early", zap.String("sync_id", s.syncID), zap.Error(err))
-			}
-			// ctx itself may already be Done here (e.g. a SIGTERM-driven cancellation
-			// cancels ctx directly, not just runCtx's derived deadline), so this
-			// checkpoint must run on a context that survives that cancellation —
-			// same pattern as the other finalize/cleanup writes in this codebase
-			// (c1file.go, clone_sync.go, syncer.go) that must complete after ctx is done.
-			// It would be nice to remove this once we're more confident in the checkpointing logic.
-			checkpointErr := s.Checkpoint(context.WithoutCancel(ctx), true)
-			if checkpointErr != nil {
-				l.Error("error checkpointing before exiting sync", zap.Error(checkpointErr))
-			}
-			return warnings, errors.Join(checkpointErr, ErrSyncNotComplete)
-		default:
 		}
 
 		switch stateAction.Op {
@@ -405,7 +391,7 @@ func (s *syncer) parallelSync(
 				}
 				if err := s.store.SyncMeta().MarkSyncSupportsDiff(ctx, s.syncID); err != nil {
 					l.Error("failed to set supports_diff marker", zap.Error(err))
-					return warnings, err
+					return s.handleOperationError(ctx, runCtx, warnings, err)
 				}
 			}
 
@@ -427,29 +413,78 @@ func (s *syncer) parallelSync(
 	return warnings, nil
 }
 
+// forcedCheckpointTimeout bounds the detached (context.WithoutCancel) context
+// used for the forced checkpoint write below. This runs precisely during an
+// orchestrator's termination grace period, so it must stay well short of a
+// typical grace period (Kubernetes defaults to 30s) — unlike
+// dotc1z.FinalizeTimeout, which bounds the much heavier WAL
+// checkpoint+save+upload tail, this is a single small state write.
+const forcedCheckpointTimeout = 15 * time.Second
+
+// handleOperationError checks whether runCtx has been cancelled — by a
+// deadline timeout, a SIGTERM/SIGINT shutdown (connectorrunner.ErrSigTerm),
+// a server-directed task cancellation, a heartbeat failure, or any other
+// cause — and if so treats it uniformly as resumable: force a checkpoint so
+// the next resume picks up from here instead of restarting, and return an
+// error that both IsSyncPreservable recognizes (via ErrSyncNotComplete) and
+// still lets a caller distinguish *why* via errors.Is(err, cause).
+//
+// batchErr is the error an in-flight operation returned (nil when called
+// from the top-of-loop check, where cancellation was observed between
+// actions rather than surfaced by a connector call). If runCtx was not
+// actually cancelled, batchErr is a genuine, unrelated operation error and
+// is returned unchanged — this function only special-cases cancellation.
 func (s *syncer) handleOperationError(
 	ctx context.Context,
 	runCtx context.Context,
 	warnings []error,
 	batchErr error,
 ) ([]error, error) {
-	if !errors.Is(context.Cause(runCtx), context.DeadlineExceeded) {
+	cause := context.Cause(runCtx)
+	if cause == nil {
 		return warnings, batchErr
 	}
-	// The run duration expired. The operation error is usually just the
-	// resulting cancellation, but a genuine connector/store failure can
-	// land in the same window — log it so expiry never masks a real bug.
-	// The sync resumes from the checkpoint, so the work is retried either
-	// way; only ErrSyncNotComplete is surfaced to keep the resumable
-	// contract for callers.
+	// The operation error is usually just the resulting cancellation, but a
+	// genuine connector/store failure can land in the same window — log it
+	// so cancellation never masks a real bug. The sync resumes from the
+	// checkpoint, so the work is retried either way; only ErrSyncNotComplete
+	// (plus cause) is surfaced to keep the resumable contract for callers.
 	if batchErr != nil && !errors.Is(batchErr, context.Canceled) && !errors.Is(batchErr, context.DeadlineExceeded) {
 		ctxzap.Extract(ctx).Error(
-			"sync operation failed while run duration expired; exiting early for resume",
+			"sync operation failed while the sync was being cancelled; exiting early for resume",
 			zap.Error(batchErr),
+			zap.NamedError("cancel_cause", cause),
 		)
 	}
-	checkpointErr := s.Checkpoint(ctx, true)
-	return warnings, errors.Join(checkpointErr, ErrSyncNotComplete)
+	l := ctxzap.Extract(ctx)
+	if errors.Is(cause, context.DeadlineExceeded) {
+		if s.recordStats {
+			l.Info("sync run duration has expired, exiting sync early", s.syncSummaryFields(trace.SpanFromContext(ctx))...)
+		} else {
+			l.Info("sync run duration has expired, exiting sync early", zap.String("sync_id", s.syncID))
+		}
+	} else {
+		l.Info("sync context cancelled, exiting sync early", zap.String("sync_id", s.syncID), zap.Error(cause))
+	}
+	// ctx itself may already be Done here (e.g. a SIGTERM-driven cancellation
+	// cancels ctx directly, not just runCtx's derived deadline), so this
+	// checkpoint must run on a context that survives that cancellation —
+	// same pattern as the other finalize/cleanup writes in this codebase
+	// (c1file.go, clone_sync.go, syncer.go) — but still bounded, so a wedged
+	// store write during the grace period doesn't just burn the whole window
+	// before getting SIGKILLed anyway.
+	// It would be nice to remove this once we're more confident in the checkpointing logic.
+	cpCtx, cpCancel := context.WithTimeout(context.WithoutCancel(ctx), forcedCheckpointTimeout)
+	defer cpCancel()
+	checkpointErr := s.Checkpoint(cpCtx, true)
+	if checkpointErr != nil {
+		l.Error("error checkpointing before exiting sync", zap.Error(checkpointErr))
+	}
+	// cause is joined in (not just logged) so a caller with more context —
+	// e.g. pkg/tasks/c1api distinguishing ErrTaskCancelled from a plain
+	// shutdown — can still inspect errors.Is(err, cause) instead of losing it
+	// behind ErrSyncNotComplete.
+	return warnings, errors.Join(checkpointErr, ErrSyncNotComplete, cause)
 }
 
 func tooManyWarnings(warningCount int, completedActionsCount uint64) bool {

--- a/pkg/sync/parallel_syncer.go
+++ b/pkg/sync/parallel_syncer.go
@@ -457,13 +457,14 @@ func (s *syncer) handleOperationError(
 		)
 	}
 	l := ctxzap.Extract(ctx)
-	if errors.Is(cause, context.DeadlineExceeded) {
+	switch {
+	case errors.Is(cause, context.DeadlineExceeded):
 		if s.recordStats {
 			l.Info("sync run duration has expired, exiting sync early", s.syncSummaryFields(trace.SpanFromContext(ctx))...)
 		} else {
 			l.Info("sync run duration has expired, exiting sync early", zap.String("sync_id", s.syncID))
 		}
-	} else if s.recordStats {
+	case s.recordStats:
 		// Same per-step/per-resource-type/retry-wait fields as the deadline
 		// branch above — these are exactly the counters used to reconstruct
 		// a sync's timeline after the fact (see CXH-2121), so a
@@ -471,7 +472,7 @@ func (s *syncer) handleOperationError(
 		// than a deadline-expired one.
 		l.Info("sync context cancelled, exiting sync early",
 			append(s.syncSummaryFields(trace.SpanFromContext(ctx)), zap.NamedError("cancel_cause", cause))...)
-	} else {
+	default:
 		l.Info("sync context cancelled, exiting sync early", zap.String("sync_id", s.syncID), zap.Error(cause))
 	}
 	// ctx itself may already be Done here (e.g. a SIGTERM-driven cancellation

--- a/pkg/sync/parallel_syncer.go
+++ b/pkg/sync/parallel_syncer.go
@@ -176,7 +176,7 @@ func (s *syncer) parallelSync(
 
 		err := s.Checkpoint(ctx, false)
 		if err != nil {
-			return warnings, err
+			return s.handleOperationError(ctx, runCtx, warnings, err)
 		}
 
 		// If we have more than 10 warnings and more than 10% of actions ended in a warning, exit the sync.
@@ -211,7 +211,7 @@ func (s *syncer) parallelSync(
 				s.state.PushAction(ctx, Action{Op: SyncResourceTypesOp})
 				err = s.Checkpoint(ctx, true)
 				if err != nil {
-					return warnings, err
+					return s.handleOperationError(ctx, runCtx, warnings, err)
 				}
 				// Don't do grant expansion or external resources in partial syncs, as we likely lack related resources/entitlements/grants
 				continue
@@ -229,7 +229,7 @@ func (s *syncer) parallelSync(
 				s.state.SetNeedsExpansion()
 				err = s.Checkpoint(ctx, true)
 				if err != nil {
-					return warnings, err
+					return s.handleOperationError(ctx, runCtx, warnings, err)
 				}
 				continue
 			}
@@ -247,7 +247,7 @@ func (s *syncer) parallelSync(
 
 			err = s.Checkpoint(ctx, true)
 			if err != nil {
-				return warnings, err
+				return s.handleOperationError(ctx, runCtx, warnings, err)
 			}
 			continue
 
@@ -463,6 +463,14 @@ func (s *syncer) handleOperationError(
 		} else {
 			l.Info("sync run duration has expired, exiting sync early", zap.String("sync_id", s.syncID))
 		}
+	} else if s.recordStats {
+		// Same per-step/per-resource-type/retry-wait fields as the deadline
+		// branch above — these are exactly the counters used to reconstruct
+		// a sync's timeline after the fact (see CXH-2121), so a
+		// SIGTERM-interrupted sync must not produce less diagnostic output
+		// than a deadline-expired one.
+		l.Info("sync context cancelled, exiting sync early",
+			append(s.syncSummaryFields(trace.SpanFromContext(ctx)), zap.NamedError("cancel_cause", cause))...)
 	} else {
 		l.Info("sync context cancelled, exiting sync early", zap.String("sync_id", s.syncID), zap.Error(cause))
 	}
@@ -480,11 +488,14 @@ func (s *syncer) handleOperationError(
 	if checkpointErr != nil {
 		l.Error("error checkpointing before exiting sync", zap.Error(checkpointErr))
 	}
-	// cause is joined in (not just logged) so a caller with more context —
-	// e.g. pkg/tasks/c1api distinguishing ErrTaskCancelled from a plain
-	// shutdown — can still inspect errors.Is(err, cause) instead of losing it
-	// behind ErrSyncNotComplete.
-	return warnings, errors.Join(checkpointErr, ErrSyncNotComplete, cause)
+	// cause and batchErr are joined in (not just logged) so a caller with
+	// more context — e.g. pkg/tasks/c1api distinguishing ErrTaskCancelled
+	// from a plain shutdown, or a retry loop that wants to know a genuine
+	// store/connector failure happened to land in the same window — can
+	// still inspect errors.Is(err, ...) instead of it being lost behind
+	// ErrSyncNotComplete. errors.Join drops nils, so this is a no-op when
+	// called from the top-of-loop check (batchErr is nil there).
+	return warnings, errors.Join(checkpointErr, ErrSyncNotComplete, cause, batchErr)
 }
 
 func tooManyWarnings(warningCount int, completedActionsCount uint64) bool {

--- a/pkg/sync/syncer_ctx_cancel_resume_test.go
+++ b/pkg/sync/syncer_ctx_cancel_resume_test.go
@@ -143,10 +143,11 @@ func (c *cancelingListResourcesConnector) ListResources(
 // TestSyncResumesAfterMidActionCancellation covers a cancellation that lands
 // *inside* an in-flight action's connector call -- the shape a SIGTERM
 // actually takes for a long fanned-out batch (e.g. a grants sync spanning
-// hours), rather than the narrow window between actions. Before the
-// finishOnCancellation routing in parallelSync's per-op return points, this
-// error propagated raw (return warnings, err) with no forced checkpoint,
-// and IsSyncPreservable did not recognize it as resumable.
+// hours), rather than the narrow window between actions. Before
+// handleOperationError's guard was widened from context.DeadlineExceeded to
+// any runCtx cancellation cause, this error propagated raw (return warnings,
+// err) with no forced checkpoint, and IsSyncPreservable did not recognize it
+// as resumable.
 func TestSyncResumesAfterMidActionCancellation(t *testing.T) {
 	const resourceTypeCount = 10
 

--- a/pkg/sync/syncer_ctx_cancel_resume_test.go
+++ b/pkg/sync/syncer_ctx_cancel_resume_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
+
+	"google.golang.org/grpc"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
@@ -14,67 +17,30 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestSyncResumesAfterDirectContextCancellation covers the SIGTERM/SIGINT
-// shutdown path (connectorrunner.ErrSigTerm), which cancels the *top-level*
-// ctx directly -- unlike WithRunDuration, whose deadline lives on a runCtx
-// derived from a still-live parent. TestCleanupContextDeadlineExceeded only
-// exercises the latter, so it can't catch a regression in this path: a
-// forced checkpoint that runs on the already-cancelled ctx instead of a
-// context.WithoutCancel copy of it.
-//
-// This must still (a) force a checkpoint before returning and (b) return
-// ErrSyncNotComplete, so a second Sync() on the same store resumes instead
-// of restarting from scratch.
-func TestSyncResumesAfterDirectContextCancellation(t *testing.T) {
-	const resourceTypeCount = 10
-
-	newConnector := func(ctx context.Context) *mockConnector {
-		mc := newMockConnector()
-		for i := range resourceTypeCount {
-			rt := v2.ResourceType_builder{
-				Id:          fmt.Sprintf("rt%d", i),
-				DisplayName: fmt.Sprintf("Type %d", i),
-				Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_USER},
-				Annotations: annotations.New(&v2.SkipEntitlementsAndGrants{}),
-			}.Build()
-			mc.AddResourceType(ctx, rt)
-			user, err := rs.NewUserResource(fmt.Sprintf("u%d", i), rt, fmt.Sprintf("u%d", i), nil,
-				rs.WithAnnotation(&v2.SkipEntitlementsAndGrants{}))
-			require.NoError(t, err)
-			mc.AddResource(ctx, user)
+func newCancelResumeConnector(ctx context.Context, resourceTypeCount int) *mockConnector {
+	mc := newMockConnector()
+	for i := range resourceTypeCount {
+		rt := v2.ResourceType_builder{
+			Id:          fmt.Sprintf("rt%d", i),
+			DisplayName: fmt.Sprintf("Type %d", i),
+			Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_USER},
+			Annotations: annotations.New(&v2.SkipEntitlementsAndGrants{}),
+		}.Build()
+		mc.AddResourceType(ctx, rt)
+		user, err := rs.NewUserResource(fmt.Sprintf("u%d", i), rt, fmt.Sprintf("u%d", i), nil,
+			rs.WithAnnotation(&v2.SkipEntitlementsAndGrants{}))
+		if err != nil {
+			panic(err)
 		}
-		return mc
+		mc.AddResource(ctx, user)
 	}
+	return mc
+}
 
-	tmpDir := t.TempDir()
-	c1zPath := filepath.Join(tmpDir, "cancel-resume.c1z")
-	bgCtx := context.Background()
+func assertResumedSingleRun(t *testing.T, bgCtx context.Context, c1zPath, tmpDir string, resourceTypeCount int) {
+	t.Helper()
 
-	cancelCtx, cancel := context.WithCancel(bgCtx)
-	seen := 0
-	syncer, err := NewSyncer(cancelCtx, newConnector(bgCtx),
-		WithC1ZPath(c1zPath),
-		WithTmpDir(tmpDir),
-		WithStorageEngine(c1zstore.EnginePebble),
-		WithProgressHandler(func(p *Progress) {
-			seen++
-			// Cancel partway through the resource-type sweep: some
-			// resource types synced, some not -- a real SIGTERM landing
-			// mid-sync rather than at a clean action boundary.
-			if seen == 3 {
-				cancel()
-			}
-		}),
-	)
-	require.NoError(t, err)
-
-	err = syncer.Sync(cancelCtx)
-	require.ErrorIs(t, err, ErrSyncNotComplete, "a direct ctx cancellation must be treated as resumable, not a hard failure")
-	require.NoError(t, syncer.Close(bgCtx))
-
-	// Fresh syncer, same store, uncancelled context: must resume the
-	// interrupted sync rather than silently starting a new one.
-	resumed, err := NewSyncer(bgCtx, newConnector(bgCtx),
+	resumed, err := NewSyncer(bgCtx, newCancelResumeConnector(bgCtx, resourceTypeCount),
 		WithC1ZPath(c1zPath),
 		WithTmpDir(tmpDir),
 		WithStorageEngine(c1zstore.EnginePebble),
@@ -98,4 +64,112 @@ func TestSyncResumesAfterDirectContextCancellation(t *testing.T) {
 	rresp, err := store.ListResources(bgCtx, v2.ResourcesServiceListResourcesRequest_builder{}.Build())
 	require.NoError(t, err)
 	require.Len(t, rresp.GetList(), resourceTypeCount, "every resource type's resource must be present after resume")
+}
+
+// TestSyncResumesAfterLoopBoundaryCancellation covers a cancellation observed
+// between actions, at the top of parallelSync's loop -- e.g. a SIGTERM
+// landing during the brief window after one action's connector calls have
+// all returned but before the next has started. This is the shape
+// WithRunDuration's own deadline always took (still covered separately by
+// TestCleanupContextDeadlineExceeded), but here the cancellation is a direct
+// cancel() on the top-level ctx, not a runCtx-only deadline -- so a forced
+// checkpoint that ran on the already-cancelled ctx instead of a
+// context.WithoutCancel copy of it would fail silently and this test would
+// catch that.
+//
+// It does NOT cover a cancellation observed mid-action, inside a connector
+// call -- see TestSyncResumesAfterMidActionCancellation for that.
+func TestSyncResumesAfterLoopBoundaryCancellation(t *testing.T) {
+	const resourceTypeCount = 10
+
+	tmpDir := t.TempDir()
+	c1zPath := filepath.Join(tmpDir, "cancel-resume-boundary.c1z")
+	bgCtx := context.Background()
+
+	cancelCtx, cancel := context.WithCancel(bgCtx)
+	var seen atomic.Int64
+	syncer, err := NewSyncer(cancelCtx, newCancelResumeConnector(bgCtx, resourceTypeCount),
+		WithC1ZPath(c1zPath),
+		WithTmpDir(tmpDir),
+		WithStorageEngine(c1zstore.EnginePebble),
+		WithProgressHandler(func(p *Progress) {
+			// mockConnector.ListResources/ListResourceTypes ignore ctx, so
+			// this cancellation is only ever observed at the next
+			// top-of-loop select, between actions -- not mid-call.
+			if seen.Add(1) == 3 {
+				cancel()
+			}
+		}),
+	)
+	require.NoError(t, err)
+
+	err = syncer.Sync(cancelCtx)
+	require.ErrorIs(t, err, ErrSyncNotComplete, "a direct ctx cancellation must be treated as resumable, not a hard failure")
+	require.NoError(t, syncer.Close(bgCtx))
+
+	assertResumedSingleRun(t, bgCtx, c1zPath, tmpDir, resourceTypeCount)
+}
+
+// cancelingListResourcesConnector wraps mockConnector so that ListResources
+// -- the per-resource-type connector call that SyncResourcesOp's fan-out
+// (syncParallel) makes once per queued action -- observes cancellation
+// exactly like a real connector RPC would: it fails with the ctx's own
+// error once the context is cancelled mid-batch, instead of the base mock's
+// ctx-blind behavior. This is what lets the test below land the
+// cancellation *inside* an in-flight action rather than only ever at a
+// clean action boundary.
+type cancelingListResourcesConnector struct {
+	*mockConnector
+	callsBeforeCancel int
+	calls             atomic.Int64
+	cancel            context.CancelFunc
+}
+
+func (c *cancelingListResourcesConnector) ListResources(
+	ctx context.Context,
+	in *v2.ResourcesServiceListResourcesRequest,
+	opts ...grpc.CallOption,
+) (*v2.ResourcesServiceListResourcesResponse, error) {
+	if int(c.calls.Add(1)) > c.callsBeforeCancel {
+		c.cancel()
+		return nil, ctx.Err()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return c.mockConnector.ListResources(ctx, in, opts...)
+}
+
+// TestSyncResumesAfterMidActionCancellation covers a cancellation that lands
+// *inside* an in-flight action's connector call -- the shape a SIGTERM
+// actually takes for a long fanned-out batch (e.g. a grants sync spanning
+// hours), rather than the narrow window between actions. Before the
+// finishOnCancellation routing in parallelSync's per-op return points, this
+// error propagated raw (return warnings, err) with no forced checkpoint,
+// and IsSyncPreservable did not recognize it as resumable.
+func TestSyncResumesAfterMidActionCancellation(t *testing.T) {
+	const resourceTypeCount = 10
+
+	tmpDir := t.TempDir()
+	c1zPath := filepath.Join(tmpDir, "cancel-resume-mid-action.c1z")
+	bgCtx := context.Background()
+
+	cancelCtx, cancel := context.WithCancel(bgCtx)
+	connector := &cancelingListResourcesConnector{
+		mockConnector:     newCancelResumeConnector(bgCtx, resourceTypeCount),
+		callsBeforeCancel: 3,
+		cancel:            cancel,
+	}
+	syncer, err := NewSyncer(cancelCtx, connector,
+		WithC1ZPath(c1zPath),
+		WithTmpDir(tmpDir),
+		WithStorageEngine(c1zstore.EnginePebble),
+	)
+	require.NoError(t, err)
+
+	err = syncer.Sync(cancelCtx)
+	require.ErrorIs(t, err, ErrSyncNotComplete, "a cancellation surfaced mid-action must still be treated as resumable, not a hard failure")
+	require.NoError(t, syncer.Close(bgCtx))
+
+	assertResumedSingleRun(t, bgCtx, c1zPath, tmpDir, resourceTypeCount)
 }

--- a/pkg/sync/syncer_ctx_cancel_resume_test.go
+++ b/pkg/sync/syncer_ctx_cancel_resume_test.go
@@ -1,0 +1,101 @@
+package sync //nolint:revive,nolintlint // we can't change the package name for backwards compatibility
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSyncResumesAfterDirectContextCancellation covers the SIGTERM/SIGINT
+// shutdown path (connectorrunner.ErrSigTerm), which cancels the *top-level*
+// ctx directly -- unlike WithRunDuration, whose deadline lives on a runCtx
+// derived from a still-live parent. TestCleanupContextDeadlineExceeded only
+// exercises the latter, so it can't catch a regression in this path: a
+// forced checkpoint that runs on the already-cancelled ctx instead of a
+// context.WithoutCancel copy of it.
+//
+// This must still (a) force a checkpoint before returning and (b) return
+// ErrSyncNotComplete, so a second Sync() on the same store resumes instead
+// of restarting from scratch.
+func TestSyncResumesAfterDirectContextCancellation(t *testing.T) {
+	const resourceTypeCount = 10
+
+	newConnector := func(ctx context.Context) *mockConnector {
+		mc := newMockConnector()
+		for i := range resourceTypeCount {
+			rt := v2.ResourceType_builder{
+				Id:          fmt.Sprintf("rt%d", i),
+				DisplayName: fmt.Sprintf("Type %d", i),
+				Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_USER},
+				Annotations: annotations.New(&v2.SkipEntitlementsAndGrants{}),
+			}.Build()
+			mc.AddResourceType(ctx, rt)
+			user, err := rs.NewUserResource(fmt.Sprintf("u%d", i), rt, fmt.Sprintf("u%d", i), nil,
+				rs.WithAnnotation(&v2.SkipEntitlementsAndGrants{}))
+			require.NoError(t, err)
+			mc.AddResource(ctx, user)
+		}
+		return mc
+	}
+
+	tmpDir := t.TempDir()
+	c1zPath := filepath.Join(tmpDir, "cancel-resume.c1z")
+	bgCtx := context.Background()
+
+	cancelCtx, cancel := context.WithCancel(bgCtx)
+	seen := 0
+	syncer, err := NewSyncer(cancelCtx, newConnector(bgCtx),
+		WithC1ZPath(c1zPath),
+		WithTmpDir(tmpDir),
+		WithStorageEngine(c1zstore.EnginePebble),
+		WithProgressHandler(func(p *Progress) {
+			seen++
+			// Cancel partway through the resource-type sweep: some
+			// resource types synced, some not -- a real SIGTERM landing
+			// mid-sync rather than at a clean action boundary.
+			if seen == 3 {
+				cancel()
+			}
+		}),
+	)
+	require.NoError(t, err)
+
+	err = syncer.Sync(cancelCtx)
+	require.ErrorIs(t, err, ErrSyncNotComplete, "a direct ctx cancellation must be treated as resumable, not a hard failure")
+	require.NoError(t, syncer.Close(bgCtx))
+
+	// Fresh syncer, same store, uncancelled context: must resume the
+	// interrupted sync rather than silently starting a new one.
+	resumed, err := NewSyncer(bgCtx, newConnector(bgCtx),
+		WithC1ZPath(c1zPath),
+		WithTmpDir(tmpDir),
+		WithStorageEngine(c1zstore.EnginePebble),
+	)
+	require.NoError(t, err)
+	require.NoError(t, resumed.Sync(bgCtx))
+	require.NoError(t, resumed.Close(bgCtx))
+
+	store, err := dotc1z.NewStore(bgCtx, c1zPath, dotc1z.WithEngine(c1zstore.EnginePebble), dotc1z.WithTmpDir(tmpDir))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, store.Close(bgCtx)) }()
+
+	lister, ok := store.(interface {
+		ListSyncRuns(ctx context.Context, pageToken string, pageSize uint32) ([]*c1zstore.SyncRun, string, error)
+	})
+	require.True(t, ok)
+	runs, _, err := lister.ListSyncRuns(bgCtx, "", 100)
+	require.NoError(t, err)
+	require.Len(t, runs, 1, "resume must seal the interrupted sync run, not start a second one")
+
+	rresp, err := store.ListResources(bgCtx, v2.ResourcesServiceListResourcesRequest_builder{}.Build())
+	require.NoError(t, err)
+	require.Len(t, rresp.GetList(), resourceTypeCount, "every resource type's resource must be present after resume")
+}


### PR DESCRIPTION
## Summary

- Catch `syscall.SIGTERM` (not just `os.Interrupt`) in `connectorrunner.Run()`, routing it through the existing graceful `cancel(ErrSigTerm)` path. Without this, an orchestrator-sent SIGTERM (Kubernetes rollout/drain/spot-reclaim, `docker stop`) terminated the process immediately with no chance to checkpoint in-flight progress. (Correction: the process dies immediately regardless of PID 1 status — the Go runtime installs its own handler for SIGTERM at startup, so the kernel's PID-1 default-action-suppression rule never actually applies to a Go binary. The observable symptom — abrupt exit, lost progress — is right, only the mechanism I originally described was wrong. Thanks @sergiocorral-conductorone.)
- **Drain in-flight tasks before `run()` returns on cancellation.** In the long-lived (non-`oneShot`) mode every task is dispatched to an untracked goroutine (`go func(t *v1.Task)`), and every caller of this runner closes the connector client (`Close()` → `c.cw.Close()`) immediately after `Run()` returns. Trapping SIGTERM alone doesn't help if nothing waits: `run()` would return the instant `ctx.Done()` fires, `Close()` would tear the connector client down, and the in-flight sync's forced checkpoint write could be racing that teardown. `run()` now calls `drainInFlightTasks` before returning on cancellation, which acquires the full semaphore weight on a **detached, 25s-bounded** context (`shutdownDrainTimeout`) — i.e. waits for every dispatched task goroutine to actually finish. New test `TestRun_DrainsInFlightTaskBeforeReturningOnCancellation` uses a task manager whose `Process` ignores `ctx.Done()` (mirroring a real checkpoint write on a detached context) and asserts `run()` doesn't return until it's released; fails without the drain, passes with it.
- Unify `parallel_syncer.go`'s cancellation handling so **any** cancellation of `runCtx` — a deadline timeout, a SIGTERM/SIGINT shutdown, a server-directed task cancellation (`ErrTaskCancelled`), a heartbeat failure (`ErrTaskHeartbeatFailed`), or any other cause — forces a checkpoint and returns a resumable `ErrSyncNotComplete`-wrapped error. This widens the guard on the existing `handleOperationError` helper (added by the concurrent Phase 5 merge, #1029, to fix the same class of bug for the deadline-only case) from `errors.Is(cause, context.DeadlineExceeded)` to any non-nil cause.
- **Every mid-action return point already routed through `handleOperationError`** (that wiring is Phase 5's, not this PR's — see the attribution note below); this PR's actual fix is generalizing what the helper does with a non-deadline cause, plus adding the one call site Phase 5 didn't cover (`MarkSyncSupportsDiff`, `parallel_syncer.go`), plus closing the two residual bypass windows below. New test `TestSyncResumesAfterMidActionCancellation` uses a connector mock that actually observes `ctx` cancellation mid-call (the base test mock ignores `ctx` entirely) — fails without the widened guard, passes with it.
- **Preserve both the cancellation cause and the in-flight operation's own error**, instead of dropping them. `handleOperationError` now returns `errors.Join(checkpointErr, ErrSyncNotComplete, cause, batchErr)` — `errors.Is(err, ErrSyncNotComplete)` still classifies it as preservable, while a caller can separately recover *why* (`errors.Is(err, cause)`, e.g. `pkg/tasks/c1api` distinguishing `ErrTaskCancelled` from a plain shutdown) and *what the interrupted operation actually returned* (`batchErr` — a genuine store/connector failure that happens to land in the same window is no longer silently swallowed on the next attempt).
- **Close two residual windows where cancellation still bypassed the helper.** The loop's throttled, non-forced `Checkpoint(ctx, false)` ran on the raw `ctx` *before* the `runCtx.Done()` check (now reordered so cancellation is checked first) — and even after that reorder, the check itself only ran once per loop iteration, so a cancellation landing in the small gap between the check and this same checkpoint call could still hit the raw ctx and return unclassified. That checkpoint call (and the three similar forced `Checkpoint(ctx, true)` calls in the `InitOp` arm) now route their errors through `handleOperationError` too, which is a no-op when `runCtx` wasn't actually cancelled.
- **Bound the forced checkpoint write.** `context.WithoutCancel(ctx)` strips the deadline as well as the cancellation, so an unbounded write here could stall for the connector's entire termination grace period and still get SIGKILLed. It's now wrapped in a 15s timeout (`forcedCheckpointTimeout`), under Kubernetes' 30s default grace period and under the runner's own 25s drain budget.
- **Restored the sync-stats summary log for a non-deadline cancellation.** Before this PR, any non-deadline cancellation returned a raw, non-`ErrSyncNotComplete` error, so `returnSyncError` logged the full stats summary (per-step durations, per-resource-type counters, retry/rate-limit wall time) on its normal path. Once the returned error satisfies `errors.Is(err, ErrSyncNotComplete)`, that logging is skipped — so a SIGTERM-interrupted sync was logging *less* diagnostic output than before this PR, using the same counters that reconstructed the CXH-2121 timeline in the first place. The non-deadline branch now mirrors the deadline branch's `s.recordStats` summary.

All of the above (drain, checkpoint-ordering residual window, batchErr preservation, stats-summary regression, PID-1 mechanism correction) were raised in a second review pass by @sergiocorral-conductorone, several independently confirmed by an automated verifier. I verified each against the code before fixing it — thank you for the thoroughness.

### Attribution correction

An earlier revision of this PR body over-credited itself: it claimed "all ~12 mid-action return points now route through a new helper," implying this PR wired that routing. It didn't — those call sites already existed on `main` (added by the Phase 5 merge, #1029, with `handleOperationError` already in place but gated to `context.DeadlineExceeded` only). This PR's actual contribution is generalizing that helper's guard to any cancellation cause (which is what actually fixes the bypass sergiocorral found), adding the one call site Phase 5 missed, and the residual-window/preservation/logging fixes above. Also fixed leftover references to an earlier local name for the helper (`finishOnCancellation`) in a test file comment — the function is `handleOperationError` throughout.

### Wire-visible behavior change worth flagging before merge

Joining `cause` and `batchErr` into the returned error changes what `pkg/tasks/c1api/manager.go`'s `finishTask` reports to C1, in two different ways depending on what's in the join:

- None of `cause` (`ErrSigTerm` / `ErrTaskCancelled` / `ErrTaskHeartbeatFailed` / `context.Canceled` / `context.DeadlineExceeded`) or `ErrSyncNotComplete` implement `GRPCStatus()`, so when `batchErr` is nil (the top-of-loop check) or itself doesn't implement it either, `status.FromError(taskError)` returns `ok=false` and falls to the sentinel switch, which now matches via `errors.Is` — `codes.Canceled` for the SIGTERM path, `codes.DeadlineExceeded` for the run-duration path — instead of the previous `codes.Unknown`.
- When a mid-action cancellation's `batchErr` *does* implement `GRPCStatus()` (the interrupted connector call itself returned a proper gRPC status, e.g. a rate-limit or transport error), `status.FromError`'s `errors.As` traversal finds it directly inside the joined tree and returns that code instead, bypassing the sentinel switch entirely.

Both directions look strictly more accurate than the previous blanket `codes.Unknown`, and `NonRetryable` classification is unaffected either way, but whether C1's task engine treats `codes.Canceled` (or whatever code `batchErr` surfaces) as retryable is outside this repo — worth confirming with whoever owns that before merge, not discovering it as a behavior change in the hosted fleet. (Flagged in two passes: @sergiocorral-conductorone for the `cause` side, the automated reviewer for the `batchErr` side.)

## Context

Investigated via a large production sync (baton-azure-devops, CXH-2121) showing ~9.6h of a 16.6h run unaccounted for: the `user` grants-sync counter reset to 1 ten times without ever completing. Only 3 of those resets corresponded to a logged, checkpoint-safe `"sync run duration has expired"` exit — the rest had no graceful-exit log at all, consistent with unhandled SIGTERM kills losing in-flight progress.

Caveats worth stating plainly, also raised in review:

- **The legacy SQLite engine (`C1File`) has a wider version of the same problem**, unaddressed here: it uses `ctx` directly in per-action store calls (e.g. `GetResource`), not just the checkpoint write, so a cancellation landing mid-action can still bypass the resumable classification there even after this PR. Production runs the Pebble engine, where the store calls this PR touches don't have that problem, but I have not audited the SQLite engine's other per-action call sites beyond confirming the checkpoint path.
- ~~I have not confirmed which task-handling path CXH-2121's connector actually runs through~~ **Resolved via @Bencheng21** (owner of the Temporal/task-engine side): the actual path is a Temporal activity in `ductone/c1`'s `sync_v0.go`, not `pkg/tasks/c1api` or `pkg/tasks/local` in this repo. Per his analysis in [ductone/c1#22446](https://github.com/ductone/c1/pull/22446) (merged 2026-08-01), that activity's upload logic checks `errors.Is(err, ErrSyncNotComplete)` **directly**, independent of the separate FF-gated `IsSyncPreservable` path (which he notes is currently broken — its feature-flag check fails on every attempt, falling back to "legacy behavior"). That means once this SDK version is adopted, `handleOperationError`'s unconditional `ErrSyncNotComplete` on *any* cancellation cause — not just `context.DeadlineExceeded` — should be picked up by that existing direct check without needing the FF path fixed. His PR is a complementary, not redundant, fix: it catches worker-drain specifically via Temporal's own `activity.GetWorkerStopChannel(ctx)` signal (works regardless of how baton-sdk classifies the error), while this PR fixes the classification at the SDK layer for every cancellation cause — including ones his drain-specific check doesn't cover, like a heartbeat timeout without an active `RecordHeartbeat`, which his own PR description lists as a still-open "companion candidate" for baton-sdk. This PR is that candidate. (I can't read `sync_v0.go` directly — this is inferred from his PR's own classification table and description, not independently verified against that file.)
- **The drain budget (25s) can't accommodate `syncer.Close()`'s own detached finalize**, which is bounded separately by `dotc1z.FinalizeTimeout` (1h default) and runs on every path including sync failure. The drain in this PR only targets getting the smaller, higher-priority forced checkpoint write (15s) safely persisted before the connector client is torn down — it does not, and cannot within any realistic termination grace period, guarantee the full c1z finalize/close tail completes too.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./pkg/sync/... ./pkg/connectorrunner/...`
- [x] `go test ./pkg/sync/... ./pkg/connectorrunner/... -count=1` — full suite green
- [x] `go test ./pkg/connectorrunner/... -race -count=1` — race-clean
- [x] `TestSyncResumesAfterLoopBoundaryCancellation` — cancellation observed between actions.
- [x] `TestSyncResumesAfterMidActionCancellation` — cancellation observed inside an in-flight connector call, via a mock that actually respects `ctx`. Fails on the narrow (deadline-only) guard, passes with the widened one.
- [x] `TestRun_DrainsInFlightTaskBeforeReturningOnCancellation` — asserts `run()` waits for an in-flight task goroutine to finish before returning on cancellation. Fails without the drain, passes with it.