### PR TITLE
artifact retention

### DIFF
--- a/docs/rfcs/0009-artifact-retention-preserve-by-default.md
+++ b/docs/rfcs/0009-artifact-retention-preserve-by-default.md
@@ -561,12 +561,16 @@ Per the step-up (silent + durable + version pair):
   checkpoint-*age* assertion against the §4.2 bound; the bound is a timeout
   on the rescue write, not an age guarantee, so the implemented oracle is
   the pair that matters: a post-cancel checkpoint happened, and the resumed
-  sync converges.) Run the case at worker counts 1 and N>1: with multiple
-  workers, siblings that exhausted the queue park in `queue.next()` while
-  the blocked call is outstanding, so the bounded-return assertion also pins
-  pool drain. On `queue.abort()` itself, the accurate claim is promptness
-  and post-failure hygiene, not deadlock: `queue.done()` precedes the error
-  return, so waiters wake when stragglers drain even without it — but
+  sync converges.) Run the case at a multi-worker count: siblings that
+  exhausted the queue park in `queue.next()` while the blocked call is
+  outstanding, so the bounded-return assertion also pins pool drain.
+  (Change order, review: an earlier draft also promised a worker-count-1
+  cell; dropped — the multi-worker count is the dimension that buys
+  something here, and a single-worker run exercises nothing the other
+  cancellation chaos tests don't already cover.) On `queue.abort()` itself,
+  the accurate claim is promptness and post-failure hygiene, not deadlock:
+  `queue.done()` precedes the error return, so waiters wake when stragglers
+  drain even without it — but
   removing it would delay exit and let post-failure transitions keep
   admitting children onto a canceled batch. It must stay on every exit.
 - **Storage verdict injection.** Force a save/commit failure; assert the

--- a/docs/rfcs/0009-artifact-retention-preserve-by-default.md
+++ b/docs/rfcs/0009-artifact-retention-preserve-by-default.md
@@ -1,0 +1,588 @@
+# RFC 0009: Sync artifact retention — preserve by default, discard on typed verdict
+
+Status: proposed
+Risk routing (REVIEW_CHECKLIST §2): error classification across the SDK ↔
+hosted-runner seam — silent + durable (a wrong discard silently costs hours of
+re-collection; a wrong preserve is bounded by existing resume budgets) with a
+correctness-affecting version pair (SDK release × runner deploy). HIGH for the
+seam contract; the retention inversion itself is a small, testable branch.
+`BUG_CATCHING.md` §5.3 (host wrappers stripping status across the seam) applies
+directly and its step-up governs verification.
+
+## 1. Problem
+
+When `syncer.Sync()` returns an error, the hosted runner decides whether to
+commit the partial c1z (the "live" checkpoint artifact the next attempt resumes
+from) or throw it away. Today that decision is an allowlist over the *stop
+reason*:
+
+1. `ErrSyncNotComplete` (run-duration expiry) → preserve, loop immediately.
+2. Timeout-shaped errors (`context.DeadlineExceeded`, `codes.DeadlineExceeded`)
+   → preserve.
+3. Worker drain (stop channel) → preserve.
+4. `IsSyncPreservable(err)` (a gRPC-code allowlist, feature-flag gated;
+   recently enabled broadly) → preserve.
+5. **Everything else → discard**, logged as "not persisting c1z to avoid
+   potential corruption."
+
+`IsSyncPreservable` (`pkg/sync/syncer.go:84`) keeps `DeadlineExceeded`,
+`Unavailable`, `NotFound`, `PermissionDenied`, `ResourceExhausted`,
+`FailedPrecondition`, `Aborted`, `Unauthenticated`, `OK`. It discards
+`Canceled`, `Unknown`, `Internal`, and every plain (non-status) Go error.
+
+Production cost, observed on a multi-day large-tenant sync: one worker recycle
+during a deploy surfaced `context canceled` from in-flight connector calls,
+fell through to branch 5, and rolled completed actions from ~222k back to
+~122k — an hour-plus of collection re-done for an artifact that was never
+inconsistent. During an earlier incident (RFC 0007), every failed attempt of a
+looping sync skipped persist and resumed from zero for ~26 hours; discard
+multiplied a scheduler bug into days of wasted work.
+
+## 2. Diagnosis
+
+### 2.1 Retention asks a question the error cannot answer
+
+"Which error did the connector return?" cannot answer "is the artifact
+consistent?" Consistency is a property of the store's commit protocol and is
+invariant to the stop reason. The codebase already commits to this: `Close()`
+finalizes the c1z on a context detached from the caller's cancellation
+(`pkg/sync/syncer.go:3731`), checkpoints are crash-consistent by contract (the
+crash harness kills the process mid-sync and requires clean resume), and the
+pebble store refuses to destroy data even when its own save fails
+(`pkg/dotc1z/pebble_store.go:1037-1052` leaves the unpacked DB on disk rather
+than deleting the only copy). A context cancel is strictly gentler than the
+SIGKILL these mechanisms already survive. There is no connector-side error —
+transport failure, timeout, cancel, application bug, garbage response — that
+can make a committed checkpoint inconsistent.
+
+### 2.2 The default branch is the destructive one
+
+An allowlist with default-discard means every *unclassified* error pays the
+maximum cost. The allowlist has grown by incident (deadline-preservation was
+added in mid-2026 after exactly this shape of loss) and will keep growing by
+incident, because the space of error shapes is open — especially across the
+lambda boundary, where old connectors serialize errors through several
+generations of encoding.
+
+### 2.3 Cancellation is systematically misclassified
+
+The SDK's own shutdown mechanics guarantee that a stopping sync surfaces
+`Canceled`-shaped errors:
+
+- `parallelSync` propagates run-duration expiry to workers by *cancelling*
+  `workerCtx` (`pkg/sync/parallel_syncer.go:140-143`); in-flight connector
+  calls observe `ctx.Err() == context.Canceled` regardless of the cause.
+- The worker loop treats any action error — including those cancels — as a
+  fatal batch error and logs "cancelling context due to error in action"
+  (`pkg/sync/parallel_syncer.go:745-750`), once per worker.
+- `handleOperationError` (`pkg/sync/parallel_syncer.go:425-448`) rescues the
+  batch error only when `context.Cause(runCtx)` is `DeadlineExceeded`,
+  converting it to a checkpoint + `ErrSyncNotComplete`. An *external* cancel —
+  activity teardown, deploy, heartbeat loss — returns bare `Canceled`, which
+  is not preservable.
+
+So the same physical event (stop a running sync) is preserved or discarded
+depending on who owned the timer. The signal cannot distinguish "infra
+recycled the worker" from anything else; a classification that cannot
+distinguish its cases and defaults to destroying work is wrong even when every
+line behaves as written.
+
+The hosted path makes shape-based preservation not just fragile but
+unimplementable: the runner's own invoke-error mapping (`mapInvokeError` in
+the hosted connector client) replaces every non-timeout lambda invoke failure
+with a *fresh* infra error — no `%w`, chain discarded — so even the `Canceled`
+identity of an action error is stripped before the syncer sees it. Any policy
+of the form "preserve when the error looks like X" is defeated by middleware
+that both sides legitimately own.
+
+### 2.4 String-matched seam contracts break under version skew
+
+A recent incident is the cautionary case: a change that added sanitization
+markers to lambda transport errors (#1048) silently broke a
+`strings.Contains` capability gate that tolerated old connector lambdas
+lacking `ListStaticEntitlements` — those syncs failed outright instead of
+skipping the step. The fix moves the gate to a typed classification
+(`codes.Unimplemented` / failure class); as of this writing that routing is
+still on a branch, and the runner's main continues to string-match the
+transport markers (which is why §4.4 freezes their text). The lesson
+generalizes: **any
+contract that crosses the connector↔SDK or SDK↔runner seam must be typed and
+conformance-tested, never `err.Error()` text**, because either side may
+re-wrap, sanitize, or re-classify independently of the other's deploy
+schedule.
+
+### 2.5 Discard is not even a working circuit breaker
+
+The one theoretical benefit of discard — escaping a poisoned checkpoint that
+deterministically re-fails on resume — does not materialize. The RFC 0007 loop
+restarted from zero every ~45 minutes and failed identically, because the bug
+was in code, not in the checkpoint. Meanwhile the runner already has explicit,
+targeted breakers: a bounded activity retry policy, a hard reset of sync
+status after ~15 attempts, and live-artifact invalidation after repeated
+corrupted-artifact failures. Those mechanisms answer "stop resuming" directly;
+retention-by-error-code answers it by accident, at the cost of §1.
+
+## 3. Invariants
+
+- **I1 — Retention is a storage question.** Whether a partial c1z is kept
+  depends only on whether the store committed it cleanly. Connector errors
+  never decide retention.
+- **I2 — Discard is a positive, typed verdict.** An artifact is discarded only
+  when a typed signal says it is unusable. No default branch discards.
+- **I3 — The seam is typed.** Every signal crossing SDK↔runner is a sentinel
+  error or typed value tested with `errors.Is`; nothing on the retention path
+  matches `err.Error()` text. The connector↔SDK interface is untouched: old
+  lambdas cannot emit new signals, so the design must not (and does not)
+  require one.
+- **I4 — Stop reason chooses control flow, not retention.** Cause
+  classification (deadline vs. cancel vs. failure) selects loop / retry /
+  terminate behavior only.
+
+## 4. Design
+
+### 4.1 SDK: name the discard verdict
+
+Add one sentinel, following the `ErrIngestInvariantViolated` pattern
+(`pkg/sync/ingest_invariants.go:126-133` — wraps without altering the
+operator-facing message, consumed via `errors.Is`):
+
+```go
+// ErrArtifactUnusable classifies STORAGE VERDICTS — the local c1z may not
+// reflect a clean commit — as distinct from connector or scheduling
+// failures. It is the only signal that permits a runner to discard a
+// partial sync artifact. Producers are storage-layer close/finalize
+// failures, which reach a runner through Close() alone; connector errors
+// never carry it. Test with errors.Is.
+var ErrArtifactUnusable = errors.New("sync artifact unusable")
+
+// ShouldDiscardSyncArtifact reports whether err carries the storage
+// verdict. Everything else — including cancellation, timeouts, and all
+// connector-side failures — preserves the artifact.
+func ShouldDiscardSyncArtifact(err error) bool {
+    return errors.Is(err, ErrArtifactUnusable)
+}
+```
+
+Producers: the close/finalize paths that had mutations to commit but failed
+before the output c1z was rewritten (e.g. a failed `save` in the pebble
+store, a failed WAL checkpoint or `saveC1z` in the sqlite finalize). The
+storage layer already distinguishes these — §2.1's save-failure path
+deliberately preserves the on-disk data and returns an error; that error is
+where the sentinel attaches.
+
+**Change order (implementation):** the producer set narrowed to paths a
+runner reaches through `Close()` alone. The mid-sync storage commits
+(`EndSync`, `CheckpointSync`, `Cleanup`) — named as candidate producers in
+an earlier draft of this section — return bare errors on purpose: they
+mutate the *working store*, not the output c1z, so a failure there leaves
+the previous artifact a faithful commit, and a verdict would instruct a
+runner to discard a still-valid artifact. Consequence for the seam: a
+`Sync()` error never carries the verdict, and both engines' post-save
+teardown failures (cleanup, engine close) stay bare for the same reason.
+
+**What "discard" means at the seam.** A verdict withholds the *commit*; it
+never deletes a stored artifact. Both runner paths open the store on a local
+copy of the currently stored c1z and commit that same path back, and both
+engines save atomically — so a verdict means the local file was never
+rewritten and is still byte-identical to what was downloaded. Skipping the
+commit therefore leaves the stored artifact intact as the next attempt's
+resume point, and committing it would have been a content no-op. A verdict
+cannot cost an earlier attempt's progress; it only declines to overwrite a
+good stored copy with a file that does not represent this run.
+
+`IsSyncPreservable` stays exported and **frozen** (deprecated in doc comment).
+Changing its behavior in place would ship a silent policy change to every
+runner that still calls it — the exact version-skew hazard of §2.4. Runners
+migrate by switching call sites in the same change that vendors the new SDK.
+
+### 4.2 SDK: stop laundering shutdown into failure
+
+Two mechanical fixes in `pkg/sync/parallel_syncer.go`. Both are
+**side-effect-only**: the error `Sync()` returns on every path is
+byte-for-byte what it returns today.
+
+1. **Worker loop** (~line 745): when an action error arrives and the run is
+   stopping, the worker is observing shutdown, not discovering a failure.
+   Suppress the "cancelling context due to error in action" error log for
+   that case, keeping genuine action failures as the only producers of the
+   line. The test is the **pre-batch** context, not the batch's own
+   cancel-cause context: the latter is canceled by the first failing sibling,
+   so keying on it would swallow the line for a second worker's independent
+   genuine failure.    This is *only* log suppression: the re-cancel is already a
+   no-op (`WithCancelCause` keeps the first cause), and `queue.abort()` **must
+   stay** on every exit — it promptly releases workers blocked in
+   `queue.next()` and gates post-failure `transition()` commits (without it,
+   exit waits for stragglers to drain and late transitions keep admitting
+   children onto a canceled batch).
+2. **Exit paths**: the stop exits force a checkpoint only for
+   `DeadlineExceeded` causes today. Extend the same best-effort checkpoint to
+   cancel causes, on a detached bounded context (`context.WithoutCancel` +
+   timeout, the established finalize pattern from `Close()` and `dotc1z`), so
+   the local file is as fresh as possible at every stop. The checkpoint is a
+   new side effect only; the returned error is exactly today's — the batch
+   error on the batch path (the runner's activity-log suppression
+   string-matches text inside it), the cancel cause at the loop top, and a
+   checkpoint failure on this new path is logged, not joined into the return.
+   `ErrSyncNotComplete` stays reserved for run-duration expiry so runners keep
+   their loop-immediately behavior (I4).
+
+   **Change order (implementation):** there are **three** such exits, not two.
+   Beyond `handleOperationError` and the `runCtx.Done()` branch, the loop-top
+   *periodic* checkpoint runs on the caller's context, so a cancel can surface
+   there as a checkpoint failure that returns before either of the other two.
+   It takes the same rescue, guarded on `ctx.Err() != nil` so a genuine store
+   failure with a live caller is not retried on a detached context.
+   **Change order (review): this exit now has a dedicated deterministic
+   instrument.** The first version of this order dispositioned it as
+   defense-in-depth without one, reasoning that determinism required a
+   production-visible after-action hook to force the "cancel lands as an op
+   completes" interleaving through the full `Sync()` stack. Review pointed
+   out a cheaper shape with no production surface: invoke `parallelSync`
+   directly — an established pattern in this suite — with a pre-canceled
+   caller context and a store stub that fails `CheckpointSync` exactly when
+   the caller's context is done. The loop's first periodic checkpoint then
+   fails deterministically, and the stub's recorded outcomes pin both the
+   rescue (a second, detached, successful write) and the guard direction (a
+   genuine store failure with a live caller gets exactly one write — no
+   detached retry).    The one-shot `InitOp` checkpoints deliberately get no rescue:
+   nothing is in the store yet worth a stop write, and the next attempt
+   rebuilds the same plan. The supports-diff marker write at the fresh
+   entry to grant expansion is likewise excluded: a metadata-only write
+   for the unused diff-sync feature, with no progress since the loop-top
+   checkpoint. The rescue pattern stays scoped to checkpoint failures. The detached window is bounded by a
+   **stop-specific** timeout (~1 minute for one sync-token write), not
+   `FinalizeTimeout` — it is caller-uninterruptible and sits in front of
+   `Sync()` returning, so it must not consume the drain grace that `Close()`
+   needs to pack and commit the c1z.
+
+   **Change order (review): a fourth candidate exit was examined and
+   deliberately left without a rescue.** After `parallelSync` returns
+   cleanly, `Sync()` forces a checkpoint that clears completed actions and
+   the entitlement graph from the token; a cancel landing there fails that
+   write and returns. A rescue at that point would be actively harmful: the
+   plan is already cleared from state, so the only token a detached write
+   could produce is the *empty* one, and a resume from an empty token pushes
+   `InitOp` and re-runs the whole collection. Failing without a write leaves
+   the last mid-plan periodic token in the store, which resumes by re-running
+   only the final batch. The rescue set is the three stop exits inside
+   `parallelSync`, where the token still describes in-progress work.
+
+### 4.3 Runner: invert the branch
+
+The hosted runner's post-`Sync()` decision becomes:
+
+```
+err := syncer.Sync(ctx)
+closeErr := closer.Close(ctx)          // detached finalize inside
+joined := errors.Join(err, closeErr)
+
+if sdkSync.ShouldDiscardSyncArtifact(joined) {
+    // typed storage verdict: skip commit; existing invalidation and
+    // budgets take over
+} else {
+    commit the live artifact           // always, on the detached finalize ctx
+}
+
+// control flow only (I4):
+//   ErrSyncNotComplete            -> loop immediately (as today)
+//   anything else                 -> return err; activity retry policy,
+//                                    attempt budgets, and non-retryable
+//                                    classification behave as today
+```
+
+The existing budgets — bounded activity retries, the ~15-attempt hard reset,
+live-artifact invalidation after repeated corrupt-open failures — are
+unchanged and are the explicit answer to poisoned checkpoints (§2.5).
+Retryability classification (`ErrIngestInvariantViolated` →
+non-retryable) is likewise unchanged and orthogonal: an invariant verdict
+stops the retry loop but does not discard the artifact, which is consistent —
+the artifact is never sealed, and preserving it is free.
+
+**The runner has two retention call sites, and the change owns both.** The
+full-sync activity's decision tree (feature-flag-gated `IsSyncPreservable`
+branch) and the incremental-sync path — which calls `IsSyncPreservable`
+*ungated* and maps "preservable" to a nil activity error. Migrating one and
+not the other leaves two classifiers over one domain with no stated relation
+(§5.3 coherence); both flip to `ShouldDiscardSyncArtifact` in the same PR.
+The grant-expansion path's `ErrSyncNotComplete` handling is control flow, not
+retention, and is untouched (I4).
+
+**Change order (implementation): the retention obligation is per exit, not
+per call site.** Counting *sync-error* branches undercounts the work — a
+failed `Close()` after an otherwise fine sync is also a retention decision,
+and each such exit returned without committing. Migrating only the sync-error
+branches would leave the same obligation discharged by some exits and not
+others (§5.9). The exits that now preserve unless the verdict is present:
+the full-sync error branch and its post-success close failure, and the
+incremental error branch, its post-success close failure, and the
+grants-only increment's close failure. A close failure that does *not* carry
+the verdict means the c1z is a faithful commit — for the post-success exits,
+of a *completed* sync, the most valuable checkpoint there is.
+
+**Change order (implementation): preserve-on-cancel requires a detached
+commit.** The full-sync path's upload already runs on a detached context, so
+it survives a canceled activity ctx; the incremental path's commit ran on the
+raw ctx. Left alone, every incremental preserve-on-cancel — worker drain,
+deploy, operator stop, i.e. exactly the cases this RFC exists for — would
+have failed with "context canceled" and lost the checkpoint, while the
+returned error became the upload failure instead of the stop reason. All
+incremental commits (including the success path, where a drain mid-upload
+would otherwise discard a completed increment) now go through one helper that
+detaches. Durability of the commit is part of the retention contract, not an
+incidental property of whichever context the call site happened to hold.
+Coverage: the detachment property is carried by a doc comment on the helper,
+not by a test — pinning it needs the runstore's package-private fake
+(blockstore + fake remote + crypto + activity env), which is not reachable
+from the activity packages. This matches how the full-sync path's identical
+property is documented on `main`. If it regresses, it regresses silently, so
+the helper is the single place either path can commit from.
+
+**No kill switch (decided at implementation).** An earlier draft gated the
+inversion behind a hosted-side feature flag whose off-state reproduced the
+old tree. Dropped, deliberately: the marginal risk the flag would guard is
+already in production — the hosted gate that selects preservation today is
+enabled fleet-wide, so the fleet already preserves the whole
+`IsSyncPreservable` allowlist, and preserve-by-default only widens that set.
+Poisoned-checkpoint escape was never the flag's job; it is the budgets'
+(bounded retries, hard reset, corrupt-open invalidation), which apply
+identically to both sets, and the
+worst case without a flag — treadmill until budgets fire, then restart from
+zero — is exactly today's behavior on discard. The one genuinely new failure
+(a broken verdict committing a stale artifact) is pinned by the SDK
+conformance suite and still only regresses to an older checkpoint. Against
+that, the flag's cost was structural: two decision trees living side by side
+until a cleanup that historically never ships. So the legacy tree is
+*deleted*, not gated, and the old gate is retired in the same PR: after this
+change there is no feature flag on either side of the retention decision. Its
+only consumer was the deleted branch — `IsSyncPreservable` survives ungated as
+the incremental path's control-flow classifier, with the superset relation
+stated in code. The rollback lever is a one-commit revert of the runner PR.
+
+### 4.4 Compatibility across the three interfaces
+
+**Connector lambda ↔ SDK (frozen, and skewed in both directions forever).**
+No new signal. Retention stops reading connector errors entirely, which
+*shrinks* the behavior surface that depends on old-connector error encodings
+instead of growing it. Old lambdas keep returning whatever serialized status
+or legacy payloads they return today; the worst any of them can cause is a
+preserved artifact and a retry, both bounded.
+
+The reverse direction — a connector rebuilt against the new tag, invoked by
+an old host — is equally inert, and unlike the runner window it can never be
+sequenced: the tag is public and connector adoption is uncontrolled, so
+old-host × new-connector is a permanent skew pair, not a rollout phase.
+Verified surfaces:
+
+- The strings the hosted runner matches (`lambda_transport:`, `logSummary:`)
+  are stamped by the *invoking client* in the host's vendored SDK
+  (`pkg/lambda/grpc/client.go`, `failure.go` — whose doc comment names the
+  downstream sanitizers, and whose failure tests pin the markers). A
+  connector build cannot alter them regardless of its SDK version.
+- The changed code does not execute in a served connector: neither
+  `pkg/lambda` nor `pkg/connectorbuilder` imports `pkg/sync`; a lambda
+  connector serves RPCs and its errors cross the seam as serialized gRPC
+  status in the response frame, which this design does not touch.
+- A service-mode connector on the new tag *does* run the §4.2 syncer changes
+  locally, but everything it reports upstream is text-insensitive at the
+  platform (`FinishTask` does no message matching) and code-preserving
+  (`%w`); it uploads only on success and deletes the local partial on error,
+  both unchanged. The only new behavior is a best-effort local checkpoint
+  that its own handler deletes moments later — waste, not a behavior change.
+
+Connector-side obligations are therefore standing seam contracts, not merge
+criteria: no SDK release may change connector-side response/error
+serialization across the lambda seam without treating it as a breaking seam
+change (the both-sides conformance suite in §5 is the enforcement).
+
+**SDK ↔ runner (the one new contract).** The typed set crossing the seam is
+small and closed: `ErrSyncNotComplete` (loop), `ErrArtifactUnusable` +
+`ShouldDiscardSyncArtifact` (retention), `ErrIngestInvariantViolated`
+(retryability, pre-existing). Conformance tests in the SDK pin the wrap shapes
+each runner relies on (the `full_sync_classify_test.go` /
+`TestIsSyncPreservable` pattern: bare, `%w`-wrapped, `errors.Join`ed with a
+close error), so a refactor that breaks `errors.Is` traversal fails in the SDK
+repo before it ships.
+
+**Service-mode connectors (verified out of scope).** Connectors running as a
+service execute their sync locally via `pkg/tasks/c1api` and upload the c1z
+**only after a successful sync**; on any error the local partial is deleted
+and only the error (as a gRPC status) reaches the platform. The platform
+therefore never holds a partial artifact from a service-mode connector —
+there is no server-side retention decision for them, and nothing in this
+design changes what they run or report. `IsSyncPreservable` has no callers in
+this repo; every retention consumer lives in the hosted runner. Service-mode
+connectors gain local preservation only via the §4.5 follow-up, on their own
+update cadence, orthogonally to this rollout.
+
+**Version skew.**
+
+| Runner | SDK | Behavior |
+|---|---|---|
+| old | new | Runner calls frozen `IsSyncPreservable`; behavior identical to today. |
+| new | old | `ShouldDiscardSyncArtifact` unavailable → the runner's vendored SDK defines it; a runner is always built against exactly one SDK, so this pair cannot occur at runtime. The runtime skew pair is connector-vs-host, covered above. |
+| new | new | Preserve by default. |
+
+**Sequencing: SDK releases land first, and stay inert.** Several SDK versions
+may be vendored into the hosted runner before the runner's branch inversion
+lands. That window is safe if and only if the SDK holds three properties,
+which are release obligations, not incidental facts:
+
+1. **Additive only.** `ErrArtifactUnusable` and `ShouldDiscardSyncArtifact`
+   are dead code until a runner calls them. Attaching the sentinel to storage
+   failures must use `%w`/`errors.Join` so existing `errors.Is` /
+   `status.FromError` traversal is unchanged — the obligation is
+   **invariance**: every error classifies under the old branch exactly as it
+   did before the sentinel attached. For most close/finalize failures that is
+   plain → not preservable → discard, the correct outcome for a storage
+   verdict. The one deadline-shaped producer (a finalize that outlives
+   `FinalizeTimeout` wraps `DeadlineExceeded`) was preservable before and
+   stays preservable: the old runner keeps the previous on-disk artifact,
+   which the atomic save left untouched — stale but faithful, harmless.
+2. **Frozen error surface.** The old runner's branches key on `Sync()`'s
+   returned shapes *and*, on the hosted path, on specific error text. The
+   full frozen set, verified against the runner's current main:
+   - `ErrSyncNotComplete` via `errors.Is` — run-duration expiry (preserve +
+     loop, no retry consumed).
+   - `ErrTooManyWarnings` via `errors.Is` — in the frozen
+     `IsSyncPreservable` allowlist; the warning-budget exit must keep
+     wrapping it with `%w`.
+   - `DeadlineExceeded` (`errors.Is` and gRPC code) — timeout preservation.
+   - `Canceled` visible at the loop-top/cause paths; connector status codes
+     passing through unaltered on the batch path.
+   - **Lambda transport marker text** `lambda_transport:` and `logSummary:` —
+     the runner's invoke-error mapping on main *string-matches these markers*
+     to classify infra failures (the typed failure-class routing that
+     replaces this is not yet on main). Rewording them re-runs the §2.4
+     incident verbatim. This text freeze lifts only when the typed routing
+     lands in the runner.
+
+   Any SDK release in the window that changes one of these silently changes
+   hosted retention, retry-budget accounting, or infra-error classification
+   under an unchanged consumer. The conformance suite (§5) pins all of them
+   so a violation fails in this repo before release.
+3. **Behavior-neutral mechanical fixes.** The §4.2 changes must not alter
+   `Sync()`'s returned errors on any path (they are specified as
+   side-effect-only, including *which* error the batch path returns — the
+   batch error, not the cancel cause). Under the old runner they only make
+   the local file fresher (invisible, since the old branch discards on
+   cancel anyway) and remove misleading logs.
+
+One tempting shortcut is rejected: mapping external cancels to
+`ErrSyncNotComplete` would make the *old* runner preserve on cancel today,
+but `ErrSyncNotComplete` returns success-incomplete — a cancel storm would
+loop the workflow without consuming any retry budget. Cancels stay errors;
+preservation for them arrives only with the runner's branch inversion.
+
+**Merge criteria (the landing gate).** The runner vendors the SDK in-tree, so
+the runner-side change is mechanically one commit: dependency bump + vendor +
+both retention call sites + old-flag retirement. The gate exploits that:
+
+1. The runner PR is written and approved **before** the SDK release is
+   tagged, built against the release candidate commit, with both call sites
+   flipped and the runner-side retention seam test (the §5 property test at
+   the shapes the runner actually sees) green. The rollback lever is a
+   one-commit revert of this PR (§4.3, no kill switch).
+2. The SDK tag is cut only once (1) holds; the runner PR switches to the tag
+   and merges immediately after. The window between tag and runner deploy is
+   thereby minutes-to-hours by policy.
+3. The window is *shortened* by (1)–(2) but **not structurally closed**: the
+   tag is public and anyone can vendor it into the runner for unrelated
+   reasons before the retention PR lands. Obligations 1–3 above therefore
+   bind the tagged release itself — they are what make the window safe, and
+   the tandem landing is what makes it short. Neither substitutes for the
+   other. The tag also reaches **connector builds** immediately (lambda and
+   service-mode), a consumer that can never be sequenced; that cell is
+   dispositioned in the connector paragraph above — safe because the design
+   adds nothing connector-side, enforced as a standing seam contract rather
+   than a rollout gate.
+4. Deploy-transient skew (old and new activity pods serving attempts of the
+   same sync during rollout, and rollback from new to old) is safe by
+   per-attempt independence: retention is decided per attempt over an
+   unchanged artifact format, either version reads artifacts the other
+   committed, and poisoned-artifact escape remains the budgets' job.
+5. Out-of-repo operational dependencies are a named checklist item, not a
+   code gate: dashboards or monitors keyed on the "not persisting c1z" log
+   line change meaning when the branch inverts, and the misleading
+   "cancelling context due to error in action" burst disappears at every
+   stop. Both are reviewed at rollout.
+
+### 4.5 Alignment: the SDK's own runner
+
+`pkg/tasks/c1api/full_sync.go:321-330` deletes the partial c1z unconditionally
+on any sync error (it predates all of this; only the "spare" replay artifact
+survives). It should adopt the same helper: keep the partial unless
+`ShouldDiscardSyncArtifact`, and let its existing spare-promotion logic prefer
+the fresher artifact. This is a follow-up in the same series, not a blocker
+for the hosted change.
+
+### 4.6 Out of scope, named: mid-window durability
+
+The live artifact is committed to the object store once per attempt, at exit.
+A hard pod kill (no drain signal, no exit path) still loses up to a full run
+window of *local* checkpoints regardless of retention policy. The levers are
+periodic mid-window live commits or shorter run windows; either is its own
+change with its own cost model (upload bandwidth × 4.8 GB artifacts) and is
+deliberately not bundled here.
+
+## 5. Verification
+
+Per the step-up (silent + durable + version pair):
+
+- **Conformance suite (both sides of the seam).** Every sentinel × wrap-shape
+  combination the production paths produce; a planted `errors.Join` /
+  sanitization change must fail these before it ships (negative control
+  reproducing the §2.4 incident shape).
+- **Frozen-surface pin for `Sync()` and the lambda transport.** Direct tests
+  that run-duration expiry returns `ErrSyncNotComplete`, the warning-budget
+  exit wraps `ErrTooManyWarnings` with `%w`, an external cancel surfaces as
+  `context.Canceled` / `codes.Canceled` at the cause paths, connector status
+  codes pass through unaltered on the batch path, and lambda invoke failures
+  carry the `lambda_transport:` / `logSummary:` markers. These are the shapes
+  and strings the *old* runner branches on during the SDK-first window (§4.4
+  sequencing); this pin makes an accidental reshaping fail in this repo
+  instead of shipping as a silent hosted retention or infra-classification
+  change. The marker pin carries a comment naming its consumer and lifts when
+  the runner's typed failure-class routing lands.
+- **Retention property test.** A fault-injecting connector produces the full
+  error taxonomy (status codes, plain errors, cancels, timeouts, lambda
+  transport strings); the oracle asserts `retention decision ==
+  presence of ErrArtifactUnusable`, never a function of the connector error.
+  The coherence pin against the frozen classifier states its exception
+  explicitly: a verdict can wrap an old-policy-*preservable* cause (a
+  finalize that outlives `FinalizeTimeout` wraps `DeadlineExceeded`), and
+  the verdict wins — discard classifies the artifact, not the cause, and a
+  carried verdict means the artifact holds no progress worth preserving.
+- **Cancellation chaos.** Extend `chaos_cancellation_test.go`: cancel with a
+  connector call blocked in flight; assert the cancel surfaces in a frozen
+  shape, no "cancelling context due to error in action" error is logged for
+  shutdown-shaped exits, a detached stop checkpoint runs *after* the cancel
+  signal, `Sync()` returns boundedly, and the artifact reopens and
+  cold-resumes to the baseline content. (An earlier draft promised a
+  checkpoint-*age* assertion against the §4.2 bound; the bound is a timeout
+  on the rescue write, not an age guarantee, so the implemented oracle is
+  the pair that matters: a post-cancel checkpoint happened, and the resumed
+  sync converges.) Run the case at worker counts 1 and N>1: with multiple
+  workers, siblings that exhausted the queue park in `queue.next()` while
+  the blocked call is outstanding, so the bounded-return assertion also pins
+  pool drain. On `queue.abort()` itself, the accurate claim is promptness
+  and post-failure hygiene, not deadlock: `queue.done()` precedes the error
+  return, so waiters wake when stragglers drain even without it — but
+  removing it would delay exit and let post-failure transitions keep
+  admitting children onto a canceled batch. It must stay on every exit.
+- **Storage verdict injection.** Force a save/commit failure; assert the
+  sentinel is carried through `Sync()`/`Close()` wrapping and the runner-side
+  branch discards — the only path that may.
+
+## 6. What this deliberately does not do
+
+- **No new connector-side signal.** Old lambdas are frozen; the design removes
+  a dependency on their error shapes rather than adding one.
+- **No in-place widening of `IsSyncPreservable`.** That ships a silent policy
+  change to unmigrated callers — the §2.4 hazard in miniature.
+- **No discard for "permanent" connector errors.** Loop prevention is
+  retryability's job (`ErrTaskNonRetryable`), poisoned-checkpoint escape is
+  the budgets' job; retention does neither.
+- **No attempt to detect "a human canceled this sync."** No such signal exists
+  on the full-sync path today, and retention must not guess at one; if a
+  product-level "cancel and forget" appears later, it arrives as an explicit
+  typed instruction to the runner, not an inference from `context.Canceled`.

--- a/internal/chaosconnector/schedule.go
+++ b/internal/chaosconnector/schedule.go
@@ -153,6 +153,17 @@ func (r *Runtime) ActiveOperations() int {
 	return r.active
 }
 
+// Fires reports how many times the rule with the given id has fired. Tests
+// whose premise is "the faulted call is in flight" must gate on this rather
+// than ActiveOperations alone: active counts every call inside the wrapper,
+// so any healthy in-flight RPC satisfies it long before the targeted rule
+// has matched.
+func (r *Runtime) Fires(id string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.fires[id]
+}
+
 // NewRuntime validates and arms a schedule.
 func NewRuntime(schedule Schedule, trace *Trace) (*Runtime, error) {
 	if err := schedule.Validate(); err != nil {

--- a/pkg/dotc1z/artifact_verdict.go
+++ b/pkg/dotc1z/artifact_verdict.go
@@ -1,0 +1,35 @@
+package dotc1z
+
+import "errors"
+
+// ErrArtifactUnusable classifies STORAGE VERDICTS — the output c1z does not
+// reflect a clean commit of this run's progress — and is the only signal
+// that permits a runner to discard a partial sync artifact (RFC 0009:
+// preserve by default, discard on typed verdict). Producers are the
+// close/finalize paths that had mutations but failed before the c1z was
+// rewritten; both engines save atomically, so a carried verdict means the
+// artifact is STALE, never torn. Failures after a successful save (cleanup,
+// engine teardown) deliberately do not carry it — the artifact is a
+// faithful commit at that point. Consumed via
+// sync.ShouldDiscardSyncArtifact; test with errors.Is.
+var ErrArtifactUnusable = errors.New("sync artifact unusable")
+
+// artifactVerdictError carries the sentinel WITHOUT altering the verdict's
+// message (operator-facing text and any error-string assertions stay
+// byte-identical — the same pattern as sync.ErrIngestInvariantViolated).
+type artifactVerdictError struct{ err error }
+
+func (e *artifactVerdictError) Error() string { return e.err.Error() }
+
+func (e *artifactVerdictError) Unwrap() []error {
+	return []error{e.err, ErrArtifactUnusable}
+}
+
+// artifactUnusable marks err as a storage verdict: the output c1z was not
+// rewritten and does not reflect the store's final state.
+func artifactUnusable(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &artifactVerdictError{err: err}
+}

--- a/pkg/dotc1z/artifact_verdict_test.go
+++ b/pkg/dotc1z/artifact_verdict_test.go
@@ -1,0 +1,192 @@
+package dotc1z_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
+)
+
+// TestArtifactVerdictOnSaveFailure is the storage-verdict injection test
+// (RFC 0009 §5): a save/finalize failure with uncommitted mutations must
+// carry ErrArtifactUnusable out of Close, for both engines. Both engines
+// write the c1z atomically (temp file + rename), so the injection plants a
+// directory at the temp path — the save fails, the previous artifact (none,
+// here) is untouched, and the verdict names exactly that: the output c1z
+// does not reflect this run's progress.
+func TestArtifactVerdictOnSaveFailure(t *testing.T) {
+	for _, engine := range []c1zstore.Engine{c1zstore.EngineSQLite, c1zstore.EnginePebble} {
+		t.Run(string(engine), func(t *testing.T) {
+			ctx := context.Background()
+			dir := t.TempDir()
+			c1zPath := filepath.Join(dir, "verdict.c1z")
+
+			store, err := dotc1z.NewStore(ctx, c1zPath, dotc1z.WithTmpDir(dir), dotc1z.WithEngine(engine))
+			require.NoError(t, err)
+
+			_, err = store.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+			require.NoError(t, err)
+			require.NoError(t, store.PutResourceTypes(ctx,
+				v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build(),
+			))
+
+			// Plant a directory at the atomic-save temp path.
+			tmpTarget := c1zPath + ".tmp"
+			require.NoError(t, os.Mkdir(tmpTarget, 0o755))
+
+			// Unconditional release: a failing require unwinds via FailNow,
+			// and on Windows live engine handles fail t.TempDir()'s cleanup,
+			// burying the real assertion message.
+			t.Cleanup(func() {
+				_ = os.Remove(tmpTarget)
+				_ = store.Close(ctx)
+			})
+
+			closeErr := store.Close(ctx)
+			require.Error(t, closeErr)
+			require.ErrorIs(t, closeErr, dotc1z.ErrArtifactUnusable,
+				"a failed save with uncommitted mutations must carry the storage verdict")
+
+			// The verdict wrapper is message-preserving: operator-facing
+			// text (and any out-of-repo log matching) stays byte-identical.
+			require.NotContains(t, closeErr.Error(), dotc1z.ErrArtifactUnusable.Error())
+
+			// "Stale, never torn": the atomic save failed before the rename,
+			// so the output path holds exactly what it held before — nothing.
+			require.NoFileExists(t, c1zPath,
+				"a failed save must leave the previous artifact untouched")
+
+			// Pebble stays open after a failed save (the unpacked DB is the
+			// only copy of the data) and Windows cannot delete files with
+			// live handles, which fails t.TempDir()'s cleanup. Closing again
+			// releases the engine and pins the advertised recovery path in
+			// one step. Sqlite needs no retry: it closes its handle before
+			// saving and its finalize removes the working dir even on the
+			// failed-save path, so nothing is held open or recoverable.
+			require.NoError(t, os.Remove(tmpTarget))
+			if engine == c1zstore.EnginePebble {
+				require.NoError(t, store.Close(ctx),
+					"pebble advertises recovery: fix the condition and Close again")
+				require.FileExists(t, c1zPath)
+			}
+		})
+	}
+}
+
+// TestArtifactVerdictAbsentOnPostSaveTeardownFailure executes the other half
+// of the verdict's iff: a failure AFTER a successful save must not carry the
+// verdict — the c1z on disk is a faithful commit at that point, and wrapping
+// teardown errors would tell a runner to discard a good artifact. The clean-
+// close test cannot pin this (its Close returns nil), so this one poisons the
+// pebble store's unpacked temp dir with an unreadable, non-empty subdirectory:
+// the save — which packages the sibling "checkpoint" path — succeeds, then
+// the post-save os.RemoveAll of the temp dir fails.
+func TestArtifactVerdictAbsentOnPostSaveTeardownFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the plant relies on unix directory-permission semantics")
+	}
+	if os.Getuid() == 0 {
+		t.Skip("root bypasses permission bits; the plant would not fire")
+	}
+	ctx := context.Background()
+	dir := t.TempDir()
+	c1zPath := filepath.Join(dir, "teardown.c1z")
+
+	store, err := dotc1z.NewStore(ctx, c1zPath, dotc1z.WithTmpDir(dir), dotc1z.WithEngine(c1zstore.EnginePebble))
+	require.NoError(t, err)
+	_, err = store.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, store.PutResourceTypes(ctx,
+		v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build(),
+	))
+	require.NoError(t, store.EndSync(ctx))
+
+	// The store's unpacked dir is created as c1z-pebble* under the base dir.
+	matches, err := filepath.Glob(filepath.Join(dir, "c1z-pebble*"))
+	require.NoError(t, err)
+	require.Len(t, matches, 1, "premise: exactly one unpacked pebble dir")
+	poison := filepath.Join(matches[0], "poison")
+	require.NoError(t, os.Mkdir(poison, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(poison, "f"), []byte("x"), 0o600))
+	require.NoError(t, os.Chmod(poison, 0o000))
+	// Restore permissions so t.TempDir()'s cleanup can clear the leftovers.
+	t.Cleanup(func() { _ = os.Chmod(poison, 0o700) })
+
+	closeErr := store.Close(ctx)
+	// If the plant ever broke the save itself, the verdict WOULD attach and
+	// the NotErrorIs below fails loudly — the premise is self-checking.
+	require.Error(t, closeErr, "premise: the post-save teardown must fail")
+	require.NotErrorIs(t, closeErr, dotc1z.ErrArtifactUnusable,
+		"a failure after a successful save must not carry the discard verdict")
+	require.FileExists(t, c1zPath,
+		"the save preceded the teardown failure: the c1z is a faithful commit")
+}
+
+// TestArtifactVerdictAbsentOnCleanClose is the negative control: a healthy
+// commit carries no verdict, and the artifact it wrote reopens.
+func TestArtifactVerdictAbsentOnCleanClose(t *testing.T) {
+	for _, engine := range []c1zstore.Engine{c1zstore.EngineSQLite, c1zstore.EnginePebble} {
+		t.Run(string(engine), func(t *testing.T) {
+			ctx := context.Background()
+			dir := t.TempDir()
+			c1zPath := filepath.Join(dir, "clean.c1z")
+
+			store, err := dotc1z.NewStore(ctx, c1zPath, dotc1z.WithTmpDir(dir), dotc1z.WithEngine(engine))
+			require.NoError(t, err)
+			_, err = store.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+			require.NoError(t, err)
+			require.NoError(t, store.PutResourceTypes(ctx,
+				v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build(),
+			))
+			require.NoError(t, store.EndSync(ctx))
+			require.NoError(t, store.Close(ctx))
+
+			reopened, err := dotc1z.NewStore(ctx, c1zPath,
+				dotc1z.WithTmpDir(dir), dotc1z.WithEngine(engine), dotc1z.WithReadOnly(true))
+			require.NoError(t, err)
+			require.NoError(t, reopened.Close(ctx))
+		})
+	}
+}
+
+// TestArtifactVerdictClearsOnRetriedClose pins the pebble store's advertised
+// recovery contract: a failed save leaves the store open with data
+// preserved; fixing the condition and closing again commits cleanly, with
+// no verdict on the retried close.
+func TestArtifactVerdictClearsOnRetriedClose(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	c1zPath := filepath.Join(dir, "retry.c1z")
+
+	store, err := dotc1z.NewStore(ctx, c1zPath, dotc1z.WithTmpDir(dir), dotc1z.WithEngine(c1zstore.EnginePebble))
+	require.NoError(t, err)
+	_, err = store.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, store.PutResourceTypes(ctx,
+		v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build(),
+	))
+
+	tmpTarget := c1zPath + ".tmp"
+	require.NoError(t, os.Mkdir(tmpTarget, 0o755))
+	// Same unconditional release as above: if the assertion below fails, the
+	// store stays open and Windows cannot clear t.TempDir().
+	t.Cleanup(func() {
+		_ = os.Remove(tmpTarget)
+		_ = store.Close(ctx)
+	})
+
+	closeErr := store.Close(ctx)
+	require.ErrorIs(t, closeErr, dotc1z.ErrArtifactUnusable)
+
+	require.NoError(t, os.Remove(tmpTarget))
+	require.NoError(t, store.Close(ctx))
+	require.FileExists(t, c1zPath)
+}

--- a/pkg/dotc1z/c1file.go
+++ b/pkg/dotc1z/c1file.go
@@ -672,7 +672,10 @@ func (c *C1File) Close(ctx context.Context) (retErr error) {
 	// state stays consistent for a retried Close.
 	if c.bulkLoad {
 		if err := c.buildDeferredIndexes(ctx); err != nil {
-			return err
+			// Storage verdict: mutations exist but the c1z was not
+			// rewritten (the working DB is preserved for a retried Close,
+			// per the comment above).
+			return artifactUnusable(err)
 		}
 	}
 
@@ -721,6 +724,13 @@ func (c *C1File) finalize(ctx context.Context) error {
 
 	l := ctxzap.Extract(finalizeCtx)
 
+	// Every error return from here through saveC1z carries the
+	// ErrArtifactUnusable storage verdict: mutations exist but the output
+	// c1z was not rewritten, so the on-disk artifact is stale relative to
+	// this run's progress (saveC1z's atomic temp+rename means it is never
+	// torn). Post-save failures (cleanup, below) deliberately do not carry
+	// the verdict — the artifact is a faithful commit at that point.
+	//
 	// Only WAL-checkpoint and close the raw DB if a handle is open.
 	// Some callers (notably TestC1ZDecoder) manually close c.rawDb to
 	// force a checkpoint before calling Close — that path skips both
@@ -735,7 +745,7 @@ func (c *C1File) finalize(ctx context.Context) error {
 		// then truncates the WAL file to zero bytes.
 		busy, log, checkpointed, err := c.truncateWAL(finalizeCtx)
 		if err != nil {
-			finalizeErr = fmt.Errorf("c1z: WAL checkpoint failed: %w", err)
+			finalizeErr = artifactUnusable(fmt.Errorf("c1z: WAL checkpoint failed: %w", err))
 			l.Error("WAL checkpoint failed before close",
 				zap.Error(err),
 				zap.String("db_path", c.dbFilePath))
@@ -745,7 +755,7 @@ func (c *C1File) finalize(ctx context.Context) error {
 			return cleanupDbDir(c.dbFilePath, finalizeErr)
 		}
 		if busy != 0 || (log >= 0 && checkpointed < log) {
-			finalizeErr = fmt.Errorf("c1z: WAL checkpoint incomplete: busy=%d log=%d checkpointed=%d", busy, log, checkpointed)
+			finalizeErr = artifactUnusable(fmt.Errorf("c1z: WAL checkpoint incomplete: busy=%d log=%d checkpointed=%d", busy, log, checkpointed))
 			l.Error("WAL checkpoint incomplete before close",
 				zap.Int("busy", busy),
 				zap.Int("log", log),
@@ -758,8 +768,8 @@ func (c *C1File) finalize(ctx context.Context) error {
 		}
 
 		if err := c.closeRawDB(finalizeCtx); err != nil {
-			finalizeErr = err
-			return cleanupDbDir(c.dbFilePath, err)
+			finalizeErr = artifactUnusable(err)
+			return cleanupDbDir(c.dbFilePath, finalizeErr)
 		}
 	}
 
@@ -768,7 +778,7 @@ func (c *C1File) finalize(ctx context.Context) error {
 	// the main database file.
 	walPath := c.dbFilePath + "-wal"
 	if walInfo, statErr := os.Stat(walPath); statErr == nil && walInfo.Size() > 0 {
-		finalizeErr = fmt.Errorf("c1z: WAL file not empty after close (size=%d) - refusing to save incomplete data", walInfo.Size())
+		finalizeErr = artifactUnusable(fmt.Errorf("c1z: WAL file not empty after close (size=%d) - refusing to save incomplete data", walInfo.Size()))
 		return cleanupDbDir(c.dbFilePath, finalizeErr)
 	}
 
@@ -786,14 +796,17 @@ func (c *C1File) finalize(ctx context.Context) error {
 	saveErr := saveC1z(c.dbFilePath, c.outputFilePath, c.encoderConcurrency)
 	uotel.EndSpanWithError(saveSpan, saveErr)
 	if saveErr != nil {
-		finalizeErr = saveErr
-		return cleanupDbDir(c.dbFilePath, saveErr)
+		finalizeErr = artifactUnusable(saveErr)
+		return cleanupDbDir(c.dbFilePath, finalizeErr)
 	}
 	if outInfo, statErr := os.Stat(c.outputFilePath); statErr == nil {
 		finalizeSpan.SetAttributes(attribute.Int64("c1z.finalize.output_bytes", outInfo.Size()))
 		recordC1ZSize(finalizeCtx, "finalize", outInfo.Size())
 	}
 
+	// No artifactUnusable here: the save above succeeded, so the c1z on
+	// disk is a faithful commit; a cleanup failure must not become a
+	// discard verdict.
 	if err := cleanupDbDir(c.dbFilePath, nil); err != nil {
 		finalizeErr = err
 		return err

--- a/pkg/dotc1z/pebble_store.go
+++ b/pkg/dotc1z/pebble_store.go
@@ -760,12 +760,19 @@ func (s *pebbleStore) Close(ctx context.Context) (retErr error) {
 			// condition and Close again; if the process exits instead, the
 			// temp dir survives on disk for manual recovery rather than
 			// being deleted out from under a failed save.
-			return fmt.Errorf("pebble store close: save failed, store left open and unsaved data preserved under %s: %w", s.tmpDir, err)
+			//
+			// Storage verdict: dirty state exists but the output c1z was
+			// not rewritten (save's atomic temp+rename means the on-disk
+			// artifact is stale, never torn).
+			return artifactUnusable(fmt.Errorf("pebble store close: save failed, store left open and unsaved data preserved under %s: %w", s.tmpDir, err))
 		}
 		s.dirty = false
 	}
 	s.closed = true
 
+	// No artifactUnusable below: the save above succeeded (or was not
+	// needed), so the c1z on disk is a faithful commit; teardown failures
+	// must not become a discard verdict.
 	defer func() {
 		if removeErr := os.RemoveAll(s.tmpDir); removeErr != nil {
 			retErr = errors.Join(retErr, removeErr)

--- a/pkg/lambda/grpc/failure_test.go
+++ b/pkg/lambda/grpc/failure_test.go
@@ -310,6 +310,13 @@ func TestClassifyLambdaFailure(t *testing.T) {
 			// Every failure must stay sanitizable: callers strip the log
 			// summary by keying off these two markers, so no path may omit
 			// either one.
+			//
+			// FROZEN marker text (RFC 0009 §4.4): the hosted runner's
+			// invoke-error mapping string-matches "lambda_transport:" and
+			// "logSummary:" to classify infra failures. Rewording either
+			// marker silently breaks that classification under an unchanged
+			// consumer (the #1048 incident shape). The freeze lifts only
+			// when the runner's typed failure-class routing lands.
 			require.Contains(t, failure.Error(), "lambda_transport:", "error string must carry the transport prefix")
 			require.Contains(t, failure.Error(), "logSummary:", "error string must carry the logSummary separator")
 		})

--- a/pkg/sync/artifact_retention.go
+++ b/pkg/sync/artifact_retention.go
@@ -1,0 +1,23 @@
+package sync
+
+import (
+	"errors"
+
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+)
+
+// ErrArtifactUnusable is the storage verdict — the local c1z may not reflect
+// a clean commit of this run's progress — and the only signal that permits a
+// runner to discard a partial sync artifact (RFC 0009). It reaches a runner
+// through Close() alone; Sync() errors and connector errors never carry it.
+// Defined in pkg/dotc1z (storage owns the verdict) and re-exported here so
+// runners depend on pkg/sync alone. Test with errors.Is.
+var ErrArtifactUnusable = dotc1z.ErrArtifactUnusable
+
+// ShouldDiscardSyncArtifact reports whether err carries the storage verdict.
+// Everything else — cancellation, timeouts, all connector-side failures —
+// preserves the artifact (RFC 0009 invariants I1/I2). Pass the join of the
+// Sync() and Close() errors; today the verdict comes from Close() alone.
+func ShouldDiscardSyncArtifact(err error) bool {
+	return errors.Is(err, ErrArtifactUnusable)
+}

--- a/pkg/sync/artifact_retention_test.go
+++ b/pkg/sync/artifact_retention_test.go
@@ -1,0 +1,176 @@
+package sync //nolint:revive,nolintlint // we can't change the package name for backwards compatibility
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/conductorone/baton-sdk/internal/chaosconnector"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+)
+
+// retentionTaxonomy is the error taxonomy the retention property test runs
+// over (RFC 0009 §5): every shape the production paths produce at the
+// SDK ↔ runner seam. The oracle for ShouldDiscardSyncArtifact is "discard ==
+// presence of ErrArtifactUnusable, never a function of the connector error".
+// Wrap-shape rows double as the conformance suite: a sanitization or
+// errors.Join refactor that breaks errors.Is traversal must fail here before
+// it ships (negative control for the #1048 incident shape).
+var retentionTaxonomy = []struct {
+	name string
+	err  error
+	// discard is the ShouldDiscardSyncArtifact verdict.
+	discard bool
+}{
+	// Storage verdicts: the only discard rows.
+	{name: "sentinel bare", err: ErrArtifactUnusable, discard: true},
+	{name: "sentinel %w-wrapped", err: fmt.Errorf("error closing store: %w", ErrArtifactUnusable), discard: true},
+	{name: "sentinel joined with sync error (runner shape)", err: errors.Join(context.Canceled, fmt.Errorf("error closing store: %w", ErrArtifactUnusable)), discard: true},
+	{name: "sentinel double-wrapped", err: fmt.Errorf("task failed: %w", errors.Join(errors.New("connector broke"), fmt.Errorf("close: %w", ErrArtifactUnusable))), discard: true},
+	{
+		// The verdict is orthogonal to the cause it wraps: C1File.finalize
+		// runs under FinalizeTimeout, so a WAL checkpoint outliving it
+		// yields a verdict wrapping context.DeadlineExceeded — a cause the
+		// old policy calls preservable. The verdict still discards; see
+		// TestRetentionPreservableCoherence for why that is coherent.
+		name:    "sentinel wrapping a finalize deadline (old-policy-preservable cause)",
+		err:     errors.Join(fmt.Errorf("c1z: WAL checkpoint failed: %w", context.DeadlineExceeded), ErrArtifactUnusable),
+		discard: true,
+	},
+
+	// Everything else preserves — including every shape the old allowlist
+	// discarded.
+	{name: "nil", err: nil, discard: false},
+	{name: "plain error", err: errors.New("plain"), discard: false},
+	{name: "bare context.Canceled", err: context.Canceled, discard: false},
+	{name: "wrapped context.Canceled", err: fmt.Errorf("sync-grants-for-resource: %w", context.Canceled), discard: false},
+	{name: "status Canceled", err: status.Error(codes.Canceled, "context canceled"), discard: false},
+	{name: "bare context.DeadlineExceeded", err: context.DeadlineExceeded, discard: false},
+	{name: "status DeadlineExceeded", err: status.Error(codes.DeadlineExceeded, "lambda_transport: function timed out"), discard: false},
+	{name: "status Internal", err: status.Error(codes.Internal, "internal error"), discard: false},
+	{name: "status Unknown", err: status.Error(codes.Unknown, "unknown"), discard: false},
+	{name: "status Unavailable", err: status.Error(codes.Unavailable, "server unavailable"), discard: false},
+	{
+		name:    "lambda transport text without status",
+		err:     errors.New("lambda_transport: failed to invoke lambda function: operation error Lambda: Invoke, https response error StatusCode: 0, RequestID: , canceled, context canceled"),
+		discard: false,
+	},
+	{name: "ErrSyncNotComplete", err: ErrSyncNotComplete, discard: false},
+	{name: "ErrSyncNotComplete joined with checkpoint error (production shape)", err: errors.Join(errors.New("checkpoint failed"), ErrSyncNotComplete), discard: false},
+	{name: "ErrTooManyWarnings production shape", err: fmt.Errorf("%w: warnings: %v completed actions: %d", ErrTooManyWarnings, []error{errors.New("w")}, 5), discard: false},
+	{name: "ErrIngestInvariantViolated", err: ErrIngestInvariantViolated, discard: false},
+	{name: "connector error joined with cancel", err: errors.Join(status.Error(codes.PermissionDenied, "denied"), context.Canceled), discard: false},
+}
+
+func TestShouldDiscardSyncArtifact(t *testing.T) {
+	for _, tt := range retentionTaxonomy {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.discard, ShouldDiscardSyncArtifact(tt.err))
+		})
+	}
+}
+
+// TestRetentionPreservableCoherence pins the stated relation between the two
+// retention classifiers over one domain (BUG_CATCHING §5.3 coherence), in
+// two halves.
+//
+// Over VERDICT-FREE errors, preserve-by-default strictly widens
+// preservation: anything the frozen IsSyncPreservable would keep,
+// ShouldDiscardSyncArtifact must also keep. (The converse is intentionally
+// false — e.g. Canceled: old policy discards, new policy preserves.)
+//
+// Verdict-carrying errors are the stated exception, not a violation: the
+// verdict classifies the ARTIFACT (mutations existed but the c1z was not
+// rewritten — stale by construction), while IsSyncPreservable classifies the
+// error's CAUSE, and a verdict can wrap any cause, including old-policy-
+// preservable ones (C1File.finalize runs under FinalizeTimeout, so a WAL
+// checkpoint outliving it wraps context.DeadlineExceeded). Discard still
+// wins and still loses nothing: a stale artifact holds no progress from this
+// run, so there is nothing for "preservable" to preserve.
+func TestRetentionPreservableCoherence(t *testing.T) {
+	for _, tt := range retentionTaxonomy {
+		t.Run(tt.name, func(t *testing.T) {
+			if errors.Is(tt.err, ErrArtifactUnusable) {
+				require.True(t, ShouldDiscardSyncArtifact(tt.err),
+					"a carried verdict discards regardless of the wrapped cause's class")
+				return
+			}
+			if IsSyncPreservable(tt.err) {
+				require.False(t, ShouldDiscardSyncArtifact(tt.err),
+					"verdict-free preservable ⊆ preserved: IsSyncPreservable keeps this error, so the new policy must not discard it")
+			}
+		})
+	}
+
+	// The exception is real, not hypothetical: pin the production shape where
+	// both classifiers fire and the verdict wins.
+	finalizeDeadlineVerdict := errors.Join(
+		fmt.Errorf("c1z: WAL checkpoint failed: %w", context.DeadlineExceeded),
+		ErrArtifactUnusable,
+	)
+	require.True(t, IsSyncPreservable(finalizeDeadlineVerdict),
+		"premise: the old policy calls this cause preservable")
+	require.True(t, ShouldDiscardSyncArtifact(finalizeDeadlineVerdict),
+		"the verdict discards even an old-policy-preservable cause")
+}
+
+// TestArtifactSentinelSeamIdentity pins the re-export: the pkg/sync sentinel
+// and the pkg/dotc1z sentinel are one value, so a verdict produced in the
+// storage layer is found by errors.Is against either name.
+func TestArtifactSentinelSeamIdentity(t *testing.T) {
+	require.ErrorIs(t, ErrArtifactUnusable, dotc1z.ErrArtifactUnusable)
+	require.ErrorIs(t, dotc1z.ErrArtifactUnusable, ErrArtifactUnusable)
+}
+
+// TestArtifactVerdictSurvivesSyncerClose is the cross-layer half of the
+// storage-verdict injection test (RFC 0009 §5): a real store save failure
+// must carry ErrArtifactUnusable through the engine's Close, syncer.Close's
+// "error closing store: %w" wrap, and the runner-style errors.Join with the
+// Sync error — the exact chain the hosted runner branches on.
+func TestArtifactVerdictSurvivesSyncerClose(t *testing.T) {
+	skipChaosInShort(t)
+	ctx := t.Context()
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "verdict.c1z")
+
+	scenario, err := chaosconnector.NewFullScenario()
+	require.NoError(t, err)
+	run, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+	require.NoError(t, err)
+	harness := newChaosHarness(t, ctx, run, path, tmpDir, chaosTransportDirect, WithWorkerCount(1))
+
+	syncErr := harness.Syncer.Sync(ctx)
+	require.NoError(t, syncErr)
+
+	// Sabotage the atomic save: the engine writes to path+".tmp" before
+	// renaming over the c1z; a directory there fails the save while the
+	// (here: nonexistent) previous artifact stays untouched.
+	tmpTarget := path + ".tmp"
+	require.NoError(t, os.Mkdir(tmpTarget, 0o755))
+
+	closeErr := harness.Syncer.Close(ctx)
+	require.Error(t, closeErr)
+	require.ErrorIs(t, closeErr, ErrArtifactUnusable)
+
+	// The runner-side branch shape: join of Sync and Close errors.
+	require.True(t, ShouldDiscardSyncArtifact(errors.Join(syncErr, closeErr)))
+
+	// RFC 0009 §4.4 obligation 1, against the production wrapper rather than a
+	// hand-built %w chain: attaching the sentinel must not move how the frozen
+	// classifier reads the error, or an unmigrated runner's retention shifts on
+	// an SDK bump. Reshaping Unwrap() []error breaks this before it ships.
+	require.False(t, IsSyncPreservable(closeErr))
+
+	// Recovery path advertised by the pebble store: fix the condition and
+	// Close again; the retried commit succeeds and carries no verdict.
+	require.NoError(t, os.Remove(tmpTarget))
+	require.NoError(t, harness.Close(ctx))
+	require.FileExists(t, path)
+}

--- a/pkg/sync/chaos_cancellation_test.go
+++ b/pkg/sync/chaos_cancellation_test.go
@@ -3,11 +3,19 @@ package sync //nolint:revive,nolintlint // backwards-compatible package name
 import (
 	"context"
 	"errors"
+	"fmt"
 	"path/filepath"
+	stdsync "sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/conductorone/baton-sdk/internal/chaosconnector"
 	chaosoracle "github.com/conductorone/baton-sdk/internal/chaosconnector/oracle"
@@ -115,5 +123,264 @@ func TestChaosConnectorCancellationTerminatesAndColdResumes(t *testing.T) {
 				assertChaosStoreMatches(t, path, tmpDir, expected)
 			})
 		}
+	}
+}
+
+// TestChaosExternalCancelStopsQuietlyAndCheckpoints covers the shutdown
+// shape the RFC 0009 §4.2 mechanical fixes target: the CALLER cancels the
+// sync context (activity teardown, deploy, operator stop) while a connector
+// call is in flight. Pins, per §4.2 and the §4.4 frozen error surface:
+//   - Sync surfaces the cancel as context.Canceled (loop-top/cause paths) or
+//     as a codes.Canceled status passing through the batch path unaltered —
+//     the two shapes the hosted runner sees during the SDK-first window;
+//   - no "cancelling context due to error in action" error log fires:
+//     workers observing shutdown are not discovering failures;
+//   - a best-effort checkpoint runs after the cancel (the detached stop
+//     checkpoint), so Close packs the freshest resumable state;
+//   - the blocked call is released and Sync returns boundedly: siblings that
+//     exhausted the queue while one call is blocked are parked in
+//     queue.next(), so this fails if the suppressed error path stops
+//     releasing them;
+//   - the artifact reopens and cold-resumes to the baseline content.
+//
+// One cell, deliberately. The mechanism is transport-independent (the chaos
+// effects apply client-side on both transports, so the cancel never crosses
+// the wire), and TestChaosConnectorCancellationTerminatesAndColdResumes above
+// already runs cancellation on both. The multi-worker count is the dimension
+// that buys something here: it is what parks siblings in queue.next().
+func TestChaosExternalCancelStopsQuietlyAndCheckpoints(t *testing.T) {
+	skipChaosInShort(t)
+	const workers = 4
+	transport := chaosTransportDirect
+	ctx := t.Context()
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "external-cancel.c1z")
+	scenario, err := chaosconnector.NewFullScenario()
+	require.NoError(t, err)
+	manifest, err := scenario.Manifest(scenario.InitialEpoch)
+	require.NoError(t, err)
+	expected := chaosoracle.ExpectedIdentities(manifest)
+
+	baselinePath := filepath.Join(tmpDir, "baseline.c1z")
+	baselineRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+	require.NoError(t, err)
+	newChaosHarness(t, ctx, baselineRun, baselinePath, tmpDir, transport, WithWorkerCount(1)).
+		SyncAndClose(t, ctx)
+	baseline := readChaosLogicalContent(t, ctx, baselinePath, tmpDir)
+
+	run, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule(chaosconnector.Rule{
+		ID: "block-until-external-cancel",
+		Match: chaosconnector.Matcher{
+			Service: chaosconnector.ExactString("EntitlementsService"),
+			Method:  chaosconnector.ExactString("ListEntitlements"),
+			Attempt: 1,
+			Phase:   chaosconnector.PhaseBeforeCall,
+		},
+		Effects:  []chaosconnector.Effect{{Kind: chaosconnector.EffectBlock, Barrier: "held-until-external-cancel"}},
+		MinFires: 1, MaxFires: 1,
+	}))
+	require.NoError(t, err)
+
+	core, capturedEntries := newCaptureCore()
+	firstCtx, cancelFirst := context.WithCancel(ctx)
+	defer cancelFirst()
+	firstCtx = ctxzap.ToContext(firstCtx, zap.New(core))
+
+	harness := newChaosHarness(t, firstCtx, run, path, tmpDir, transport, WithWorkerCount(workers))
+	sc, ok := harness.Syncer.(*syncer)
+	require.True(t, ok)
+	var cancelIssued atomic.Bool
+	var checkpointAfterCancel atomic.Bool
+	sc.testCheckpointHook = func(string) {
+		if cancelIssued.Load() {
+			checkpointAfterCancel.Store(true)
+		}
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- harness.Syncer.Sync(firstCtx) }()
+	// The premise gates on the blocking rule having FIRED, not just on
+	// an active operation: ActiveOperations counts every call inside
+	// the fault wrapper, so any healthy in-flight RPC satisfies it
+	// long before the sync reaches the blocked entitlements call —
+	// and canceling that early tests startup teardown, not a
+	// mid-collection stop.
+	require.Eventually(t, func() bool {
+		return run.Runtime().Fires("block-until-external-cancel") > 0 &&
+			run.Runtime().ActiveOperations() > 0
+	}, 5*time.Second, 10*time.Millisecond,
+		"external-cancel premise requires the blocked connector call to be in flight")
+	cancelIssued.Store(true)
+	cancelFirst()
+
+	var firstErr error
+	select {
+	case firstErr = <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("external cancel must terminate the sync boundedly; the worker pool is likely hung")
+	}
+	// The frozen surface (RFC 0009 §4.4) admits two cancel shapes,
+	// racing on which exit path observes the cancel first:
+	// context.Canceled from the loop-top/cause paths, or the
+	// connector's codes.Canceled status passing through the batch
+	// path unaltered (grpc-go status errors do not satisfy
+	// errors.Is against context.Canceled). Both must stay
+	// recognizable; anything else is a reshaped cancel.
+	require.True(t,
+		errors.Is(firstErr, context.Canceled) || status.Code(firstErr) == codes.Canceled,
+		"frozen surface (RFC 0009 §4.4): an external cancel must surface as context.Canceled "+
+			"or a codes.Canceled status, got: %v", firstErr)
+	require.Zero(t, run.Runtime().ActiveOperations(),
+		"external cancel must release the blocked connector call")
+
+	require.Nil(t, findEntry(capturedEntries(), zapcore.ErrorLevel, "cancelling context due to error in action"),
+		"workers observing shutdown must not log action-failure errors (RFC 0009 §4.2)")
+	require.True(t, checkpointAfterCancel.Load(),
+		"the detached stop checkpoint must run after an external cancel (RFC 0009 §4.2)")
+
+	require.NoError(t, harness.Close(ctx))
+	require.NoError(t, run.Runtime().VerifyRequired())
+
+	interruptedRuns := readChaosSyncRuns(t, ctx, path, tmpDir)
+	require.Len(t, interruptedRuns, 1)
+	require.Nil(t, interruptedRuns[0].EndedAt)
+	syncID := interruptedRuns[0].ID
+
+	resumeRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+	require.NoError(t, err)
+	resumeHarness := newChaosHarness(t, ctx, resumeRun, path, tmpDir, transport, WithWorkerCount(1))
+	resumeHarness.SyncAndClose(t, ctx)
+	finalRuns := readChaosSyncRuns(t, ctx, path, tmpDir)
+	require.Len(t, finalRuns, 1)
+	require.Equal(t, syncID, finalRuns[0].ID)
+	require.NotNil(t, finalRuns[0].EndedAt)
+	actual := readChaosLogicalContent(t, ctx, path, tmpDir)
+	require.NoError(t, chaosoracle.CompareLogicalContent(baseline, actual))
+	assertChaosStoreMatches(t, path, tmpDir, expected)
+}
+
+// TestChaosActionErrorStillLogsCancelCause is the positive control for the
+// suppression assertion above (the instrument must fail on a planted
+// violation, REVIEW_CHECKLIST §2): a genuine action failure while the run
+// context is still live must keep producing the "cancelling context due to
+// error in action" error log — suppression applies only to shutdown-shaped
+// exits.
+func TestChaosActionErrorStillLogsCancelCause(t *testing.T) {
+	skipChaosInShort(t)
+	ctx := t.Context()
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "action-error.c1z")
+	scenario, err := chaosconnector.NewFullScenario()
+	require.NoError(t, err)
+	run, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule(chaosconnector.Rule{
+		ID: "fatal-entitlement-call",
+		Match: chaosconnector.Matcher{
+			Service: chaosconnector.ExactString("EntitlementsService"),
+			Method:  chaosconnector.ExactString("ListEntitlements"),
+			Attempt: 1,
+			Phase:   chaosconnector.PhaseBeforeCall,
+		},
+		Effects:  []chaosconnector.Effect{{Kind: chaosconnector.EffectError, Code: codes.InvalidArgument, Message: "injected fatal"}},
+		MinFires: 1, MaxFires: 1,
+	}))
+	require.NoError(t, err)
+
+	core, capturedEntries := newCaptureCore()
+	syncCtx := ctxzap.ToContext(ctx, zap.New(core))
+	harness := newChaosHarness(t, syncCtx, run, path, tmpDir, chaosTransportDirect, WithWorkerCount(1))
+
+	require.Error(t, harness.Syncer.Sync(syncCtx))
+	require.NotNil(t, findEntry(capturedEntries(), zapcore.ErrorLevel, "cancelling context due to error in action"),
+		"a genuine action failure must still log the cancel cause")
+	require.NoError(t, harness.Close(ctx))
+}
+
+// TestParallelBatchSecondGenuineFailureStillLogs pins the suppression's scope
+// at worker granularity: the guard reads the caller's context, not the
+// batch's cancel-cause context, so a second worker's independent genuine
+// failure — which necessarily arrives after the first failure has already
+// canceled the batch context — still logs "cancelling context due to error
+// in action". Both workers rendezvous inside their actions before either
+// returns its error, so both failures are deterministically genuine
+// discoveries, not shutdown observations. Under a batch-context guard this
+// fails with exactly one logged line.
+func TestParallelBatchSecondGenuineFailureStillLogs(t *testing.T) {
+	ctx := t.Context()
+	core, capturedEntries := newCaptureCore()
+	ctx = ctxzap.ToContext(ctx, zap.New(core))
+
+	st := newEmptySchedulerState(t)
+	first := st.pushAction(ctx, Action{Op: SyncGrantsOp, ResourceID: "group-1"})
+	second := st.pushAction(ctx, Action{Op: SyncGrantsOp, ResourceID: "group-2"})
+	s := &syncer{state: st, workerCount: 2}
+
+	// Bounded rendezvous, not a WaitGroup: if the pool ever stops dispatching
+	// these two actions concurrently, the premise is broken and this must fail
+	// loudly rather than block a worker forever and hang the package.
+	var mu stdsync.Mutex
+	arrived := 0
+	bothArrived := make(chan struct{})
+	var premiseFailed atomic.Bool
+	f := func(ctx context.Context, action *Action) error {
+		mu.Lock()
+		arrived++
+		if arrived == 2 {
+			close(bothArrived)
+		}
+		mu.Unlock()
+		select {
+		case <-bothArrived:
+		case <-time.After(30 * time.Second):
+			premiseFailed.Store(true)
+		}
+		return fmt.Errorf("injected genuine failure for %s", action.ResourceID)
+	}
+
+	_, err := s.syncParallel(ctx, newTestRetryer(ctx), []*Action{first, second}, f)
+	require.Error(t, err)
+	require.False(t, premiseFailed.Load(),
+		"premise: both actions must be in flight before either fails, so the second failure is a genuine discovery")
+
+	logged := 0
+	for _, entry := range capturedEntries() {
+		if entry.level == zapcore.ErrorLevel && contains(entry.message, "cancelling context due to error in action") {
+			logged++
+		}
+	}
+	require.Equal(t, 2, logged,
+		"within a live run every genuine action failure must log the cancel cause")
+}
+
+// TestParallelBatchFailureDuringStopStaysQuiet pins the other side of the
+// suppression rule, the cell the two tests above leave open: a genuine action
+// failure that races a stop is suppressed too. Production reaches this on
+// run-duration expiry, where parallelSync's AfterFunc cancels workerCtx — the
+// context syncParallel receives — with a DeadlineExceeded cause, so the shape
+// is reproduced by cancelling the pre-batch context with that cause from
+// inside the action. The suppression is deliberate: the sync is on its way out
+// and about to checkpoint, and the failure still reaches the caller in the
+// returned error, which is what this asserts alongside the missing log.
+func TestParallelBatchFailureDuringStopStaysQuiet(t *testing.T) {
+	core, capturedEntries := newCaptureCore()
+	ctx := ctxzap.ToContext(t.Context(), zap.New(core))
+	preBatchCtx, stop := context.WithCancelCause(ctx)
+	defer stop(nil)
+
+	st := newEmptySchedulerState(t)
+	action := st.pushAction(ctx, Action{Op: SyncGrantsOp, ResourceID: "group-1"})
+	s := &syncer{state: st, workerCount: 1}
+
+	f := func(ctx context.Context, action *Action) error {
+		stop(context.DeadlineExceeded)
+		return fmt.Errorf("genuine failure racing the run-duration deadline")
+	}
+
+	_, err := s.syncParallel(preBatchCtx, newTestRetryer(ctx), []*Action{action}, f)
+	require.Error(t, err, "the failure must still reach the caller")
+
+	for _, entry := range capturedEntries() {
+		require.False(t,
+			entry.level == zapcore.ErrorLevel && contains(entry.message, "cancelling context due to error in action"),
+			"a failure observed while the run is stopping must not log as a discovery")
 	}
 }

--- a/pkg/sync/parallel_syncer.go
+++ b/pkg/sync/parallel_syncer.go
@@ -163,6 +163,14 @@ func (s *syncer) parallelSync(
 
 		err := s.Checkpoint(ctx, false)
 		if err != nil {
+			// An external cancel landing between batches surfaces here,
+			// before the runCtx.Done() select below — the third stop exit
+			// (RFC 0009 §4.2). Same detached rescue, err returned
+			// unchanged. Guarded on ctx.Err() so a genuine store failure
+			// with a live caller is not retried on a detached context.
+			if ctx.Err() != nil {
+				s.checkpointOnStop(ctx)
+			}
 			return warnings, err
 		}
 
@@ -191,6 +199,9 @@ func (s *syncer) parallelSync(
 				return warnings, errors.Join(checkpointErr, ErrSyncNotComplete)
 			default:
 				l.Error("sync context cancelled", zap.String("sync_id", s.syncID), zap.Error(err))
+				// Best-effort checkpoint on the way out; err is returned
+				// unchanged (RFC 0009 §4.2, side-effect-only).
+				s.checkpointOnStop(ctx)
 				return warnings, err
 			}
 		default:
@@ -399,6 +410,9 @@ func (s *syncer) parallelSync(
 					l.Info("sync data collection complete", s.syncSummaryFields(trace.SpanFromContext(ctx))...)
 				}
 				if err := s.store.SyncMeta().MarkSyncSupportsDiff(ctx, s.syncID); err != nil {
+					// No detached rescue on this exit (RFC 0009 §4.2): a
+					// metadata-only write for the unused diff-sync feature,
+					// with no progress since the loop-top checkpoint.
 					l.Error("failed to set supports_diff marker", zap.Error(err))
 					return warnings, err
 				}
@@ -428,7 +442,14 @@ func (s *syncer) handleOperationError(
 	warnings []error,
 	batchErr error,
 ) ([]error, error) {
-	if !errors.Is(context.Cause(runCtx), context.DeadlineExceeded) {
+	cause := context.Cause(runCtx)
+	if !errors.Is(cause, context.DeadlineExceeded) {
+		// A non-nil cause means the run is stopping (external cancel), not
+		// failing: best-effort checkpoint, then return batchErr unchanged —
+		// the stop reason must reach the runner byte-for-byte (RFC 0009 §4.2).
+		if cause != nil {
+			s.checkpointOnStop(ctx)
+		}
 		return warnings, batchErr
 	}
 	// The run duration expired. The operation error is usually just the
@@ -445,6 +466,28 @@ func (s *syncer) handleOperationError(
 	}
 	checkpointErr := s.Checkpoint(ctx, true)
 	return warnings, errors.Join(checkpointErr, ErrSyncNotComplete)
+}
+
+// stopCheckpointTimeout bounds checkpointOnStop: one sync-token write, not
+// the finalize+upload tail that FinalizeTimeout budgets an hour for. The
+// window is caller-uninterruptible and precedes Sync() returning, so it
+// must not eat the drain grace Close() needs to pack the c1z.
+const stopCheckpointTimeout = time.Minute
+
+// checkpointOnStop force-checkpoints on a context detached from the caller's
+// cancellation — at a stop exit that context is already canceled, so an
+// attached write could never succeed. Best-effort freshness for the c1z
+// that Close() packs: failures are logged, never returned, and the stop
+// reason reaches the runner unchanged (RFC 0009 §4.2). The run-duration
+// expiry exits deliberately stay attached instead; if an external cancel
+// lands inside that one write, the stale token costs at most one checkpoint
+// interval of idempotent re-work on resume — accepted.
+func (s *syncer) checkpointOnStop(ctx context.Context) {
+	checkpointCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), stopCheckpointTimeout)
+	defer cancel()
+	if err := s.Checkpoint(checkpointCtx, true); err != nil {
+		ctxzap.Extract(ctx).Error("error checkpointing while stopping sync", zap.Error(err))
+	}
 }
 
 func tooManyWarnings(warningCount int, completedActionsCount uint64) bool {
@@ -701,6 +744,11 @@ func (s *syncer) syncParallel(ctx context.Context, retryer *retry.Retryer, actio
 	var batchErr error
 	defer func() { uotel.EndSpanWithError(span, batchErr) }()
 
+	// The batch context below is canceled by the first failing action, so it
+	// cannot distinguish a stop from a sibling failure. Keep the pre-batch
+	// context (workerCtx: canceled on external cancel and run-duration
+	// expiry, both stops) for the log-suppression test in the worker loop.
+	preBatchCtx := ctx
 	ctx, cancel := context.WithCancelCause(ctx)
 	defer cancel(nil)
 
@@ -743,7 +791,19 @@ func (s *syncer) syncParallel(ctx context.Context, retryer *retry.Retryer, actio
 				resultsMu.Unlock()
 				queue.done()
 				if r.err != nil {
-					l.Error("cancelling context due to error in action", zap.Any("action", action), zap.Error(r.err))
+					// Log only failures discovered during a live run: a done
+					// pre-batch context means the run is stopping and this
+					// error is the stop observed from inside an action
+					// (RFC 0009 §4.2). The batch ctx is deliberately not the
+					// test — the first failing sibling cancels it, which
+					// would swallow a second worker's independent failure.
+					// Only the log is conditional; the error reaches the
+					// caller in the batch error regardless, and queue.abort()
+					// must always run — it releases workers blocked in
+					// queue.next().
+					if preBatchCtx.Err() == nil {
+						l.Error("cancelling context due to error in action", zap.Any("action", action), zap.Error(r.err))
+					}
 					cancel(fmt.Errorf("cancelling context due to error in action %v: %w", action, r.err))
 					queue.abort()
 					return

--- a/pkg/sync/stop_checkpoint_test.go
+++ b/pkg/sync/stop_checkpoint_test.go
@@ -1,0 +1,90 @@
+package sync //nolint:revive,nolintlint // backwards-compatible package name
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
+)
+
+// errInjectedCheckpointWrite is a fixed sentinel so the guard test can pin
+// the returned error's identity, not just its presence.
+var errInjectedCheckpointWrite = errors.New("injected checkpoint write failure")
+
+// checkpointOutcomeStore stubs the single store call the loop-top periodic
+// checkpoint reaches (CheckpointSync) and records the outcome of each call.
+// Every other method panics through the embedded nil interface, which is
+// part of the assertion — this exit must touch nothing else in the store.
+type checkpointOutcomeStore struct {
+	c1zstore.Store
+	failWhenCallerDone bool
+	failAlways         bool
+	outcomes           []error
+}
+
+func (s *checkpointOutcomeStore) CheckpointSync(ctx context.Context, _ string) error {
+	var err error
+	switch {
+	case s.failAlways:
+		err = errInjectedCheckpointWrite
+	case s.failWhenCallerDone && ctx.Err() != nil:
+		err = ctx.Err()
+	}
+	s.outcomes = append(s.outcomes, err)
+	return err
+}
+
+// TestPeriodicCheckpointStopExitTakesDetachedRescue pins the third stop exit
+// (RFC 0009 §4.2 change order) deterministically: the loop-top periodic
+// checkpoint runs on the caller's context, so an external cancel landing
+// between batches surfaces as a checkpoint failure before the runCtx.Done()
+// select can observe it. That exit must take the same best-effort detached
+// checkpoint as the other two stop exits. The store's CheckpointSync fails
+// exactly when the caller's context is done, so the periodic write fails
+// (canceled caller) and the rescue write succeeds only if it really is
+// detached — the recorded outcomes pin both facts at once.
+func TestPeriodicCheckpointStopExitTakesDetachedRescue(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	st := newEmptySchedulerState(t)
+	st.pushAction(ctx, Action{Op: SyncGrantsOp, ResourceID: "group-1"})
+	store := &checkpointOutcomeStore{failWhenCallerDone: true}
+	s := &syncer{state: st, store: store, workerCount: 1}
+
+	// The stop lands "between batches": the loop's first periodic checkpoint
+	// is the first code to observe it.
+	cancel()
+
+	_, err := s.parallelSync(ctx, ctx, nil)
+	// Identity, not just presence: the stop reason must reach the caller
+	// unchanged (RFC 0009 §4.2, side-effect-only). A regression that joined
+	// the rescue's outcome or rewrapped the cancel would still be an error;
+	// it would not still be context.Canceled.
+	require.ErrorIs(t, err, context.Canceled,
+		"the stop reason must reach the caller byte-for-byte, not rewrapped")
+
+	require.Len(t, store.outcomes, 2, "the periodic write plus exactly one detached rescue write")
+	require.Error(t, store.outcomes[0], "premise: the periodic checkpoint on the canceled caller context fails")
+	require.NoError(t, store.outcomes[1], "the detached stop checkpoint must run and succeed")
+}
+
+// TestPeriodicCheckpointFailureWithLiveCallerIsNotRetried pins the guard
+// direction on the same branch: a genuine store failure while the caller is
+// live is a real error, not a stop, and retrying it on a detached context
+// would launder a store fault into a second caller-uninterruptible write.
+// Exactly one CheckpointSync call may happen.
+func TestPeriodicCheckpointFailureWithLiveCallerIsNotRetried(t *testing.T) {
+	ctx := t.Context()
+	st := newEmptySchedulerState(t)
+	st.pushAction(ctx, Action{Op: SyncGrantsOp, ResourceID: "group-1"})
+	store := &checkpointOutcomeStore{failAlways: true}
+	s := &syncer{state: st, store: store, workerCount: 1}
+
+	_, err := s.parallelSync(ctx, ctx, nil)
+	require.ErrorIs(t, err, errInjectedCheckpointWrite,
+		"the store failure must reach the caller unchanged")
+	require.Len(t, store.outcomes, 1,
+		"a genuine store failure with a live caller must not be retried on a detached context")
+}

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -81,6 +81,12 @@ var connectorCallMethods = []string{
 // This either means that there was no error, or that the error is recoverable (we can resume the sync and possibly succeed next time).
 // Timeouts (context.DeadlineExceeded or codes.DeadlineExceeded, e.g. an AWS Lambda hard timeout) are
 // preservable because the sync can resume from the checkpoint.
+//
+// FROZEN (RFC 0009): superseded by ShouldDiscardSyncArtifact
+// (preserve-by-default). This behavior must not change — older runners
+// branch on it, so widening it in place ships a silent retention change.
+// Prose freeze rather than `Deprecated:` because unmigrated callers are
+// intentional during rollout and must not fail staticcheck on an SDK bump.
 func IsSyncPreservable(err error) bool {
 	if err == nil {
 		return true
@@ -1056,6 +1062,10 @@ func (s *syncer) Sync(ctx context.Context) error {
 
 	err = s.Checkpoint(ctx, true)
 	if err != nil {
+		// Deliberately no detached rescue (RFC 0009 §4.2): the plan is
+		// already cleared, so a rescue could only write the empty token, and
+		// resuming from an empty token re-runs the whole collection. Failing
+		// without a write resumes from the last mid-plan token instead.
 		return s.returnSyncError(l, span, err)
 	}
 

--- a/pkg/sync/syncer_preservable_test.go
+++ b/pkg/sync/syncer_preservable_test.go
@@ -11,6 +11,14 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// TestIsSyncPreservable is a FROZEN-surface pin (RFC 0009 §4.4): runners
+// built against older SDKs branch on exactly these classifications during
+// the SDK-first rollout window, so this table asserts today's behavior and
+// must not be "fixed" to widen it — the preserve-by-default policy ships as
+// the separate ShouldDiscardSyncArtifact helper instead. The joined and
+// %w-wrapped rows pin the production shapes (run-duration expiry joins a
+// checkpoint error with ErrSyncNotComplete; the warning-budget exit wraps
+// ErrTooManyWarnings with %w).
 func TestIsSyncPreservable(t *testing.T) {
 	tests := []struct {
 		name string
@@ -21,12 +29,22 @@ func TestIsSyncPreservable(t *testing.T) {
 		{name: "ErrSyncNotComplete", err: ErrSyncNotComplete, want: true},
 		{name: "ErrTooManyWarnings", err: ErrTooManyWarnings, want: true},
 		{name: "wrapped ErrSyncNotComplete", err: fmt.Errorf("wrapped: %w", ErrSyncNotComplete), want: true},
+		{name: "ErrSyncNotComplete joined with checkpoint error (production shape)", err: errors.Join(errors.New("checkpoint failed"), ErrSyncNotComplete), want: true},
+		{name: "ErrTooManyWarnings production shape", err: fmt.Errorf("%w: warnings: %v completed actions: %d", ErrTooManyWarnings, []error{errors.New("w")}, 5), want: true},
 		{name: "status Unavailable", err: status.Error(codes.Unavailable, "server unavailable"), want: true},
 		{name: "status DeadlineExceeded", err: status.Error(codes.DeadlineExceeded, "lambda_transport: function timed out"), want: true},
 		{name: "bare context.DeadlineExceeded", err: context.DeadlineExceeded, want: true},
 		{name: "wrapped context.DeadlineExceeded", err: fmt.Errorf("wrapped: %w", context.DeadlineExceeded), want: true},
 		{name: "status Internal", err: status.Error(codes.Internal, "internal error"), want: false},
 		{name: "plain error", err: errors.New("plain"), want: false},
+		// Frozen discards: the old policy loses these; the fix is the new
+		// helper at migrated call sites, never an in-place widening here.
+		{name: "bare context.Canceled", err: context.Canceled, want: false},
+		{name: "status Canceled", err: status.Error(codes.Canceled, "context canceled"), want: false},
+		// A storage verdict is not preservable under the old branch either
+		// — the correct outcome for both policies (RFC 0009 §4.4 obligation
+		// 1: attaching the sentinel must not change old-runner behavior).
+		{name: "ErrArtifactUnusable", err: fmt.Errorf("error closing store: %w", ErrArtifactUnusable), want: false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Preserve-by-default artifact retention 

**Title:** `sync: preserve-by-default artifact retention`

### Why

Today a partial sync artifact survives only if the sync error matches an
allowlist (`ErrSyncNotComplete`, timeout-class errors, `IsSyncPreservable`).
Everything else — including routine external cancellation from a worker
drain, deploy, or operator stop — discards the checkpoint, and the next
attempt restarts from whatever was uploaded last, potentially hours of work
ago. Classifying connector errors to decide retention is also the wrong
dependency: connector error shapes are an uncontrolled, version-skewed
surface (see §2.4 of the RFC for the incident this caused).

This PR inverts the contract: **retention is preserve-by-default, and the
only signal that permits discarding a partial artifact is a typed storage
verdict.** Full design, invariants, and compatibility analysis in
[`docs/rfcs/0009-artifact-retention-preserve-by-default.md`](docs/rfcs/0009-artifact-retention-preserve-by-default.md).

### The new contract

- `dotc1z.ErrArtifactUnusable` — a sentinel attached by the storage layer
  when mutations existed but the output c1z was **not rewritten**: the file
  on disk is stale relative to the run's progress (never torn — both engines
  write atomically). Attached via a message-preserving wrapper, so operator-
  facing text and existing string matching are byte-identical.
- `sync.ShouldDiscardSyncArtifact(err)` — the seam API for runners: pass the
  join of the `Sync()` and `Close()` errors; true only on the typed verdict.
  Everything else — cancellation, timeouts, all connector failures —
  preserves. Escaping a poisoned checkpoint stays the retry budgets' job.

Producers are wired at the close/finalize failure paths of both storage
engines (SQLite `finalize`, Pebble `Close`). Failures *after* a successful
save (cleanup, teardown) deliberately do not carry the verdict — the
artifact is a faithful commit at that point.

### Mechanical fixes in the parallel syncer (side-effect-only)

- **Best-effort checkpoint on external cancel:** the exit paths that today
  checkpoint only on `DeadlineExceeded` causes now also checkpoint on cancel
  causes, on a detached bounded context, so the local file is as fresh as
  possible at every stop. The returned error is byte-for-byte unchanged on
  every path; a checkpoint failure is logged, never joined.
- **Log suppression:** a worker observing shutdown (ctx already done) no
  longer logs "cancelling context due to error in action" — genuine action
  failures are that line's only producers now. Cancel/abort semantics are
  untouched.

### What deliberately does not change (frozen surfaces)

Old runners vendor this SDK before their retention branch flips, so the
shapes they branch on are frozen and now pinned by tests:

- `IsSyncPreservable` — frozen as-is (widening it would ship a silent policy
  change to unmigrated callers); doc comment marks it.
- `Sync()` error shapes: `ErrSyncNotComplete` for run-duration expiry,
  `%w`-wrapped `ErrTooManyWarnings`, cancel/deadline visibility, connector
  status codes passing through unaltered on the batch path.
- Lambda transport marker text (`lambda_transport:`, `logSummary:`) — the
  hosted runner string-matches these today; the pins carry a comment naming
  the consumer and lift when typed routing lands there.

The new symbols are dead code until a runner calls them, so this release is
inert for every existing consumer, including connector builds that pick up
the tag immediately (nothing here executes in a served connector).

### Verification

- Conformance suite for every sentinel × wrap shape the production paths
  produce, including cross-layer traversal through `Sync()`/`Close()` joins
  (`artifact_retention_test.go`, `artifact_verdict_test.go`).
- Frozen-surface pins: `IsSyncPreservable` behavior table expanded with
  production error shapes; lambda marker assertions marked FROZEN
  (`syncer_preservable_test.go`, `failure_test.go`).
- Cancellation chaos extended: external cancel exits quietly, checkpoints,
  and cold-resumes; every worker exits (no `queue.next()` hang); positive
  control that genuine action errors still log the cancel cause
  (`chaos_cancellation_test.go`).
- Storage-verdict injection: forced save failures carry the verdict through
  close; clean closes and retried closes do not.

### Rollout

Lands in tandem with the hosted runner change per the RFC's merge cri