### PR TITLE
Fix generic XML arrays for HTTP connectors

### DIFF
--- a/pkg/uhttp/wrapper.go
+++ b/pkg/uhttp/wrapper.go
@@ -230,6 +230,25 @@ func WithAlwaysXMLResponse(response any) DoOption {
 	}
 }
 
+// WithAlwaysGenericXMLResponse ignores the response content type and unmarshals XML into a generic map.
+func WithAlwaysGenericXMLResponse(response *map[string]any) DoOption {
+	return func(resp *WrapperResponse) error {
+		if response == nil {
+			return status.Error(codes.InvalidArgument, "response is nil")
+		}
+
+		if resp.StatusCode == http.StatusNoContent {
+			return nil
+		}
+
+		if resp.StatusCode >= 200 && resp.StatusCode < 300 && len(resp.Body) == 0 {
+			return nil
+		}
+
+		return withGenericXMLResponse(response, resp)
+	}
+}
+
 type ErrorResponse interface {
 	Message() string
 }
@@ -374,21 +393,24 @@ func WithGenericResponse(response *map[string]any) DoOption {
 		}
 
 		if IsXMLContentType(resp.Header.Get(ContentType)) {
-			var xm xmlMap
-			err = WithXMLResponse(&xm)(resp)
-			if err != nil {
-				return err
-			}
-			if vMap, ok := xm.data.(map[string]any); ok {
-				*response = vMap
-			} else {
-				return status.Errorf(codes.Internal, "unsupported XML structure: %T", xm.data)
-			}
-			return nil
+			return withGenericXMLResponse(response, resp)
 		}
 
 		return status.Error(codes.Unknown, fmt.Sprintf("unsupported content type: %s", resp.Header.Get(ContentType)))
 	}
+}
+
+func withGenericXMLResponse(response *map[string]any, resp *WrapperResponse) error {
+	var xm xmlMap
+	err := WithAlwaysXMLResponse(&xm)(resp)
+	if err != nil {
+		return err
+	}
+	if vMap, ok := xm.data.(map[string]any); ok {
+		*response = vMap
+		return nil
+	}
+	return status.Errorf(codes.Internal, "unsupported XML structure: %T", xm.data)
 }
 
 func WrapErrors(preferredCode codes.Code, statusMsg string, errs ...error) error {

--- a/pkg/uhttp/wrapper_test.go
+++ b/pkg/uhttp/wrapper_test.go
@@ -407,19 +407,39 @@ func TestWrapper_WithGenericResponse(t *testing.T) {
 		err := WithGenericResponse(&respBody)(&resp)
 		require.NoError(t, err)
 		require.Equal(t, map[string]any{
-			"items": []map[string]any{
-				{
+			"items": []any{
+				map[string]any{
 					"item": map[string]any{
 						"name": "John",
 						"age":  "30",
 					},
 				},
-				{
+				map[string]any{
 					"item": map[string]any{
 						"name": "Jane",
 						"age":  "25",
 					},
 				},
+			},
+		}, respBody)
+	})
+
+	t.Run("should marshal XML despite an incorrect content type", func(t *testing.T) {
+		exampleResponse := `<?xml version="1.0" encoding="UTF-8"?><SERVICE_RESPONSE><USER_LIST><USER><LOGIN>john@example.com</LOGIN></USER><USER><LOGIN>jane@example.com</LOGIN></USER></USER_LIST></SERVICE_RESPONSE>`
+		resp := WrapperResponse{
+			Header:     http.Header{"Content-Type": []string{"text/plain"}},
+			Body:       []byte(exampleResponse),
+			StatusCode: http.StatusOK,
+		}
+		var respBody map[string]any
+
+		err := WithAlwaysGenericXMLResponse(&respBody)(&resp)
+
+		require.NoError(t, err)
+		require.Equal(t, map[string]any{
+			"USER_LIST": []any{
+				map[string]any{"USER": map[string]any{"LOGIN": "john@example.com"}},
+				map[string]any{"USER": map[string]any{"LOGIN": "jane@example.com"}},
 			},
 		}, respBody)
 	})

--- a/pkg/uhttp/xml.go
+++ b/pkg/uhttp/xml.go
@@ -23,7 +23,7 @@ func (x *xmlMap) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 
 // unmarshalXMLElement reads tokens from the decoder for the current element
 // (after its start element has been consumed) until the matching end element.
-// It returns a map[string]any if there are child elements, a []map[string]any
+// It returns a map[string]any if there are child elements, a []any
 // if there are duplicate child element names, or a string if the element
 // contains only text.
 func unmarshalXMLElement(d *xml.Decoder) (any, error) {
@@ -67,7 +67,7 @@ func unmarshalXMLElement(d *xml.Decoder) (any, error) {
 				return text, nil
 			}
 			if hasDuplicates {
-				result := make([]map[string]any, 0, len(entries))
+				result := make([]any, 0, len(entries))
 				for _, e := range entries {
 					result = append(result, map[string]any{e.key: e.value})
 				}

--- a/pkg/uhttp/xml_test.go
+++ b/pkg/uhttp/xml_test.go
@@ -27,12 +27,12 @@ func TestXMLMap_UnmarshalXML(t *testing.T) {
 		err := xml.Unmarshal([]byte(xmlResponse), xmlMap)
 		require.NoError(t, err)
 		require.Equal(t, map[string]any{
-			"items": []map[string]any{
-				{"item": map[string]any{
+			"items": []any{
+				map[string]any{"item": map[string]any{
 					"name": "John",
 					"age":  "30",
 				}},
-				{"item": map[string]any{
+				map[string]any{"item": map[string]any{
 					"name": "Jane",
 					"age":  "25",
 				}},


### PR DESCRIPTION
Some XML APIs return repeated elements as a Go slice that JSONPath cannot read. They also sometimes send XML without an XML content type.

### `pkg/uhttp/wrapper.go`

Where: lines 233-250 and 395-413.

Adds `WithAlwaysGenericXMLResponse` and shares the generic XML map decoder with content-type based parsing. A connector can explicitly request XML parsing without needing a Go struct, even when the server labels its response incorrectly.

### `pkg/uhttp/xml.go`

Where: lines 24-74.

Returns repeated XML elements as `[]any` instead of a concrete map slice. JSONPath recognizes `[]any` as an array, so generic XML collections can be selected the same way as JSON collections.

### Tests

Covers repeated XML elements and a response labeled as plain text. The existing typed XML decoder remains covered separately.

Tests:

- `go test ./pkg/uhttp/...`
- `make lint`