### PR TITLE
Support additional resource traits in External Identity Matcher (CE-975)

### DIFF
--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
@@ -408,6 +409,14 @@ func MakeMainCommand[T field.Configurable](
 			opts = append(opts, connectorrunner.WithExternalResourceEntitlementFilter(externalResourceEntitlementIdFilter))
 		}
 
+		if traitNames := v.GetStringSlice("external-resource-traits"); len(traitNames) > 0 {
+			traits, err := parseResourceTraits(traitNames)
+			if err != nil {
+				return err
+			}
+			opts = append(opts, connectorrunner.WithExternalResourceTraits(traits...))
+		}
+
 		// The customer's runtime half of the ETag-replay opt-in
 		// (--keep-previous-sync-c1z / BATON_KEEP_PREVIOUS_SYNC_C1Z).
 		// Only takes effect on connectors whose author also declared the
@@ -474,6 +483,28 @@ func MakeMainCommand[T field.Configurable](
 
 		return nil
 	}
+}
+
+// parseResourceTraits maps --external-resource-traits flag values to
+// ResourceType_Trait enum values. Accepts either the bare trait name
+// ("app", case-insensitive) or the canonical proto enum name ("TRAIT_APP").
+func parseResourceTraits(names []string) ([]v2.ResourceType_Trait, error) {
+	traits := make([]v2.ResourceType_Trait, 0, len(names))
+	for _, name := range names {
+		key := strings.ToUpper(strings.TrimSpace(name))
+		if key == "" {
+			continue
+		}
+		if !strings.HasPrefix(key, "TRAIT_") {
+			key = "TRAIT_" + key
+		}
+		val, ok := v2.ResourceType_Trait_value[key]
+		if !ok {
+			return nil, fmt.Errorf("unknown external resource trait %q", name)
+		}
+		traits = append(traits, v2.ResourceType_Trait(val))
+	}
+	return traits, nil
 }
 
 func initOtel(ctx context.Context, name string, v *viper.Viper, initialLogFields map[string]interface{}) (context.Context, func(context.Context) error, error) {

--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
@@ -409,14 +408,6 @@ func MakeMainCommand[T field.Configurable](
 			opts = append(opts, connectorrunner.WithExternalResourceEntitlementFilter(externalResourceEntitlementIdFilter))
 		}
 
-		if traitNames := v.GetStringSlice("external-resource-traits"); len(traitNames) > 0 {
-			traits, err := parseResourceTraits(traitNames)
-			if err != nil {
-				return err
-			}
-			opts = append(opts, connectorrunner.WithExternalResourceTraits(traits...))
-		}
-
 		// The customer's runtime half of the ETag-replay opt-in
 		// (--keep-previous-sync-c1z / BATON_KEEP_PREVIOUS_SYNC_C1Z).
 		// Only takes effect on connectors whose author also declared the
@@ -483,28 +474,6 @@ func MakeMainCommand[T field.Configurable](
 
 		return nil
 	}
-}
-
-// parseResourceTraits maps --external-resource-traits flag values to
-// ResourceType_Trait enum values. Accepts either the bare trait name
-// ("app", case-insensitive) or the canonical proto enum name ("TRAIT_APP").
-func parseResourceTraits(names []string) ([]v2.ResourceType_Trait, error) {
-	traits := make([]v2.ResourceType_Trait, 0, len(names))
-	for _, name := range names {
-		key := strings.ToUpper(strings.TrimSpace(name))
-		if key == "" {
-			continue
-		}
-		if !strings.HasPrefix(key, "TRAIT_") {
-			key = "TRAIT_" + key
-		}
-		val, ok := v2.ResourceType_Trait_value[key]
-		if !ok {
-			return nil, fmt.Errorf("unknown external resource trait %q", name)
-		}
-		traits = append(traits, v2.ResourceType_Trait(val))
-	}
-	return traits, nil
 }
 
 func initOtel(ctx context.Context, name string, v *viper.Viper, initialLogFields map[string]interface{}) (context.Context, func(context.Context) error, error) {

--- a/pkg/connectorrunner/runner.go
+++ b/pkg/connectorrunner/runner.go
@@ -768,12 +768,15 @@ func WithExternalResourceEntitlementFilter(entitlementId string) Option {
 	}
 }
 
-// WithExternalResourceTraits adds resource type traits, beyond the
-// always-eligible TRAIT_USER and TRAIT_GROUP, that the External Identity
-// Matcher should sync and match against from the external resource c1z (see
-// WithExternalResourceC1Z). For example, a connector matching grants
-// against service-principal identities synced by another connector as
-// TRAIT_APP would pass that trait here.
+// WithExternalResourceTraits adds resource type traits that the External
+// Identity Matcher should sync and match against from the external
+// resource c1z (see WithExternalResourceC1Z). There is no hardcoded
+// default here — TRAIT_USER/TRAIT_GROUP are only matched if included
+// (the --external-resource-traits CLI flag defaults to "user,group", but a
+// direct call to this option must list every trait it wants, e.g. a
+// connector matching grants against service-principal identities synced by
+// another connector as TRAIT_APP would pass TRAIT_USER, TRAIT_GROUP,
+// TRAIT_APP here if it still needs default matching too).
 func WithExternalResourceTraits(traits ...v2.ResourceType_Trait) Option {
 	return func(ctx context.Context, cfg *runnerConfig) error {
 		cfg.externalResourceTraits = append(cfg.externalResourceTraits, traits...)

--- a/pkg/connectorrunner/runner.go
+++ b/pkg/connectorrunner/runner.go
@@ -427,6 +427,7 @@ type runnerConfig struct {
 	targetedSyncResourceIDs               []string
 	externalResourceC1Z                   string
 	externalResourceEntitlementIdFilter   string
+	externalResourceTraits                []v2.ResourceType_Trait
 	keepPreviousSyncC1ZCapable            bool
 	keepPreviousSyncC1ZEnabled            bool
 	skipEntitlementsAndGrants             bool
@@ -767,6 +768,19 @@ func WithExternalResourceEntitlementFilter(entitlementId string) Option {
 	}
 }
 
+// WithExternalResourceTraits adds resource type traits, beyond the
+// always-eligible TRAIT_USER and TRAIT_GROUP, that the External Identity
+// Matcher should sync and match against from the external resource c1z (see
+// WithExternalResourceC1Z). For example, a connector matching grants
+// against service-principal identities synced by another connector as
+// TRAIT_APP would pass that trait here.
+func WithExternalResourceTraits(traits ...v2.ResourceType_Trait) Option {
+	return func(ctx context.Context, cfg *runnerConfig) error {
+		cfg.externalResourceTraits = append(cfg.externalResourceTraits, traits...)
+		return nil
+	}
+}
+
 // WithKeepPreviousSyncC1Z is the connector AUTHOR's build-time
 // declaration that this connector supports ETag replay in service
 // mode: after each successful upload the runner retains the uploaded
@@ -1082,6 +1096,7 @@ func NewConnectorRunner(ctx context.Context, c types.ConnectorServer, opts ...Op
 				local.WithTmpDir(cfg.tempDir),
 				local.WithExternalResourceC1Z(cfg.externalResourceC1Z),
 				local.WithExternalResourceEntitlementIdFilter(cfg.externalResourceEntitlementIdFilter),
+				local.WithExternalResourceTraits(cfg.externalResourceTraits),
 				local.WithTargetedSyncResources(resources),
 				local.WithSkipEntitlementsAndGrants(cfg.skipEntitlementsAndGrants),
 				local.WithSkipGrants(cfg.skipGrants),
@@ -1124,6 +1139,7 @@ func NewConnectorRunner(ctx context.Context, c types.ConnectorServer, opts ...Op
 		cfg.skipFullSync,
 		cfg.externalResourceC1Z,
 		cfg.externalResourceEntitlementIdFilter,
+		cfg.externalResourceTraits,
 		resources,
 		cfg.syncResourceTypeIDs,
 		cfg.workerCount,

--- a/pkg/connectorrunner/runner.go
+++ b/pkg/connectorrunner/runner.go
@@ -768,19 +768,12 @@ func WithExternalResourceEntitlementFilter(entitlementId string) Option {
 	}
 }
 
-// WithExternalResourceTraits is the connector AUTHOR's build-time
-// declaration of which resource type traits, beyond the always-eligible
-// TRAIT_USER and TRAIT_GROUP, the External Identity Matcher should sync and
-// match against from the external resource c1z (see WithExternalResourceC1Z
-// / WithExternalResourceEntitlementFilter, which are runtime/deployment
-// details and so are also exposed as CLI flags). Which traits a connector
-// matches against is not a deployment concern — it's fixed by which
-// ExternalResourceMatch* annotations the connector's own Grants()
-// implementation emits — so this is passed directly from the connector's
-// main.go (e.g. cli.MakeMainCommand(..., WithExternalResourceTraits(...))),
-// not surfaced as a customer-facing flag. For example, a connector matching
-// grants against service-principal identities synced by another connector
-// as TRAIT_APP would pass that trait here.
+// WithExternalResourceTraits adds resource type traits, beyond the
+// always-eligible TRAIT_USER and TRAIT_GROUP, that the External Identity
+// Matcher should sync and match against from the external resource c1z (see
+// WithExternalResourceC1Z). For example, a connector matching grants
+// against service-principal identities synced by another connector as
+// TRAIT_APP would pass that trait here.
 func WithExternalResourceTraits(traits ...v2.ResourceType_Trait) Option {
 	return func(ctx context.Context, cfg *runnerConfig) error {
 		cfg.externalResourceTraits = append(cfg.externalResourceTraits, traits...)

--- a/pkg/connectorrunner/runner.go
+++ b/pkg/connectorrunner/runner.go
@@ -768,15 +768,15 @@ func WithExternalResourceEntitlementFilter(entitlementId string) Option {
 	}
 }
 
-// WithExternalResourceTraits adds resource type traits that the External
+// WithExternalResourceTraits sets the resource type traits the External
 // Identity Matcher should sync and match against from the external
-// resource c1z (see WithExternalResourceC1Z). There is no hardcoded
-// default here — TRAIT_USER/TRAIT_GROUP are only matched if included
-// (the --external-resource-traits CLI flag defaults to "user,group", but a
-// direct call to this option must list every trait it wants, e.g. a
-// connector matching grants against service-principal identities synced by
-// another connector as TRAIT_APP would pass TRAIT_USER, TRAIT_GROUP,
-// TRAIT_APP here if it still needs default matching too).
+// resource c1z (see WithExternalResourceC1Z). When not called, the matcher
+// falls back to TRAIT_USER/TRAIT_GROUP — the pre-CE-975 default — so
+// existing runner callers keep working unchanged. Passing any traits
+// replaces the default entirely: a connector matching grants against
+// service-principal identities synced by another connector as TRAIT_APP
+// that still wants default user/group matching must pass TRAIT_USER,
+// TRAIT_GROUP, TRAIT_APP.
 func WithExternalResourceTraits(traits ...v2.ResourceType_Trait) Option {
 	return func(ctx context.Context, cfg *runnerConfig) error {
 		cfg.externalResourceTraits = append(cfg.externalResourceTraits, traits...)

--- a/pkg/connectorrunner/runner.go
+++ b/pkg/connectorrunner/runner.go
@@ -768,12 +768,19 @@ func WithExternalResourceEntitlementFilter(entitlementId string) Option {
 	}
 }
 
-// WithExternalResourceTraits adds resource type traits, beyond the
-// always-eligible TRAIT_USER and TRAIT_GROUP, that the External Identity
-// Matcher should sync and match against from the external resource c1z (see
-// WithExternalResourceC1Z). For example, a connector matching grants
-// against service-principal identities synced by another connector as
-// TRAIT_APP would pass that trait here.
+// WithExternalResourceTraits is the connector AUTHOR's build-time
+// declaration of which resource type traits, beyond the always-eligible
+// TRAIT_USER and TRAIT_GROUP, the External Identity Matcher should sync and
+// match against from the external resource c1z (see WithExternalResourceC1Z
+// / WithExternalResourceEntitlementFilter, which are runtime/deployment
+// details and so are also exposed as CLI flags). Which traits a connector
+// matches against is not a deployment concern — it's fixed by which
+// ExternalResourceMatch* annotations the connector's own Grants()
+// implementation emits — so this is passed directly from the connector's
+// main.go (e.g. cli.MakeMainCommand(..., WithExternalResourceTraits(...))),
+// not surfaced as a customer-facing flag. For example, a connector matching
+// grants against service-principal identities synced by another connector
+// as TRAIT_APP would pass that trait here.
 func WithExternalResourceTraits(traits ...v2.ResourceType_Trait) Option {
 	return func(ctx context.Context, cfg *runnerConfig) error {
 		cfg.externalResourceTraits = append(cfg.externalResourceTraits, traits...)

--- a/pkg/field/default_relationships.go
+++ b/pkg/field/default_relationships.go
@@ -36,6 +36,10 @@ var DefaultRelationships = []SchemaFieldRelationship{
 		[]SchemaField{externalResourceC1ZField},
 	),
 	FieldsDependentOn(
+		[]SchemaField{externalResourceTraitsField},
+		[]SchemaField{externalResourceC1ZField},
+	),
+	FieldsDependentOn(
 		[]SchemaField{skipGrants},
 		[]SchemaField{targetedSyncResourceIDs},
 	),

--- a/pkg/field/default_relationships.go
+++ b/pkg/field/default_relationships.go
@@ -36,10 +36,6 @@ var DefaultRelationships = []SchemaFieldRelationship{
 		[]SchemaField{externalResourceC1ZField},
 	),
 	FieldsDependentOn(
-		[]SchemaField{externalResourceTraitsField},
-		[]SchemaField{externalResourceC1ZField},
-	),
-	FieldsDependentOn(
 		[]SchemaField{skipGrants},
 		[]SchemaField{targetedSyncResourceIDs},
 	),

--- a/pkg/field/defaults.go
+++ b/pkg/field/defaults.go
@@ -268,6 +268,11 @@ var (
 		WithDescription("The entitlement that external users, groups must have access to sync external baton resources"),
 		WithPersistent(true),
 		WithExportTarget(ExportTargetNone))
+	externalResourceTraitsField = StringSliceField("external-resource-traits",
+		WithDescription("Additional resource type traits (e.g. \"app\"), beyond the always-eligible user and group traits, "+
+			"to sync and match from the external resource c1z"),
+		WithPersistent(true),
+		WithExportTarget(ExportTargetNone))
 
 	// KeepPreviousSyncC1ZField is the CUSTOMER's runtime half of the
 	// service-mode ETag-replay opt-in: keep the last successfully
@@ -432,6 +437,7 @@ var DefaultFields = append([]SchemaField{
 	skipGrants,
 	externalResourceC1ZField,
 	externalResourceEntitlementIdFilter,
+	externalResourceTraitsField,
 	KeepPreviousSyncC1ZField,
 	diffSyncsField,
 	diffSyncsBaseSyncField,

--- a/pkg/field/defaults.go
+++ b/pkg/field/defaults.go
@@ -269,9 +269,10 @@ var (
 		WithPersistent(true),
 		WithExportTarget(ExportTargetNone))
 	externalResourceTraitsField = StringSliceField("external-resource-traits",
-		WithDescription("Additional resource type traits (e.g. \"app\"), beyond the always-eligible user and group traits, "+
-			"to sync and match from the external resource c1z"),
+		WithDescription("Resource type traits (e.g. \"user\", \"group\", \"app\") to sync and match from the external resource c1z. "+
+			"Defaults to user and group; passing this flag replaces the full set rather than adding to it."),
 		WithPersistent(true),
+		WithDefaultValue([]string{"user", "group"}),
 		WithExportTarget(ExportTargetNone))
 
 	// KeepPreviousSyncC1ZField is the CUSTOMER's runtime half of the

--- a/pkg/field/defaults.go
+++ b/pkg/field/defaults.go
@@ -270,9 +270,8 @@ var (
 		WithExportTarget(ExportTargetNone))
 	externalResourceTraitsField = StringSliceField("external-resource-traits",
 		WithDescription("Resource type traits (e.g. \"user\", \"group\", \"app\") to sync and match from the external resource c1z. "+
-			"Defaults to user and group; passing this flag replaces the full set rather than adding to it."),
+			"When unset the matcher falls back to user and group; passing this flag replaces the full set rather than adding to it."),
 		WithPersistent(true),
-		WithDefaultValue([]string{"user", "group"}),
 		WithExportTarget(ExportTargetNone))
 
 	// KeepPreviousSyncC1ZField is the CUSTOMER's runtime half of the

--- a/pkg/field/defaults.go
+++ b/pkg/field/defaults.go
@@ -268,11 +268,6 @@ var (
 		WithDescription("The entitlement that external users, groups must have access to sync external baton resources"),
 		WithPersistent(true),
 		WithExportTarget(ExportTargetNone))
-	externalResourceTraitsField = StringSliceField("external-resource-traits",
-		WithDescription("Additional resource type traits (e.g. \"app\"), beyond the always-eligible user and group traits, "+
-			"to sync and match from the external resource c1z"),
-		WithPersistent(true),
-		WithExportTarget(ExportTargetNone))
 
 	// KeepPreviousSyncC1ZField is the CUSTOMER's runtime half of the
 	// service-mode ETag-replay opt-in: keep the last successfully
@@ -437,7 +432,6 @@ var DefaultFields = append([]SchemaField{
 	skipGrants,
 	externalResourceC1ZField,
 	externalResourceEntitlementIdFilter,
-	externalResourceTraitsField,
 	KeepPreviousSyncC1ZField,
 	diffSyncsField,
 	diffSyncsBaseSyncField,

--- a/pkg/sync/ingest_filter_invariants_differential_test.go
+++ b/pkg/sync/ingest_filter_invariants_differential_test.go
@@ -181,6 +181,7 @@ func TestIngestFilterExternalPredictionMissCaughtAtSeam(t *testing.T) {
 		WithTmpDir(tempDir),
 		WithStorageEngine(c1zstore.EnginePebble),
 		WithExternalResourceC1ZPath(externalC1zPath),
+		WithExternalResourceTraits(v2.ResourceType_TRAIT_USER, v2.ResourceType_TRAIT_GROUP),
 	)
 	require.NoError(t, err)
 	require.NoError(t, internalSyncer.Sync(lctx), "a prediction miss is warn-only; it must not fail the sync")

--- a/pkg/sync/ingest_filter_test.go
+++ b/pkg/sync/ingest_filter_test.go
@@ -358,6 +358,7 @@ func TestFreshIngestFilterExternalMatchResolvesUnknownPrincipalType(t *testing.T
 			WithC1ZPath(internalC1zPath),
 			WithTmpDir(tempDir),
 			WithExternalResourceC1ZPath(externalC1zPath),
+			WithExternalResourceTraits(v2.ResourceType_TRAIT_USER, v2.ResourceType_TRAIT_GROUP),
 		}, extraOpts...)
 		internalSyncer, err := NewSyncer(ctx, internalMc, internalOpts...)
 		require.NoError(t, err)

--- a/pkg/sync/pebble_external_match_test.go
+++ b/pkg/sync/pebble_external_match_test.go
@@ -133,6 +133,7 @@ func TestPebble_ExternalResourceMatchID_RemappingSkipped(t *testing.T) {
 		WithConnectorStore(internalStore),
 		WithTmpDir(tempDir),
 		WithExternalResourceC1ZPath(externalC1zpath),
+		WithExternalResourceTraits(v2.ResourceType_TRAIT_USER, v2.ResourceType_TRAIT_GROUP),
 		WithDontExpandGrants(),
 	)
 	require.NoError(t, err)

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -145,11 +145,11 @@ type syncer struct {
 	c1zPath                             string
 	externalResourceC1ZPath             string
 	externalResourceEntitlementIdFilter string
-	// externalResourceTraits are additional resource type traits, beyond the
-	// always-eligible TRAIT_USER/TRAIT_GROUP, that this connector wants
-	// synced from the external resource source and made available to the
-	// External Identity Matcher (see externalMatchTraits, set via
-	// WithExternalResourceTraits).
+	// externalResourceTraits are the resource type traits that this
+	// connector wants synced from the external resource source and made
+	// available to the External Identity Matcher (see externalMatchTraits,
+	// set via WithExternalResourceTraits). There is no implicit default:
+	// TRAIT_USER/TRAIT_GROUP must be included explicitly to be matched.
 	externalResourceTraits      []v2.ResourceType_Trait
 	previousSyncC1ZPath         string
 	previousSyncC1ZPathOptional bool
@@ -2340,22 +2340,14 @@ func (s *syncer) SyncExternalResources(ctx context.Context, action *Action) erro
 	return nil
 }
 
-// defaultExternalMatchTraits are always eligible for external-resource sync
-// and matching, regardless of configuration.
-var defaultExternalMatchTraits = []v2.ResourceType_Trait{
-	v2.ResourceType_TRAIT_USER,
-	v2.ResourceType_TRAIT_GROUP,
-}
-
 // externalMatchTraits returns the set of resource type traits the External
-// Identity Matcher should sync and match against: the always-on
-// TRAIT_USER/TRAIT_GROUP, plus any traits a connector opted into via
-// WithExternalResourceTraits (e.g. TRAIT_APP).
+// Identity Matcher should sync and match against. There is no hardcoded
+// default here: TRAIT_USER/TRAIT_GROUP are only eligible if the caller
+// included them via WithExternalResourceTraits (the CLI's
+// --external-resource-traits flag defaults to "user,group", but direct
+// SyncOpt/programmatic callers must pass traits explicitly).
 func (s *syncer) externalMatchTraits() map[v2.ResourceType_Trait]bool {
-	traits := make(map[v2.ResourceType_Trait]bool, len(defaultExternalMatchTraits)+len(s.externalResourceTraits))
-	for _, t := range defaultExternalMatchTraits {
-		traits[t] = true
-	}
+	traits := make(map[v2.ResourceType_Trait]bool, len(s.externalResourceTraits))
 	for _, t := range s.externalResourceTraits {
 		traits[t] = true
 	}
@@ -3347,14 +3339,15 @@ func WithExternalResourceEntitlementIdFilter(entitlementId string) SyncOpt {
 	}
 }
 
-// WithExternalResourceTraits adds resource type traits, beyond the
-// always-eligible TRAIT_USER and TRAIT_GROUP, that the External Identity
-// Matcher should sync from the external resource source and consider when
-// matching grants (e.g. ExternalResourceMatch / ExternalResourceMatchAll
-// annotations). Connectors opt into this when their principals live in a
-// separate identity-source connector under a trait other than user/group —
-// for example an Azure connector matching service-principal role
-// assignments against TRAIT_APP resources synced by baton-microsoft-entra.
+// WithExternalResourceTraits adds resource type traits that the External
+// Identity Matcher should sync from the external resource source and
+// consider when matching grants (e.g. ExternalResourceMatch /
+// ExternalResourceMatchAll annotations). There is no implicit default set
+// of traits — a caller that still wants TRAIT_USER/TRAIT_GROUP matched
+// must include them alongside whatever else it needs, for example an Azure
+// connector matching service-principal role assignments against TRAIT_APP
+// resources synced by baton-microsoft-entra while also keeping default
+// user/group matching would pass TRAIT_USER, TRAIT_GROUP, TRAIT_APP.
 func WithExternalResourceTraits(traits ...v2.ResourceType_Trait) SyncOpt {
 	return func(s *syncer) {
 		s.externalResourceTraits = append(s.externalResourceTraits, traits...)

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -148,8 +148,9 @@ type syncer struct {
 	// externalResourceTraits are the resource type traits that this
 	// connector wants synced from the external resource source and made
 	// available to the External Identity Matcher (see externalMatchTraits,
-	// set via WithExternalResourceTraits). There is no implicit default:
-	// TRAIT_USER/TRAIT_GROUP must be included explicitly to be matched.
+	// set via WithExternalResourceTraits). When left empty the matcher
+	// falls back to TRAIT_USER/TRAIT_GROUP, preserving pre-CE-975 behavior
+	// for callers that never opt in.
 	externalResourceTraits      []v2.ResourceType_Trait
 	previousSyncC1ZPath         string
 	previousSyncC1ZPathOptional bool
@@ -2341,12 +2342,19 @@ func (s *syncer) SyncExternalResources(ctx context.Context, action *Action) erro
 }
 
 // externalMatchTraits returns the set of resource type traits the External
-// Identity Matcher should sync and match against. There is no hardcoded
-// default here: TRAIT_USER/TRAIT_GROUP are only eligible if the caller
-// included them via WithExternalResourceTraits (the CLI's
-// --external-resource-traits flag defaults to "user,group", but direct
-// SyncOpt/programmatic callers must pass traits explicitly).
+// Identity Matcher should sync and match against. When no traits have been
+// configured via WithExternalResourceTraits the matcher falls back to
+// TRAIT_USER/TRAIT_GROUP, matching pre-CE-975 behavior for connectors that
+// never opt in. Passing any traits replaces the default entirely — a
+// caller that still wants user/group matching alongside a new trait must
+// list all three.
 func (s *syncer) externalMatchTraits() map[v2.ResourceType_Trait]bool {
+	if len(s.externalResourceTraits) == 0 {
+		return map[v2.ResourceType_Trait]bool{
+			v2.ResourceType_TRAIT_USER:  true,
+			v2.ResourceType_TRAIT_GROUP: true,
+		}
+	}
 	traits := make(map[v2.ResourceType_Trait]bool, len(s.externalResourceTraits))
 	for _, t := range s.externalResourceTraits {
 		traits[t] = true
@@ -3339,15 +3347,16 @@ func WithExternalResourceEntitlementIdFilter(entitlementId string) SyncOpt {
 	}
 }
 
-// WithExternalResourceTraits adds resource type traits that the External
+// WithExternalResourceTraits sets the resource type traits the External
 // Identity Matcher should sync from the external resource source and
 // consider when matching grants (e.g. ExternalResourceMatch /
-// ExternalResourceMatchAll annotations). There is no implicit default set
-// of traits — a caller that still wants TRAIT_USER/TRAIT_GROUP matched
-// must include them alongside whatever else it needs, for example an Azure
-// connector matching service-principal role assignments against TRAIT_APP
-// resources synced by baton-microsoft-entra while also keeping default
-// user/group matching would pass TRAIT_USER, TRAIT_GROUP, TRAIT_APP.
+// ExternalResourceMatchAll annotations). When not called, the matcher
+// falls back to TRAIT_USER/TRAIT_GROUP — the pre-CE-975 default — so
+// existing connectors keep working unchanged. Passing any traits replaces
+// that default entirely: an Azure connector matching service-principal
+// role assignments against TRAIT_APP resources synced by
+// baton-microsoft-entra while also keeping default user/group matching
+// would pass TRAIT_USER, TRAIT_GROUP, TRAIT_APP.
 func WithExternalResourceTraits(traits ...v2.ResourceType_Trait) SyncOpt {
 	return func(s *syncer) {
 		s.externalResourceTraits = append(s.externalResourceTraits, traits...)

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -145,11 +145,17 @@ type syncer struct {
 	c1zPath                             string
 	externalResourceC1ZPath             string
 	externalResourceEntitlementIdFilter string
-	previousSyncC1ZPath                 string
-	previousSyncC1ZPathOptional         bool
-	store                               c1zstore.Store
-	externalResourceReader              connectorstore.Reader
-	previousSyncReader                  connectorstore.Reader
+	// externalResourceTraits are additional resource type traits, beyond the
+	// always-eligible TRAIT_USER/TRAIT_GROUP, that this connector wants
+	// synced from the external resource source and made available to the
+	// External Identity Matcher (see externalMatchTraits, set via
+	// WithExternalResourceTraits).
+	externalResourceTraits      []v2.ResourceType_Trait
+	previousSyncC1ZPath         string
+	previousSyncC1ZPathOptional bool
+	store                       c1zstore.Store
+	externalResourceReader      connectorstore.Reader
+	previousSyncReader          connectorstore.Reader
 	// Ingestion-invariant state (see ingest_invariants.go):
 	// childSchedule is the monotone record backing invariant I4;
 	// resourcesPhaseRanHere gates I4 to processes that actually ran the
@@ -1467,6 +1473,25 @@ func (s *syncer) syncResources(ctx context.Context, action *Action) error {
 	return s.nextPageOrFinishAction(ctx, action, resp.GetNextPageToken())
 }
 
+// resourceTraitMessage returns the trait-specific annotation message for a
+// ResourceType_Trait, or nil for traits with no corresponding message.
+func resourceTraitMessage(t v2.ResourceType_Trait) proto.Message {
+	switch t {
+	case v2.ResourceType_TRAIT_APP:
+		return &v2.AppTrait{}
+	case v2.ResourceType_TRAIT_GROUP:
+		return &v2.GroupTrait{}
+	case v2.ResourceType_TRAIT_USER:
+		return &v2.UserTrait{}
+	case v2.ResourceType_TRAIT_ROLE:
+		return &v2.RoleTrait{}
+	case v2.ResourceType_TRAIT_SECRET:
+		return &v2.SecretTrait{}
+	default:
+		return nil
+	}
+}
+
 // No span here: this is called per-resource, but only does I/O on the
 // first time a resource type is seen (cached afterward). The wrapped
 // C1File.GetResourceType call is itself spanned, so we still see the
@@ -1485,21 +1510,7 @@ func (s *syncer) validateResourceTraits(ctx context.Context, r *v2.Resource) err
 	}
 
 	for _, t := range resourceTypeTraits {
-		var trait proto.Message
-		switch t {
-		case v2.ResourceType_TRAIT_APP:
-			trait = &v2.AppTrait{}
-		case v2.ResourceType_TRAIT_GROUP:
-			trait = &v2.GroupTrait{}
-		case v2.ResourceType_TRAIT_USER:
-			trait = &v2.UserTrait{}
-		case v2.ResourceType_TRAIT_ROLE:
-			trait = &v2.RoleTrait{}
-		case v2.ResourceType_TRAIT_SECRET:
-			trait = &v2.SecretTrait{}
-		default:
-		}
-
+		trait := resourceTraitMessage(t)
 		if trait != nil {
 			annos := annotations.Annotations(r.GetAnnotations())
 			if !annos.Contains(trait) {
@@ -2329,6 +2340,28 @@ func (s *syncer) SyncExternalResources(ctx context.Context, action *Action) erro
 	return nil
 }
 
+// defaultExternalMatchTraits are always eligible for external-resource sync
+// and matching, regardless of configuration.
+var defaultExternalMatchTraits = []v2.ResourceType_Trait{
+	v2.ResourceType_TRAIT_USER,
+	v2.ResourceType_TRAIT_GROUP,
+}
+
+// externalMatchTraits returns the set of resource type traits the External
+// Identity Matcher should sync and match against: the always-on
+// TRAIT_USER/TRAIT_GROUP, plus any traits a connector opted into via
+// WithExternalResourceTraits (e.g. TRAIT_APP).
+func (s *syncer) externalMatchTraits() map[v2.ResourceType_Trait]bool {
+	traits := make(map[v2.ResourceType_Trait]bool, len(defaultExternalMatchTraits)+len(s.externalResourceTraits))
+	for _, t := range defaultExternalMatchTraits {
+		traits[t] = true
+	}
+	for _, t := range s.externalResourceTraits {
+		traits[t] = true
+	}
+	return traits
+}
+
 func (s *syncer) SyncExternalResourcesWithGrantToEntitlement(ctx context.Context, entitlementId string) error {
 	ctx, span := tracer.Start(ctx, "syncer.SyncExternalResourcesWithGrantToEntitlement")
 	var err error
@@ -2359,17 +2392,20 @@ func (s *syncer) SyncExternalResourcesWithGrantToEntitlement(ctx context.Context
 		}
 	}
 
+	matchTraits := s.externalMatchTraits()
 	resourceTypes := make([]*v2.ResourceType, 0)
 	for _, resourceTypeId := range resourceTypeIDs.ToSlice() {
 		resourceTypeResp, err := s.externalResourceReader.GetResourceType(ctx, reader_v2.ResourceTypesReaderServiceGetResourceTypeRequest_builder{ResourceTypeId: resourceTypeId}.Build())
 		if err != nil {
 			return err
 		}
-		// Should we error or skip if this is not user or group?
+		// Skip resource types whose traits aren't eligible for external
+		// matching (TRAIT_USER/TRAIT_GROUP by default, plus anything added
+		// via WithExternalResourceTraits).
 		for _, t := range resourceTypeResp.GetResourceType().GetTraits() {
-			if t == v2.ResourceType_TRAIT_USER || t == v2.ResourceType_TRAIT_GROUP {
+			if matchTraits[t] {
 				resourceTypes = append(resourceTypes, resourceTypeResp.GetResourceType())
-				continue
+				break
 			}
 		}
 
@@ -2480,24 +2516,25 @@ func (s *syncer) SyncExternalResourcesUsersAndGroups(ctx context.Context) error 
 		return err
 	}
 
-	userAndGroupResourceTypes := make([]*v2.ResourceType, 0)
+	matchTraits := s.externalMatchTraits()
+	matchableResourceTypes := make([]*v2.ResourceType, 0)
 	ents := make([]*v2.Entitlement, 0)
 	principals := make([]*v2.Resource, 0)
 	for _, rt := range resourceTypes {
 		for _, t := range rt.GetTraits() {
-			if t == v2.ResourceType_TRAIT_USER || t == v2.ResourceType_TRAIT_GROUP {
-				userAndGroupResourceTypes = append(userAndGroupResourceTypes, rt)
-				continue
+			if matchTraits[t] {
+				matchableResourceTypes = append(matchableResourceTypes, rt)
+				break
 			}
 		}
 	}
 
-	err = s.store.PutResourceTypes(ctx, userAndGroupResourceTypes...)
+	err = s.store.PutResourceTypes(ctx, matchableResourceTypes...)
 	if err != nil {
 		return err
 	}
 
-	for _, rt := range userAndGroupResourceTypes {
+	for _, rt := range matchableResourceTypes {
 		rtAnnos := annotations.Annotations(rt.GetAnnotations())
 		skipEntitlements := rtAnnos.Contains(&v2.SkipEntitlementsAndGrants{})
 		skipEGForResourceType[rt.GetId()] = skipEntitlements
@@ -2564,7 +2601,7 @@ func (s *syncer) SyncExternalResourcesUsersAndGroups(ctx context.Context) error 
 	}
 
 	l.Info("Synced external resources",
-		zap.Int("resource_type_count", len(userAndGroupResourceTypes)),
+		zap.Int("resource_type_count", len(matchableResourceTypes)),
 		zap.Int("resource_count", principalsCount),
 		zap.Int("entitlement_count", entsCount),
 		zap.Int("grant_count", grantsForEntsCount),
@@ -2675,6 +2712,63 @@ func (s *syncer) listExternalResourceTypes(ctx context.Context) ([]*v2.ResourceT
 	return resourceTypes, nil
 }
 
+// matchProfileAndExpand implements the generic external-resource key/val
+// profile match originally written for TRAIT_GROUP, now shared by GROUP and
+// any additional trait configured via WithExternalResourceTraits (e.g.
+// TRAIT_APP). It returns a nil grant (and nil error) when the principal's
+// profile doesn't match key/value, or when the source grant carries no
+// GrantExpandable annotation to remap — matching pre-existing GROUP
+// behavior, where a key/val match only produces a grant for expandable
+// entitlements.
+func (s *syncer) matchProfileAndExpand(
+	ctx context.Context,
+	l *zap.Logger,
+	grant *v2.Grant,
+	principal *v2.Resource,
+	key, value string,
+	expandableAnno *v2.GrantExpandable,
+	expandableEntitlementsResourceMap map[string][]string,
+) (*v2.Grant, error) {
+	profileVal, ok := resource.GetProfileStringValue(resource.GetProfile(principal), key)
+	if !ok || !strings.EqualFold(profileVal, value) {
+		return nil, nil
+	}
+	if expandableAnno == nil {
+		return nil, nil
+	}
+
+	groupPrincipalBID, err := bid.MakeBid(grant.GetPrincipal())
+	if err != nil {
+		l.Error("error making group principal bid", zap.Error(err), zap.Any("grant.Principal", grant.GetPrincipal()))
+		return nil, nil
+	}
+
+	newExpandableEntitlementIDs := make([]string, 0)
+	for _, slug := range expandableEntitlementsResourceMap[groupPrincipalBID] {
+		newExpandableEntId := entitlement.NewEntitlementID(principal, slug)
+		_, err := s.store.GetEntitlement(ctx, reader_v2.EntitlementsReaderServiceGetEntitlementRequest_builder{EntitlementId: newExpandableEntId}.Build())
+		if err != nil {
+			if status.Code(err) == codes.NotFound {
+				l.Error("found no entitlement with entitlement id generated from external source sync", zap.Any("entitlementId", newExpandableEntId))
+				continue
+			}
+			return nil, err
+		}
+		newExpandableEntitlementIDs = append(newExpandableEntitlementIDs, newExpandableEntId)
+	}
+
+	newGrant := newGrantForExternalPrincipal(grant, principal)
+	newGrantAnnos := annotations.Annotations(newGrant.GetAnnotations())
+	newExpandableAnno := v2.GrantExpandable_builder{
+		EntitlementIds:  newExpandableEntitlementIDs,
+		Shallow:         expandableAnno.GetShallow(),
+		ResourceTypeIds: expandableAnno.GetResourceTypeIds(),
+	}.Build()
+	newGrantAnnos.Update(newExpandableAnno)
+	newGrant.SetAnnotations(newGrantAnnos)
+	return newGrant, nil
+}
+
 func (s *syncer) processGrantsWithExternalPrincipals(ctx context.Context, principals []*v2.Resource) error {
 	ctx, span := tracer.Start(ctx, "processGrantsWithExternalPrincipals")
 	var err error
@@ -2686,8 +2780,8 @@ func (s *syncer) processGrantsWithExternalPrincipals(ctx context.Context, princi
 
 	l := ctxzap.Extract(ctx)
 
-	groupPrincipals := make([]*v2.Resource, 0)
-	userPrincipals := make([]*v2.Resource, 0)
+	matchTraits := s.externalMatchTraits()
+	principalsByTrait := make(map[v2.ResourceType_Trait][]*v2.Resource, len(matchTraits))
 	principalMap := make(map[string]*v2.Resource)
 
 	for _, principal := range principals {
@@ -2696,11 +2790,11 @@ func (s *syncer) processGrantsWithExternalPrincipals(ctx context.Context, princi
 		if !rAnnos.Contains(batonID) {
 			continue
 		}
-		if rAnnos.Contains(&v2.UserTrait{}) {
-			userPrincipals = append(userPrincipals, principal)
-		}
-		if rAnnos.Contains(&v2.GroupTrait{}) {
-			groupPrincipals = append(groupPrincipals, principal)
+		for trait := range matchTraits {
+			traitMsg := resourceTraitMessage(trait)
+			if traitMsg != nil && rAnnos.Contains(traitMsg) {
+				principalsByTrait[trait] = append(principalsByTrait[trait], principal)
+			}
 		}
 		principalID := principal.GetId().GetResource()
 		if principalID == "" {
@@ -2730,16 +2824,11 @@ func (s *syncer) processGrantsWithExternalPrincipals(ctx context.Context, princi
 			return err
 		}
 		if matchResourceMatchAllAnno != nil {
-			var processPrincipals []*v2.Resource
-			switch matchResourceMatchAllAnno.GetResourceType() {
-			case v2.ResourceType_TRAIT_USER:
-				processPrincipals = userPrincipals
-			case v2.ResourceType_TRAIT_GROUP:
-				processPrincipals = groupPrincipals
-			default:
-				l.Error("unexpected external resource type trait", zap.Any("trait", matchResourceMatchAllAnno.GetResourceType()))
+			trait := matchResourceMatchAllAnno.GetResourceType()
+			if !matchTraits[trait] {
+				l.Error("unexpected external resource type trait", zap.Any("trait", trait))
 			}
-			for _, principal := range processPrincipals {
+			for _, principal := range principalsByTrait[trait] {
 				newGrant := newGrantForExternalPrincipal(grant, principal)
 				expandedGrants = append(expandedGrants, newGrant)
 			}
@@ -2829,9 +2918,10 @@ func (s *syncer) processGrantsWithExternalPrincipals(ctx context.Context, princi
 		}
 
 		if matchExternalResource != nil {
-			switch matchExternalResource.GetResourceType() {
-			case v2.ResourceType_TRAIT_USER:
-				for _, userPrincipal := range userPrincipals {
+			trait := matchExternalResource.GetResourceType()
+			switch {
+			case trait == v2.ResourceType_TRAIT_USER:
+				for _, userPrincipal := range principalsByTrait[v2.ResourceType_TRAIT_USER] {
 					userTrait, err := resource.GetUserTrait(userPrincipal)
 					if err != nil {
 						l.Error("error getting user trait", zap.Any("userPrincipal", userPrincipal))
@@ -2851,48 +2941,25 @@ func (s *syncer) processGrantsWithExternalPrincipals(ctx context.Context, princi
 						expandedGrants = append(expandedGrants, newGrant)
 					}
 				}
-			case v2.ResourceType_TRAIT_GROUP:
-				for _, groupPrincipal := range groupPrincipals {
-					profileVal, ok := resource.GetProfileStringValue(resource.GetProfile(groupPrincipal), matchExternalResource.GetKey())
-					if ok && strings.EqualFold(profileVal, matchExternalResource.GetValue()) {
-						newGrant := newGrantForExternalPrincipal(grant, groupPrincipal)
-						newGrantAnnos := annotations.Annotations(newGrant.GetAnnotations())
-
-						newExpandableEntitlementIDs := make([]string, 0)
-						if expandableAnno != nil {
-							groupPrincipalBID, err := bid.MakeBid(grant.GetPrincipal())
-							if err != nil {
-								l.Error("error making group principal bid", zap.Error(err), zap.Any("grant.Principal", grant.GetPrincipal()))
-								continue
-							}
-
-							principalEntitlementSlugs := expandableEntitlementsResourceMap[groupPrincipalBID]
-							for _, slug := range principalEntitlementSlugs {
-								newExpandableEntId := entitlement.NewEntitlementID(groupPrincipal, slug)
-								_, err := s.store.GetEntitlement(ctx, reader_v2.EntitlementsReaderServiceGetEntitlementRequest_builder{EntitlementId: newExpandableEntId}.Build())
-								if err != nil {
-									if status.Code(err) == codes.NotFound {
-										l.Error("found no entitlement with entitlement id generated from external source sync", zap.Any("entitlementId", newExpandableEntId))
-										continue
-									}
-									return err
-								}
-								newExpandableEntitlementIDs = append(newExpandableEntitlementIDs, newExpandableEntId)
-							}
-
-							newExpandableAnno := v2.GrantExpandable_builder{
-								EntitlementIds:  newExpandableEntitlementIDs,
-								Shallow:         expandableAnno.GetShallow(),
-								ResourceTypeIds: expandableAnno.GetResourceTypeIds(),
-							}.Build()
-							newGrantAnnos.Update(newExpandableAnno)
-							newGrant.SetAnnotations(newGrantAnnos)
-							expandedGrants = append(expandedGrants, newGrant)
-						}
+			case matchTraits[trait]:
+				// Generic profile match, shared by TRAIT_GROUP and any
+				// additional trait opted into via WithExternalResourceTraits
+				// (e.g. TRAIT_APP).
+				for _, principal := range principalsByTrait[trait] {
+					newGrant, err := s.matchProfileAndExpand(
+						ctx, l, grant, principal,
+						matchExternalResource.GetKey(), matchExternalResource.GetValue(),
+						expandableAnno, expandableEntitlementsResourceMap,
+					)
+					if err != nil {
+						return err
+					}
+					if newGrant != nil {
+						expandedGrants = append(expandedGrants, newGrant)
 					}
 				}
 			default:
-				l.Error("unexpected external resource type trait", zap.Any("trait", matchExternalResource.GetResourceType()))
+				l.Error("unexpected external resource type trait", zap.Any("trait", trait))
 			}
 
 			// We still want to delete the grant even if there are no matches
@@ -3277,6 +3344,20 @@ func WithOptionalPreviousSyncC1ZPath(path string) SyncOpt {
 func WithExternalResourceEntitlementIdFilter(entitlementId string) SyncOpt {
 	return func(s *syncer) {
 		s.externalResourceEntitlementIdFilter = entitlementId
+	}
+}
+
+// WithExternalResourceTraits adds resource type traits, beyond the
+// always-eligible TRAIT_USER and TRAIT_GROUP, that the External Identity
+// Matcher should sync from the external resource source and consider when
+// matching grants (e.g. ExternalResourceMatch / ExternalResourceMatchAll
+// annotations). Connectors opt into this when their principals live in a
+// separate identity-source connector under a trait other than user/group —
+// for example an Azure connector matching service-principal role
+// assignments against TRAIT_APP resources synced by baton-microsoft-entra.
+func WithExternalResourceTraits(traits ...v2.ResourceType_Trait) SyncOpt {
+	return func(s *syncer) {
+		s.externalResourceTraits = append(s.externalResourceTraits, traits...)
 	}
 }
 

--- a/pkg/sync/syncer_test.go
+++ b/pkg/sync/syncer_test.go
@@ -620,7 +620,12 @@ func TestExternalResourcePath(t *testing.T) {
 		require.NoError(t, err)
 
 		internalC1zpath := filepath.Join(tempDir, "internal.c1z")
-		internalOpts := append([]SyncOpt{WithC1ZPath(internalC1zpath), WithTmpDir(tempDir), WithExternalResourceC1ZPath(externalC1zpath)}, extraOpts...)
+		internalOpts := append([]SyncOpt{
+			WithC1ZPath(internalC1zpath),
+			WithTmpDir(tempDir),
+			WithExternalResourceC1ZPath(externalC1zpath),
+			WithExternalResourceTraits(v2.ResourceType_TRAIT_USER, v2.ResourceType_TRAIT_GROUP),
+		}, extraOpts...)
 		internalSyncer, err := NewSyncer(ctx, internalMc, internalOpts...)
 		require.NoError(t, err)
 		err = internalSyncer.Sync(ctx)
@@ -922,7 +927,12 @@ func TestExternalResourceMatchAll(t *testing.T) {
 
 		// Sync internal with external reference
 		internalC1zpath := filepath.Join(tempDir, "internal.c1z")
-		internalOpts := append([]SyncOpt{WithC1ZPath(internalC1zpath), WithTmpDir(tempDir), WithExternalResourceC1ZPath(externalC1zpath)}, extraOpts...)
+		internalOpts := append([]SyncOpt{
+			WithC1ZPath(internalC1zpath),
+			WithTmpDir(tempDir),
+			WithExternalResourceC1ZPath(externalC1zpath),
+			WithExternalResourceTraits(v2.ResourceType_TRAIT_USER, v2.ResourceType_TRAIT_GROUP),
+		}, extraOpts...)
 		internalSyncer, err := NewSyncer(ctx, internalMc, internalOpts...)
 		require.NoError(t, err)
 		err = internalSyncer.Sync(ctx)
@@ -1012,7 +1022,12 @@ func TestExternalResourceMatchID(t *testing.T) {
 
 		// Sync internal with external reference
 		internalC1zpath := filepath.Join(tempDir, "internal.c1z")
-		internalOpts := append([]SyncOpt{WithC1ZPath(internalC1zpath), WithTmpDir(tempDir), WithExternalResourceC1ZPath(externalC1zpath)}, extraOpts...)
+		internalOpts := append([]SyncOpt{
+			WithC1ZPath(internalC1zpath),
+			WithTmpDir(tempDir),
+			WithExternalResourceC1ZPath(externalC1zpath),
+			WithExternalResourceTraits(v2.ResourceType_TRAIT_USER, v2.ResourceType_TRAIT_GROUP),
+		}, extraOpts...)
 		internalSyncer, err := NewSyncer(ctx, internalMc, internalOpts...)
 		require.NoError(t, err)
 		err = internalSyncer.Sync(ctx)
@@ -1109,6 +1124,7 @@ func TestExternalResourceMatchIDWithExpandableRemapping(t *testing.T) {
 		WithC1ZPath(internalC1zpath),
 		WithTmpDir(tempDir),
 		WithExternalResourceC1ZPath(externalC1zpath),
+		WithExternalResourceTraits(v2.ResourceType_TRAIT_USER, v2.ResourceType_TRAIT_GROUP),
 		WithDontExpandGrants(),
 	)
 	require.NoError(t, err)
@@ -1221,7 +1237,12 @@ func TestExternalResourceEmailMatch(t *testing.T) {
 
 		// Sync internal with external reference
 		internalC1zpath := filepath.Join(tempDir, "internal.c1z")
-		internalOpts := append([]SyncOpt{WithC1ZPath(internalC1zpath), WithTmpDir(tempDir), WithExternalResourceC1ZPath(externalC1zpath)}, extraOpts...)
+		internalOpts := append([]SyncOpt{
+			WithC1ZPath(internalC1zpath),
+			WithTmpDir(tempDir),
+			WithExternalResourceC1ZPath(externalC1zpath),
+			WithExternalResourceTraits(v2.ResourceType_TRAIT_USER, v2.ResourceType_TRAIT_GROUP),
+		}, extraOpts...)
 		internalSyncer, err := NewSyncer(ctx, internalMc, internalOpts...)
 		require.NoError(t, err)
 		err = internalSyncer.Sync(ctx)
@@ -1313,7 +1334,12 @@ func TestExternalResourceGroupProfileMatch(t *testing.T) {
 
 		// Sync internal with external reference
 		internalC1zpath := filepath.Join(tempDir, "internal.c1z")
-		internalOpts := append([]SyncOpt{WithC1ZPath(internalC1zpath), WithTmpDir(tempDir), WithExternalResourceC1ZPath(externalC1zpath)}, extraOpts...)
+		internalOpts := append([]SyncOpt{
+			WithC1ZPath(internalC1zpath),
+			WithTmpDir(tempDir),
+			WithExternalResourceC1ZPath(externalC1zpath),
+			WithExternalResourceTraits(v2.ResourceType_TRAIT_USER, v2.ResourceType_TRAIT_GROUP),
+		}, extraOpts...)
 		internalSyncer, err := NewSyncer(ctx, internalMc, internalOpts...)
 		require.NoError(t, err)
 		err = internalSyncer.Sync(ctx)

--- a/pkg/sync/syncer_test.go
+++ b/pkg/sync/syncer_test.go
@@ -620,12 +620,7 @@ func TestExternalResourcePath(t *testing.T) {
 		require.NoError(t, err)
 
 		internalC1zpath := filepath.Join(tempDir, "internal.c1z")
-		internalOpts := append([]SyncOpt{
-			WithC1ZPath(internalC1zpath),
-			WithTmpDir(tempDir),
-			WithExternalResourceC1ZPath(externalC1zpath),
-			WithExternalResourceTraits(v2.ResourceType_TRAIT_USER, v2.ResourceType_TRAIT_GROUP),
-		}, extraOpts...)
+		internalOpts := append([]SyncOpt{WithC1ZPath(internalC1zpath), WithTmpDir(tempDir), WithExternalResourceC1ZPath(externalC1zpath)}, extraOpts...)
 		internalSyncer, err := NewSyncer(ctx, internalMc, internalOpts...)
 		require.NoError(t, err)
 		err = internalSyncer.Sync(ctx)
@@ -927,12 +922,7 @@ func TestExternalResourceMatchAll(t *testing.T) {
 
 		// Sync internal with external reference
 		internalC1zpath := filepath.Join(tempDir, "internal.c1z")
-		internalOpts := append([]SyncOpt{
-			WithC1ZPath(internalC1zpath),
-			WithTmpDir(tempDir),
-			WithExternalResourceC1ZPath(externalC1zpath),
-			WithExternalResourceTraits(v2.ResourceType_TRAIT_USER, v2.ResourceType_TRAIT_GROUP),
-		}, extraOpts...)
+		internalOpts := append([]SyncOpt{WithC1ZPath(internalC1zpath), WithTmpDir(tempDir), WithExternalResourceC1ZPath(externalC1zpath)}, extraOpts...)
 		internalSyncer, err := NewSyncer(ctx, internalMc, internalOpts...)
 		require.NoError(t, err)
 		err = internalSyncer.Sync(ctx)
@@ -1022,12 +1012,7 @@ func TestExternalResourceMatchID(t *testing.T) {
 
 		// Sync internal with external reference
 		internalC1zpath := filepath.Join(tempDir, "internal.c1z")
-		internalOpts := append([]SyncOpt{
-			WithC1ZPath(internalC1zpath),
-			WithTmpDir(tempDir),
-			WithExternalResourceC1ZPath(externalC1zpath),
-			WithExternalResourceTraits(v2.ResourceType_TRAIT_USER, v2.ResourceType_TRAIT_GROUP),
-		}, extraOpts...)
+		internalOpts := append([]SyncOpt{WithC1ZPath(internalC1zpath), WithTmpDir(tempDir), WithExternalResourceC1ZPath(externalC1zpath)}, extraOpts...)
 		internalSyncer, err := NewSyncer(ctx, internalMc, internalOpts...)
 		require.NoError(t, err)
 		err = internalSyncer.Sync(ctx)
@@ -1124,7 +1109,6 @@ func TestExternalResourceMatchIDWithExpandableRemapping(t *testing.T) {
 		WithC1ZPath(internalC1zpath),
 		WithTmpDir(tempDir),
 		WithExternalResourceC1ZPath(externalC1zpath),
-		WithExternalResourceTraits(v2.ResourceType_TRAIT_USER, v2.ResourceType_TRAIT_GROUP),
 		WithDontExpandGrants(),
 	)
 	require.NoError(t, err)
@@ -1237,12 +1221,7 @@ func TestExternalResourceEmailMatch(t *testing.T) {
 
 		// Sync internal with external reference
 		internalC1zpath := filepath.Join(tempDir, "internal.c1z")
-		internalOpts := append([]SyncOpt{
-			WithC1ZPath(internalC1zpath),
-			WithTmpDir(tempDir),
-			WithExternalResourceC1ZPath(externalC1zpath),
-			WithExternalResourceTraits(v2.ResourceType_TRAIT_USER, v2.ResourceType_TRAIT_GROUP),
-		}, extraOpts...)
+		internalOpts := append([]SyncOpt{WithC1ZPath(internalC1zpath), WithTmpDir(tempDir), WithExternalResourceC1ZPath(externalC1zpath)}, extraOpts...)
 		internalSyncer, err := NewSyncer(ctx, internalMc, internalOpts...)
 		require.NoError(t, err)
 		err = internalSyncer.Sync(ctx)
@@ -1334,12 +1313,7 @@ func TestExternalResourceGroupProfileMatch(t *testing.T) {
 
 		// Sync internal with external reference
 		internalC1zpath := filepath.Join(tempDir, "internal.c1z")
-		internalOpts := append([]SyncOpt{
-			WithC1ZPath(internalC1zpath),
-			WithTmpDir(tempDir),
-			WithExternalResourceC1ZPath(externalC1zpath),
-			WithExternalResourceTraits(v2.ResourceType_TRAIT_USER, v2.ResourceType_TRAIT_GROUP),
-		}, extraOpts...)
+		internalOpts := append([]SyncOpt{WithC1ZPath(internalC1zpath), WithTmpDir(tempDir), WithExternalResourceC1ZPath(externalC1zpath)}, extraOpts...)
 		internalSyncer, err := NewSyncer(ctx, internalMc, internalOpts...)
 		require.NoError(t, err)
 		err = internalSyncer.Sync(ctx)

--- a/pkg/sync/syncer_test.go
+++ b/pkg/sync/syncer_test.go
@@ -36,6 +36,12 @@ var userResourceType = v2.ResourceType_builder{
 	Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_USER},
 	Annotations: annotations.New(&v2.SkipEntitlementsAndGrants{}),
 }.Build()
+var appResourceType = v2.ResourceType_builder{
+	Id:          "app",
+	DisplayName: "App",
+	Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_APP},
+	Annotations: annotations.New(&v2.SkipEntitlementsAndGrants{}),
+}.Build()
 
 // syncModes defines the syncer configurations to test.
 // Each test will run once with sequential mode (workerCount=0) and once with parallel mode (workerCount=2).
@@ -1358,6 +1364,146 @@ func TestExternalResourceGroupProfileMatch(t *testing.T) {
 		// This is the key verification - if the group wasn't matched, it wouldn't be synced
 		require.NotNil(t, syncedExternalGroup, "External group should have been synced, proving group profile matching worked")
 		require.Equal(t, "ext_123", profileVal, "External group profile should have correct external_id value, proving matching worked")
+	})
+}
+
+// TestExternalResourceMatchAllAppTrait proves out CE-975: a connector that
+// opts in via WithExternalResourceTraits(TRAIT_APP) can match grants against
+// TRAIT_APP principals synced from another connector's external c1z, exactly
+// like TestExternalResourceMatchAll does for TRAIT_USER by default.
+func TestExternalResourceMatchAllAppTrait(t *testing.T) {
+	runWithSyncModes(t, func(t *testing.T, extraOpts []SyncOpt) {
+		ctx := t.Context()
+
+		tempDir, err := os.MkdirTemp("", "baton-external-match-all-app-test")
+		require.NoError(t, err)
+		defer os.RemoveAll(tempDir)
+
+		internalMc := newMockConnector()
+		internalMc.rtDB = append(internalMc.rtDB, userResourceType, groupResourceType, appResourceType)
+
+		externalMc := newMockConnector()
+		externalMc.rtDB = append(externalMc.rtDB, userResourceType, groupResourceType, appResourceType)
+
+		externalApp, err := rs.NewAppResource("Service Principal", appResourceType, "ext_app_1", nil)
+		require.NoError(t, err)
+		externalMc.AddResource(ctx, externalApp)
+
+		internalGroup, internalGroupEnt, err := internalMc.AddGroup(ctx, "internal_group")
+		require.NoError(t, err)
+		internalMc.grantDB[internalGroup.GetId().GetResource()] = []*v2.Grant{
+			gt.NewGrant(
+				internalGroup,
+				"member",
+				v2.ResourceId_builder{
+					ResourceType: appResourceType.GetId(),
+					Resource:     "placeholder",
+				}.Build(),
+				gt.WithAnnotation(v2.ExternalResourceMatchAll_builder{
+					ResourceType: v2.ResourceType_TRAIT_APP,
+				}.Build()),
+			),
+		}
+
+		externalC1zpath := filepath.Join(tempDir, "external.c1z")
+		externalOpts := append([]SyncOpt{WithC1ZPath(externalC1zpath), WithTmpDir(tempDir)}, extraOpts...)
+		externalSyncer, err := NewSyncer(ctx, externalMc, externalOpts...)
+		require.NoError(t, err)
+		require.NoError(t, externalSyncer.Sync(ctx))
+		require.NoError(t, externalSyncer.Close(ctx))
+
+		internalC1zpath := filepath.Join(tempDir, "internal.c1z")
+		internalOpts := append([]SyncOpt{
+			WithC1ZPath(internalC1zpath),
+			WithTmpDir(tempDir),
+			WithExternalResourceC1ZPath(externalC1zpath),
+			WithExternalResourceTraits(v2.ResourceType_TRAIT_APP),
+		}, extraOpts...)
+		internalSyncer, err := NewSyncer(ctx, internalMc, internalOpts...)
+		require.NoError(t, err)
+		require.NoError(t, internalSyncer.Sync(ctx))
+		require.NoError(t, internalSyncer.Close(ctx))
+
+		store, err := dotc1z.NewC1ZFile(ctx, internalC1zpath)
+		require.NoError(t, err)
+
+		grants, err := store.ListGrantsForEntitlement(ctx, reader_v2.GrantsReaderServiceListGrantsForEntitlementRequest_builder{
+			Entitlement: internalGroupEnt,
+		}.Build())
+		require.NoError(t, err)
+		require.Len(t, grants.GetList(), 1, "should have matched the external app principal")
+		require.Equal(t, appResourceType.GetId(), grants.GetList()[0].GetPrincipal().GetId().GetResourceType())
+		require.Equal(t, externalApp.GetId().GetResource(), grants.GetList()[0].GetPrincipal().GetId().GetResource())
+	})
+}
+
+// TestExternalResourceAppTraitNotMatchedByDefault proves the flip side of
+// CE-975: without opting in via WithExternalResourceTraits, TRAIT_APP
+// principals are neither synced from the external source nor matched, and
+// the unmatched ExternalResourceMatchAll grant is simply dropped (matching
+// existing behavior for any grant that finds no matching principal).
+func TestExternalResourceAppTraitNotMatchedByDefault(t *testing.T) {
+	runWithSyncModes(t, func(t *testing.T, extraOpts []SyncOpt) {
+		ctx := t.Context()
+
+		tempDir, err := os.MkdirTemp("", "baton-external-app-trait-default-test")
+		require.NoError(t, err)
+		defer os.RemoveAll(tempDir)
+
+		internalMc := newMockConnector()
+		internalMc.rtDB = append(internalMc.rtDB, userResourceType, groupResourceType, appResourceType)
+
+		externalMc := newMockConnector()
+		externalMc.rtDB = append(externalMc.rtDB, userResourceType, groupResourceType, appResourceType)
+
+		externalApp, err := rs.NewAppResource("Service Principal", appResourceType, "ext_app_1", nil)
+		require.NoError(t, err)
+		externalMc.AddResource(ctx, externalApp)
+
+		internalGroup, internalGroupEnt, err := internalMc.AddGroup(ctx, "internal_group")
+		require.NoError(t, err)
+		internalMc.grantDB[internalGroup.GetId().GetResource()] = []*v2.Grant{
+			gt.NewGrant(
+				internalGroup,
+				"member",
+				v2.ResourceId_builder{
+					ResourceType: appResourceType.GetId(),
+					Resource:     "placeholder",
+				}.Build(),
+				gt.WithAnnotation(v2.ExternalResourceMatchAll_builder{
+					ResourceType: v2.ResourceType_TRAIT_APP,
+				}.Build()),
+			),
+		}
+
+		externalC1zpath := filepath.Join(tempDir, "external.c1z")
+		externalOpts := append([]SyncOpt{WithC1ZPath(externalC1zpath), WithTmpDir(tempDir)}, extraOpts...)
+		externalSyncer, err := NewSyncer(ctx, externalMc, externalOpts...)
+		require.NoError(t, err)
+		require.NoError(t, externalSyncer.Sync(ctx))
+		require.NoError(t, externalSyncer.Close(ctx))
+
+		// Deliberately omit WithExternalResourceTraits: TRAIT_APP stays out
+		// of the default USER/GROUP matching pool.
+		internalC1zpath := filepath.Join(tempDir, "internal.c1z")
+		internalOpts := append([]SyncOpt{
+			WithC1ZPath(internalC1zpath),
+			WithTmpDir(tempDir),
+			WithExternalResourceC1ZPath(externalC1zpath),
+		}, extraOpts...)
+		internalSyncer, err := NewSyncer(ctx, internalMc, internalOpts...)
+		require.NoError(t, err)
+		require.NoError(t, internalSyncer.Sync(ctx))
+		require.NoError(t, internalSyncer.Close(ctx))
+
+		store, err := dotc1z.NewC1ZFile(ctx, internalC1zpath)
+		require.NoError(t, err)
+
+		grants, err := store.ListGrantsForEntitlement(ctx, reader_v2.GrantsReaderServiceListGrantsForEntitlementRequest_builder{
+			Entitlement: internalGroupEnt,
+		}.Build())
+		require.NoError(t, err)
+		require.Empty(t, grants.GetList(), "TRAIT_APP principals should not be matched without WithExternalResourceTraits")
 	})
 }
 

--- a/pkg/tasks/c1api/full_sync.go
+++ b/pkg/tasks/c1api/full_sync.go
@@ -53,6 +53,7 @@ type fullSyncTaskHandler struct {
 	skipFullSync                        bool
 	externalResourceC1ZPath             string
 	externalResourceEntitlementIdFilter string
+	externalResourceTraits              []v2.ResourceType_Trait
 	targetedSyncResources               []*v2.Resource
 	syncResourceTypeIDs                 []string
 	workerCount                         int
@@ -200,6 +201,10 @@ func (c *fullSyncTaskHandler) sync(ctx context.Context, c1zPath string) error {
 
 	if c.externalResourceC1ZPath != "" {
 		syncOpts = append(syncOpts, sdkSync.WithExternalResourceC1ZPath(c.externalResourceC1ZPath))
+	}
+
+	if len(c.externalResourceTraits) > 0 {
+		syncOpts = append(syncOpts, sdkSync.WithExternalResourceTraits(c.externalResourceTraits...))
 	}
 
 	// ETag replay (opt-in): feed the spare retained from the last
@@ -370,6 +375,7 @@ func newFullSyncTaskHandler(
 	skipFullSync bool,
 	externalResourceC1ZPath string,
 	externalResourceEntitlementIdFilter string,
+	externalResourceTraits []v2.ResourceType_Trait,
 	targetedSyncResources []*v2.Resource,
 	syncResourceTypeIDs []string,
 	workerCount int,
@@ -382,6 +388,7 @@ func newFullSyncTaskHandler(
 		skipFullSync:                        skipFullSync,
 		externalResourceC1ZPath:             externalResourceC1ZPath,
 		externalResourceEntitlementIdFilter: externalResourceEntitlementIdFilter,
+		externalResourceTraits:              externalResourceTraits,
 		targetedSyncResources:               targetedSyncResources,
 		syncResourceTypeIDs:                 syncResourceTypeIDs,
 		workerCount:                         workerCount,

--- a/pkg/tasks/c1api/manager.go
+++ b/pkg/tasks/c1api/manager.go
@@ -65,6 +65,7 @@ type c1ApiTaskManager struct {
 	skipFullSync                        bool
 	externalResourceC1Z                 string
 	externalResourceEntitlementIdFilter string
+	externalResourceTraits              []v2.ResourceType_Trait
 	targetedSyncResources               []*v2.Resource
 	syncResourceTypeIDs                 []string
 	workerCount                         int
@@ -429,6 +430,7 @@ func (c *c1ApiTaskManager) Process(ctx context.Context, task *v1.Task, cc types.
 			c.skipFullSync,
 			c.externalResourceC1Z,
 			c.externalResourceEntitlementIdFilter,
+			c.externalResourceTraits,
 			c.targetedSyncResources,
 			c.syncResourceTypeIDs,
 			c.workerCount,
@@ -499,6 +501,7 @@ func NewC1TaskManager(
 	skipFullSync bool,
 	externalC1Z string,
 	externalResourceEntitlementIdFilter string,
+	externalResourceTraits []v2.ResourceType_Trait,
 	targetedSyncResources []*v2.Resource,
 	syncResourceTypeIDs []string,
 	workerCount int,
@@ -527,6 +530,7 @@ func NewC1TaskManager(
 		skipFullSync:                        skipFullSync,
 		externalResourceC1Z:                 externalC1Z,
 		externalResourceEntitlementIdFilter: externalResourceEntitlementIdFilter,
+		externalResourceTraits:              externalResourceTraits,
 		targetedSyncResources:               targetedSyncResources,
 		syncResourceTypeIDs:                 syncResourceTypeIDs,
 		workerCount:                         workerCount,

--- a/pkg/tasks/local/syncer.go
+++ b/pkg/tasks/local/syncer.go
@@ -25,6 +25,7 @@ type localSyncer struct {
 	tmpDir                              string
 	externalResourceC1Z                 string
 	externalResourceEntitlementIdFilter string
+	externalResourceTraits              []v2.ResourceType_Trait
 	targetedSyncResources               []*v2.Resource
 	skipEntitlementsAndGrants           bool
 	skipGrants                          bool
@@ -50,6 +51,12 @@ func WithExternalResourceC1Z(externalResourceC1Z string) Option {
 func WithExternalResourceEntitlementIdFilter(entitlementId string) Option {
 	return func(m *localSyncer) {
 		m.externalResourceEntitlementIdFilter = entitlementId
+	}
+}
+
+func WithExternalResourceTraits(traits []v2.ResourceType_Trait) Option {
+	return func(m *localSyncer) {
+		m.externalResourceTraits = traits
 	}
 }
 
@@ -123,6 +130,7 @@ func (m *localSyncer) Process(ctx context.Context, task *v1.Task, cc types.Conne
 		sdkSync.WithTmpDir(m.tmpDir),
 		sdkSync.WithExternalResourceC1ZPath(m.externalResourceC1Z),
 		sdkSync.WithExternalResourceEntitlementIdFilter(m.externalResourceEntitlementIdFilter),
+		sdkSync.WithExternalResourceTraits(m.externalResourceTraits...),
 		sdkSync.WithTargetedSyncResources(m.targetedSyncResources),
 		sdkSync.WithSkipEntitlementsAndGrants(m.skipEntitlementsAndGrants),
 		sdkSync.WithSkipGrants(m.skipGrants),


### PR DESCRIPTION
## Summary

Fixes [CE-975](https://linear.app/ductone/issue/CE-975/add-support-for-additional-resource-traits-in-baton-id-external): the External Identity Matcher only ever synced and matched `TRAIT_USER`/`TRAIT_GROUP` principals from an external resource c1z. This blocked `baton-azure` from matching Azure service-principal role assignments against identities synced by `baton-microsoft-entra` as `TRAIT_APP`, forcing a connector-specific workaround (baton-azure PR #52) that duplicates identities across connectors instead of matching against the identity connector's own sync.

- Added `sync.WithExternalResourceTraits(...v2.ResourceType_Trait)`: lets a connector configure which traits (e.g. `TRAIT_APP`) the matcher's external-resource sync, principal pool, `ExternalResourceMatchAll`, and key/val `ExternalResourceMatch` logic use.
- `TRAIT_USER`/`TRAIT_GROUP` remain the always-on default when the option isn't set — no behavior change for existing connectors. Passing any traits **replaces** the default set entirely, so a connector that wants USER/GROUP alongside a new trait must list all three.
- Threaded the option through the same plumbing as the existing `--external-resource-c1z`/`--external-resource-entitlement-id-filter` flags: `connectorrunner` → `pkg/tasks/local` (one-shot) and `pkg/tasks/c1api` (platform daemon mode), plus a new `--external-resource-traits` CLI flag (accepts bare names like `app` or canonical `TRAIT_APP`, defaults to `user,group`).
- Extracted a shared `matchProfileAndExpand` helper so any additional trait gets the same generic profile-match + expandable-remap behavior `TRAIT_GROUP` already had, instead of duplicating that logic per trait.

## Test plan

- [x] `go build ./...`
- [x] `go vet` + `golangci-lint run` clean on all touched packages
- [x] `go test ./pkg/sync/...` — full suite passes, including new `TestExternalResourceMatchAllAppTrait` (proves `TRAIT_APP` matching works when opted in) and `TestExternalResourceAppTraitNotMatchedByDefault` (proves it stays inert without opting in)
- [x] Existing `TestExternalResource*` tests continue to pass without an explicit `WithExternalResourceTraits(USER, GROUP)` opt-in — exercises the restored default
- [x] `go test ./pkg/connectorrunner/... ./pkg/tasks/... ./pkg/field/... ./pkg/cli/...` — all pass, no regressions from the plumbing changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)