### PR TITLE
feat(cli): project served-policy egress into lambda RunTimeOpts

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -24,6 +24,29 @@ type RunTimeOpts struct {
 	TokenSource         oauth2.TokenSource
 	SelectedAuthMethod  string
 	SyncResourceTypeIDs []string
+	// EgressPolicy carries the server-computed egress policy delivered on the
+	// connector-config response, when one is present. It is nil for connectors
+	// served without a policy envelope; the connector decides how (and whether)
+	// to enforce it.
+	EgressPolicy *EgressPolicy
+}
+
+// EgressPolicy is the connector-facing projection of a served-policy envelope's
+// egress section: the fields a connector runtime needs to enforce egress,
+// extracted after the SDK verified the envelope's binding to this response.
+// The envelope's digests, versions, and capability section are not surfaced —
+// they are the SDK's contract to verify, not the connector's.
+type EgressPolicy struct {
+	// Governed is true when the response carried a served-policy envelope. A
+	// governed connector enforces its allowlist even when AllowedHosts is empty
+	// (an empty governed allowlist is deny-all), and a malformed or unsupported
+	// envelope resolves to governed-with-no-hosts so enforcement fails closed.
+	Governed bool
+	// AllowedHosts is the effective per-instance egress allowlist (canonical
+	// hostnames). Empty under Governed is a valid deny-all policy.
+	AllowedHosts []string
+	// HTTPSOnly reports whether the runtime must refuse non-https egress.
+	HTTPSOnly bool
 }
 
 // GetConnectorFunc is a function type that creates a connector instance.

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -37,13 +37,9 @@ type RunTimeOpts struct {
 // The envelope's digests, versions, and capability section are not surfaced —
 // they are the SDK's contract to verify, not the connector's.
 type EgressPolicy struct {
-	// Governed is true when the response carried a served-policy envelope. A
-	// governed connector enforces its allowlist even when AllowedHosts is empty
-	// (an empty governed allowlist is deny-all), and a malformed or unsupported
-	// envelope resolves to governed-with-no-hosts so enforcement fails closed.
-	Governed bool
 	// AllowedHosts is the effective per-instance egress allowlist (canonical
-	// hostnames). Empty under Governed is a valid deny-all policy.
+	// hostnames). A non-nil *EgressPolicy with empty AllowedHosts is a valid
+	// deny-all policy.
 	AllowedHosts []string
 	// HTTPSOnly reports whether the runtime must refuse non-https egress.
 	HTTPSOnly bool

--- a/pkg/cli/lambda_server__added.go
+++ b/pkg/cli/lambda_server__added.go
@@ -47,6 +47,12 @@ const (
 	lambdaConnectorConfigVersionHeader = "x-baton-connector-config-version"
 	lambdaConnectorDrainTimeout        = 30 * time.Second
 	lambdaConnectorCloseTimeout        = 10 * time.Second
+
+	// Served-policy envelope contract versions this SDK understands. An
+	// envelope outside these resolves to a governed-with-no-hosts (deny-all)
+	// policy rather than being read.
+	servedPolicyEnvelopeVersion = 1
+	egressSectionSchemaVersion  = 1
 )
 
 type lambdaConnectorGeneration struct {
@@ -393,6 +399,7 @@ func OptionallyAddLambdaCommand[T field.Configurable](
 				}),
 				SelectedAuthMethod:  authMethodStr,
 				SyncResourceTypeIDs: effectiveConfig.GetStringSlice("sync-resource-types"),
+				EgressPolicy:        egressPolicyFromResponse(config),
 			}
 
 			if hasOauthField(schemaFields) {
@@ -482,10 +489,51 @@ func OptionallyAddLambdaCommand[T field.Configurable](
 }
 
 func lambdaConnectorConfigVersion(config *v1.GetConnectorConfigResponse) string {
-	if config == nil || config.GetLastUpdated() == nil {
+	if config == nil {
+		return ""
+	}
+	// Prefer the server-stamped durable config-version handle: it is the same
+	// value the invoker sends back in the config-version header, so a warm
+	// generation's version matches the requested version and does not force a
+	// spurious reload. Older servers omit it; fall back to last_updated.
+	if config.HasConfigVersion() {
+		return config.GetConfigVersion()
+	}
+	if config.GetLastUpdated() == nil {
 		return ""
 	}
 	return config.GetLastUpdated().AsTime().UTC().Format(time.RFC3339Nano)
+}
+
+// egressPolicyFromResponse projects the connector-facing egress policy from the
+// response's served-policy envelope, or nil when no envelope is present. A
+// present envelope is Governed even when it fails a binding, version, or
+// section check — such an envelope resolves to governed-with-no-hosts so the
+// connector fails closed (deny-all) rather than serving unenforced. The
+// config-version binding (the envelope's config_version must be non-empty and
+// equal to the response's) is the one cross-field check the SDK is uniquely
+// positioned to make; deeper content validation is the connector's.
+func egressPolicyFromResponse(config *v1.GetConnectorConfigResponse) *EgressPolicy {
+	if config == nil || !config.HasServedPolicyEnvelope() {
+		return nil
+	}
+	env := config.GetServedPolicyEnvelope()
+	policy := &EgressPolicy{Governed: true}
+
+	if env.GetEnvelopeVersion() != servedPolicyEnvelopeVersion {
+		return policy
+	}
+	cv := env.GetConfigVersion()
+	if cv == "" || cv != config.GetConfigVersion() {
+		return policy
+	}
+	egress := env.GetEgress()
+	if egress == nil || egress.GetSchemaVersion() != egressSectionSchemaVersion {
+		return policy
+	}
+	policy.AllowedHosts = egress.GetAllowedHosts()
+	policy.HTTPSOnly = egress.GetHttpsOnly()
+	return policy
 }
 
 func lambdaLogLevelConfigFromViper(v *viper.Viper) (lambdaLogLevelConfig, error) {

--- a/pkg/cli/lambda_server__added.go
+++ b/pkg/cli/lambda_server__added.go
@@ -507,18 +507,18 @@ func lambdaConnectorConfigVersion(config *v1.GetConnectorConfigResponse) string 
 
 // egressPolicyFromResponse projects the connector-facing egress policy from the
 // response's served-policy envelope, or nil when no envelope is present. A
-// present envelope is Governed even when it fails a binding, version, or
-// section check — such an envelope resolves to governed-with-no-hosts so the
-// connector fails closed (deny-all) rather than serving unenforced. The
-// config-version binding (the envelope's config_version must be non-empty and
-// equal to the response's) is the one cross-field check the SDK is uniquely
-// positioned to make; deeper content validation is the connector's.
+// present envelope yields a non-nil policy even when it fails a binding,
+// version, or section check — such an envelope resolves to a present policy with
+// no hosts so the connector fails closed (deny-all) rather than serving
+// unenforced. The config-version binding (the envelope's config_version must be
+// non-empty and equal to the response's) is the one cross-field check the SDK is
+// uniquely positioned to make; deeper content validation is the connector's.
 func egressPolicyFromResponse(config *v1.GetConnectorConfigResponse) *EgressPolicy {
 	if config == nil || !config.HasServedPolicyEnvelope() {
 		return nil
 	}
 	env := config.GetServedPolicyEnvelope()
-	policy := &EgressPolicy{Governed: true}
+	policy := &EgressPolicy{}
 
 	if env.GetEnvelopeVersion() != servedPolicyEnvelopeVersion {
 		return policy

--- a/pkg/cli/lambda_server__added_test.go
+++ b/pkg/cli/lambda_server__added_test.go
@@ -6,9 +6,82 @@ import (
 	"testing"
 	"time"
 
+	v1 "github.com/conductorone/baton-sdk/pb/c1/connectorapi/baton/v1"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 )
+
+func TestEgressPolicyFromResponse(t *testing.T) {
+	t.Parallel()
+
+	newResp := func(cv string, env *v1.ServedPolicyEnvelope) *v1.GetConnectorConfigResponse {
+		r := &v1.GetConnectorConfigResponse{}
+		if cv != "" {
+			r.SetConfigVersion(cv)
+		}
+		if env != nil {
+			r.SetServedPolicyEnvelope(env)
+		}
+		return r
+	}
+	goodEnvelope := func(cv string) *v1.ServedPolicyEnvelope {
+		return v1.ServedPolicyEnvelope_builder{
+			EnvelopeVersion: servedPolicyEnvelopeVersion,
+			ConfigVersion:   cv,
+			Egress: v1.EgressSection_builder{
+				SchemaVersion: egressSectionSchemaVersion,
+				HttpsOnly:     true,
+				AllowedHosts:  []string{"api.example.com"},
+			}.Build(),
+		}.Build()
+	}
+
+	t.Run("no envelope is ungoverned", func(t *testing.T) {
+		require.Nil(t, egressPolicyFromResponse(newResp("cv-1", nil)))
+		require.Nil(t, egressPolicyFromResponse(nil))
+	})
+
+	t.Run("valid envelope surfaces hosts and https_only", func(t *testing.T) {
+		p := egressPolicyFromResponse(newResp("cv-1", goodEnvelope("cv-1")))
+		require.NotNil(t, p)
+		require.True(t, p.Governed)
+		require.True(t, p.HTTPSOnly)
+		require.Equal(t, []string{"api.example.com"}, p.AllowedHosts)
+	})
+
+	t.Run("binding mismatch is governed deny-all", func(t *testing.T) {
+		// Envelope config_version differs from the response's.
+		p := egressPolicyFromResponse(newResp("cv-1", goodEnvelope("cv-2")))
+		require.NotNil(t, p)
+		require.True(t, p.Governed)
+		require.Empty(t, p.AllowedHosts)
+	})
+
+	t.Run("empty response config_version is governed deny-all", func(t *testing.T) {
+		p := egressPolicyFromResponse(newResp("", goodEnvelope("")))
+		require.NotNil(t, p)
+		require.True(t, p.Governed)
+		require.Empty(t, p.AllowedHosts)
+	})
+
+	t.Run("unsupported envelope version is governed deny-all", func(t *testing.T) {
+		env := goodEnvelope("cv-1")
+		env.SetEnvelopeVersion(999)
+		p := egressPolicyFromResponse(newResp("cv-1", env))
+		require.NotNil(t, p)
+		require.True(t, p.Governed)
+		require.Empty(t, p.AllowedHosts)
+	})
+
+	t.Run("unsupported egress schema version is governed deny-all", func(t *testing.T) {
+		env := goodEnvelope("cv-1")
+		env.GetEgress().SetSchemaVersion(999)
+		p := egressPolicyFromResponse(newResp("cv-1", env))
+		require.NotNil(t, p)
+		require.True(t, p.Governed)
+		require.Empty(t, p.AllowedHosts)
+	})
+}
 
 func TestLambdaLogLevelConfigExpiresDebug(t *testing.T) {
 	t.Parallel()

--- a/pkg/cli/lambda_server__added_test.go
+++ b/pkg/cli/lambda_server__added_test.go
@@ -47,7 +47,6 @@ func TestEgressPolicyFromResponse(t *testing.T) {
 		t.Parallel()
 		p := egressPolicyFromResponse(newResp("cv-1", goodEnvelope("cv-1")))
 		require.NotNil(t, p)
-		require.True(t, p.Governed)
 		require.True(t, p.HTTPSOnly)
 		require.Equal(t, []string{"api.example.com"}, p.AllowedHosts)
 	})
@@ -57,7 +56,6 @@ func TestEgressPolicyFromResponse(t *testing.T) {
 		// Envelope config_version differs from the response's.
 		p := egressPolicyFromResponse(newResp("cv-1", goodEnvelope("cv-2")))
 		require.NotNil(t, p)
-		require.True(t, p.Governed)
 		require.Empty(t, p.AllowedHosts)
 	})
 
@@ -65,7 +63,6 @@ func TestEgressPolicyFromResponse(t *testing.T) {
 		t.Parallel()
 		p := egressPolicyFromResponse(newResp("", goodEnvelope("")))
 		require.NotNil(t, p)
-		require.True(t, p.Governed)
 		require.Empty(t, p.AllowedHosts)
 	})
 
@@ -75,7 +72,6 @@ func TestEgressPolicyFromResponse(t *testing.T) {
 		env.SetEnvelopeVersion(999)
 		p := egressPolicyFromResponse(newResp("cv-1", env))
 		require.NotNil(t, p)
-		require.True(t, p.Governed)
 		require.Empty(t, p.AllowedHosts)
 	})
 
@@ -85,7 +81,6 @@ func TestEgressPolicyFromResponse(t *testing.T) {
 		env.GetEgress().SetSchemaVersion(999)
 		p := egressPolicyFromResponse(newResp("cv-1", env))
 		require.NotNil(t, p)
-		require.True(t, p.Governed)
 		require.Empty(t, p.AllowedHosts)
 	})
 }

--- a/pkg/cli/lambda_server__added_test.go
+++ b/pkg/cli/lambda_server__added_test.go
@@ -9,6 +9,7 @@ import (
 	v1 "github.com/conductorone/baton-sdk/pb/c1/connectorapi/baton/v1"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestEgressPolicyFromResponse(t *testing.T) {
@@ -37,11 +38,13 @@ func TestEgressPolicyFromResponse(t *testing.T) {
 	}
 
 	t.Run("no envelope is ungoverned", func(t *testing.T) {
+		t.Parallel()
 		require.Nil(t, egressPolicyFromResponse(newResp("cv-1", nil)))
 		require.Nil(t, egressPolicyFromResponse(nil))
 	})
 
 	t.Run("valid envelope surfaces hosts and https_only", func(t *testing.T) {
+		t.Parallel()
 		p := egressPolicyFromResponse(newResp("cv-1", goodEnvelope("cv-1")))
 		require.NotNil(t, p)
 		require.True(t, p.Governed)
@@ -50,6 +53,7 @@ func TestEgressPolicyFromResponse(t *testing.T) {
 	})
 
 	t.Run("binding mismatch is governed deny-all", func(t *testing.T) {
+		t.Parallel()
 		// Envelope config_version differs from the response's.
 		p := egressPolicyFromResponse(newResp("cv-1", goodEnvelope("cv-2")))
 		require.NotNil(t, p)
@@ -58,6 +62,7 @@ func TestEgressPolicyFromResponse(t *testing.T) {
 	})
 
 	t.Run("empty response config_version is governed deny-all", func(t *testing.T) {
+		t.Parallel()
 		p := egressPolicyFromResponse(newResp("", goodEnvelope("")))
 		require.NotNil(t, p)
 		require.True(t, p.Governed)
@@ -65,6 +70,7 @@ func TestEgressPolicyFromResponse(t *testing.T) {
 	})
 
 	t.Run("unsupported envelope version is governed deny-all", func(t *testing.T) {
+		t.Parallel()
 		env := goodEnvelope("cv-1")
 		env.SetEnvelopeVersion(999)
 		p := egressPolicyFromResponse(newResp("cv-1", env))
@@ -74,6 +80,7 @@ func TestEgressPolicyFromResponse(t *testing.T) {
 	})
 
 	t.Run("unsupported egress schema version is governed deny-all", func(t *testing.T) {
+		t.Parallel()
 		env := goodEnvelope("cv-1")
 		env.GetEgress().SetSchemaVersion(999)
 		p := egressPolicyFromResponse(newResp("cv-1", env))
@@ -81,6 +88,37 @@ func TestEgressPolicyFromResponse(t *testing.T) {
 		require.True(t, p.Governed)
 		require.Empty(t, p.AllowedHosts)
 	})
+}
+
+func TestLambdaConnectorConfigVersion(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 7, 27, 10, 30, 0, 0, time.UTC)
+
+	// config_version stamped: preferred even when last_updated is also present.
+	preferConfigVersion := &v1.GetConnectorConfigResponse{}
+	preferConfigVersion.SetConfigVersion("cv-1")
+	preferConfigVersion.SetLastUpdated(timestamppb.New(ts))
+
+	// Older server: no config_version, falls back to last_updated.
+	lastUpdatedOnly := &v1.GetConnectorConfigResponse{}
+	lastUpdatedOnly.SetLastUpdated(timestamppb.New(ts))
+
+	for _, tc := range []struct {
+		name   string
+		config *v1.GetConnectorConfigResponse
+		want   string
+	}{
+		{"nil config", nil, ""},
+		{"config_version preferred over last_updated", preferConfigVersion, "cv-1"},
+		{"falls back to last_updated when config_version absent", lastUpdatedOnly, ts.Format(time.RFC3339Nano)},
+		{"empty when neither is set", &v1.GetConnectorConfigResponse{}, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, lambdaConnectorConfigVersion(tc.config))
+		})
+	}
 }
 
 func TestLambdaLogLevelConfigExpiresDebug(t *testing.T) {


### PR DESCRIPTION
The lambda server is the only place that sees the connector-config response envelope, so it extracts the envelope's egress section and hands it to the connector via a new RunTimeOpts.EgressPolicy (Governed, AllowedHosts, HTTPSOnly). It performs the one cross-field check it is positioned for — the envelope's config_version must be non-empty and equal to the response's — and version-gates the envelope and egress section. Any binding, version, or section failure resolves to a governed policy with no hosts, so an enforcing connector fails closed (deny-all) rather than serving unenforced. Connectors served without an envelope receive a nil EgressPolicy and keep their prior behavior.

Also prefer the server-stamped config_version for the lambda generation handle (falling back to last_updated), so a warm generation's version matches the handle the invoker sends back and does not force a spurious reload.