### PR TITLE
[DRAFT] Agent/warn invalid connector data

### DIFF
--- a/docs/CHAOS_CONNECTOR.md
+++ b/docs/CHAOS_CONNECTOR.md
@@ -277,10 +277,10 @@ does not yet emit exact entitlement/grant conflict counters: doing that would
 require either a read before every put or sync-wide identity state. Neither
 cost is introduced implicitly by these tests.
 
-`LifecycleCorpus` crosses one representative of each data policy with an
-interrupted entitlement page and persisted resume. It verifies that dropped
-rows remain absent, hard-invalid rows cannot seal, retained dangling rows
-survive, and an interrupted response is replaced by the resume-time answer.
+`LifecycleCorpus` crosses each materially different outcome with an interrupted
+entitlement page and persisted resume. It verifies that skipped rows remain
+absent, retained dangling rows survive, and an interrupted response is replaced
+by the resume-time answer.
 Page-chain replay is at-least-once: a dropped row before the cut is observed
 and counted once in each attempt, while remaining absent from both artifacts.
 Every successful resume must finish the original sync ID and match the complete

--- a/internal/chaosconnector/corpus.go
+++ b/internal/chaosconnector/corpus.go
@@ -45,7 +45,7 @@ func InitialDataCorpus() []CorpusCase {
 		{
 			Name:   "entitlement-missing-resource",
 			Class:  DataRepresentationInvalid,
-			Policy: DataPolicyFail,
+			Policy: DataPolicySkipReport,
 			Apply: func(scenario *Scenario) error {
 				dataset, err := initialDataset(scenario)
 				if err != nil {

--- a/internal/chaosconnector/lifecycle_corpus.go
+++ b/internal/chaosconnector/lifecycle_corpus.go
@@ -6,7 +6,6 @@ import (
 
 const (
 	LifecycleDropCaseName   = "lifecycle/drop-does-not-resurrect"
-	LifecycleFailCaseName   = "lifecycle/hard-invalid-never-seals"
 	LifecycleRetainCaseName = "lifecycle/warn-retain-survives-resume"
 	LifecycleDriftCaseName  = "lifecycle/resume-uses-current-answer"
 )
@@ -52,19 +51,6 @@ func LifecycleCorpus() []LifecycleCase {
 			Resume: LifecycleAttemptExpectation{
 				Sealed:              true,
 				EntitlementsDropped: 1,
-			},
-		},
-		{
-			Name:                 LifecycleFailCaseName,
-			Policy:               DataPolicyFail,
-			BuildInitial:         hardInvalidLifecycleScenario,
-			BuildResume:          hardInvalidLifecycleScenario,
-			InterruptSchedule:    lifecycleInterruptSchedule("bad"),
-			InterruptedPageToken: "bad",
-			Identity:             "",
-			Resume: LifecycleAttemptExpectation{
-				MustFail:      true,
-				ErrorContains: "entitlement with missing identity",
 			},
 		},
 		{
@@ -141,19 +127,6 @@ func dropLifecycleScenario() (*Scenario, error) {
 		Resource:    resource,
 	}.Build()
 	setLifecycleEntitlementPages(dataset, []*v2.Entitlement{entitlement}, "cut", nil)
-	return scenario, nil
-}
-
-func hardInvalidLifecycleScenario() (*Scenario, error) {
-	scenario, dataset, err := newLifecycleScenario()
-	if err != nil {
-		return nil, err
-	}
-	malformed := v2.Entitlement_builder{
-		DisplayName: "Lifecycle missing identity",
-		Resource:    baselineResource(dataset),
-	}.Build()
-	setLifecycleEntitlementPages(dataset, nil, "bad", []*v2.Entitlement{malformed})
 	return scenario, nil
 }
 

--- a/internal/chaosconnector/lifecycle_corpus_test.go
+++ b/internal/chaosconnector/lifecycle_corpus_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestLifecycleCorpusCoversPolicyEquivalenceClasses(t *testing.T) {
 	corpus := LifecycleCorpus()
-	require.Len(t, corpus, 4)
+	require.Len(t, corpus, 3)
 
 	policies := make(map[DataPolicy]bool)
 	names := make(map[string]struct{}, len(corpus))
@@ -32,7 +32,6 @@ func TestLifecycleCorpusCoversPolicyEquivalenceClasses(t *testing.T) {
 	}
 
 	require.True(t, policies[DataPolicySkipReport])
-	require.True(t, policies[DataPolicyFail])
 	require.True(t, policies[DataPolicyWarnRetain])
 	require.True(t, policies[DataPolicyAccept])
 }

--- a/internal/chaosconnector/referential_corpus.go
+++ b/internal/chaosconnector/referential_corpus.go
@@ -68,7 +68,7 @@ func resourceReferentialCases() []ReferentialCase {
 			Name:      "resource/" + string(state),
 			Entity:    ReferentialResource,
 			Reference: state,
-			Policy:    DataPolicyFail,
+			Policy:    DataPolicySkipReport,
 			Apply: func(scenario *Scenario) error {
 				dataset, err := initialDataset(scenario)
 				if err != nil {
@@ -200,7 +200,7 @@ func grantReferentialCases() []ReferentialCase {
 func entitlementPolicy(state ReferenceShape) DataPolicy {
 	switch state {
 	case ReferenceCarrierNil:
-		return DataPolicyFail
+		return DataPolicySkipReport
 	case ReferenceTypeUnknown:
 		return DataPolicySkipReport
 	case ReferenceRowMissing:
@@ -209,7 +209,7 @@ func entitlementPolicy(state ReferenceShape) DataPolicy {
 		return DataPolicyAccept
 	case ReferenceExternalIDEmpty, ReferenceResourceNil, ReferenceIdentityNil,
 		ReferenceTypeEmpty, ReferenceObjectIDEmpty:
-		return DataPolicyFail
+		return DataPolicySkipReport
 	default:
 		return DataPolicyUnresolved
 	}

--- a/pb/c1/storage/v3/records.pb.go
+++ b/pb/c1/storage/v3/records.pb.go
@@ -2035,9 +2035,14 @@ type IngestQualityStats struct {
 	// checkpoint provenance, respectively.
 	// Counts remain useful diagnostics; reason flags carry replay eligibility
 	// even for warn-and-retain policies that do not drop a row.
-	ReasonFlags   uint64 `protobuf:"varint,7,opt,name=reason_flags,json=reasonFlags,proto3" json:"reason_flags,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	ReasonFlags uint64 `protobuf:"varint,7,opt,name=reason_flags,json=reasonFlags,proto3" json:"reason_flags,omitempty"`
+	// Attempt-level observations. A retry or resumed page may observe the same
+	// malformed connector record again.
+	InvalidResourceTypesObserved uint64 `protobuf:"varint,8,opt,name=invalid_resource_types_observed,json=invalidResourceTypesObserved,proto3" json:"invalid_resource_types_observed,omitempty"`
+	InvalidResourcesObserved     uint64 `protobuf:"varint,9,opt,name=invalid_resources_observed,json=invalidResourcesObserved,proto3" json:"invalid_resources_observed,omitempty"`
+	InvalidEntitlementsObserved  uint64 `protobuf:"varint,10,opt,name=invalid_entitlements_observed,json=invalidEntitlementsObserved,proto3" json:"invalid_entitlements_observed,omitempty"`
+	unknownFields                protoimpl.UnknownFields
+	sizeCache                    protoimpl.SizeCache
 }
 
 func (x *IngestQualityStats) Reset() {
@@ -2114,6 +2119,27 @@ func (x *IngestQualityStats) GetReasonFlags() uint64 {
 	return 0
 }
 
+func (x *IngestQualityStats) GetInvalidResourceTypesObserved() uint64 {
+	if x != nil {
+		return x.InvalidResourceTypesObserved
+	}
+	return 0
+}
+
+func (x *IngestQualityStats) GetInvalidResourcesObserved() uint64 {
+	if x != nil {
+		return x.InvalidResourcesObserved
+	}
+	return 0
+}
+
+func (x *IngestQualityStats) GetInvalidEntitlementsObserved() uint64 {
+	if x != nil {
+		return x.InvalidEntitlementsObserved
+	}
+	return 0
+}
+
 func (x *IngestQualityStats) SetSourceCacheReplayBlocked(v bool) {
 	x.SourceCacheReplayBlocked = v
 }
@@ -2142,6 +2168,18 @@ func (x *IngestQualityStats) SetReasonFlags(v uint64) {
 	x.ReasonFlags = v
 }
 
+func (x *IngestQualityStats) SetInvalidResourceTypesObserved(v uint64) {
+	x.InvalidResourceTypesObserved = v
+}
+
+func (x *IngestQualityStats) SetInvalidResourcesObserved(v uint64) {
+	x.InvalidResourcesObserved = v
+}
+
+func (x *IngestQualityStats) SetInvalidEntitlementsObserved(v uint64) {
+	x.InvalidEntitlementsObserved = v
+}
+
 type IngestQualityStats_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
@@ -2160,6 +2198,11 @@ type IngestQualityStats_builder struct {
 	// Counts remain useful diagnostics; reason flags carry replay eligibility
 	// even for warn-and-retain policies that do not drop a row.
 	ReasonFlags uint64
+	// Attempt-level observations. A retry or resumed page may observe the same
+	// malformed connector record again.
+	InvalidResourceTypesObserved uint64
+	InvalidResourcesObserved     uint64
+	InvalidEntitlementsObserved  uint64
 }
 
 func (b0 IngestQualityStats_builder) Build() *IngestQualityStats {
@@ -2173,6 +2216,9 @@ func (b0 IngestQualityStats_builder) Build() *IngestQualityStats {
 	x.ExpansionResourceTypesDropped = b.ExpansionResourceTypesDropped
 	x.ExpansionsDropped = b.ExpansionsDropped
 	x.ReasonFlags = b.ReasonFlags
+	x.InvalidResourceTypesObserved = b.InvalidResourceTypesObserved
+	x.InvalidResourcesObserved = b.InvalidResourcesObserved
+	x.InvalidEntitlementsObserved = b.InvalidEntitlementsObserved
 	return m0
 }
 
@@ -2824,7 +2870,7 @@ const file_c1_storage_v3_records_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\v2\x17.c1.storage.v3.CallStatR\x05value:\x028\x01\x1a]\n" +
 	"\x16SessionStoreStatsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12-\n" +
-	"\x05value\x18\x02 \x01(\v2\x17.c1.storage.v3.CallStatR\x05value:\x028\x01\"\x80\x03\n" +
+	"\x05value\x18\x02 \x01(\v2\x17.c1.storage.v3.CallStatR\x05value:\x028\x01\"\xc9\x04\n" +
 	"\x12IngestQualityStats\x12=\n" +
 	"\x1bsource_cache_replay_blocked\x18\x01 \x01(\bR\x18sourceCacheReplayBlocked\x121\n" +
 	"\x14entitlements_dropped\x18\x02 \x01(\x04R\x13entitlementsDropped\x12%\n" +
@@ -2832,7 +2878,11 @@ const file_c1_storage_v3_records_proto_rawDesc = "" +
 	"\x17grant_resources_dropped\x18\x04 \x01(\x04R\x15grantResourcesDropped\x12G\n" +
 	" expansion_resource_types_dropped\x18\x05 \x01(\x04R\x1dexpansionResourceTypesDropped\x12-\n" +
 	"\x12expansions_dropped\x18\x06 \x01(\x04R\x11expansionsDropped\x12!\n" +
-	"\freason_flags\x18\a \x01(\x04R\vreasonFlags\"\x86\x01\n" +
+	"\freason_flags\x18\a \x01(\x04R\vreasonFlags\x12E\n" +
+	"\x1finvalid_resource_types_observed\x18\b \x01(\x04R\x1cinvalidResourceTypesObserved\x12<\n" +
+	"\x1ainvalid_resources_observed\x18\t \x01(\x04R\x18invalidResourcesObserved\x12B\n" +
+	"\x1dinvalid_entitlements_observed\x18\n" +
+	" \x01(\x04R\x1binvalidEntitlementsObserved\"\x86\x01\n" +
 	"\bCallStat\x12\x14\n" +
 	"\x05count\x18\x01 \x01(\x03R\x05count\x12\x19\n" +
 	"\btotal_ms\x18\x02 \x01(\x03R\atotalMs\x12\x15\n" +

--- a/pb/c1/storage/v3/records.pb.validate.go
+++ b/pb/c1/storage/v3/records.pb.validate.go
@@ -1939,6 +1939,12 @@ func (m *IngestQualityStats) validate(all bool) error {
 
 	// no validation rules for ReasonFlags
 
+	// no validation rules for InvalidResourceTypesObserved
+
+	// no validation rules for InvalidResourcesObserved
+
+	// no validation rules for InvalidEntitlementsObserved
+
 	if len(errors) > 0 {
 		return IngestQualityStatsMultiError(errors)
 	}

--- a/pb/c1/storage/v3/records_protoopaque.pb.go
+++ b/pb/c1/storage/v3/records_protoopaque.pb.go
@@ -1951,6 +1951,9 @@ type IngestQualityStats struct {
 	xxx_hidden_ExpansionResourceTypesDropped uint64                 `protobuf:"varint,5,opt,name=expansion_resource_types_dropped,json=expansionResourceTypesDropped,proto3"`
 	xxx_hidden_ExpansionsDropped             uint64                 `protobuf:"varint,6,opt,name=expansions_dropped,json=expansionsDropped,proto3"`
 	xxx_hidden_ReasonFlags                   uint64                 `protobuf:"varint,7,opt,name=reason_flags,json=reasonFlags,proto3"`
+	xxx_hidden_InvalidResourceTypesObserved  uint64                 `protobuf:"varint,8,opt,name=invalid_resource_types_observed,json=invalidResourceTypesObserved,proto3"`
+	xxx_hidden_InvalidResourcesObserved      uint64                 `protobuf:"varint,9,opt,name=invalid_resources_observed,json=invalidResourcesObserved,proto3"`
+	xxx_hidden_InvalidEntitlementsObserved   uint64                 `protobuf:"varint,10,opt,name=invalid_entitlements_observed,json=invalidEntitlementsObserved,proto3"`
 	unknownFields                            protoimpl.UnknownFields
 	sizeCache                                protoimpl.SizeCache
 }
@@ -2029,6 +2032,27 @@ func (x *IngestQualityStats) GetReasonFlags() uint64 {
 	return 0
 }
 
+func (x *IngestQualityStats) GetInvalidResourceTypesObserved() uint64 {
+	if x != nil {
+		return x.xxx_hidden_InvalidResourceTypesObserved
+	}
+	return 0
+}
+
+func (x *IngestQualityStats) GetInvalidResourcesObserved() uint64 {
+	if x != nil {
+		return x.xxx_hidden_InvalidResourcesObserved
+	}
+	return 0
+}
+
+func (x *IngestQualityStats) GetInvalidEntitlementsObserved() uint64 {
+	if x != nil {
+		return x.xxx_hidden_InvalidEntitlementsObserved
+	}
+	return 0
+}
+
 func (x *IngestQualityStats) SetSourceCacheReplayBlocked(v bool) {
 	x.xxx_hidden_SourceCacheReplayBlocked = v
 }
@@ -2057,6 +2081,18 @@ func (x *IngestQualityStats) SetReasonFlags(v uint64) {
 	x.xxx_hidden_ReasonFlags = v
 }
 
+func (x *IngestQualityStats) SetInvalidResourceTypesObserved(v uint64) {
+	x.xxx_hidden_InvalidResourceTypesObserved = v
+}
+
+func (x *IngestQualityStats) SetInvalidResourcesObserved(v uint64) {
+	x.xxx_hidden_InvalidResourcesObserved = v
+}
+
+func (x *IngestQualityStats) SetInvalidEntitlementsObserved(v uint64) {
+	x.xxx_hidden_InvalidEntitlementsObserved = v
+}
+
 type IngestQualityStats_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
@@ -2075,6 +2111,11 @@ type IngestQualityStats_builder struct {
 	// Counts remain useful diagnostics; reason flags carry replay eligibility
 	// even for warn-and-retain policies that do not drop a row.
 	ReasonFlags uint64
+	// Attempt-level observations. A retry or resumed page may observe the same
+	// malformed connector record again.
+	InvalidResourceTypesObserved uint64
+	InvalidResourcesObserved     uint64
+	InvalidEntitlementsObserved  uint64
 }
 
 func (b0 IngestQualityStats_builder) Build() *IngestQualityStats {
@@ -2088,6 +2129,9 @@ func (b0 IngestQualityStats_builder) Build() *IngestQualityStats {
 	x.xxx_hidden_ExpansionResourceTypesDropped = b.ExpansionResourceTypesDropped
 	x.xxx_hidden_ExpansionsDropped = b.ExpansionsDropped
 	x.xxx_hidden_ReasonFlags = b.ReasonFlags
+	x.xxx_hidden_InvalidResourceTypesObserved = b.InvalidResourceTypesObserved
+	x.xxx_hidden_InvalidResourcesObserved = b.InvalidResourcesObserved
+	x.xxx_hidden_InvalidEntitlementsObserved = b.InvalidEntitlementsObserved
 	return m0
 }
 
@@ -2716,7 +2760,7 @@ const file_c1_storage_v3_records_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\v2\x17.c1.storage.v3.CallStatR\x05value:\x028\x01\x1a]\n" +
 	"\x16SessionStoreStatsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12-\n" +
-	"\x05value\x18\x02 \x01(\v2\x17.c1.storage.v3.CallStatR\x05value:\x028\x01\"\x80\x03\n" +
+	"\x05value\x18\x02 \x01(\v2\x17.c1.storage.v3.CallStatR\x05value:\x028\x01\"\xc9\x04\n" +
 	"\x12IngestQualityStats\x12=\n" +
 	"\x1bsource_cache_replay_blocked\x18\x01 \x01(\bR\x18sourceCacheReplayBlocked\x121\n" +
 	"\x14entitlements_dropped\x18\x02 \x01(\x04R\x13entitlementsDropped\x12%\n" +
@@ -2724,7 +2768,11 @@ const file_c1_storage_v3_records_proto_rawDesc = "" +
 	"\x17grant_resources_dropped\x18\x04 \x01(\x04R\x15grantResourcesDropped\x12G\n" +
 	" expansion_resource_types_dropped\x18\x05 \x01(\x04R\x1dexpansionResourceTypesDropped\x12-\n" +
 	"\x12expansions_dropped\x18\x06 \x01(\x04R\x11expansionsDropped\x12!\n" +
-	"\freason_flags\x18\a \x01(\x04R\vreasonFlags\"\x86\x01\n" +
+	"\freason_flags\x18\a \x01(\x04R\vreasonFlags\x12E\n" +
+	"\x1finvalid_resource_types_observed\x18\b \x01(\x04R\x1cinvalidResourceTypesObserved\x12<\n" +
+	"\x1ainvalid_resources_observed\x18\t \x01(\x04R\x18invalidResourcesObserved\x12B\n" +
+	"\x1dinvalid_entitlements_observed\x18\n" +
+	" \x01(\x04R\x1binvalidEntitlementsObserved\"\x86\x01\n" +
 	"\bCallStat\x12\x14\n" +
 	"\x05count\x18\x01 \x01(\x03R\x05count\x12\x19\n" +
 	"\btotal_ms\x18\x02 \x01(\x03R\atotalMs\x12\x15\n" +

--- a/pkg/dotc1z/c1zstore/sync_token_stats.go
+++ b/pkg/dotc1z/c1zstore/sync_token_stats.go
@@ -33,6 +33,9 @@ type tokenIngestQuality struct {
 	GrantResourcesDropped         uint64 `json:"grant_resources_dropped,omitempty"`
 	ExpansionResourceTypesDropped uint64 `json:"expansion_resource_types_dropped,omitempty"`
 	ExpansionsDropped             uint64 `json:"expansions_dropped,omitempty"`
+	InvalidResourceTypesObserved  uint64 `json:"invalid_resource_types_observed,omitempty"`
+	InvalidResourcesObserved      uint64 `json:"invalid_resources_observed,omitempty"`
+	InvalidEntitlementsObserved   uint64 `json:"invalid_entitlements_observed,omitempty"`
 	ReasonFlags                   uint64 `json:"reason_flags,omitempty"`
 }
 
@@ -116,6 +119,9 @@ func toStorageIngestQuality(in *tokenIngestQuality) *v3.IngestQualityStats {
 		GrantResourcesDropped:         in.GrantResourcesDropped,
 		ExpansionResourceTypesDropped: in.ExpansionResourceTypesDropped,
 		ExpansionsDropped:             in.ExpansionsDropped,
+		InvalidResourceTypesObserved:  in.InvalidResourceTypesObserved,
+		InvalidResourcesObserved:      in.InvalidResourcesObserved,
+		InvalidEntitlementsObserved:   in.InvalidEntitlementsObserved,
 		ReasonFlags:                   in.ReasonFlags,
 	}.Build()
 }

--- a/pkg/dotc1z/c1zstore/sync_token_stats_test.go
+++ b/pkg/dotc1z/c1zstore/sync_token_stats_test.go
@@ -19,12 +19,17 @@ func TestApplySyncTokenStatsRecordPreservesIngestQualityPresence(t *testing.T) {
 			want:       &v3.IngestQualityStats{},
 		},
 		{
-			name:       "blocked",
-			checkpoint: `{"version":1,"ingest_quality":{"source_cache_replay_blocked":true,"grants_dropped":3,"reason_flags":2}}`,
+			name: "blocked",
+			checkpoint: `{"version":1,"ingest_quality":{"source_cache_replay_blocked":true,"grants_dropped":3,` +
+				`"invalid_resource_types_observed":4,"invalid_resources_observed":5,` +
+				`"invalid_entitlements_observed":6,"reason_flags":2}}`,
 			want: v3.IngestQualityStats_builder{
-				SourceCacheReplayBlocked: true,
-				GrantsDropped:            3,
-				ReasonFlags:              2,
+				SourceCacheReplayBlocked:     true,
+				GrantsDropped:                3,
+				InvalidResourceTypesObserved: 4,
+				InvalidResourcesObserved:     5,
+				InvalidEntitlementsObserved:  6,
+				ReasonFlags:                  2,
 			}.Build(),
 		},
 	} {

--- a/pkg/sync/chaos_connector_test.go
+++ b/pkg/sync/chaos_connector_test.go
@@ -139,7 +139,7 @@ func TestChaosConnectorDuplicateResourceIsIdempotent(t *testing.T) {
 	assertChaosStoreMatches(t, c1zPath, tmpDir, chaosoracle.ExpectedIdentities(manifest))
 }
 
-func TestChaosConnectorEmptyResourceFailsWithoutSealing(t *testing.T) {
+func TestChaosConnectorEmptyResourceIsSkipped(t *testing.T) {
 	ctx := t.Context()
 	tmpDir := t.TempDir()
 	c1zPath := filepath.Join(tmpDir, "chaos-empty-resource.c1z")
@@ -162,9 +162,7 @@ func TestChaosConnectorEmptyResourceFailsWithoutSealing(t *testing.T) {
 	}))
 	require.NoError(t, err)
 	harness := newChaosHarness(t, ctx, run, c1zPath, tmpDir, chaosTransportDirect)
-	syncErr := harness.Syncer.Sync(ctx)
-	require.ErrorContains(t, syncErr, "resource with missing identity")
-	require.Equal(t, codes.Internal, status.Code(syncErr))
+	require.NoError(t, harness.Syncer.Sync(ctx))
 	require.NoError(t, harness.Close(ctx))
 	require.NoError(t, run.Runtime().VerifyRequired())
 
@@ -179,10 +177,10 @@ func TestChaosConnectorEmptyResourceFailsWithoutSealing(t *testing.T) {
 	defer func() { require.NoError(t, store.Close(ctx)) }()
 	latest, err := store.SyncMeta().LatestFullSync(ctx)
 	require.NoError(t, err)
-	require.Nil(t, latest, "empty connector records must not seal a sync")
+	require.NotNil(t, latest, "skipping an unkeyable resource must still seal the sync")
 }
 
-func TestChaosConnectorEmptyResourceTypeFailsWithoutSealing(t *testing.T) {
+func TestChaosConnectorEmptyResourceTypeIsSkipped(t *testing.T) {
 	ctx := t.Context()
 	tmpDir := t.TempDir()
 	c1zPath := filepath.Join(tmpDir, "chaos-empty-resource-type.c1z")
@@ -205,9 +203,7 @@ func TestChaosConnectorEmptyResourceTypeFailsWithoutSealing(t *testing.T) {
 	}))
 	require.NoError(t, err)
 	harness := newChaosHarness(t, ctx, run, c1zPath, tmpDir, chaosTransportDirect)
-	syncErr := harness.Syncer.Sync(ctx)
-	require.ErrorContains(t, syncErr, "resource type with missing identity")
-	require.Equal(t, codes.Internal, status.Code(syncErr))
+	require.NoError(t, harness.Syncer.Sync(ctx))
 	require.NoError(t, harness.Close(ctx))
 	require.NoError(t, run.Runtime().VerifyRequired())
 
@@ -222,7 +218,7 @@ func TestChaosConnectorEmptyResourceTypeFailsWithoutSealing(t *testing.T) {
 	defer func() { require.NoError(t, store.Close(ctx)) }()
 	latest, err := store.SyncMeta().LatestFullSync(ctx)
 	require.NoError(t, err)
-	require.Nil(t, latest, "an unkeyable resource type must not seal a sync")
+	require.NotNil(t, latest, "skipping an unkeyable resource type must still seal the sync")
 }
 
 func TestChaosConnectorDuplicateEnqueueAnnotationFailsWithoutSealing(t *testing.T) {
@@ -361,7 +357,7 @@ func TestChaosConnectorFatalErrorDoesNotSeal(t *testing.T) {
 	require.Nil(t, latest, "fatal connector error must not produce a sealed full sync")
 }
 
-func TestChaosConnectorMalformedEntitlementFailsCleanly(t *testing.T) {
+func TestChaosConnectorMalformedEntitlementIsSkipped(t *testing.T) {
 	ctx := t.Context()
 	tmpDir := t.TempDir()
 	c1zPath := filepath.Join(tmpDir, "chaos-malformed-entitlement.c1z")
@@ -375,14 +371,13 @@ func TestChaosConnectorMalformedEntitlementFailsCleanly(t *testing.T) {
 		}
 	}
 	require.NotNil(t, corpusCase.Apply, "entitlement-missing-resource corpus case must exist")
-	require.Equal(t, chaosconnector.DataPolicyFail, corpusCase.Policy)
+	require.Equal(t, chaosconnector.DataPolicySkipReport, corpusCase.Policy)
 	require.NoError(t, corpusCase.Apply(scenario))
 
 	run, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
 	require.NoError(t, err)
 	harness := newChaosHarness(t, ctx, run, c1zPath, tmpDir, chaosTransportDirect)
-	syncErr := harness.Syncer.Sync(ctx)
-	require.ErrorContains(t, syncErr, "missing resource")
+	require.NoError(t, harness.Syncer.Sync(ctx))
 	require.NoError(t, harness.Close(ctx))
 	store, err := dotc1z.NewStore(
 		ctx,
@@ -395,7 +390,7 @@ func TestChaosConnectorMalformedEntitlementFailsCleanly(t *testing.T) {
 	defer func() { require.NoError(t, store.Close(ctx)) }()
 	latest, err := store.SyncMeta().LatestFullSync(ctx)
 	require.NoError(t, err)
-	require.Nil(t, latest, "malformed connector data must not seal")
+	require.NotNil(t, latest, "skipped malformed connector data must not prevent sealing")
 }
 
 func TestChaosConnectorSeededFanoutWithRetries(t *testing.T) {

--- a/pkg/sync/chaos_referential_test.go
+++ b/pkg/sync/chaos_referential_test.go
@@ -65,7 +65,11 @@ func runReferentialCorpusCase(
 			require.Zero(t, concreteSyncer.ingestFilterStats.entitlementsDropped.Load())
 			require.Zero(t, concreteSyncer.ingestFilterStats.grantsDropped.Load())
 		case chaosconnector.ReferentialEntitlement:
-			require.EqualValues(t, 1, concreteSyncer.ingestFilterStats.entitlementsDropped.Load())
+			if corpusCase.Reference == chaosconnector.ReferenceTypeUnknown {
+				require.EqualValues(t, 1, concreteSyncer.ingestFilterStats.entitlementsDropped.Load())
+			} else {
+				require.Zero(t, concreteSyncer.ingestFilterStats.entitlementsDropped.Load())
+			}
 		case chaosconnector.ReferentialGrant:
 			require.EqualValues(t, 1, concreteSyncer.ingestFilterStats.grantsDropped.Load())
 		}

--- a/pkg/sync/connector_resource_validation_test.go
+++ b/pkg/sync/connector_resource_validation_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 )
@@ -16,42 +16,38 @@ func TestValidateConnectorResourceIdentity(t *testing.T) {
 	}.Build()
 
 	tests := []struct {
-		name        string
-		resource    *v2.Resource
-		errContains string
+		name     string
+		resource *v2.Resource
+		reason   string
 	}{
 		{name: "valid identity", resource: valid},
-		{name: "nil resource", errContains: "nil resource"},
+		{name: "nil resource", reason: connectorDataNil},
 		{
-			name:        "missing identity",
-			resource:    v2.Resource_builder{}.Build(),
-			errContains: "missing identity",
+			name:     "missing identity",
+			resource: v2.Resource_builder{}.Build(),
+			reason:   connectorDataMissingIdentity,
 		},
 		{
 			name: "missing resource type",
 			resource: v2.Resource_builder{
 				Id: v2.ResourceId_builder{Resource: "u1"}.Build(),
 			}.Build(),
-			errContains: "missing identity",
+			reason: connectorDataMissingIdentity,
 		},
 		{
 			name: "missing resource id",
 			resource: v2.Resource_builder{
 				Id: v2.ResourceId_builder{ResourceType: "user"}.Build(),
 			}.Build(),
-			errContains: "missing identity",
+			reason: connectorDataMissingIdentity,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := validateConnectorResource(test.resource)
-			if test.errContains == "" {
-				require.NoError(t, err)
-				return
-			}
-			require.Equal(t, codes.Internal, status.Code(err))
-			require.ErrorContains(t, err, test.errContains)
+			reason, err := validateConnectorResource(test.resource)
+			require.NoError(t, err)
+			require.Equal(t, test.reason, reason)
 		})
 	}
 }
@@ -63,7 +59,7 @@ func TestValidateConnectorEntitlementIdentity(t *testing.T) {
 	tests := []struct {
 		name        string
 		entitlement *v2.Entitlement
-		errContains string
+		reason      string
 	}{
 		{
 			name: "valid identity",
@@ -72,28 +68,24 @@ func TestValidateConnectorEntitlementIdentity(t *testing.T) {
 				Resource: validResource,
 			}.Build(),
 		},
-		{name: "nil entitlement", errContains: "nil entitlement"},
+		{name: "nil entitlement", reason: connectorDataNil},
 		{
 			name:        "missing entitlement id",
 			entitlement: v2.Entitlement_builder{Resource: validResource}.Build(),
-			errContains: "missing identity",
+			reason:      connectorDataMissingIdentity,
 		},
 		{
 			name:        "missing resource",
 			entitlement: v2.Entitlement_builder{Id: "member"}.Build(),
-			errContains: "missing resource identity",
+			reason:      connectorDataMissingResourceIdentity,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := validateConnectorEntitlement(test.entitlement)
-			if test.errContains == "" {
-				require.NoError(t, err)
-				return
-			}
-			require.Equal(t, codes.Internal, status.Code(err))
-			require.ErrorContains(t, err, test.errContains)
+			reason, err := validateConnectorEntitlement(test.entitlement)
+			require.NoError(t, err)
+			require.Equal(t, test.reason, reason)
 		})
 	}
 }
@@ -102,29 +94,75 @@ func TestValidateConnectorResourceTypeIdentity(t *testing.T) {
 	tests := []struct {
 		name         string
 		resourceType *v2.ResourceType
-		errContains  string
+		reason       string
 	}{
 		{
 			name:         "valid identity",
 			resourceType: v2.ResourceType_builder{Id: "user"}.Build(),
 		},
-		{name: "nil resource type", errContains: "nil resource type"},
+		{name: "nil resource type", reason: connectorDataNil},
 		{
 			name:         "missing identity",
 			resourceType: v2.ResourceType_builder{}.Build(),
-			errContains:  "missing identity",
+			reason:       connectorDataMissingIdentity,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := validateConnectorResourceType(test.resourceType)
-			if test.errContains == "" {
-				require.NoError(t, err)
-				return
-			}
-			require.Equal(t, codes.Internal, status.Code(err))
-			require.ErrorContains(t, err, test.errContains)
+			reason, err := validateConnectorResourceType(test.resourceType)
+			require.NoError(t, err)
+			require.Equal(t, test.reason, reason)
 		})
 	}
+}
+
+func TestInvalidConnectorDataSummaryReportsObservedCounts(t *testing.T) {
+	core, entries := newCaptureCore()
+	logger := zap.New(core)
+	s := &syncer{}
+
+	filtered, err := filterConnectorData(s, connectorDataResource,
+		[]*v2.Resource{nil, v2.Resource_builder{}.Build()},
+		validateConnectorResource,
+	)
+	require.NoError(t, err)
+	require.Empty(t, filtered)
+	s.logInvalidConnectorDataSummary(logger)
+
+	warning := findEntry(entries(), zapcore.WarnLevel, "connector returned invalid data; skipped records")
+	require.NotNil(t, warning)
+	require.EqualValues(t, 2, fieldInt(t, warning, "invalid_records_observed"))
+	require.EqualValues(t, 2, fieldInt(t, warning, "invalid_resources_observed"))
+}
+
+func BenchmarkFilterConnectorDataValidPage(b *testing.B) {
+	resource := v2.Resource_builder{
+		Id: v2.ResourceId_builder{ResourceType: "user", Resource: "u1"}.Build(),
+	}.Build()
+	resources := make([]*v2.Resource, 100)
+	for i := range resources {
+		resources[i] = resource
+	}
+	s := &syncer{}
+	b.Run("validation-only-baseline", func(b *testing.B) {
+		b.ReportAllocs()
+		for range b.N {
+			for _, value := range resources {
+				reason, err := validateConnectorResource(value)
+				if err != nil || reason != "" {
+					b.Fatalf("unexpected validation result: reason=%q err=%v", reason, err)
+				}
+			}
+		}
+	})
+	b.Run("filter", func(b *testing.B) {
+		b.ReportAllocs()
+		for range b.N {
+			filtered, err := filterConnectorData(s, connectorDataResource, resources, validateConnectorResource)
+			if err != nil || len(filtered) != len(resources) {
+				b.Fatalf("unexpected filter result: len=%d err=%v", len(filtered), err)
+			}
+		}
+	})
 }

--- a/pkg/sync/ingest_filter.go
+++ b/pkg/sync/ingest_filter.go
@@ -24,14 +24,17 @@ import (
 )
 
 type ingestFilterStats struct {
-	entitlementsDropped   atomic.Uint64
-	grantsDropped         atomic.Uint64
-	grantResourcesDropped atomic.Uint64
-	expansionTypesDropped atomic.Uint64
-	expansionsDropped     atomic.Uint64
-	replayBlocked         atomic.Bool
-	reasonFlags           atomic.Uint64
-	known                 atomic.Bool
+	entitlementsDropped          atomic.Uint64
+	grantsDropped                atomic.Uint64
+	grantResourcesDropped        atomic.Uint64
+	expansionTypesDropped        atomic.Uint64
+	expansionsDropped            atomic.Uint64
+	invalidResourceTypesObserved atomic.Uint64
+	invalidResourcesObserved     atomic.Uint64
+	invalidEntitlementsObserved  atomic.Uint64
+	replayBlocked                atomic.Bool
+	reasonFlags                  atomic.Uint64
+	known                        atomic.Bool
 }
 
 const (
@@ -90,6 +93,9 @@ func (s *ingestFilterStats) snapshot() *IngestQualityCheckpoint {
 		GrantResourcesDropped:         s.grantResourcesDropped.Load(),
 		ExpansionResourceTypesDropped: s.expansionTypesDropped.Load(),
 		ExpansionsDropped:             s.expansionsDropped.Load(),
+		InvalidResourceTypesObserved:  s.invalidResourceTypesObserved.Load(),
+		InvalidResourcesObserved:      s.invalidResourcesObserved.Load(),
+		InvalidEntitlementsObserved:   s.invalidEntitlementsObserved.Load(),
 		ReasonFlags:                   s.reasonFlags.Load(),
 	}
 }
@@ -105,6 +111,9 @@ func (s *ingestFilterStats) restore(snapshot *IngestQualityCheckpoint) {
 	s.grantResourcesDropped.Store(snapshot.GrantResourcesDropped)
 	s.expansionTypesDropped.Store(snapshot.ExpansionResourceTypesDropped)
 	s.expansionsDropped.Store(snapshot.ExpansionsDropped)
+	s.invalidResourceTypesObserved.Store(snapshot.InvalidResourceTypesObserved)
+	s.invalidResourcesObserved.Store(snapshot.InvalidResourcesObserved)
+	s.invalidEntitlementsObserved.Store(snapshot.InvalidEntitlementsObserved)
 	s.reasonFlags.Store(snapshot.ReasonFlags)
 }
 
@@ -179,10 +188,10 @@ func (s *syncer) filterFreshEntitlements(
 	}
 	out := make([]*v2.Entitlement, 0, len(entitlements))
 	for _, entitlement := range entitlements {
-		// A literal nil entry carries nothing to store or validate; engines
-		// skip nil writes inconsistently (pebble silently, sqlite not at
-		// all), so drop it here.
+		// Preserve nil for the connector-data filter so it can warn before
+		// dropping the record consistently across engines.
 		if entitlement == nil {
+			out = append(out, entitlement)
 			continue
 		}
 		// A missing resource ref is malformed-but-present data, not evidence

--- a/pkg/sync/ingest_filter_test.go
+++ b/pkg/sync/ingest_filter_test.go
@@ -490,6 +490,52 @@ func TestInsertResourceGrantsRejectsReservedBatonIDResource(t *testing.T) {
 	require.Empty(t, drives.GetList(), "reserved ownership row must not reach storage through grant uplift")
 }
 
+func TestInsertResourceGrantsSkipsUnkeyableDiscoveredResource(t *testing.T) {
+	ctx := t.Context()
+	tempDir := t.TempDir()
+	c1zPath := filepath.Join(tempDir, "irg-unkeyable-resource.c1z")
+	mc := newInsertResourceGrantsMockConnector(true)
+	mc.rtDB = append(mc.rtDB, v2.ResourceType_builder{Id: "shared_drive", DisplayName: "Shared Drive"}.Build())
+	group, _, err := mc.AddGroup(ctx, "g1")
+	require.NoError(t, err)
+	user, err := mc.AddUser(ctx, "u1")
+	require.NoError(t, err)
+	malformedDrive := v2.Resource_builder{
+		Id: v2.ResourceId_builder{ResourceType: "shared_drive"}.Build(),
+	}.Build()
+	mc.grantDB[group.GetId().GetResource()] = []*v2.Grant{
+		v2.Grant_builder{
+			Id: "malformed-drive-access",
+			Entitlement: v2.Entitlement_builder{
+				Id:       "malformed-drive-access",
+				Resource: malformedDrive,
+			}.Build(),
+			Principal: user,
+		}.Build(),
+	}
+
+	syncerInstance, err := NewSyncer(ctx, mc,
+		WithC1ZPath(c1zPath),
+		WithTmpDir(tempDir),
+		WithStorageEngine(c1zstore.EnginePebble),
+	)
+	require.NoError(t, err)
+	require.NoError(t, syncerInstance.Sync(ctx))
+	require.NoError(t, syncerInstance.Close(ctx))
+
+	store, err := dotc1z.NewStore(ctx, c1zPath,
+		dotc1z.WithEngine(c1zstore.EnginePebble),
+		dotc1z.WithTmpDir(tempDir),
+		dotc1z.WithReadOnly(true),
+	)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, store.Close(ctx)) }()
+	drives, err := store.ListResources(ctx,
+		v2.ResourcesServiceListResourcesRequest_builder{ResourceTypeId: "shared_drive"}.Build())
+	require.NoError(t, err)
+	require.Empty(t, drives.GetList(), "unkeyable grant-discovered resource must not reach storage")
+}
+
 // TestFreshIngestFilterRunsBeforeExclusionGroupValidation: an entitlement the
 // filter drops must not mutate exclusion-group state or fail the sync. Before
 // the ordering fix this sync failed with an "exclusion group used on multiple
@@ -529,11 +575,10 @@ func TestFreshIngestFilterRunsBeforeExclusionGroupValidation(t *testing.T) {
 	require.Contains(t, entIDs, scheduledEnt.GetId())
 }
 
-// TestFreshIngestFilterDropsNilEntries: literal nil entries carry nothing to
-// store or validate and are dropped, while malformed-but-present records
-// (missing refs) stay on the normal write path. Neither counts as a
-// disabled-type drop.
-func TestFreshIngestFilterDropsNilEntries(t *testing.T) {
+// TestFreshIngestFilterRoutesNilEntries: nil entitlements continue to connector
+// data validation so they are counted and reported; nil grants retain their
+// existing drop behavior. Neither counts as a disabled-type drop.
+func TestFreshIngestFilterRoutesNilEntries(t *testing.T) {
 	ctx, err := logging.Init(t.Context())
 	require.NoError(t, err)
 	store := newIngestFilterStore(ctx, t, c1zstore.EnginePebble)
@@ -547,7 +592,7 @@ func TestFreshIngestFilterDropsNilEntries(t *testing.T) {
 	goodEnt := ingestFilterEntitlement(ingestFilterResource("group", "g1"), "group:g1:member")
 	entitlements, err := s.filterFreshEntitlements(ctx, []*v2.Entitlement{nil, missingRefEnt, goodEnt})
 	require.NoError(t, err)
-	require.Equal(t, []*v2.Entitlement{missingRefEnt, goodEnt}, entitlements)
+	require.Equal(t, []*v2.Entitlement{nil, missingRefEnt, goodEnt}, entitlements)
 
 	missingRefGrant := v2.Grant_builder{Id: "no-refs"}.Build()
 	goodGrant := ingestFilterGrant("good", goodEnt, ingestFilterResource("group", "g2"))

--- a/pkg/sync/resource_ownership_test.go
+++ b/pkg/sync/resource_ownership_test.go
@@ -37,6 +37,15 @@ func TestPutConnectorResourcesRejectsReservedOwnership(t *testing.T) {
 	)
 	require.Zero(t, store.putCalls, "reserved marker must be rejected before any store write")
 
+	malformedReserved := v2.Resource_builder{
+		Annotations: annotations.New(&v2.BatonID{}),
+	}.Build()
+	require.ErrorContains(t,
+		syncer.putConnectorResources(t.Context(), malformedReserved),
+		"SDK-reserved BatonID ownership annotation",
+	)
+	require.Zero(t, store.putCalls, "reserved ownership must remain fatal even when identity is missing")
+
 	clean := v2.Resource_builder{
 		Id: v2.ResourceId_builder{
 			ResourceType: "user",

--- a/pkg/sync/state.go
+++ b/pkg/sync/state.go
@@ -303,6 +303,9 @@ type IngestQualityCheckpoint struct {
 	GrantResourcesDropped         uint64 `json:"grant_resources_dropped,omitempty"`
 	ExpansionResourceTypesDropped uint64 `json:"expansion_resource_types_dropped,omitempty"`
 	ExpansionsDropped             uint64 `json:"expansions_dropped,omitempty"`
+	InvalidResourceTypesObserved  uint64 `json:"invalid_resource_types_observed,omitempty"`
+	InvalidResourcesObserved      uint64 `json:"invalid_resources_observed,omitempty"`
+	InvalidEntitlementsObserved   uint64 `json:"invalid_entitlements_observed,omitempty"`
 	ReasonFlags                   uint64 `json:"reason_flags,omitempty"`
 }
 

--- a/pkg/sync/state_test.go
+++ b/pkg/sync/state_test.go
@@ -526,6 +526,9 @@ func TestStateIngestQualityRoundTripPreservesCleanPresence(t *testing.T) {
 			GrantResourcesDropped:         3,
 			ExpansionResourceTypesDropped: 4,
 			ExpansionsDropped:             5,
+			InvalidResourceTypesObserved:  6,
+			InvalidResourcesObserved:      7,
+			InvalidEntitlementsObserved:   8,
 			ReasonFlags:                   63,
 		},
 	} {

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -852,6 +852,7 @@ func (s *syncer) Sync(ctx context.Context) error {
 	}
 
 	l := ctxzap.Extract(ctx)
+	defer s.logInvalidConnectorDataSummary(l)
 
 	runCtx := ctx
 	var runCanc context.CancelFunc
@@ -1180,12 +1181,10 @@ func (s *syncer) listAllResourceTypes(ctx context.Context) iter.Seq2[[]*v2.Resou
 				_ = yield(nil, err)
 				return
 			}
-			resourceTypes := resp.GetList()
-			for _, resourceType := range resourceTypes {
-				if err := validateConnectorResourceType(resourceType); err != nil {
-					_ = yield(nil, err)
-					return
-				}
+			resourceTypes, err := filterConnectorData(s, connectorDataResourceType, resp.GetList(), validateConnectorResourceType)
+			if err != nil {
+				_ = yield(nil, err)
+				return
 			}
 			if len(resourceTypes) > 0 {
 				if !yield(resourceTypes, err) {
@@ -1222,10 +1221,9 @@ func (s *syncer) SyncResourceTypes(ctx context.Context, action *Action) error {
 	if err != nil {
 		return err
 	}
-	for _, resourceType := range resp.GetList() {
-		if err := validateConnectorResourceType(resourceType); err != nil {
-			return err
-		}
+	connectorResourceTypes, err := filterConnectorData(s, connectorDataResourceType, resp.GetList(), validateConnectorResourceType)
+	if err != nil {
+		return err
 	}
 
 	var resourceTypes []*v2.ResourceType
@@ -1234,13 +1232,13 @@ func (s *syncer) SyncResourceTypes(ctx context.Context, action *Action) error {
 		for _, rt := range s.syncResourceTypes {
 			syncResourceTypeMap[rt] = true
 		}
-		for _, rt := range resp.GetList() {
+		for _, rt := range connectorResourceTypes {
 			if shouldSync := syncResourceTypeMap[rt.GetId()]; shouldSync {
 				resourceTypes = append(resourceTypes, rt)
 			}
 		}
 	} else {
-		resourceTypes = resp.GetList()
+		resourceTypes = connectorResourceTypes
 	}
 
 	err = s.store.PutResourceTypes(ctx, resourceTypes...)
@@ -1448,9 +1446,14 @@ func (s *syncer) SyncTargetedResource(ctx context.Context, action *Action) error
 	if resource == nil {
 		return s.nextPageOrFinishAction(ctx, action, "")
 	}
-	if err := validateConnectorResource(resource); err != nil {
+	resources, err := filterConnectorData(s, connectorDataResource, []*v2.Resource{resource}, validateConnectorResource)
+	if err != nil {
 		return err
 	}
+	if len(resources) == 0 {
+		return s.nextPageOrFinishAction(ctx, action, "")
+	}
+	resource = resources[0]
 
 	// Save our resource in the DB
 	if err := s.putConnectorResources(ctx, resource); err != nil {
@@ -1592,11 +1595,12 @@ func (s *syncer) syncResources(ctx context.Context, action *Action) error {
 		return err
 	}
 
+	resources, err := filterConnectorData(s, connectorDataResource, resp.GetList(), validateConnectorResource)
+	if err != nil {
+		return err
+	}
 	bulkPutResoruces := []*v2.Resource{}
-	for _, r := range resp.GetList() {
-		if err := validateConnectorResource(r); err != nil {
-			return err
-		}
+	for _, r := range resources {
 		validatedResource := false
 
 		// Check if we've already synced this resource, skip it if we have
@@ -1678,52 +1682,127 @@ func resourceTraitMessage(t v2.ResourceType_Trait) proto.Message {
 	}
 }
 
-func validateConnectorResource(resource *v2.Resource) error {
-	if resource == nil {
-		return status.Error(codes.Internal, "connector returned a nil resource")
+const (
+	connectorDataResourceType            = "resource type"
+	connectorDataResource                = "resource"
+	connectorDataEntitlement             = "entitlement"
+	connectorDataNil                     = "nil record"
+	connectorDataMissingIdentity         = "missing identity"
+	connectorDataMissingResourceIdentity = "missing resource identity"
+)
+
+func (s *syncer) observeInvalidConnectorData(kind string) {
+	switch kind {
+	case connectorDataResourceType:
+		s.ingestFilterStats.invalidResourceTypesObserved.Add(1)
+	case connectorDataResource:
+		s.ingestFilterStats.invalidResourcesObserved.Add(1)
+	case connectorDataEntitlement:
+		s.ingestFilterStats.invalidEntitlementsObserved.Add(1)
+	default:
+		panic(fmt.Sprintf("unsupported connector data kind %q", kind))
 	}
-	resourceID := resource.GetId()
-	if resourceID == nil || resourceID.GetResourceType() == "" || resourceID.GetResource() == "" {
-		return status.Error(codes.Internal, "connector returned a resource with missing identity")
+}
+
+func (s *syncer) logInvalidConnectorDataSummary(l *zap.Logger) {
+	resourceTypes := s.ingestFilterStats.invalidResourceTypesObserved.Load()
+	resources := s.ingestFilterStats.invalidResourcesObserved.Load()
+	entitlements := s.ingestFilterStats.invalidEntitlementsObserved.Load()
+	total := resourceTypes + resources + entitlements
+	if total == 0 {
+		return
+	}
+	l.Warn("connector returned invalid data; skipped records",
+		zap.Uint64("invalid_records_observed", total),
+		zap.Uint64("invalid_resource_types_observed", resourceTypes),
+		zap.Uint64("invalid_resources_observed", resources),
+		zap.Uint64("invalid_entitlements_observed", entitlements),
+	)
+}
+
+type connectorDataRecord interface {
+	*v2.ResourceType | *v2.Resource | *v2.Entitlement
+}
+
+func filterConnectorData[T connectorDataRecord](
+	s *syncer,
+	kind string,
+	values []T,
+	validate func(T) (string, error),
+) ([]T, error) {
+	var out []T
+	for i, value := range values {
+		reason, err := validate(value)
+		if err != nil {
+			return nil, err
+		}
+		if reason == "" {
+			if out != nil {
+				out = append(out, value)
+			}
+			continue
+		}
+		if out == nil {
+			out = make([]T, 0, len(values)-1)
+			out = append(out, values[:i]...)
+		}
+		s.observeInvalidConnectorData(kind)
+	}
+	if out == nil {
+		return values, nil
+	}
+	return out, nil
+}
+
+func validateConnectorResource(resource *v2.Resource) (string, error) {
+	if resource == nil {
+		return connectorDataNil, nil
 	}
 	resourceAnnos := annotations.Annotations(resource.GetAnnotations())
 	if resourceAnnos.Contains(&v2.BatonID{}) {
-		return status.Error(codes.Internal,
+		return "", status.Error(codes.Internal,
 			"connector returned a resource with SDK-reserved BatonID ownership annotation")
 	}
-	return nil
+	resourceID := resource.GetId()
+	if resourceID == nil || resourceID.GetResourceType() == "" || resourceID.GetResource() == "" {
+		return connectorDataMissingIdentity, nil
+	}
+	return "", nil
 }
 
 func (s *syncer) putConnectorResources(ctx context.Context, resources ...*v2.Resource) error {
-	for _, resource := range resources {
-		if err := validateConnectorResource(resource); err != nil {
-			return err
-		}
+	resources, err := filterConnectorData(s, connectorDataResource, resources, validateConnectorResource)
+	if err != nil {
+		return err
 	}
 	return s.store.PutResources(ctx, resources...)
 }
 
-func validateConnectorEntitlement(entitlement *v2.Entitlement) error {
+func validateConnectorEntitlement(entitlement *v2.Entitlement) (string, error) {
 	if entitlement == nil {
-		return status.Error(codes.Internal, "connector returned a nil entitlement")
+		return connectorDataNil, nil
 	}
 	if entitlement.GetId() == "" {
-		return status.Error(codes.Internal, "connector returned an entitlement with missing identity")
+		return connectorDataMissingIdentity, nil
 	}
-	if err := validateConnectorResource(entitlement.GetResource()); err != nil {
-		return status.Error(codes.Internal, "connector returned an entitlement with missing resource identity")
+	reason, err := validateConnectorResource(entitlement.GetResource())
+	if err != nil {
+		return "", err
 	}
-	return nil
+	if reason != "" {
+		return connectorDataMissingResourceIdentity, nil
+	}
+	return "", nil
 }
 
-func validateConnectorResourceType(resourceType *v2.ResourceType) error {
+func validateConnectorResourceType(resourceType *v2.ResourceType) (string, error) {
 	if resourceType == nil {
-		return status.Error(codes.Internal, "connector returned a nil resource type")
+		return connectorDataNil, nil
 	}
 	if resourceType.GetId() == "" {
-		return status.Error(codes.Internal, "connector returned a resource type with missing identity")
+		return connectorDataMissingIdentity, nil
 	}
-	return nil
+	return "", nil
 }
 
 // No span here: this is called per-resource, but only does I/O on the
@@ -1975,10 +2054,9 @@ func (s *syncer) syncEntitlementsForResource(ctx context.Context, action *Action
 	if err != nil {
 		return fmt.Errorf("sync-entitlements: filtering disabled-type references: %w", err)
 	}
-	for _, entitlement := range entitlements {
-		if err := validateConnectorEntitlement(entitlement); err != nil {
-			return err
-		}
+	entitlements, err = filterConnectorData(s, connectorDataEntitlement, entitlements, validateConnectorEntitlement)
+	if err != nil {
+		return err
 	}
 	err = s.store.PutEntitlements(ctx, entitlements...)
 	if err != nil {
@@ -2569,13 +2647,29 @@ func (s *syncer) syncGrantsForResource(ctx context.Context, action *Action) erro
 		// dropped for an unscheduled principal type. Resources of unscheduled
 		// types are skipped — uplift can't resolve their type, so the row
 		// would be dead data.
-		for _, g := range grants {
+		var validInsertGrants []*v2.Grant
+		for i, g := range grants {
 			resource := g.GetEntitlement().GetResource()
+			reason, err := validateConnectorResource(resource)
+			if err != nil {
+				return fmt.Errorf("sync-grants-for-resource: validating grant-discovered resource: %w", err)
+			}
+			if reason != "" {
+				s.observeInvalidConnectorData(connectorDataResource)
+				if validInsertGrants == nil {
+					validInsertGrants = make([]*v2.Grant, 0, len(grants)-1)
+					validInsertGrants = append(validInsertGrants, grants[:i]...)
+				}
+				continue
+			}
 			ok, err := s.filterFreshGrantResource(ctx, resource)
 			if err != nil {
 				return fmt.Errorf("sync-grants-for-resource: filtering grant-discovered resource: %w", err)
 			}
 			if !ok {
+				if validInsertGrants != nil {
+					validInsertGrants = append(validInsertGrants, g)
+				}
 				continue
 			}
 			bid, err := bid.MakeBid(resource)
@@ -2583,6 +2677,12 @@ func (s *syncer) syncGrantsForResource(ctx context.Context, action *Action) erro
 				return err
 			}
 			resourcesToInsertMap[bid] = resource
+			if validInsertGrants != nil {
+				validInsertGrants = append(validInsertGrants, g)
+			}
+		}
+		if validInsertGrants != nil {
+			grants = validInsertGrants
 		}
 	}
 

--- a/pkg/sync/type_scoped_test.go
+++ b/pkg/sync/type_scoped_test.go
@@ -477,7 +477,7 @@ func TestParallelActionQueueReleasesDequeuedStorage(t *testing.T) {
 	require.Zero(t, queue.outstanding)
 }
 
-func TestEmptyResourceIDFailsBeforePerResourceCalls(t *testing.T) {
+func TestEmptyResourceIDIsSkippedBeforePerResourceCalls(t *testing.T) {
 	ctx := t.Context()
 	tmpDir := t.TempDir()
 	resourceType := v2.ResourceType_builder{
@@ -497,7 +497,7 @@ func TestEmptyResourceIDFailsBeforePerResourceCalls(t *testing.T) {
 		WithTmpDir(tmpDir),
 	)
 	require.NoError(t, err)
-	require.ErrorContains(t, s.Sync(ctx), "connector returned a resource with missing identity")
+	require.NoError(t, s.Sync(ctx))
 	require.NoError(t, s.Close(ctx))
 	require.Zero(t, connector.entitlementCalls)
 	require.Zero(t, connector.grantCalls)

--- a/proto/c1/storage/v3/records.proto
+++ b/proto/c1/storage/v3/records.proto
@@ -356,6 +356,11 @@ message IngestQualityStats {
   // Counts remain useful diagnostics; reason flags carry replay eligibility
   // even for warn-and-retain policies that do not drop a row.
   uint64 reason_flags = 7;
+  // Attempt-level observations. A retry or resumed page may observe the same
+  // malformed connector record again.
+  uint64 invalid_resource_types_observed = 8;
+  uint64 invalid_resources_observed = 9;
+  uint64 invalid_entitlements_observed = 10;
 }
 
 // CallStat mirrors c1.reader.v2.CallStat for the storage sidecar.


### PR DESCRIPTION
change default behavior to warn instead of explode in the case of severely malformed connector data.