### PR TITLE
[CXP-498] Make external principal fold key EqualFold-exact

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,10 @@ fuzz-smoke: ## Run each native Go fuzzer for FUZZ_TIME (default 30s).
 	go test -run '^$$' -fuzz '^FuzzCondenseFWBW_Cancellation$$' -fuzztime=$(FUZZ_TIME) ./pkg/sync/expand/scc
 	go test -run '^$$' -fuzz '^FuzzCondenseFWBW_FromBytes$$' -fuzztime=$(FUZZ_TIME) ./pkg/sync/expand/scc
 
+.PHONY: verification-check
+verification-check: ## Run reference-model parity instruments behind the verification tag.
+	go test -tags=verification -count=1 -timeout=30m -run '^TestVerification' ./...
+
 .PHONY: differential-check
 differential-check: ## Differential-fuzz SQLite and Pebble for DIFFERENTIAL_TIME.
 	BATON_EXPAND_FUZZ_DURATION=$(DIFFERENTIAL_TIME) go test -v -count=1 -timeout=30m -run '^TestFullPipelineDifferentialFuzz$$' ./pkg/sync/expand
@@ -125,7 +129,7 @@ chaos-soak: ## Run extended seeded chaos connector fanout schedules.
 
 # race-check already includes chaos-full-check's complete deterministic corpus.
 .PHONY: test-extra
-test-extra: race-check compat-check interrupt-check fuzz-smoke differential-check bench-smoke ## Run bounded confidence checks omitted from CI.
+test-extra: race-check compat-check interrupt-check verification-check fuzz-smoke differential-check bench-smoke ## Run bounded confidence checks omitted from CI.
 
 .PHONY: test-nightly
 test-nightly: ## Run extended confidence, fuzz, scheduler, and errorfs checks.

--- a/pkg/sync/external_principal_index.go
+++ b/pkg/sync/external_principal_index.go
@@ -2,6 +2,8 @@ package sync //nolint:revive,nolintlint // matches the existing package name
 
 import (
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -157,20 +159,54 @@ func (idx *externalPrincipalIndex) matchUserTraitEmail(address string) []int {
 
 // foldKey normalizes a value for case-insensitive comparison, and is the single
 // definition of "these two external match values are the same": two values match
-// when their foldKey outputs are equal. Bucket keys, bucket lookups, and every
-// confirmation pass all run through it, so the prefilter and the comparison can
-// never disagree.
+// when their foldKey outputs are equal. Bucket keys and bucket lookups both run
+// through it, so bucketing decides matching outright — there is no confirmation
+// pass behind it to catch a disagreement.
 //
-// strings.ToLower is a context-free lowercase mapping, not full Unicode case
-// folding, so the two differ on a small number of pairs — Greek sigma is the
-// usual example, where strings.EqualFold("ΣΤΕΦΑΝΟΣ", "στεφανος") is true but the
-// lowercase forms differ in the final letter. Values like that are treated as
-// distinct here. That is an accepted tradeoff for now: it keeps normalization
-// consistent everywhere rather than having bucketing and confirmation disagree,
-// which would silently drop matches. Nothing is restricted to ASCII — non-ASCII
-// values are lowercased and compared like any other.
+// That makes exactness against strings.EqualFold a requirement, not a nicety.
+// The linear scan this index replaces compared with EqualFold, so foldKey must
+// place two values in the same bucket exactly when EqualFold reports them equal.
+// strings.ToLower does not: it is a context-free lowercase mapping rather than
+// case folding, and it disagrees in both directions.
+//
+//   - EqualFold("Σ", "ς") is true, but the lowercase forms differ ("σ" vs "ς"),
+//     so ToLower bucketing would silently drop a grant the scan emitted.
+//   - EqualFold("İ", "i") is false, but ToLower("İ") is "i", so ToLower
+//     bucketing would manufacture a grant the scan never emitted.
+//
+// EqualFold reports two strings equal exactly when they have the same rune count
+// and each rune pair shares a unicode.SimpleFold orbit. Canonicalizing every rune
+// to the minimum of its own orbit therefore reproduces EqualFold's equivalence
+// classes exactly. Nothing is restricted to ASCII; the fast path below is a
+// shortcut for it, not a limitation.
 func foldKey(s string) string {
-	return strings.ToLower(s)
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		b.WriteRune(foldRune(r))
+	}
+	return b.String()
+}
+
+// foldRune returns the smallest rune in r's unicode.SimpleFold orbit, which is
+// the canonical representative of every rune EqualFold treats as equal to r.
+func foldRune(r rune) rune {
+	if r < utf8.RuneSelf {
+		// ASCII agrees with the orbit walk below, which canonicalizes an
+		// ASCII letter to its uppercase form ('a' and 'A' orbit together, and
+		// 'A' is the smaller). Special-cased only to skip the walk.
+		if 'a' <= r && r <= 'z' {
+			return r - ('a' - 'A')
+		}
+		return r
+	}
+	smallest := r
+	for folded := unicode.SimpleFold(r); folded != r; folded = unicode.SimpleFold(folded) {
+		if folded < smallest {
+			smallest = folded
+		}
+	}
+	return smallest
 }
 
 // mergePositions returns the ascending, deduplicated union of two ascending

--- a/pkg/sync/external_principal_index_test.go
+++ b/pkg/sync/external_principal_index_test.go
@@ -1,6 +1,7 @@
 package sync //nolint:revive,nolintlint // matches the existing package name
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -176,34 +177,80 @@ func TestExternalPrincipalIndexSkipsUnreadableUserTrait(t *testing.T) {
 	require.Equal(t, []string{"readable"}, resolvedIDs(idx, idx.matchProfile("upn", "shared@example.com")))
 }
 
-// Bucketing and the confirmation pass both normalize through foldKey, so they
-// can never disagree about whether two values match. Nothing is restricted to
-// ASCII: non-ASCII values are lowercased and compared like any other. A
-// mismatch here would mean a real grant is silently dropped -- the candidate
-// would be filtered out by bucketing before confirmation ever runs.
+// Bucketing decides matching outright -- there is no confirmation pass behind
+// it -- so foldKey has to agree with the strings.EqualFold comparison the linear
+// scan used, in both directions. A false negative silently drops a real grant;
+// a false positive silently grants a principal the scan never matched.
+//
+// Every case states its expectation and then pins it to EqualFold, so a case
+// added later cannot quietly encode a divergence.
 func TestExternalPrincipalIndexNonASCIIMatching(t *testing.T) {
 	for _, tc := range []struct {
 		name          string
 		stored, query string
+		matches       bool
 	}{
-		{name: "ascii", stored: "UPPER@example.com", query: "upper@example.com"},
-		{name: "latin with diaeresis", stored: "Ann-Sofie.Ö", query: "ann-sofie.ö"},
-		{name: "cyrillic", stored: "ПЕТРОВ", query: "петров"},
-		{name: "greek accented", stored: "ΜΆΙΟΣ", query: "μάιοσ"},
-		{name: "cjk is caseless", stored: "山田太郎", query: "山田太郎"},
-		// strings.ToLower("İ") is "i", but strings.EqualFold("İ", "I") is
-		// false. Any comparison downstream of the index -- notably
-		// matchProfileAndExpand -- must fold the same way, or it will reject a
-		// principal the index matched and silently drop the grant.
-		{name: "turkish dotted capital i", stored: "İSTANBUL", query: "istanbul"},
+		{name: "ascii", stored: "UPPER@example.com", query: "upper@example.com", matches: true},
+		{name: "latin with diaeresis", stored: "Ann-Sofie.Ö", query: "ann-sofie.ö", matches: true},
+		{name: "cyrillic", stored: "ПЕТРОВ", query: "петров", matches: true},
+		{name: "greek accented", stored: "ΜΆΙΟΣ", query: "μάιοσ", matches: true},
+		{name: "cjk is caseless", stored: "山田太郎", query: "山田太郎", matches: true},
+		// Final sigma folds together with medial sigma, so this matches even
+		// though the two lowercase forms differ ("σ" vs "ς"). Bucketing on
+		// strings.ToLower would drop it.
+		{name: "greek final sigma", stored: "ΣΤΕΦΑΝΟΣ", query: "στεφανος", matches: true},
+		{name: "greek final sigma single rune", stored: "Σ", query: "ς", matches: true},
+		// The dotted capital I does not fold to "i", so this must not match
+		// even though strings.ToLower("İ") is "i". Bucketing on ToLower would
+		// manufacture a grant here.
+		{name: "turkish dotted capital i", stored: "İSTANBUL", query: "istanbul", matches: false},
+		// Case folding is per-rune, so it never expands "ß" to "ss".
+		{name: "sharp s does not expand", stored: "ß", query: "ss", matches: false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.matches, strings.EqualFold(tc.stored, tc.query),
+				"premise: the index must agree with the EqualFold comparison it replaced")
+
 			idx := newExternalUserPrincipalIndex([]*v2.Resource{
 				testUserPrincipal(t, "user_a", map[string]any{"userPrincipalName": tc.stored}),
 			}, zap.NewNop())
 
-			require.Equal(t, []string{"user_a"}, resolvedIDs(idx, idx.matchProfile("userPrincipalName", tc.query)),
-				"stored %q should match query %q", tc.stored, tc.query)
+			expected := []string{}
+			if tc.matches {
+				expected = []string{"user_a"}
+			}
+			require.Equal(t, expected, resolvedIDs(idx, idx.matchProfile("userPrincipalName", tc.query)),
+				"stored %q vs query %q", tc.stored, tc.query)
+		})
+	}
+}
+
+// foldKey is the whole matching decision, so it must reproduce EqualFold's
+// equivalence classes exactly rather than approximate them.
+func TestFoldKeyAgreesWithEqualFold(t *testing.T) {
+	for _, tc := range []struct{ a, b string }{
+		{a: "", b: ""},
+		{a: "UPPER@example.com", b: "upper@example.com"},
+		{a: "Ann-Sofie.Ö", b: "ann-sofie.ö"},
+		{a: "ПЕТРОВ", b: "петров"},
+		{a: "ΜΆΙΟΣ", b: "μάιοσ"},
+		{a: "ΣΤΕΦΑΝΟΣ", b: "στεφανος"},
+		{a: "Σ", b: "ς"},
+		{a: "σ", b: "ς"},
+		{a: "İSTANBUL", b: "istanbul"},
+		{a: "İ", b: "i"},
+		{a: "ı", b: "i"},
+		{a: "K", b: "k"}, // KELVIN SIGN
+		{a: "ẞ", b: "ß"},
+		{a: "ß", b: "ss"},
+		{a: "ſ", b: "s"}, // LATIN SMALL LETTER LONG S
+		{a: "山田太郎", b: "山田太郎"},
+		{a: "abc", b: "abd"},
+		{a: "abc", b: "abcd"},
+	} {
+		t.Run(tc.a+"/"+tc.b, func(t *testing.T) {
+			require.Equal(t, strings.EqualFold(tc.a, tc.b), foldKey(tc.a) == foldKey(tc.b),
+				"foldKey(%q)=%q foldKey(%q)=%q", tc.a, foldKey(tc.a), tc.b, foldKey(tc.b))
 		})
 	}
 }

--- a/pkg/sync/external_principal_index_verification_test.go
+++ b/pkg/sync/external_principal_index_verification_test.go
@@ -28,6 +28,19 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/types/resource"
 )
 
+// referenceContainsEmail restates the syncer's deleted userTraitContainsEmail
+// helper. The reference model must not share code with the implementation it
+// checks, so this stays a local copy even though it is a few lines of
+// duplication.
+func referenceContainsEmail(emails []*v2.UserTrait_Email, address string) bool {
+	for _, email := range emails {
+		if strings.EqualFold(email.GetAddress(), address) {
+			return true
+		}
+	}
+	return false
+}
+
 // linearUserMatchPositions is a test-only reference model copied from the
 // phase-6a implementation. It deliberately does not share bucketing or merge
 // logic with externalPrincipalIndex.
@@ -38,7 +51,7 @@ func linearUserMatchPositions(principals []*v2.Resource, key, value string) []in
 		if err != nil {
 			continue
 		}
-		if key == "email" && userTraitContainsEmail(userTrait.GetEmails(), value) {
+		if key == "email" && referenceContainsEmail(userTrait.GetEmails(), value) {
 			matches = append(matches, i)
 			continue
 		}
@@ -94,10 +107,21 @@ func TestVerificationExternalPrincipalIndexMatchesPhase6AReference(t *testing.T)
 	}
 }
 
-func TestVerificationExternalPrincipalIndexRandomizedASCIIParity(t *testing.T) {
-	rng := rand.New(rand.NewSource(0xC1))
+func TestVerificationExternalPrincipalIndexRandomizedParity(t *testing.T) {
+	// A fixed seed is the point: a parity failure has to be replayable.
+	rng := rand.New(rand.NewSource(0xC1)) //nolint:gosec // deterministic fixture generator, not security-sensitive
 	keys := []string{"email", "upn", "login", "external_id"}
-	values := []string{"alpha@example.com", "BRAVO@example.com", "charlie", "DELTA", ""}
+	// The value set deliberately reaches past ASCII. ToLower and EqualFold
+	// agree on every ASCII pair, so an ASCII-only generator cannot observe the
+	// normalization divergences that motivated foldKey: Greek final sigma
+	// (EqualFold matches, ToLower does not) and the Turkish dotted capital I
+	// (ToLower matches, EqualFold does not).
+	values := []string{
+		"alpha@example.com", "BRAVO@example.com", "charlie", "DELTA", "",
+		"στεφανος", "ΣΤΕΦΑΝΟΣ", "Σ", "ς",
+		"İstanbul", "istanbul", "ı",
+		"ПЕТРОВ", "Ann-Sofie.Ö", "ß", "ẞ", "ſharp",
+	}
 
 	for topology := 0; topology < 200; topology++ {
 		principalCount := 1 + rng.Intn(20)
@@ -136,7 +160,7 @@ func TestVerificationExternalPrincipalIndexRandomizedASCIIParity(t *testing.T) {
 
 		for _, key := range keys {
 			for _, value := range values {
-				for _, query := range []string{value, strings.ToUpper(value)} {
+				for _, query := range []string{value, strings.ToUpper(value), strings.ToLower(value)} {
 					require.Equal(t,
 						linearUserMatchPositions(principals, key, query),
 						indexedUserMatchPositions(principals, key, query),
@@ -148,21 +172,32 @@ func TestVerificationExternalPrincipalIndexRandomizedASCIIParity(t *testing.T) {
 	}
 }
 
+// The two normalization divergences that ToLower bucketing produced, pinned
+// individually so a regression names itself instead of surfacing as one
+// randomized topology failure.
 func TestVerificationExternalPrincipalIndexUnicodeEqualFoldParity(t *testing.T) {
-	// EqualFold treats Greek sigma and final sigma as equal, while ToLower
-	// produces different bucket keys ("σ" and "ς"). The phase-6a scan therefore
-	// matches this pair and the index prefilter currently does not.
-	const stored = "Σ"
-	const query = "ς"
-	require.True(t, strings.EqualFold(stored, query), "test premise")
-
-	principals := []*v2.Resource{
-		testUserPrincipal(t, "unicode", map[string]any{"upn": stored}),
+	for _, tc := range []struct {
+		name          string
+		stored, query string
+	}{
+		// EqualFold treats medial and final sigma as equal, while ToLower
+		// produces different bucket keys ("σ" and "ς"). Bucketing on ToLower
+		// dropped a match the scan made.
+		{name: "greek final sigma", stored: "Σ", query: "ς"},
+		// ToLower("İ") is "i", but the two do not case-fold together.
+		// Bucketing on ToLower invented a match the scan never made.
+		{name: "turkish dotted capital i", stored: "İ", query: "i"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			principals := []*v2.Resource{
+				testUserPrincipal(t, "unicode", map[string]any{"upn": tc.stored}),
+			}
+			require.Equal(t,
+				linearUserMatchPositions(principals, "upn", tc.query),
+				indexedUserMatchPositions(principals, "upn", tc.query),
+			)
+		})
 	}
-	require.Equal(t,
-		linearUserMatchPositions(principals, "upn", query),
-		indexedUserMatchPositions(principals, "upn", query),
-	)
 }
 
 func TestVerificationExternalPrincipalIndexDeduplicatesRepeatedTraitEmail(t *testing.T) {
@@ -207,21 +242,6 @@ func (s *interruptingExternalMatchStore) DeleteGrantByRefs(ctx context.Context, 
 		return fmt.Errorf("verification premise: wrapped store lacks DeleteGrantByRefs")
 	}
 	return deleter.DeleteGrantByRefs(ctx, grant)
-}
-
-func externalMatchGrantIDs(ctx context.Context, store c1zstore.Store) ([]string, error) {
-	var ids []string
-	for ga, err := range store.Grants().ListWithAnnotations(ctx) {
-		if err != nil {
-			return nil, err
-		}
-		annos := annotations.Annotations(ga.Grant.GetAnnotations())
-		if annos.ContainsAny(&v2.ExternalResourceMatchAll{}, &v2.ExternalResourceMatch{}, &v2.ExternalResourceMatchID{}) {
-			ids = append(ids, ga.Grant.GetId())
-		}
-	}
-	slices.Sort(ids)
-	return ids, nil
 }
 
 func verificationPrincipals(t *testing.T) []*v2.Resource {


### PR DESCRIPTION
Stacked on #1046 — base is `jallers/cxp-498-external-principal-index`, so the diff here is just this change.

## Problem

`matchProfile` has no confirmation pass: bucket membership *is* the match decision. So `foldKey` has to reproduce the `strings.EqualFold` comparison the linear scan used, exactly. `strings.ToLower` is a context-free lowercase mapping rather than case folding, and it disagrees in both directions:

| pair | `EqualFold` (the scan) | `ToLower` (the index) |
|---|---|---|
| `Σ` / `ς` | true | **false** — grant silently dropped |
| `ΣΤΕΦΑΝΟΣ` / `στεφανος` | true | **false** — grant silently dropped |
| `ſ` / `s` | true | **false** — grant silently dropped |
| `İSTANBUL` / `istanbul` | **false** | true — grant manufactured |
| `İ` / `i` | **false** | true — grant manufactured |
| `ΜΆΙΟΣ`/`μάιοσ`, `K`(U+212A)/`k`, `ẞ`/`ß`, `ß`/`ss`, `Ö`, Cyrillic, CJK | agree | agree |

The dotted-capital-I direction matters most: the index granted a principal the scan would have rejected, which contradicts #1046's "bucketing is a prefilter only, so it can never manufacture a match the old scan wouldn't have made."

A confirmation pass can't rescue the false-negative cases — the candidate is filtered out before confirmation would run. The fold key itself has to be exact.

## Fix

`strings.EqualFold` reports two strings equal exactly when they have the same rune count and each rune pair shares a `unicode.SimpleFold` orbit. `foldKey` now canonicalizes every rune to the minimum of its own orbit, with an ASCII fast path. That reproduces EqualFold's equivalence classes exactly, which is what makes the absent confirmation pass sound rather than a silent narrowing.

## Tests

- `TestExternalPrincipalIndexNonASCIIMatching` now carries an expectation per case and pins it to `strings.EqualFold`, so a case added later can't quietly encode a divergence. Its `turkish dotted capital i` case asserted a match; it now asserts none.
- `TestFoldKeyAgreesWithEqualFold` covers the equivalence directly, including `ı`, `ẞ`/`ß`, `ß`/`ss`, the Kelvin sign, long s, and differing-length pairs.
- **Repairs `external_principal_index_verification_test.go`.** It has not compiled since this branch deleted `userTraitContainsEmail` (`go vet -tags verification ./pkg/sync/` failed on it). Its reference model now keeps a local copy of that helper rather than sharing code with the implementation it checks.
- The randomized parity generator reaches past ASCII. `ToLower` and `EqualFold` agree on every ASCII pair, so `…RandomizedASCIIParity` structurally could not observe any of these divergences; renamed to `…RandomizedParity`.
- The Unicode parity case became a table covering both directions.
- Adds a `verification-check` make target and wires it into `test-extra`. No target passed `-tags=verification`, which is how the file rotted unnoticed. Also clears the two lint findings that tag surfaces (a pre-existing `gosec` on the fixed test seed, and a dead `externalMatchGrantIDs` helper).

Confirmed all four instruments fail against the previous `ToLower` `foldKey`, then pass with the fix:

```
--- FAIL: TestVerificationExternalPrincipalIndexRandomizedParity
--- FAIL: TestVerificationExternalPrincipalIndexUnicodeEqualFoldParity/greek_final_sigma
--- FAIL: TestVerificationExternalPrincipalIndexUnicodeEqualFoldParity/turkish_dotted_capital_i
--- FAIL: TestExternalPrincipalIndexNonASCIIMatching/{greek_final_sigma,greek_final_sigma_single_rune,turkish_dotted_capital_i}
--- FAIL: TestFoldKeyAgreesWithEqualFold/{ΣΤΕΦΑΝΟΣ/στεφανος,Σ/ς,σ/ς,İSTANBUL/istanbul,İ/i,ſ/s}
```

`go test ./pkg/sync/` passes, `make verification-check` passes, `make lint` and `golangci-lint run --build-tags=verification ./pkg/sync/...` both report 0 issues.

## Note on cost

Orbit-walking is more work per rune than `ToLower`, but only off the ASCII fast path, and `foldKey` runs once per indexed value plus once per lookup — not per candidate. It does not reintroduce anything proportional to grants × principals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)