### PR TITLE
Bound inline_wait at the wire with a one-day validation ceiling

### DIFF
--- a/pb/c1/connector/v2/action.pb.go
+++ b/pb/c1/connector/v2/action.pb.go
@@ -10,6 +10,7 @@ package v2
 
 import (
 	v1 "github.com/conductorone/baton-sdk/pb/c1/config/v1"
+	_ "github.com/envoyproxy/protoc-gen-validate/validate"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	anypb "google.golang.org/protobuf/types/known/anypb"
@@ -314,11 +315,13 @@ type InvokeActionRequest struct {
 	// to finish before returning its in-flight status. The wait is an upper
 	// bound on blocking, not a guarantee: the server may answer sooner, and it
 	// may silently cap an oversized wait rather than reject it. Unset or
-	// non-positive values take the server's default. The server does not
+	// zero values take the server's default. The server does not
 	// shorten the wait to fit the call's deadline, so callers must set their
 	// RPC deadline above the requested wait: a deadline that fires first fails
 	// the call, and although the action keeps running server-side, its id is
-	// never delivered, so the outcome is unreachable to that caller.
+	// never delivered, so the outcome is unreachable to that caller. Negative
+	// waits and waits beyond the validated ceiling are rejected outright as
+	// caller bugs, while values within the bounds may still be capped.
 	InlineWait    *durationpb.Duration `protobuf:"bytes,5,opt,name=inline_wait,json=inlineWait,proto3" json:"inline_wait,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -438,11 +441,13 @@ type InvokeActionRequest_builder struct {
 	// to finish before returning its in-flight status. The wait is an upper
 	// bound on blocking, not a guarantee: the server may answer sooner, and it
 	// may silently cap an oversized wait rather than reject it. Unset or
-	// non-positive values take the server's default. The server does not
+	// zero values take the server's default. The server does not
 	// shorten the wait to fit the call's deadline, so callers must set their
 	// RPC deadline above the requested wait: a deadline that fires first fails
 	// the call, and although the action keeps running server-side, its id is
-	// never delivered, so the outcome is unreachable to that caller.
+	// never delivered, so the outcome is unreachable to that caller. Negative
+	// waits and waits beyond the validated ceiling are rejected outright as
+	// caller bugs, while values within the bounds may still be capped.
 	InlineWait *durationpb.Duration
 }
 
@@ -1096,7 +1101,7 @@ var File_c1_connector_v2_action_proto protoreflect.FileDescriptor
 
 const file_c1_connector_v2_action_proto_rawDesc = "" +
 	"\n" +
-	"\x1cc1/connector/v2/action.proto\x12\x0fc1.connector.v2\x1a\x19c1/config/v1/config.proto\x1a\x19google/protobuf/any.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1cgoogle/protobuf/struct.proto\"\xfb\x02\n" +
+	"\x1cc1/connector/v2/action.proto\x12\x0fc1.connector.v2\x1a\x19c1/config/v1/config.proto\x1a\x19google/protobuf/any.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x17validate/validate.proto\"\xfb\x02\n" +
 	"\x11BatonActionSchema\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x121\n" +
 	"\targuments\x18\x02 \x03(\v2\x13.c1.config.v1.FieldR\targuments\x12:\n" +
@@ -1106,13 +1111,13 @@ const file_c1_connector_v2_action_proto_rawDesc = "" +
 	"\vdescription\x18\x06 \x01(\tR\vdescription\x12<\n" +
 	"\vaction_type\x18\a \x03(\x0e2\x1b.c1.connector.v2.ActionTypeR\n" +
 	"actionType\x12(\n" +
-	"\x10resource_type_id\x18\b \x01(\tR\x0eresourceTypeId\"\xf4\x01\n" +
+	"\x10resource_type_id\x18\b \x01(\tR\x0eresourceTypeId\"\x84\x02\n" +
 	"\x13InvokeActionRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12+\n" +
 	"\x04args\x18\x02 \x01(\v2\x17.google.protobuf.StructR\x04args\x126\n" +
 	"\vannotations\x18\x03 \x03(\v2\x14.google.protobuf.AnyR\vannotations\x12(\n" +
-	"\x10resource_type_id\x18\x04 \x01(\tR\x0eresourceTypeId\x12:\n" +
-	"\vinline_wait\x18\x05 \x01(\v2\x19.google.protobuf.DurationR\n" +
+	"\x10resource_type_id\x18\x04 \x01(\tR\x0eresourceTypeId\x12J\n" +
+	"\vinline_wait\x18\x05 \x01(\v2\x19.google.protobuf.DurationB\x0e\xfaB\v\xaa\x01\b\"\x04\b\x80\xa3\x052\x00R\n" +
 	"inlineWait\"\xe3\x01\n" +
 	"\x14InvokeActionResponse\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12:\n" +

--- a/pb/c1/connector/v2/action.pb.go
+++ b/pb/c1/connector/v2/action.pb.go
@@ -320,8 +320,9 @@ type InvokeActionRequest struct {
 	// RPC deadline above the requested wait: a deadline that fires first fails
 	// the call, and although the action keeps running server-side, its id is
 	// never delivered, so the outcome is unreachable to that caller. Negative
-	// waits and waits beyond the validated ceiling are rejected outright as
-	// caller bugs, while values within the bounds may still be capped.
+	// waits and waits beyond the validated ceiling are rejected as caller
+	// bugs where the transport enforces validation rules; the server-side
+	// cap is the backstop everywhere.
 	InlineWait    *durationpb.Duration `protobuf:"bytes,5,opt,name=inline_wait,json=inlineWait,proto3" json:"inline_wait,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -446,8 +447,9 @@ type InvokeActionRequest_builder struct {
 	// RPC deadline above the requested wait: a deadline that fires first fails
 	// the call, and although the action keeps running server-side, its id is
 	// never delivered, so the outcome is unreachable to that caller. Negative
-	// waits and waits beyond the validated ceiling are rejected outright as
-	// caller bugs, while values within the bounds may still be capped.
+	// waits and waits beyond the validated ceiling are rejected as caller
+	// bugs where the transport enforces validation rules; the server-side
+	// cap is the backstop everywhere.
 	InlineWait *durationpb.Duration
 }
 

--- a/pb/c1/connector/v2/action.pb.validate.go
+++ b/pb/c1/connector/v2/action.pb.validate.go
@@ -336,32 +336,34 @@ func (m *InvokeActionRequest) validate(all bool) error {
 
 	// no validation rules for ResourceTypeId
 
-	if all {
-		switch v := interface{}(m.GetInlineWait()).(type) {
-		case interface{ ValidateAll() error }:
-			if err := v.ValidateAll(); err != nil {
-				errors = append(errors, InvokeActionRequestValidationError{
-					field:  "InlineWait",
-					reason: "embedded message failed validation",
-					cause:  err,
-				})
-			}
-		case interface{ Validate() error }:
-			if err := v.Validate(); err != nil {
-				errors = append(errors, InvokeActionRequestValidationError{
-					field:  "InlineWait",
-					reason: "embedded message failed validation",
-					cause:  err,
-				})
-			}
-		}
-	} else if v, ok := interface{}(m.GetInlineWait()).(interface{ Validate() error }); ok {
-		if err := v.Validate(); err != nil {
-			return InvokeActionRequestValidationError{
+	if d := m.GetInlineWait(); d != nil {
+		dur, err := d.AsDuration(), d.CheckValid()
+		if err != nil {
+			err = InvokeActionRequestValidationError{
 				field:  "InlineWait",
-				reason: "embedded message failed validation",
+				reason: "value is not a valid duration",
 				cause:  err,
 			}
+			if !all {
+				return err
+			}
+			errors = append(errors, err)
+		} else {
+
+			lte := time.Duration(86400*time.Second + 0*time.Nanosecond)
+			gte := time.Duration(0*time.Second + 0*time.Nanosecond)
+
+			if dur < gte || dur > lte {
+				err := InvokeActionRequestValidationError{
+					field:  "InlineWait",
+					reason: "value must be inside range [0s, 24h0m0s]",
+				}
+				if !all {
+					return err
+				}
+				errors = append(errors, err)
+			}
+
 		}
 	}
 

--- a/pb/c1/connector/v2/action_protoopaque.pb.go
+++ b/pb/c1/connector/v2/action_protoopaque.pb.go
@@ -10,6 +10,7 @@ package v2
 
 import (
 	v1 "github.com/conductorone/baton-sdk/pb/c1/config/v1"
+	_ "github.com/envoyproxy/protoc-gen-validate/validate"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	anypb "google.golang.org/protobuf/types/known/anypb"
@@ -435,11 +436,13 @@ type InvokeActionRequest_builder struct {
 	// to finish before returning its in-flight status. The wait is an upper
 	// bound on blocking, not a guarantee: the server may answer sooner, and it
 	// may silently cap an oversized wait rather than reject it. Unset or
-	// non-positive values take the server's default. The server does not
+	// zero values take the server's default. The server does not
 	// shorten the wait to fit the call's deadline, so callers must set their
 	// RPC deadline above the requested wait: a deadline that fires first fails
 	// the call, and although the action keeps running server-side, its id is
-	// never delivered, so the outcome is unreachable to that caller.
+	// never delivered, so the outcome is unreachable to that caller. Negative
+	// waits and waits beyond the validated ceiling are rejected outright as
+	// caller bugs, while values within the bounds may still be capped.
 	InlineWait *durationpb.Duration
 }
 
@@ -1107,7 +1110,7 @@ var File_c1_connector_v2_action_proto protoreflect.FileDescriptor
 
 const file_c1_connector_v2_action_proto_rawDesc = "" +
 	"\n" +
-	"\x1cc1/connector/v2/action.proto\x12\x0fc1.connector.v2\x1a\x19c1/config/v1/config.proto\x1a\x19google/protobuf/any.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1cgoogle/protobuf/struct.proto\"\xfb\x02\n" +
+	"\x1cc1/connector/v2/action.proto\x12\x0fc1.connector.v2\x1a\x19c1/config/v1/config.proto\x1a\x19google/protobuf/any.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x17validate/validate.proto\"\xfb\x02\n" +
 	"\x11BatonActionSchema\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x121\n" +
 	"\targuments\x18\x02 \x03(\v2\x13.c1.config.v1.FieldR\targuments\x12:\n" +
@@ -1117,13 +1120,13 @@ const file_c1_connector_v2_action_proto_rawDesc = "" +
 	"\vdescription\x18\x06 \x01(\tR\vdescription\x12<\n" +
 	"\vaction_type\x18\a \x03(\x0e2\x1b.c1.connector.v2.ActionTypeR\n" +
 	"actionType\x12(\n" +
-	"\x10resource_type_id\x18\b \x01(\tR\x0eresourceTypeId\"\xf4\x01\n" +
+	"\x10resource_type_id\x18\b \x01(\tR\x0eresourceTypeId\"\x84\x02\n" +
 	"\x13InvokeActionRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12+\n" +
 	"\x04args\x18\x02 \x01(\v2\x17.google.protobuf.StructR\x04args\x126\n" +
 	"\vannotations\x18\x03 \x03(\v2\x14.google.protobuf.AnyR\vannotations\x12(\n" +
-	"\x10resource_type_id\x18\x04 \x01(\tR\x0eresourceTypeId\x12:\n" +
-	"\vinline_wait\x18\x05 \x01(\v2\x19.google.protobuf.DurationR\n" +
+	"\x10resource_type_id\x18\x04 \x01(\tR\x0eresourceTypeId\x12J\n" +
+	"\vinline_wait\x18\x05 \x01(\v2\x19.google.protobuf.DurationB\x0e\xfaB\v\xaa\x01\b\"\x04\b\x80\xa3\x052\x00R\n" +
 	"inlineWait\"\xe3\x01\n" +
 	"\x14InvokeActionResponse\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12:\n" +

--- a/pb/c1/connector/v2/action_protoopaque.pb.go
+++ b/pb/c1/connector/v2/action_protoopaque.pb.go
@@ -441,8 +441,9 @@ type InvokeActionRequest_builder struct {
 	// RPC deadline above the requested wait: a deadline that fires first fails
 	// the call, and although the action keeps running server-side, its id is
 	// never delivered, so the outcome is unreachable to that caller. Negative
-	// waits and waits beyond the validated ceiling are rejected outright as
-	// caller bugs, while values within the bounds may still be capped.
+	// waits and waits beyond the validated ceiling are rejected as caller
+	// bugs where the transport enforces validation rules; the server-side
+	// cap is the backstop everywhere.
 	InlineWait *durationpb.Duration
 }
 

--- a/pkg/actions/actions.go
+++ b/pkg/actions/actions.go
@@ -229,7 +229,9 @@ const (
 )
 
 // clampInlineWait bounds a requested inline wait: non-positive values take
-// the server default and oversized values are capped at maxInlineWait.
+// the server default and oversized values are capped at maxInlineWait. Not
+// every transport enforces the wire validation rules, so this clamp is the
+// only universal bound.
 func clampInlineWait(inlineWait time.Duration) time.Duration {
 	if inlineWait <= 0 {
 		return defaultInlineWait

--- a/pkg/connectorbuilder/actions_inline_wait_test.go
+++ b/pkg/connectorbuilder/actions_inline_wait_test.go
@@ -83,3 +83,35 @@ func TestInvokeActionThreadsInlineWaitFromRequest(t *testing.T) {
 	require.GreaterOrEqual(t, elapsed, time.Second)
 	require.Less(t, elapsed, 3*time.Second)
 }
+
+// The wire ceiling rejects waits that are almost certainly caller bugs;
+// values at or below it are the server-side clamp's business, and the
+// lenient non-positive contract survives validation.
+func TestInlineWaitValidationCeiling(t *testing.T) {
+	cases := []struct {
+		name    string
+		wait    *durationpb.Duration
+		wantErr bool
+	}{
+		{"unset passes", nil, false},
+		{"negative is rejected", durationpb.New(-time.Second), true},
+		{"zero passes", durationpb.New(0), false},
+		{"at the ceiling passes", durationpb.New(24 * time.Hour), false},
+		{"beyond the ceiling is rejected", durationpb.New(24*time.Hour + time.Second), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := v2.InvokeActionRequest_builder{
+				Name:       "bounded-action",
+				InlineWait: tc.wait,
+			}.Build()
+			err := req.Validate()
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "InlineWait")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/proto/c1/connector/v2/action.proto
+++ b/proto/c1/connector/v2/action.proto
@@ -6,6 +6,7 @@ import "c1/config/v1/config.proto";
 import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
+import "validate/validate.proto";
 
 option go_package = "github.com/conductorone/baton-sdk/pb/c1/connector/v2";
 
@@ -67,12 +68,17 @@ message InvokeActionRequest {
   // to finish before returning its in-flight status. The wait is an upper
   // bound on blocking, not a guarantee: the server may answer sooner, and it
   // may silently cap an oversized wait rather than reject it. Unset or
-  // non-positive values take the server's default. The server does not
+  // zero values take the server's default. The server does not
   // shorten the wait to fit the call's deadline, so callers must set their
   // RPC deadline above the requested wait: a deadline that fires first fails
   // the call, and although the action keeps running server-side, its id is
-  // never delivered, so the outcome is unreachable to that caller.
-  google.protobuf.Duration inline_wait = 5;
+  // never delivered, so the outcome is unreachable to that caller. Negative
+  // waits and waits beyond the validated ceiling are rejected outright as
+  // caller bugs, while values within the bounds may still be capped.
+  google.protobuf.Duration inline_wait = 5 [(validate.rules).duration = {
+    gte: {},
+    lte: {seconds: 86400}
+  }];
 }
 
 message InvokeActionResponse {

--- a/proto/c1/connector/v2/action.proto
+++ b/proto/c1/connector/v2/action.proto
@@ -73,8 +73,9 @@ message InvokeActionRequest {
   // RPC deadline above the requested wait: a deadline that fires first fails
   // the call, and although the action keeps running server-side, its id is
   // never delivered, so the outcome is unreachable to that caller. Negative
-  // waits and waits beyond the validated ceiling are rejected outright as
-  // caller bugs, while values within the bounds may still be capped.
+  // waits and waits beyond the validated ceiling are rejected as caller
+  // bugs where the transport enforces validation rules; the server-side
+  // cap is the backstop everywhere.
   google.protobuf.Duration inline_wait = 5 [(validate.rules).duration = {
     gte: {},
     lte: {seconds: 86400}


### PR DESCRIPTION
Waits beyond a day are almost certainly caller bugs, so the request now fails validation outright instead of being silently capped; the server-side clamp keeps governing everything at or below the ceiling. Unset and non-positive values still pass, preserving the take-the- default contract, which the validation table pins alongside both sides of the boundary.