### PR TITLE
Give the skip-sync run-duration test the family's Windows setup budget

### DIFF
--- a/pkg/sync/type_scoped_test.go
+++ b/pkg/sync/type_scoped_test.go
@@ -873,7 +873,7 @@ func TestSkipSyncHonorsRunDuration(t *testing.T) {
 		WithC1ZPath(filepath.Join(tmpDir, "skip-run-duration.c1z")),
 		WithTmpDir(tmpDir),
 		WithSkipFullSync(),
-		WithRunDuration(5*time.Second),
+		WithRunDuration(8*time.Second),
 	)
 	require.NoError(t, err)
 


### PR DESCRIPTION
TestSkipSyncHonorsRunDuration gave the whole run five seconds, the tightest budget in its family, and on slow Windows runners store setup can consume all of it — the deadline fires before Validate is reached and the premise assertion fails. Its siblings settled on a deliberately generous eight seconds after the same failure mode; this test now matches them. The added seconds are spent waiting out the run duration by design.