### PR TITLE
Let InvokeAction callers request a longer inline wait

### DIFF
--- a/pb/c1/connector/v2/action.pb.go
+++ b/pb/c1/connector/v2/action.pb.go
@@ -311,9 +311,11 @@ type InvokeActionRequest struct {
 	// Optional: if set, invokes a resource-scoped action
 	ResourceTypeId string `protobuf:"bytes,4,opt,name=resource_type_id,json=resourceTypeId,proto3" json:"resource_type_id,omitempty"`
 	// Optional: how long the server may block this call waiting for the action
-	// to finish before returning its in-flight status. Unset leaves the wait at
-	// the server's default, and the server may silently cap an oversized wait
-	// rather than reject it. The server does not shorten the wait to fit the
+	// to finish before returning its in-flight status. The wait is an upper
+	// bound on blocking, not a guarantee: the server may answer sooner, and it
+	// may silently cap an oversized wait rather than reject it. Unset or
+	// non-positive values take the server's default. The server does not
+	// shorten the wait to fit the
 	// call's deadline, so callers must set their RPC deadline above the
 	// requested wait; a deadline that fires first fails the call instead of
 	// returning an in-flight status with an action id, while the action itself
@@ -434,9 +436,11 @@ type InvokeActionRequest_builder struct {
 	// Optional: if set, invokes a resource-scoped action
 	ResourceTypeId string
 	// Optional: how long the server may block this call waiting for the action
-	// to finish before returning its in-flight status. Unset leaves the wait at
-	// the server's default, and the server may silently cap an oversized wait
-	// rather than reject it. The server does not shorten the wait to fit the
+	// to finish before returning its in-flight status. The wait is an upper
+	// bound on blocking, not a guarantee: the server may answer sooner, and it
+	// may silently cap an oversized wait rather than reject it. Unset or
+	// non-positive values take the server's default. The server does not
+	// shorten the wait to fit the
 	// call's deadline, so callers must set their RPC deadline above the
 	// requested wait; a deadline that fires first fails the call instead of
 	// returning an in-flight status with an action id, while the action itself

--- a/pb/c1/connector/v2/action.pb.go
+++ b/pb/c1/connector/v2/action.pb.go
@@ -312,7 +312,8 @@ type InvokeActionRequest struct {
 	ResourceTypeId string `protobuf:"bytes,4,opt,name=resource_type_id,json=resourceTypeId,proto3" json:"resource_type_id,omitempty"`
 	// Optional: how long the server may block this call waiting for the action
 	// to finish before returning its in-flight status. Unset leaves the wait at
-	// the server's default. The server does not shorten the wait to fit the
+	// the server's default, and the server may silently cap an oversized wait
+	// rather than reject it. The server does not shorten the wait to fit the
 	// call's deadline, so callers must set their RPC deadline above the
 	// requested wait; a deadline that fires first fails the call instead of
 	// returning an in-flight status with an action id, while the action itself
@@ -434,7 +435,8 @@ type InvokeActionRequest_builder struct {
 	ResourceTypeId string
 	// Optional: how long the server may block this call waiting for the action
 	// to finish before returning its in-flight status. Unset leaves the wait at
-	// the server's default. The server does not shorten the wait to fit the
+	// the server's default, and the server may silently cap an oversized wait
+	// rather than reject it. The server does not shorten the wait to fit the
 	// call's deadline, so callers must set their RPC deadline above the
 	// requested wait; a deadline that fires first fails the call instead of
 	// returning an in-flight status with an action id, while the action itself

--- a/pb/c1/connector/v2/action.pb.go
+++ b/pb/c1/connector/v2/action.pb.go
@@ -13,6 +13,7 @@ import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	anypb "google.golang.org/protobuf/types/known/anypb"
+	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	structpb "google.golang.org/protobuf/types/known/structpb"
 	reflect "reflect"
 	unsafe "unsafe"
@@ -309,8 +310,12 @@ type InvokeActionRequest struct {
 	Annotations []*anypb.Any           `protobuf:"bytes,3,rep,name=annotations,proto3" json:"annotations,omitempty"`
 	// Optional: if set, invokes a resource-scoped action
 	ResourceTypeId string `protobuf:"bytes,4,opt,name=resource_type_id,json=resourceTypeId,proto3" json:"resource_type_id,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// Optional: how long the server may block this call waiting for the action
+	// to finish before returning its in-flight status. Unset leaves the wait at
+	// the server's default.
+	InlineWait    *durationpb.Duration `protobuf:"bytes,5,opt,name=inline_wait,json=inlineWait,proto3" json:"inline_wait,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *InvokeActionRequest) Reset() {
@@ -366,6 +371,13 @@ func (x *InvokeActionRequest) GetResourceTypeId() string {
 	return ""
 }
 
+func (x *InvokeActionRequest) GetInlineWait() *durationpb.Duration {
+	if x != nil {
+		return x.InlineWait
+	}
+	return nil
+}
+
 func (x *InvokeActionRequest) SetName(v string) {
 	x.Name = v
 }
@@ -382,6 +394,10 @@ func (x *InvokeActionRequest) SetResourceTypeId(v string) {
 	x.ResourceTypeId = v
 }
 
+func (x *InvokeActionRequest) SetInlineWait(v *durationpb.Duration) {
+	x.InlineWait = v
+}
+
 func (x *InvokeActionRequest) HasArgs() bool {
 	if x == nil {
 		return false
@@ -389,8 +405,19 @@ func (x *InvokeActionRequest) HasArgs() bool {
 	return x.Args != nil
 }
 
+func (x *InvokeActionRequest) HasInlineWait() bool {
+	if x == nil {
+		return false
+	}
+	return x.InlineWait != nil
+}
+
 func (x *InvokeActionRequest) ClearArgs() {
 	x.Args = nil
+}
+
+func (x *InvokeActionRequest) ClearInlineWait() {
+	x.InlineWait = nil
 }
 
 type InvokeActionRequest_builder struct {
@@ -401,6 +428,10 @@ type InvokeActionRequest_builder struct {
 	Annotations []*anypb.Any
 	// Optional: if set, invokes a resource-scoped action
 	ResourceTypeId string
+	// Optional: how long the server may block this call waiting for the action
+	// to finish before returning its in-flight status. Unset leaves the wait at
+	// the server's default.
+	InlineWait *durationpb.Duration
 }
 
 func (b0 InvokeActionRequest_builder) Build() *InvokeActionRequest {
@@ -411,6 +442,7 @@ func (b0 InvokeActionRequest_builder) Build() *InvokeActionRequest {
 	x.Args = b.Args
 	x.Annotations = b.Annotations
 	x.ResourceTypeId = b.ResourceTypeId
+	x.InlineWait = b.InlineWait
 	return m0
 }
 
@@ -1052,7 +1084,7 @@ var File_c1_connector_v2_action_proto protoreflect.FileDescriptor
 
 const file_c1_connector_v2_action_proto_rawDesc = "" +
 	"\n" +
-	"\x1cc1/connector/v2/action.proto\x12\x0fc1.connector.v2\x1a\x19c1/config/v1/config.proto\x1a\x19google/protobuf/any.proto\x1a\x1cgoogle/protobuf/struct.proto\"\xfb\x02\n" +
+	"\x1cc1/connector/v2/action.proto\x12\x0fc1.connector.v2\x1a\x19c1/config/v1/config.proto\x1a\x19google/protobuf/any.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1cgoogle/protobuf/struct.proto\"\xfb\x02\n" +
 	"\x11BatonActionSchema\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x121\n" +
 	"\targuments\x18\x02 \x03(\v2\x13.c1.config.v1.FieldR\targuments\x12:\n" +
@@ -1062,12 +1094,14 @@ const file_c1_connector_v2_action_proto_rawDesc = "" +
 	"\vdescription\x18\x06 \x01(\tR\vdescription\x12<\n" +
 	"\vaction_type\x18\a \x03(\x0e2\x1b.c1.connector.v2.ActionTypeR\n" +
 	"actionType\x12(\n" +
-	"\x10resource_type_id\x18\b \x01(\tR\x0eresourceTypeId\"\xb8\x01\n" +
+	"\x10resource_type_id\x18\b \x01(\tR\x0eresourceTypeId\"\xf4\x01\n" +
 	"\x13InvokeActionRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12+\n" +
 	"\x04args\x18\x02 \x01(\v2\x17.google.protobuf.StructR\x04args\x126\n" +
 	"\vannotations\x18\x03 \x03(\v2\x14.google.protobuf.AnyR\vannotations\x12(\n" +
-	"\x10resource_type_id\x18\x04 \x01(\tR\x0eresourceTypeId\"\xe3\x01\n" +
+	"\x10resource_type_id\x18\x04 \x01(\tR\x0eresourceTypeId\x12:\n" +
+	"\vinline_wait\x18\x05 \x01(\v2\x19.google.protobuf.DurationR\n" +
+	"inlineWait\"\xe3\x01\n" +
 	"\x14InvokeActionResponse\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12:\n" +
 	"\x06status\x18\x02 \x01(\x0e2\".c1.connector.v2.BatonActionStatusR\x06status\x126\n" +
@@ -1139,6 +1173,7 @@ var file_c1_connector_v2_action_proto_goTypes = []any{
 	(*v1.Constraint)(nil),             // 12: c1.config.v1.Constraint
 	(*structpb.Struct)(nil),           // 13: google.protobuf.Struct
 	(*anypb.Any)(nil),                 // 14: google.protobuf.Any
+	(*durationpb.Duration)(nil),       // 15: google.protobuf.Duration
 }
 var file_c1_connector_v2_action_proto_depIdxs = []int32{
 	11, // 0: c1.connector.v2.BatonActionSchema.arguments:type_name -> c1.config.v1.Field
@@ -1147,32 +1182,33 @@ var file_c1_connector_v2_action_proto_depIdxs = []int32{
 	1,  // 3: c1.connector.v2.BatonActionSchema.action_type:type_name -> c1.connector.v2.ActionType
 	13, // 4: c1.connector.v2.InvokeActionRequest.args:type_name -> google.protobuf.Struct
 	14, // 5: c1.connector.v2.InvokeActionRequest.annotations:type_name -> google.protobuf.Any
-	0,  // 6: c1.connector.v2.InvokeActionResponse.status:type_name -> c1.connector.v2.BatonActionStatus
-	14, // 7: c1.connector.v2.InvokeActionResponse.annotations:type_name -> google.protobuf.Any
-	13, // 8: c1.connector.v2.InvokeActionResponse.response:type_name -> google.protobuf.Struct
-	14, // 9: c1.connector.v2.GetActionStatusRequest.annotations:type_name -> google.protobuf.Any
-	0,  // 10: c1.connector.v2.GetActionStatusResponse.status:type_name -> c1.connector.v2.BatonActionStatus
-	14, // 11: c1.connector.v2.GetActionStatusResponse.annotations:type_name -> google.protobuf.Any
-	13, // 12: c1.connector.v2.GetActionStatusResponse.response:type_name -> google.protobuf.Struct
-	14, // 13: c1.connector.v2.GetActionSchemaRequest.annotations:type_name -> google.protobuf.Any
-	2,  // 14: c1.connector.v2.GetActionSchemaResponse.schema:type_name -> c1.connector.v2.BatonActionSchema
-	14, // 15: c1.connector.v2.GetActionSchemaResponse.annotations:type_name -> google.protobuf.Any
-	14, // 16: c1.connector.v2.ListActionSchemasRequest.annotations:type_name -> google.protobuf.Any
-	2,  // 17: c1.connector.v2.ListActionSchemasResponse.schemas:type_name -> c1.connector.v2.BatonActionSchema
-	14, // 18: c1.connector.v2.ListActionSchemasResponse.annotations:type_name -> google.protobuf.Any
-	3,  // 19: c1.connector.v2.ActionService.InvokeAction:input_type -> c1.connector.v2.InvokeActionRequest
-	5,  // 20: c1.connector.v2.ActionService.GetActionStatus:input_type -> c1.connector.v2.GetActionStatusRequest
-	7,  // 21: c1.connector.v2.ActionService.GetActionSchema:input_type -> c1.connector.v2.GetActionSchemaRequest
-	9,  // 22: c1.connector.v2.ActionService.ListActionSchemas:input_type -> c1.connector.v2.ListActionSchemasRequest
-	4,  // 23: c1.connector.v2.ActionService.InvokeAction:output_type -> c1.connector.v2.InvokeActionResponse
-	6,  // 24: c1.connector.v2.ActionService.GetActionStatus:output_type -> c1.connector.v2.GetActionStatusResponse
-	8,  // 25: c1.connector.v2.ActionService.GetActionSchema:output_type -> c1.connector.v2.GetActionSchemaResponse
-	10, // 26: c1.connector.v2.ActionService.ListActionSchemas:output_type -> c1.connector.v2.ListActionSchemasResponse
-	23, // [23:27] is the sub-list for method output_type
-	19, // [19:23] is the sub-list for method input_type
-	19, // [19:19] is the sub-list for extension type_name
-	19, // [19:19] is the sub-list for extension extendee
-	0,  // [0:19] is the sub-list for field type_name
+	15, // 6: c1.connector.v2.InvokeActionRequest.inline_wait:type_name -> google.protobuf.Duration
+	0,  // 7: c1.connector.v2.InvokeActionResponse.status:type_name -> c1.connector.v2.BatonActionStatus
+	14, // 8: c1.connector.v2.InvokeActionResponse.annotations:type_name -> google.protobuf.Any
+	13, // 9: c1.connector.v2.InvokeActionResponse.response:type_name -> google.protobuf.Struct
+	14, // 10: c1.connector.v2.GetActionStatusRequest.annotations:type_name -> google.protobuf.Any
+	0,  // 11: c1.connector.v2.GetActionStatusResponse.status:type_name -> c1.connector.v2.BatonActionStatus
+	14, // 12: c1.connector.v2.GetActionStatusResponse.annotations:type_name -> google.protobuf.Any
+	13, // 13: c1.connector.v2.GetActionStatusResponse.response:type_name -> google.protobuf.Struct
+	14, // 14: c1.connector.v2.GetActionSchemaRequest.annotations:type_name -> google.protobuf.Any
+	2,  // 15: c1.connector.v2.GetActionSchemaResponse.schema:type_name -> c1.connector.v2.BatonActionSchema
+	14, // 16: c1.connector.v2.GetActionSchemaResponse.annotations:type_name -> google.protobuf.Any
+	14, // 17: c1.connector.v2.ListActionSchemasRequest.annotations:type_name -> google.protobuf.Any
+	2,  // 18: c1.connector.v2.ListActionSchemasResponse.schemas:type_name -> c1.connector.v2.BatonActionSchema
+	14, // 19: c1.connector.v2.ListActionSchemasResponse.annotations:type_name -> google.protobuf.Any
+	3,  // 20: c1.connector.v2.ActionService.InvokeAction:input_type -> c1.connector.v2.InvokeActionRequest
+	5,  // 21: c1.connector.v2.ActionService.GetActionStatus:input_type -> c1.connector.v2.GetActionStatusRequest
+	7,  // 22: c1.connector.v2.ActionService.GetActionSchema:input_type -> c1.connector.v2.GetActionSchemaRequest
+	9,  // 23: c1.connector.v2.ActionService.ListActionSchemas:input_type -> c1.connector.v2.ListActionSchemasRequest
+	4,  // 24: c1.connector.v2.ActionService.InvokeAction:output_type -> c1.connector.v2.InvokeActionResponse
+	6,  // 25: c1.connector.v2.ActionService.GetActionStatus:output_type -> c1.connector.v2.GetActionStatusResponse
+	8,  // 26: c1.connector.v2.ActionService.GetActionSchema:output_type -> c1.connector.v2.GetActionSchemaResponse
+	10, // 27: c1.connector.v2.ActionService.ListActionSchemas:output_type -> c1.connector.v2.ListActionSchemasResponse
+	24, // [24:28] is the sub-list for method output_type
+	20, // [20:24] is the sub-list for method input_type
+	20, // [20:20] is the sub-list for extension type_name
+	20, // [20:20] is the sub-list for extension extendee
+	0,  // [0:20] is the sub-list for field type_name
 }
 
 func init() { file_c1_connector_v2_action_proto_init() }

--- a/pb/c1/connector/v2/action.pb.go
+++ b/pb/c1/connector/v2/action.pb.go
@@ -315,11 +315,10 @@ type InvokeActionRequest struct {
 	// bound on blocking, not a guarantee: the server may answer sooner, and it
 	// may silently cap an oversized wait rather than reject it. Unset or
 	// non-positive values take the server's default. The server does not
-	// shorten the wait to fit the
-	// call's deadline, so callers must set their RPC deadline above the
-	// requested wait; a deadline that fires first fails the call instead of
-	// returning an in-flight status with an action id, while the action itself
-	// keeps running and stays queryable through GetActionStatus.
+	// shorten the wait to fit the call's deadline, so callers must set their
+	// RPC deadline above the requested wait: a deadline that fires first fails
+	// the call, and although the action keeps running server-side, its id is
+	// never delivered, so the outcome is unreachable to that caller.
 	InlineWait    *durationpb.Duration `protobuf:"bytes,5,opt,name=inline_wait,json=inlineWait,proto3" json:"inline_wait,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -440,11 +439,10 @@ type InvokeActionRequest_builder struct {
 	// bound on blocking, not a guarantee: the server may answer sooner, and it
 	// may silently cap an oversized wait rather than reject it. Unset or
 	// non-positive values take the server's default. The server does not
-	// shorten the wait to fit the
-	// call's deadline, so callers must set their RPC deadline above the
-	// requested wait; a deadline that fires first fails the call instead of
-	// returning an in-flight status with an action id, while the action itself
-	// keeps running and stays queryable through GetActionStatus.
+	// shorten the wait to fit the call's deadline, so callers must set their
+	// RPC deadline above the requested wait: a deadline that fires first fails
+	// the call, and although the action keeps running server-side, its id is
+	// never delivered, so the outcome is unreachable to that caller.
 	InlineWait *durationpb.Duration
 }
 

--- a/pb/c1/connector/v2/action.pb.go
+++ b/pb/c1/connector/v2/action.pb.go
@@ -312,7 +312,11 @@ type InvokeActionRequest struct {
 	ResourceTypeId string `protobuf:"bytes,4,opt,name=resource_type_id,json=resourceTypeId,proto3" json:"resource_type_id,omitempty"`
 	// Optional: how long the server may block this call waiting for the action
 	// to finish before returning its in-flight status. Unset leaves the wait at
-	// the server's default.
+	// the server's default. The server does not shorten the wait to fit the
+	// call's deadline, so callers must set their RPC deadline above the
+	// requested wait; a deadline that fires first fails the call instead of
+	// returning an in-flight status with an action id, while the action itself
+	// keeps running and stays queryable through GetActionStatus.
 	InlineWait    *durationpb.Duration `protobuf:"bytes,5,opt,name=inline_wait,json=inlineWait,proto3" json:"inline_wait,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -430,7 +434,11 @@ type InvokeActionRequest_builder struct {
 	ResourceTypeId string
 	// Optional: how long the server may block this call waiting for the action
 	// to finish before returning its in-flight status. Unset leaves the wait at
-	// the server's default.
+	// the server's default. The server does not shorten the wait to fit the
+	// call's deadline, so callers must set their RPC deadline above the
+	// requested wait; a deadline that fires first fails the call instead of
+	// returning an in-flight status with an action id, while the action itself
+	// keeps running and stays queryable through GetActionStatus.
 	InlineWait *durationpb.Duration
 }
 

--- a/pb/c1/connector/v2/action.pb.validate.go
+++ b/pb/c1/connector/v2/action.pb.validate.go
@@ -336,6 +336,35 @@ func (m *InvokeActionRequest) validate(all bool) error {
 
 	// no validation rules for ResourceTypeId
 
+	if all {
+		switch v := interface{}(m.GetInlineWait()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, InvokeActionRequestValidationError{
+					field:  "InlineWait",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, InvokeActionRequestValidationError{
+					field:  "InlineWait",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetInlineWait()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return InvokeActionRequestValidationError{
+				field:  "InlineWait",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if len(errors) > 0 {
 		return InvokeActionRequestMultiError(errors)
 	}

--- a/pb/c1/connector/v2/action_protoopaque.pb.go
+++ b/pb/c1/connector/v2/action_protoopaque.pb.go
@@ -436,11 +436,10 @@ type InvokeActionRequest_builder struct {
 	// bound on blocking, not a guarantee: the server may answer sooner, and it
 	// may silently cap an oversized wait rather than reject it. Unset or
 	// non-positive values take the server's default. The server does not
-	// shorten the wait to fit the
-	// call's deadline, so callers must set their RPC deadline above the
-	// requested wait; a deadline that fires first fails the call instead of
-	// returning an in-flight status with an action id, while the action itself
-	// keeps running and stays queryable through GetActionStatus.
+	// shorten the wait to fit the call's deadline, so callers must set their
+	// RPC deadline above the requested wait: a deadline that fires first fails
+	// the call, and although the action keeps running server-side, its id is
+	// never delivered, so the outcome is unreachable to that caller.
 	InlineWait *durationpb.Duration
 }
 

--- a/pb/c1/connector/v2/action_protoopaque.pb.go
+++ b/pb/c1/connector/v2/action_protoopaque.pb.go
@@ -13,6 +13,7 @@ import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	anypb "google.golang.org/protobuf/types/known/anypb"
+	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	structpb "google.golang.org/protobuf/types/known/structpb"
 	reflect "reflect"
 	unsafe "unsafe"
@@ -313,6 +314,7 @@ type InvokeActionRequest struct {
 	xxx_hidden_Args           *structpb.Struct       `protobuf:"bytes,2,opt,name=args,proto3"`
 	xxx_hidden_Annotations    *[]*anypb.Any          `protobuf:"bytes,3,rep,name=annotations,proto3"`
 	xxx_hidden_ResourceTypeId string                 `protobuf:"bytes,4,opt,name=resource_type_id,json=resourceTypeId,proto3"`
+	xxx_hidden_InlineWait     *durationpb.Duration   `protobuf:"bytes,5,opt,name=inline_wait,json=inlineWait,proto3"`
 	unknownFields             protoimpl.UnknownFields
 	sizeCache                 protoimpl.SizeCache
 }
@@ -372,6 +374,13 @@ func (x *InvokeActionRequest) GetResourceTypeId() string {
 	return ""
 }
 
+func (x *InvokeActionRequest) GetInlineWait() *durationpb.Duration {
+	if x != nil {
+		return x.xxx_hidden_InlineWait
+	}
+	return nil
+}
+
 func (x *InvokeActionRequest) SetName(v string) {
 	x.xxx_hidden_Name = v
 }
@@ -388,6 +397,10 @@ func (x *InvokeActionRequest) SetResourceTypeId(v string) {
 	x.xxx_hidden_ResourceTypeId = v
 }
 
+func (x *InvokeActionRequest) SetInlineWait(v *durationpb.Duration) {
+	x.xxx_hidden_InlineWait = v
+}
+
 func (x *InvokeActionRequest) HasArgs() bool {
 	if x == nil {
 		return false
@@ -395,8 +408,19 @@ func (x *InvokeActionRequest) HasArgs() bool {
 	return x.xxx_hidden_Args != nil
 }
 
+func (x *InvokeActionRequest) HasInlineWait() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_InlineWait != nil
+}
+
 func (x *InvokeActionRequest) ClearArgs() {
 	x.xxx_hidden_Args = nil
+}
+
+func (x *InvokeActionRequest) ClearInlineWait() {
+	x.xxx_hidden_InlineWait = nil
 }
 
 type InvokeActionRequest_builder struct {
@@ -407,6 +431,10 @@ type InvokeActionRequest_builder struct {
 	Annotations []*anypb.Any
 	// Optional: if set, invokes a resource-scoped action
 	ResourceTypeId string
+	// Optional: how long the server may block this call waiting for the action
+	// to finish before returning its in-flight status. Unset leaves the wait at
+	// the server's default.
+	InlineWait *durationpb.Duration
 }
 
 func (b0 InvokeActionRequest_builder) Build() *InvokeActionRequest {
@@ -417,6 +445,7 @@ func (b0 InvokeActionRequest_builder) Build() *InvokeActionRequest {
 	x.xxx_hidden_Args = b.Args
 	x.xxx_hidden_Annotations = &b.Annotations
 	x.xxx_hidden_ResourceTypeId = b.ResourceTypeId
+	x.xxx_hidden_InlineWait = b.InlineWait
 	return m0
 }
 
@@ -1072,7 +1101,7 @@ var File_c1_connector_v2_action_proto protoreflect.FileDescriptor
 
 const file_c1_connector_v2_action_proto_rawDesc = "" +
 	"\n" +
-	"\x1cc1/connector/v2/action.proto\x12\x0fc1.connector.v2\x1a\x19c1/config/v1/config.proto\x1a\x19google/protobuf/any.proto\x1a\x1cgoogle/protobuf/struct.proto\"\xfb\x02\n" +
+	"\x1cc1/connector/v2/action.proto\x12\x0fc1.connector.v2\x1a\x19c1/config/v1/config.proto\x1a\x19google/protobuf/any.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1cgoogle/protobuf/struct.proto\"\xfb\x02\n" +
 	"\x11BatonActionSchema\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x121\n" +
 	"\targuments\x18\x02 \x03(\v2\x13.c1.config.v1.FieldR\targuments\x12:\n" +
@@ -1082,12 +1111,14 @@ const file_c1_connector_v2_action_proto_rawDesc = "" +
 	"\vdescription\x18\x06 \x01(\tR\vdescription\x12<\n" +
 	"\vaction_type\x18\a \x03(\x0e2\x1b.c1.connector.v2.ActionTypeR\n" +
 	"actionType\x12(\n" +
-	"\x10resource_type_id\x18\b \x01(\tR\x0eresourceTypeId\"\xb8\x01\n" +
+	"\x10resource_type_id\x18\b \x01(\tR\x0eresourceTypeId\"\xf4\x01\n" +
 	"\x13InvokeActionRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12+\n" +
 	"\x04args\x18\x02 \x01(\v2\x17.google.protobuf.StructR\x04args\x126\n" +
 	"\vannotations\x18\x03 \x03(\v2\x14.google.protobuf.AnyR\vannotations\x12(\n" +
-	"\x10resource_type_id\x18\x04 \x01(\tR\x0eresourceTypeId\"\xe3\x01\n" +
+	"\x10resource_type_id\x18\x04 \x01(\tR\x0eresourceTypeId\x12:\n" +
+	"\vinline_wait\x18\x05 \x01(\v2\x19.google.protobuf.DurationR\n" +
+	"inlineWait\"\xe3\x01\n" +
 	"\x14InvokeActionResponse\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12:\n" +
 	"\x06status\x18\x02 \x01(\x0e2\".c1.connector.v2.BatonActionStatusR\x06status\x126\n" +
@@ -1159,6 +1190,7 @@ var file_c1_connector_v2_action_proto_goTypes = []any{
 	(*v1.Constraint)(nil),             // 12: c1.config.v1.Constraint
 	(*structpb.Struct)(nil),           // 13: google.protobuf.Struct
 	(*anypb.Any)(nil),                 // 14: google.protobuf.Any
+	(*durationpb.Duration)(nil),       // 15: google.protobuf.Duration
 }
 var file_c1_connector_v2_action_proto_depIdxs = []int32{
 	11, // 0: c1.connector.v2.BatonActionSchema.arguments:type_name -> c1.config.v1.Field
@@ -1167,32 +1199,33 @@ var file_c1_connector_v2_action_proto_depIdxs = []int32{
 	1,  // 3: c1.connector.v2.BatonActionSchema.action_type:type_name -> c1.connector.v2.ActionType
 	13, // 4: c1.connector.v2.InvokeActionRequest.args:type_name -> google.protobuf.Struct
 	14, // 5: c1.connector.v2.InvokeActionRequest.annotations:type_name -> google.protobuf.Any
-	0,  // 6: c1.connector.v2.InvokeActionResponse.status:type_name -> c1.connector.v2.BatonActionStatus
-	14, // 7: c1.connector.v2.InvokeActionResponse.annotations:type_name -> google.protobuf.Any
-	13, // 8: c1.connector.v2.InvokeActionResponse.response:type_name -> google.protobuf.Struct
-	14, // 9: c1.connector.v2.GetActionStatusRequest.annotations:type_name -> google.protobuf.Any
-	0,  // 10: c1.connector.v2.GetActionStatusResponse.status:type_name -> c1.connector.v2.BatonActionStatus
-	14, // 11: c1.connector.v2.GetActionStatusResponse.annotations:type_name -> google.protobuf.Any
-	13, // 12: c1.connector.v2.GetActionStatusResponse.response:type_name -> google.protobuf.Struct
-	14, // 13: c1.connector.v2.GetActionSchemaRequest.annotations:type_name -> google.protobuf.Any
-	2,  // 14: c1.connector.v2.GetActionSchemaResponse.schema:type_name -> c1.connector.v2.BatonActionSchema
-	14, // 15: c1.connector.v2.GetActionSchemaResponse.annotations:type_name -> google.protobuf.Any
-	14, // 16: c1.connector.v2.ListActionSchemasRequest.annotations:type_name -> google.protobuf.Any
-	2,  // 17: c1.connector.v2.ListActionSchemasResponse.schemas:type_name -> c1.connector.v2.BatonActionSchema
-	14, // 18: c1.connector.v2.ListActionSchemasResponse.annotations:type_name -> google.protobuf.Any
-	3,  // 19: c1.connector.v2.ActionService.InvokeAction:input_type -> c1.connector.v2.InvokeActionRequest
-	5,  // 20: c1.connector.v2.ActionService.GetActionStatus:input_type -> c1.connector.v2.GetActionStatusRequest
-	7,  // 21: c1.connector.v2.ActionService.GetActionSchema:input_type -> c1.connector.v2.GetActionSchemaRequest
-	9,  // 22: c1.connector.v2.ActionService.ListActionSchemas:input_type -> c1.connector.v2.ListActionSchemasRequest
-	4,  // 23: c1.connector.v2.ActionService.InvokeAction:output_type -> c1.connector.v2.InvokeActionResponse
-	6,  // 24: c1.connector.v2.ActionService.GetActionStatus:output_type -> c1.connector.v2.GetActionStatusResponse
-	8,  // 25: c1.connector.v2.ActionService.GetActionSchema:output_type -> c1.connector.v2.GetActionSchemaResponse
-	10, // 26: c1.connector.v2.ActionService.ListActionSchemas:output_type -> c1.connector.v2.ListActionSchemasResponse
-	23, // [23:27] is the sub-list for method output_type
-	19, // [19:23] is the sub-list for method input_type
-	19, // [19:19] is the sub-list for extension type_name
-	19, // [19:19] is the sub-list for extension extendee
-	0,  // [0:19] is the sub-list for field type_name
+	15, // 6: c1.connector.v2.InvokeActionRequest.inline_wait:type_name -> google.protobuf.Duration
+	0,  // 7: c1.connector.v2.InvokeActionResponse.status:type_name -> c1.connector.v2.BatonActionStatus
+	14, // 8: c1.connector.v2.InvokeActionResponse.annotations:type_name -> google.protobuf.Any
+	13, // 9: c1.connector.v2.InvokeActionResponse.response:type_name -> google.protobuf.Struct
+	14, // 10: c1.connector.v2.GetActionStatusRequest.annotations:type_name -> google.protobuf.Any
+	0,  // 11: c1.connector.v2.GetActionStatusResponse.status:type_name -> c1.connector.v2.BatonActionStatus
+	14, // 12: c1.connector.v2.GetActionStatusResponse.annotations:type_name -> google.protobuf.Any
+	13, // 13: c1.connector.v2.GetActionStatusResponse.response:type_name -> google.protobuf.Struct
+	14, // 14: c1.connector.v2.GetActionSchemaRequest.annotations:type_name -> google.protobuf.Any
+	2,  // 15: c1.connector.v2.GetActionSchemaResponse.schema:type_name -> c1.connector.v2.BatonActionSchema
+	14, // 16: c1.connector.v2.GetActionSchemaResponse.annotations:type_name -> google.protobuf.Any
+	14, // 17: c1.connector.v2.ListActionSchemasRequest.annotations:type_name -> google.protobuf.Any
+	2,  // 18: c1.connector.v2.ListActionSchemasResponse.schemas:type_name -> c1.connector.v2.BatonActionSchema
+	14, // 19: c1.connector.v2.ListActionSchemasResponse.annotations:type_name -> google.protobuf.Any
+	3,  // 20: c1.connector.v2.ActionService.InvokeAction:input_type -> c1.connector.v2.InvokeActionRequest
+	5,  // 21: c1.connector.v2.ActionService.GetActionStatus:input_type -> c1.connector.v2.GetActionStatusRequest
+	7,  // 22: c1.connector.v2.ActionService.GetActionSchema:input_type -> c1.connector.v2.GetActionSchemaRequest
+	9,  // 23: c1.connector.v2.ActionService.ListActionSchemas:input_type -> c1.connector.v2.ListActionSchemasRequest
+	4,  // 24: c1.connector.v2.ActionService.InvokeAction:output_type -> c1.connector.v2.InvokeActionResponse
+	6,  // 25: c1.connector.v2.ActionService.GetActionStatus:output_type -> c1.connector.v2.GetActionStatusResponse
+	8,  // 26: c1.connector.v2.ActionService.GetActionSchema:output_type -> c1.connector.v2.GetActionSchemaResponse
+	10, // 27: c1.connector.v2.ActionService.ListActionSchemas:output_type -> c1.connector.v2.ListActionSchemasResponse
+	24, // [24:28] is the sub-list for method output_type
+	20, // [20:24] is the sub-list for method input_type
+	20, // [20:20] is the sub-list for extension type_name
+	20, // [20:20] is the sub-list for extension extendee
+	0,  // [0:20] is the sub-list for field type_name
 }
 
 func init() { file_c1_connector_v2_action_proto_init() }

--- a/pb/c1/connector/v2/action_protoopaque.pb.go
+++ b/pb/c1/connector/v2/action_protoopaque.pb.go
@@ -433,7 +433,8 @@ type InvokeActionRequest_builder struct {
 	ResourceTypeId string
 	// Optional: how long the server may block this call waiting for the action
 	// to finish before returning its in-flight status. Unset leaves the wait at
-	// the server's default. The server does not shorten the wait to fit the
+	// the server's default, and the server may silently cap an oversized wait
+	// rather than reject it. The server does not shorten the wait to fit the
 	// call's deadline, so callers must set their RPC deadline above the
 	// requested wait; a deadline that fires first fails the call instead of
 	// returning an in-flight status with an action id, while the action itself

--- a/pb/c1/connector/v2/action_protoopaque.pb.go
+++ b/pb/c1/connector/v2/action_protoopaque.pb.go
@@ -433,7 +433,11 @@ type InvokeActionRequest_builder struct {
 	ResourceTypeId string
 	// Optional: how long the server may block this call waiting for the action
 	// to finish before returning its in-flight status. Unset leaves the wait at
-	// the server's default.
+	// the server's default. The server does not shorten the wait to fit the
+	// call's deadline, so callers must set their RPC deadline above the
+	// requested wait; a deadline that fires first fails the call instead of
+	// returning an in-flight status with an action id, while the action itself
+	// keeps running and stays queryable through GetActionStatus.
 	InlineWait *durationpb.Duration
 }
 

--- a/pb/c1/connector/v2/action_protoopaque.pb.go
+++ b/pb/c1/connector/v2/action_protoopaque.pb.go
@@ -432,9 +432,11 @@ type InvokeActionRequest_builder struct {
 	// Optional: if set, invokes a resource-scoped action
 	ResourceTypeId string
 	// Optional: how long the server may block this call waiting for the action
-	// to finish before returning its in-flight status. Unset leaves the wait at
-	// the server's default, and the server may silently cap an oversized wait
-	// rather than reject it. The server does not shorten the wait to fit the
+	// to finish before returning its in-flight status. The wait is an upper
+	// bound on blocking, not a guarantee: the server may answer sooner, and it
+	// may silently cap an oversized wait rather than reject it. Unset or
+	// non-positive values take the server's default. The server does not
+	// shorten the wait to fit the
 	// call's deadline, so callers must set their RPC deadline above the
 	// requested wait; a deadline that fires first fails the call instead of
 	// returning an in-flight status with an action id, while the action itself

--- a/pkg/actions/actions.go
+++ b/pkg/actions/actions.go
@@ -214,7 +214,13 @@ func (oa *OutstandingAction) setOutcome(ctx context.Context, rv *structpb.Struct
 	}
 }
 
-const maxOldActions = 1000
+const (
+	maxOldActions = 1000
+
+	// defaultInlineWait bounds the invoke-time wait when the caller does not
+	// request one.
+	defaultInlineWait = 1 * time.Second
+)
 
 // ActionRegistry provides methods for registering actions.
 // Used by both GlobalActionProvider (global actions) and ResourceActionProvider (resource-scoped actions).
@@ -541,15 +547,32 @@ func (a *ActionManager) InvokeAction(
 	resourceTypeID string,
 	args *structpb.Struct,
 ) (string, v2.BatonActionStatus, *structpb.Struct, annotations.Annotations, error) {
-	if resourceTypeID != "" {
-		return a.invokeResourceAction(ctx, resourceTypeID, name, args)
+	return a.InvokeActionWithWait(ctx, name, resourceTypeID, args, 0)
+}
+
+// InvokeActionWithWait is InvokeAction with an explicit bound on how long the
+// call may block waiting for the handler before returning the action's
+// in-flight status; zero or negative keeps the default.
+func (a *ActionManager) InvokeActionWithWait(
+	ctx context.Context,
+	name string,
+	resourceTypeID string,
+	args *structpb.Struct,
+	inlineWait time.Duration,
+) (string, v2.BatonActionStatus, *structpb.Struct, annotations.Annotations, error) {
+	if inlineWait <= 0 {
+		inlineWait = defaultInlineWait
 	}
 
-	return a.invokeGlobalAction(ctx, name, args)
+	if resourceTypeID != "" {
+		return a.invokeResourceAction(ctx, resourceTypeID, name, args, inlineWait)
+	}
+
+	return a.invokeGlobalAction(ctx, name, args, inlineWait)
 }
 
 // invokeGlobalAction invokes a global (non-resource-scoped) action.
-func (a *ActionManager) invokeGlobalAction(ctx context.Context, name string, args *structpb.Struct) (string, v2.BatonActionStatus, *structpb.Struct, annotations.Annotations, error) {
+func (a *ActionManager) invokeGlobalAction(ctx context.Context, name string, args *structpb.Struct, inlineWait time.Duration) (string, v2.BatonActionStatus, *structpb.Struct, annotations.Annotations, error) {
 	a.mu.RLock()
 	handler, ok := a.handlers[name]
 	schema, schemaOk := a.schemas[name]
@@ -571,9 +594,8 @@ func (a *ActionManager) invokeGlobalAction(ctx context.Context, name string, arg
 
 	done := make(chan struct{})
 
-	// If handler exits within a second, return result.
-	// If handler takes longer than 1 second, return status pending.
-	// If handler takes longer than an hour, return status failed.
+	// The handler runs detached. Return its final result if it finishes
+	// within the inline wait; otherwise return the in-flight status.
 	go func() { // #nosec G118 -- action handlers intentionally outlive the request context and keep only trace/log metadata.
 		defer close(done)
 		defer func() {
@@ -597,7 +619,7 @@ func (a *ActionManager) invokeGlobalAction(ctx context.Context, name string, arg
 	case <-done:
 		id, st, rv, annos := oa.result()
 		return id, st, rv, annos, nil
-	case <-time.After(1 * time.Second):
+	case <-time.After(inlineWait):
 		id, st, rv, annos := oa.result()
 		return id, st, rv, annos, nil
 	case <-ctx.Done():
@@ -626,6 +648,7 @@ func (a *ActionManager) invokeResourceAction(
 	resourceTypeID string,
 	actionName string,
 	args *structpb.Struct,
+	inlineWait time.Duration,
 ) (string, v2.BatonActionStatus, *structpb.Struct, annotations.Annotations, error) {
 	if resourceTypeID == "" {
 		return "", v2.BatonActionStatus_BATON_ACTION_STATUS_FAILED, nil, nil, status.Error(codes.InvalidArgument, "resource type ID is required")
@@ -699,7 +722,7 @@ func (a *ActionManager) invokeResourceAction(
 	case <-done:
 		id, st, rv, annos := oa.result()
 		return id, st, rv, annos, nil
-	case <-time.After(1 * time.Second):
+	case <-time.After(inlineWait):
 		id, st, rv, annos := oa.result()
 		return id, st, rv, annos, nil
 	case <-ctx.Done():

--- a/pkg/actions/actions.go
+++ b/pkg/actions/actions.go
@@ -220,7 +220,25 @@ const (
 	// defaultInlineWait bounds the invoke-time wait when the caller does not
 	// request one.
 	defaultInlineWait = 1 * time.Second
+
+	// maxInlineWait caps the requested wait at the handler context budget:
+	// holding the call open longer than a handler may run is never useful,
+	// and a saturated Duration must not pin the request forever on the
+	// deadline-less contexts service mode and the Lambda transport produce.
+	maxInlineWait = 1 * time.Hour
 )
+
+// clampInlineWait bounds a requested inline wait: non-positive values take
+// the server default and oversized values are capped at maxInlineWait.
+func clampInlineWait(inlineWait time.Duration) time.Duration {
+	if inlineWait <= 0 {
+		return defaultInlineWait
+	}
+	if inlineWait > maxInlineWait {
+		return maxInlineWait
+	}
+	return inlineWait
+}
 
 // ActionRegistry provides methods for registering actions.
 // Used by both GlobalActionProvider (global actions) and ResourceActionProvider (resource-scoped actions).
@@ -560,9 +578,7 @@ func (a *ActionManager) InvokeActionWithWait(
 	args *structpb.Struct,
 	inlineWait time.Duration,
 ) (string, v2.BatonActionStatus, *structpb.Struct, annotations.Annotations, error) {
-	if inlineWait <= 0 {
-		inlineWait = defaultInlineWait
-	}
+	inlineWait = clampInlineWait(inlineWait)
 
 	if resourceTypeID != "" {
 		return a.invokeResourceAction(ctx, resourceTypeID, name, args, inlineWait)
@@ -572,7 +588,12 @@ func (a *ActionManager) InvokeActionWithWait(
 }
 
 // invokeGlobalAction invokes a global (non-resource-scoped) action.
-func (a *ActionManager) invokeGlobalAction(ctx context.Context, name string, args *structpb.Struct, inlineWait time.Duration) (string, v2.BatonActionStatus, *structpb.Struct, annotations.Annotations, error) {
+func (a *ActionManager) invokeGlobalAction(
+	ctx context.Context,
+	name string,
+	args *structpb.Struct,
+	inlineWait time.Duration,
+) (string, v2.BatonActionStatus, *structpb.Struct, annotations.Annotations, error) {
 	a.mu.RLock()
 	handler, ok := a.handlers[name]
 	schema, schemaOk := a.schemas[name]
@@ -615,11 +636,16 @@ func (a *ActionManager) invokeGlobalAction(ctx context.Context, name string, arg
 		oa.setOutcome(ctx, rv, annos, oaErr)
 	}()
 
+	// A stopped timer releases immediately; time.After would pin a runtime
+	// timer for the full wait after the handler already finished.
+	waitTimer := time.NewTimer(inlineWait)
+	defer waitTimer.Stop()
+
 	select {
 	case <-done:
 		id, st, rv, annos := oa.result()
 		return id, st, rv, annos, nil
-	case <-time.After(inlineWait):
+	case <-waitTimer.C:
 		id, st, rv, annos := oa.result()
 		return id, st, rv, annos, nil
 	case <-ctx.Done():
@@ -717,12 +743,16 @@ func (a *ActionManager) invokeResourceAction(
 		oa.setOutcome(ctx, rv, annos, oaErr)
 	}()
 
-	// Wait for completion or timeout
+	// A stopped timer releases immediately; time.After would pin a runtime
+	// timer for the full wait after the handler already finished.
+	waitTimer := time.NewTimer(inlineWait)
+	defer waitTimer.Stop()
+
 	select {
 	case <-done:
 		id, st, rv, annos := oa.result()
 		return id, st, rv, annos, nil
-	case <-time.After(inlineWait):
+	case <-waitTimer.C:
 		id, st, rv, annos := oa.result()
 		return id, st, rv, annos, nil
 	case <-ctx.Done():

--- a/pkg/actions/actions.go
+++ b/pkg/actions/actions.go
@@ -580,7 +580,7 @@ func (a *ActionManager) InvokeActionWithWait(
 ) (string, v2.BatonActionStatus, *structpb.Struct, annotations.Annotations, error) {
 	clamped := clampInlineWait(inlineWait)
 	if clamped < inlineWait {
-		ctxzap.Extract(ctx).Debug("capping requested inline wait",
+		ctxzap.Extract(ctx).Warn("capping requested inline wait",
 			zap.Duration("requested", inlineWait),
 			zap.Duration("capped", clamped))
 	}

--- a/pkg/actions/actions.go
+++ b/pkg/actions/actions.go
@@ -578,7 +578,13 @@ func (a *ActionManager) InvokeActionWithWait(
 	args *structpb.Struct,
 	inlineWait time.Duration,
 ) (string, v2.BatonActionStatus, *structpb.Struct, annotations.Annotations, error) {
-	inlineWait = clampInlineWait(inlineWait)
+	clamped := clampInlineWait(inlineWait)
+	if clamped < inlineWait {
+		ctxzap.Extract(ctx).Debug("capping requested inline wait",
+			zap.Duration("requested", inlineWait),
+			zap.Duration("capped", clamped))
+	}
+	inlineWait = clamped
 
 	if resourceTypeID != "" {
 		return a.invokeResourceAction(ctx, resourceTypeID, name, args, inlineWait)
@@ -636,8 +642,8 @@ func (a *ActionManager) invokeGlobalAction(
 		oa.setOutcome(ctx, rv, annos, oaErr)
 	}()
 
-	// A stopped timer releases immediately; time.After would pin a runtime
-	// timer for the full wait after the handler already finished.
+	// Stop releases the timer deterministically when the handler wins the
+	// select; an abandoned time.After timer would only be GC-eligible.
 	waitTimer := time.NewTimer(inlineWait)
 	defer waitTimer.Stop()
 
@@ -743,8 +749,8 @@ func (a *ActionManager) invokeResourceAction(
 		oa.setOutcome(ctx, rv, annos, oaErr)
 	}()
 
-	// A stopped timer releases immediately; time.After would pin a runtime
-	// timer for the full wait after the handler already finished.
+	// Stop releases the timer deterministically when the handler wins the
+	// select; an abandoned time.After timer would only be GC-eligible.
 	waitTimer := time.NewTimer(inlineWait)
 	defer waitTimer.Stop()
 

--- a/pkg/actions/actions_test.go
+++ b/pkg/actions/actions_test.go
@@ -845,3 +845,59 @@ func TestCancelledInvokeStatusErrorPairing(t *testing.T) {
 		}
 	}
 }
+
+// testBlockingActionHandler blocks until release is closed (or the handler
+// context ends), so tests control exactly when the action completes.
+func testBlockingActionHandler(release <-chan struct{}) ActionHandler {
+	return func(ctx context.Context, args *structpb.Struct) (*structpb.Struct, annotations.Annotations, error) {
+		select {
+		case <-release:
+		case <-ctx.Done():
+			return nil, nil, status.Error(codes.Canceled, "context canceled")
+		}
+		return &structpb.Struct{
+			Fields: map[string]*structpb.Value{
+				"success": {Kind: &structpb.Value_BoolValue{BoolValue: true}},
+			},
+		}, nil, nil
+	}
+}
+
+func TestInvokeActionHonorsRequestedWait(t *testing.T) {
+	ctx := t.Context()
+	m := NewActionManager(ctx)
+
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	require.NoError(t, m.Register(ctx, testActionSchema, testBlockingActionHandler(release)))
+
+	start := time.Now()
+	actionId, actionStatus, _, _, err := m.InvokeActionWithWait(ctx, "lock_account", "", testInput, 2*time.Second)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	require.NotEmpty(t, actionId)
+	require.Equal(t, v2.BatonActionStatus_BATON_ACTION_STATUS_RUNNING, actionStatus)
+	require.GreaterOrEqual(t, elapsed, 2*time.Second)
+}
+
+func TestInvokeActionCompletesWithinRequestedWait(t *testing.T) {
+	ctx := t.Context()
+	m := NewActionManager(ctx)
+
+	release := make(chan struct{})
+	require.NoError(t, m.Register(ctx, testActionSchema, testBlockingActionHandler(release)))
+
+	// Complete the handler after the default one-second wait would have
+	// expired but well inside the requested window.
+	go func() {
+		time.Sleep(1500 * time.Millisecond)
+		close(release)
+	}()
+
+	_, actionStatus, rv, _, err := m.InvokeActionWithWait(ctx, "lock_account", "", testInput, 10*time.Second)
+	require.NoError(t, err)
+	require.Equal(t, v2.BatonActionStatus_BATON_ACTION_STATUS_COMPLETE, actionStatus)
+	require.NotNil(t, rv)
+	require.True(t, rv.Fields["success"].GetBoolValue())
+}

--- a/pkg/actions/actions_test.go
+++ b/pkg/actions/actions_test.go
@@ -3,6 +3,7 @@ package actions
 import (
 	"context"
 	"fmt"
+	"math"
 	"runtime"
 	"testing"
 	"time"
@@ -900,4 +901,49 @@ func TestInvokeActionCompletesWithinRequestedWait(t *testing.T) {
 	require.Equal(t, v2.BatonActionStatus_BATON_ACTION_STATUS_COMPLETE, actionStatus)
 	require.NotNil(t, rv)
 	require.True(t, rv.Fields["success"].GetBoolValue())
+}
+
+func TestClampInlineWait(t *testing.T) {
+	cases := []struct {
+		name string
+		in   time.Duration
+		want time.Duration
+	}{
+		{"zero takes the default", 0, defaultInlineWait},
+		{"negative takes the default", -time.Second, defaultInlineWait},
+		{"in range passes through", 42 * time.Second, 42 * time.Second},
+		{"oversized is capped", 300 * time.Hour, maxInlineWait},
+		{"saturated duration is capped", time.Duration(math.MaxInt64), maxInlineWait},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, clampInlineWait(tc.in))
+		})
+	}
+}
+
+func TestResourceActionInlineWaitThreads(t *testing.T) {
+	ctx := t.Context()
+	m := NewActionManager(ctx)
+
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	handler := func(hctx context.Context, _ *structpb.Struct) (*structpb.Struct, annotations.Annotations, error) {
+		select {
+		case <-release:
+		case <-hctx.Done():
+		}
+		return &structpb.Struct{}, nil, nil
+	}
+	require.NoError(t, m.RegisterResourceAction(ctx, "repository", testActionSchema, handler))
+
+	// The resource-scoped path duplicates the invoke select; the requested
+	// wait must thread through it just like the global path.
+	start := time.Now()
+	_, actionStatus, _, _, err := m.InvokeActionWithWait(ctx, "lock_account", "repository", testInput, 2*time.Second)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	require.Equal(t, v2.BatonActionStatus_BATON_ACTION_STATUS_RUNNING, actionStatus)
+	require.GreaterOrEqual(t, elapsed, 2*time.Second)
 }

--- a/pkg/connectorbuilder/actions.go
+++ b/pkg/connectorbuilder/actions.go
@@ -3,6 +3,7 @@ package connectorbuilder
 import (
 	"context"
 	"fmt"
+	"time"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/actions"
@@ -30,6 +31,17 @@ type ActionManager interface {
 		name string,
 		resourceTypeID string,
 		args *structpb.Struct,
+	) (string, v2.BatonActionStatus, *structpb.Struct, annotations.Annotations, error)
+
+	// InvokeActionWithWait is InvokeAction with an explicit bound on how long
+	// the call may block waiting for the handler; zero or negative keeps the
+	// manager's default.
+	InvokeActionWithWait(
+		ctx context.Context,
+		name string,
+		resourceTypeID string,
+		args *structpb.Struct,
+		inlineWait time.Duration,
 	) (string, v2.BatonActionStatus, *structpb.Struct, annotations.Annotations, error)
 
 	// GetActionStatus returns the status of an outstanding action.
@@ -154,7 +166,7 @@ func (b *builder) InvokeAction(ctx context.Context, request *v2.InvokeActionRequ
 
 	resourceTypeID := request.GetResourceTypeId()
 
-	id, actionStatus, resp, annos, err := b.actionManager.InvokeAction(ctx, request.GetName(), resourceTypeID, request.GetArgs())
+	id, actionStatus, resp, annos, err := b.actionManager.InvokeActionWithWait(ctx, request.GetName(), resourceTypeID, request.GetArgs(), request.GetInlineWait().AsDuration())
 	if err != nil {
 		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
 		return nil, fmt.Errorf("error: invoking action failed: %w", err)

--- a/pkg/connectorbuilder/actions_inline_wait_test.go
+++ b/pkg/connectorbuilder/actions_inline_wait_test.go
@@ -41,8 +41,8 @@ func (t *testBlockingGlobalActionProvider) GlobalActions(ctx context.Context, re
 }
 
 // The inline_wait request field must reach the action manager: a blocking
-// action invoked with a two-second wait returns RUNNING no earlier than that,
-// while an unset field keeps the default short wait.
+// action invoked with a three-second wait returns RUNNING no earlier than
+// that, while an unset field keeps the default short wait.
 func TestInvokeActionThreadsInlineWaitFromRequest(t *testing.T) {
 	ctx := t.Context()
 

--- a/pkg/connectorbuilder/actions_inline_wait_test.go
+++ b/pkg/connectorbuilder/actions_inline_wait_test.go
@@ -1,0 +1,85 @@
+package connectorbuilder
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/actions"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// Connectors return *actions.ActionManager as their deprecated
+// CustomActionManager (baton-microsoft-entra, baton-zendesk, ...), so its
+// method set must keep satisfying that interface.
+var _ CustomActionManager = (*actions.ActionManager)(nil)
+
+// testBlockingGlobalActionProvider registers one action whose handler blocks
+// until release is closed.
+type testBlockingGlobalActionProvider struct {
+	ConnectorBuilder
+	release chan struct{}
+}
+
+func (t *testBlockingGlobalActionProvider) GlobalActions(ctx context.Context, registry actions.ActionRegistry) error {
+	schema := v2.BatonActionSchema_builder{
+		Name:        "blocking-action",
+		DisplayName: "Blocking Action",
+	}.Build()
+	handler := func(hctx context.Context, _ *structpb.Struct) (*structpb.Struct, annotations.Annotations, error) {
+		select {
+		case <-t.release:
+		case <-hctx.Done():
+		}
+		return &structpb.Struct{}, nil, nil
+	}
+	return registry.Register(ctx, schema, handler)
+}
+
+// The inline_wait request field must reach the action manager: a blocking
+// action invoked with a two-second wait returns RUNNING no earlier than that,
+// while an unset field keeps the default short wait.
+func TestInvokeActionThreadsInlineWaitFromRequest(t *testing.T) {
+	ctx := t.Context()
+
+	provider := &testBlockingGlobalActionProvider{
+		ConnectorBuilder: newTestConnector([]ResourceSyncer{}),
+		release:          make(chan struct{}),
+	}
+	t.Cleanup(func() { close(provider.release) })
+
+	connector, err := NewConnector(ctx, provider)
+	require.NoError(t, err)
+
+	start := time.Now()
+	resp, err := connector.InvokeAction(ctx, v2.InvokeActionRequest_builder{
+		Name:       "blocking-action",
+		Args:       &structpb.Struct{},
+		InlineWait: durationpb.New(3 * time.Second),
+	}.Build())
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.GetId())
+	require.Equal(t, v2.BatonActionStatus_BATON_ACTION_STATUS_RUNNING, resp.GetStatus())
+	require.GreaterOrEqual(t, elapsed, 3*time.Second)
+
+	// An unset field keeps the default wait: the ceiling only has to exclude
+	// the explicit three-second wait above, leaving two seconds of slack over
+	// the one-second nominal.
+	start = time.Now()
+	resp, err = connector.InvokeAction(ctx, v2.InvokeActionRequest_builder{
+		Name: "blocking-action",
+		Args: &structpb.Struct{},
+	}.Build())
+	elapsed = time.Since(start)
+
+	require.NoError(t, err)
+	require.Equal(t, v2.BatonActionStatus_BATON_ACTION_STATUS_RUNNING, resp.GetStatus())
+	require.GreaterOrEqual(t, elapsed, time.Second)
+	require.Less(t, elapsed, 3*time.Second)
+}

--- a/proto/c1/connector/v2/action.proto
+++ b/proto/c1/connector/v2/action.proto
@@ -65,7 +65,8 @@ message InvokeActionRequest {
   string resource_type_id = 4;
   // Optional: how long the server may block this call waiting for the action
   // to finish before returning its in-flight status. Unset leaves the wait at
-  // the server's default. The server does not shorten the wait to fit the
+  // the server's default, and the server may silently cap an oversized wait
+  // rather than reject it. The server does not shorten the wait to fit the
   // call's deadline, so callers must set their RPC deadline above the
   // requested wait; a deadline that fires first fails the call instead of
   // returning an in-flight status with an action id, while the action itself

--- a/proto/c1/connector/v2/action.proto
+++ b/proto/c1/connector/v2/action.proto
@@ -65,7 +65,11 @@ message InvokeActionRequest {
   string resource_type_id = 4;
   // Optional: how long the server may block this call waiting for the action
   // to finish before returning its in-flight status. Unset leaves the wait at
-  // the server's default.
+  // the server's default. The server does not shorten the wait to fit the
+  // call's deadline, so callers must set their RPC deadline above the
+  // requested wait; a deadline that fires first fails the call instead of
+  // returning an in-flight status with an action id, while the action itself
+  // keeps running and stays queryable through GetActionStatus.
   google.protobuf.Duration inline_wait = 5;
 }
 

--- a/proto/c1/connector/v2/action.proto
+++ b/proto/c1/connector/v2/action.proto
@@ -64,9 +64,11 @@ message InvokeActionRequest {
   // Optional: if set, invokes a resource-scoped action
   string resource_type_id = 4;
   // Optional: how long the server may block this call waiting for the action
-  // to finish before returning its in-flight status. Unset leaves the wait at
-  // the server's default, and the server may silently cap an oversized wait
-  // rather than reject it. The server does not shorten the wait to fit the
+  // to finish before returning its in-flight status. The wait is an upper
+  // bound on blocking, not a guarantee: the server may answer sooner, and it
+  // may silently cap an oversized wait rather than reject it. Unset or
+  // non-positive values take the server's default. The server does not
+  // shorten the wait to fit the
   // call's deadline, so callers must set their RPC deadline above the
   // requested wait; a deadline that fires first fails the call instead of
   // returning an in-flight status with an action id, while the action itself

--- a/proto/c1/connector/v2/action.proto
+++ b/proto/c1/connector/v2/action.proto
@@ -4,6 +4,7 @@ package c1.connector.v2;
 
 import "c1/config/v1/config.proto";
 import "google/protobuf/any.proto";
+import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 
 option go_package = "github.com/conductorone/baton-sdk/pb/c1/connector/v2";
@@ -62,6 +63,10 @@ message InvokeActionRequest {
   repeated google.protobuf.Any annotations = 3;
   // Optional: if set, invokes a resource-scoped action
   string resource_type_id = 4;
+  // Optional: how long the server may block this call waiting for the action
+  // to finish before returning its in-flight status. Unset leaves the wait at
+  // the server's default.
+  google.protobuf.Duration inline_wait = 5;
 }
 
 message InvokeActionResponse {

--- a/proto/c1/connector/v2/action.proto
+++ b/proto/c1/connector/v2/action.proto
@@ -68,11 +68,10 @@ message InvokeActionRequest {
   // bound on blocking, not a guarantee: the server may answer sooner, and it
   // may silently cap an oversized wait rather than reject it. Unset or
   // non-positive values take the server's default. The server does not
-  // shorten the wait to fit the
-  // call's deadline, so callers must set their RPC deadline above the
-  // requested wait; a deadline that fires first fails the call instead of
-  // returning an in-flight status with an action id, while the action itself
-  // keeps running and stays queryable through GetActionStatus.
+  // shorten the wait to fit the call's deadline, so callers must set their
+  // RPC deadline above the requested wait: a deadline that fires first fails
+  // the call, and although the action keeps running server-side, its id is
+  // never delivered, so the outcome is unreachable to that caller.
   google.protobuf.Duration inline_wait = 5;
 }
 


### PR DESCRIPTION
Add an optional `inline_wait` duration to `InvokeActionRequest` and thread it through the action manager via a new `InvokeActionWithWait` method: the invoke blocks up to the requested wait for the handler to finish before returning the action's in-flight status. Unset keeps the one-second default.
The existing `InvokeAction` signature is unchanged, so connectors that return the manager as their deprecated `CustomActionManager` keep compiling; a compile-time assertion pins that. This lets a platform that cannot poll a connector afterward hold the invocation open long enough to collect the action's real terminal status.

Why an explicit `inline_wait` field instead of deriving the wait from the RPC deadline:

The obvious alternative was to have `InvokeAction` wait until just short of `ctx.Deadline()`. We implemented that first and abandoned it, for four reasons:

1. Existing callers already send deadlines that don't mean "wait longer." Deadlines are ambient transport metadata: gRPC clients, proxies, and the Lambda transport (which propagates grpc-timeout on every call) all attach or adjust them as RPC hygiene. The moment the SDK starts interpreting a deadline as wait intent, every existing caller's behavior changes silently — a client that today calls `InvokeAction` with a routine 30-second timeout and gets `RUNNING` after one second would suddenly block for ~30 seconds, with no code change on its side. A new field can't be sent by accident: absent field means exactly the old behavior, on both old and new callers.
2. A deadline can't say "wait this long and still answer me." If the server waits until the deadline, the response races the client's hangup and a coin flip turns a successful RUNNING-with-ID response into `DeadlineExceeded`. Deadline-derived waiting therefore forces the server to guess a safety margin for a transport it can't see. With a field, the two concerns separate cleanly: the caller requests a wait and sets its deadline above it, owning the margin arithmetic it's actually positioned to know (its own budgets, its transport overhead).
3. Not every context has a deadline. Service-mode connectors invoke handlers under deadline-less contexts by design. A deadline-derived scheme has to invent sentinel behavior for that case; an optional field's absence already has a well-defined meaning (server default).
4. Version skew handles itself. Old connectors deserialize the request, skip the unknown field, and keep the default one-second wait — the caller sees RUNNING and handles it exactly as before. Old callers never set the field and get identical behavior from new connectors. There is no deploy-ordering constraint between the platform and the connector fleet, and no flag day.
5. We tried it, and review couldn't converge on it. The deadline-derived implementation turned one parameter into a derivation layer: the SDK had to reverse-engineer intent from the deadline by subtracting margins it could only guess at, and every review pass found another edge in that arithmetic — how much of the deadline a Lambda cold start eats before the handler even runs, how much to reserve so the response escapes before the client hangs up, what to clamp to when the deadline is absurdly large, what floor to apply when it's nearly exhausted, what to do when there's no deadline at all. Each fix added a constant, a branch, and a wall-clock-slack test that was timing-sensitive by construction. Callers had the mirror-image problem: a call site that wanted a two-second wait got one second back, because the margin subtraction was invisible at the point of use — and the workaround was a context-helper API for pinning wait intent onto the deadline, i.e. a side channel for exactly the information a field states directly. Moving to the field deleted the entire derivation layer and its test surface: the caller states a number, the server waits that long, and the margins live with the caller, who actually knows its budgets.

A side benefit: the wait rides the request, so it appears in request logs and wire captures — an invoke's behavior is reproducible from the request alone rather than from ambient context state at the call site.