### PR TITLE
crash harness and Makefile cleaning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,39 +4,53 @@ GOARCH = $(shell go env GOARCH)
 BUILD_DIR = dist/${GOOS}_${GOARCH}
 OUTPUT_PATH = ${BUILD_DIR}/baton
 
+# Durations and iteration counts used by the opt-in confidence suites.
+# Override at invocation time, for example: make fuzz-smoke FUZZ_TIME=2m.
+FUZZ_TIME ?= 30s
+DIFFERENTIAL_TIME ?= 30s
+SOAK_ITERATIONS ?= 25
+NIGHTLY_FUZZ_TIME ?= 5m
+NIGHTLY_DIFFERENTIAL_TIME ?= 10m
+
+.DEFAULT_GOAL := help
+
+.PHONY: help
+help: ## List build, test, and confidence targets.
+	@awk 'BEGIN {FS = ":.*## "; printf "Usage: make <target>\n\nTargets:\n"} /^[a-zA-Z0-9_-]+:.*## / {printf "  %-24s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
 .PHONY: build
-build: frontend
+build: frontend ## Build the frontend and baton binary.
 	rm -f ${OUTPUT_PATH}
 	mkdir -p ${BUILD_DIR}
 	go build -o ${OUTPUT_PATH} ./cmd/baton
 
 .PHONY: frontend
-frontend:
+frontend: ## Build the embedded React frontend.
 	cd frontend && npm install && npm run build
 
 .PHONY: lint
-lint:
+lint: ## Run golangci-lint.
 	golangci-lint run --timeout=3m
 
 .PHONY: update-deps
-update-deps:
+update-deps: ## Update and tidy Go dependencies.
 	go get -d -u ./...
 	go mod tidy -v
 
 .PHONY: add-deps
-add-dep:
+add-dep: ## Tidy Go dependencies after adding one.
 	go mod tidy -v
 
 .PHONY: protogen
-protogen:
+protogen: ## Generate protobuf code.
 	buf generate
 
 .PHONY: protofmt
-protofmt:
+protofmt: ## Format protobuf definitions.
 	buf format -w
 
 .PHONY: test
-test:
+test: ## Run the Go test suite used by CI.
 	go test -tags=baton_lambda_support -v ./...
 
 # Two-artifact checkpoint compatibility matrix: builds the harness against
@@ -44,16 +58,81 @@ test:
 # both directions. See cmd/baton-compat-harness. Override the old release
 # with BATON_COMPAT_OLD_REF=<tag>.
 .PHONY: compat-check
-compat-check:
+compat-check: ## Exchange checkpoints with a pinned older SDK.
 	BATON_COMPAT=1 go test -v -count=1 -run TestCheckpointCompatAcrossSDKVersions ./cmd/baton-compat-harness
 
-# Real-binary interruption instrument: builds a demo-style connector from
-# this tree as a real CLI binary, SIGINTs and SIGKILLs it mid-sync, and
-# requires resumed syncs to seal a store content-identical to an
+# Real-binary interruption instrument: builds a deterministic connector from
+# this tree, runs budget-bounded sync sessions, SIGKILLs them at varied
+# offsets, and requires resumed syncs to seal a store content-identical to an
 # uninterrupted baseline. See cmd/baton-crash-harness.
-.PHONY: demo-crash-check
-demo-crash-check:
+.PHONY: crash-check
+crash-check: ## Exercise cross-process checkpoint/resume under hard kills.
 	BATON_DEMO_CRASH=1 go test -v -count=1 -timeout=30m -run TestCrashResumeRealConnector ./cmd/baton-crash-harness
+
+.PHONY: demo-crash-check
+demo-crash-check: crash-check ## Deprecated alias for crash-check.
+
+.PHONY: checkpoint-cut-check
+checkpoint-cut-check: ## Resume from every durable checkpoint cut.
+	BATON_CUT_SWEEP=full go test -v -count=1 -timeout=30m -run TestCheckpointCutEnumeration ./pkg/sync
+
+.PHONY: interrupt-check
+interrupt-check: checkpoint-cut-check crash-check ## Run in-process cut and real-process interruption checks.
+
+.PHONY: race-check
+race-check: ## Run the complete Go suite with the race detector.
+	go test -race -tags=baton_lambda_support -count=1 -timeout=30m ./...
+
+.PHONY: fuzz-smoke
+fuzz-smoke: ## Run each native Go fuzzer for FUZZ_TIME (default 30s).
+	go test -run '^$$' -fuzz '^FuzzCondenseFWBW_Cancellation$$' -fuzztime=$(FUZZ_TIME) ./pkg/sync/expand/scc
+	go test -run '^$$' -fuzz '^FuzzCondenseFWBW_FromBytes$$' -fuzztime=$(FUZZ_TIME) ./pkg/sync/expand/scc
+
+.PHONY: differential-check
+differential-check: ## Differential-fuzz SQLite and Pebble for DIFFERENTIAL_TIME.
+	BATON_EXPAND_FUZZ_DURATION=$(DIFFERENTIAL_TIME) go test -v -count=1 -timeout=30m -run '^TestFullPipelineDifferentialFuzz$$' ./pkg/sync/expand
+
+.PHONY: bench-smoke
+bench-smoke: ## Run the bounded checkpoint cost benchmarks once.
+	go test -run '^$$' -bench 'Benchmark(CheckpointToken|SpawnedCursorAdmission)' -benchtime=1x -benchmem ./pkg/sync
+
+.PHONY: bench
+bench: ## Run curated checkpoint and medium full-sync benchmarks.
+	go test -run '^$$' -bench 'Benchmark(CheckpointToken|SpawnedCursorAdmission)' -benchmem ./pkg/sync
+	SYNC_BENCH_SCALE=medium go test -tags=baton_lambda_support,batonsdkv2 -run '^$$' -bench '^BenchmarkFullSync_BatonDemoShape$$' -benchtime=1x -benchmem ./pkg/sync
+
+.PHONY: scheduler-soak
+scheduler-soak: ## Run randomized scheduler cases under race detection.
+	BATON_SOAK_ITERATIONS=$(SOAK_ITERATIONS) go test -race -v -count=1 -timeout=30m -run TestSchedulerSoakRandomizedFanoutWithFailures ./pkg/sync
+
+.PHONY: errorfs-soak
+errorfs-soak: ## Sweep whole-sync Pebble crash points using errorfs.
+	BATON_SOAK=1 go test -v -count=1 -timeout=30m -run TestErrorFSWholeSyncRandomSweepSoak ./pkg/dotc1z/engine/pebble
+
+.PHONY: test-extra
+test-extra: race-check compat-check interrupt-check fuzz-smoke differential-check bench-smoke ## Run bounded confidence checks omitted from CI.
+
+.PHONY: test-nightly
+test-nightly: ## Run extended confidence, fuzz, scheduler, and errorfs checks.
+	$(MAKE) test-extra FUZZ_TIME=$(NIGHTLY_FUZZ_TIME) DIFFERENTIAL_TIME=$(NIGHTLY_DIFFERENTIAL_TIME)
+	$(MAKE) scheduler-soak
+	$(MAKE) errorfs-soak
+
+# Production-scale compactor experiments are deliberately excluded from
+# test-extra and test-nightly: they create multi-million-row fixtures and may
+# consume hours and substantial disk. Their BATON_* sizing variables remain
+# available as documented in docs/TESTING.md and the test files.
+.PHONY: prodscale-check
+prodscale-check: ## Run the multi-million-row compactor experiment.
+	BATON_PROD_SCALE_TEST=1 go test -v -count=1 -timeout=60m -run 'TestProdScale' ./pkg/synccompactor
+
+.PHONY: prodscale-crossover
+prodscale-crossover: ## Measure fold/overlay crossover at production scale.
+	BATON_PROD_SCALE_CROSSOVER=1 go test -v -count=1 -timeout=60m -run TestProdScaleFoldOverlayCrossover ./pkg/synccompactor
+
+.PHONY: prodscale-topebble
+prodscale-topebble: ## Measure SQLite-to-Pebble conversion at production scale.
+	BATON_PROD_SCALE_TOPEBBLE=1 go test -v -count=1 -timeout=180m -run TestProdScaleToPebbleCurve ./pkg/synccompactor
 
 .PHONY: pkg/sdk/version.go
 pkg/sdk/version.go:

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,14 @@ test:
 compat-check:
 	BATON_COMPAT=1 go test -v -count=1 -run TestCheckpointCompatAcrossSDKVersions ./cmd/baton-compat-harness
 
+# Real-binary interruption instrument: builds a demo-style connector from
+# this tree as a real CLI binary, SIGINTs and SIGKILLs it mid-sync, and
+# requires resumed syncs to seal a store content-identical to an
+# uninterrupted baseline. See cmd/baton-crash-harness.
+.PHONY: demo-crash-check
+demo-crash-check:
+	BATON_DEMO_CRASH=1 go test -v -count=1 -timeout=30m -run TestCrashResumeRealConnector ./cmd/baton-crash-harness
+
 .PHONY: pkg/sdk/version.go
 pkg/sdk/version.go:
 	echo $(VERSION)

--- a/README.md
+++ b/README.md
@@ -124,6 +124,12 @@ Use "baton [command] --help" for more information about a command.
 
 To build changes to any protocol buffers, run `make protogen` - this requires an installation of `buf` in `$PATH`.
 
+## Testing
+
+Run `make help` to see the available test and confidence suites. See
+[docs/TESTING.md](./docs/TESTING.md) for the distinction between CI,
+pre-release, nightly, benchmark, and production-scale checks.
+
 ## Learn more about Baton
 
 The [Baton documentation site contains more documentation and example use cases](https://www.conductorone.com/docs/baton/intro/).

--- a/cmd/baton-crash-harness/driver_test.go
+++ b/cmd/baton-crash-harness/driver_test.go
@@ -4,7 +4,7 @@
 // keeps the tag-gated harness binary from rotting against HEAD.
 //
 // TestCrashResumeRealConnector is the instrument itself, gated behind
-// BATON_DEMO_CRASH=1 (run via `make demo-crash-check`). It composes real
+// BATON_DEMO_CRASH=1 (run via `make crash-check`). It composes real
 // processes into a production-shaped sync history:
 //
 //   - budget-bounded sessions (-run-duration-ms): the session
@@ -113,7 +113,7 @@ func TestCrashHarnessBuildsAgainstHead(t *testing.T) {
 
 func TestCrashResumeRealConnector(t *testing.T) {
 	if os.Getenv("BATON_DEMO_CRASH") == "" {
-		t.Skip("real-binary crash/resume instrument; set BATON_DEMO_CRASH=1 (or run `make demo-crash-check`)")
+		t.Skip("real-binary crash/resume instrument; set BATON_DEMO_CRASH=1 (or run `make crash-check`)")
 	}
 	if runtime.GOOS == "windows" {
 		t.Skip("the interruption schedule relies on unix signal semantics")

--- a/cmd/baton-crash-harness/driver_test.go
+++ b/cmd/baton-crash-harness/driver_test.go
@@ -1,0 +1,425 @@
+// Driver for the real-binary interruption instrument (main.go).
+//
+// TestCrashHarnessBuildsAgainstHead always runs: it is the compile gate that
+// keeps the tag-gated harness binary from rotting against HEAD.
+//
+// TestCrashResumeRealConnector is the instrument itself, gated behind
+// BATON_DEMO_CRASH=1 (run via `make demo-crash-check`). It composes real
+// processes into a production-shaped sync history:
+//
+//   - budget-bounded sessions (-run-duration-ms): the session
+//     force-checkpoints on expiry, durably saves the c1z, and exits; the
+//     next session — a fresh process, like the next task in production —
+//     resumes from the artifact.
+//   - SIGKILLs armed at varying offsets: some land mid-sync, some inside
+//     the end-of-session save itself. Nothing gets to react; the next
+//     session must fall back to whatever artifact survived, uncorrupted.
+//
+// The in-repo suites (checkpoint cut enumeration, resume adversary,
+// scheduler soak) interrupt the syncer in-process at points the harness can
+// name; none of them exercise a real process boundary. Per
+// docs/BUG_CATCHING.md §1 the invariant under interruption is
+// content-completeness of the surviving artifact, not any particular resume
+// behavior — so the oracle is ID sets against an uninterrupted baseline of
+// the same deterministic connector, not counts or error text.
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
+)
+
+// Dataset flags passed to the binary and the totals they imply (the
+// connector is deterministic, so the totals are exact). usersPerGroup is
+// restated from main.go, which is excluded from this compilation by its
+// build tag.
+const (
+	harnessUsers         = 3000
+	harnessGroups        = 150
+	harnessUsersPerGroup = 20
+	// Stretches every paginated connector call so sessions are
+	// interruptible mid-action and the sequential cells outlive
+	// minCheckpointInterval, exercising the production checkpoint cadence.
+	harnessPageDelayMs = 25
+
+	wantResources = harnessUsers + harnessGroups
+	wantEnts      = harnessGroups
+	wantGrants    = harnessGroups * harnessUsersPerGroup
+
+	// maxSessions bounds the crash loop. The slowest cell runs ~15s of
+	// connector time — call it eight budget sessions — and at most half the
+	// sessions are killed, so 40 leaves generous headroom.
+	maxSessions = 40
+)
+
+// killFractions are the SIGKILL arming delays as fractions of the cell's
+// session budget, cycled over killed sessions. They land early-sync,
+// mid-sync, and in or after the end-of-session checkpoint save — the last is
+// the window where a hard death races the artifact rewrite itself.
+var killFractions = []float64{0.35, 0.75, 1.05, 1.3}
+
+type cellConfig struct {
+	engine  string
+	workers int
+	// budgetMs bounds each crash-loop session, mirroring production's
+	// budget-bounded connector tasks. Sized per cell so every history
+	// spans enough sessions to satisfy the vacuity quotas below: parallel
+	// cells sync in a few seconds, the sequential cell in ~15s.
+	budgetMs int
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	require.NoError(t, err)
+	return root
+}
+
+func buildHarness(t *testing.T, out string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "go", "build", "-tags", "crashharness", "-o", out, "./cmd/baton-crash-harness")
+	cmd.Dir = repoRoot(t)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "build harness:\n%s", output)
+}
+
+// TestCrashHarnessBuildsAgainstHead is the ungated compile gate: the harness
+// binary must always build against the current tree.
+func TestCrashHarnessBuildsAgainstHead(t *testing.T) {
+	buildHarness(t, filepath.Join(t.TempDir(), "baton-crash-harness"))
+}
+
+func TestCrashResumeRealConnector(t *testing.T) {
+	if os.Getenv("BATON_DEMO_CRASH") == "" {
+		t.Skip("real-binary crash/resume instrument; set BATON_DEMO_CRASH=1 (or run `make demo-crash-check`)")
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("the interruption schedule relies on unix signal semantics")
+	}
+	tmp := t.TempDir()
+	bin := filepath.Join(tmp, "baton-crash-harness")
+	buildHarness(t, bin)
+
+	cells := []cellConfig{
+		{engine: "sqlite", workers: 4, budgetMs: 1000},
+		{engine: "pebble", workers: 4, budgetMs: 1000},
+		{engine: "pebble", workers: 0, budgetMs: 2000},
+	}
+	for _, cell := range cells {
+		t.Run(fmt.Sprintf("%s_workers_%d", cell.engine, cell.workers), func(t *testing.T) {
+			cellTmp := t.TempDir()
+
+			// Uninterrupted baseline contents. The connector is
+			// deterministic, so the baseline is exact — this doubles as the
+			// vacuity guard on the dataset flags.
+			baselinePath := filepath.Join(cellTmp, "baseline.c1z")
+			res := runSession(t, bin, cell, cellTmp, baselinePath, 0, 0)
+			require.NoError(t, res.err, "baseline sync failed:\n%s", res.output)
+			require.True(t, res.result.Complete, "baseline must complete:\n%s", res.output)
+			baseline := snapshotStore(t, baselinePath, cellTmp)
+			require.Zero(t, baseline.unfinishedRuns, "baseline must seal its sync")
+			require.Len(t, baseline.resources, wantResources)
+			require.Len(t, baseline.entitlements, wantEnts)
+			require.Len(t, baseline.grants, wantGrants)
+
+			// Interruption loop: budget-bounded sessions, with a SIGKILL
+			// armed on every second session.
+			crashPath := filepath.Join(cellTmp, "crash.c1z")
+			completed := false
+			budgetSessions := 0
+			killedSessions := 0
+			sawUnfinished := false
+			sawCheckpointToken := false
+			for i := 0; i < maxSessions; i++ {
+				killAfter := time.Duration(0)
+				if i%2 == 1 {
+					frac := killFractions[(i/2)%len(killFractions)]
+					killAfter = time.Duration(frac * float64(cell.budgetMs) * float64(time.Millisecond))
+				}
+				res := runSession(t, bin, cell, cellTmp, crashPath, cell.budgetMs, killAfter)
+				switch {
+				case res.killed:
+					killedSessions++
+				case res.err != nil:
+					t.Fatalf("session %d failed:\n%s", i, res.output)
+				case res.result.Complete:
+					completed = true
+				case res.result.NotComplete:
+					budgetSessions++
+				default:
+					t.Fatalf("session %d reported neither complete nor not_complete:\n%s", i, res.output)
+				}
+				if completed {
+					break
+				}
+				if unfinished, token, ok := tryInspect(crashPath, cellTmp); ok && unfinished > 0 {
+					sawUnfinished = true
+					if token {
+						sawCheckpointToken = true
+					}
+				}
+			}
+			require.True(t, completed, "sync did not complete within %d sessions", maxSessions)
+			// Meta-assertions against a vacuous harness: the history must
+			// actually contain budget expiries, hard kills, and durable
+			// mid-flight checkpoints for resumes to pick up. If these fire,
+			// grow the dataset, the page delay, or the schedule.
+			require.GreaterOrEqual(t, budgetSessions, 2, "history contains too few budget-expired sessions")
+			require.GreaterOrEqual(t, killedSessions, 2, "history contains too few killed sessions")
+			require.True(t, sawUnfinished, "no session left a durable unfinished sync; the harness never exercised resume")
+			require.True(t, sawCheckpointToken, "no durable unfinished sync carried a checkpoint token; resumes always restarted from scratch")
+
+			final := snapshotStore(t, crashPath, cellTmp)
+			require.Zero(t, final.unfinishedRuns, "resumed store must seal its sync")
+			requireSameSet(t, "resources", baseline.resources, final.resources)
+			requireSameSet(t, "entitlements", baseline.entitlements, final.entitlements)
+			requireSameSet(t, "grants", baseline.grants, final.grants)
+		})
+	}
+}
+
+// sessionOutcome mirrors main.go's HARNESS_RESULT json (a distinct type so
+// the package also compiles when the crashharness build tag pulls in both
+// files, e.g. under the linter).
+type sessionOutcome struct {
+	Complete    bool   `json:"complete"`
+	NotComplete bool   `json:"not_complete"`
+	SyncErr     string `json:"sync_err"`
+}
+
+type runResult struct {
+	result sessionOutcome
+	killed bool
+	err    error
+	output string
+}
+
+// runSession executes one real sync session of the harness binary.
+// killAfter > 0 arms a SIGKILL; runDurationMs > 0 bounds the session budget.
+func runSession(t *testing.T, bin string, cell cellConfig, cellTmp, c1zPath string, runDurationMs int, killAfter time.Duration) runResult {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin,
+		"-c1z", c1zPath,
+		"-users", strconv.Itoa(harnessUsers),
+		"-groups", strconv.Itoa(harnessGroups),
+		"-page-delay-ms", strconv.Itoa(harnessPageDelayMs),
+		"-run-duration-ms", strconv.Itoa(runDurationMs),
+	)
+	cmd.Dir = cellTmp
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	cmd.Env = append(os.Environ(),
+		"TMPDIR="+cellTmp,
+		"BATON_STORAGE_ENGINE="+cell.engine,
+		"BATON_WORKERS="+strconv.Itoa(cell.workers),
+	)
+	require.NoError(t, cmd.Start())
+	var fired atomic.Bool
+	var timer *time.Timer
+	if killAfter > 0 {
+		timer = time.AfterFunc(killAfter, func() {
+			fired.Store(true)
+			_ = cmd.Process.Kill() // ignore error: the process may already have exited
+		})
+	}
+	err := cmd.Wait()
+	if timer != nil {
+		timer.Stop()
+	}
+	res := runResult{err: err, output: out.String()}
+	if err != nil && fired.Load() {
+		// Only a signaled death counts as killed: a session that finished
+		// before the kill landed completed on its own.
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			if ws, ok := exitErr.Sys().(syscall.WaitStatus); ok && ws.Signaled() && ws.Signal() == syscall.SIGKILL {
+				res.killed = true
+				res.err = nil
+			}
+		}
+	}
+	if !res.killed && res.err == nil {
+		for _, line := range strings.Split(res.output, "\n") {
+			if strings.HasPrefix(line, "HARNESS_RESULT ") {
+				res.err = json.Unmarshal([]byte(strings.TrimPrefix(line, "HARNESS_RESULT ")), &res.result)
+			}
+		}
+	}
+	return res
+}
+
+type storeSnapshot struct {
+	resources      []string
+	entitlements   []string
+	grants         []string
+	unfinishedRuns int
+}
+
+// syncRunLister is the store surface run inspection needs.
+type syncRunLister interface {
+	ListSyncRuns(ctx context.Context, pageToken string, pageSize uint32) ([]*c1zstore.SyncRun, string, error)
+}
+
+func snapshotStore(t *testing.T, c1zPath, tmpDir string) storeSnapshot {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	store, err := dotc1z.NewStore(ctx, c1zPath, dotc1z.WithTmpDir(tmpDir))
+	require.NoError(t, err, "open %s", c1zPath)
+	defer func() { _ = store.Close(ctx) }()
+
+	snap := storeSnapshot{}
+	unfinished, _, err := inspectRuns(ctx, store)
+	require.NoError(t, err)
+	snap.unfinishedRuns = unfinished
+
+	pageToken := ""
+	for {
+		resp, err := store.ListResources(ctx, v2.ResourcesServiceListResourcesRequest_builder{PageToken: pageToken}.Build())
+		require.NoError(t, err)
+		for _, r := range resp.GetList() {
+			snap.resources = append(snap.resources, r.GetId().GetResourceType()+"|"+r.GetId().GetResource())
+		}
+		if pageToken = resp.GetNextPageToken(); pageToken == "" {
+			break
+		}
+	}
+	for {
+		resp, err := store.ListEntitlements(ctx, v2.EntitlementsServiceListEntitlementsRequest_builder{PageToken: pageToken}.Build())
+		require.NoError(t, err)
+		for _, e := range resp.GetList() {
+			snap.entitlements = append(snap.entitlements, e.GetId())
+		}
+		if pageToken = resp.GetNextPageToken(); pageToken == "" {
+			break
+		}
+	}
+	for {
+		resp, err := store.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{PageToken: pageToken}.Build())
+		require.NoError(t, err)
+		for _, g := range resp.GetList() {
+			snap.grants = append(snap.grants, g.GetId())
+		}
+		if pageToken = resp.GetNextPageToken(); pageToken == "" {
+			break
+		}
+	}
+	slices.Sort(snap.resources)
+	slices.Sort(snap.entitlements)
+	slices.Sort(snap.grants)
+	return snap
+}
+
+// inspectRuns reports the number of unfinished sync runs and whether any of
+// them carries a non-empty checkpoint token.
+func inspectRuns(ctx context.Context, store c1zstore.Store) (int, bool, error) {
+	lister, ok := store.(syncRunLister)
+	if !ok {
+		return 0, false, errors.New("store does not implement ListSyncRuns")
+	}
+	unfinished := 0
+	tokenSeen := false
+	pageToken := ""
+	for {
+		runs, next, err := lister.ListSyncRuns(ctx, pageToken, 100)
+		if err != nil {
+			return 0, false, err
+		}
+		for _, run := range runs {
+			if run.EndedAt == nil {
+				unfinished++
+				if run.SyncToken != "" {
+					tokenSeen = true
+				}
+			}
+		}
+		if next == "" {
+			return unfinished, tokenSeen, nil
+		}
+		pageToken = next
+	}
+}
+
+// tryInspect opens a possibly-partial artifact between sessions. Failure to
+// open is not an error here — the artifact may not have been saved yet — it
+// just contributes no evidence; the resuming binary and the final
+// snapshotStore are the authorities on openability.
+func tryInspect(c1zPath, tmpDir string) (int, bool, bool) {
+	if _, err := os.Stat(c1zPath); err != nil {
+		return 0, false, false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	store, err := dotc1z.NewStore(ctx, c1zPath, dotc1z.WithTmpDir(tmpDir))
+	if err != nil {
+		return 0, false, false
+	}
+	defer func() { _ = store.Close(ctx) }()
+	unfinished, tokenSeen, err := inspectRuns(ctx, store)
+	if err != nil {
+		return 0, false, false
+	}
+	return unfinished, tokenSeen, true
+}
+
+// requireSameSet fails with a bounded diff instead of dumping two multi-
+// thousand-element slices.
+func requireSameSet(t *testing.T, kind string, baseline, final []string) {
+	t.Helper()
+	if slices.Equal(baseline, final) {
+		return
+	}
+	baseSet := make(map[string]struct{}, len(baseline))
+	for _, v := range baseline {
+		baseSet[v] = struct{}{}
+	}
+	finalSet := make(map[string]struct{}, len(final))
+	for _, v := range final {
+		finalSet[v] = struct{}{}
+	}
+	var missing, extra []string
+	for _, v := range baseline {
+		if _, ok := finalSet[v]; !ok {
+			missing = append(missing, v)
+		}
+	}
+	for _, v := range final {
+		if _, ok := baseSet[v]; !ok {
+			extra = append(extra, v)
+		}
+	}
+	const maxShown = 10
+	if len(missing) > maxShown {
+		missing = append(missing[:maxShown], fmt.Sprintf("... and %d more", len(missing)-maxShown))
+	}
+	if len(extra) > maxShown {
+		extra = append(extra[:maxShown], fmt.Sprintf("... and %d more", len(extra)-maxShown))
+	}
+	t.Fatalf("%s diverged after interrupted resume: baseline=%d final=%d\nmissing from final: %v\nunexpected in final: %v",
+		kind, len(baseline), len(final), missing, extra)
+}

--- a/cmd/baton-crash-harness/main.go
+++ b/cmd/baton-crash-harness/main.go
@@ -1,0 +1,330 @@
+//go:build crashharness
+
+// Command baton-crash-harness is the connector half of the real-binary
+// interruption instrument (see driver_test.go). It runs one sync session of
+// a deterministic connector as a real OS process and exits — the driver
+// composes sessions into production-shaped histories:
+//
+//   - `-run-duration-ms` bounds a session the way production budgets bound a
+//     connector task: on expiry the syncer force-checkpoints, the store
+//     close durably saves the c1z, and the process exits cleanly reporting
+//     NOT_COMPLETE. The next session — a new process, like the next task on
+//     a possibly different machine — resumes from that artifact.
+//   - a SIGKILL from the driver lands between two arbitrary instructions,
+//     taking the connector, working store, and temp state with it —
+//     including mid-save. The next session must fall back to whatever
+//     artifact survived.
+//
+// The dataset is a pure function of the flags (no fixtures, no randomness),
+// so any two completed syncs of the same flags must produce identical
+// stores — that determinism is the driver's oracle. `-page-delay-ms`
+// stretches every paginated connector call so sessions are interruptible
+// mid-action and sequential syncs outlive the production checkpoint cadence
+// (minCheckpointInterval).
+//
+// The storage engine and worker count come from BATON_STORAGE_ENGINE and
+// BATON_WORKERS, mirroring the CI demo matrix. The final stdout line is
+// HARNESS_RESULT <json> for the driver to parse.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
+	sdksync "github.com/conductorone/baton-sdk/pkg/sync"
+	et "github.com/conductorone/baton-sdk/pkg/types/entitlement"
+	gt "github.com/conductorone/baton-sdk/pkg/types/grant"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+)
+
+const (
+	resourcePageSize = 50
+	grantPageSize    = 10
+	usersPerGroup    = 20
+)
+
+type crashConnector struct {
+	delay time.Duration
+
+	userType  *v2.ResourceType
+	groupType *v2.ResourceType
+	users     []*v2.Resource
+	groups    []*v2.Resource
+	entsBy    map[string]*v2.Entitlement
+	grantsBy  map[string][]*v2.Grant
+
+	v2.AssetServiceClient
+	v2.GrantManagerServiceClient
+	v2.ResourceManagerServiceClient
+	v2.AccountManagerServiceClient
+	v2.ResourceDeleterServiceClient
+	v2.CredentialManagerServiceClient
+	v2.EventServiceClient
+	v2.TicketsServiceClient
+	v2.ActionServiceClient
+	v2.ResourceGetterServiceClient
+	v2.EntitlementsServiceClient
+}
+
+func newCrashConnector(users, groups int, delay time.Duration) (*crashConnector, error) {
+	c := &crashConnector{
+		delay:    delay,
+		entsBy:   make(map[string]*v2.Entitlement, groups),
+		grantsBy: make(map[string][]*v2.Grant, groups),
+	}
+	c.userType = v2.ResourceType_builder{
+		Id:          "user",
+		DisplayName: "User",
+		Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_USER},
+		// Users carry no entitlements or grants; without this annotation
+		// the syncer enumerates all 3000 anyway and every empty response
+		// pays the page delay (+150s sequential).
+		Annotations: annotations.New(&v2.SkipEntitlementsAndGrants{}),
+	}.Build()
+	c.groupType = v2.ResourceType_builder{
+		Id:          "group",
+		DisplayName: "Group",
+		Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_GROUP},
+	}.Build()
+	for i := 0; i < users; i++ {
+		id := fmt.Sprintf("user-%05d", i)
+		user, err := rs.NewUserResource(id, c.userType, id, nil)
+		if err != nil {
+			return nil, err
+		}
+		c.users = append(c.users, user)
+	}
+	for i := 0; i < groups; i++ {
+		id := fmt.Sprintf("group-%04d", i)
+		group, err := rs.NewGroupResource(id, c.groupType, id, nil)
+		if err != nil {
+			return nil, err
+		}
+		c.groups = append(c.groups, group)
+		key := group.GetId().GetResource()
+		c.entsBy[key] = et.NewAssignmentEntitlement(group, "member", et.WithGrantableTo(c.userType))
+		members := make([]*v2.Grant, 0, usersPerGroup)
+		for k := 0; k < usersPerGroup; k++ {
+			// Deterministic spread across the user population; distinct
+			// within a group (k*13 < len(users) for the driver's sizes).
+			user := c.users[(i*7+k*13)%len(c.users)]
+			members = append(members, gt.NewGrant(group, "member", user.GetId()))
+		}
+		c.grantsBy[key] = members
+	}
+	return c, nil
+}
+
+// parsePageToken decodes the "off-N" cursor this connector hands out.
+func parsePageToken(token string) (int, error) {
+	if token == "" {
+		return 0, nil
+	}
+	n, err := strconv.Atoi(strings.TrimPrefix(token, "off-"))
+	if err != nil {
+		return 0, fmt.Errorf("bad page token %q: %w", token, err)
+	}
+	return n, nil
+}
+
+// pageOf returns items[start:start+size] plus the cursor for the next page.
+func pageOf[T any](items []T, start, size int) ([]T, string) {
+	end := start + size
+	next := ""
+	if end < len(items) {
+		next = fmt.Sprintf("off-%d", end)
+	} else {
+		end = len(items)
+	}
+	return items[start:end], next
+}
+
+func (c *crashConnector) ListResourceTypes(
+	_ context.Context, _ *v2.ResourceTypesServiceListResourceTypesRequest, _ ...grpc.CallOption,
+) (*v2.ResourceTypesServiceListResourceTypesResponse, error) {
+	return v2.ResourceTypesServiceListResourceTypesResponse_builder{
+		List: []*v2.ResourceType{c.userType, c.groupType},
+	}.Build(), nil
+}
+
+func (c *crashConnector) ListResources(
+	_ context.Context, in *v2.ResourcesServiceListResourcesRequest, _ ...grpc.CallOption,
+) (*v2.ResourcesServiceListResourcesResponse, error) {
+	time.Sleep(c.delay)
+	start, err := parsePageToken(in.GetPageToken())
+	if err != nil {
+		return nil, err
+	}
+	var pool []*v2.Resource
+	switch in.GetResourceTypeId() {
+	case "user":
+		pool = c.users
+	case "group":
+		pool = c.groups
+	default:
+		return nil, fmt.Errorf("unknown resource type %q", in.GetResourceTypeId())
+	}
+	page, next := pageOf(pool, start, resourcePageSize)
+	return v2.ResourcesServiceListResourcesResponse_builder{
+		List:          page,
+		NextPageToken: next,
+	}.Build(), nil
+}
+
+func (c *crashConnector) ListEntitlements(
+	_ context.Context, in *v2.EntitlementsServiceListEntitlementsRequest, _ ...grpc.CallOption,
+) (*v2.EntitlementsServiceListEntitlementsResponse, error) {
+	ent, ok := c.entsBy[in.GetResource().GetId().GetResource()]
+	if !ok {
+		// Empty pages are free so the page delay only prices real work.
+		return v2.EntitlementsServiceListEntitlementsResponse_builder{}.Build(), nil
+	}
+	time.Sleep(c.delay)
+	return v2.EntitlementsServiceListEntitlementsResponse_builder{
+		List: []*v2.Entitlement{ent},
+	}.Build(), nil
+}
+
+func (c *crashConnector) ListStaticEntitlements(
+	_ context.Context, _ *v2.EntitlementsServiceListStaticEntitlementsRequest, _ ...grpc.CallOption,
+) (*v2.EntitlementsServiceListStaticEntitlementsResponse, error) {
+	return v2.EntitlementsServiceListStaticEntitlementsResponse_builder{}.Build(), nil
+}
+
+func (c *crashConnector) ListGrants(
+	_ context.Context, in *v2.GrantsServiceListGrantsRequest, _ ...grpc.CallOption,
+) (*v2.GrantsServiceListGrantsResponse, error) {
+	start, err := parsePageToken(in.GetPageToken())
+	if err != nil {
+		return nil, err
+	}
+	members := c.grantsBy[in.GetResource().GetId().GetResource()]
+	if len(members) == 0 {
+		// Empty pages are free so the page delay only prices real work.
+		return v2.GrantsServiceListGrantsResponse_builder{}.Build(), nil
+	}
+	time.Sleep(c.delay)
+	page, next := pageOf(members, start, grantPageSize)
+	return v2.GrantsServiceListGrantsResponse_builder{
+		List:          page,
+		NextPageToken: next,
+	}.Build(), nil
+}
+
+func (c *crashConnector) GetMetadata(
+	_ context.Context, _ *v2.ConnectorServiceGetMetadataRequest, _ ...grpc.CallOption,
+) (*v2.ConnectorServiceGetMetadataResponse, error) {
+	return v2.ConnectorServiceGetMetadataResponse_builder{
+		Metadata: v2.ConnectorMetadata_builder{DisplayName: "crash-harness"}.Build(),
+	}.Build(), nil
+}
+
+func (c *crashConnector) Validate(
+	_ context.Context, _ *v2.ConnectorServiceValidateRequest, _ ...grpc.CallOption,
+) (*v2.ConnectorServiceValidateResponse, error) {
+	return v2.ConnectorServiceValidateResponse_builder{}.Build(), nil
+}
+
+func (c *crashConnector) Cleanup(
+	_ context.Context, _ *v2.ConnectorServiceCleanupRequest, _ ...grpc.CallOption,
+) (*v2.ConnectorServiceCleanupResponse, error) {
+	return v2.ConnectorServiceCleanupResponse_builder{}.Build(), nil
+}
+
+// harnessResult is the machine-readable summary the driver parses from the
+// final HARNESS_RESULT stdout line.
+type harnessResult struct {
+	Complete    bool   `json:"complete"`
+	NotComplete bool   `json:"not_complete"`
+	SyncErr     string `json:"sync_err,omitempty"`
+}
+
+func run() error {
+	c1zPath := flag.String("c1z", "", "path to the c1z file")
+	users := flag.Int("users", 3000, "number of user resources to serve")
+	groups := flag.Int("groups", 150, "number of group resources to serve")
+	pageDelayMs := flag.Int("page-delay-ms", 0, "sleep per paginated connector call")
+	runDurationMs := flag.Int("run-duration-ms", 0, "session budget; 0 runs to completion")
+	flag.Parse()
+	if *c1zPath == "" {
+		return errors.New("usage: -c1z path [-users n] [-groups n] [-page-delay-ms n] [-run-duration-ms n]")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+	logger, err := zap.NewDevelopment()
+	if err != nil {
+		return err
+	}
+	ctx = ctxzap.ToContext(ctx, logger)
+
+	connector, err := newCrashConnector(*users, *groups, time.Duration(*pageDelayMs)*time.Millisecond)
+	if err != nil {
+		return err
+	}
+
+	opts := []sdksync.SyncOpt{
+		sdksync.WithC1ZPath(*c1zPath),
+		sdksync.WithTmpDir(os.TempDir()),
+	}
+	if engine := os.Getenv("BATON_STORAGE_ENGINE"); engine != "" {
+		opts = append(opts, sdksync.WithStorageEngine(c1zstore.Engine(engine)))
+	}
+	if workers := os.Getenv("BATON_WORKERS"); workers != "" {
+		n, err := strconv.Atoi(workers)
+		if err != nil {
+			return fmt.Errorf("bad BATON_WORKERS %q: %w", workers, err)
+		}
+		if n > 0 {
+			opts = append(opts, sdksync.WithWorkerCount(n))
+		}
+	}
+	if *runDurationMs > 0 {
+		opts = append(opts, sdksync.WithRunDuration(time.Duration(*runDurationMs)*time.Millisecond))
+	}
+
+	s, err := sdksync.NewSyncer(ctx, connector, opts...)
+	if err != nil {
+		return fmt.Errorf("new syncer: %w", err)
+	}
+	syncErr := s.Sync(ctx)
+	if closeErr := s.Close(ctx); closeErr != nil {
+		return fmt.Errorf("close: %w", closeErr)
+	}
+
+	result := harnessResult{Complete: syncErr == nil}
+	if syncErr != nil {
+		result.SyncErr = syncErr.Error()
+		result.NotComplete = errors.Is(syncErr, sdksync.ErrSyncNotComplete)
+		if !result.NotComplete {
+			return fmt.Errorf("sync: %w", syncErr)
+		}
+	}
+	encoded, err := json.Marshal(result)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("HARNESS_RESULT %s\n", encoded) //nolint:forbidigo // the result line is the driver protocol, not logging
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "FATAL: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,101 @@
+# Testing and confidence suites
+
+The repository has several classes of verification with intentionally
+different cost and infrastructure requirements. Use the named Make targets
+instead of invoking hidden `BATON_*` switches directly.
+
+Run `make help` for the current target list.
+
+## CI-equivalent tests
+
+`make test` runs the ordinary Go test suite with the same build tag used by
+CI. Pull-request CI also runs lint, protobuf checks, and the full build.
+
+Tests in this tier should be deterministic, self-contained, and reasonably
+fast. A test that only skips on Windows with `testing.Short()` is still a CI
+test on the other platforms.
+
+## Bounded checks omitted from CI
+
+`make test-extra` is the memorable pre-merge/pre-release command. It composes:
+
+- `make race-check` — the complete Go suite under the race detector.
+- `make compat-check` — exchanges real checkpoint artifacts between HEAD and
+  a pinned older SDK release. Override the old release with
+  `BATON_COMPAT_OLD_REF=<tag>`.
+- `make interrupt-check` — runs both the exhaustive in-process checkpoint-cut
+  sweep and the real-process crash/resume harness.
+- `make fuzz-smoke` — runs each native Go fuzzer for a bounded duration.
+  Override it with `FUZZ_TIME=2m`, for example.
+- `make differential-check` — compares complete SQLite and Pebble artifacts
+  over generated cases for a bounded duration. Override it with
+  `DIFFERENTIAL_TIME=5m`.
+- `make bench-smoke` — executes the checkpoint cost curves once, catching
+  crashes and making the current cost visible without running every
+  benchmark in the repository.
+
+These checks are opt-in because they use the race detector, build additional
+SDK versions, launch and kill real processes, or have wall-clock runtimes
+that are inappropriate for every pull request.
+
+## Nightly checks
+
+`make test-nightly` runs `test-extra` with longer fuzz durations, then adds:
+
+- `make scheduler-soak` — randomized scheduler fan-out and failure histories
+  under the race detector.
+- `make errorfs-soak` — randomized whole-sync Pebble failure-point sweeps
+  against a crashable filesystem.
+
+The defaults can be changed without editing test code:
+
+```sh
+make test-nightly \
+  NIGHTLY_FUZZ_TIME=15m \
+  NIGHTLY_DIFFERENTIAL_TIME=30m \
+  SOAK_ITERATIONS=100
+```
+
+## Benchmarks
+
+Do not use `go test ./... -bench=.` as a general confidence command. The
+repository contains 10-million-edge benchmarks, multi-million-row
+compactions, and benchmarks that require external c1z fixtures.
+
+- `make bench-smoke` executes the bounded checkpoint curves once.
+- `make bench` runs the repeatable checkpoint suite plus the medium
+  end-to-end SQLite/Pebble sync benchmark.
+- Specialized benchmark source files document their required fixture paths
+  and scale variables.
+
+Benchmark output is evidence, not a pass/fail regression gate. When comparing
+branches, capture multiple runs and use `benchstat`.
+
+## Production-scale experiments
+
+Production-scale compactor experiments are deliberately excluded from
+`test-extra` and `test-nightly`. They can consume hours and substantial disk:
+
+- `make prodscale-check`
+- `make prodscale-crossover`
+- `make prodscale-topebble`
+
+Their fixture directory and dimensions can be overridden with the
+`BATON_PROD_SCALE_*`, `BATON_CROSSOVER_*`, and `BATON_TOPEBBLE_*` variables
+documented in `pkg/synccompactor/prodscale*_test.go`.
+
+## Fixture-driven diagnostics
+
+Some tests are diagnostic tools rather than suites and therefore cannot be
+part of an umbrella target:
+
+- `BATON_PEBBLE_PATH` / `BATON_SQL_PATH` compare supplied expansion artifacts.
+- `BATON_WHALE_PEBBLE_PATH` / `BATON_WHALE_OUT_PATH` expand a supplied whale
+  fixture and retain the result.
+- `BATON_MIGRATE_C1Z_PATH` migrates a supplied artifact.
+- `BATON_INSPECT_*` variables drive low-level Pebble layout and hash
+  inspection.
+
+These remain close to the tests that define their input contract. They are
+listed here so repository-wide confidence tooling is discoverable from one
+place.


### PR DESCRIPTION
## Add real-binary crash/resume harness (make demo-crash-check)

### Adds an opt-in instrument that exercises sync interruption across a real process boundary — the one axis the in-process suites (checkpoint cut enumeration, resume adversary, scheduler soak) can't cover.

### cmd/baton-crash-harness is a deterministic connector built as a real binary (tag-gated, like the compat harness). The driver composes real processes into a production-shaped history:

Budget-bounded sessions (-run-duration-ms): the syncer force-checkpoints on expiry, durably saves the c1z, and exits; the next session — a fresh process — resumes from the artifact.
SIGKILLs armed to land early-sync, mid-sync, and inside the end-of-session save itself, where a hard death races the artifact rewrite.
Oracle: after the interrupted history completes, resource/entitlement/grant ID sets must exactly match an uninterrupted baseline. Runs three cells (sqlite/4 workers, pebble/4, pebble/sequential — the last outlives the 10s checkpoint cadence). Meta-assertions fail the run if the history didn't actually contain kills, budget expiries, and durable mid-flight checkpoint tokens, so it can't pass vacuously.

Gated behind BATON_DEMO_CRASH=1 (~70s locally); an ungated compile-gate test keeps the binary building against HEAD. No production code changes.