### PR TITLE
If doing short tests, don't run chaos tests.

### DIFF
--- a/pkg/sync/chaos_cancellation_test.go
+++ b/pkg/sync/chaos_cancellation_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestChaosConnectorCancellationTerminatesAndColdResumes(t *testing.T) {
+	skipChaosInShort(t)
 	cases := []struct {
 		name    string
 		effect  chaosconnector.Effect

--- a/pkg/sync/chaos_collection_fault_test.go
+++ b/pkg/sync/chaos_collection_fault_test.go
@@ -22,6 +22,7 @@ type collectionFaultTarget struct {
 }
 
 func TestChaosConnectorResourcesAndEntitlementsFaultMatrix(t *testing.T) {
+	skipChaosInShort(t)
 	targets := []collectionFaultTarget{
 		{
 			name:    "resources",

--- a/pkg/sync/chaos_combined_fault_test.go
+++ b/pkg/sync/chaos_combined_fault_test.go
@@ -131,6 +131,7 @@ func (g *chaosFatalGate) err() error {
 }
 
 func TestChaosConnectorLostResponseThenFilesystemFailureResumes(t *testing.T) {
+	skipChaosInShort(t)
 	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Second)
 	defer cancel()
 

--- a/pkg/sync/chaos_connector_test.go
+++ b/pkg/sync/chaos_connector_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func TestChaosConnectorCleanSyncMatchesManifest(t *testing.T) {
+	skipChaosInShort(t)
 	for _, workers := range []int{1, 4} {
 		t.Run(fmt.Sprintf("workers=%d", workers), func(t *testing.T) {
 			ctx := t.Context()
@@ -58,6 +59,7 @@ func TestChaosConnectorCleanSyncMatchesManifest(t *testing.T) {
 }
 
 func TestChaosConnectorGRPCSyncMatchesManifest(t *testing.T) {
+	skipChaosInShort(t)
 	ctx := t.Context()
 	tmpDir := t.TempDir()
 	c1zPath := filepath.Join(tmpDir, "chaos-grpc.c1z")
@@ -76,6 +78,7 @@ func TestChaosConnectorGRPCSyncMatchesManifest(t *testing.T) {
 }
 
 func TestChaosConnectorUnknownResponseDataIsIgnored(t *testing.T) {
+	skipChaosInShort(t)
 	for _, mutation := range []string{
 		chaosconnector.MutationUnknownAnnotation,
 		chaosconnector.MutationUnknownProtoField,
@@ -110,6 +113,7 @@ func TestChaosConnectorUnknownResponseDataIsIgnored(t *testing.T) {
 }
 
 func TestChaosConnectorDuplicateResourceIsIdempotent(t *testing.T) {
+	skipChaosInShort(t)
 	ctx := t.Context()
 	tmpDir := t.TempDir()
 	c1zPath := filepath.Join(tmpDir, "chaos-duplicate-resource.c1z")
@@ -140,6 +144,7 @@ func TestChaosConnectorDuplicateResourceIsIdempotent(t *testing.T) {
 }
 
 func TestChaosConnectorEmptyResourceIsSkipped(t *testing.T) {
+	skipChaosInShort(t)
 	ctx := t.Context()
 	tmpDir := t.TempDir()
 	c1zPath := filepath.Join(tmpDir, "chaos-empty-resource.c1z")
@@ -181,6 +186,7 @@ func TestChaosConnectorEmptyResourceIsSkipped(t *testing.T) {
 }
 
 func TestChaosConnectorEmptyResourceTypeIsSkipped(t *testing.T) {
+	skipChaosInShort(t)
 	ctx := t.Context()
 	tmpDir := t.TempDir()
 	c1zPath := filepath.Join(tmpDir, "chaos-empty-resource-type.c1z")
@@ -222,6 +228,7 @@ func TestChaosConnectorEmptyResourceTypeIsSkipped(t *testing.T) {
 }
 
 func TestChaosConnectorDuplicateEnqueueAnnotationFailsWithoutSealing(t *testing.T) {
+	skipChaosInShort(t)
 	ctx := t.Context()
 	tmpDir := t.TempDir()
 	c1zPath := filepath.Join(tmpDir, "chaos-duplicate-enqueue.c1z")
@@ -266,6 +273,7 @@ func TestChaosConnectorDuplicateEnqueueAnnotationFailsWithoutSealing(t *testing.
 }
 
 func TestChaosConnectorCyclicPageTokensTerminateWithoutDuplicateRows(t *testing.T) {
+	skipChaosInShort(t)
 	t.Skip("pinned seen-set cycle termination, removed by RFC 0007 phase 1 " +
 		"(docs/rfcs/0007-scheduler-cursor-accounting.md): the queue keeps no identity history, " +
 		"so a period-2 continuation cycle spins until the run-duration budget — the " +
@@ -320,6 +328,7 @@ func TestChaosConnectorCyclicPageTokensTerminateWithoutDuplicateRows(t *testing.
 }
 
 func TestChaosConnectorFatalErrorDoesNotSeal(t *testing.T) {
+	skipChaosInShort(t)
 	ctx := t.Context()
 	tmpDir := t.TempDir()
 	c1zPath := filepath.Join(tmpDir, "chaos-fatal.c1z")
@@ -363,6 +372,7 @@ func TestChaosConnectorFatalErrorDoesNotSeal(t *testing.T) {
 }
 
 func TestChaosConnectorMalformedEntitlementIsSkipped(t *testing.T) {
+	skipChaosInShort(t)
 	ctx := t.Context()
 	tmpDir := t.TempDir()
 	c1zPath := filepath.Join(tmpDir, "chaos-malformed-entitlement.c1z")
@@ -399,6 +409,7 @@ func TestChaosConnectorMalformedEntitlementIsSkipped(t *testing.T) {
 }
 
 func TestChaosConnectorSeededFanoutWithRetries(t *testing.T) {
+	skipChaosInShort(t)
 	iterations := 1
 	if value := os.Getenv("BATON_CHAOS_ITERATIONS"); value != "" {
 		parsed, err := strconv.Atoi(value)

--- a/pkg/sync/chaos_external_principal_test.go
+++ b/pkg/sync/chaos_external_principal_test.go
@@ -72,6 +72,7 @@ func (s *chaosExternalPrincipalCutStore) DeleteEntitlementByRefs(
 }
 
 func TestChaosConnectorExternalPrincipalCorpus(t *testing.T) {
+	skipChaosInShort(t)
 	for _, corpusCase := range chaosconnector.ExternalPrincipalCorpus() {
 		for _, transport := range []chaosTransport{chaosTransportDirect, chaosTransportGRPC} {
 			t.Run(corpusCase.Name+"/"+transport.String(), func(t *testing.T) {
@@ -170,6 +171,7 @@ func TestChaosConnectorExternalPrincipalCorpus(t *testing.T) {
 }
 
 func TestChaosConnectorExternalPrincipalCorpusResumesAfterRewriteCut(t *testing.T) {
+	skipChaosInShort(t)
 	for _, corpusCase := range chaosconnector.ExternalPrincipalCorpus() {
 		t.Run(corpusCase.Name, func(t *testing.T) {
 			ctx := t.Context()
@@ -273,6 +275,7 @@ func TestChaosConnectorExternalPrincipalCorpusResumesAfterRewriteCut(t *testing.
 }
 
 func TestChaosConnectorExternalPrincipalResumeUsesCurrentExternalAnswer(t *testing.T) {
+	skipChaosInShort(t)
 	var corpusCase chaosconnector.ExternalPrincipalCase
 	for _, candidate := range chaosconnector.ExternalPrincipalCorpus() {
 		if candidate.Name == "external-principal/all-users" {
@@ -426,6 +429,7 @@ func TestChaosConnectorExternalPrincipalResumeUsesCurrentExternalAnswer(t *testi
 }
 
 func TestChaosConnectorSQLiteExternalPrincipalResumeDegradesWithoutFailure(t *testing.T) {
+	skipChaosInShort(t)
 	var corpusCase chaosconnector.ExternalPrincipalCase
 	for _, candidate := range chaosconnector.ExternalPrincipalCorpus() {
 		if candidate.Name == "external-principal/id-match" {

--- a/pkg/sync/chaos_grants_fault_test.go
+++ b/pkg/sync/chaos_grants_fault_test.go
@@ -30,6 +30,7 @@ type grantFaultCase struct {
 }
 
 func TestChaosConnectorListGrantsFaultMatrix(t *testing.T) {
+	skipChaosInShort(t)
 	cases := []grantFaultCase{
 		{
 			name:         "retryable",

--- a/pkg/sync/chaos_harness_test.go
+++ b/pkg/sync/chaos_harness_test.go
@@ -43,6 +43,15 @@ func chaosFaultTransports() []chaosTransport {
 	}
 }
 
+// skipChaosInShort skips the chaos connector suite under -short. Windows CI
+// runs with -short because its filesystem is too slow for the full suite.
+func skipChaosInShort(t *testing.T) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("skipping chaos connector suite in short mode")
+	}
+}
+
 // chaosHarness owns one run's scenario-to-transport-to-syncer stack. Tests
 // customize sync behavior with options without repeating adapter wiring or
 // forgetting transport cleanup.
@@ -63,6 +72,7 @@ func newChaosHarness(
 	opts ...SyncOpt,
 ) *chaosHarness {
 	t.Helper()
+	skipChaosInShort(t)
 	builder, err := chaosconnector.NewBuilder(run)
 	require.NoError(t, err)
 	server, err := builder.Server(ctx)

--- a/pkg/sync/chaos_lifecycle_test.go
+++ b/pkg/sync/chaos_lifecycle_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestChaosConnectorDataPolicyLifecycleCorpus(t *testing.T) {
+	skipChaosInShort(t)
 	for _, transport := range []chaosTransport{chaosTransportDirect, chaosTransportGRPC} {
 		t.Run(transport.String(), func(t *testing.T) {
 			for _, corpusCase := range chaosconnector.LifecycleCorpus() {

--- a/pkg/sync/chaos_mutation_policy_test.go
+++ b/pkg/sync/chaos_mutation_policy_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestChaosConnectorReservedBatonIDOwnershipIsRejected(t *testing.T) {
+	skipChaosInShort(t)
 	for _, transport := range []chaosTransport{chaosTransportDirect, chaosTransportGRPC} {
 		t.Run(transport.String(), func(t *testing.T) {
 			ctx := t.Context()
@@ -47,6 +48,7 @@ func TestChaosConnectorReservedBatonIDOwnershipIsRejected(t *testing.T) {
 }
 
 func TestChaosConnectorMalformedKnownAnnotationFailsWithoutSealing(t *testing.T) {
+	skipChaosInShort(t)
 	for _, transport := range chaosFaultTransports() {
 		t.Run(transport.String(), func(t *testing.T) {
 			ctx := t.Context()
@@ -69,6 +71,7 @@ func TestChaosConnectorMalformedKnownAnnotationFailsWithoutSealing(t *testing.T)
 }
 
 func TestChaosConnectorClearedNextPageTokenSealsOnlyVisiblePrefix(t *testing.T) {
+	skipChaosInShort(t)
 	for _, transport := range chaosFaultTransports() {
 		t.Run(transport.String(), func(t *testing.T) {
 			ctx := t.Context()
@@ -106,6 +109,7 @@ func TestChaosConnectorClearedNextPageTokenSealsOnlyVisiblePrefix(t *testing.T) 
 }
 
 func TestChaosConnectorReversedResponseOrderPreservesLogicalContent(t *testing.T) {
+	skipChaosInShort(t)
 	for _, transport := range chaosFaultTransports() {
 		t.Run(transport.String(), func(t *testing.T) {
 			ctx := t.Context()

--- a/pkg/sync/chaos_referential_test.go
+++ b/pkg/sync/chaos_referential_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestChaosConnectorReferentialCorpus(t *testing.T) {
+	skipChaosInShort(t)
 	for _, corpusCase := range chaosconnector.ReferentialCorpus() {
 		t.Run(corpusCase.Name, func(t *testing.T) {
 			for _, transport := range []chaosTransport{chaosTransportDirect, chaosTransportGRPC} {

--- a/pkg/sync/chaos_semantic_test.go
+++ b/pkg/sync/chaos_semantic_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestChaosConnectorSemanticCorpus(t *testing.T) {
+	skipChaosInShort(t)
 	for _, corpusCase := range chaosconnector.SemanticCorpus() {
 		t.Run(corpusCase.Name, func(t *testing.T) {
 			for _, transport := range []chaosTransport{chaosTransportDirect, chaosTransportGRPC} {
@@ -27,6 +28,7 @@ func TestChaosConnectorSemanticCorpus(t *testing.T) {
 }
 
 func TestChaosConnectorRetryDriftCorpus(t *testing.T) {
+	skipChaosInShort(t)
 	for _, corpusCase := range chaosconnector.TemporalCorpus() {
 		t.Run(corpusCase.Name, func(t *testing.T) {
 			runTemporalCorpusCase(t, corpusCase)
@@ -35,6 +37,7 @@ func TestChaosConnectorRetryDriftCorpus(t *testing.T) {
 }
 
 func TestChaosConnectorConcurrentDuplicateCompletionOrder(t *testing.T) {
+	skipChaosInShort(t)
 	for _, corpusCase := range chaosconnector.ConcurrentDuplicateCorpus() {
 		t.Run(corpusCase.Name, func(t *testing.T) {
 			runConcurrentDuplicateCase(t, corpusCase)
@@ -43,6 +46,7 @@ func TestChaosConnectorConcurrentDuplicateCompletionOrder(t *testing.T) {
 }
 
 func TestChaosConnectorConcurrentDuplicateResumeOrder(t *testing.T) {
+	skipChaosInShort(t)
 	for _, corpusCase := range chaosconnector.ConcurrentDuplicateCorpus() {
 		t.Run(corpusCase.Name, func(t *testing.T) {
 			runConcurrentDuplicateResumeCase(t, corpusCase)

--- a/pkg/sync/checkpoint_cut_test.go
+++ b/pkg/sync/checkpoint_cut_test.go
@@ -487,6 +487,9 @@ func enumerateCutPoints(total, limit int) []int {
 }
 
 func TestCheckpointCutEnumeration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping checkpoint cut enumeration in short mode")
+	}
 	tmpDir := t.TempDir()
 	base, expectedEntIDs, userID := buildCutFixture(t)
 

--- a/pkg/sync/scheduler_soak_test.go
+++ b/pkg/sync/scheduler_soak_test.go
@@ -155,6 +155,9 @@ func soakSeeds(t *testing.T) []int64 {
 }
 
 func TestSchedulerSoakRandomizedFanoutWithFailures(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping scheduler soak test in short mode")
+	}
 	for _, seed := range soakSeeds(t) {
 		t.Run(fmt.Sprintf("seed=%d", seed), func(t *testing.T) {
 			runSchedulerSoak(t, seed)


### PR DESCRIPTION
This also skips the chaos tests in Windows CI, reducing the chance it'll time out.