### PR TITLE
Run the nightly confidence suites nightly

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,6 +61,22 @@ jobs:
           go-version-file: "go.mod"
       - name: Run bounded chaos checks under race detection
         run: make chaos-check
+  race-shard-audit:
+    # The nightly race sweep is sharded by package (see the Makefile). This
+    # asserts the shards still cover every package exactly once, so a newly
+    # added package cannot quietly fall out of instrumented coverage. Seconds
+    # to run, and the gap it catches is otherwise invisible.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: "go.mod"
+      - name: Verify the nightly race shards cover every package
+        run: make race-shard-audit
   baton-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -64,9 +64,13 @@ jobs:
       - name: Verify the race shards cover every package
         run: make race-shard-audit
 
-  # Every job timeout below sits above the Makefile's RACE_SHARD_TIMEOUT, so a
-  # hung shard is killed by Go — which dumps every goroutine's stack, the only
-  # useful artifact from a hang — rather than by the runner, which just stops.
+  # Go's -timeout is per test binary (see RACE_SHARD_TIMEOUT), so it bounds one
+  # package's run rather than a shard's. For the single-package shards a budget
+  # above that timeout is therefore enough to guarantee Go kills a hang first and
+  # dumps every goroutine's stack, the only useful artifact from a hang. The
+  # multi-package shards get budgets far above it instead, because their honest
+  # total can exceed what any one binary is allowed while a runner-enforced stop
+  # would keep nothing; package counts below are from `make race-shard-audit`.
   race:
     name: race (${{ matrix.shard }})
     runs-on: ubuntu-latest
@@ -77,27 +81,27 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # The store shell and its admission/close machinery.
+          # The store shell and its admission/close machinery (1 package).
           - shard: dotc1z
             timeout: 60
-          # Every storage engine, including the Pebble adapter and codecs.
+          # Every storage engine, including the Pebble adapter and codecs (5).
           - shard: engine
-            timeout: 60
-          # The sync engine: scheduler, chaos corpora, checkpoint cut sweep.
+            timeout: 90
+          # The sync engine: scheduler, chaos corpora, expansion (1 package).
           - shard: sync
             timeout: 60
-          # Grant expansion and strongly-connected-component condensation.
+          # Grant expansion and strongly-connected-component condensation (2).
           - shard: expand
-            timeout: 50
-          # Compaction, fold, and the c1z sanitizer.
+            timeout: 90
+          # Compaction, fold, and the c1z sanitizer (4 packages).
           - shard: compactor
-            timeout: 60
-          # CLI plus the crash and compat harnesses.
+            timeout: 90
+          # CLI plus the crash and compat harnesses (3 packages).
           - shard: cmd
-            timeout: 50
-          # Everything not named above, by construction.
+            timeout: 90
+          # Everything not named above, by construction (70 packages).
           - shard: rest
-            timeout: 50
+            timeout: 120
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -121,16 +121,22 @@ jobs:
       matrix:
         include:
           # Exhaustive in-process checkpoint cuts plus the real-process
-          # crash/resume harness, which spawns and hard-kills connectors.
+          # crash/resume harness, which spawns and hard-kills connectors. This is
+          # two targets, each with its own 30m go-test ceiling, so the budget has
+          # to clear 60m of ceilings plus the builds ahead of them — at 60m the
+          # runner could stop the job the same minute Go would have dumped stacks.
           - name: interrupt
             target: interrupt-check
-            timeout: 60
+            timeout: 90
           # Exchanges mid-flight checkpoints with a pinned older SDK build. The
           # budget clears compat-check's 45m go-test timeout, which in turn
           # clears the harness's own per-step deadlines; see the Makefile.
           - name: compat
             target: compat-check
             timeout: 60
+          # Two fuzz targets, each running for FUZZ_TIME. The budget covers the
+          # default; a dispatch that asks for a long fuzz_time has to be under
+          # half of it, since -timeout cannot bound a fuzzing session.
           - name: fuzz
             target: fuzz-smoke
             timeout: 45

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,156 @@
+name: nightly
+
+# The opt-in confidence suites documented in docs/TESTING.md, run every night.
+# They cannot gate a pull request: the instrumented sweep alone is hours of
+# work, and the soaks and fuzzers are sized in wall-clock time rather than in
+# assertions. ci.yaml stays the fast gate; this is where the slow, randomized,
+# and process-killing checks actually get exercised.
+#
+# Everything runs as concurrent jobs rather than one serial `make test-nightly`,
+# so a nightly suite actually finishes overnight instead of bleeding into the
+# workday, and a failure names the tier or shard that broke instead of one red
+# check covering everything. The race sweep is sharded because nearly all of its
+# wall clock sits in a handful of packages; `make race-shard-audit` proves the
+# shards still cover every package exactly once.
+#
+# Scheduled workflows only run from the default branch, so changes here take
+# effect once merged to main, not from a pull request.
+
+on:
+  schedule:
+    # 08:00 UTC daily.
+    - cron: "0 8 * * *"
+  workflow_dispatch:
+    inputs:
+      fuzz_time:
+        description: "Per-fuzzer duration (e.g. 15m)"
+        required: false
+      differential_time:
+        description: "Differential fuzz duration (e.g. 30m)"
+        required: false
+      soak_iterations:
+        description: "Randomized scheduler soak iterations"
+        required: false
+      chaos_iterations:
+        description: "Seeded chaos fan-out iterations"
+        required: false
+
+permissions:
+  contents: read
+
+# The Makefile declares these with `?=`, so environment values win. Scheduled
+# runs get the nightly sizing below; a manual run can widen any of them without
+# editing this file, which is what you want when re-running a suspicious tier.
+env:
+  FUZZ_TIME: ${{ inputs.fuzz_time || '5m' }}
+  DIFFERENTIAL_TIME: ${{ inputs.differential_time || '10m' }}
+  SOAK_ITERATIONS: ${{ inputs.soak_iterations || '25' }}
+  CHAOS_ITERATIONS: ${{ inputs.chaos_iterations || '25' }}
+
+jobs:
+  # Seconds, and it fails when a newly added package would have escaped the
+  # sharded sweep. ci.yaml runs this too, where it can actually block the gap.
+  shard-audit:
+    name: race shard audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: "go.mod"
+      - name: Verify the race shards cover every package
+        run: make race-shard-audit
+
+  race:
+    name: race (${{ matrix.shard }})
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ matrix.timeout }}
+    strategy:
+      # Every shard reports independently: one shard failing must not hide a
+      # race detector finding in another.
+      fail-fast: false
+      matrix:
+        include:
+          # The store shell and its admission/close machinery.
+          - shard: dotc1z
+            timeout: 60
+          # Every storage engine, including the Pebble adapter and codecs.
+          - shard: engine
+            timeout: 60
+          # The sync engine: scheduler, chaos corpora, checkpoint cut sweep.
+          - shard: sync
+            timeout: 60
+          # Grant expansion and strongly-connected-component condensation.
+          - shard: expand
+            timeout: 45
+          # Compaction, fold, and the c1z sanitizer.
+          - shard: compactor
+            timeout: 60
+          # CLI plus the crash and compat harnesses.
+          - shard: cmd
+            timeout: 30
+          # Everything not named above, by construction.
+          - shard: rest
+            timeout: 45
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: "go.mod"
+      - name: Race-check the ${{ matrix.shard }} shard
+        run: make race-check-shard SHARD=${{ matrix.shard }}
+
+  suite:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ matrix.timeout }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Exhaustive in-process checkpoint cuts plus the real-process
+          # crash/resume harness, which spawns and hard-kills connectors.
+          - name: interrupt
+            target: interrupt-check
+            timeout: 60
+          # Exchanges mid-flight checkpoints with a pinned older SDK build.
+          - name: compat
+            target: compat-check
+            timeout: 30
+          - name: fuzz
+            target: fuzz-smoke
+            timeout: 45
+          # Compares complete SQLite and Pebble artifacts over generated cases.
+          - name: differential
+            target: differential-check
+            timeout: 45
+          - name: scheduler-soak
+            target: scheduler-soak
+            timeout: 45
+          - name: chaos-soak
+            target: chaos-soak
+            timeout: 45
+          # Randomized whole-sync Pebble failure points against a crashable
+          # filesystem.
+          - name: errorfs-soak
+            target: errorfs-soak
+            timeout: 45
+          # Output is evidence rather than a pass/fail gate, but running the
+          # curves catches crashes and keeps the current cost visible.
+          - name: bench-smoke
+            target: bench-smoke
+            timeout: 30
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: "go.mod"
+      - name: make ${{ matrix.target }}
+        run: make ${{ matrix.target }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -125,10 +125,12 @@ jobs:
           - name: interrupt
             target: interrupt-check
             timeout: 60
-          # Exchanges mid-flight checkpoints with a pinned older SDK build.
+          # Exchanges mid-flight checkpoints with a pinned older SDK build. The
+          # budget clears compat-check's 45m go-test timeout, which in turn
+          # clears the harness's own per-step deadlines; see the Makefile.
           - name: compat
             target: compat-check
-            timeout: 30
+            timeout: 60
           - name: fuzz
             target: fuzz-smoke
             timeout: 45

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -64,6 +64,9 @@ jobs:
       - name: Verify the race shards cover every package
         run: make race-shard-audit
 
+  # Every job timeout below sits above the Makefile's RACE_SHARD_TIMEOUT, so a
+  # hung shard is killed by Go — which dumps every goroutine's stack, the only
+  # useful artifact from a hang — rather than by the runner, which just stops.
   race:
     name: race (${{ matrix.shard }})
     runs-on: ubuntu-latest
@@ -85,16 +88,16 @@ jobs:
             timeout: 60
           # Grant expansion and strongly-connected-component condensation.
           - shard: expand
-            timeout: 45
+            timeout: 50
           # Compaction, fold, and the c1z sanitizer.
           - shard: compactor
             timeout: 60
           # CLI plus the crash and compat harnesses.
           - shard: cmd
-            timeout: 30
+            timeout: 50
           # Everything not named above, by construction.
           - shard: rest
-            timeout: 45
+            timeout: 50
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -148,9 +151,46 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          # compat-check materializes a pinned old release with
+          # `git worktree add --detach <tmp> v0.20.2`, which needs the tag and
+          # its history. The default shallow checkout has neither, and the
+          # harness fails with "invalid reference".
+          fetch-depth: 0
       - name: Install Go
         uses: actions/setup-go@v6
         with:
           go-version-file: "go.mod"
       - name: make ${{ matrix.target }}
         run: make ${{ matrix.target }}
+
+  # A nightly nobody reads fails the same way the un-run suites did. GitHub
+  # emails a scheduled workflow's failures only to whoever last edited the cron
+  # line, so a red run reaches one inbox and no place the team looks. File it
+  # instead — one open issue that later failures append to, rather than a fresh
+  # issue every night for as long as something stays broken.
+  report:
+    name: report failures
+    needs: [shard-audit, race, suite]
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Open or update the nightly failure issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          title="nightly suite is failing"
+          body="The nightly run on $(date -u +%Y-%m-%d) failed. Which tier broke is in the run: $RUN_URL"
+          existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --limit 100 \
+            --json number,title --jq "[.[] | select(.title == \"$title\") | .number] | first // empty")
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" --body "$body"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" --title "$title" --body "$body"
+          fi

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,59 @@ interrupt-check: checkpoint-cut-check crash-check ## Run in-process cut and real
 
 .PHONY: race-check
 race-check: ## Run the complete Go suite with the race detector.
-	go test -race -tags=baton_lambda_support -count=1 -timeout=30m ./...
+	go test -race -tags=baton_lambda_support -count=1 -timeout=45m ./...
+
+# Nightly race shards. A serial instrumented ./... sweep is hours of work, and
+# nearly all of it sits in a handful of packages, so the nightly workflow runs
+# these shards as concurrent jobs instead. That is what keeps a "nightly" suite
+# finishing overnight rather than bleeding into the next workday, and it names
+# the shard that broke instead of one red check covering everything.
+#
+# `rest` is the complement of the named shards, so every package belongs to
+# exactly one shard by construction: a newly added package joins `rest`
+# automatically rather than silently escaping the sweep. race-shard-audit
+# proves that property by counting.
+RACE_SHARD_NAMES := dotc1z engine sync expand compactor cmd rest
+
+RACE_PKG := github.com/conductorone/baton-sdk
+RACE_SHARD_dotc1z := ^$(RACE_PKG)/pkg/dotc1z$$
+RACE_SHARD_engine := ^$(RACE_PKG)/pkg/dotc1z/engine($$|/)
+RACE_SHARD_sync := ^$(RACE_PKG)/pkg/sync$$
+RACE_SHARD_expand := ^$(RACE_PKG)/pkg/sync/expand($$|/)
+RACE_SHARD_compactor := ^$(RACE_PKG)/(pkg/synccompactor($$|/)|pkg/c1zsanitize$$)
+RACE_SHARD_cmd := ^$(RACE_PKG)/cmd($$|/)
+RACE_SHARD_NAMED := $(RACE_SHARD_dotc1z)|$(RACE_SHARD_engine)|$(RACE_SHARD_sync)|$(RACE_SHARD_expand)|$(RACE_SHARD_compactor)|$(RACE_SHARD_cmd)
+
+.PHONY: race-shard-list
+race-shard-list: ## Print the packages in race shard SHARD.
+	@test -n "$(SHARD)" || { echo "race-shard-list: set SHARD to one of: $(RACE_SHARD_NAMES)" >&2; exit 2; }
+	@if [ "$(SHARD)" = "rest" ]; then \
+		go list ./... | grep -vE '$(RACE_SHARD_NAMED)'; \
+	else \
+		test -n '$(RACE_SHARD_$(SHARD))' || { echo "race-shard-list: unknown shard '$(SHARD)'" >&2; exit 2; }; \
+		go list ./... | grep -E '$(RACE_SHARD_$(SHARD))'; \
+	fi
+
+.PHONY: race-check-shard
+race-check-shard: ## Race-check one nightly shard, for example SHARD=dotc1z.
+	go test -race -tags=baton_lambda_support -count=1 -timeout=45m \
+		$$($(MAKE) --no-print-directory race-shard-list SHARD=$(SHARD))
+
+.PHONY: race-shard-audit
+race-shard-audit: ## Verify the race shards cover every package exactly once.
+	@total=$$(go list ./... | wc -l | tr -d ' '); sum=0; \
+	for s in $(RACE_SHARD_NAMES); do \
+		n=$$($(MAKE) --no-print-directory race-shard-list SHARD=$$s | wc -l | tr -d ' '); \
+		printf '  %-10s %3s packages\n' "$$s" "$$n"; \
+		sum=$$((sum + n)); \
+	done; \
+	printf '  %-10s %3s packages\n' "union" "$$sum"; \
+	printf '  %-10s %3s packages\n' "go list" "$$total"; \
+	if [ "$$sum" != "$$total" ]; then \
+		echo "race-shard-audit: union is $$sum but ./... is $$total — the shards overlap or leave a gap" >&2; \
+		exit 1; \
+	fi; \
+	echo "race-shard-audit: every package is covered exactly once"
 
 .PHONY: fuzz-smoke
 fuzz-smoke: ## Run each native Go fuzzer for FUZZ_TIME (default 30s).

--- a/Makefile
+++ b/Makefile
@@ -147,23 +147,35 @@ race-shard-list: ## Print the packages in race shard SHARD.
 # The package list is captured before the test runs so a bad SHARD fails as a
 # bad SHARD. Left inside the argument list, its exit status is swallowed by
 # command substitution and go test reports a confusing "no packages" instead.
+# An empty list cannot get past the capture — the list ends in grep, which exits
+# 1 when it matches nothing — so this reports it here rather than testing $$pkgs
+# afterwards, which would never run.
 .PHONY: race-check-shard
 race-check-shard: ## Race-check one nightly shard, for example SHARD=dotc1z.
-	@pkgs=$$($(MAKE) --no-print-directory race-shard-list SHARD=$(SHARD)) || exit 1; \
-	test -n "$$pkgs" || { echo "race-check-shard: shard '$(SHARD)' matched no packages" >&2; exit 1; }; \
+	@pkgs=$$($(MAKE) --no-print-directory race-shard-list SHARD=$(SHARD)) || { \
+		echo "race-check-shard: no packages for SHARD='$(SHARD)' (see above)" >&2; \
+		exit 1; \
+	}; \
 	set -x; go test -race -tags=$(RACE_TAGS) -count=1 -timeout=$(RACE_SHARD_TIMEOUT) $$pkgs
 
 # Each shard's list is captured rather than piped straight into wc, for the same
 # reason as race-check-shard above: at the head of a pipe its exit status is
-# lost, so a broken go list counts as zero packages and the audit blames an
-# overlap or a gap for something that is neither.
+# lost. That is worse than a confusing message. A named shard's list ends in
+# grep, which exits 1 when its pattern matches nothing, and a pattern that has
+# drifted from the package tree takes nothing out of `rest` — so `rest` absorbs
+# the orphaned packages, the union still equals ./..., and the count-based audit
+# passes while a whole nightly job runs an empty package set. Failing on the
+# list's status is what catches that, which is why it says which shard and why.
 .PHONY: race-shard-audit
 race-shard-audit: ## Verify the race shards cover every package exactly once.
 	@total=$$(go list -tags=$(RACE_TAGS) ./... | wc -l | tr -d ' '); sum=0; \
 	test "$$total" -gt 0 || { echo "race-shard-audit: go list returned no packages" >&2; exit 1; }; \
 	for s in $(RACE_SHARD_NAMES); do \
-		out=$$($(MAKE) --no-print-directory race-shard-list SHARD=$$s) || exit 1; \
-		n=$$(printf '%s' "$$out" | grep -c '^' || true); \
+		out=$$($(MAKE) --no-print-directory race-shard-list SHARD=$$s) || { \
+			echo "race-shard-audit: shard '$$s' listed no packages: RACE_SHARD_$$s is either undefined or no longer matches anything" >&2; \
+			exit 1; \
+		}; \
+		n=$$(printf '%s' "$$out" | grep -c '^'); \
 		printf '  %-10s %3s packages\n' "$$s" "$$n"; \
 		sum=$$((sum + n)); \
 	done; \

--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,11 @@ race-shard-audit: ## Verify the race shards cover every package exactly once.
 	test "$$total" -gt 0 || { echo "race-shard-audit: go list returned no packages" >&2; exit 1; }; \
 	for s in $(RACE_SHARD_NAMES); do \
 		out=$$($(MAKE) --no-print-directory race-shard-list SHARD=$$s) || { \
-			echo "race-shard-audit: shard '$$s' listed no packages: RACE_SHARD_$$s is either undefined or no longer matches anything" >&2; \
+			if [ "$$s" = rest ]; then \
+				echo "race-shard-audit: the 'rest' complement is empty: the named shards now match every package" >&2; \
+			else \
+				echo "race-shard-audit: shard '$$s' listed no packages: RACE_SHARD_$$s is either undefined or no longer matches anything" >&2; \
+			fi; \
 			exit 1; \
 		}; \
 		n=$$(printf '%s' "$$out" | grep -c '^'); \

--- a/Makefile
+++ b/Makefile
@@ -59,14 +59,22 @@ test: ## Run the Go test suite used by CI.
 # both directions. See cmd/baton-compat-harness. Override the old release
 # with BATON_COMPAT_OLD_REF=<tag>.
 #
-# The timeout is explicit because this test's own sub-budgets exceed Go's 10m
-# default several times over: two harness builds at 5m each, then eight
-# gen/resume runs at 3m. On a cold runner, compiling the pinned release's whole
-# dependency set can spend the default before the matrix starts, and the
-# failure reads as a test timeout rather than as slow builds.
+# The timeout has to clear the sum of this test's own sub-budgets rather than
+# just its expected runtime: a worktree checkout at 5m, two harness builds at 5m
+# each, and eight gen/resume runs at 3m come to about 39m of ceilings. Below that
+# sum — and Go's 10m default is far below it — a slow-but-healthy run dies as
+# "test timed out" and says nothing about which step was slow, which is the whole
+# failure mode this value exists to avoid. A genuine hang is caught by the step's
+# own context within a few minutes, so a global ceiling this high costs nothing.
+# nightly.yaml keeps the job budget above it, so Go reports before the runner.
+#
+# For scale: the whole target takes about a minute on a warm developer machine,
+# where the four exchange cells are 2-3s each and the two builds are nearly all
+# of it. The ceiling is a backstop for a cold runner compiling two dependency
+# sets, not a number this is expected to approach.
 .PHONY: compat-check
 compat-check: ## Exchange checkpoints with a pinned older SDK.
-	BATON_COMPAT=1 go test -v -count=1 -timeout=25m -run TestCheckpointCompatAcrossSDKVersions ./cmd/baton-compat-harness
+	BATON_COMPAT=1 go test -v -count=1 -timeout=45m -run TestCheckpointCompatAcrossSDKVersions ./cmd/baton-compat-harness
 
 # Real-binary interruption instrument: builds a deterministic connector from
 # this tree, runs budget-bounded sync sessions, SIGKILLs them at varied

--- a/Makefile
+++ b/Makefile
@@ -105,28 +105,42 @@ RACE_SHARD_compactor := ^$(RACE_PKG)/(pkg/synccompactor($$|/)|pkg/c1zsanitize$$)
 RACE_SHARD_cmd := ^$(RACE_PKG)/cmd($$|/)
 RACE_SHARD_NAMED := $(RACE_SHARD_dotc1z)|$(RACE_SHARD_engine)|$(RACE_SHARD_sync)|$(RACE_SHARD_expand)|$(RACE_SHARD_compactor)|$(RACE_SHARD_cmd)
 
+# The shards run under RACE_TAGS, so they are enumerated under it too. A
+# package whose files all sit behind that tag would otherwise be missing from
+# every shard and from the audit's total at once, and the audit would call that
+# full coverage — the exact gap it exists to catch.
+RACE_TAGS := baton_lambda_support
+
+# Go's own timeout has to fire before the CI job's, or a hung shard is killed
+# without the goroutine dump that says where it hung. nightly.yaml keeps every
+# shard's job timeout above this.
+RACE_SHARD_TIMEOUT := 45m
+
+NIGHTLY_WORKFLOW := .github/workflows/nightly.yaml
+
 .PHONY: race-shard-list
 race-shard-list: ## Print the packages in race shard SHARD.
 	@test -n "$(SHARD)" || { echo "race-shard-list: set SHARD to one of: $(RACE_SHARD_NAMES)" >&2; exit 2; }
 	@if [ "$(SHARD)" = "rest" ]; then \
-		go list ./... | grep -vE '$(RACE_SHARD_NAMED)'; \
+		go list -tags=$(RACE_TAGS) ./... | grep -vE '$(RACE_SHARD_NAMED)'; \
 	else \
 		test -n '$(RACE_SHARD_$(SHARD))' || { echo "race-shard-list: unknown shard '$(SHARD)'" >&2; exit 2; }; \
-		go list ./... | grep -E '$(RACE_SHARD_$(SHARD))'; \
+		go list -tags=$(RACE_TAGS) ./... | grep -E '$(RACE_SHARD_$(SHARD))'; \
 	fi
 
+# The package list is captured before the test runs so a bad SHARD fails as a
+# bad SHARD. Left inside the argument list, its exit status is swallowed by
+# command substitution and go test reports a confusing "no packages" instead.
 .PHONY: race-check-shard
 race-check-shard: ## Race-check one nightly shard, for example SHARD=dotc1z.
-	# The full-tier env matches race-check. Sharding is a scheduling change, not
-	# a coverage one: without these the shards would quietly run the short
-	# variants of the very cases the nightly exists to exercise.
-	BATON_FULL_TESTS=1 BATON_CUT_SWEEP=full \
-		go test -race -tags=baton_lambda_support -count=1 -timeout=45m \
-		$$($(MAKE) --no-print-directory race-shard-list SHARD=$(SHARD))
+	@pkgs=$$($(MAKE) --no-print-directory race-shard-list SHARD=$(SHARD)) || exit 1; \
+	test -n "$$pkgs" || { echo "race-check-shard: shard '$(SHARD)' matched no packages" >&2; exit 1; }; \
+	set -x; go test -race -tags=$(RACE_TAGS) -count=1 -timeout=$(RACE_SHARD_TIMEOUT) $$pkgs
 
 .PHONY: race-shard-audit
 race-shard-audit: ## Verify the race shards cover every package exactly once.
-	@total=$$(go list ./... | wc -l | tr -d ' '); sum=0; \
+	@total=$$(go list -tags=$(RACE_TAGS) ./... | wc -l | tr -d ' '); sum=0; \
+	test "$$total" -gt 0 || { echo "race-shard-audit: go list returned no packages" >&2; exit 1; }; \
 	for s in $(RACE_SHARD_NAMES); do \
 		n=$$($(MAKE) --no-print-directory race-shard-list SHARD=$$s | wc -l | tr -d ' '); \
 		printf '  %-10s %3s packages\n' "$$s" "$$n"; \
@@ -138,7 +152,24 @@ race-shard-audit: ## Verify the race shards cover every package exactly once.
 		echo "race-shard-audit: union is $$sum but ./... is $$total — the shards overlap or leave a gap" >&2; \
 		exit 1; \
 	fi; \
+	$(MAKE) --no-print-directory race-shard-matrix-audit; \
 	echo "race-shard-audit: every package is covered exactly once"
+
+# Counting packages proves the shards cover the repository, not that anything
+# runs them: nightly.yaml names the shards in its matrix. A shard added here
+# and not there would take its packages out of `rest` and into a job that does
+# not exist, and the count would still balance.
+.PHONY: race-shard-matrix-audit
+race-shard-matrix-audit: ## Verify nightly.yaml runs exactly the declared shards.
+	@declared=$$(printf '%s\n' $(RACE_SHARD_NAMES) | sort); \
+	matrix=$$(sed -n 's/^ *- shard: *\([a-z0-9_-]*\).*/\1/p' $(NIGHTLY_WORKFLOW) | sort); \
+	test -n "$$matrix" || { echo "race-shard-matrix-audit: no shards found in $(NIGHTLY_WORKFLOW)" >&2; exit 1; }; \
+	if [ "$$declared" != "$$matrix" ]; then \
+		echo "race-shard-matrix-audit: RACE_SHARD_NAMES and $(NIGHTLY_WORKFLOW) disagree" >&2; \
+		echo "  Makefile:  $$(echo $$declared | tr '\n' ' ')" >&2; \
+		echo "  workflow:  $$(echo $$matrix | tr '\n' ' ')" >&2; \
+		exit 1; \
+	fi
 
 .PHONY: fuzz-smoke
 fuzz-smoke: ## Run each native Go fuzzer for FUZZ_TIME (default 30s).

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,11 @@ race-shard-list: ## Print the packages in race shard SHARD.
 
 .PHONY: race-check-shard
 race-check-shard: ## Race-check one nightly shard, for example SHARD=dotc1z.
-	go test -race -tags=baton_lambda_support -count=1 -timeout=45m \
+	# The full-tier env matches race-check. Sharding is a scheduling change, not
+	# a coverage one: without these the shards would quietly run the short
+	# variants of the very cases the nightly exists to exercise.
+	BATON_FULL_TESTS=1 BATON_CUT_SWEEP=full \
+		go test -race -tags=baton_lambda_support -count=1 -timeout=45m \
 		$$($(MAKE) --no-print-directory race-shard-list SHARD=$(SHARD))
 
 .PHONY: race-shard-audit

--- a/Makefile
+++ b/Makefile
@@ -58,9 +58,15 @@ test: ## Run the Go test suite used by CI.
 # HEAD and a pinned past release, and exchanges mid-flight checkpoints in
 # both directions. See cmd/baton-compat-harness. Override the old release
 # with BATON_COMPAT_OLD_REF=<tag>.
+#
+# The timeout is explicit because this test's own sub-budgets exceed Go's 10m
+# default several times over: two harness builds at 5m each, then eight
+# gen/resume runs at 3m. On a cold runner, compiling the pinned release's whole
+# dependency set can spend the default before the matrix starts, and the
+# failure reads as a test timeout rather than as slow builds.
 .PHONY: compat-check
 compat-check: ## Exchange checkpoints with a pinned older SDK.
-	BATON_COMPAT=1 go test -v -count=1 -run TestCheckpointCompatAcrossSDKVersions ./cmd/baton-compat-harness
+	BATON_COMPAT=1 go test -v -count=1 -timeout=25m -run TestCheckpointCompatAcrossSDKVersions ./cmd/baton-compat-harness
 
 # Real-binary interruption instrument: builds a deterministic connector from
 # this tree, runs budget-bounded sync sessions, SIGKILLs them at varied
@@ -111,9 +117,19 @@ RACE_SHARD_NAMED := $(RACE_SHARD_dotc1z)|$(RACE_SHARD_engine)|$(RACE_SHARD_sync)
 # full coverage — the exact gap it exists to catch.
 RACE_TAGS := baton_lambda_support
 
-# Go's own timeout has to fire before the CI job's, or a hung shard is killed
-# without the goroutine dump that says where it hung. nightly.yaml keeps every
-# shard's job timeout above this.
+# A hang is only diagnosable if Go is the one that kills it: the runner's
+# timeout stops the job and keeps nothing, while Go's dumps every goroutine's
+# stack. Go applies this timeout per test binary rather than per invocation, so
+# for a one-package shard a job budget above this value is enough, while a shard
+# spanning many packages can legitimately run far longer in total than any one
+# binary is allowed. nightly.yaml gives those shards budgets well clear of this
+# value instead of the small margin that would do if the clock were per shard.
+#
+# The value is generous on purpose: the one-package sync shard takes about 12
+# minutes on a developer machine, and CI runners are smaller, so a tighter
+# timeout would start killing slow-but-healthy packages. If a shard ever does
+# trip this, the dump says which test was still running, and that is the number
+# to raise.
 RACE_SHARD_TIMEOUT := 45m
 
 NIGHTLY_WORKFLOW := .github/workflows/nightly.yaml
@@ -137,12 +153,17 @@ race-check-shard: ## Race-check one nightly shard, for example SHARD=dotc1z.
 	test -n "$$pkgs" || { echo "race-check-shard: shard '$(SHARD)' matched no packages" >&2; exit 1; }; \
 	set -x; go test -race -tags=$(RACE_TAGS) -count=1 -timeout=$(RACE_SHARD_TIMEOUT) $$pkgs
 
+# Each shard's list is captured rather than piped straight into wc, for the same
+# reason as race-check-shard above: at the head of a pipe its exit status is
+# lost, so a broken go list counts as zero packages and the audit blames an
+# overlap or a gap for something that is neither.
 .PHONY: race-shard-audit
 race-shard-audit: ## Verify the race shards cover every package exactly once.
 	@total=$$(go list -tags=$(RACE_TAGS) ./... | wc -l | tr -d ' '); sum=0; \
 	test "$$total" -gt 0 || { echo "race-shard-audit: go list returned no packages" >&2; exit 1; }; \
 	for s in $(RACE_SHARD_NAMES); do \
-		n=$$($(MAKE) --no-print-directory race-shard-list SHARD=$$s | wc -l | tr -d ' '); \
+		out=$$($(MAKE) --no-print-directory race-shard-list SHARD=$$s) || exit 1; \
+		n=$$(printf '%s' "$$out" | grep -c '^' || true); \
 		printf '  %-10s %3s packages\n' "$$s" "$$n"; \
 		sum=$$((sum + n)); \
 	done; \

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -99,6 +99,12 @@ otherwise the gap would be invisible until someone went looking. It also checks
 that the shard names in the Makefile and in `nightly.yaml` still agree, since a
 shard declared in only one of the two balances the count while running nowhere.
 
+Counting alone cannot catch a shard whose pattern has gone stale: a pattern that
+matches nothing removes nothing from `rest`, so `rest` quietly absorbs the
+packages and the union still equals `./...`. The audit therefore fails on the
+shard listing itself, and names the shard, rather than inferring a gap from the
+totals.
+
 ## Benchmarks
 
 Do not use `go test ./... -bench=.` as a general confidence command. The

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -84,6 +84,13 @@ make race-check-shard SHARD=sync # instrument just that shard
 usually what you want locally when you are not trying to reproduce a specific
 package's failure.
 
+Both carry the same full-tier environment (`BATON_FULL_TESTS=1`,
+`BATON_CUT_SWEEP=full`), so sharding changes only how the work is scheduled,
+never what is covered. That environment is also why the nightly has no separate
+`make test-full` job: the shards already run those cases, under the race
+detector, so a second uninstrumented pass would double the compute to cover a
+strict subset.
+
 The `rest` shard is the complement of the named shards, so every package
 belongs to exactly one shard by construction and a newly added package joins
 `rest` automatically rather than silently escaping instrumentation.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -84,18 +84,20 @@ make race-check-shard SHARD=sync # instrument just that shard
 usually what you want locally when you are not trying to reproduce a specific
 package's failure.
 
-Both carry the same full-tier environment (`BATON_FULL_TESTS=1`,
-`BATON_CUT_SWEEP=full`), so sharding changes only how the work is scheduled,
-never what is covered. That environment is also why the nightly has no separate
-`make test-full` job: the shards already run those cases, under the race
-detector, so a second uninstrumented pass would double the compute to cover a
-strict subset.
+A shard runs the same command as `race-check` with a narrower package list and
+no extra environment, so reproducing a shard failure locally needs no special
+setup. The exhaustive checkpoint-cut sweep is deliberately not part of it: the
+nightly `interrupt` job runs that sweep on its own budget, and repeating it
+under the race detector inside a shard would buy a second copy of the most
+expensive test in the repository.
 
 The `rest` shard is the complement of the named shards, so every package
 belongs to exactly one shard by construction and a newly added package joins
 `rest` automatically rather than silently escaping instrumentation.
 `make race-shard-audit` proves that by counting, and pull-request CI runs it —
-otherwise the gap would be invisible until someone went looking.
+otherwise the gap would be invisible until someone went looking. It also checks
+that the shard names in the Makefile and in `nightly.yaml` still agree, since a
+shard declared in only one of the two balances the count while running nowhere.
 
 ## Benchmarks
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -9,7 +9,8 @@ Run `make help` for the current target list.
 ## CI-equivalent tests
 
 `make test` runs the ordinary Go test suite with the same build tag used by
-CI. Pull-request CI also runs lint, protobuf checks, and the full build.
+CI. Pull-request CI also runs lint, protobuf checks, the full build, and
+`make race-shard-audit` (see [Race shards](#race-shards)).
 
 Tests in this tier should be deterministic, self-contained, and reasonably
 fast. A test that only skips on Windows with `testing.Short()` is still a CI
@@ -55,6 +56,39 @@ make test-nightly \
   NIGHTLY_DIFFERENTIAL_TIME=30m \
   SOAK_ITERATIONS=100
 ```
+
+### The nightly workflow
+
+`.github/workflows/nightly.yaml` runs these checks every night at 08:00 UTC,
+and on demand via `workflow_dispatch` with optional duration and iteration
+overrides. It does not invoke `make test-nightly` directly: that target runs
+the tiers serially, which is hours of wall clock. The workflow runs one job per
+tier instead, so the suite finishes overnight and a failure names the tier that
+broke rather than presenting one red check.
+
+Because scheduled workflows only run from the default branch, changes to the
+workflow take effect once merged, not from a pull request.
+
+### Race shards
+
+Nearly all of the instrumented sweep's wall clock sits in a handful of
+packages, so the nightly runs it as concurrent shards:
+
+```sh
+make race-shard-audit            # what the shards are, and that they are complete
+make race-shard-list SHARD=sync  # the packages in one shard
+make race-check-shard SHARD=sync # instrument just that shard
+```
+
+`make race-check` still runs the whole sweep in one serial pass, which is
+usually what you want locally when you are not trying to reproduce a specific
+package's failure.
+
+The `rest` shard is the complement of the named shards, so every package
+belongs to exactly one shard by construction and a newly added package joins
+`rest` automatically rather than silently escaping instrumentation.
+`make race-shard-audit` proves that by counting, and pull-request CI runs it —
+otherwise the gap would be invisible until someone went looking.
 
 ## Benchmarks
 

--- a/pkg/dotc1z/pool.go
+++ b/pkg/dotc1z/pool.go
@@ -3,8 +3,21 @@ package dotc1z
 import (
 	"os"
 	"sync"
+	"sync/atomic"
 
 	"github.com/klauspost/compress/zstd"
+)
+
+// encoderPuts and decoderPuts count codecs handed back to the pools.
+//
+// They exist because sync.Pool cannot answer "did that code return its
+// codec?". A later Get is allowed to miss for reasons unrelated to the code
+// under test: a GC empties the pool, and these pools are process-wide, so any
+// concurrently running caller can take the item first. Counting the Put is
+// stable where observing the Get is not.
+var (
+	encoderPuts atomic.Int64
+	decoderPuts atomic.Int64
 )
 
 // poolDisabled is an operational kill-switch. Set BATON_ZSTD_POOL_DISABLE=1
@@ -63,6 +76,7 @@ func putEncoder(enc *zstd.Encoder) {
 	// Reset to nil writer to release reference to previous output.
 	// This is safe even if the encoder was already closed.
 	enc.Reset(nil)
+	encoderPuts.Add(1)
 	encoderPool.Put(enc)
 }
 
@@ -108,5 +122,6 @@ func putDecoder(dec *zstd.Decoder) {
 	if err := dec.Reset(nil); err != nil {
 		return
 	}
+	decoderPuts.Add(1)
 	decoderPool.Put(dec)
 }

--- a/pkg/dotc1z/pool.go
+++ b/pkg/dotc1z/pool.go
@@ -10,11 +10,12 @@ import (
 
 // encoderPuts and decoderPuts count codecs handed back to the pools.
 //
-// They exist because sync.Pool cannot answer "did that code return its
-// codec?". A later Get is allowed to miss for reasons unrelated to the code
-// under test: a GC empties the pool, and these pools are process-wide, so any
-// concurrently running caller can take the item first. Counting the Put is
-// stable where observing the Get is not.
+// They exist because sync.Pool cannot answer "did that code return its codec?".
+// A later Get is allowed to miss for reasons that have nothing to do with the
+// code under test: a GC empties the pool, and under the race detector Put
+// discards one item in four by design (sync/pool.go), so a test that concludes
+// "not pooled" from a missed Get is wrong a quarter of the time. These counters
+// increment before the Put reaches the pool, so they survive that drop.
 var (
 	encoderPuts atomic.Int64
 	decoderPuts atomic.Int64

--- a/pkg/dotc1z/pool_test.go
+++ b/pkg/dotc1z/pool_test.go
@@ -297,8 +297,10 @@ func TestPoolGrowsFromSaveC1z(t *testing.T) {
 
 	// Assert on the Put, not on a later Get: the pools are process-wide, so a
 	// concurrently running test can take the encoder saveC1z returned, and a
-	// missed Get would then look like the bug this test is guarding.
-	require.Greater(t, encoderPuts.Load(), putsBefore, "saveC1z should have returned its encoder to the pool")
+	// missed Get would then look like the bug this test is guarding. The count
+	// is exact rather than a delta so the assertion is about this call and not
+	// about whatever else happens to be putting encoders back.
+	require.Equal(t, putsBefore+1, encoderPuts.Load(), "saveC1z should have returned exactly its own encoder to the pool")
 }
 
 // TestPoolGrowsFromDecoder verifies that NewDecoder populates the decoder pool
@@ -340,8 +342,10 @@ func TestPoolGrowsFromDecoder(t *testing.T) {
 
 	// Assert on the Put, not on a later Get: the pools are process-wide, so a
 	// concurrently running test can take the decoder Close returned, and a
-	// missed Get would then look like the bug this test is guarding.
-	require.Greater(t, decoderPuts.Load(), putsBefore, "NewDecoder.Close should have returned its decoder to the pool")
+	// missed Get would then look like the bug this test is guarding. The count
+	// is exact rather than a delta so the assertion is about this call and not
+	// about whatever else happens to be putting decoders back.
+	require.Equal(t, putsBefore+1, decoderPuts.Load(), "NewDecoder.Close should have returned exactly its own decoder to the pool")
 }
 
 func TestPooledRoundTrip(t *testing.T) {

--- a/pkg/dotc1z/pool_test.go
+++ b/pkg/dotc1z/pool_test.go
@@ -23,13 +23,18 @@ func TestEncoderPool(t *testing.T) {
 		// First call won't be from pool (pool is empty)
 		require.False(t, fromPool)
 
-		// Return to pool and get again
+		// Return to pool and get again. Retry: these pools are process-wide,
+		// so a concurrently running caller can take the encoder between the
+		// Put and the Get. Losing that race says nothing about whether Get
+		// reports a pooled encoder, which is what this asserts.
+		var fromPool2 bool
+		for attempt := 0; attempt < 100 && !fromPool2; attempt++ {
+			putEncoder(enc)
+			enc, fromPool2 = getEncoder()
+			require.NotNil(t, enc)
+		}
+		require.True(t, fromPool2, "getEncoder never reported an encoder from the pool")
 		putEncoder(enc)
-
-		enc2, fromPool2 := getEncoder()
-		require.NotNil(t, enc2)
-		require.True(t, fromPool2)
-		putEncoder(enc2)
 	})
 
 	t.Run("pooled encoder produces correct output", func(t *testing.T) {
@@ -117,12 +122,16 @@ func TestDecoderPool(t *testing.T) {
 		require.NotNil(t, dec)
 		require.False(t, fromPool) // First call, pool is empty
 
+		// Retry for the same reason as the encoder case: a concurrently
+		// running caller may take the decoder between the Put and the Get.
+		var fromPool2 bool
+		for attempt := 0; attempt < 100 && !fromPool2; attempt++ {
+			putDecoder(dec)
+			dec, fromPool2 = getDecoder()
+			require.NotNil(t, dec)
+		}
+		require.True(t, fromPool2, "getDecoder never reported a decoder from the pool")
 		putDecoder(dec)
-
-		dec2, fromPool2 := getDecoder()
-		require.NotNil(t, dec2)
-		require.True(t, fromPool2)
-		putDecoder(dec2)
 	})
 
 	t.Run("pooled decoder produces correct output", func(t *testing.T) {
@@ -282,13 +291,14 @@ func TestPoolGrowsFromSaveC1z(t *testing.T) {
 	require.NoError(t, err)
 
 	c1zFile := filepath.Join(tmpDir, "test.c1z")
+	putsBefore := encoderPuts.Load()
 	err = saveC1z(dbFile, c1zFile, pooledEncoderConcurrency)
 	require.NoError(t, err)
 
-	// Now the pool should have an encoder.
-	enc2, fromPool2 := getEncoder()
-	require.True(t, fromPool2, "saveC1z should have returned encoder to pool")
-	putEncoder(enc2)
+	// Assert on the Put, not on a later Get: the pools are process-wide, so a
+	// concurrently running test can take the encoder saveC1z returned, and a
+	// missed Get would then look like the bug this test is guarding.
+	require.Greater(t, encoderPuts.Load(), putsBefore, "saveC1z should have returned its encoder to the pool")
 }
 
 // TestPoolGrowsFromDecoder verifies that NewDecoder populates the decoder pool
@@ -312,14 +322,11 @@ func TestPoolGrowsFromDecoder(t *testing.T) {
 	err = saveC1z(dbFile, c1zFile, pooledEncoderConcurrency)
 	require.NoError(t, err)
 
-	// Drain encoder pool (saveC1z added one) so we're only asserting on the decoder pool below.
-	enc, _ := getEncoder()
-	_ = enc.Close()
-
 	// Now use NewDecoder which should populate the decoder pool.
 	f, err := os.Open(c1zFile)
 	require.NoError(t, err)
 
+	putsBefore := decoderPuts.Load()
 	decoder, err := NewDecoder(f)
 	require.NoError(t, err)
 
@@ -331,10 +338,10 @@ func TestPoolGrowsFromDecoder(t *testing.T) {
 	err = f.Close()
 	require.NoError(t, err)
 
-	// Now the decoder pool should have a decoder.
-	dec2, fromPool2 := getDecoder()
-	require.True(t, fromPool2, "NewDecoder.Close should have returned decoder to pool")
-	putDecoder(dec2)
+	// Assert on the Put, not on a later Get: the pools are process-wide, so a
+	// concurrently running test can take the decoder Close returned, and a
+	// missed Get would then look like the bug this test is guarding.
+	require.Greater(t, decoderPuts.Load(), putsBefore, "NewDecoder.Close should have returned its decoder to the pool")
 }
 
 func TestPooledRoundTrip(t *testing.T) {

--- a/pkg/dotc1z/pool_test.go
+++ b/pkg/dotc1z/pool_test.go
@@ -23,10 +23,13 @@ func TestEncoderPool(t *testing.T) {
 		// First call won't be from pool (pool is empty)
 		require.False(t, fromPool)
 
-		// Return to pool and get again. Retry: these pools are process-wide,
-		// so a concurrently running caller can take the encoder between the
-		// Put and the Get. Losing that race says nothing about whether Get
-		// reports a pooled encoder, which is what this asserts.
+		// Retry, and do not simplify this to a single put/get: under the race
+		// detector sync.Pool.Put drops one item in four on the floor on
+		// purpose (`runtime_randn(4) == 0` in sync/pool.go), so a lone
+		// assertion fails a quarter of the time in the nightly race shard.
+		// withIsolatedPools cannot help — a fresh pool, a disabled GC, and one
+		// P still leave the drop, which was measured at ~25% of puts. A real
+		// regression, where nothing is ever pooled, still fails every attempt.
 		var fromPool2 bool
 		for attempt := 0; attempt < 100 && !fromPool2; attempt++ {
 			putEncoder(enc)
@@ -122,8 +125,8 @@ func TestDecoderPool(t *testing.T) {
 		require.NotNil(t, dec)
 		require.False(t, fromPool) // First call, pool is empty
 
-		// Retry for the same reason as the encoder case: a concurrently
-		// running caller may take the decoder between the Put and the Get.
+		// Retry for the same reason as the encoder case above: the race
+		// detector's build of sync.Pool discards one put in four.
 		var fromPool2 bool
 		for attempt := 0; attempt < 100 && !fromPool2; attempt++ {
 			putDecoder(dec)
@@ -209,8 +212,13 @@ func TestDecoderPool(t *testing.T) {
 // between Put and Get (routine after blocking file syscalls — Sync, Close,
 // Rename — especially on slow Windows CI filesystems), the item is parked
 // where Get cannot see it and exact-membership assertions fail. One P means
-// one slot, making Put→Get deterministic; the stdlib's own sync.Pool tests
-// use the same trick.
+// one slot; the stdlib's own sync.Pool tests use the same trick.
+//
+// None of this makes Put→Get deterministic under the race detector, and no
+// helper can: that build of sync.Pool.Put throws one item in four away
+// deliberately. A test that needs to observe a pooled item has to retry the
+// Get; a test that only needs to know the code returned its codec should count
+// the Put instead (see encoderPuts and decoderPuts).
 func withIsolatedPools(t *testing.T) {
 	t.Helper()
 	origEnc := encoderPool
@@ -295,11 +303,11 @@ func TestPoolGrowsFromSaveC1z(t *testing.T) {
 	err = saveC1z(dbFile, c1zFile, pooledEncoderConcurrency)
 	require.NoError(t, err)
 
-	// Assert on the Put, not on a later Get: the pools are process-wide, so a
-	// concurrently running test can take the encoder saveC1z returned, and a
-	// missed Get would then look like the bug this test is guarding. The count
-	// is exact rather than a delta so the assertion is about this call and not
-	// about whatever else happens to be putting encoders back.
+	// What this test is about is whether saveC1z hands its encoder back, so
+	// count the put. Asserting on a later get instead would fail a quarter of
+	// the time under the race detector, which drops one put in four on purpose;
+	// the count is taken before the pool sees the item. It is exact rather than
+	// a delta so an unexpected second put fails here too.
 	require.Equal(t, putsBefore+1, encoderPuts.Load(), "saveC1z should have returned exactly its own encoder to the pool")
 }
 
@@ -340,11 +348,10 @@ func TestPoolGrowsFromDecoder(t *testing.T) {
 	err = f.Close()
 	require.NoError(t, err)
 
-	// Assert on the Put, not on a later Get: the pools are process-wide, so a
-	// concurrently running test can take the decoder Close returned, and a
-	// missed Get would then look like the bug this test is guarding. The count
-	// is exact rather than a delta so the assertion is about this call and not
-	// about whatever else happens to be putting decoders back.
+	// Count the put, for the same reason as the encoder case above. This is the
+	// assertion that was failing the nightly race shard when it read the pool
+	// through a get: the detector's one-in-four drop, not a decoder that went
+	// unpooled.
 	require.Equal(t, putsBefore+1, decoderPuts.Load(), "NewDecoder.Close should have returned exactly its own decoder to the pool")
 }
 


### PR DESCRIPTION
The opt-in suites in docs/TESTING.md had no scheduled runner, so the race detector, soaks, fuzzers, and crash harness only ran when someone remembered to run them. Live data races reached main as a result.

Add .github/workflows/nightly.yaml. It runs one job per tier rather than invoking `make test-nightly`, which is serial and hours long: a nightly suite has to finish overnight to be worth having, and a per-tier job names what broke instead of presenting one red check.

The race sweep is the long pole, with nearly all of its wall clock in a handful of packages, so shard it and run the shards concurrently. The `rest` shard is the complement of the named shards, so every package belongs to exactly one shard by construction and a new package joins `rest` instead of quietly falling out of instrumented coverage. `make race-shard-audit` proves that by counting, and pull-request CI runs it, since the gap it catches is otherwise invisible.