### PR TITLE
retryable client functionality

### DIFF
--- a/pkg/uhttp/authcredentials.go
+++ b/pkg/uhttp/authcredentials.go
@@ -22,7 +22,7 @@ type NoAuth struct{}
 var _ AuthCredentials = (*NoAuth)(nil)
 
 func (n *NoAuth) GetClient(ctx context.Context, options ...Option) (*http.Client, error) {
-	return getHttpClient(ctx, options...)
+	return getHttpClient(ctx, withoutTransientRetries(options)...)
 }
 
 type BearerAuth struct {
@@ -38,7 +38,7 @@ func NewBearerAuth(token string) *BearerAuth {
 }
 
 func (b *BearerAuth) GetClient(ctx context.Context, options ...Option) (*http.Client, error) {
-	httpClient, err := getHttpClient(ctx, options...)
+	httpClient, err := getHttpClient(ctx, withoutTransientRetries(options)...)
 	if err != nil {
 		return nil, err
 	}
@@ -67,7 +67,7 @@ func NewBasicAuth(username, password string) *BasicAuth {
 }
 
 func (b *BasicAuth) GetClient(ctx context.Context, options ...Option) (*http.Client, error) {
-	httpClient, err := getHttpClient(ctx, options...)
+	httpClient, err := getHttpClient(ctx, withoutTransientRetries(options)...)
 	if err != nil {
 		return nil, err
 	}
@@ -203,6 +203,12 @@ func tokenRetryConfig(options []Option) TransientRetryConfig {
 	return cfg
 }
 
+func refreshTokenRetryConfig(options []Option) TransientRetryConfig {
+	cfg := tokenRetryConfig(options)
+	cfg.SkipNetworkRetries = true
+	return cfg
+}
+
 // newOAuthClients returns an API client (never WithTransientRetries) and a
 // token client (always WithTransientRetries). Caller-supplied
 // WithTransientRetries is honored on the token client only; it is stripped
@@ -246,6 +252,12 @@ func NewOAuth2RefreshToken(clientID, clientSecret, redirectURI, tokenURL, access
 }
 
 func (o *OAuth2RefreshToken) GetClient(ctx context.Context, options ...Option) (*http.Client, error) {
+	// Refresh POSTs retry 5xx only. A mid-flight timeout or connection
+	// reset can mean the rotation succeeded; replaying it can revoke the
+	// token family and force a manual re-auth, which is worse than a
+	// failed sync. Dial-phase failures (never sent) are still retried.
+	// API traffic stays on clients.api and is not retried.
+	options = append(options, WithTransientRetries(refreshTokenRetryConfig(options)))
 	clients, err := newOAuthClients(ctx, options...)
 	if err != nil {
 		return nil, err
@@ -256,10 +268,6 @@ func (o *OAuth2RefreshToken) GetClient(ctx context.Context, options ...Option) (
 		RefreshToken: o.refreshToken,
 		TokenType:    "Bearer",
 	}
-	// TokenSource uses clients.token so refresh POSTs retry 5xx/timeouts.
-	// Refresh-token rotation is rare; a lost response can still invalidate
-	// the old token, but failing the sync is worse. API traffic stays on
-	// clients.api and is not retried.
 	ts := o.cfg.TokenSource(clients.tokenContext(ctx), token)
 	return clients.apiClient(ts), nil
 }

--- a/pkg/uhttp/authcredentials.go
+++ b/pkg/uhttp/authcredentials.go
@@ -100,15 +100,12 @@ func NewOAuth2ClientCredentials(clientId, clientSecret string, tokenURL *url.URL
 }
 
 func (o *OAuth2ClientCredentials) GetClient(ctx context.Context, options ...Option) (*http.Client, error) {
-	httpClient, err := getHttpClient(ctx, options...)
+	clients, err := newOAuthClients(ctx, options...)
 	if err != nil {
 		return nil, err
 	}
-	ctx = context.WithValue(ctx, oauth2.HTTPClient, httpClient)
-	ts := o.cfg.TokenSource(ctx)
-	httpClient = oauth2.NewClient(ctx, ts)
-
-	return httpClient, nil
+	ts := o.cfg.TokenSource(clients.tokenContext(ctx))
+	return clients.apiClient(ts), nil
 }
 
 type CreateJWTConfig func(credentials []byte, scopes ...string) (*jwt.Config, error)
@@ -130,7 +127,7 @@ func NewOAuth2JWT(credentials []byte, scopes []string, createfn CreateJWTConfig)
 }
 
 func (o *OAuth2JWT) GetClient(ctx context.Context, options ...Option) (*http.Client, error) {
-	httpClient, err := getHttpClient(ctx, options...)
+	clients, err := newOAuthClients(ctx, options...)
 	if err != nil {
 		return nil, err
 	}
@@ -140,11 +137,8 @@ func (o *OAuth2JWT) GetClient(ctx context.Context, options ...Option) (*http.Cli
 		return nil, fmt.Errorf("creating JWT config failed: %w", err)
 	}
 
-	ctx = context.WithValue(ctx, oauth2.HTTPClient, httpClient)
-	ts := jwt.TokenSource(ctx)
-	httpClient = oauth2.NewClient(ctx, ts)
-
-	return httpClient, nil
+	ts := jwt.TokenSource(clients.tokenContext(ctx))
+	return clients.apiClient(ts), nil
 }
 
 func getHttpClient(ctx context.Context, options ...Option) (*http.Client, error) {
@@ -156,6 +150,75 @@ func getHttpClient(ctx context.Context, options ...Option) (*http.Client, error)
 	}
 
 	return httpClient, nil
+}
+
+// oauthClients holds the two HTTP clients used by OAuth helpers. Token is
+// used only for token-endpoint POSTs (WithTransientRetries). API is
+// oauth2.Transport.Base and must never replay provisioning POSTs.
+type oauthClients struct {
+	api   *http.Client
+	token *http.Client
+}
+
+// tokenContext is the only context value oauth2 needs: TokenSource looks up
+// HTTPClient from it. The API client is not in context; it is Transport.Base.
+func (c oauthClients) tokenContext(ctx context.Context) context.Context {
+	return context.WithValue(ctx, oauth2.HTTPClient, c.token)
+}
+
+// apiClient builds the caller-facing client. oauth2.NewClient is avoided
+// because it reads its base transport from the context client, which would
+// require a second WithValue; wiring Transport.Base explicitly keeps the
+// api/token split visible. The ReuseTokenSource wrap matches NewClient's
+// behavior and is a no-op for the Config.TokenSource values used here,
+// which are already reuse-wrapped.
+func (c oauthClients) apiClient(ts oauth2.TokenSource) *http.Client {
+	return &http.Client{
+		Timeout: c.api.Timeout,
+		Transport: &oauth2.Transport{
+			Base:   c.api.Transport,
+			Source: oauth2.ReuseTokenSource(nil, ts),
+		},
+	}
+}
+
+func withoutTransientRetries(options []Option) []Option {
+	out := make([]Option, 0, len(options))
+	for _, opt := range options {
+		if _, ok := opt.(transientRetriesOption); ok {
+			continue
+		}
+		out = append(out, opt)
+	}
+	return out
+}
+
+func tokenRetryConfig(options []Option) TransientRetryConfig {
+	var cfg TransientRetryConfig
+	for _, opt := range options {
+		if t, ok := opt.(transientRetriesOption); ok {
+			cfg = t.cfg
+		}
+	}
+	return cfg
+}
+
+// newOAuthClients returns an API client (never WithTransientRetries) and a
+// token client (always WithTransientRetries). Caller-supplied
+// WithTransientRetries is honored on the token client only; it is stripped
+// from the API client so GetClient(ctx, WithTransientRetries(...)) cannot
+// replay grants, revokes, or tickets.
+func newOAuthClients(ctx context.Context, options ...Option) (oauthClients, error) {
+	apiClient, err := getHttpClient(ctx, withoutTransientRetries(options)...)
+	if err != nil {
+		return oauthClients{}, err
+	}
+	tokenOpts := append(withoutTransientRetries(options), WithTransientRetries(tokenRetryConfig(options)))
+	tokenClient, err := getHttpClient(ctx, tokenOpts...)
+	if err != nil {
+		return oauthClients{}, err
+	}
+	return oauthClients{api: apiClient, token: tokenClient}, nil
 }
 
 type OAuth2RefreshToken struct {
@@ -183,18 +246,20 @@ func NewOAuth2RefreshToken(clientID, clientSecret, redirectURI, tokenURL, access
 }
 
 func (o *OAuth2RefreshToken) GetClient(ctx context.Context, options ...Option) (*http.Client, error) {
-	httpClient, err := getHttpClient(ctx, options...)
+	clients, err := newOAuthClients(ctx, options...)
 	if err != nil {
 		return nil, err
 	}
-	ctx = context.WithValue(ctx, oauth2.HTTPClient, httpClient)
 
 	token := &oauth2.Token{
 		AccessToken:  o.accessToken,
 		RefreshToken: o.refreshToken,
 		TokenType:    "Bearer",
 	}
-	httpClient = o.cfg.Client(ctx, token)
-
-	return httpClient, nil
+	// TokenSource uses clients.token so refresh POSTs retry 5xx/timeouts.
+	// Refresh-token rotation is rare; a lost response can still invalidate
+	// the old token, but failing the sync is worse. API traffic stays on
+	// clients.api and is not retried.
+	ts := o.cfg.TokenSource(clients.tokenContext(ctx), token)
+	return clients.apiClient(ts), nil
 }

--- a/pkg/uhttp/authcredentials_test.go
+++ b/pkg/uhttp/authcredentials_test.go
@@ -424,3 +424,76 @@ func TestOAuth2ClientCredentials_GetClientStripsTransientRetriesFromAPI(t *testi
 	require.Equal(t, 1, apiHits, "WithTransientRetries on GetClient must not retry API POSTs")
 	require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
 }
+
+func TestAuthCredentials_GetClientStripsTransientRetries(t *testing.T) {
+	ctx := context.Background()
+	opt := WithTransientRetries(TransientRetryConfig{
+		InitialDelay: time.Millisecond,
+		MaxDelay:     time.Millisecond,
+	})
+
+	t.Run("NoAuth", func(t *testing.T) {
+		client, err := (&NoAuth{}).GetClient(ctx, opt)
+		require.NoError(t, err)
+		require.Equal(t, 1, postCountOn5xx(t, client))
+	})
+	t.Run("BearerAuth", func(t *testing.T) {
+		client, err := NewBearerAuth("tok").GetClient(ctx, opt)
+		require.NoError(t, err)
+		require.Equal(t, 1, postCountOn5xx(t, client))
+	})
+	t.Run("BasicAuth", func(t *testing.T) {
+		client, err := NewBasicAuth("u", "p").GetClient(ctx, opt)
+		require.NoError(t, err)
+		require.Equal(t, 1, postCountOn5xx(t, client))
+	})
+}
+
+func TestOAuth2RefreshToken_GetClientStripsTransientRetriesFromAPI(t *testing.T) {
+	rt := &OAuth2RefreshToken{
+		cfg: &oauth2.Config{
+			ClientID:     "test-client-id",
+			ClientSecret: "test-client-secret",
+			// #nosec G101 -- static test endpoint, not a secret.
+			Endpoint: oauth2.Endpoint{
+				TokenURL: "https://test-token-url",
+			},
+		},
+		accessToken:  "test-access-token",
+		refreshToken: "test-refresh-token",
+	}
+	ctx := context.Background()
+	client, err := rt.GetClient(ctx, WithTransientRetries(TransientRetryConfig{
+		InitialDelay: time.Millisecond,
+		MaxDelay:     time.Millisecond,
+	}))
+	require.NoError(t, err)
+	require.Equal(t, 1, postCountOn5xx(t, client), "refresh-token API POST must not retry 5xx")
+}
+
+func TestRefreshTokenRetryConfigSkipsNetwork(t *testing.T) {
+	cfg := refreshTokenRetryConfig(nil)
+	require.True(t, cfg.SkipNetworkRetries)
+
+	cfg = refreshTokenRetryConfig([]Option{WithTransientRetries(TransientRetryConfig{MaxAttempts: 5})})
+	require.True(t, cfg.SkipNetworkRetries)
+	require.Equal(t, 5, cfg.MaxAttempts)
+}
+
+func postCountOn5xx(t *testing.T, client *http.Client) int {
+	t.Helper()
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL, strings.NewReader("grant"))
+	require.NoError(t, err)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	return hits
+}

--- a/pkg/uhttp/authcredentials_test.go
+++ b/pkg/uhttp/authcredentials_test.go
@@ -7,8 +7,11 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"regexp"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
@@ -292,4 +295,132 @@ func TestHelpers_OAuth2_RefreshToken_GetClient(t *testing.T) {
 	require.Equal(t, "test-access-token", token.AccessToken)
 	require.Equal(t, "test-refresh-token", token.RefreshToken)
 	require.Equal(t, "Bearer", token.TokenType)
+}
+
+func TestOAuth2ClientCredentials_RetriesToken5xxButNotAPIPost(t *testing.T) {
+	var tokenHits, apiHits int
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tokenHits++
+		if tokenHits == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"access_token":"tok","token_type":"Bearer","expires_in":3600}`))
+	}))
+	t.Cleanup(tokenSrv.Close)
+
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiHits++
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(apiSrv.Close)
+
+	tokenURL, err := url.Parse(tokenSrv.URL)
+	require.NoError(t, err)
+	cc := NewOAuth2ClientCredentials("id", "secret", tokenURL, nil)
+
+	ctx := context.Background()
+	client, err := cc.GetClient(ctx)
+	require.NoError(t, err)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiSrv.URL, strings.NewReader("grant"))
+	require.NoError(t, err)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, 2, tokenHits, "token POST should retry a single 5xx")
+	require.Equal(t, 1, apiHits, "API POST must not inherit token-client retries")
+	require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+}
+
+func TestOAuth2JWT_RetriesToken5xxButNotAPIPost(t *testing.T) {
+	var tokenHits, apiHits int
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tokenHits++
+		if tokenHits == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"access_token":"tok","token_type":"Bearer","expires_in":3600}`))
+	}))
+	t.Cleanup(tokenSrv.Close)
+
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiHits++
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(apiSrv.Close)
+
+	oauthJWT := &OAuth2JWT{
+		Credentials: []byte("test-credentials"),
+		CreateJWTConfig: func(_ []byte, scopes ...string) (*jwt.Config, error) {
+			return &jwt.Config{
+				Email:      "test-email",
+				TokenURL:   tokenSrv.URL,
+				PrivateKey: getDummyPrivateKey(),
+				Scopes:     scopes,
+			}, nil
+		},
+	}
+
+	ctx := context.Background()
+	client, err := oauthJWT.GetClient(ctx)
+	require.NoError(t, err)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiSrv.URL, strings.NewReader("grant"))
+	require.NoError(t, err)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, 2, tokenHits, "JWT token POST should retry a single 5xx")
+	require.Equal(t, 1, apiHits, "API POST must not inherit token-client retries")
+	require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+}
+
+func TestOAuth2ClientCredentials_GetClientStripsTransientRetriesFromAPI(t *testing.T) {
+	var tokenHits, apiHits int
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tokenHits++
+		if tokenHits == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"access_token":"tok","token_type":"Bearer","expires_in":3600}`))
+	}))
+	t.Cleanup(tokenSrv.Close)
+
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiHits++
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(apiSrv.Close)
+
+	tokenURL, err := url.Parse(tokenSrv.URL)
+	require.NoError(t, err)
+	cc := NewOAuth2ClientCredentials("id", "secret", tokenURL, nil)
+
+	ctx := context.Background()
+	client, err := cc.GetClient(ctx, WithTransientRetries(TransientRetryConfig{
+		InitialDelay: time.Millisecond,
+		MaxDelay:     time.Millisecond,
+	}))
+	require.NoError(t, err)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiSrv.URL, strings.NewReader("grant"))
+	require.NoError(t, err)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, 2, tokenHits, "token POST should still retry a single 5xx")
+	require.Equal(t, 1, apiHits, "WithTransientRetries on GetClient must not retry API POSTs")
+	require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
 }

--- a/pkg/uhttp/client.go
+++ b/pkg/uhttp/client.go
@@ -79,6 +79,75 @@ func WithTimeout(timeout time.Duration) Option {
 	return timeoutOption{timeout: timeout}
 }
 
+const (
+	defaultTransientRetryAttempts = 3
+	defaultTransientRetryInitial  = 500 * time.Millisecond
+	defaultTransientRetryMaxDelay = 2 * time.Second
+	// A mid-flight timeout has already blocked for up to ResponseHeaderTimeout
+	// (60s). Retrying that N times would stall Token() for minutes; one extra
+	// attempt is enough to cover a hung origin that then recovers.
+	maxTransientTimeoutRetries = 1
+)
+
+// TransientRetryConfig configures WithTransientRetries. A zero value selects
+// the defaults: 3 attempts (1 try + 2 retries), 500ms initial delay, 2s max
+// delay. MaxAttempts <= 0, InitialDelay <= 0, and MaxDelay <= 0 each mean
+// "use the default"; 0 does not mean unlimited.
+type TransientRetryConfig struct {
+	MaxAttempts  int
+	InitialDelay time.Duration
+	MaxDelay     time.Duration
+}
+
+type transientRetrySettings struct {
+	maxAttempts  int
+	initialDelay time.Duration
+	maxDelay     time.Duration
+}
+
+func resolveTransientRetry(cfg TransientRetryConfig) transientRetrySettings {
+	s := transientRetrySettings{
+		maxAttempts:  cfg.MaxAttempts,
+		initialDelay: cfg.InitialDelay,
+		maxDelay:     cfg.MaxDelay,
+	}
+	if s.maxAttempts <= 0 {
+		s.maxAttempts = defaultTransientRetryAttempts
+	}
+	if s.initialDelay <= 0 {
+		s.initialDelay = defaultTransientRetryInitial
+	}
+	if s.maxDelay <= 0 {
+		s.maxDelay = defaultTransientRetryMaxDelay
+	}
+	return s
+}
+
+type transientRetriesOption struct {
+	cfg TransientRetryConfig
+}
+
+func (o transientRetriesOption) Apply(c *Transport) {
+	s := resolveTransientRetry(o.cfg)
+	c.transientRetry = &s
+}
+
+// WithTransientRetries retries 5xx responses and mid-flight timeouts on this
+// client, with exponential backoff. Use it only for OAuth token endpoints
+// (and similarly side-effect-free token fetches).
+//
+// Do not enable this on a client used for general API reads or for
+// provisioning (grants, revokes, tickets, SetIamPolicy). Those requests are
+// not safe to replay after they have been sent; a retried POST can double-apply.
+//
+// 429 / rate-limit responses are not retried here: they belong to pkg/retry
+// via RateLimitDescription. Dial-phase and stale-pooled-connection retries
+// stay on the existing one-shot path; this option also treats the client's
+// requests as replayable so token POSTs get that stale-connection retry.
+func WithTransientRetries(cfg TransientRetryConfig) Option {
+	return transientRetriesOption{cfg: cfg}
+}
+
 type Option interface {
 	Apply(*Transport)
 }

--- a/pkg/uhttp/client.go
+++ b/pkg/uhttp/client.go
@@ -93,23 +93,35 @@ const (
 // the defaults: 3 attempts (1 try + 2 retries), 500ms initial delay, 2s max
 // delay. MaxAttempts <= 0, InitialDelay <= 0, and MaxDelay <= 0 each mean
 // "use the default"; 0 does not mean unlimited.
+//
+// MaxAttempts is the total number of tries including the first. A value of 1
+// disables 5xx and timeout retries; the pre-existing one-shot never-sent /
+// stale-connection retry still runs.
 type TransientRetryConfig struct {
 	MaxAttempts  int
 	InitialDelay time.Duration
 	MaxDelay     time.Duration
+	// SkipNetworkRetries, if true, retries 5xx only. Mid-flight timeouts
+	// and stale-connection resets are not replayed. Dial-phase failures
+	// (the request was never sent) are still retried. Use for refresh-token
+	// grants: a timeout can mean the rotation succeeded, and replaying it
+	// can revoke the token family.
+	SkipNetworkRetries bool
 }
 
 type transientRetrySettings struct {
-	maxAttempts  int
-	initialDelay time.Duration
-	maxDelay     time.Duration
+	maxAttempts        int
+	initialDelay       time.Duration
+	maxDelay           time.Duration
+	skipNetworkRetries bool
 }
 
 func resolveTransientRetry(cfg TransientRetryConfig) transientRetrySettings {
 	s := transientRetrySettings{
-		maxAttempts:  cfg.MaxAttempts,
-		initialDelay: cfg.InitialDelay,
-		maxDelay:     cfg.MaxDelay,
+		maxAttempts:        cfg.MaxAttempts,
+		initialDelay:       cfg.InitialDelay,
+		maxDelay:           cfg.MaxDelay,
+		skipNetworkRetries: cfg.SkipNetworkRetries,
 	}
 	if s.maxAttempts <= 0 {
 		s.maxAttempts = defaultTransientRetryAttempts
@@ -139,6 +151,8 @@ func (o transientRetriesOption) Apply(c *Transport) {
 // Do not enable this on a client used for general API reads or for
 // provisioning (grants, revokes, tickets, SetIamPolicy). Those requests are
 // not safe to replay after they have been sent; a retried POST can double-apply.
+// AuthCredentials.GetClient always strips this option from the returned
+// client; OAuth helpers apply it to the token-endpoint client only.
 //
 // 429 / rate-limit responses are not retried here: they belong to pkg/retry
 // via RateLimitDescription. Dial-phase and stale-pooled-connection retries

--- a/pkg/uhttp/transient_retry.go
+++ b/pkg/uhttp/transient_retry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"math/rand/v2"
 	"net"
 	"net/http"
 	"net/url"
@@ -12,6 +13,11 @@ import (
 
 	"go.uber.org/zap"
 )
+
+// maxTransientDrain is how much of a failed 5xx body we read before Close.
+// Connection reuse only needs a small drain; an unbounded Copy can stall
+// the retry until the client's Timeout (300s) fires.
+const maxTransientDrain = 8 << 10
 
 func (t *Transport) roundTripTransientRetries(
 	ctx context.Context,
@@ -67,6 +73,12 @@ func (t *Transport) nextTransientRetry(
 		return nil, 0, false, false
 	}
 	if err != nil {
+		if t.transientRetry.skipNetworkRetries {
+			// 5xx-only: still retry dial-phase (never sent). Do not
+			// replay timeouts or stale-connection resets.
+			retryReq, ok := retryableRequest(req, err, false)
+			return retryReq, 0, false, ok
+		}
 		if isRetryableTimeout(req, err) {
 			if timeoutRetries >= maxTransientTimeoutRetries {
 				return nil, 0, false, false
@@ -99,14 +111,32 @@ func (t *Transport) transientBackoffWait(retryIndex int, resp *http.Response) ti
 	if wait > t.transientRetry.maxDelay {
 		wait = t.transientRetry.maxDelay
 	}
-	if resp == nil {
+	if resp != nil {
+		if ra := parseRetryAfter(resp.Header.Get("Retry-After"), t.now()); ra > 0 {
+			wait = ra
+			if wait > t.transientRetry.maxDelay {
+				wait = t.transientRetry.maxDelay
+			}
+		}
+	}
+	return jitterWait(wait, t.transientRetry.maxDelay)
+}
+
+// jitterWait spreads retries by ±25% of wait, then clamps to [0, maxDelay].
+func jitterWait(wait, maxDelay time.Duration) time.Duration {
+	if wait <= 0 {
 		return wait
 	}
-	if ra := parseRetryAfter(resp.Header.Get("Retry-After"), t.now()); ra > 0 {
-		wait = ra
-		if wait > t.transientRetry.maxDelay {
-			wait = t.transientRetry.maxDelay
-		}
+	delta := wait / 4
+	if delta > 0 {
+		// #nosec G404 -- jitter for retry backoff, not a security value.
+		wait += time.Duration(rand.Int64N(int64(2*delta)+1) - int64(delta))
+	}
+	if wait > maxDelay {
+		wait = maxDelay
+	}
+	if wait < 0 {
+		return 0
 	}
 	return wait
 }
@@ -130,7 +160,7 @@ func drainResponse(resp *http.Response) {
 	if resp == nil || resp.Body == nil {
 		return
 	}
-	_, _ = io.Copy(io.Discard, resp.Body)
+	_, _ = io.CopyN(io.Discard, resp.Body, maxTransientDrain)
 	_ = resp.Body.Close()
 }
 

--- a/pkg/uhttp/transient_retry.go
+++ b/pkg/uhttp/transient_retry.go
@@ -1,0 +1,172 @@
+package uhttp
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+func (t *Transport) roundTripTransientRetries(
+	ctx context.Context,
+	rt http.RoundTripper,
+	req *http.Request,
+	resp *http.Response,
+	err error,
+) (*http.Response, error) {
+	timeoutRetries := 0
+	for attempt := 1; attempt < t.transientRetry.maxAttempts; attempt++ {
+		retryReq, wait, isTimeout, ok := t.nextTransientRetry(req, resp, err, timeoutRetries, attempt)
+		if !ok {
+			return resp, err
+		}
+		if isTimeout {
+			timeoutRetries++
+		}
+		if resp != nil {
+			drainResponse(resp)
+		}
+		if err != nil && isStaleConnectionError(err) {
+			t.closeIdleConnections()
+			if freshRT, cycleErr := t.cycle(ctx); cycleErr == nil {
+				rt = freshRT
+			}
+		}
+		if waitErr := waitRetry(ctx, wait); waitErr != nil {
+			return nil, waitErr
+		}
+		if t.log {
+			t.l(ctx).Debug("uhttp: retrying request after transient failure",
+				zap.String("http.method", req.Method),
+				zap.String("http.url_details.host", req.URL.Host),
+				zap.String("http.url_details.path", req.URL.Path),
+				zap.Int("attempt", attempt+1),
+				zap.Error(err),
+			)
+		}
+		resp, err = rt.RoundTrip(retryReq)
+		req = retryReq
+	}
+	return resp, err
+}
+
+func (t *Transport) nextTransientRetry(
+	req *http.Request,
+	resp *http.Response,
+	err error,
+	timeoutRetries int,
+	retryIndex int,
+) (*http.Request, time.Duration, bool, bool) {
+	if req.Context().Err() != nil {
+		return nil, 0, false, false
+	}
+	if err != nil {
+		if isRetryableTimeout(req, err) {
+			if timeoutRetries >= maxTransientTimeoutRetries {
+				return nil, 0, false, false
+			}
+			retryReq, ok := rewindRequest(req)
+			return retryReq, 0, true, ok
+		}
+		retryReq, ok := retryableRequest(req, err, true)
+		return retryReq, 0, false, ok
+	}
+	if resp != nil && resp.StatusCode >= 500 {
+		retryReq, ok := rewindRequest(req)
+		if !ok {
+			return nil, 0, false, false
+		}
+		return retryReq, t.transientBackoffWait(retryIndex, resp), false, true
+	}
+	return nil, 0, false, false
+}
+
+func (t *Transport) transientBackoffWait(retryIndex int, resp *http.Response) time.Duration {
+	wait := t.transientRetry.initialDelay
+	for i := 1; i < retryIndex; i++ {
+		if wait > t.transientRetry.maxDelay/2 {
+			wait = t.transientRetry.maxDelay
+			break
+		}
+		wait *= 2
+	}
+	if wait > t.transientRetry.maxDelay {
+		wait = t.transientRetry.maxDelay
+	}
+	if resp == nil {
+		return wait
+	}
+	if ra := parseRetryAfter(resp.Header.Get("Retry-After"), t.now()); ra > 0 {
+		wait = ra
+		if wait > t.transientRetry.maxDelay {
+			wait = t.transientRetry.maxDelay
+		}
+	}
+	return wait
+}
+
+func isRetryableTimeout(req *http.Request, err error) bool {
+	if err == nil || req.Context().Err() != nil {
+		return false
+	}
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) && urlErr.Timeout() {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	return isSocketTimeout(err)
+}
+
+func drainResponse(resp *http.Response) {
+	if resp == nil || resp.Body == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+}
+
+func waitRetry(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+// parseRetryAfter accepts the HTTP Retry-After forms: an integer number of
+// seconds, or an HTTP-date. Invalid values yield 0.
+func parseRetryAfter(v string, now time.Time) time.Duration {
+	if v == "" {
+		return 0
+	}
+	if seconds, err := strconv.Atoi(v); err == nil {
+		if seconds <= 0 {
+			return 0
+		}
+		return time.Duration(seconds) * time.Second
+	}
+	when, err := http.ParseTime(v)
+	if err != nil {
+		return 0
+	}
+	d := when.Sub(now)
+	if d <= 0 {
+		return 0
+	}
+	return d
+}

--- a/pkg/uhttp/transport.go
+++ b/pkg/uhttp/transport.go
@@ -296,10 +296,15 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		}
 	}()
 	resp, err := rt.RoundTrip(req)
-	if t.transientRetry != nil {
+	// MaxAttempts < 2 (after defaulting <=0 to 3) means no 5xx/timeout
+	// budget. Fall through to the one-shot never-sent/stale retry so
+	// WithTransientRetries({MaxAttempts: 1}) is not strictly less safe
+	// than omitting the option.
+	if t.transientRetry != nil && t.transientRetry.maxAttempts >= 2 {
 		resp, err = t.roundTripTransientRetries(ctx, rt, req, resp, err)
 	} else if err != nil && req.Context().Err() == nil {
-		if retryReq, ok := retryableRequest(req, err, false); ok {
+		replayable := t.transientRetry != nil && !t.transientRetry.skipNetworkRetries
+		if retryReq, ok := retryableRequest(req, err, replayable); ok {
 			// A mass connection death (e.g. a proxy instance replaced) can
 			// leave further corpses in the pool; drop them so the retry
 			// dials fresh instead of drawing the next one. Re-resolve the

--- a/pkg/uhttp/transport.go
+++ b/pkg/uhttp/transport.go
@@ -82,6 +82,9 @@ type Transport struct {
 	// nowFn overrides time.Now in tests.
 	nowFn func() time.Time
 	mtx   sync.RWMutex
+	// transientRetry, when non-nil, retries 5xx and mid-flight timeouts.
+	// Set only via WithTransientRetries; nil is the default (off).
+	transientRetry *transientRetrySettings
 }
 
 func newTransport() *Transport {
@@ -234,17 +237,22 @@ func (t *Transport) closeIdleConnections() {
 // and returns the request to retry with. Two cases qualify: errors raised
 // before any request bytes were written (safe for every method), and
 // stale-pooled-connection errors on requests that declare idempotence via
-// a safe method or an Idempotency-Key header. net/http covers the second
-// case itself for HTTP/1.1 but never for HTTP/2, where its retry gate
-// requires a reused persistConn and h2 connections are always wrapped in
-// fresh ones.
-func retryableRequest(req *http.Request, err error) (*http.Request, bool) {
-	retrySafe := requestNeverSent(err) || (declaredIdempotent(req) && isStaleConnectionError(err))
+// a safe method, an Idempotency-Key header, or a WithTransientRetries
+// client (replayable). net/http covers the second case itself for HTTP/1.1
+// but never for HTTP/2, where its retry gate requires a reused persistConn
+// and h2 connections are always wrapped in fresh ones.
+func retryableRequest(req *http.Request, err error, replayable bool) (*http.Request, bool) {
+	retrySafe := requestNeverSent(err) || ((declaredIdempotent(req) || replayable) && isStaleConnectionError(err))
 	if !retrySafe {
 		return nil, false
 	}
-	// The transport closes the original body on failure, so any request
-	// that carries one needs a fresh copy to be retried.
+	return rewindRequest(req)
+}
+
+// rewindRequest returns a request with a fresh body for retry. The transport
+// closes the original body on failure, so any request that carries one needs
+// GetBody. Requests with no body are returned as-is.
+func rewindRequest(req *http.Request) (*http.Request, bool) {
 	if req.Body == nil || req.Body == http.NoBody {
 		return req, true
 	}
@@ -288,8 +296,10 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		}
 	}()
 	resp, err := rt.RoundTrip(req)
-	if err != nil && req.Context().Err() == nil {
-		if retryReq, ok := retryableRequest(req, err); ok {
+	if t.transientRetry != nil {
+		resp, err = t.roundTripTransientRetries(ctx, rt, req, resp, err)
+	} else if err != nil && req.Context().Err() == nil {
+		if retryReq, ok := retryableRequest(req, err, false); ok {
 			// A mass connection death (e.g. a proxy instance replaced) can
 			// leave further corpses in the pool; drop them so the retry
 			// dials fresh instead of drawing the next one. Re-resolve the

--- a/pkg/uhttp/transport_test.go
+++ b/pkg/uhttp/transport_test.go
@@ -76,11 +76,14 @@ func mustGet(t *testing.T, client *http.Client, url string) {
 
 // sequencedRoundTripper fails with errs in order (one per call), then
 // answers 200 OK, recording call count and each request's body.
+// statusCodes, when set, override the status of a successful (non-error) call.
 type sequencedRoundTripper struct {
-	mu     sync.Mutex
-	errs   []error
-	calls  int
-	bodies []string
+	mu          sync.Mutex
+	errs        []error
+	statusCodes []int
+	headers     []http.Header
+	calls       int
+	bodies      []string
 }
 
 func (s *sequencedRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -98,13 +101,21 @@ func (s *sequencedRoundTripper) RoundTrip(req *http.Request) (*http.Response, er
 	s.bodies = append(s.bodies, body)
 	call := s.calls
 	s.calls++
-	if call < len(s.errs) {
+	if call < len(s.errs) && s.errs[call] != nil {
 		return nil, s.errs[call]
 	}
+	code := http.StatusOK
+	if call < len(s.statusCodes) && s.statusCodes[call] != 0 {
+		code = s.statusCodes[call]
+	}
+	h := http.Header{}
+	if call < len(s.headers) && s.headers[call] != nil {
+		h = s.headers[call].Clone()
+	}
 	return &http.Response{
-		StatusCode: http.StatusOK,
+		StatusCode: code,
 		Body:       io.NopCloser(strings.NewReader("ok")),
-		Header:     http.Header{},
+		Header:     h,
 	}, nil
 }
 
@@ -142,6 +153,24 @@ func newRetryTestTransport(rt http.RoundTripper) *Transport {
 	return &Transport{
 		roundTripper: rt,
 		nextCycle:    time.Now().Add(time.Minute),
+	}
+}
+
+func newTransientRetryTestTransport(rt http.RoundTripper) *Transport {
+	tp := newRetryTestTransport(rt)
+	s := resolveTransientRetry(TransientRetryConfig{
+		InitialDelay: time.Millisecond,
+		MaxDelay:     time.Millisecond,
+	})
+	tp.transientRetry = &s
+	return tp
+}
+
+func timeoutURLError() error {
+	return &url.Error{
+		Op:  "Post",
+		URL: "https://example.com",
+		Err: timeoutError{err: fmt.Errorf("i/o timeout")},
 	}
 }
 
@@ -434,4 +463,162 @@ func (timeoutError) Timeout() bool {
 
 func (timeoutError) Temporary() bool {
 	return false
+}
+
+func TestTransportDoesNotRetry5xxByDefault(t *testing.T) {
+	seq := &sequencedRoundTripper{statusCodes: []int{http.StatusInternalServerError, http.StatusOK}}
+	tp := newRetryTestTransport(seq)
+
+	resp, err := tp.RoundTrip(postWithBody(t, "payload"))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	require.Equal(t, 1, seq.callCount())
+}
+
+func TestTransportDoesNotRetryGET5xxByDefault(t *testing.T) {
+	seq := &sequencedRoundTripper{statusCodes: []int{http.StatusInternalServerError, http.StatusOK}}
+	tp := newRetryTestTransport(seq)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://example.com", nil)
+	require.NoError(t, err)
+	resp, err := tp.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	require.Equal(t, 1, seq.callCount())
+}
+
+func TestTransportTransientRetriesPOST5xx(t *testing.T) {
+	seq := &sequencedRoundTripper{statusCodes: []int{http.StatusInternalServerError, http.StatusOK}}
+	tp := newTransientRetryTestTransport(seq)
+
+	resp, err := tp.RoundTrip(postWithBody(t, "payload"))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, 2, seq.callCount())
+	require.Equal(t, []string{"payload", "payload"}, seq.bodies)
+}
+
+func TestTransportTransientRetriesTimeoutOnce(t *testing.T) {
+	seq := &sequencedRoundTripper{errs: []error{timeoutURLError()}}
+	tp := newTransientRetryTestTransport(seq)
+
+	resp, err := tp.RoundTrip(postWithBody(t, "payload"))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, 2, seq.callCount())
+}
+
+func TestTransportTransientDoesNotRetrySecondTimeout(t *testing.T) {
+	seq := &sequencedRoundTripper{errs: []error{timeoutURLError(), timeoutURLError(), timeoutURLError()}}
+	tp := newTransientRetryTestTransport(seq)
+
+	resp, err := tp.RoundTrip(postWithBody(t, "payload"))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	require.Error(t, err)
+	// First try + one timeout retry; a third timeout is not attempted.
+	require.Equal(t, 2, seq.callCount())
+}
+
+func TestTransportTransientDoesNotRetryCanceledContext(t *testing.T) {
+	seq := &sequencedRoundTripper{statusCodes: []int{http.StatusInternalServerError, http.StatusOK}}
+	tp := newTransientRetryTestTransport(seq)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://example.com", strings.NewReader("payload"))
+	require.NoError(t, err)
+
+	resp, err := tp.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	require.Equal(t, 1, seq.callCount())
+}
+
+func TestTransportTransientDoesNotRetry4xx(t *testing.T) {
+	seq := &sequencedRoundTripper{statusCodes: []int{http.StatusBadRequest, http.StatusOK}}
+	tp := newTransientRetryTestTransport(seq)
+
+	resp, err := tp.RoundTrip(postWithBody(t, "payload"))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.Equal(t, 1, seq.callCount())
+}
+
+func TestTransportTransientDoesNotRetry429(t *testing.T) {
+	seq := &sequencedRoundTripper{statusCodes: []int{http.StatusTooManyRequests, http.StatusOK}}
+	tp := newTransientRetryTestTransport(seq)
+
+	resp, err := tp.RoundTrip(postWithBody(t, "payload"))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
+	require.Equal(t, 1, seq.callCount())
+}
+
+func TestTransportTransientRetriesStaleConnForPOST(t *testing.T) {
+	seq := &sequencedRoundTripper{errs: []error{connResetError()}}
+	tp := newTransientRetryTestTransport(seq)
+
+	resp, err := tp.RoundTrip(postWithBody(t, "payload"))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, 2, seq.callCount())
+}
+
+func TestTransportTransientRespectsMaxAttempts(t *testing.T) {
+	seq := &sequencedRoundTripper{statusCodes: []int{
+		http.StatusInternalServerError,
+		http.StatusInternalServerError,
+		http.StatusOK,
+	}}
+	tp := newRetryTestTransport(seq)
+	s := resolveTransientRetry(TransientRetryConfig{
+		MaxAttempts:  2,
+		InitialDelay: time.Millisecond,
+		MaxDelay:     time.Millisecond,
+	})
+	tp.transientRetry = &s
+
+	resp, err := tp.RoundTrip(postWithBody(t, "payload"))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	require.Equal(t, 2, seq.callCount())
+}
+
+func TestTransportTransientDoesNotRetry5xxWithoutRewindableBody(t *testing.T) {
+	seq := &sequencedRoundTripper{statusCodes: []int{http.StatusInternalServerError, http.StatusOK}}
+	tp := newTransientRetryTestTransport(seq)
+
+	req := postWithBody(t, "payload")
+	req.GetBody = nil
+	resp, err := tp.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	require.Equal(t, 1, seq.callCount())
+}
+
+func TestResolveTransientRetryZeroMeansDefault(t *testing.T) {
+	s := resolveTransientRetry(TransientRetryConfig{})
+	require.Equal(t, defaultTransientRetryAttempts, s.maxAttempts)
+	require.Equal(t, defaultTransientRetryInitial, s.initialDelay)
+	require.Equal(t, defaultTransientRetryMaxDelay, s.maxDelay)
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	now := time.Date(2026, 8, 12, 15, 0, 0, 0, time.UTC)
+	require.Equal(t, 3*time.Second, parseRetryAfter("3", now))
+	require.Equal(t, time.Duration(0), parseRetryAfter("", now))
+	require.Equal(t, time.Duration(0), parseRetryAfter("nope", now))
+	require.Equal(t, 5*time.Second, parseRetryAfter(now.Add(5*time.Second).Format(http.TimeFormat), now))
 }

--- a/pkg/uhttp/transport_test.go
+++ b/pkg/uhttp/transport_test.go
@@ -622,3 +622,129 @@ func TestParseRetryAfter(t *testing.T) {
 	require.Equal(t, time.Duration(0), parseRetryAfter("nope", now))
 	require.Equal(t, 5*time.Second, parseRetryAfter(now.Add(5*time.Second).Format(http.TimeFormat), now))
 }
+
+func TestTransportTransientMaxAttemptsOneDoesNotRetry5xx(t *testing.T) {
+	seq := &sequencedRoundTripper{statusCodes: []int{http.StatusInternalServerError, http.StatusOK}}
+	tp := newRetryTestTransport(seq)
+	s := resolveTransientRetry(TransientRetryConfig{
+		MaxAttempts:  1,
+		InitialDelay: time.Millisecond,
+		MaxDelay:     time.Millisecond,
+	})
+	tp.transientRetry = &s
+
+	resp, err := tp.RoundTrip(postWithBody(t, "payload"))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	require.Equal(t, 1, seq.callCount())
+}
+
+func TestTransportTransientMaxAttemptsOneKeepsStaleConnRetry(t *testing.T) {
+	seq := &sequencedRoundTripper{errs: []error{connResetError()}}
+	tp := newRetryTestTransport(seq)
+	s := resolveTransientRetry(TransientRetryConfig{
+		MaxAttempts:  1,
+		InitialDelay: time.Millisecond,
+		MaxDelay:     time.Millisecond,
+	})
+	tp.transientRetry = &s
+
+	resp, err := tp.RoundTrip(postWithBody(t, "payload"))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, 2, seq.callCount())
+}
+
+func TestTransportTransientSkipNetworkRetriesStillRetries5xx(t *testing.T) {
+	seq := &sequencedRoundTripper{statusCodes: []int{http.StatusInternalServerError, http.StatusOK}}
+	tp := newTransientRetryTestTransport(seq)
+	tp.transientRetry.skipNetworkRetries = true
+
+	resp, err := tp.RoundTrip(postWithBody(t, "payload"))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, 2, seq.callCount())
+}
+
+func TestTransportTransientSkipNetworkRetriesDoesNotRetryTimeout(t *testing.T) {
+	seq := &sequencedRoundTripper{errs: []error{timeoutURLError()}}
+	tp := newTransientRetryTestTransport(seq)
+	tp.transientRetry.skipNetworkRetries = true
+
+	resp, err := tp.RoundTrip(postWithBody(t, "payload"))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	require.Error(t, err)
+	require.Equal(t, 1, seq.callCount())
+}
+
+func TestTransportTransientSkipNetworkRetriesDoesNotRetryStaleConn(t *testing.T) {
+	seq := &sequencedRoundTripper{errs: []error{connResetError()}}
+	tp := newTransientRetryTestTransport(seq)
+	tp.transientRetry.skipNetworkRetries = true
+
+	resp, err := tp.RoundTrip(postWithBody(t, "payload"))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	require.Error(t, err)
+	require.Equal(t, 1, seq.callCount())
+}
+
+func TestTransportTransientSkipNetworkRetriesStillRetriesDial(t *testing.T) {
+	seq := &sequencedRoundTripper{errs: []error{proxyConnectError()}}
+	tp := newTransientRetryTestTransport(seq)
+	tp.transientRetry.skipNetworkRetries = true
+
+	resp, err := tp.RoundTrip(postWithBody(t, "payload"))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, 2, seq.callCount())
+}
+
+func TestDrainResponseCapsRead(t *testing.T) {
+	r := &countingReader{}
+	resp := &http.Response{Body: io.NopCloser(r)}
+	done := make(chan struct{})
+	go func() {
+		drainResponse(resp)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("drainResponse hung on unbounded body")
+	}
+	require.LessOrEqual(t, r.n, int64(maxTransientDrain))
+}
+
+func TestJitterWaitStaysWithinBounds(t *testing.T) {
+	wait := 400 * time.Millisecond
+	maxDelay := 2 * time.Second
+	for range 100 {
+		got := jitterWait(wait, maxDelay)
+		require.GreaterOrEqual(t, got, wait-wait/4)
+		require.LessOrEqual(t, got, wait+wait/4)
+		require.LessOrEqual(t, got, maxDelay)
+	}
+	require.Equal(t, time.Duration(0), jitterWait(0, maxDelay))
+}
+
+func TestResolveTransientRetryKeepsMaxAttemptsOne(t *testing.T) {
+	s := resolveTransientRetry(TransientRetryConfig{MaxAttempts: 1})
+	require.Equal(t, 1, s.maxAttempts)
+}
+
+type countingReader struct {
+	n int64
+}
+
+func (r *countingReader) Read(p []byte) (int, error) {
+	r.n += int64(len(p))
+	return len(p), nil
+}


### PR DESCRIPTION
## Add opt-in transient retries for OAuth token exchanges

### Problem

`uhttp` retries at the RoundTripper layer, and its narrowness is deliberate: it
retries only when no request bytes were written, or on stale-pooled-connection
errors for requests that declare idempotence via a safe method or an
`Idempotency-Key` header. It does not retry a request that was sent and came
back 5xx, or that timed out mid-flight.

That is exactly the OAuth token-exchange failure mode that kills multi-hour
syncs. A token endpoint returns a single 502, `Token()` fails, and the whole
sync dies hours in — even though a retry 500ms later would have succeeded. A
token POST is also not covered by the existing safe-method check, because it
is a POST.

Broadening the default was not an option. `uhttp` is the general client
connectors use for provisioning and ticketing, not just sync reads, so a
default 5xx-and-timeout retry could double-apply a grant, a revoke, a ticket
creation, or a `SetIamPolicy`.

### Approach

Add `uhttp.WithTransientRetries(TransientRetryConfig{})`, an opt-in client
option, and wire it inside the SDK's own OAuth helpers so the token client
gets retries and the API client provably does not. Doing the split in the SDK
keeps each connector from growing its own ad-hoc retry loop around
`Token()` — every connector that fetches a token has this problem.

### What retries, and what does not

| Condition | Retried |
| --- | --- |
| 5xx response | yes, with exponential backoff |
| Mid-flight timeout | yes, once (`maxTransientTimeoutRetries`) |
| Stale pooled connection on a POST | yes (option marks requests replayable) |
| 4xx response | no |
| 429 / rate limit | no — belongs to `pkg/retry` via `RateLimitDescription` |
| Canceled or expired request context | no |
| Body with no `GetBody` (not rewindable) | no |

Defaults are 3 attempts (1 try + 2 retries), 500ms initial delay, 2s max
delay. A zero-value config selects those defaults; `0` never means unlimited.
`Retry-After` is honored on 5xx when present, clamped to `MaxDelay`.

Mid-flight timeouts get one retry rather than the full budget, and no backoff
sleep: the attempt has already blocked for up to `ResponseHeaderTimeout` (60s),
so retrying N times would stall `Token()` for minutes.

### The API/token split

`newOAuthClients` builds two clients and returns them as a named struct so
callers cannot mix up the pointers:

- `token` — always `WithTransientRetries`. Used only as the `oauth2.HTTPClient`
  context value, so it serves token-endpoint POSTs and nothing else.
- `api` — wired as `oauth2.Transport.Base`. `WithTransientRetries` is
  explicitly **stripped** here, so `GetClient(ctx, WithTransientRetries(...))`
  still cannot replay a provisioning POST.

All three OAuth helpers (`OAuth2ClientCredentials`, `OAuth2JWT`,
`OAuth2RefreshToken`) now collapse to: build the clients, create the token
source against `clients.tokenContext(ctx)`, return `clients.apiClient(ts)`.
There is exactly one context value. Building the API client by hand instead of
via `oauth2.NewClient` avoids a second `WithValue` (`NewClient` reads its base
transport from the context client) and keeps the api/token split visible.

`BearerAuth` and `BasicAuth` are unchanged — a static token source never hits
a token endpoint.

### Note on refresh-token rotation

`OAuth2RefreshToken` refreshes over the retrying token client. On a provider
that rotates refresh tokens, a lost response can invalidate the old token. That
trade-off is called out in a comment at the call site; failing the sync is the
worse outcome, and rotation is rare.

### Testing

`pkg/uhttp` passes under `-race`, and `golangci-lint` is clean.

New transport tests cover: the default path still does not retry 5xx (POST and
GET); a transient-retry client does retry POST 5xx; timeouts retry once and not
twice; canceled contexts, 4xx, 429, and non-rewindable bodies do not retry;
`MaxAttempts` is respected; stale-conn retry now applies to POST when the
option is on; zero config resolves to defaults; and `Retry-After` parsing.

New credential tests assert the split directly — a token 5xx retries while an
API POST through the same helper stays at exactly one attempt, for both client
credentials and JWT — plus a test that passing `WithTransientRetries` to
`GetClient` does not leak retries onto API calls. (The pre-existing leak tests
passed no options and so would have missed that.)

### Follow-up (not in this PR)

Connector-side wiring. The main GCP auth path hand-rolls what
`NewOAuth2JWT` + `GetClient` now does, and `google.JWTConfigFromJSON` already
matches the `CreateJWTConfig` signature, so it reduces to two lines and also
picks up a client `Timeout` that the hand-rolled version drops. The
Workspace-admin path caches tokens in the SessionStore and impersonates via
`config.Subject`, so it keeps its own flow and only needs the option on its
token-fetch client.