### PR TITLE
Consolidate action status predicates in pkg/actions

### DIFF
--- a/pkg/actions/actions.go
+++ b/pkg/actions/actions.go
@@ -24,16 +24,16 @@ import (
 
 type ActionHandler func(ctx context.Context, args *structpb.Struct) (*structpb.Struct, annotations.Annotations, error)
 
-// IsInFlightActionStatus reports whether the status describes an action
+// IsInFlight reports whether the status describes an action
 // still executing: PENDING or RUNNING.
-func IsInFlightActionStatus(s v2.BatonActionStatus) bool {
+func IsInFlight(s v2.BatonActionStatus) bool {
 	return s == v2.BatonActionStatus_BATON_ACTION_STATUS_PENDING || s == v2.BatonActionStatus_BATON_ACTION_STATUS_RUNNING
 }
 
-// IsSettledActionStatus reports whether the status is terminal: COMPLETE or
+// IsSettled reports whether the status is terminal: COMPLETE or
 // FAILED. It is the single gate deciding which statuses are final; a new
 // terminal enum value must be added here to be treated as settled anywhere.
-func IsSettledActionStatus(s v2.BatonActionStatus) bool {
+func IsSettled(s v2.BatonActionStatus) bool {
 	return s == v2.BatonActionStatus_BATON_ACTION_STATUS_COMPLETE || s == v2.BatonActionStatus_BATON_ACTION_STATUS_FAILED
 }
 
@@ -73,7 +73,7 @@ func (oa *OutstandingAction) SetStatus(ctx context.Context, status v2.BatonActio
 // (a handler finishing after its request was cancelled), hence debug level.
 // It requires oa's mutex to be held.
 func (oa *OutstandingAction) setStatusLocked(ctx context.Context, status v2.BatonActionStatus) bool {
-	if IsSettledActionStatus(oa.Status) {
+	if IsSettled(oa.Status) {
 		ctxzap.Extract(ctx).Debug("dropping status transition on terminal action",
 			zap.String("action_id", oa.Id),
 			zap.String("action_name", oa.Name),
@@ -157,7 +157,7 @@ func (oa *OutstandingAction) evictable() bool {
 	if oa.cancelled {
 		return false
 	}
-	return IsSettledActionStatus(oa.Status)
+	return IsSettled(oa.Status)
 }
 
 // Result returns the action's identity and current outcome. The snapshot is

--- a/pkg/actions/actions.go
+++ b/pkg/actions/actions.go
@@ -24,6 +24,19 @@ import (
 
 type ActionHandler func(ctx context.Context, args *structpb.Struct) (*structpb.Struct, annotations.Annotations, error)
 
+// IsInFlightActionStatus reports whether the status describes an action
+// still executing: PENDING or RUNNING.
+func IsInFlightActionStatus(s v2.BatonActionStatus) bool {
+	return s == v2.BatonActionStatus_BATON_ACTION_STATUS_PENDING || s == v2.BatonActionStatus_BATON_ACTION_STATUS_RUNNING
+}
+
+// IsSettledActionStatus reports whether the status is terminal: COMPLETE or
+// FAILED. It is the single gate deciding which statuses are final; a new
+// terminal enum value must be added here to be treated as settled anywhere.
+func IsSettledActionStatus(s v2.BatonActionStatus) bool {
+	return s == v2.BatonActionStatus_BATON_ACTION_STATUS_COMPLETE || s == v2.BatonActionStatus_BATON_ACTION_STATUS_FAILED
+}
+
 type OutstandingAction struct {
 	Id        string
 	Name      string
@@ -60,7 +73,7 @@ func (oa *OutstandingAction) SetStatus(ctx context.Context, status v2.BatonActio
 // (a handler finishing after its request was cancelled), hence debug level.
 // It requires oa's mutex to be held.
 func (oa *OutstandingAction) setStatusLocked(ctx context.Context, status v2.BatonActionStatus) bool {
-	if oa.Status == v2.BatonActionStatus_BATON_ACTION_STATUS_COMPLETE || oa.Status == v2.BatonActionStatus_BATON_ACTION_STATUS_FAILED {
+	if IsSettledActionStatus(oa.Status) {
 		ctxzap.Extract(ctx).Debug("dropping status transition on terminal action",
 			zap.String("action_id", oa.Id),
 			zap.String("action_name", oa.Name),
@@ -144,7 +157,7 @@ func (oa *OutstandingAction) evictable() bool {
 	if oa.cancelled {
 		return false
 	}
-	return oa.Status == v2.BatonActionStatus_BATON_ACTION_STATUS_COMPLETE || oa.Status == v2.BatonActionStatus_BATON_ACTION_STATUS_FAILED
+	return IsSettledActionStatus(oa.Status)
 }
 
 // Result returns the action's identity and current outcome. The snapshot is

--- a/pkg/actions/actions_test.go
+++ b/pkg/actions/actions_test.go
@@ -963,8 +963,8 @@ func TestActionStatusPredicates(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.status.String(), func(t *testing.T) {
-			require.Equal(t, tc.inFlight, IsInFlightActionStatus(tc.status))
-			require.Equal(t, tc.settled, IsSettledActionStatus(tc.status))
+			require.Equal(t, tc.inFlight, IsInFlight(tc.status))
+			require.Equal(t, tc.settled, IsSettled(tc.status))
 		})
 	}
 }

--- a/pkg/actions/actions_test.go
+++ b/pkg/actions/actions_test.go
@@ -947,3 +947,24 @@ func TestResourceActionInlineWaitThreads(t *testing.T) {
 	require.Equal(t, v2.BatonActionStatus_BATON_ACTION_STATUS_RUNNING, actionStatus)
 	require.GreaterOrEqual(t, elapsed, 2*time.Second)
 }
+
+func TestActionStatusPredicates(t *testing.T) {
+	cases := []struct {
+		status   v2.BatonActionStatus
+		inFlight bool
+		settled  bool
+	}{
+		{v2.BatonActionStatus_BATON_ACTION_STATUS_UNSPECIFIED, false, false},
+		{v2.BatonActionStatus_BATON_ACTION_STATUS_UNKNOWN, false, false},
+		{v2.BatonActionStatus_BATON_ACTION_STATUS_PENDING, true, false},
+		{v2.BatonActionStatus_BATON_ACTION_STATUS_RUNNING, true, false},
+		{v2.BatonActionStatus_BATON_ACTION_STATUS_COMPLETE, false, true},
+		{v2.BatonActionStatus_BATON_ACTION_STATUS_FAILED, false, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.status.String(), func(t *testing.T) {
+			require.Equal(t, tc.inFlight, IsInFlightActionStatus(tc.status))
+			require.Equal(t, tc.settled, IsSettledActionStatus(tc.status))
+		})
+	}
+}

--- a/pkg/connectorbuilder/actions.go
+++ b/pkg/connectorbuilder/actions.go
@@ -266,7 +266,7 @@ func registerLegacyAction(
 		// A settled status at the invoke seam resolves like a terminal
 		// poll. The SDK's own manager reports handler failures in-band as
 		// FAILED with a nil error, so this must not resolve as success.
-		if isSettledActionStatus(actionStatus) {
+		if actions.IsSettledActionStatus(actionStatus) {
 			return resp, annos, legacyStatusErr(schema.GetName(), actionStatus, resp)
 		}
 
@@ -313,14 +313,14 @@ func registerLegacyAction(
 			}
 			// Keep the last meaningful response for the error exits above;
 			// an indeterminate poll's payload must not replace it.
-			if pollResp != nil && (isInFlightActionStatus(st) || isSettledActionStatus(st)) {
+			if pollResp != nil && (actions.IsInFlightActionStatus(st) || actions.IsSettledActionStatus(st)) {
 				resp, annos = pollResp, pollAnnos
 			}
 
 			switch {
-			case isInFlightActionStatus(st):
+			case actions.IsInFlightActionStatus(st):
 				statusErrs = 0
-			case isSettledActionStatus(st):
+			case actions.IsSettledActionStatus(st):
 				// The settling poll's own payload is the failure account;
 				// resp may hold an older in-flight snapshot.
 				return resp, annos, legacyStatusErr(schema.GetName(), st, pollResp)
@@ -354,18 +354,6 @@ func legacyStatusErr(name string, st v2.BatonActionStatus, resp *structpb.Struct
 		return fmt.Errorf("legacy action %q failed: %s", name, inner)
 	}
 	return fmt.Errorf("legacy action %q failed", name)
-}
-
-func isInFlightActionStatus(s v2.BatonActionStatus) bool {
-	return s == v2.BatonActionStatus_BATON_ACTION_STATUS_PENDING || s == v2.BatonActionStatus_BATON_ACTION_STATUS_RUNNING
-}
-
-// isSettledActionStatus is the single gate deciding which statuses resolve
-// immediately, at the invoke seam and from polls alike. A new terminal enum
-// value must be added here, or it takes the indeterminate path: polled to
-// the tolerance threshold, then failed closed.
-func isSettledActionStatus(s v2.BatonActionStatus) bool {
-	return s == v2.BatonActionStatus_BATON_ACTION_STATUS_COMPLETE || s == v2.BatonActionStatus_BATON_ACTION_STATUS_FAILED
 }
 
 // addActionManager handles deprecated CustomActionManager and RegisterActionManagerLimited interfaces

--- a/pkg/connectorbuilder/actions.go
+++ b/pkg/connectorbuilder/actions.go
@@ -266,7 +266,7 @@ func registerLegacyAction(
 		// A settled status at the invoke seam resolves like a terminal
 		// poll. The SDK's own manager reports handler failures in-band as
 		// FAILED with a nil error, so this must not resolve as success.
-		if actions.IsSettledActionStatus(actionStatus) {
+		if actions.IsSettled(actionStatus) {
 			return resp, annos, legacyStatusErr(schema.GetName(), actionStatus, resp)
 		}
 
@@ -313,14 +313,14 @@ func registerLegacyAction(
 			}
 			// Keep the last meaningful response for the error exits above;
 			// an indeterminate poll's payload must not replace it.
-			if pollResp != nil && (actions.IsInFlightActionStatus(st) || actions.IsSettledActionStatus(st)) {
+			if pollResp != nil && (actions.IsInFlight(st) || actions.IsSettled(st)) {
 				resp, annos = pollResp, pollAnnos
 			}
 
 			switch {
-			case actions.IsInFlightActionStatus(st):
+			case actions.IsInFlight(st):
 				statusErrs = 0
-			case actions.IsSettledActionStatus(st):
+			case actions.IsSettled(st):
 				// The settling poll's own payload is the failure account;
 				// resp may hold an older in-flight snapshot.
 				return resp, annos, legacyStatusErr(schema.GetName(), st, pollResp)

--- a/pkg/tasks/local/action_invoker.go
+++ b/pkg/tasks/local/action_invoker.go
@@ -12,6 +12,7 @@ import (
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	v1 "github.com/conductorone/baton-sdk/pb/c1/connectorapi/baton/v1"
+	"github.com/conductorone/baton-sdk/pkg/actions"
 	"github.com/conductorone/baton-sdk/pkg/tasks"
 	"github.com/conductorone/baton-sdk/pkg/types"
 	"github.com/conductorone/baton-sdk/pkg/uotel"
@@ -83,7 +84,7 @@ func (m *localActionInvoker) Process(ctx context.Context, task *v1.Task, cc type
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
 
-	for status == v2.BatonActionStatus_BATON_ACTION_STATUS_PENDING || status == v2.BatonActionStatus_BATON_ACTION_STATUS_RUNNING {
+	for actions.IsInFlightActionStatus(status) {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()

--- a/pkg/tasks/local/action_invoker.go
+++ b/pkg/tasks/local/action_invoker.go
@@ -84,7 +84,7 @@ func (m *localActionInvoker) Process(ctx context.Context, task *v1.Task, cc type
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
 
-	for actions.IsInFlightActionStatus(status) {
+	for actions.IsInFlight(status) {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()


### PR DESCRIPTION
The in-flight and settled status classifications were hand-rolled in four places: the lifecycle gate and eviction check in the action manager, the legacy wrapper's seam and poll loop, and the local invoker's poll condition. The two predicates now live exported next to the lifecycle they describe, every site uses them, and a table pins the classification of all six enum values. The settled predicate remains the single place a new terminal enum value must be added to be treated as final anywhere.