### PR TITLE
[CXP-498] Pin external-resource match folding as a behavioral contract

### DIFF
--- a/internal/chaosconnector/external_principal_corpus.go
+++ b/internal/chaosconnector/external_principal_corpus.go
@@ -1,6 +1,8 @@
 package chaosconnector
 
 import (
+	"fmt"
+
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/bid"
@@ -15,6 +17,11 @@ const (
 	ExternalGroupTypeID   = "external-group"
 	InternalGroupTypeID   = "internal-group"
 	ExternalPlaceholderID = "external-placeholder"
+
+	// ExternalFoldUserID is the principal the case-folding cells add to the
+	// external world. It is deliberately separate from the standard principals
+	// so a fold expectation cannot be satisfied by one of them.
+	ExternalFoldUserID = "external-fold-user"
 )
 
 type ExternalMatchKind string
@@ -36,6 +43,11 @@ type ExternalPrincipalCase struct {
 	Value                string
 	ExpectedPrincipalIDs []string
 	Expandable           bool
+
+	// ExternalWorld optionally adds to or edits the external dataset for this
+	// case, for cases whose question cannot be asked of the standard world.
+	// Nil leaves that world untouched, which is the common case.
+	ExternalWorld func(*Dataset) error
 }
 
 func ExternalPrincipalCorpus() []ExternalPrincipalCase {
@@ -101,6 +113,54 @@ func ExternalPrincipalCorpus() []ExternalPrincipalCase {
 			Key:   "department",
 			Value: "finance",
 		},
+
+		// External matching compares with strings.EqualFold, which is Unicode
+		// simple case folding rather than lowercasing both sides. The two
+		// relations disagree in both directions, and each direction is a
+		// distinct access-correctness failure. The exhaustive pair table lives
+		// at the comparison seam in
+		// pkg/sync/external_match_folding_test.go; these cells carry
+		// representatives of both directions the rest of the way, so the value
+		// also has to survive a sealed external c1z and cross both transports
+		// before it is matched. Profile values travel as structpb.Struct and
+		// trait emails as v2.UserTrait_Email, so each encoding gets a witness.
+		{
+			// Medial and final sigma fold together while their lowercase forms
+			// differ, so folding by lowercasing would drop this grant.
+			Name:                 "external-principal/fold-profile-final-sigma",
+			Match:                ExternalMatchAttribute,
+			Trait:                v2.ResourceType_TRAIT_USER,
+			Key:                  "upn",
+			Value:                "στεφανος",
+			ExpectedPrincipalIDs: []string{ExternalFoldUserID},
+			ExternalWorld: withExternalUser(ExternalFoldUserID,
+				map[string]any{"upn": "ΣΤΕΦΑΝΟΣ"}),
+		},
+		{
+			// The dotted capital I lowercases to "i" but does not fold with it,
+			// so folding by lowercasing would manufacture a grant here. This is
+			// also the case a store-side NFKC-style normalization would break,
+			// by decomposing the stored value.
+			Name:  "external-principal/fold-profile-dotted-capital-i-miss",
+			Match: ExternalMatchAttribute,
+			Trait: v2.ResourceType_TRAIT_USER,
+			Key:   "upn",
+			Value: "istanbul",
+			ExternalWorld: withExternalUser(ExternalFoldUserID,
+				map[string]any{"upn": "İSTANBUL"}),
+		},
+		{
+			// Same fold as the first cell, reached through the user-trait email
+			// route rather than a profile field.
+			Name:                 "external-principal/fold-email-final-sigma",
+			Match:                ExternalMatchAttribute,
+			Trait:                v2.ResourceType_TRAIT_USER,
+			Key:                  "email",
+			Value:                "στεφανος@example.com",
+			ExpectedPrincipalIDs: []string{ExternalFoldUserID},
+			ExternalWorld: withExternalUser(ExternalFoldUserID, nil,
+				rs.WithEmail("ΣΤΕΦΑΝΟΣ@example.com", true)),
+		},
 	}
 }
 
@@ -109,11 +169,58 @@ func (c ExternalPrincipalCase) Build() (*Scenario, *Scenario, error) {
 	if err != nil {
 		return nil, nil, err
 	}
+	if c.ExternalWorld != nil {
+		// externalPrincipalSourceScenario builds a fresh world on every call,
+		// so a case can edit its own copy without reaching another case.
+		dataset, datasetErr := initialDataset(external)
+		if datasetErr != nil {
+			return nil, nil, datasetErr
+		}
+		if worldErr := c.ExternalWorld(dataset); worldErr != nil {
+			return nil, nil, worldErr
+		}
+	}
 	internal, err := c.internalCarrierScenario()
 	if err != nil {
 		return nil, nil, err
 	}
 	return external, internal, nil
+}
+
+// withExternalUser returns an ExternalWorld that appends one user principal to
+// the external world's first resource page.
+func withExternalUser(
+	objectID string,
+	profile map[string]any,
+	traitOpts ...rs.UserTraitOption,
+) func(*Dataset) error {
+	return func(dataset *Dataset) error {
+		userType, err := datasetResourceType(dataset, ExternalUserTypeID)
+		if err != nil {
+			return err
+		}
+		opts := make([]rs.ResourceOption, 0, 1)
+		if profile != nil {
+			opts = append(opts, rs.WithResourceProfile(profile))
+		}
+		user, err := rs.NewUserResource(objectID, userType, objectID, traitOpts, opts...)
+		if err != nil {
+			return err
+		}
+		page := dataset.Resources[ExternalUserTypeID][""]
+		page.List = append(page.List, user)
+		dataset.Resources[ExternalUserTypeID][""] = page
+		return nil
+	}
+}
+
+func datasetResourceType(dataset *Dataset, id string) (*v2.ResourceType, error) {
+	for _, resourceType := range dataset.ResourceTypes {
+		if resourceType.GetId() == id {
+			return resourceType, nil
+		}
+	}
+	return nil, fmt.Errorf("chaosconnector: external world has no resource type %q", id)
 }
 
 func externalPrincipalSourceScenario() (*Scenario, error) {

--- a/pkg/sync/external_match_folding_test.go
+++ b/pkg/sync/external_match_folding_test.go
@@ -1,0 +1,251 @@
+package sync //nolint:revive,nolintlint // matches the existing package name
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
+	gt "github.com/conductorone/baton-sdk/pkg/types/grant"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+)
+
+// External-resource key/value matching compares with strings.EqualFold. These
+// tests pin that comparison as a behavioral contract at the
+// processGrantsWithExternalPrincipals seam rather than at whatever internal
+// helper happens to implement it, so an implementation that swaps the
+// comparison out has to answer for the difference.
+//
+// EqualFold is Unicode simple case folding, which is not the same relation as
+// lowercasing both sides. The two disagree in both directions, and each
+// direction is a distinct access-correctness failure:
+//
+//   - EqualFold true, lowercase forms differ: a real grant is silently dropped
+//     and a principal loses access it should have.
+//   - EqualFold false, lowercase forms equal: a grant is manufactured and a
+//     principal gains access it should not have.
+//
+// Every case below states its expectation and then pins that expectation to
+// strings.EqualFold, so a case added later cannot quietly encode a divergence.
+
+// externalMatchFoldCase is one (stored value, queried value) pair together with
+// whether external matching must pair them.
+type externalMatchFoldCase struct {
+	name          string
+	stored, query string
+	matches       bool
+}
+
+func externalMatchFoldCases() []externalMatchFoldCase {
+	return []externalMatchFoldCase{
+		{name: "identical", stored: "target@example.com", query: "target@example.com", matches: true},
+		{name: "ascii case differs", stored: "TARGET@Example.com", query: "target@example.com", matches: true},
+		{name: "latin with diaeresis", stored: "Ann-Sofie.Ö", query: "ann-sofie.ö", matches: true},
+		{name: "cyrillic", stored: "ПЕТРОВ", query: "петров", matches: true},
+		{name: "cjk is caseless", stored: "山田太郎", query: "山田太郎", matches: true},
+		{name: "different values", stored: "target@example.com", query: "other@example.com", matches: false},
+
+		// Medial and final sigma case-fold together, so these match even though
+		// their lowercase forms differ ("σ" vs "ς"). An implementation that
+		// bucketed on strings.ToLower would drop the grant.
+		{name: "greek final sigma", stored: "Σ", query: "ς", matches: true},
+		{name: "greek final sigma in word", stored: "ΣΤΕΦΑΝΟΣ", query: "στεφανος", matches: true},
+		// Long s folds with ordinary s, and strings.ToLower leaves it alone.
+		{name: "latin long s", stored: "ſ", query: "s", matches: true},
+
+		// The dotted capital I does not fold to "i", so these must not match
+		// even though strings.ToLower("İ") is "i". An implementation that
+		// bucketed on strings.ToLower would manufacture the grant.
+		{name: "turkish dotted capital i", stored: "İ", query: "i", matches: false},
+		{name: "turkish dotted capital i in word", stored: "İSTANBUL", query: "istanbul", matches: false},
+		// Dotless i likewise does not fold with "i".
+		{name: "turkish dotless i", stored: "ı", query: "i", matches: false},
+
+		// Case folding is per-rune, so it never expands "ß" into "ss".
+		{name: "sharp s does not expand", stored: "ß", query: "ss", matches: false},
+		{name: "capital sharp s folds", stored: "ẞ", query: "ß", matches: true},
+	}
+}
+
+func TestExternalResourceMatchProfileFoldingContract(t *testing.T) {
+	for _, tc := range externalMatchFoldCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.matches, strings.EqualFold(tc.stored, tc.query),
+				"premise: external matching compares with strings.EqualFold")
+
+			principal := externalMatchPrincipal(t, "external-user-1",
+				map[string]any{"upn": tc.stored})
+			matched := runExternalMatchFold(t, principal, "upn", tc.query)
+
+			require.Equal(t, tc.matches, matched,
+				"profile %q vs match value %q: expected matched=%t", tc.stored, tc.query, tc.matches)
+		})
+	}
+}
+
+func TestExternalResourceMatchEmailFoldingContract(t *testing.T) {
+	for _, tc := range externalMatchFoldCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.matches, strings.EqualFold(tc.stored, tc.query),
+				"premise: external matching compares with strings.EqualFold")
+
+			principal := externalMatchPrincipal(t, "external-user-1", nil,
+				rs.WithEmail(tc.stored, true))
+			matched := runExternalMatchFold(t, principal, "email", tc.query)
+
+			require.Equal(t, tc.matches, matched,
+				"user-trait email %q vs match value %q: expected matched=%t", tc.stored, tc.query, tc.matches)
+		})
+	}
+}
+
+// A principal that a carrier can reach by more than one route still receives
+// exactly one grant. Both routes are reachable at once for the "email" key,
+// which matches a user-trait address as well as a profile field of that name.
+func TestExternalResourceMatchEmitsOneGrantPerPrincipal(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		principal func(*testing.T) *v2.Resource
+	}{
+		{
+			name: "two trait addresses folding alike",
+			principal: func(t *testing.T) *v2.Resource {
+				return externalMatchPrincipal(t, "external-user-1", nil,
+					rs.WithEmail("shared@example.com", true),
+					rs.WithEmail("SHARED@example.com", false),
+				)
+			},
+		},
+		{
+			name: "trait address and profile email",
+			principal: func(t *testing.T) *v2.Resource {
+				return externalMatchPrincipal(t, "external-user-1",
+					map[string]any{"email": "shared@example.com"},
+					rs.WithEmail("SHARED@example.com", true),
+				)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			principals := []*v2.Resource{tc.principal(t)}
+			observed := observeExternalMatch(t, principals, "email", "shared@example.com")
+			require.Equal(t, []string{"external-user-1"}, observed.principalIDs,
+				"a principal reachable by two routes must still receive one grant")
+			require.Zero(t, observed.carriers, "the carrier must not survive")
+		})
+	}
+}
+
+// externalMatchPrincipal builds an external user principal. The BatonID marker
+// is what processGrantsWithExternalPrincipals uses to recognize a copied
+// external principal, so a principal without it is ignored outright.
+func externalMatchPrincipal(
+	t *testing.T,
+	objectID string,
+	profile map[string]any,
+	traitOpts ...rs.UserTraitOption,
+) *v2.Resource {
+	t.Helper()
+	opts := make([]rs.ResourceOption, 0, 1)
+	if profile != nil {
+		opts = append(opts, rs.WithResourceProfile(profile))
+	}
+	principal, err := rs.NewUserResource(objectID, userResourceType, objectID, traitOpts, opts...)
+	require.NoError(t, err)
+
+	annos := annotations.Annotations(principal.GetAnnotations())
+	annos.Update(&v2.BatonID{})
+	principal.SetAnnotations(annos)
+	return principal
+}
+
+// runExternalMatchFold reports whether the single supplied principal received a
+// rewritten grant, and asserts the carrier was consumed either way.
+func runExternalMatchFold(t *testing.T, principal *v2.Resource, key, value string) bool {
+	t.Helper()
+	observed := observeExternalMatch(t, []*v2.Resource{principal}, key, value)
+	require.Zero(t, observed.carriers,
+		"the carrier is consumed whether or not it matched")
+	require.LessOrEqual(t, len(observed.principalIDs), 1, "one principal cannot yield two grants")
+	return len(observed.principalIDs) == 1
+}
+
+type externalMatchObservation struct {
+	principalIDs []string
+	carriers     int
+}
+
+// observeExternalMatch seeds a store with one carrier grant annotated for
+// external matching, runs the production rewrite step against principals, and
+// reports which principals ended up granted.
+func observeExternalMatch(
+	t *testing.T,
+	principals []*v2.Resource,
+	key, value string,
+) externalMatchObservation {
+	t.Helper()
+	ctx := t.Context()
+	tmpDir := t.TempDir()
+
+	store, err := dotc1z.NewStore(ctx, filepath.Join(tmpDir, "internal.c1z"),
+		dotc1z.WithEngine(c1zstore.EnginePebble),
+		dotc1z.WithTmpDir(tmpDir),
+	)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, store.Close(ctx)) }()
+
+	_, err = store.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+
+	group, err := rs.NewGroupResource("Internal Group", groupResourceType, "internal-group-1", nil)
+	require.NoError(t, err)
+	placeholder := v2.ResourceId_builder{
+		ResourceType: userResourceType.GetId(),
+		Resource:     externalMatchPlaceholderID,
+	}.Build()
+	carrier := gt.NewGrant(group, "member", placeholder,
+		gt.WithAnnotation(v2.ExternalResourceMatch_builder{
+			Key:          key,
+			Value:        value,
+			ResourceType: v2.ResourceType_TRAIT_USER,
+		}.Build()),
+	)
+	require.NoError(t, store.PutGrants(ctx, carrier))
+
+	state := newState()
+	state.SetHasExternalResourcesGrants()
+	state.PushAction(ctx, Action{Op: SyncExternalResourcesOp})
+
+	syncer := &syncer{store: store, state: state}
+	require.NoError(t, syncer.processGrantsWithExternalPrincipals(ctx, principals))
+
+	return readExternalMatchGrants(t, ctx, store)
+}
+
+const externalMatchPlaceholderID = "placeholder"
+
+func readExternalMatchGrants(
+	t *testing.T,
+	ctx context.Context,
+	store c1zstore.Store,
+) externalMatchObservation {
+	t.Helper()
+	observed := externalMatchObservation{}
+	for annotated, err := range store.Grants().ListWithAnnotations(ctx) {
+		require.NoError(t, err)
+		principalID := annotated.Grant.GetPrincipal().GetId().GetResource()
+		if principalID == externalMatchPlaceholderID {
+			observed.carriers++
+			continue
+		}
+		observed.principalIDs = append(observed.principalIDs, principalID)
+	}
+	return observed
+}


### PR DESCRIPTION
Tests only — no production change. Passes on `main`.

## Why

External-resource key/value matching compares with `strings.EqualFold`, and nothing asserted that. The existing `TestExternalResource*` tests each end with exactly one matching principal and an ASCII value, so they structurally cannot observe *which* case-insensitive relation is in use — every plausible one agrees on ASCII.

That makes the comparison an unpinned contract, which is exactly the kind of thing a matching rewrite can change without any test noticing.

`EqualFold` is Unicode simple case folding, not lowercasing both sides. The two disagree in both directions, and each direction is a distinct access-correctness failure:

| stored / queried | `EqualFold` | lowercase both | if implemented as lowercasing |
|---|---|---|---|
| `Σ` / `ς` | match | differ | grant **dropped** — principal loses access |
| `ΣΤΕΦΑΝΟΣ` / `στεφανος` | match | differ | grant **dropped** |
| `ſ` / `s` | match | differ | grant **dropped** |
| `İ` / `i` | no match | equal | grant **manufactured** — principal gains access |
| `İSTANBUL` / `istanbul` | no match | equal | grant **manufactured** |
| `ı`/`i`, `ß`/`ss`, `ẞ`/`ß`, `Ö`, Cyrillic, CJK, ASCII | agree | agree | fine |

## Two layers

**The exhaustive table, at the comparison seam** — `pkg/sync/external_match_folding_test.go`. 14 pairs across both routes a user can be matched by (a profile field, a user-trait email), driven through `processGrantsWithExternalPrincipals`. Deliberately at the seam rather than at whatever internal helper implements the comparison, so it survives a rewrite and reports on it. Every case states its expectation and then pins it to `strings.EqualFold`, so a case added later can't quietly encode a divergence instead of reporting one. 28 subtests, 5.7s.

Also pins **one grant per principal** when a carrier can reach that principal by more than one route — possible for the `email` key, which matches a user-trait address as well as a profile field of that name.

**Three representatives, through the chaos corpus** — `internal/chaosconnector/external_principal_corpus.go`. The seam test hands principals in as in-memory objects, so it proves the comparison but not that an awkward value survives reaching it. These cells carry both fold directions the rest of the way: the value round-trips through a sealed external c1z and crosses both transports before it is matched, and the resume-cut and sealing oracles come along free.

| cell | route | stored | match value | expects |
|---|---|---|---|---|
| `fold-profile-final-sigma` | profile `upn` | `ΣΤΕΦΑΝΟΣ` | `στεφανος` | match |
| `fold-profile-dotted-capital-i-miss` | profile `upn` | `İSTANBUL` | `istanbul` | no match |
| `fold-email-final-sigma` | user-trait email | `ΣΤΕΦΑΝΟΣ@example.com` | `στεφανος@example.com` | match |

Profile values travel as `structpb.Struct` and trait emails as `v2.UserTrait_Email`, so each encoding gets a witness. The dotted-`İ` cell also probes whether anything in the store applies NFKC-style normalization, which would decompose the stored value and change the answer.

Only three, not the full table: each corpus cell costs ~1.4s in `TestChaosConnectorExternalPrincipalCorpus` (two transports) plus ~1.6s in `…CorpusResumesAfterRewriteCut`, which iterates the whole corpus. Moving all 28 assertions there would be ~84s against 5.7s at the seam, and would inflate `chaos-full-check` and `race-check` — for a property that is pure string comparison.

### `ExternalWorld`

Cases previously shared one hardcoded external world (`externalPrincipalSourceScenario`), so none could supply its own principal. `ExternalPrincipalCase.ExternalWorld` is an opt-in mutator applied to the per-case copy `Build` already constructs; cells without one are unaffected. It reuses the existing `initialDataset` helper. This also unblocks the multi-match fan-out cell we discussed separately.

Corpus expectations stay declared rather than computed from `strings.EqualFold` — the corpus is a declared-manifest artifact per `docs/CHAOS_CONNECTOR.md`, and the exhaustive table that warrants self-pinning lives at the seam.

## Relationship to #1046

#1046 replaces the linear scan with an index whose bucketing normalizes with `strings.ToLower`. Both layers fail on that branch.

Seam — 10 subtests, the 5 divergent pairs across both routes:

```
--- FAIL: TestExternalResourceMatchProfileFoldingContract/greek_final_sigma
--- FAIL: TestExternalResourceMatchProfileFoldingContract/greek_final_sigma_in_word
--- FAIL: TestExternalResourceMatchProfileFoldingContract/latin_long_s
--- FAIL: TestExternalResourceMatchProfileFoldingContract/turkish_dotted_capital_i
--- FAIL: TestExternalResourceMatchProfileFoldingContract/turkish_dotted_capital_i_in_word
--- FAIL: TestExternalResourceMatchEmailFoldingContract/... (same five)

    profile "Σ" vs match value "ς": expected matched=true   (got false — grant dropped)
    profile "İ" vs match value "i": expected matched=false  (got true  — grant manufactured)
```

Corpus — all three cells, on both transports:

```
--- FAIL: .../fold-profile-final-sigma/{direct,grpc}
      chaos oracle: external principal mismatch: expected [external-fold-user], actual []
--- FAIL: .../fold-profile-dotted-capital-i-miss/{direct,grpc}
      chaos oracle: external principal mismatch: expected [], actual [external-fold-user]
--- FAIL: .../fold-email-final-sigma/{direct,grpc}
      chaos oracle: external principal mismatch: expected [external-fold-user], actual []
```

Landing this first means #1046 gets that signal from CI and can reconcile the normalization deliberately, rather than the difference going unobserved.

## Note

`pkg/sync/external_principal_index_verification_test.go` is `//go:build verification` and does not compile on `main` at all — it references `newExternalUserPrincipalIndex`, `mergePositions`, `testUserPrincipal`, and `testGroupPrincipal`, none of which exist here (they arrive with #1046). No Makefile target passes `-tags=verification`, so it isn't caught. Left alone here since it belongs with #1046; noting it so it isn't mistaken for coverage that currently runs.

## Testing

`go test ./pkg/sync/` passes, `go test ./internal/chaosconnector/...` passes, `make lint` reports 0 issues. Corpus additions measured at ~4s on `TestChaosConnectorExternalPrincipalCorpus` (12.5s → 16.7s) and ~5s on its resume-cut pass (14.7s → 19.7s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)