### PR TITLE
fix(sync): thread runCtx into workers and retryer so WithRunDuration bounds them

### DIFF
--- a/pkg/sync/parallel_syncer.go
+++ b/pkg/sync/parallel_syncer.go
@@ -252,9 +252,9 @@ func (s *syncer) parallelSync(
 
 		case SyncResourceTypesOp:
 			err = s.timedStep(SyncResourceTypesOp, func() error {
-				return s.SyncResourceTypes(ctx, stateAction)
+				return s.SyncResourceTypes(runCtx, stateAction)
 			})
-			if !s.timedShouldWaitAndRetry(ctx, SyncResourceTypesOp, stateAction.ResourceTypeID, retryer, err) {
+			if !s.timedShouldWaitAndRetry(runCtx, SyncResourceTypesOp, stateAction.ResourceTypeID, retryer, err) {
 				return warnings, err
 			}
 			continue
@@ -262,16 +262,16 @@ func (s *syncer) parallelSync(
 		case SyncResourcesOp:
 			if stateAction.ResourceTypeID == "" && stateAction.ResourceID == "" {
 				err = s.timedStep(SyncResourcesOp, func() error {
-					return s.SyncResources(ctx, stateAction)
+					return s.SyncResources(runCtx, stateAction)
 				})
-				if !s.timedShouldWaitAndRetry(ctx, SyncResourcesOp, stateAction.ResourceTypeID, retryer, err) {
+				if !s.timedShouldWaitAndRetry(runCtx, SyncResourcesOp, stateAction.ResourceTypeID, retryer, err) {
 					return warnings, err
 				}
 				continue
 			}
 			resourceActions := s.state.PeekMatchingActions(ctx, SyncResourcesOp)
 			err = s.timedStep(SyncResourcesOp, func() error {
-				w, syncErr := s.syncParallel(ctx, retryer, resourceActions, s.SyncResources)
+				w, syncErr := s.syncParallel(runCtx, retryer, resourceActions, s.SyncResources)
 				warnings = append(warnings, w...)
 				return syncErr
 			})
@@ -283,7 +283,7 @@ func (s *syncer) parallelSync(
 		case SyncTargetedResourceOp:
 			targetedResourceActions := s.state.PeekMatchingActions(ctx, SyncTargetedResourceOp)
 			err = s.timedStep(SyncTargetedResourceOp, func() error {
-				w, syncErr := s.syncParallel(ctx, retryer, targetedResourceActions, s.SyncTargetedResource)
+				w, syncErr := s.syncParallel(runCtx, retryer, targetedResourceActions, s.SyncTargetedResource)
 				warnings = append(warnings, w...)
 				return syncErr
 			})
@@ -294,7 +294,7 @@ func (s *syncer) parallelSync(
 
 		case SyncStaticEntitlementsOp:
 			err = s.timedStep(SyncStaticEntitlementsOp, func() error {
-				return s.SyncStaticEntitlements(ctx, stateAction)
+				return s.SyncStaticEntitlements(runCtx, stateAction)
 			})
 			if isWarning(ctx, err) {
 				l.Warn("skipping sync static entitlements action", zap.Any("stateAction", stateAction), zap.Error(err))
@@ -302,14 +302,14 @@ func (s *syncer) parallelSync(
 				s.state.FinishAction(ctx, stateAction)
 				continue
 			}
-			if !s.timedShouldWaitAndRetry(ctx, SyncStaticEntitlementsOp, stateAction.ResourceTypeID, retryer, err) {
+			if !s.timedShouldWaitAndRetry(runCtx, SyncStaticEntitlementsOp, stateAction.ResourceTypeID, retryer, err) {
 				return warnings, err
 			}
 			continue
 		case SyncEntitlementsOp:
 			if stateAction.ResourceTypeID == "" && stateAction.ResourceID == "" {
 				err = s.timedStep(SyncEntitlementsOp, func() error {
-					return s.SyncEntitlements(ctx, stateAction)
+					return s.SyncEntitlements(runCtx, stateAction)
 				})
 				if isWarning(ctx, err) {
 					l.Warn("skipping sync entitlement action", zap.Any("stateAction", stateAction), zap.Error(err))
@@ -317,14 +317,14 @@ func (s *syncer) parallelSync(
 					s.state.FinishAction(ctx, stateAction)
 					continue
 				}
-				if !s.timedShouldWaitAndRetry(ctx, SyncEntitlementsOp, stateAction.ResourceTypeID, retryer, err) {
+				if !s.timedShouldWaitAndRetry(runCtx, SyncEntitlementsOp, stateAction.ResourceTypeID, retryer, err) {
 					return warnings, err
 				}
 				continue
 			}
 			entitlementActions := s.state.PeekMatchingActions(ctx, SyncEntitlementsOp)
 			err = s.timedStep(SyncEntitlementsOp, func() error {
-				w, syncErr := s.syncParallel(ctx, retryer, entitlementActions, s.SyncEntitlements)
+				w, syncErr := s.syncParallel(runCtx, retryer, entitlementActions, s.SyncEntitlements)
 				warnings = append(warnings, w...)
 				return syncErr
 			})
@@ -336,7 +336,7 @@ func (s *syncer) parallelSync(
 		case SyncGrantsOp:
 			if stateAction.ResourceTypeID == "" && stateAction.ResourceID == "" {
 				err = s.timedStep(SyncGrantsOp, func() error {
-					return s.SyncGrants(ctx, stateAction)
+					return s.SyncGrants(runCtx, stateAction)
 				})
 				if isWarning(ctx, err) {
 					l.Warn("skipping sync grant action", zap.Any("stateAction", stateAction), zap.Error(err))
@@ -344,7 +344,7 @@ func (s *syncer) parallelSync(
 					s.state.FinishAction(ctx, stateAction)
 					continue
 				}
-				if !s.timedShouldWaitAndRetry(ctx, SyncGrantsOp, stateAction.ResourceTypeID, retryer, err) {
+				if !s.timedShouldWaitAndRetry(runCtx, SyncGrantsOp, stateAction.ResourceTypeID, retryer, err) {
 					return warnings, err
 				}
 				continue
@@ -352,7 +352,7 @@ func (s *syncer) parallelSync(
 
 			grantActions := s.state.PeekMatchingActions(ctx, SyncGrantsOp)
 			err = s.timedStep(SyncGrantsOp, func() error {
-				w, syncErr := s.syncParallel(ctx, retryer, grantActions, s.SyncGrants)
+				w, syncErr := s.syncParallel(runCtx, retryer, grantActions, s.SyncGrants)
 				warnings = append(warnings, w...)
 				return syncErr
 			})
@@ -363,17 +363,17 @@ func (s *syncer) parallelSync(
 
 		case SyncExternalResourcesOp:
 			err = s.timedStep(SyncExternalResourcesOp, func() error {
-				return s.SyncExternalResources(ctx, stateAction)
+				return s.SyncExternalResources(runCtx, stateAction)
 			})
-			if !s.timedShouldWaitAndRetry(ctx, SyncExternalResourcesOp, stateAction.ResourceTypeID, retryer, err) {
+			if !s.timedShouldWaitAndRetry(runCtx, SyncExternalResourcesOp, stateAction.ResourceTypeID, retryer, err) {
 				return warnings, err
 			}
 			continue
 		case SyncAssetsOp:
 			err = s.timedStep(SyncAssetsOp, func() error {
-				return s.SyncAssets(ctx, stateAction)
+				return s.SyncAssets(runCtx, stateAction)
 			})
-			if !s.timedShouldWaitAndRetry(ctx, SyncAssetsOp, stateAction.ResourceTypeID, retryer, err) {
+			if !s.timedShouldWaitAndRetry(runCtx, SyncAssetsOp, stateAction.ResourceTypeID, retryer, err) {
 				return warnings, err
 			}
 			continue
@@ -400,8 +400,8 @@ func (s *syncer) parallelSync(
 				continue
 			}
 
-			err = s.SyncGrantExpansion(ctx, stateAction)
-			if !retryer.ShouldWaitAndRetry(ratelimit.WithWaitLabel(ctx, stateAction.ResourceTypeID), err) {
+			err = s.SyncGrantExpansion(runCtx, stateAction)
+			if !retryer.ShouldWaitAndRetry(ratelimit.WithWaitLabel(runCtx, stateAction.ResourceTypeID), err) {
 				return warnings, err
 			}
 			continue


### PR DESCRIPTION
## Summary
- Route `runCtx` (the SDK's own `WithRunDuration` timer) through every connector-handler invocation, `syncParallel` call, and retryer-wait site inside `parallelSync`'s op dispatch switch. On `main`, only the outer loop's top-of-loop select watches `runCtx` — every downstream call uses the parent `ctx`, so the soft budget never actually reaches the code paths that need to observe it.
- Keep the parent `ctx` for checkpoint writes, in-memory state reads/mutations, logger extraction, and the one-shot `MarkSyncSupportsDiff` store write — those need to survive `runCtx` expiration.

## Motivation

`Syncer.Sync` at `syncer.go:790-797` layers a soft deadline on top of the caller-provided ctx:

```go
runCtx := ctx
if s.runDuration > 0 {
    runCtx, runCanc = context.WithTimeout(ctx, s.runDuration)
}
```

Intent: give the SDK a chance to wrap up cleanly (force-checkpoint, return `ErrSyncNotComplete`) using the still-live parent `ctx` after the soft budget expires but before the caller's hard deadline lands.

But on `main`, only one place actually observes `runCtx` — the top-of-loop select at `parallel_syncer.go:167`. Every op-handler call, every `syncParallel` invocation, every retryer sleep is passed `ctx`. So if the current batch takes longer than the `WithRunDuration` budget — very common with `workers=1` and users that need multiple retries — the SDK's soft timer fires but no code inside the batch feels it. Workers keep grinding until the caller's ctx (e.g. Temporal's `StartToCloseTimeout`) fires much later, and by that point the cancellation lands mid-batch and takes one of the raw-return sites, bypassing the outer loop's force-checkpoint path.

Threading `runCtx` into the worker paths makes the soft timer enforce itself. When `WithRunDuration` fires:

1. In-flight connector gRPC calls die with `codes.DeadlineExceeded`
2. `syncOneAction`'s retryer sleep wakes up (now watching `runCtx`) → `ShouldWaitAndRetry` returns false
3. Workers return, `syncParallel` returns `batchErr` carrying `codes.DeadlineExceeded`
4. Error propagates to callers who can recognize it via `errors.Is(err, context.DeadlineExceeded)` or `status.Code(err) == codes.DeadlineExceeded` — the standard "resumable timeout" pattern

The parent `ctx` remains alive during this window, so the outer loop's throttled and forced `Checkpoint(ctx, ...)` calls still succeed as before.

## Scope

| Site | Old | New |
|---|---|---|
| `SyncResourceTypes`, `SyncResources`, `SyncStaticEntitlements`, `SyncEntitlements`, `SyncGrants`, `SyncExternalResources`, `SyncAssets`, `SyncGrantExpansion` handler calls | `ctx` | `runCtx` |
| `syncParallel` invocations (4 sites: SyncResourcesOp, SyncTargetedResourceOp, SyncEntitlementsOp, SyncGrantsOp) | `ctx` | `runCtx` |
| `timedShouldWaitAndRetry` calls (7 sites) | `ctx` | `runCtx` |
| `retryer.ShouldWaitAndRetry(ratelimit.WithWaitLabel(...))` in the grant-expansion branch | `ctx` | `runCtx` |

## Kept as `ctx` (intentional)

- `s.Checkpoint(ctx, false)` at line 154 and force-checkpoint at line 177 — writes must outlive `runCtx`
- `s.state.PeekMatchingActions`, `s.state.FinishAction`, `s.state.EntitlementGraph` — in-memory, no ctx-cancel risk
- `isWarning(ctx, err)` — logger extraction only
- `s.store.SyncMeta().MarkSyncSupportsDiff(ctx, s.syncID)` — one-shot setup write

## What this does NOT change
- Top-of-loop select at line 167 still only recognizes `DeadlineExceeded`. Other cancellation causes (worker drain, workflow explicit cancel, heartbeat timeout) still fall through to the `default:` raw-return branch. That's a separate fix.
- No changes to `pkg/connectorrunner/runner.go` (SIGTERM handling), `pkg/retry`, or `pkg/sync/state.go`.
- The `parallel_syncer.go:132` function signature is unchanged — the `runCtx` parameter was already there, it just wasn't being used.

## Test plan
- [x] `go build ./pkg/sync/...`
- [x] `go test ./pkg/sync/ -count=1 -timeout 180s` — passes (~28s)
- [x] `go test ./pkg/sync/expand -count=1 -timeout 180s` — passes (~30s; requires extended timeout on some machines)