### PR TITLE
cxp-846 return XML as a generic map: map targets and non-map roots

### DIFF
--- a/pkg/uhttp/wrapper.go
+++ b/pkg/uhttp/wrapper.go
@@ -264,9 +264,24 @@ func unmarshalXMLToMap(response *map[string]any, resp *WrapperResponse) error {
 	}
 	vMap, ok := xm.data.(map[string]any)
 	if !ok {
-		// A document whose root holds only text decodes to a string, which has no
-		// sensible map representation.
-		return status.Errorf(codes.Internal, "unsupported XML structure: %T", xm.data)
+		// The root's content has no map representation in two cases, and both used
+		// to fail outright with "unsupported XML structure":
+		//
+		//   - Its direct children repeat: <Users><User/><User/></Users> decodes to
+		//     a []map[string]any. A root-level list is a common API shape, so this
+		//     was a real gap rather than an edge case.
+		//   - It holds only text: <Code>OK</Code> decodes to a string.
+		//
+		// Key it by the root element name, which is otherwise discarded, so the
+		// document is reachable by a path instead of being an error.
+		//
+		// Note the arity seam this leaves: a root holding a *single* <User> decodes
+		// to a map and keeps the root stripped, so its path is "User" while the
+		// repeated case is "Users". One config cannot serve both. Closing that
+		// needs the decoder to group repeated children under their shared name,
+		// which would also make the slice case here unreachable.
+		*response = map[string]any{xm.root: xm.data}
+		return nil
 	}
 	*response = vMap
 	return nil

--- a/pkg/uhttp/wrapper.go
+++ b/pkg/uhttp/wrapper.go
@@ -217,10 +217,26 @@ func WithXMLResponse(response any) DoOption {
 }
 
 // Ignore content type header and always try to parse the response as XML.
+//
+// A *map[string]any target is decoded through the generic xmlMap decoder, since
+// encoding/xml cannot unmarshal into a map and would fail for every input. Any
+// other target keeps going straight to xml.Unmarshal, so callers passing a typed
+// struct are unaffected.
 func WithAlwaysXMLResponse(response any) DoOption {
 	return func(resp *WrapperResponse) error {
 		if response == nil && len(resp.Body) == 0 {
 			return nil
+		}
+		if genericResponse, ok := response.(*map[string]any); ok {
+			// Scoped to the map target so the struct path below keeps its exact
+			// existing behavior, including for 204 and empty bodies.
+			if resp.StatusCode == http.StatusNoContent {
+				return nil
+			}
+			if resp.StatusCode >= 200 && resp.StatusCode < 300 && len(resp.Body) == 0 {
+				return nil
+			}
+			return unmarshalXMLToMap(genericResponse, resp)
 		}
 		err := xml.Unmarshal(resp.Body, response)
 		if err != nil {
@@ -228,6 +244,32 @@ func WithAlwaysXMLResponse(response any) DoOption {
 		}
 		return nil
 	}
+}
+
+// unmarshalXMLToMap decodes an XML body into a generic map via the xmlMap decoder.
+// encoding/xml cannot unmarshal into a map directly, so any caller wanting an
+// arbitrary XML document as a map has to route through xmlMap.
+func unmarshalXMLToMap(response *map[string]any, resp *WrapperResponse) error {
+	// A typed-nil target, e.g. WithAlwaysXMLResponse((*map[string]any)(nil)), gets
+	// past an `any == nil` check because the interface still carries a type. Guard
+	// here rather than at each call site so assigning through it cannot panic.
+	// encoding/xml rejected this with "nil pointer passed to Unmarshal".
+	if response == nil {
+		return status.Error(codes.InvalidArgument, "response is nil")
+	}
+
+	var xm xmlMap
+	if err := xml.Unmarshal(resp.Body, &xm); err != nil {
+		return fmt.Errorf("failed to unmarshal xml response: %w. status code: %d", err, resp.StatusCode)
+	}
+	vMap, ok := xm.data.(map[string]any)
+	if !ok {
+		// A document whose root holds only text decodes to a string, which has no
+		// sensible map representation.
+		return status.Errorf(codes.Internal, "unsupported XML structure: %T", xm.data)
+	}
+	*response = vMap
+	return nil
 }
 
 type ErrorResponse interface {
@@ -374,17 +416,7 @@ func WithGenericResponse(response *map[string]any) DoOption {
 		}
 
 		if IsXMLContentType(resp.Header.Get(ContentType)) {
-			var xm xmlMap
-			err = WithXMLResponse(&xm)(resp)
-			if err != nil {
-				return err
-			}
-			if vMap, ok := xm.data.(map[string]any); ok {
-				*response = vMap
-			} else {
-				return status.Errorf(codes.Internal, "unsupported XML structure: %T", xm.data)
-			}
-			return nil
+			return unmarshalXMLToMap(response, resp)
 		}
 
 		return status.Error(codes.Unknown, fmt.Sprintf("unsupported content type: %s", resp.Header.Get(ContentType)))

--- a/pkg/uhttp/wrapper_test.go
+++ b/pkg/uhttp/wrapper_test.go
@@ -249,6 +249,116 @@ func TestWrapper_WithXMLResponse(t *testing.T) {
 	})
 }
 
+func TestWrapper_WithAlwaysXMLResponse(t *testing.T) {
+	const userList = `<?xml version="1.0" encoding="UTF-8"?><SERVICE_RESPONSE><USER_LIST>` +
+		`<USER><LOGIN>john@example.com</LOGIN></USER>` +
+		`<USER><LOGIN>jane@example.com</LOGIN></USER>` +
+		`</USER_LIST></SERVICE_RESPONSE>`
+
+	newResp := func(body string, contentType string, statusCode int) WrapperResponse {
+		header := http.Header{}
+		if contentType != "" {
+			header.Add("Content-Type", contentType)
+		}
+		return WrapperResponse{
+			Header:     header,
+			Body:       []byte(body),
+			StatusCode: statusCode,
+		}
+	}
+
+	t.Run("should decode into a map despite a non-XML content type", func(t *testing.T) {
+		// encoding/xml cannot unmarshal into a map, so before this a *map[string]any
+		// target failed for every input with "unknown type map[string]interface {}".
+		resp := newResp(userList, "text/plain", http.StatusOK)
+		var respBody map[string]any
+
+		err := WithAlwaysXMLResponse(&respBody)(&resp)
+
+		require.NoError(t, err)
+		// The shape is whatever the existing xmlMap decoder produces: a container
+		// with repeated children becomes a []map[string]any of single-key maps.
+		// This change only makes the map target reachable; it does not reshape
+		// anything, so the generic path's output is unchanged.
+		require.Equal(t, map[string]any{
+			"USER_LIST": []map[string]any{
+				{"USER": map[string]any{"LOGIN": "john@example.com"}},
+				{"USER": map[string]any{"LOGIN": "jane@example.com"}},
+			},
+		}, respBody)
+	})
+
+	t.Run("should leave the typed struct path unchanged", func(t *testing.T) {
+		exampleResponse := example{Name: "John", Age: 30}
+		buf := new(bytes.Buffer)
+		require.NoError(t, xml.NewEncoder(buf).Encode(exampleResponse))
+		resp := newResp(buf.String(), "text/plain", http.StatusOK)
+
+		responseBody := example{}
+		err := WithAlwaysXMLResponse(&responseBody)(&resp)
+
+		require.NoError(t, err)
+		require.Equal(t, exampleResponse, responseBody)
+	})
+
+	t.Run("should error when a map target gets a document with only root text", func(t *testing.T) {
+		resp := newResp(`<?xml version="1.0" encoding="UTF-8"?><root>bare text</root>`, "text/plain", http.StatusOK)
+		var respBody map[string]any
+
+		err := WithAlwaysXMLResponse(&respBody)(&resp)
+
+		require.Error(t, err)
+		require.Equal(t, codes.Internal, status.Code(err))
+		require.Contains(t, err.Error(), "unsupported XML structure: string")
+	})
+
+	t.Run("should not decode a map target on 204", func(t *testing.T) {
+		resp := newResp("", "text/plain", http.StatusNoContent)
+		var respBody map[string]any
+
+		err := WithAlwaysXMLResponse(&respBody)(&resp)
+
+		require.NoError(t, err)
+		require.Nil(t, respBody)
+	})
+
+	t.Run("should not decode a map target on an empty 200 body", func(t *testing.T) {
+		resp := newResp("", "text/plain", http.StatusOK)
+		var respBody map[string]any
+
+		err := WithAlwaysXMLResponse(&respBody)(&resp)
+
+		require.NoError(t, err)
+		require.Nil(t, respBody)
+	})
+
+	t.Run("should error rather than panic on a typed-nil map target", func(t *testing.T) {
+		// (*map[string]any)(nil) gets past an `any == nil` check because the
+		// interface still carries a type, so the map branch is reached with a nil
+		// pointer. encoding/xml used to reject this with "nil pointer passed to
+		// Unmarshal"; assigning through it would panic.
+		resp := newResp(userList, "text/plain", http.StatusOK)
+
+		var respBody *map[string]any
+		err := WithAlwaysXMLResponse(respBody)(&resp)
+
+		require.Error(t, err)
+		require.Equal(t, codes.InvalidArgument, status.Code(err))
+	})
+
+	t.Run("WithXMLResponse keeps rejecting map targets", func(t *testing.T) {
+		// Deliberately left alone: it is reached by WithResponse and by three
+		// connectors that pass typed structs, so its behavior is not widened here.
+		resp := newResp(userList, "application/xml", http.StatusOK)
+		var respBody map[string]any
+
+		err := WithXMLResponse(&respBody)(&resp)
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unknown type map[string]interface {}")
+	})
+}
+
 func TestWrapper_WithResponse(t *testing.T) {
 	exampleResponse := example{
 		Name: "John",

--- a/pkg/uhttp/wrapper_test.go
+++ b/pkg/uhttp/wrapper_test.go
@@ -301,15 +301,49 @@ func TestWrapper_WithAlwaysXMLResponse(t *testing.T) {
 		require.Equal(t, exampleResponse, responseBody)
 	})
 
-	t.Run("should error when a map target gets a document with only root text", func(t *testing.T) {
+	t.Run("should key a root-level list by the root element name", func(t *testing.T) {
+		// A root whose own children repeat decodes to a []map[string]any, which has
+		// no map representation and used to fail with "unsupported XML structure".
+		// Keying it by the root name makes this common shape reachable by a path.
+		resp := newResp(`<users><user><login>a</login></user>`+
+			`<user><login>b</login></user></users>`, "text/plain", http.StatusOK)
+		var respBody map[string]any
+
+		err := WithAlwaysXMLResponse(&respBody)(&resp)
+
+		require.NoError(t, err)
+		require.Equal(t, map[string]any{
+			"users": []map[string]any{
+				{"user": map[string]any{"login": "a"}},
+				{"user": map[string]any{"login": "b"}},
+			},
+		}, respBody)
+	})
+
+	t.Run("should keep stripping the root when its content is a map", func(t *testing.T) {
+		// The same document at one item takes the map path, where the root name is
+		// discarded as it always has been — so the path is "user" here and "users"
+		// above. Pinning the seam: one config cannot serve both arities until the
+		// decoder groups repeated children under their shared name.
+		resp := newResp(`<users><user><login>a</login></user></users>`, "text/plain", http.StatusOK)
+		var respBody map[string]any
+
+		err := WithAlwaysXMLResponse(&respBody)(&resp)
+
+		require.NoError(t, err)
+		require.Equal(t, map[string]any{
+			"user": map[string]any{"login": "a"},
+		}, respBody)
+	})
+
+	t.Run("should key a text-only root by the root element name", func(t *testing.T) {
 		resp := newResp(`<?xml version="1.0" encoding="UTF-8"?><root>bare text</root>`, "text/plain", http.StatusOK)
 		var respBody map[string]any
 
 		err := WithAlwaysXMLResponse(&respBody)(&resp)
 
-		require.Error(t, err)
-		require.Equal(t, codes.Internal, status.Code(err))
-		require.Contains(t, err.Error(), "unsupported XML structure: string")
+		require.NoError(t, err)
+		require.Equal(t, map[string]any{"root": "bare text"}, respBody)
 	})
 
 	t.Run("should not decode a map target on 204", func(t *testing.T) {

--- a/pkg/uhttp/xml.go
+++ b/pkg/uhttp/xml.go
@@ -2,8 +2,21 @@ package uhttp
 
 import (
 	"encoding/xml"
+	"fmt"
 	"strings"
 )
+
+// maxXMLDepth bounds how deep unmarshalXMLElement will recurse. Without it, a
+// body of a few MB of nested open tags exhausts the goroutine stack, and a Go
+// stack overflow is a fatal runtime error rather than a panic, so recover()
+// cannot turn it back into a failed request: the process dies mid-sync.
+// Measured on the 1 GB default stack limit, ~1M levels is fatal and ~500k is
+// not, which a 7 MB response reaches.
+//
+// The limit only has to sit below that ceiling while staying clear of real
+// documents, which nest tens of levels at most. encoding/json caps nesting at
+// 10000 for the same reason, so this matches the standard library.
+const maxXMLDepth = 10_000
 
 // xmlMap implements xml.Unmarshaler and can unmarshal arbitrary XML into a
 // map[string]any structure. Leaf elements become string values, and elements
@@ -17,7 +30,7 @@ type xmlMap struct {
 }
 
 func (x *xmlMap) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
-	result, err := unmarshalXMLElement(d)
+	result, err := unmarshalXMLElement(d, 0)
 	if err != nil {
 		return err
 	}
@@ -31,7 +44,15 @@ func (x *xmlMap) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 // It returns a map[string]any if there are child elements, a []map[string]any
 // if there are duplicate child element names, or a string if the element
 // contains only text.
-func unmarshalXMLElement(d *xml.Decoder) (any, error) {
+//
+// depth is the caller's nesting level, checked against maxXMLDepth so a
+// pathologically nested body fails as a request error instead of taking the
+// process down with a stack overflow.
+func unmarshalXMLElement(d *xml.Decoder, depth int) (any, error) {
+	if depth > maxXMLDepth {
+		return nil, fmt.Errorf("xml nesting exceeds the maximum depth of %d", maxXMLDepth)
+	}
+
 	type entry struct {
 		key   string
 		value any
@@ -48,7 +69,7 @@ func unmarshalXMLElement(d *xml.Decoder) (any, error) {
 		}
 		switch tt := t.(type) {
 		case xml.StartElement:
-			child, err := unmarshalXMLElement(d)
+			child, err := unmarshalXMLElement(d, depth+1)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/uhttp/xml.go
+++ b/pkg/uhttp/xml.go
@@ -8,8 +8,12 @@ import (
 // xmlMap implements xml.Unmarshaler and can unmarshal arbitrary XML into a
 // map[string]any structure. Leaf elements become string values, and elements
 // with children become nested maps.
+// The root element's own name is recorded but not used as a key, so a document's
+// paths start at its root's children. Callers need it only when the root content
+// has no map representation and has to be keyed by something.
 type xmlMap struct {
 	data any
+	root string
 }
 
 func (x *xmlMap) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
@@ -18,6 +22,7 @@ func (x *xmlMap) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 		return err
 	}
 	x.data = result
+	x.root = start.Name.Local
 	return nil
 }
 

--- a/pkg/uhttp/xml_test.go
+++ b/pkg/uhttp/xml_test.go
@@ -3,6 +3,7 @@ package uhttp
 import (
 	"encoding/xml"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -55,4 +56,36 @@ func TestXMLMap_UnmarshalXML(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, map[string]any{}, xmlMap.data)
 	})
+
+	t.Run("should reject a body nested past the depth limit", func(t *testing.T) {
+		// Without the limit this is not a returned error but a fatal stack
+		// overflow, which recover() cannot catch, so the process dies rather
+		// than the request failing. A few MB of open tags is enough.
+		err := xml.Unmarshal([]byte(nestedXML(maxXMLDepth*2)), &xmlMap{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "xml nesting exceeds the maximum depth")
+	})
+
+	t.Run("should accept a body nested up to the depth limit", func(t *testing.T) {
+		// The limit sits far above anything a real API returns, so it must not
+		// turn deep-but-legitimate documents into errors.
+		xm := &xmlMap{}
+		require.NoError(t, xml.Unmarshal([]byte(nestedXML(maxXMLDepth)), xm))
+		require.NotNil(t, xm.data)
+	})
+}
+
+// nestedXML builds a document of depth levels of the same element, with text at
+// the centre: <a><a>…x…</a></a>.
+func nestedXML(depth int) string {
+	var b strings.Builder
+	b.Grow(depth*7 + 1)
+	for range depth {
+		b.WriteString("<a>")
+	}
+	b.WriteString("x")
+	for range depth {
+		b.WriteString("</a>")
+	}
+	return b.String()
 }


### PR DESCRIPTION
## Summary

Two fixes that make `uhttp` able to hand an arbitrary XML document back as a generic map.

**1. `WithAlwaysXMLResponse` rejected map targets.** It hands its target straight to `encoding/xml`, which cannot unmarshal into a map, so a `*map[string]any` target failed for **every** response with a body:

```
failed to unmarshal xml response: unknown type map[string]interface {}. status code: 200
```

Route that one target type through the `xmlMap` decoder `WithGenericResponse` already uses, sharing the code as `unmarshalXMLToMap`.

**2. A non-map XML root hard-failed.** `unmarshalXMLToMap` required the root element's *content* to be a map and returned `Internal: unsupported XML structure` otherwise — which a root-level list hits, a common API shape. Key those documents by the root element name instead. Added in response to review feedback; `unmarshalXMLToMap` can no longer fail on structure at all.

**3. The generic decoder had no recursion bound.** `unmarshalXMLElement` recursed once per nesting level on a body read with an unbounded `io.ReadAll`, so deeply nested open tags exhausted the goroutine stack — and a Go stack overflow is *fatal*, not a panic, so `recover()` could not turn it back into a failed request. Measured: a 3.5 MB body of 500k nested tags decodes; a **7 MB body of 1M nested tags kills the process**. Capped at 10000 levels. Also raised in review.

**Scope note.** An earlier revision reshaped the decoder so repeated siblings grouped under their shared key. That commit is dropped — see [Deferred](#deferred). No existing *shape* changes here: `xml.go` gains a `root` field and a depth bound, but the mapping from document to map is untouched.

## Why

Callers wanting an arbitrary XML document as a map have no working option today. Concretely, baton-http maps `parse_as: xml` onto `WithAlwaysXMLResponse(&map[string]any{})`, so **that config key has never functioned** since it was added in `65f49692` — it hard-fails on every response with a body.

And fix 1 alone would not have been enough for the shape that matters most. `<Users><User/><User/></Users>` decodes to a `[]map[string]any`, so it still died in `unmarshalXMLToMap` — arguably the main case `parse_as: xml` is wanted for.

## Compatibility

**Scoped by target type.** The new branch in `WithAlwaysXMLResponse` fires only for `*map[string]any`; every other target falls through to the unchanged `xml.Unmarshal` call. All existing call sites in the connector fleet pass typed structs or `nil`. `WithXMLResponse` — which panorama, litmos, and sage-intacct use — is not modified, and a test pins that it still rejects map targets.

**With one exception noted below, every divergence is `error → something else`, never `success → something else`:**

| input, map target | before | after |
|---|---|---|
| XML body | error `unknown type map[string]interface {}` | decoded map |
| 204 / empty 2xx body | error | `nil`, map left empty |
| typed-nil `(*map[string]any)(nil)` | error `nil pointer passed to Unmarshal` | `InvalidArgument: response is nil` |
| root's children repeat (`<Users><User/><User/></Users>`) | error `unsupported XML structure: []map[string]interface {}` | `{"Users": [{"User":…},{"User":…}]}` |
| root holds only text (`<Code>OK</Code>`) | error `unsupported XML structure: string` | `{"Code": "OK"}` |

**The one exception is the depth cap.** A body nested past 10000 levels previously did not error — it took the process down with a fatal stack overflow. It now returns an error. That is the improvement, but unlike everything else here it is a behavior change on input that did not previously fail, and it applies to `WithGenericResponse` as well, which already reached the decoder for any XML content-type response. Real documents nest tens of levels at most, so the limit is ~300x clear of anything legitimate, and `encoding/json` caps nesting at 10000 for the same reason.

The last two rows also apply to **`WithGenericResponse`**, since both paths share `unmarshalXMLToMap`. Both were hard errors there too, so the same argument covers it — but note that this PR does change generic-path behavior for those two document shapes, not only the map target.

`WithAlwaysXMLResponse` and `WithGenericResponse` now produce **byte-identical** output for the same document, asserted by test. That matters downstream: a baton-http config gets the same tree whether or not it sets `parse_as: xml`.

The `WithGenericResponse` refactor is a pure extraction: its XML branch previously routed through `WithXMLResponse(&xm)`, whose content-type and nil checks are both dead inside that branch (already guarded by `IsXMLContentType`, and `&xm` is never nil). Same decoder, same error wrapping, one code path.

The typed-nil guard addresses the earlier review finding: the map branch would have turned `encoding/xml`'s clean "nil pointer passed to Unmarshal" into a nil-pointer panic. It lives inside `unmarshalXMLToMap` rather than at each call site, so assigning through the pointer cannot panic. A typed nil survives an `any == nil` check because the interface still carries a type.

## Known limitation: the arity seam

Keying by the root name is reactive, so it inherits the decoder's arity asymmetry:

| document | decoded | path |
|---|---|---|
| `<users><user/><user/></users>` | `{"users": [{"user":…},{"user":…}]}` | `users` |
| `<users><user/></users>` | `{"user": {…}}` | `user` |

One child means nothing repeats, so the content is a map, so the root name is discarded as always. **One config cannot serve both arities for a root-level list.** This is pinned by a test rather than left to be rediscovered.

It is still a clear improvement: previously the ≥2 case — the one essentially every real tenant hits — failed outright, and the error it produced was an opaque `Internal` from inside the SDK rather than something a config author could act on.

Grouping repeated children under their shared name is what closes the seam, and it would make the slice case here unreachable. Nested lists already have no seam, thanks to ConductorOne/baton-http#144.

## Testing

`go build ./...`, `go test ./pkg/uhttp/...`, and `golangci-lint run ./pkg/uhttp/...` (0 issues) all pass.

Depth cap tested in both directions — a body at 2× the limit errors, and a body at the limit still decodes, so the cap cannot later be tightened into one that rejects real responses.

Cases on `WithAlwaysXMLResponse`: map target decoding despite a non-XML content type, the typed-struct path unchanged, a root-level list keyed by the root name, a single-child root still stripping it (the seam), a text-only root keyed by the root name, 204 and empty-200 leaving the map untouched, a typed-nil target erroring rather than panicking, and `WithXMLResponse` still rejecting map targets.

Verified end-to-end against baton-http#144 through a Go workspace — raw XML → `WithGenericResponse` → `ExtractItems`:

```
root-level list, 2 users   items_path=users   2 items    (was: SDK hard error)
root-level list, 1 user    items_path=user    1 item
nested list, 2 users       items_path=users   2 items
nested list, 1 user        items_path=users   1 item     <- same path both arities
text-only root             items_path=code    correctly "not an array, got string"
```

## <a name="deferred"></a>Deferred: the decoder shape change

The dropped commit made a container with 2+ same-named children decode to `{"USER_LIST": {"USER": [...]}}` instead of `{"USER_LIST": [{"USER":…},{"USER":…}]}`, so that `jsonpath` could walk it.

It is not needed for the consumer problem it targeted — baton-http's `items_path` failing on XML list responses — which is fixed entirely by ConductorOne/baton-http#144, at the extraction sites, with no SDK release.

And it carries a risk this PR does not. `[]map[string]any` is only untraversable for **jsonpath**; CEL and Go templates walk it fine. In baton-http, responses on the provisioning, action, and pre-request paths never reach items extraction and are read solely by CEL — so `cel:size(response.body.USER_LIST)` returns N today and would return 1 after the reshape: a silent wrong answer in a config that works.

Worth noting it has gained a second motivation, though — it is also what would close the arity seam above and retire the slice branch entirely. So it is deferred for its own audit, not dismissed.

Part of [CXP-846](https://linear.app/ductone/issue/CXP-846)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

