### PR TITLE
Correctly classify more HTTP errors as retryable.

### DIFF
--- a/pkg/uhttp/errors.go
+++ b/pkg/uhttp/errors.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"syscall"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -24,9 +23,39 @@ func wrapTransientNetworkError(err error) error {
 	if errors.Is(err, io.ErrUnexpectedEOF) {
 		return WrapErrors(codes.Unavailable, "unexpected EOF", err)
 	}
-	if errors.Is(err, syscall.ECONNRESET) {
+	// A bare EOF reaching the caller means the peer closed the connection
+	// before any response headers arrived, usually a pooled connection it
+	// had already torn down.
+	if errors.Is(err, io.EOF) {
+		return WrapErrors(codes.Unavailable, "connection closed before response", err)
+	}
+	if isConnectionReset(err) {
 		return WrapErrors(codes.Unavailable, "connection reset", err)
 	}
+	if isConnectionRefused(err) {
+		return WrapErrors(codes.Unavailable, "connection refused", err)
+	}
+	if isBrokenPipe(err) {
+		return WrapErrors(codes.Unavailable, "broken pipe", err)
+	}
+	if isNetworkUnreachable(err) {
+		return WrapErrors(codes.Unavailable, "network unreachable", err)
+	}
+
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		switch {
+		case dnsErr.IsTimeout:
+			return WrapErrors(codes.DeadlineExceeded, "dns lookup timeout", err)
+		case dnsErr.IsTemporary:
+			return WrapErrors(codes.Unavailable, "temporary dns lookup failure", err)
+		case dnsErr.IsNotFound:
+			return WrapErrors(codes.InvalidArgument, "dns lookup failed: NXDOMAIN", err)
+		default:
+			return WrapErrors(codes.Unavailable, "dns lookup failed", err)
+		}
+	}
+
 	if isHTTP2ClientConnectionLost(err) {
 		return WrapErrors(codes.Unavailable, "http2 client connection lost", err)
 	}
@@ -45,6 +74,10 @@ func wrapTransientNetworkError(err error) error {
 	// (e.g. tls.handshakeTimeoutError at the RoundTrip level).
 	var netErr net.Error
 	if errors.As(err, &netErr) && netErr.Timeout() {
+		return WrapErrors(codes.DeadlineExceeded, fmt.Sprintf("network timeout: %v", err), err)
+	}
+	// Winsock timeouts do not satisfy the check above, so they need their own.
+	if isSocketTimeout(err) {
 		return WrapErrors(codes.DeadlineExceeded, fmt.Sprintf("network timeout: %v", err), err)
 	}
 
@@ -75,7 +108,9 @@ func requestNeverSent(err error) bool {
 // that died between requests: the reset/EOF classes a proxy or origin
 // produces when it tore the connection down while it sat in the pool.
 func isStaleConnectionError(err error) bool {
-	return errors.Is(err, syscall.ECONNRESET) ||
+	return isConnectionReset(err) ||
+		isBrokenPipe(err) ||
+		errors.Is(err, io.EOF) ||
 		errors.Is(err, io.ErrUnexpectedEOF) ||
 		isHTTP2ClientConnectionLost(err)
 }

--- a/pkg/uhttp/errors_other.go
+++ b/pkg/uhttp/errors_other.go
@@ -1,0 +1,38 @@
+//go:build !windows
+
+package uhttp
+
+import (
+	"errors"
+	"syscall"
+)
+
+// The socket-failure predicates below are split per platform because Winsock
+// reports these conditions with WSAE* codes that are distinct syscall.Errno
+// values from the POSIX names, and syscall.Errno.Is does not bridge the two.
+// See errors_windows.go for the Winsock spellings.
+
+func isConnectionReset(err error) bool {
+	return errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.ECONNABORTED)
+}
+
+func isConnectionRefused(err error) bool {
+	return errors.Is(err, syscall.ECONNREFUSED)
+}
+
+func isBrokenPipe(err error) bool {
+	return errors.Is(err, syscall.EPIPE)
+}
+
+func isNetworkUnreachable(err error) bool {
+	return errors.Is(err, syscall.EHOSTUNREACH) ||
+		errors.Is(err, syscall.ENETUNREACH) ||
+		errors.Is(err, syscall.ENETDOWN)
+}
+
+// isSocketTimeout is always false here: syscall.Errno.Timeout() already reports
+// true for ETIMEDOUT, so the net.Error timeout branch in
+// wrapTransientNetworkError catches it.
+func isSocketTimeout(error) bool {
+	return false
+}

--- a/pkg/uhttp/errors_test.go
+++ b/pkg/uhttp/errors_test.go
@@ -1,0 +1,290 @@
+package uhttp
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/url"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/conductorone/baton-sdk/pkg/retry"
+)
+
+func TestWrapTransientNetworkError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		wantCode codes.Code
+		wantMsg  string
+	}{
+		{
+			name:     "unexpected EOF",
+			err:      io.ErrUnexpectedEOF,
+			wantCode: codes.Unavailable,
+			wantMsg:  "unexpected EOF",
+		},
+		{
+			name: "connection reset",
+			err: &url.Error{
+				Op:  "Get",
+				URL: "https://example.com",
+				Err: &net.OpError{
+					Op:  "read",
+					Net: "tcp",
+					Err: os.NewSyscallError("read", syscall.ECONNRESET),
+				},
+			},
+			wantCode: codes.Unavailable,
+			wantMsg:  "connection reset",
+		},
+		{
+			name: "connection refused",
+			err: &url.Error{
+				Op:  "Get",
+				URL: "https://example.com",
+				Err: &net.OpError{
+					Op:  "dial",
+					Net: "tcp",
+					Err: os.NewSyscallError("connect", syscall.ECONNREFUSED),
+				},
+			},
+			wantCode: codes.Unavailable,
+			wantMsg:  "connection refused",
+		},
+		{
+			name: "broken pipe",
+			err: &net.OpError{
+				Op:  "write",
+				Net: "tcp",
+				Err: os.NewSyscallError("write", syscall.EPIPE),
+			},
+			wantCode: codes.Unavailable,
+			wantMsg:  "broken pipe",
+		},
+		{
+			name: "bare EOF",
+			err: &url.Error{
+				Op:  "Get",
+				URL: "https://example.com",
+				Err: io.EOF,
+			},
+			wantCode: codes.Unavailable,
+			wantMsg:  "connection closed before response",
+		},
+		{
+			name: "host unreachable",
+			err: &net.OpError{
+				Op:  "dial",
+				Net: "tcp",
+				Err: os.NewSyscallError("connect", syscall.EHOSTUNREACH),
+			},
+			wantCode: codes.Unavailable,
+			wantMsg:  "network unreachable",
+		},
+		{
+			name: "network unreachable",
+			err: &net.OpError{
+				Op:  "dial",
+				Net: "tcp",
+				Err: os.NewSyscallError("connect", syscall.ENETUNREACH),
+			},
+			wantCode: codes.Unavailable,
+			wantMsg:  "network unreachable",
+		},
+		{
+			name: "network down",
+			err: &net.OpError{
+				Op:  "dial",
+				Net: "tcp",
+				Err: os.NewSyscallError("connect", syscall.ENETDOWN),
+			},
+			wantCode: codes.Unavailable,
+			wantMsg:  "network unreachable",
+		},
+		{
+			// NXDOMAIN is a configuration error, not a blip: terminal, so the
+			// sync fails instead of retrying a hostname that will never
+			// resolve. Pinned in detail by TestWrapTransientNetworkError_NXDOMAINIsTerminal.
+			name: "dns not found",
+			err: &url.Error{
+				Op:  "Get",
+				URL: "https://example.invalid",
+				Err: &net.OpError{
+					Op:  "dial",
+					Net: "tcp",
+					Err: &net.DNSError{
+						Err:        "no such host",
+						Name:       "example.invalid",
+						IsNotFound: true,
+					},
+				},
+			},
+			wantCode: codes.InvalidArgument,
+			wantMsg:  "dns lookup failed",
+		},
+		{
+			name: "dns timeout",
+			err: &url.Error{
+				Op:  "Get",
+				URL: "https://example.com",
+				Err: &net.OpError{
+					Op:  "dial",
+					Net: "tcp",
+					Err: &net.DNSError{
+						Err:       "i/o timeout",
+						Name:      "example.com",
+						IsTimeout: true,
+					},
+				},
+			},
+			wantCode: codes.DeadlineExceeded,
+			wantMsg:  "dns lookup timeout",
+		},
+		{
+			name: "dns temporary",
+			err: &url.Error{
+				Op:  "Get",
+				URL: "https://example.com",
+				Err: &net.OpError{
+					Op:  "dial",
+					Net: "tcp",
+					Err: &net.DNSError{
+						Err:         "server misbehaving",
+						Name:        "example.com",
+						IsTemporary: true,
+					},
+				},
+			},
+			wantCode: codes.Unavailable,
+			wantMsg:  "temporary dns lookup failure",
+		},
+		{
+			// http2 surfaces this as a plain error with no typed sentinel.
+			name:     "http2 client connection lost",
+			err:      fmt.Errorf(`Get "https://example.com": http2: client connection lost`),
+			wantCode: codes.Unavailable,
+			wantMsg:  "http2 client connection lost",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := wrapTransientNetworkError(tt.err)
+			st, ok := status.FromError(got)
+			require.True(t, ok, "got %v", got)
+			require.Equal(t, tt.wantCode, st.Code())
+			require.Contains(t, st.Message(), tt.wantMsg)
+			require.ErrorIs(t, got, tt.err)
+		})
+	}
+}
+
+// NXDOMAIN is the one classification here that is deliberately terminal: a
+// hostname that does not resolve is a misconfiguration, so retrying it burns
+// the retry budget on every action and preserving the sync hides the cause.
+// The transient DNS case is the control, proving the assertion is about
+// NXDOMAIN specifically rather than about DNS failures in general.
+func TestWrapTransientNetworkError_NXDOMAINIsTerminal(t *testing.T) {
+	dnsFailure := func(dnsErr *net.DNSError) error {
+		return &url.Error{
+			Op:  "Get",
+			URL: "https://example.invalid",
+			Err: &net.OpError{Op: "dial", Net: "tcp", Err: dnsErr},
+		}
+	}
+	newRetryer := func() *retry.Retryer {
+		return retry.NewRetryer(t.Context(), retry.RetryConfig{
+			MaxAttempts:  3,
+			InitialDelay: time.Millisecond,
+			MaxDelay:     time.Millisecond,
+		})
+	}
+
+	nxdomain := wrapTransientNetworkError(dnsFailure(&net.DNSError{
+		Err:        "no such host",
+		Name:       "example.invalid",
+		IsNotFound: true,
+	}))
+	require.Equal(t, codes.InvalidArgument, status.Code(nxdomain))
+	require.False(t, newRetryer().ShouldWaitAndRetry(t.Context(), nxdomain),
+		"a hostname that does not resolve must not be retried")
+
+	temporary := wrapTransientNetworkError(dnsFailure(&net.DNSError{
+		Err:         "server misbehaving",
+		Name:        "example.invalid",
+		IsTemporary: true,
+	}))
+	require.Equal(t, codes.Unavailable, status.Code(temporary))
+	require.True(t, newRetryer().ShouldWaitAndRetry(t.Context(), temporary),
+		"a temporary resolver failure must still be retried")
+}
+
+func TestWrapTransientNetworkError_LeavesNonTransientAlone(t *testing.T) {
+	err := fmt.Errorf("something went wrong")
+	got := wrapTransientNetworkError(err)
+	require.Equal(t, err, got)
+
+	st, ok := status.FromError(got)
+	require.False(t, ok)
+	require.Equal(t, codes.Unknown, st.Code())
+}
+
+// isStaleConnectionError gates the transport's own retry of idempotent
+// requests, so the set it recognizes is a behavioral contract.
+func TestIsStaleConnectionError(t *testing.T) {
+	stale := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "connection reset",
+			err: &net.OpError{
+				Op:  "read",
+				Net: "tcp",
+				Err: os.NewSyscallError("read", syscall.ECONNRESET),
+			},
+		},
+		{
+			name: "broken pipe",
+			err: &net.OpError{
+				Op:  "write",
+				Net: "tcp",
+				Err: os.NewSyscallError("write", syscall.EPIPE),
+			},
+		},
+		{name: "unexpected EOF", err: io.ErrUnexpectedEOF},
+		{name: "http2 client connection lost", err: fmt.Errorf("http2: client connection lost")},
+	}
+	for _, tt := range stale {
+		t.Run(tt.name, func(t *testing.T) {
+			require.True(t, isStaleConnectionError(tt.err))
+		})
+	}
+
+	notStale := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "connection refused is a dial failure, not a stale pooled conn",
+			err: &net.OpError{
+				Op:  "dial",
+				Net: "tcp",
+				Err: os.NewSyscallError("connect", syscall.ECONNREFUSED),
+			},
+		},
+		{name: "unrelated error", err: fmt.Errorf("something went wrong")},
+	}
+	for _, tt := range notStale {
+		t.Run(tt.name, func(t *testing.T) {
+			require.False(t, isStaleConnectionError(tt.err))
+		})
+	}
+}

--- a/pkg/uhttp/errors_windows.go
+++ b/pkg/uhttp/errors_windows.go
@@ -1,0 +1,54 @@
+//go:build windows
+
+package uhttp
+
+import (
+	"errors"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+// Winsock reports socket failures with WSAE* codes, which are distinct
+// syscall.Errno values from the POSIX names of the same conditions.
+// syscall.Errno.Is on Windows only bridges the permission/exist/not-exist/
+// unsupported families, so matching the POSIX names alone silently fails to
+// classify any real socket error on Windows. Each predicate therefore accepts
+// both spellings.
+
+func isConnectionReset(err error) bool {
+	// Windows reports as WSAECONNABORTED some teardowns that POSIX reports as
+	// ECONNRESET or EPIPE, so it belongs with the reset class rather than
+	// being a separate condition.
+	return errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, windows.WSAECONNRESET) ||
+		errors.Is(err, windows.WSAECONNABORTED)
+}
+
+func isConnectionRefused(err error) bool {
+	return errors.Is(err, syscall.ECONNREFUSED) ||
+		errors.Is(err, windows.WSAECONNREFUSED)
+}
+
+func isBrokenPipe(err error) bool {
+	// WSAESHUTDOWN ("cannot send after socket shutdown") is the Winsock
+	// counterpart of writing to a pipe the peer already closed.
+	return errors.Is(err, syscall.EPIPE) ||
+		errors.Is(err, windows.WSAESHUTDOWN)
+}
+
+func isNetworkUnreachable(err error) bool {
+	return errors.Is(err, syscall.EHOSTUNREACH) ||
+		errors.Is(err, syscall.ENETUNREACH) ||
+		errors.Is(err, syscall.ENETDOWN) ||
+		errors.Is(err, windows.WSAEHOSTUNREACH) ||
+		errors.Is(err, windows.WSAENETUNREACH) ||
+		errors.Is(err, windows.WSAENETDOWN)
+}
+
+// isSocketTimeout restores the parity that net.Error.Timeout() misses on
+// Windows: syscall.Errno.Timeout() recognizes only the POSIX ETIMEDOUT value,
+// so a WSAETIMEDOUT would otherwise fall through unclassified.
+func isSocketTimeout(err error) bool {
+	return errors.Is(err, windows.WSAETIMEDOUT)
+}

--- a/pkg/uhttp/errors_windows_test.go
+++ b/pkg/uhttp/errors_windows_test.go
@@ -1,0 +1,72 @@
+//go:build windows
+
+package uhttp
+
+import (
+	"net"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Winsock reports socket failures with WSAE* codes rather than the POSIX
+// errnos, and syscall.Errno.Is does not bridge them, so matching only the
+// POSIX names would silently classify every real Windows socket failure as
+// codes.Unknown: non-retryable and non-preservable.
+func TestWrapTransientNetworkError_Winsock(t *testing.T) {
+	tests := []struct {
+		name     string
+		op       string
+		errno    error
+		wantCode codes.Code
+		wantMsg  string
+	}{
+		{name: "WSAECONNRESET", op: "read", errno: windows.WSAECONNRESET, wantCode: codes.Unavailable, wantMsg: "connection reset"},
+		{name: "WSAECONNABORTED", op: "read", errno: windows.WSAECONNABORTED, wantCode: codes.Unavailable, wantMsg: "connection reset"},
+		{name: "WSAECONNREFUSED", op: "dial", errno: windows.WSAECONNREFUSED, wantCode: codes.Unavailable, wantMsg: "connection refused"},
+		{name: "WSAESHUTDOWN", op: "write", errno: windows.WSAESHUTDOWN, wantCode: codes.Unavailable, wantMsg: "broken pipe"},
+		{name: "WSAEHOSTUNREACH", op: "dial", errno: windows.WSAEHOSTUNREACH, wantCode: codes.Unavailable, wantMsg: "network unreachable"},
+		{name: "WSAENETUNREACH", op: "dial", errno: windows.WSAENETUNREACH, wantCode: codes.Unavailable, wantMsg: "network unreachable"},
+		{name: "WSAENETDOWN", op: "dial", errno: windows.WSAENETDOWN, wantCode: codes.Unavailable, wantMsg: "network unreachable"},
+		{name: "WSAETIMEDOUT", op: "dial", errno: windows.WSAETIMEDOUT, wantCode: codes.DeadlineExceeded, wantMsg: "network timeout"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := &url.Error{
+				Op:  "Get",
+				URL: "https://example.com",
+				Err: &net.OpError{
+					Op:  tt.op,
+					Net: "tcp",
+					Err: os.NewSyscallError(tt.op, tt.errno),
+				},
+			}
+
+			got := wrapTransientNetworkError(err)
+			st, ok := status.FromError(got)
+			require.True(t, ok, "got %v", got)
+			require.Equal(t, tt.wantCode, st.Code())
+			require.Contains(t, st.Message(), tt.wantMsg)
+			require.ErrorIs(t, got, err)
+		})
+	}
+}
+
+// The transport's own retry of idempotent requests must recognize the Winsock
+// spellings too, or a stale pooled connection is never retried on Windows.
+func TestIsStaleConnectionError_Winsock(t *testing.T) {
+	for _, errno := range []error{windows.WSAECONNRESET, windows.WSAECONNABORTED, windows.WSAESHUTDOWN} {
+		err := &net.OpError{Op: "read", Net: "tcp", Err: os.NewSyscallError("read", errno)}
+		require.True(t, isStaleConnectionError(err), "errno %v", errno)
+	}
+
+	notStale := &net.OpError{Op: "dial", Net: "tcp", Err: os.NewSyscallError("connect", windows.WSAECONNREFUSED)}
+	require.False(t, isStaleConnectionError(notStale),
+		"connection refused is a dial failure, not a stale pooled connection")
+}


### PR DESCRIPTION
We were incorrectly returning errors that were classified as non-retryable and non-preservable, meaning some network errors could fail a sync and cause us to throw away existing work.