### PR TITLE
fix(uhttp): make CreateCacheKey's header set opt-in

### DIFF
--- a/pkg/uhttp/client.go
+++ b/pkg/uhttp/client.go
@@ -117,13 +117,16 @@ var defaultCacheKeyHeaders = map[string]struct{}{
 	"Range":        {},
 }
 
+// CreateCacheKey generates a cache key based on the request URL, query parameters, and headers.
 func CreateCacheKey(req *http.Request, extraCacheKeyHeaders ...string) (string, error) {
 	if req == nil {
 		return "", fmt.Errorf("request is nil")
 	}
 
 	var sortedParams []string
+	// Normalize the URL path
 	path := strings.ToLower(req.URL.Path)
+	// Combine the path with sorted query parameters
 	queryParams := req.URL.Query()
 	for k, v := range queryParams {
 		for _, value := range v {
@@ -133,6 +136,7 @@ func CreateCacheKey(req *http.Request, extraCacheKeyHeaders ...string) (string, 
 
 	sort.Strings(sortedParams)
 	queryString := strings.Join(sortedParams, "&")
+	// Include relevant headers in the cache key
 	var headerParts []string
 	for key, values := range req.Header {
 		_, ok := defaultCacheKeyHeaders[key]
@@ -149,8 +153,10 @@ func CreateCacheKey(req *http.Request, extraCacheKeyHeaders ...string) (string, 
 
 	sort.Strings(headerParts)
 	headersString := strings.Join(headerParts, "&")
+	// Create a unique string for the cache key
 	cacheString := fmt.Sprintf("%s?%s&headers=%s", path, queryString, headersString)
 
+	// Hash the cache string to create a key
 	hash := sha256.New()
 	_, err := hash.Write([]byte(cacheString))
 	if err != nil {

--- a/pkg/uhttp/client.go
+++ b/pkg/uhttp/client.go
@@ -139,14 +139,19 @@ func CreateCacheKey(req *http.Request, extraCacheKeyHeaders ...string) (string, 
 	// Include relevant headers in the cache key
 	var headerParts []string
 	for key, values := range req.Header {
-		_, ok := defaultCacheKeyHeaders[key]
-		for i := 0; !ok && i < len(extraCacheKeyHeaders); i++ {
-			ok = http.CanonicalHeaderKey(extraCacheKeyHeaders[i]) == key
-		}
-		if !ok {
+		if _, ok := defaultCacheKeyHeaders[key]; !ok {
 			continue
 		}
 		for _, value := range values {
+			headerParts = append(headerParts, fmt.Sprintf("%s=%s", key, value))
+		}
+	}
+	for _, h := range extraCacheKeyHeaders {
+		key := http.CanonicalHeaderKey(h)
+		if _, ok := defaultCacheKeyHeaders[key]; ok {
+			continue
+		}
+		for _, value := range req.Header[key] {
 			headerParts = append(headerParts, fmt.Sprintf("%s=%s", key, value))
 		}
 	}

--- a/pkg/uhttp/client.go
+++ b/pkg/uhttp/client.go
@@ -104,18 +104,18 @@ func NewClient(ctx context.Context, options ...Option) (*http.Client, error) {
 }
 
 type icache interface {
-	Get(req *http.Request) (*http.Response, error)
-	Set(req *http.Request, value *http.Response) error
+	Get(req *http.Request, extraCacheKeyHeaders ...string) (*http.Response, error)
+	Set(req *http.Request, value *http.Response, extraCacheKeyHeaders ...string) error
 	Clear(ctx context.Context) error
 	Stats(ctx context.Context) CacheStats
 }
 
 // defaultCacheKeyHeaders are always folded into the cache key returned by
-// CreateCacheKey. Headers outside this set are ignored unless a connector
-// opts in with WithCacheKeyHeaders: hashing every header by default would
-// key the cache on values that have nothing to do with the response --
-// transport-injected headers like User-Agent, tracing/correlation IDs, etc.
-// -- and would defeat caching for connectors that never asked for that.
+// CreateCacheKey. Headers outside this set are ignored unless a caller
+// names them via extraCacheKeyHeaders: folding in every header by default
+// would key the cache on values that have nothing to do with the response
+// -- transport-injected headers like User-Agent, tracing/correlation IDs,
+// etc. -- and would defeat caching for callers who never asked for that.
 var defaultCacheKeyHeaders = map[string]struct{}{
 	"Accept":       {},
 	"Content-Type": {},
@@ -123,45 +123,25 @@ var defaultCacheKeyHeaders = map[string]struct{}{
 	"Range":        {},
 }
 
-type cacheKeyHeadersCtxKey struct{}
-
-// WithCacheKeyHeaders returns a shallow copy of req whose HTTP response
-// cache key (CreateCacheKey) additionally hashes the named headers, on top
-// of the default set (Accept, Content-Type, Cookie, Range). Use this when a
-// connector varies otherwise-identical requests by a header the cache
-// doesn't key on by default -- e.g. a per-call Authorization token or a
-// tenant/version header -- so those requests don't collide in the cache.
-func WithCacheKeyHeaders(req *http.Request, headers ...string) *http.Request {
-	if len(headers) == 0 {
-		return req
-	}
-	canonical := make([]string, len(headers))
-	for i, h := range headers {
-		canonical[i] = http.CanonicalHeaderKey(h)
-	}
-	return req.WithContext(context.WithValue(req.Context(), cacheKeyHeadersCtxKey{}, canonical))
-}
-
-func cacheKeyHeaderAllowed(req *http.Request, key string) bool {
-	if _, ok := defaultCacheKeyHeaders[key]; ok {
-		return true
-	}
-	extra, _ := req.Context().Value(cacheKeyHeadersCtxKey{}).([]string)
-	for _, h := range extra {
-		if h == key {
-			return true
-		}
-	}
-	return false
-}
-
 // CreateCacheKey generates a cache key based on the request URL, query
 // parameters, and headers. Only defaultCacheKeyHeaders -- plus any headers
-// named via WithCacheKeyHeaders -- are folded in; see those for why.
-func CreateCacheKey(req *http.Request) (string, error) {
+// named in extraCacheKeyHeaders -- are folded in; see defaultCacheKeyHeaders
+// for why the set isn't just "every header." Pass extraCacheKeyHeaders when
+// a request varies by a header outside the default set -- e.g. a per-call
+// Authorization token or a tenant/version header -- so requests that only
+// differ in that header don't collide in the cache.
+func CreateCacheKey(req *http.Request, extraCacheKeyHeaders ...string) (string, error) {
 	if req == nil {
 		return "", fmt.Errorf("request is nil")
 	}
+	allowedHeaders := make(map[string]struct{}, len(defaultCacheKeyHeaders)+len(extraCacheKeyHeaders))
+	for h := range defaultCacheKeyHeaders {
+		allowedHeaders[h] = struct{}{}
+	}
+	for _, h := range extraCacheKeyHeaders {
+		allowedHeaders[http.CanonicalHeaderKey(h)] = struct{}{}
+	}
+
 	var sortedParams []string
 	// Normalize the URL path
 	path := strings.ToLower(req.URL.Path)
@@ -178,7 +158,7 @@ func CreateCacheKey(req *http.Request) (string, error) {
 	// Include only the allowed headers in the cache key.
 	var headerParts []string
 	for key, values := range req.Header {
-		if !cacheKeyHeaderAllowed(req, key) {
+		if _, ok := allowedHeaders[key]; !ok {
 			continue
 		}
 		for _, value := range values {

--- a/pkg/uhttp/client.go
+++ b/pkg/uhttp/client.go
@@ -110,13 +110,6 @@ type icache interface {
 	Stats(ctx context.Context) CacheStats
 }
 
-var defaultCacheKeyHeaders = map[string]struct{}{
-	"Accept":       {},
-	"Content-Type": {},
-	"Cookie":       {},
-	"Range":        {},
-}
-
 // CreateCacheKey generates a cache key based on the request URL, query parameters, and headers.
 func CreateCacheKey(req *http.Request, extraCacheKeyHeaders ...string) (string, error) {
 	if req == nil {
@@ -139,18 +132,14 @@ func CreateCacheKey(req *http.Request, extraCacheKeyHeaders ...string) (string, 
 	// Include relevant headers in the cache key
 	var headerParts []string
 	for key, values := range req.Header {
-		if _, ok := defaultCacheKeyHeaders[key]; !ok {
-			continue
-		}
 		for _, value := range values {
-			headerParts = append(headerParts, fmt.Sprintf("%s=%s", key, value))
+			if key == "Accept" || key == "Content-Type" || key == "Cookie" || key == "Range" {
+				headerParts = append(headerParts, fmt.Sprintf("%s=%s", key, value))
+			}
 		}
 	}
 	for _, h := range extraCacheKeyHeaders {
 		key := http.CanonicalHeaderKey(h)
-		if _, ok := defaultCacheKeyHeaders[key]; ok {
-			continue
-		}
 		for _, value := range req.Header[key] {
 			headerParts = append(headerParts, fmt.Sprintf("%s=%s", key, value))
 		}

--- a/pkg/uhttp/client.go
+++ b/pkg/uhttp/client.go
@@ -110,12 +110,54 @@ type icache interface {
 	Stats(ctx context.Context) CacheStats
 }
 
-// CreateCacheKey generates a cache key based on the request URL, query parameters, and headers.
-//
-// Every header is folded into the key. Dropping a header here would let two
-// requests that differ only in that header collide on the same cache entry
-// -- e.g. requests carrying different Authorization or other per-request
-// auth headers would otherwise be served each other's cached response.
+// defaultCacheKeyHeaders are always folded into the cache key returned by
+// CreateCacheKey. Headers outside this set are ignored unless a connector
+// opts in with WithCacheKeyHeaders: hashing every header by default would
+// key the cache on values that have nothing to do with the response --
+// transport-injected headers like User-Agent, tracing/correlation IDs, etc.
+// -- and would defeat caching for connectors that never asked for that.
+var defaultCacheKeyHeaders = map[string]struct{}{
+	"Accept":       {},
+	"Content-Type": {},
+	"Cookie":       {},
+	"Range":        {},
+}
+
+type cacheKeyHeadersCtxKey struct{}
+
+// WithCacheKeyHeaders returns a shallow copy of req whose HTTP response
+// cache key (CreateCacheKey) additionally hashes the named headers, on top
+// of the default set (Accept, Content-Type, Cookie, Range). Use this when a
+// connector varies otherwise-identical requests by a header the cache
+// doesn't key on by default -- e.g. a per-call Authorization token or a
+// tenant/version header -- so those requests don't collide in the cache.
+func WithCacheKeyHeaders(req *http.Request, headers ...string) *http.Request {
+	if len(headers) == 0 {
+		return req
+	}
+	canonical := make([]string, len(headers))
+	for i, h := range headers {
+		canonical[i] = http.CanonicalHeaderKey(h)
+	}
+	return req.WithContext(context.WithValue(req.Context(), cacheKeyHeadersCtxKey{}, canonical))
+}
+
+func cacheKeyHeaderAllowed(req *http.Request, key string) bool {
+	if _, ok := defaultCacheKeyHeaders[key]; ok {
+		return true
+	}
+	extra, _ := req.Context().Value(cacheKeyHeadersCtxKey{}).([]string)
+	for _, h := range extra {
+		if h == key {
+			return true
+		}
+	}
+	return false
+}
+
+// CreateCacheKey generates a cache key based on the request URL, query
+// parameters, and headers. Only defaultCacheKeyHeaders -- plus any headers
+// named via WithCacheKeyHeaders -- are folded in; see those for why.
 func CreateCacheKey(req *http.Request) (string, error) {
 	if req == nil {
 		return "", fmt.Errorf("request is nil")
@@ -133,9 +175,12 @@ func CreateCacheKey(req *http.Request) (string, error) {
 
 	sort.Strings(sortedParams)
 	queryString := strings.Join(sortedParams, "&")
-	// Include every header in the cache key.
+	// Include only the allowed headers in the cache key.
 	var headerParts []string
 	for key, values := range req.Header {
+		if !cacheKeyHeaderAllowed(req, key) {
+			continue
+		}
 		for _, value := range values {
 			headerParts = append(headerParts, fmt.Sprintf("%s=%s", key, value))
 		}

--- a/pkg/uhttp/client.go
+++ b/pkg/uhttp/client.go
@@ -111,6 +111,11 @@ type icache interface {
 }
 
 // CreateCacheKey generates a cache key based on the request URL, query parameters, and headers.
+//
+// Every header is folded into the key. Dropping a header here would let two
+// requests that differ only in that header collide on the same cache entry
+// -- e.g. requests carrying different Authorization or other per-request
+// auth headers would otherwise be served each other's cached response.
 func CreateCacheKey(req *http.Request) (string, error) {
 	if req == nil {
 		return "", fmt.Errorf("request is nil")
@@ -128,13 +133,11 @@ func CreateCacheKey(req *http.Request) (string, error) {
 
 	sort.Strings(sortedParams)
 	queryString := strings.Join(sortedParams, "&")
-	// Include relevant headers in the cache key
+	// Include every header in the cache key.
 	var headerParts []string
 	for key, values := range req.Header {
 		for _, value := range values {
-			if key == "Accept" || key == "Content-Type" || key == "Cookie" || key == "Range" {
-				headerParts = append(headerParts, fmt.Sprintf("%s=%s", key, value))
-			}
+			headerParts = append(headerParts, fmt.Sprintf("%s=%s", key, value))
 		}
 	}
 

--- a/pkg/uhttp/client.go
+++ b/pkg/uhttp/client.go
@@ -110,12 +110,6 @@ type icache interface {
 	Stats(ctx context.Context) CacheStats
 }
 
-// defaultCacheKeyHeaders are always folded into the cache key returned by
-// CreateCacheKey. Headers outside this set are ignored unless a caller
-// names them via extraCacheKeyHeaders: folding in every header by default
-// would key the cache on values that have nothing to do with the response
-// -- transport-injected headers like User-Agent, tracing/correlation IDs,
-// etc. -- and would defeat caching for callers who never asked for that.
 var defaultCacheKeyHeaders = map[string]struct{}{
 	"Accept":       {},
 	"Content-Type": {},
@@ -123,29 +117,13 @@ var defaultCacheKeyHeaders = map[string]struct{}{
 	"Range":        {},
 }
 
-// CreateCacheKey generates a cache key based on the request URL, query
-// parameters, and headers. Only defaultCacheKeyHeaders -- plus any headers
-// named in extraCacheKeyHeaders -- are folded in; see defaultCacheKeyHeaders
-// for why the set isn't just "every header." Pass extraCacheKeyHeaders when
-// a request varies by a header outside the default set -- e.g. a per-call
-// Authorization token or a tenant/version header -- so requests that only
-// differ in that header don't collide in the cache.
 func CreateCacheKey(req *http.Request, extraCacheKeyHeaders ...string) (string, error) {
 	if req == nil {
 		return "", fmt.Errorf("request is nil")
 	}
-	allowedHeaders := make(map[string]struct{}, len(defaultCacheKeyHeaders)+len(extraCacheKeyHeaders))
-	for h := range defaultCacheKeyHeaders {
-		allowedHeaders[h] = struct{}{}
-	}
-	for _, h := range extraCacheKeyHeaders {
-		allowedHeaders[http.CanonicalHeaderKey(h)] = struct{}{}
-	}
 
 	var sortedParams []string
-	// Normalize the URL path
 	path := strings.ToLower(req.URL.Path)
-	// Combine the path with sorted query parameters
 	queryParams := req.URL.Query()
 	for k, v := range queryParams {
 		for _, value := range v {
@@ -155,10 +133,13 @@ func CreateCacheKey(req *http.Request, extraCacheKeyHeaders ...string) (string, 
 
 	sort.Strings(sortedParams)
 	queryString := strings.Join(sortedParams, "&")
-	// Include only the allowed headers in the cache key.
 	var headerParts []string
 	for key, values := range req.Header {
-		if _, ok := allowedHeaders[key]; !ok {
+		_, ok := defaultCacheKeyHeaders[key]
+		for i := 0; !ok && i < len(extraCacheKeyHeaders); i++ {
+			ok = http.CanonicalHeaderKey(extraCacheKeyHeaders[i]) == key
+		}
+		if !ok {
 			continue
 		}
 		for _, value := range values {
@@ -168,10 +149,8 @@ func CreateCacheKey(req *http.Request, extraCacheKeyHeaders ...string) (string, 
 
 	sort.Strings(headerParts)
 	headersString := strings.Join(headerParts, "&")
-	// Create a unique string for the cache key
 	cacheString := fmt.Sprintf("%s?%s&headers=%s", path, queryString, headersString)
 
-	// Hash the cache string to create a key
 	hash := sha256.New()
 	_, err := hash.Write([]byte(cacheString))
 	if err != nil {

--- a/pkg/uhttp/client_test.go
+++ b/pkg/uhttp/client_test.go
@@ -1,0 +1,71 @@
+package uhttp
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func newCacheKeyRequest(t *testing.T, headerKey, headerValue string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.com/widgets?id=1", nil)
+	require.NoError(t, err)
+	if headerKey != "" {
+		req.Header.Set(headerKey, headerValue)
+	}
+	return req
+}
+
+func TestCreateCacheKey_NilRequest(t *testing.T) {
+	_, err := CreateCacheKey(nil)
+	require.Error(t, err)
+}
+
+func TestCreateCacheKey_IdenticalRequestsMatch(t *testing.T) {
+	req1 := newCacheKeyRequest(t, "Accept", "application/json")
+	req2 := newCacheKeyRequest(t, "Accept", "application/json")
+
+	key1, err := CreateCacheKey(req1)
+	require.NoError(t, err)
+	key2, err := CreateCacheKey(req2)
+	require.NoError(t, err)
+	require.Equal(t, key1, key2)
+}
+
+// TestCreateCacheKey_HeaderOutsideOldAllowlistChangesKey guards against the
+// bug where only Accept, Content-Type, Cookie, and Range were folded into
+// the key: any other differing header (e.g. Authorization) produced an
+// identical key and the wrong cached response would be served.
+func TestCreateCacheKey_HeaderOutsideOldAllowlistChangesKey(t *testing.T) {
+	headers := []string{"Authorization", "X-Api-Version", "X-Tenant-Id"}
+	for _, header := range headers {
+		t.Run(header, func(t *testing.T) {
+			reqA := newCacheKeyRequest(t, header, "value-a")
+			reqB := newCacheKeyRequest(t, header, "value-b")
+
+			keyA, err := CreateCacheKey(reqA)
+			require.NoError(t, err)
+			keyB, err := CreateCacheKey(reqB)
+			require.NoError(t, err)
+			require.NotEqual(t, keyA, keyB, "requests differing only in %s must not share a cache key", header)
+		})
+	}
+}
+
+func TestCreateCacheKey_PreviouslyAllowlistedHeadersStillChangeKey(t *testing.T) {
+	headers := []string{"Accept", "Content-Type", "Cookie", "Range"}
+	for _, header := range headers {
+		t.Run(header, func(t *testing.T) {
+			reqA := newCacheKeyRequest(t, header, "value-a")
+			reqB := newCacheKeyRequest(t, header, "value-b")
+
+			keyA, err := CreateCacheKey(reqA)
+			require.NoError(t, err)
+			keyB, err := CreateCacheKey(reqB)
+			require.NoError(t, err)
+			require.NotEqual(t, keyA, keyB)
+		})
+	}
+}

--- a/pkg/uhttp/client_test.go
+++ b/pkg/uhttp/client_test.go
@@ -34,12 +34,14 @@ func TestCreateCacheKey_IdenticalRequestsMatch(t *testing.T) {
 	require.Equal(t, key1, key2)
 }
 
-// TestCreateCacheKey_HeaderOutsideOldAllowlistChangesKey guards against the
-// bug where only Accept, Content-Type, Cookie, and Range were folded into
-// the key: any other differing header (e.g. Authorization) produced an
-// identical key and the wrong cached response would be served.
-func TestCreateCacheKey_HeaderOutsideOldAllowlistChangesKey(t *testing.T) {
-	headers := []string{"Authorization", "X-Api-Version", "X-Tenant-Id"}
+// TestCreateCacheKey_HeadersOutsideDefaultSetAreIgnoredByDefault documents
+// current, intentional behavior: only defaultCacheKeyHeaders affect the key
+// unless a connector opts in via WithCacheKeyHeaders. Folding in every
+// header unconditionally would key the cache on values that have nothing
+// to do with the response (transport-injected headers, tracing IDs, etc.)
+// and silently tank the hit rate for every connector that never asked for it.
+func TestCreateCacheKey_HeadersOutsideDefaultSetAreIgnoredByDefault(t *testing.T) {
+	headers := []string{"Authorization", "X-Api-Version", "X-Tenant-Id", "User-Agent"}
 	for _, header := range headers {
 		t.Run(header, func(t *testing.T) {
 			reqA := newCacheKeyRequest(t, header, "value-a")
@@ -49,12 +51,12 @@ func TestCreateCacheKey_HeaderOutsideOldAllowlistChangesKey(t *testing.T) {
 			require.NoError(t, err)
 			keyB, err := CreateCacheKey(reqB)
 			require.NoError(t, err)
-			require.NotEqual(t, keyA, keyB, "requests differing only in %s must not share a cache key", header)
+			require.Equal(t, keyA, keyB, "%s is not in the default set and must not affect the key", header)
 		})
 	}
 }
 
-func TestCreateCacheKey_PreviouslyAllowlistedHeadersStillChangeKey(t *testing.T) {
+func TestCreateCacheKey_DefaultHeadersStillChangeKey(t *testing.T) {
 	headers := []string{"Accept", "Content-Type", "Cookie", "Range"}
 	for _, header := range headers {
 		t.Run(header, func(t *testing.T) {
@@ -68,4 +70,45 @@ func TestCreateCacheKey_PreviouslyAllowlistedHeadersStillChangeKey(t *testing.T)
 			require.NotEqual(t, keyA, keyB)
 		})
 	}
+}
+
+// TestCreateCacheKey_WithCacheKeyHeaders_OptsInAdditionalHeaders is the
+// regression test for CE-1056: a connector that knows a header varies the
+// response (e.g. Authorization scoping the result set) can now opt that
+// header into the key instead of the two requests silently colliding.
+func TestCreateCacheKey_WithCacheKeyHeaders_OptsInAdditionalHeaders(t *testing.T) {
+	reqA := WithCacheKeyHeaders(newCacheKeyRequest(t, "Authorization", "value-a"), "Authorization")
+	reqB := WithCacheKeyHeaders(newCacheKeyRequest(t, "Authorization", "value-b"), "Authorization")
+
+	keyA, err := CreateCacheKey(reqA)
+	require.NoError(t, err)
+	keyB, err := CreateCacheKey(reqB)
+	require.NoError(t, err)
+	require.NotEqual(t, keyA, keyB)
+}
+
+// TestCreateCacheKey_WithCacheKeyHeaders_OnlyAffectsNamedHeaders confirms
+// opting a header in doesn't widen the key to every header -- a header not
+// named in WithCacheKeyHeaders still falls back to the default-set rule.
+func TestCreateCacheKey_WithCacheKeyHeaders_OnlyAffectsNamedHeaders(t *testing.T) {
+	reqA := newCacheKeyRequest(t, "X-Tenant-Id", "tenant-a")
+	reqA.Header.Set("Authorization", "same-token")
+	reqA = WithCacheKeyHeaders(reqA, "Authorization")
+
+	reqB := newCacheKeyRequest(t, "X-Tenant-Id", "tenant-b")
+	reqB.Header.Set("Authorization", "same-token")
+	reqB = WithCacheKeyHeaders(reqB, "Authorization")
+
+	keyA, err := CreateCacheKey(reqA)
+	require.NoError(t, err)
+	keyB, err := CreateCacheKey(reqB)
+	require.NoError(t, err)
+	require.Equal(t, keyA, keyB, "X-Tenant-Id was never opted in, so it must not affect the key")
+}
+
+// TestCreateCacheKey_WithCacheKeyHeaders_NoHeadersIsNoop confirms the zero
+// value (no extra headers) leaves the request, and its cache key, unchanged.
+func TestCreateCacheKey_WithCacheKeyHeaders_NoHeadersIsNoop(t *testing.T) {
+	req := newCacheKeyRequest(t, "Accept", "application/json")
+	require.Same(t, req, WithCacheKeyHeaders(req))
 }

--- a/pkg/uhttp/client_test.go
+++ b/pkg/uhttp/client_test.go
@@ -36,10 +36,10 @@ func TestCreateCacheKey_IdenticalRequestsMatch(t *testing.T) {
 
 // TestCreateCacheKey_HeadersOutsideDefaultSetAreIgnoredByDefault documents
 // current, intentional behavior: only defaultCacheKeyHeaders affect the key
-// unless a connector opts in via WithCacheKeyHeaders. Folding in every
-// header unconditionally would key the cache on values that have nothing
-// to do with the response (transport-injected headers, tracing IDs, etc.)
-// and silently tank the hit rate for every connector that never asked for it.
+// unless a caller opts in via extraCacheKeyHeaders. Folding in every header
+// unconditionally would key the cache on values that have nothing to do
+// with the response (transport-injected headers, tracing IDs, etc.) and
+// silently tank the hit rate for every caller who never asked for that.
 func TestCreateCacheKey_HeadersOutsideDefaultSetAreIgnoredByDefault(t *testing.T) {
 	headers := []string{"Authorization", "X-Api-Version", "X-Tenant-Id", "User-Agent"}
 	for _, header := range headers {
@@ -72,43 +72,48 @@ func TestCreateCacheKey_DefaultHeadersStillChangeKey(t *testing.T) {
 	}
 }
 
-// TestCreateCacheKey_WithCacheKeyHeaders_OptsInAdditionalHeaders is the
-// regression test for CE-1056: a connector that knows a header varies the
+// TestCreateCacheKey_ExtraCacheKeyHeadersOptsInAdditionalHeaders is the
+// regression test for CE-1056: a caller that knows a header varies the
 // response (e.g. Authorization scoping the result set) can now opt that
 // header into the key instead of the two requests silently colliding.
-func TestCreateCacheKey_WithCacheKeyHeaders_OptsInAdditionalHeaders(t *testing.T) {
-	reqA := WithCacheKeyHeaders(newCacheKeyRequest(t, "Authorization", "value-a"), "Authorization")
-	reqB := WithCacheKeyHeaders(newCacheKeyRequest(t, "Authorization", "value-b"), "Authorization")
+func TestCreateCacheKey_ExtraCacheKeyHeadersOptsInAdditionalHeaders(t *testing.T) {
+	reqA := newCacheKeyRequest(t, "Authorization", "value-a")
+	reqB := newCacheKeyRequest(t, "Authorization", "value-b")
 
-	keyA, err := CreateCacheKey(reqA)
+	keyA, err := CreateCacheKey(reqA, "Authorization")
 	require.NoError(t, err)
-	keyB, err := CreateCacheKey(reqB)
+	keyB, err := CreateCacheKey(reqB, "Authorization")
 	require.NoError(t, err)
 	require.NotEqual(t, keyA, keyB)
 }
 
-// TestCreateCacheKey_WithCacheKeyHeaders_OnlyAffectsNamedHeaders confirms
+// TestCreateCacheKey_ExtraCacheKeyHeadersOnlyAffectsNamedHeaders confirms
 // opting a header in doesn't widen the key to every header -- a header not
-// named in WithCacheKeyHeaders still falls back to the default-set rule.
-func TestCreateCacheKey_WithCacheKeyHeaders_OnlyAffectsNamedHeaders(t *testing.T) {
+// passed in extraCacheKeyHeaders still falls back to the default-set rule.
+func TestCreateCacheKey_ExtraCacheKeyHeadersOnlyAffectsNamedHeaders(t *testing.T) {
 	reqA := newCacheKeyRequest(t, "X-Tenant-Id", "tenant-a")
 	reqA.Header.Set("Authorization", "same-token")
-	reqA = WithCacheKeyHeaders(reqA, "Authorization")
 
 	reqB := newCacheKeyRequest(t, "X-Tenant-Id", "tenant-b")
 	reqB.Header.Set("Authorization", "same-token")
-	reqB = WithCacheKeyHeaders(reqB, "Authorization")
 
-	keyA, err := CreateCacheKey(reqA)
+	keyA, err := CreateCacheKey(reqA, "Authorization")
 	require.NoError(t, err)
-	keyB, err := CreateCacheKey(reqB)
+	keyB, err := CreateCacheKey(reqB, "Authorization")
 	require.NoError(t, err)
 	require.Equal(t, keyA, keyB, "X-Tenant-Id was never opted in, so it must not affect the key")
 }
 
-// TestCreateCacheKey_WithCacheKeyHeaders_NoHeadersIsNoop confirms the zero
-// value (no extra headers) leaves the request, and its cache key, unchanged.
-func TestCreateCacheKey_WithCacheKeyHeaders_NoHeadersIsNoop(t *testing.T) {
-	req := newCacheKeyRequest(t, "Accept", "application/json")
-	require.Same(t, req, WithCacheKeyHeaders(req))
+// TestCreateCacheKey_ExtraCacheKeyHeadersCanonicalizesNames confirms header
+// names passed to extraCacheKeyHeaders match regardless of casing, since
+// req.Header stores them canonicalized.
+func TestCreateCacheKey_ExtraCacheKeyHeadersCanonicalizesNames(t *testing.T) {
+	reqA := newCacheKeyRequest(t, "Authorization", "value-a")
+	reqB := newCacheKeyRequest(t, "Authorization", "value-b")
+
+	keyA, err := CreateCacheKey(reqA, "authorization")
+	require.NoError(t, err)
+	keyB, err := CreateCacheKey(reqB, "authorization")
+	require.NoError(t, err)
+	require.NotEqual(t, keyA, keyB)
 }

--- a/pkg/uhttp/client_test.go
+++ b/pkg/uhttp/client_test.go
@@ -117,3 +117,17 @@ func TestCreateCacheKey_ExtraCacheKeyHeadersCanonicalizesNames(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEqual(t, keyA, keyB)
 }
+
+// TestCreateCacheKey_DoesNotMutateCallersExtraCacheKeyHeadersSlice guards
+// against canonicalizing extraCacheKeyHeaders in place: a variadic spread
+// (headers...) shares the caller's backing array rather than copying it, so
+// writing into extraCacheKeyHeaders[i] would silently rewrite a slice the
+// caller still holds a reference to (e.g. one reused across many calls).
+func TestCreateCacheKey_DoesNotMutateCallersExtraCacheKeyHeadersSlice(t *testing.T) {
+	headers := []string{"x-tenant-id"}
+	req := newCacheKeyRequest(t, "X-Tenant-Id", "tenant-a")
+
+	_, err := CreateCacheKey(req, headers...)
+	require.NoError(t, err)
+	require.Equal(t, []string{"x-tenant-id"}, headers, "CreateCacheKey must not rewrite the caller's slice contents")
+}

--- a/pkg/uhttp/dbcache.go
+++ b/pkg/uhttp/dbcache.go
@@ -190,12 +190,12 @@ func (d *DBCache) removeDB(ctx context.Context) error {
 }
 
 // Get returns cached response (if exists).
-func (d *DBCache) Get(req *http.Request) (*http.Response, error) {
+func (d *DBCache) Get(req *http.Request, extraCacheKeyHeaders ...string) (*http.Response, error) {
 	var (
 		isFound = false
 		resp    *http.Response
 	)
-	key, err := CreateCacheKey(req)
+	key, err := CreateCacheKey(req, extraCacheKeyHeaders...)
 	if err != nil {
 		return nil, err
 	}
@@ -250,8 +250,8 @@ func (d *DBCache) pick(ctx context.Context, key string) ([]byte, error) {
 }
 
 // Set stores and save response in the db.
-func (d *DBCache) Set(req *http.Request, value *http.Response) error {
-	key, err := CreateCacheKey(req)
+func (d *DBCache) Set(req *http.Request, value *http.Response, extraCacheKeyHeaders ...string) error {
+	key, err := CreateCacheKey(req, extraCacheKeyHeaders...)
 	if err != nil {
 		return err
 	}

--- a/pkg/uhttp/gocache.go
+++ b/pkg/uhttp/gocache.go
@@ -58,13 +58,13 @@ func NewNoopCache(ctx context.Context) *NoopCache {
 	return &NoopCache{}
 }
 
-func (g *NoopCache) Get(req *http.Request) (*http.Response, error) {
+func (g *NoopCache) Get(req *http.Request, extraCacheKeyHeaders ...string) (*http.Response, error) {
 	// This isn't threadsafe but who cares? It's the noop cache.
 	g.counter++
 	return nil, nil
 }
 
-func (n *NoopCache) Set(req *http.Request, value *http.Response) error {
+func (n *NoopCache) Set(req *http.Request, value *http.Response, extraCacheKeyHeaders ...string) error {
 	return nil
 }
 
@@ -219,12 +219,12 @@ func (g *GoCache) Stats(ctx context.Context) CacheStats {
 	}
 }
 
-func (g *GoCache) Get(req *http.Request) (*http.Response, error) {
+func (g *GoCache) Get(req *http.Request, extraCacheKeyHeaders ...string) (*http.Response, error) {
 	if g.rootLibrary == nil {
 		return nil, nil
 	}
 
-	key, err := CreateCacheKey(req)
+	key, err := CreateCacheKey(req, extraCacheKeyHeaders...)
 	if err != nil {
 		return nil, err
 	}
@@ -247,12 +247,12 @@ func (g *GoCache) Get(req *http.Request) (*http.Response, error) {
 	return resp, nil
 }
 
-func (g *GoCache) Set(req *http.Request, value *http.Response) error {
+func (g *GoCache) Set(req *http.Request, value *http.Response, extraCacheKeyHeaders ...string) error {
 	if g.rootLibrary == nil {
 		return nil
 	}
 
-	key, err := CreateCacheKey(req)
+	key, err := CreateCacheKey(req, extraCacheKeyHeaders...)
 	if err != nil {
 		return err
 	}

--- a/pkg/uhttp/wrapper.go
+++ b/pkg/uhttp/wrapper.go
@@ -112,7 +112,7 @@ func ClearCaches(ctx context.Context) error {
 type (
 	HttpClient interface {
 		HttpClient() *http.Client
-		Do(req *http.Request, options ...DoOption) (*http.Response, error)
+		Do(req *http.Request, options ...CallOption) (*http.Response, error)
 		NewRequest(ctx context.Context, method string, url *url.URL, options ...RequestOption) (*http.Request, error)
 	}
 	BaseHttpClient struct {
@@ -125,6 +125,29 @@ type (
 	DoOption      func(resp *WrapperResponse) error
 	RequestOption func() (io.ReadWriter, map[string]string, error)
 )
+
+type doConfig struct {
+	respOptions     []DoOption
+	cacheKeyHeaders []string
+}
+
+type CallOption interface {
+	applyDo(*doConfig)
+}
+
+func (o DoOption) applyDo(c *doConfig) {
+	c.respOptions = append(c.respOptions, o)
+}
+
+type cacheKeyHeadersOption []string
+
+func (o cacheKeyHeadersOption) applyDo(c *doConfig) {
+	c.cacheKeyHeaders = append(c.cacheKeyHeaders, o...)
+}
+
+func WithCacheKeyHeaders(headers ...string) CallOption {
+	return cacheKeyHeadersOption(headers)
+}
 
 func NewBaseHttpClient(httpClient *http.Client, opts ...WrapperOption) *BaseHttpClient {
 	ctx := context.TODO()
@@ -435,12 +458,12 @@ func (c *BaseHttpClient) recordCacheMiss(ctx context.Context) {
 	counter.Add(ctx, 1, nil)
 }
 
-func (c *BaseHttpClient) Do(req *http.Request, options ...DoOption) (*http.Response, error) {
-	return c.do(req, nil, options...)
-}
-
-func (c *BaseHttpClient) DoWithCacheKeyHeaders(req *http.Request, cacheKeyHeaders []string, options ...DoOption) (*http.Response, error) {
-	return c.do(req, cacheKeyHeaders, options...)
+func (c *BaseHttpClient) Do(req *http.Request, options ...CallOption) (*http.Response, error) {
+	var cfg doConfig
+	for _, o := range options {
+		o.applyDo(&cfg)
+	}
+	return c.do(req, cfg.cacheKeyHeaders, cfg.respOptions...)
 }
 
 func (c *BaseHttpClient) do(req *http.Request, cacheKeyHeaders []string, options ...DoOption) (*http.Response, error) {

--- a/pkg/uhttp/wrapper.go
+++ b/pkg/uhttp/wrapper.go
@@ -436,6 +436,21 @@ func (c *BaseHttpClient) recordCacheMiss(ctx context.Context) {
 }
 
 func (c *BaseHttpClient) Do(req *http.Request, options ...DoOption) (*http.Response, error) {
+	return c.do(req, nil, options...)
+}
+
+// DoWithCacheKeyHeaders behaves exactly like Do, except the named headers
+// are additionally folded into the HTTP response cache key for this call,
+// on top of the default set (Accept, Content-Type, Cookie, Range). Use this
+// instead of Do when the request varies by a header the cache wouldn't
+// otherwise key on -- e.g. a per-call Authorization token or a
+// tenant/version header -- so requests that only differ in that header
+// don't collide in the cache. See CreateCacheKey.
+func (c *BaseHttpClient) DoWithCacheKeyHeaders(req *http.Request, cacheKeyHeaders []string, options ...DoOption) (*http.Response, error) {
+	return c.do(req, cacheKeyHeaders, options...)
+}
+
+func (c *BaseHttpClient) do(req *http.Request, cacheKeyHeaders []string, options ...DoOption) (*http.Response, error) {
 	var (
 		err  error
 		resp *http.Response
@@ -448,7 +463,7 @@ func (c *BaseHttpClient) Do(req *http.Request, options ...DoOption) (*http.Respo
 	}
 
 	if req.Method == http.MethodGet && req.Header.Get("Cache-Control") != "no-cache" {
-		resp, err = c.baseHttpCache.Get(req)
+		resp, err = c.baseHttpCache.Get(req, cacheKeyHeaders...)
 		if err != nil {
 			return nil, err
 		}
@@ -529,7 +544,7 @@ func (c *BaseHttpClient) Do(req *http.Request, options ...DoOption) (*http.Respo
 	}
 
 	if req.Method == http.MethodGet && resp.StatusCode == http.StatusOK {
-		cacheErr := c.baseHttpCache.Set(req, resp)
+		cacheErr := c.baseHttpCache.Set(req, resp, cacheKeyHeaders...)
 		if cacheErr != nil {
 			l.Warn("error setting cache", zap.String("url", req.URL.String()), zap.Error(cacheErr))
 		}

--- a/pkg/uhttp/wrapper.go
+++ b/pkg/uhttp/wrapper.go
@@ -439,13 +439,6 @@ func (c *BaseHttpClient) Do(req *http.Request, options ...DoOption) (*http.Respo
 	return c.do(req, nil, options...)
 }
 
-// DoWithCacheKeyHeaders behaves exactly like Do, except the named headers
-// are additionally folded into the HTTP response cache key for this call,
-// on top of the default set (Accept, Content-Type, Cookie, Range). Use this
-// instead of Do when the request varies by a header the cache wouldn't
-// otherwise key on -- e.g. a per-call Authorization token or a
-// tenant/version header -- so requests that only differ in that header
-// don't collide in the cache. See CreateCacheKey.
 func (c *BaseHttpClient) DoWithCacheKeyHeaders(req *http.Request, cacheKeyHeaders []string, options ...DoOption) (*http.Response, error) {
 	return c.do(req, cacheKeyHeaders, options...)
 }
@@ -475,15 +468,6 @@ func (c *BaseHttpClient) do(req *http.Request, cacheKeyHeaders []string, options
 	}
 
 	if resp == nil {
-		// Round trip on a clone, not req itself. http.Client.Do forks the
-		// Request struct internally (any non-zero Timeout, which uhttp.NewClient
-		// always sets, triggers this) but that fork is shallow -- the Header map
-		// is still the same one req points to. Transport-level RoundTrippers
-		// (e.g. userAgentTripper) mutate that shared map, so without cloning
-		// here, req.Header gains headers (like User-Agent) between the
-		// Get above and the Set below, and CreateCacheKey(req) would hash a
-		// different header set for each -- a store that no future lookup can
-		// ever match.
 		resp, err = c.HttpClient.Do(req.Clone(req.Context())) // #nosec G704 -- this HTTP wrapper intentionally supports arbitrary connector-defined endpoints.
 		if err != nil {
 			l.Error("base-http-client: HTTP error response", zap.Error(err))

--- a/pkg/uhttp/wrapper.go
+++ b/pkg/uhttp/wrapper.go
@@ -460,7 +460,16 @@ func (c *BaseHttpClient) Do(req *http.Request, options ...DoOption) (*http.Respo
 	}
 
 	if resp == nil {
-		resp, err = c.HttpClient.Do(req) // #nosec G704 -- this HTTP wrapper intentionally supports arbitrary connector-defined endpoints.
+		// Round trip on a clone, not req itself. http.Client.Do forks the
+		// Request struct internally (any non-zero Timeout, which uhttp.NewClient
+		// always sets, triggers this) but that fork is shallow -- the Header map
+		// is still the same one req points to. Transport-level RoundTrippers
+		// (e.g. userAgentTripper) mutate that shared map, so without cloning
+		// here, req.Header gains headers (like User-Agent) between the
+		// Get above and the Set below, and CreateCacheKey(req) would hash a
+		// different header set for each -- a store that no future lookup can
+		// ever match.
+		resp, err = c.HttpClient.Do(req.Clone(req.Context())) // #nosec G704 -- this HTTP wrapper intentionally supports arbitrary connector-defined endpoints.
 		if err != nil {
 			l.Error("base-http-client: HTTP error response", zap.Error(err))
 			return resp, wrapTransientNetworkError(err)

--- a/pkg/uhttp/wrapper_test.go
+++ b/pkg/uhttp/wrapper_test.go
@@ -746,7 +746,7 @@ func (h *headerInjectingRoundTripper) RoundTrip(req *http.Request) (*http.Respon
 
 // TestWrapper_Do_CachesDespiteRoundTripHeaderInjection guards against a
 // regression where a header a connector opts into the cache key via
-// DoWithCacheKeyHeaders gets mutated by a RoundTripper further down the
+// WithCacheKeyHeaders gets mutated by a RoundTripper further down the
 // transport chain (transport.go's userAgentTripper does exactly this for
 // User-Agent, which is why this used to bite by default before the cache
 // key was scoped down to an explicit allowlist).
@@ -788,7 +788,7 @@ func TestWrapper_Do_CachesDespiteRoundTripHeaderInjection(t *testing.T) {
 		require.NoError(t, err)
 		require.Empty(t, req.Header.Get("X-Injected-By-Transport"), "test setup: header must start unset for this to reproduce the bug")
 
-		resp, err := client.DoWithCacheKeyHeaders(req, []string{"X-Injected-By-Transport"})
+		resp, err := client.Do(req, WithCacheKeyHeaders("X-Injected-By-Transport"))
 		require.NoError(t, err)
 		resp.Body.Close()
 	}

--- a/pkg/uhttp/wrapper_test.go
+++ b/pkg/uhttp/wrapper_test.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -726,4 +728,48 @@ func TestWrapper_RedactSensitiveHeaders(t *testing.T) {
 		"Proxy-Authorization": {"REDACTED"},
 		"Custom-Api-Key":      {"REDACTED"},
 	}, redactedHeaders)
+}
+
+// TestWrapper_Do_CachesAcrossTransportHeaderInjection guards against a
+// regression where the transport's userAgentTripper (transport.go) sets
+// User-Agent on the same Header map the request was built with. http.Client
+// forks the *http.Request struct on every call (uhttp.NewClient always sets
+// a non-zero Timeout, which makes the fork unconditional), but that fork is
+// shallow, so the Header map -- and therefore the mutation -- is still
+// visible on the request Do() passed in. If Do() round-trips on req itself,
+// CreateCacheKey(req) hashes a different header set for the cache.Set below
+// than it did for the cache.Get above, and no future identical request can
+// ever match the stored key: the cache becomes write-only.
+func TestWrapper_Do_CachesAcrossTransportHeaderInjection(t *testing.T) {
+	var hits int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer ts.Close()
+
+	// A real client built via NewClient, so the real userAgentTripper is in
+	// the round-trip chain -- not a fake transport standing in for it.
+	httpClient, err := NewClient(ctx)
+	require.NoError(t, err)
+
+	client, err := NewBaseHttpClientWithContext(ctx, httpClient)
+	require.NoError(t, err)
+
+	u, err := url.Parse(ts.URL)
+	require.NoError(t, err)
+
+	for i := 0; i < 2; i++ {
+		req, err := client.NewRequest(ctx, http.MethodGet, u)
+		require.NoError(t, err)
+		require.Empty(t, req.Header.Get("User-Agent"), "request must not pre-set User-Agent for this test to reproduce the bug")
+
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		resp.Body.Close()
+	}
+
+	require.EqualValues(t, 1, atomic.LoadInt32(&hits),
+		"second identical GET should be served from cache, not reach the server again")
 }

--- a/pkg/uhttp/wrapper_test.go
+++ b/pkg/uhttp/wrapper_test.go
@@ -746,7 +746,7 @@ func (h *headerInjectingRoundTripper) RoundTrip(req *http.Request) (*http.Respon
 
 // TestWrapper_Do_CachesDespiteRoundTripHeaderInjection guards against a
 // regression where a header a connector opts into the cache key via
-// WithCacheKeyHeaders gets mutated by a RoundTripper further down the
+// DoWithCacheKeyHeaders gets mutated by a RoundTripper further down the
 // transport chain (transport.go's userAgentTripper does exactly this for
 // User-Agent, which is why this used to bite by default before the cache
 // key was scoped down to an explicit allowlist).
@@ -787,9 +787,8 @@ func TestWrapper_Do_CachesDespiteRoundTripHeaderInjection(t *testing.T) {
 		req, err := client.NewRequest(ctx, http.MethodGet, u)
 		require.NoError(t, err)
 		require.Empty(t, req.Header.Get("X-Injected-By-Transport"), "test setup: header must start unset for this to reproduce the bug")
-		req = WithCacheKeyHeaders(req, "X-Injected-By-Transport")
 
-		resp, err := client.Do(req)
+		resp, err := client.DoWithCacheKeyHeaders(req, []string{"X-Injected-By-Transport"})
 		require.NoError(t, err)
 		resp.Body.Close()
 	}

--- a/pkg/uhttp/wrapper_test.go
+++ b/pkg/uhttp/wrapper_test.go
@@ -730,17 +730,36 @@ func TestWrapper_RedactSensitiveHeaders(t *testing.T) {
 	}, redactedHeaders)
 }
 
-// TestWrapper_Do_CachesAcrossTransportHeaderInjection guards against a
-// regression where the transport's userAgentTripper (transport.go) sets
-// User-Agent on the same Header map the request was built with. http.Client
-// forks the *http.Request struct on every call (uhttp.NewClient always sets
-// a non-zero Timeout, which makes the fork unconditional), but that fork is
-// shallow, so the Header map -- and therefore the mutation -- is still
-// visible on the request Do() passed in. If Do() round-trips on req itself,
-// CreateCacheKey(req) hashes a different header set for the cache.Set below
-// than it did for the cache.Get above, and no future identical request can
-// ever match the stored key: the cache becomes write-only.
-func TestWrapper_Do_CachesAcrossTransportHeaderInjection(t *testing.T) {
+// headerInjectingRoundTripper simulates a transport-level RoundTripper (like
+// userAgentTripper in transport.go) that sets a header directly on the
+// *http.Request it's handed, rather than on a private copy.
+type headerInjectingRoundTripper struct {
+	next  http.RoundTripper
+	key   string
+	value string
+}
+
+func (h *headerInjectingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Set(h.key, h.value)
+	return h.next.RoundTrip(req)
+}
+
+// TestWrapper_Do_CachesDespiteRoundTripHeaderInjection guards against a
+// regression where a header a connector opts into the cache key via
+// WithCacheKeyHeaders gets mutated by a RoundTripper further down the
+// transport chain (transport.go's userAgentTripper does exactly this for
+// User-Agent, which is why this used to bite by default before the cache
+// key was scoped down to an explicit allowlist).
+//
+// BaseHttpClient.Do computes the cache key from req before the round trip
+// (Get) and again from the same req after it (Set). http.Client.Do forks
+// the *http.Request struct on every call once Timeout > 0 (which
+// uhttp.NewClient always sets), but that fork is shallow, so Header stays
+// the same map the caller passed in -- any RoundTripper that mutates it
+// mutates the very request Do() is holding. If Do() round-tripped on req
+// itself rather than a clone, the Set key would differ from every future
+// Get key for that header and the cache would become write-only.
+func TestWrapper_Do_CachesDespiteRoundTripHeaderInjection(t *testing.T) {
 	var hits int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt32(&hits, 1)
@@ -749,10 +768,14 @@ func TestWrapper_Do_CachesAcrossTransportHeaderInjection(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	// A real client built via NewClient, so the real userAgentTripper is in
-	// the round-trip chain -- not a fake transport standing in for it.
-	httpClient, err := NewClient(ctx)
-	require.NoError(t, err)
+	httpClient := &http.Client{
+		Timeout: 30 * time.Second, // matches uhttp.NewClient's guarantee of Timeout > 0
+		Transport: &headerInjectingRoundTripper{
+			next:  http.DefaultTransport,
+			key:   "X-Injected-By-Transport",
+			value: "anything",
+		},
+	}
 
 	client, err := NewBaseHttpClientWithContext(ctx, httpClient)
 	require.NoError(t, err)
@@ -763,7 +786,8 @@ func TestWrapper_Do_CachesAcrossTransportHeaderInjection(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		req, err := client.NewRequest(ctx, http.MethodGet, u)
 		require.NoError(t, err)
-		require.Empty(t, req.Header.Get("User-Agent"), "request must not pre-set User-Agent for this test to reproduce the bug")
+		require.Empty(t, req.Header.Get("X-Injected-By-Transport"), "test setup: header must start unset for this to reproduce the bug")
+		req = WithCacheKeyHeaders(req, "X-Injected-By-Transport")
 
 		resp, err := client.Do(req)
 		require.NoError(t, err)


### PR DESCRIPTION
## Summary
- `CreateCacheKey` only folded `Accept`, `Content-Type`, `Cookie`, and `Range` into the HTTP response cache key. Any other request header was silently ignored, so two GET requests differing only in an unlisted header (e.g. `Authorization`, a custom API-version or tenant header) collided on the same cache entry and one request could be served the other's cached response.
- `CreateCacheKey` keeps that original default set unchanged. A new variadic parameter, `extraCacheKeyHeaders`, lets a caller fold additional headers into the key on top of it: `CreateCacheKey(req, "Authorization")`. This threads through `icache.Get`/`Set` and its three implementers (`GoCache`, `DBCache`, `NoopCache`) — all additive, so nothing existing breaks.
- Connector-facing entry point: `BaseHttpClient.Do` now takes `CallOption` instead of `DoOption`. `DoOption` gained an `applyDo` method so every existing `WithJSONResponse`/`WithErrorResponse`/etc. call site keeps compiling unchanged (Go wraps the returned `DoOption` into the `CallOption` interface automatically). `WithCacheKeyHeaders(headers...)` is the new option:
  ```go
  resp, err := client.Do(req, uhttp.WithCacheKeyHeaders("Authorization"), uhttp.WithJSONResponse(&result))
  ```
- Along the way, fixed a related bug in `BaseHttpClient.Do`: it computes the cache key from `req` before the round trip (`Get`) and again from the same `req` after it (`Set`). `http.Client.Do` forks the `*http.Request` struct on every call once `Timeout > 0` (which `uhttp.NewClient` always sets), but that fork is shallow, so `Header` stays the same map the caller passed in — a `RoundTripper` further down the chain (e.g. `userAgentTripper`, which sets `User-Agent`) mutates that shared map, so if a caller opts a header into the key that some `RoundTripper` also touches, the `Set` key could differ from every future `Get` key and the cache would become write-only for that request shape. Fixed by round-tripping on `req.Clone(req.Context())` instead of `req` itself.

## Test plan
- [x] `pkg/uhttp/client_test.go`: default set unaffected by headers outside it; `extraCacheKeyHeaders` opts a header in (case-insensitively) without widening the key to everything else.
- [x] `pkg/uhttp/wrapper_test.go`: `TestWrapper_Do_CachesDespiteRoundTripHeaderInjection` opts a header into the key via `WithCacheKeyHeaders` and injects it via a `RoundTripper` between `Get` and `Set` — confirmed it fails without the request-clone fix and passes with it.
- [x] `go test ./pkg/uhttp/...` and `go test ./...` (whole module)
- [x] `golangci-lint run ./pkg/uhttp/...`
- [x] `go build ./...`