### PR TITLE
Replace deprecated bufbuild actions with new buf-action.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,17 +96,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Setup
-        uses: bufbuild/buf-setup-action@v1
-        with:
-          version: '1.50.0'
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Lint
-        uses: bufbuild/buf-lint-action@v1
       - name: Breaking change detection against `main`
-        uses: bufbuild/buf-breaking-action@v1
+        uses: bufbuild/buf-action@v1
         with:
-          against: 'https://github.com/conductorone/baton-sdk.git#branch=main'
+          version: '1.72.0'
+          breaking_against: 'https://github.com/conductorone/baton-sdk.git#branch=main'
+          breaking: true
+          format: true
+          lint: true
+          pr_comment: false
+          push: false
   baton-demo-test:
     strategy:
       matrix:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,22 +4,20 @@ on:
     branches:
       - main
 jobs:
-  lint-and-breaking-change-detection:
+  buf-lint-and-breaking-change-detection:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
-      - name: Setup
-        uses: bufbuild/buf-setup-action@v1
-        with:
-          version: '1.50.0'
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Lint
-        uses: bufbuild/buf-lint-action@v1
+        uses: actions/checkout@v6
       - name: Breaking change detection against `main`
-        uses: bufbuild/buf-breaking-action@v1
+        uses: bufbuild/buf-action@v1
         with:
-          against: 'https://github.com/conductorone/baton-sdk.git#branch=main,ref=HEAD~1'
+          version: '1.72.0'
+          breaking: true
+          format: false
+          lint: true
+          pr_comment: false
+          push: false
   go-lint:
     runs-on: ubuntu-latest
     steps:

--- a/buf.yaml
+++ b/buf.yaml
@@ -6,7 +6,7 @@ deps:
   - buf.build/googleapis/googleapis
 lint:
   use:
-    - DEFAULT
+    - STANDARD
   except:
     - FIELD_NOT_REQUIRED
     - PACKAGE_NO_IMPORT_CYCLE

--- a/proto/c1/connector/v2/action.proto
+++ b/proto/c1/connector/v2/action.proto
@@ -77,7 +77,7 @@ message InvokeActionRequest {
   // bugs where the transport enforces validation rules; the server-side
   // cap is the backstop everywhere.
   google.protobuf.Duration inline_wait = 5 [(validate.rules).duration = {
-    gte: {},
+    gte: {}
     lte: {seconds: 86400}
   }];
 }


### PR DESCRIPTION
Only check for breaking changes against main, and use the github.event.before instead of the previous commit.

Pull requests now check for lint errors, breaking changes, and formatting errors.

Also use buf v1.72.0 instead of v1.50.0.