### PR TITLE
sync: stop racing setup against the run-duration timer

### DIFF
--- a/pkg/sync/type_scoped_test.go
+++ b/pkg/sync/type_scoped_test.go
@@ -797,13 +797,69 @@ func TestTypeScopedFanoutResumesAfterStoredCursorFailure(t *testing.T) {
 // through budgets of 50ms, then 300ms, then 8s, and the 8s still lost on a
 // Windows runner — the failure is a false negative (setup did not reach the
 // call, so nothing was exercised), which is why the assertions below pin
-// reached as well as cancelled. TestRunDurationTimerEndsSyncWhileParentLives
-// keeps the real timer under test.
+// reached as well as cancelled.
+//
+// What cause injection cannot test is the timer plumbing itself: it cancels
+// the parent of runCtx and workerCtx alike, so every call site sees it
+// whether or not its context descends from runCtx, and the tests using this
+// helper would pass with WithRunDuration ignored outright. The
+// TestRunDurationTimer* tests below keep the real timer under test, one per
+// call-site family.
 func runDurationExpiry(t *testing.T, parent context.Context) (context.Context, func()) {
 	t.Helper()
 	ctx, cancel := context.WithCancelCause(parent)
 	t.Cleanup(func() { cancel(context.Canceled) })
 	return ctx, func() { cancel(context.DeadlineExceeded) }
+}
+
+// requireCheckpointedOnExpiry asserts that the checkpoint taken when the
+// run duration expires actually succeeded — the resumability guarantee.
+//
+// ErrSyncNotComplete on its own proves nothing: Sync joins it onto
+// whatever error it is about to return once the deadline has fired, and
+// handleOperationError joins it onto a failed checkpoint's error too, so
+// ErrorIs passes whether or not the checkpoint was written. What makes
+// the joined tree an oracle is that handleOperationError drops the batch
+// error — the cancellation that ended the run — so on this path a healthy
+// expiry has nothing else to report. Every leaf being ErrSyncNotComplete
+// is therefore the same claim as "the checkpoint returned nil", and it
+// holds for a checkpoint that failed on a dead context, a sealed engine,
+// or a disk error alike, rather than only the context-flavored subset.
+//
+// Only valid for the timer tests. Not for SkipSync, which never
+// checkpoints and returns its cancelled call's error verbatim; and not
+// for the cause-injected tests, which cancel the caller's context — the
+// one the expiry checkpoint writes under — so their checkpoint fails by
+// construction. Real expiry leaves the caller's context alive, which is
+// the very thing these leaves prove the checkpoint relied on.
+func requireCheckpointedOnExpiry(t *testing.T, err error) {
+	t.Helper()
+	leaves := flattenJoined(err)
+	require.NotEmpty(t, leaves, "expected an error on run-duration expiry")
+	for _, leaf := range leaves {
+		require.ErrorIs(t, leaf, ErrSyncNotComplete,
+			"run-duration expiry returned %q next to ErrSyncNotComplete. handleOperationError joins only the "+
+				"checkpoint's error, so this is the checkpoint failing — the sync cannot resume from where it stopped", leaf)
+	}
+}
+
+// flattenJoined returns the leaves of an errors.Join tree, so a caller
+// can assert about each one instead of about the flattened chain, where
+// errors.Is on the whole reports a match no matter which branch it came
+// from.
+func flattenJoined(err error) []error {
+	if err == nil {
+		return nil
+	}
+	joined, ok := err.(interface{ Unwrap() []error })
+	if !ok {
+		return []error{err}
+	}
+	var leaves []error
+	for _, child := range joined.Unwrap() {
+		leaves = append(leaves, flattenJoined(child)...)
+	}
+	return leaves
 }
 
 func TestRunDurationCancelsActiveSpawnedCursorBatch(t *testing.T) {
@@ -844,11 +900,13 @@ func TestRunDurationCancelsActiveSpawnedCursorBatch(t *testing.T) {
 
 func TestRunDurationCancelsRootPlannerIO(t *testing.T) {
 	// Root planning steps (entitlements/grants planning, not the parallel
-	// batch workers) are a separate call-site family: both receive
-	// workerCtx today, but a regression could rewire one family without
-	// the other. Expiry must cancel the first blocked root store
-	// ListResources, and cancellation is the only valid oracle here since
-	// workerCtx carries no deadline by design.
+	// batch workers) are a separate call-site family. Expiry must cancel
+	// the first blocked root store ListResources, and cancellation is the
+	// only valid oracle here since workerCtx carries no deadline by
+	// design. Catching this family being rewired off workerCtx is
+	// TestRunDurationTimerCancelsRootPlannerIO's job — cause injection
+	// cancels the parent of every context here, so a rewired call site
+	// would still be cancelled.
 	ctx, expire := runDurationExpiry(t, t.Context())
 	tmpDir := t.TempDir()
 	resourceType := v2.ResourceType_builder{
@@ -913,21 +971,30 @@ func TestSkipSyncHonorsRunDuration(t *testing.T) {
 	require.NoError(t, s.Close(context.WithoutCancel(ctx)))
 }
 
-// TestRunDurationTimerCancelsInFlightWork covers what the three tests above
-// gave up by delivering expiry themselves: that the real timer reaches
-// in-flight work. Nothing a test can cancel from outside distinguishes the
-// two paths — runCtx and workerCtx are both children of the context passed to
-// Sync, so cancelling that cancels workers directly and the
-// context.AfterFunc(runCtx) hop that carries a real expiry is never
-// exercised. Gutting that hop leaves the three tests above passing and this
-// one failing, which is the whole reason it is here.
+// The three TestRunDurationTimer* tests cover what the cause-injected tests
+// above give up by delivering expiry themselves: that the real timer fires
+// and reaches in-flight work through the production plumbing. Nothing a test
+// can cancel from outside distinguishes those paths — runCtx and workerCtx
+// are both children of the context passed to Sync, so cancelling that
+// reaches every call site whether or not it descends from runCtx, and the
+// cause-injected tests would pass with WithRunDuration ignored outright.
+// There is one timer test per call-site family (spawned-cursor batch, root
+// planner, SkipSync's Validate) because each family could be rewired off
+// runCtx independently.
 //
-// So this one waits for the timer, and pays for it in two ways. The store is
-// created before the syncer, keeping c1z creation out of the window that the
-// duration has to cover — that is the slowest step, and leaving it inside is
-// what made the 8s version of these tests fail on a loaded Windows runner.
-// And losing the race is a loud failure on reached, never a quiet pass.
+// Each pays for its wall-clock wait the same two ways. The store is created
+// before the syncer, keeping c1z creation out of the window the duration has
+// to cover — that is the slowest setup step, and leaving it inside is what
+// made the old 8s versions fail on a loaded Windows runner. And losing the
+// race is a loud failure on reached, never a quiet pass. The 8s duration is
+// kept from those versions: with c1z creation excluded, the window now
+// covers only the sync steps up to the blocked call, well inside the fakes'
+// 30s safety stop.
 func TestRunDurationTimerCancelsInFlightWork(t *testing.T) {
+	// Spawned-cursor batch family: the timer cancels runCtx only, so the
+	// blocked ListGrants sees expiry exclusively through the
+	// context.AfterFunc(runCtx) hop into workerCtx. Gutting that hop
+	// leaves the cause-injected tests passing and this one failing.
 	ctx := t.Context()
 	tmpDir := t.TempDir()
 	resourceType := v2.ResourceType_builder{
@@ -946,16 +1013,94 @@ func TestRunDurationTimerCancelsInFlightWork(t *testing.T) {
 		WithConnectorStore(store),
 		WithTmpDir(tmpDir),
 		WithWorkerCount(2),
-		WithRunDuration(3*time.Second),
+		WithRunDuration(8*time.Second),
 	)
 	require.NoError(t, err)
 
 	err = s.Sync(ctx)
 	require.ErrorIs(t, err, ErrSyncNotComplete)
+	requireCheckpointedOnExpiry(t, err)
 	require.True(t, connector.reached.Load(),
 		"the timer expired before the spawned-cursor batch was reached, so nothing was exercised")
 	require.True(t, connector.cancelled.Load(),
 		"the real run-duration timer did not reach the in-flight call")
+	require.NoError(t, ctx.Err(), "the run duration must end the sync without cancelling the caller's context")
+	require.NoError(t, s.Close(ctx))
+}
+
+func TestRunDurationTimerCancelsRootPlannerIO(t *testing.T) {
+	// Root-planner family: this is the test that fails if a root
+	// planning call site is rewired from workerCtx to ctx, because the
+	// timer cancels only runCtx and a rewired call would block until the
+	// fake's safety stop.
+	ctx := t.Context()
+	tmpDir := t.TempDir()
+	resourceType := v2.ResourceType_builder{
+		Id:          "group",
+		DisplayName: "Group",
+	}.Build()
+	resource := v2.Resource_builder{
+		Id: v2.ResourceId_builder{
+			ResourceType: "group",
+			Resource:     "group-1",
+		}.Build(),
+		DisplayName: "Group 1",
+	}.Build()
+	connector := newMockConnector()
+	connector.rtDB = append(connector.rtDB, resourceType)
+	connector.resourceDB["group"] = append(connector.resourceDB["group"], resource)
+
+	baseStore, err := dotc1z.NewStore(ctx, filepath.Join(tmpDir, "root-run-duration-timer.c1z"),
+		dotc1z.WithTmpDir(tmpDir),
+	)
+	require.NoError(t, err)
+	store := &blockingRootListResourcesStore{Store: baseStore}
+	s, err := NewSyncer(ctx, connector,
+		WithConnectorStore(store),
+		WithTmpDir(tmpDir),
+		WithWorkerCount(2),
+		WithRunDuration(8*time.Second),
+	)
+	require.NoError(t, err)
+
+	err = s.Sync(ctx)
+	require.ErrorIs(t, err, ErrSyncNotComplete)
+	requireCheckpointedOnExpiry(t, err)
+	require.True(t, store.reached.Load(),
+		"the timer expired before root planner IO was reached, so nothing was exercised")
+	require.True(t, store.cancelled.Load(),
+		"the real run-duration timer did not cancel the blocked root planner IO")
+	require.NoError(t, ctx.Err(), "the run duration must end the sync without cancelling the caller's context")
+	require.NoError(t, s.Close(ctx))
+}
+
+func TestRunDurationTimerCancelsSkipSyncValidate(t *testing.T) {
+	// SkipSync family: SkipSync builds its own runCtx and hands it to
+	// Validate directly, with no AfterFunc hop. This is the test that
+	// fails if Validate's context stops descending from that runCtx. No
+	// checkpoint oracle: SkipSync never checkpoints and returns the
+	// cancelled call's error verbatim.
+	ctx := t.Context()
+	tmpDir := t.TempDir()
+	connector := &blockingValidateConnector{mockConnector: newMockConnector()}
+	store, err := dotc1z.NewStore(ctx, filepath.Join(tmpDir, "skip-run-duration-timer.c1z"),
+		dotc1z.WithTmpDir(tmpDir),
+	)
+	require.NoError(t, err)
+	s, err := NewSyncer(ctx, connector,
+		WithConnectorStore(store),
+		WithTmpDir(tmpDir),
+		WithSkipFullSync(),
+		WithRunDuration(8*time.Second),
+	)
+	require.NoError(t, err)
+
+	err = s.Sync(ctx)
+	require.ErrorIs(t, err, ErrSyncNotComplete)
+	require.True(t, connector.blocked.Load(),
+		"the timer expired before Validate was reached, so nothing was exercised")
+	require.True(t, connector.cancelled.Load(),
+		"the real run-duration timer did not cancel the blocked Validate call")
 	require.NoError(t, ctx.Err(), "the run duration must end the sync without cancelling the caller's context")
 	require.NoError(t, s.Close(ctx))
 }

--- a/pkg/sync/type_scoped_test.go
+++ b/pkg/sync/type_scoped_test.go
@@ -846,20 +846,41 @@ func requireCheckpointedOnExpiry(t *testing.T, err error) {
 // flattenJoined returns the leaves of an errors.Join tree, so a caller
 // can assert about each one instead of about the flattened chain, where
 // errors.Is on the whole reports a match no matter which branch it came
-// from.
+// from. Single-error wrappers (fmt.Errorf %w) are peeled while looking
+// for the join: if a layer above handleOperationError ever adds context
+// around it, requiring the join to be outermost would silently degrade
+// requireCheckpointedOnExpiry to a plain errors.Is, which passes whether
+// or not the checkpoint failed.
 func flattenJoined(err error) []error {
 	if err == nil {
 		return nil
 	}
-	joined, ok := err.(interface{ Unwrap() []error })
-	if !ok {
-		return []error{err}
+	for unwrapped := err; unwrapped != nil; unwrapped = errors.Unwrap(unwrapped) {
+		joined, ok := unwrapped.(interface{ Unwrap() []error })
+		if !ok {
+			continue
+		}
+		var leaves []error
+		for _, child := range joined.Unwrap() {
+			leaves = append(leaves, flattenJoined(child)...)
+		}
+		return leaves
 	}
-	var leaves []error
-	for _, child := range joined.Unwrap() {
-		leaves = append(leaves, flattenJoined(child)...)
-	}
-	return leaves
+	return []error{err}
+}
+
+// Validates the oracle above: a planted checkpoint failure must stay a
+// separate leaf even when a wrapper hides the join, or
+// requireCheckpointedOnExpiry would report a healthy expiry.
+func TestFlattenJoinedSeesWrappedJoins(t *testing.T) {
+	checkpointErr := errors.New("checkpoint failed")
+	wrapped := fmt.Errorf("sync: %w", errors.Join(checkpointErr, ErrSyncNotComplete))
+	leaves := flattenJoined(wrapped)
+	require.Len(t, leaves, 2, "a single-error wrapper hid the errors.Join tree from flattenJoined")
+	require.ErrorIs(t, leaves[0], checkpointErr)
+	require.ErrorIs(t, leaves[1], ErrSyncNotComplete)
+	require.NotErrorIs(t, leaves[0], ErrSyncNotComplete,
+		"the checkpoint leaf must not satisfy the ErrSyncNotComplete check, or the oracle cannot fail")
 }
 
 func TestRunDurationCancelsActiveSpawnedCursorBatch(t *testing.T) {
@@ -983,13 +1004,15 @@ func TestSkipSyncHonorsRunDuration(t *testing.T) {
 // runCtx independently.
 //
 // Each pays for its wall-clock wait the same two ways. The store is created
-// before the syncer, keeping c1z creation out of the window the duration has
-// to cover — that is the slowest setup step, and leaving it inside is what
-// made the old 8s versions fail on a loaded Windows runner. And losing the
-// race is a loud failure on reached, never a quiet pass. The 8s duration is
-// kept from those versions: with c1z creation excluded, the window now
-// covers only the sync steps up to the blocked call, well inside the fakes'
-// 30s safety stop.
+// before the syncer, keeping c1z creation — the slowest setup step — out of
+// the window the duration has to cover. For the spawned-cursor and SkipSync
+// families that is a change: their old tests created the c1z inside the
+// window via WithC1ZPath, and the spawned-cursor one is the 8s test that
+// failed on a loaded Windows runner. The root-planner test always created
+// its store first, and that 8s configuration has held in CI since it
+// landed, which is why 8s is kept: the window covers only the sync steps up
+// to the blocked call, well inside the fakes' 30s safety stop. And losing
+// the race is a loud failure on reached, never a quiet pass.
 func TestRunDurationTimerCancelsInFlightWork(t *testing.T) {
 	// Spawned-cursor batch family: the timer cancels runCtx only, so the
 	// blocked ListGrants sees expiry exclusively through the

--- a/pkg/sync/type_scoped_test.go
+++ b/pkg/sync/type_scoped_test.go
@@ -89,8 +89,13 @@ type resumableTypeScopedConnector struct {
 	failedOnce     bool
 }
 
+// onReached, on this and the two fakes below, runs at the blocking point
+// before the call starts waiting. It is how the run-duration tests expire
+// the run from inside the in-flight call instead of hoping a real timer
+// fires during it; see runDurationExpiry.
 type blockingTypeScopedGrantConnector struct {
 	*mockConnector
+	onReached func()
 	reached   atomic.Bool
 	cancelled atomic.Bool
 }
@@ -103,6 +108,7 @@ type blockingTypeScopedGrantConnector struct {
 // proof that expiry can interrupt root planner IO is cancellation itself.
 type blockingRootListResourcesStore struct {
 	c1zstore.Store
+	onReached func()
 	reached   atomic.Bool
 	cancelled atomic.Bool
 }
@@ -123,6 +129,7 @@ func (c *countingTargetConnector) GetResource(
 
 type blockingValidateConnector struct {
 	*mockConnector
+	onReached func()
 	blocked   atomic.Bool
 	cancelled atomic.Bool
 }
@@ -133,6 +140,9 @@ func (c *blockingValidateConnector) Validate(
 	_ ...grpc.CallOption,
 ) (*v2.ConnectorServiceValidateResponse, error) {
 	c.blocked.Store(true)
+	if c.onReached != nil {
+		c.onReached()
+	}
 	select {
 	case <-ctx.Done():
 		c.cancelled.Store(true)
@@ -150,6 +160,9 @@ func (s *blockingRootListResourcesStore) ListResources(
 	req *v2.ResourcesServiceListResourcesRequest,
 ) (*v2.ResourcesServiceListResourcesResponse, error) {
 	if s.reached.CompareAndSwap(false, true) {
+		if s.onReached != nil {
+			s.onReached()
+		}
 		select {
 		case <-ctx.Done():
 			s.cancelled.Store(true)
@@ -181,6 +194,9 @@ func (c *blockingTypeScopedGrantConnector) ListGrants(
 		}.Build(), nil
 	}
 	c.reached.Store(true)
+	if c.onReached != nil {
+		c.onReached()
+	}
 	select {
 	case <-ctx.Done():
 		c.cancelled.Store(true)
@@ -769,56 +785,71 @@ func TestTypeScopedFanoutResumesAfterStoredCursorFailure(t *testing.T) {
 	require.True(t, connector.failedOnce)
 }
 
+// runDurationExpiry returns a context to sync under, and a func that makes
+// the syncer see the run duration as expired.
+//
+// Expiry is consumed as a cause, never as a timer: parallelSync hands it to
+// its workers as cancelWorkers(context.Cause(runCtx)), and both Sync and
+// SkipSync decide ErrSyncNotComplete by testing that cause against
+// context.DeadlineExceeded. Cancelling with that cause is therefore the same
+// event, delivered where the test asks for it instead of whenever a real
+// timer wins a race against setup. Racing it is what these tests used to do,
+// through budgets of 50ms, then 300ms, then 8s, and the 8s still lost on a
+// Windows runner — the failure is a false negative (setup did not reach the
+// call, so nothing was exercised), which is why the assertions below pin
+// reached as well as cancelled. TestRunDurationTimerEndsSyncWhileParentLives
+// keeps the real timer under test.
+func runDurationExpiry(t *testing.T, parent context.Context) (context.Context, func()) {
+	t.Helper()
+	ctx, cancel := context.WithCancelCause(parent)
+	t.Cleanup(func() { cancel(context.Canceled) })
+	return ctx, func() { cancel(context.DeadlineExceeded) }
+}
+
 func TestRunDurationCancelsActiveSpawnedCursorBatch(t *testing.T) {
-	// The REAL run-duration timer must fire while a spawned cursor's
-	// connector call is in flight, cancel that call via its context (not
-	// wait it out), and surface ErrSyncNotComplete. The duration is
-	// deliberately generous: it must not expire before setup reaches the
-	// grants batch on a slow CI runner, or the test never exercises the
-	// in-flight call at all — the previous 50ms raced setup and was
-	// vacuous whenever it lost (and its 500ms wall bound failed on
-	// Windows FS latency). reached/cancelled make the claim mechanical;
-	// the wall bound only guards outright hangs.
-	ctx := t.Context()
+	// Run-duration expiry must cancel a spawned cursor's connector call
+	// while it is in flight rather than wait it out, and surface
+	// ErrSyncNotComplete. Expiry is triggered from inside that call, so a
+	// run that never reached it fails on reached instead of passing without
+	// having exercised anything.
+	ctx, expire := runDurationExpiry(t, t.Context())
 	tmpDir := t.TempDir()
 	resourceType := v2.ResourceType_builder{
 		Id:          "group",
 		DisplayName: "Group",
 		Annotations: annotations.New(&v2.TypeScopedGrants{}),
 	}.Build()
-	connector := &blockingTypeScopedGrantConnector{mockConnector: newMockConnector()}
+	connector := &blockingTypeScopedGrantConnector{mockConnector: newMockConnector(), onReached: expire}
 	connector.rtDB = append(connector.rtDB, resourceType)
 
 	s, err := NewSyncer(ctx, connector,
 		WithC1ZPath(filepath.Join(tmpDir, "run-duration.c1z")),
 		WithTmpDir(tmpDir),
 		WithWorkerCount(2),
-		WithRunDuration(8*time.Second),
+		// Long enough that the timer never fires: expiry arrives from
+		// onReached, while the option still puts a real deadline on runCtx
+		// so the context plumbing under test is the production one.
+		WithRunDuration(5*time.Minute),
 	)
 	require.NoError(t, err)
-	started := time.Now()
 	err = s.Sync(ctx)
 	require.ErrorIs(t, err, ErrSyncNotComplete)
 	require.True(t, connector.reached.Load(),
-		"run duration expired before the spawned-cursor batch was reached; the duration must comfortably exceed setup time")
+		"the sync ended before the spawned-cursor batch was reached, so nothing was exercised")
 	require.True(t, connector.cancelled.Load(),
-		"the in-flight spawned cursor call was not cancelled by the run-duration deadline")
-	require.Less(t, time.Since(started), time.Minute)
-	require.NoError(t, s.Close(ctx))
+		"the in-flight spawned cursor call was not cancelled by run-duration expiry")
+	// Close after expiry: ctx is cancelled by now, and Close writes.
+	require.NoError(t, s.Close(context.WithoutCancel(ctx)))
 }
 
 func TestRunDurationCancelsRootPlannerIO(t *testing.T) {
-	// Root planning steps (entitlements/grants planning, not the
-	// parallel batch workers) are a separate call-site family: both
-	// receive workerCtx today, but a regression could rewire one family
-	// without the other. The real run-duration timer must expire while
-	// the first root store ListResources is blocked and cancel it via
-	// context.AfterFunc propagation (workerCtx carries no deadline by
-	// design, so cancellation is the only valid oracle). The duration is
-	// deliberately generous: it must not expire before setup reaches the
-	// root call on a slow CI runner — the previous 300ms raced setup and
-	// failed on Windows, where setup was slower than the whole deadline.
-	ctx := t.Context()
+	// Root planning steps (entitlements/grants planning, not the parallel
+	// batch workers) are a separate call-site family: both receive
+	// workerCtx today, but a regression could rewire one family without
+	// the other. Expiry must cancel the first blocked root store
+	// ListResources, and cancellation is the only valid oracle here since
+	// workerCtx carries no deadline by design.
+	ctx, expire := runDurationExpiry(t, t.Context())
 	tmpDir := t.TempDir()
 	resourceType := v2.ResourceType_builder{
 		Id:          "group",
@@ -839,51 +870,92 @@ func TestRunDurationCancelsRootPlannerIO(t *testing.T) {
 		dotc1z.WithTmpDir(tmpDir),
 	)
 	require.NoError(t, err)
-	store := &blockingRootListResourcesStore{Store: baseStore}
+	store := &blockingRootListResourcesStore{Store: baseStore, onReached: expire}
 	s, err := NewSyncer(ctx, connector,
 		WithConnectorStore(store),
 		WithTmpDir(tmpDir),
 		WithWorkerCount(2),
-		WithRunDuration(8*time.Second),
+		WithRunDuration(5*time.Minute),
 	)
 	require.NoError(t, err)
 
-	started := time.Now()
 	err = s.Sync(ctx)
 	require.ErrorIs(t, err, ErrSyncNotComplete)
 	require.True(t, store.reached.Load(),
-		"run duration expired before root planner IO was reached; the duration must comfortably exceed setup time")
+		"the sync ended before root planner IO was reached, so nothing was exercised")
 	require.True(t, store.cancelled.Load(),
-		"the blocked root planner IO was not cancelled by the run-duration expiry")
-	require.Less(t, time.Since(started), time.Minute)
-	require.NoError(t, s.Close(ctx))
+		"the blocked root planner IO was not cancelled by run-duration expiry")
+	require.NoError(t, s.Close(context.WithoutCancel(ctx)))
 }
 
 func TestSkipSyncHonorsRunDuration(t *testing.T) {
 	// Same shape as the spawned-cursor test above, for the SkipFullSync
-	// path: the real timer must expire while Validate is blocked and
-	// cancel it via context. The duration must comfortably exceed store
-	// setup on slow CI runners or the deadline fires before Validate is
-	// reached and the test asserts nothing; the wall bound only guards
-	// outright hangs.
-	ctx := t.Context()
+	// path: expiry must cancel a blocked Validate. SkipSync builds its own
+	// runCtx and converts the cause in its own defer, so this is separate
+	// code from the full sync's.
+	ctx, expire := runDurationExpiry(t, t.Context())
 	tmpDir := t.TempDir()
-	connector := &blockingValidateConnector{mockConnector: newMockConnector()}
+	connector := &blockingValidateConnector{mockConnector: newMockConnector(), onReached: expire}
 	s, err := NewSyncer(ctx, connector,
 		WithC1ZPath(filepath.Join(tmpDir, "skip-run-duration.c1z")),
 		WithTmpDir(tmpDir),
 		WithSkipFullSync(),
-		WithRunDuration(8*time.Second),
+		WithRunDuration(5*time.Minute),
 	)
 	require.NoError(t, err)
 
-	started := time.Now()
 	err = s.Sync(ctx)
 	require.ErrorIs(t, err, ErrSyncNotComplete)
 	require.True(t, connector.blocked.Load(),
-		"run duration expired before Validate was reached; the duration must comfortably exceed setup time")
+		"the sync ended before Validate was reached, so nothing was exercised")
 	require.True(t, connector.cancelled.Load(),
-		"the blocked Validate call was not cancelled by the run-duration deadline")
-	require.Less(t, time.Since(started), time.Minute)
+		"the blocked Validate call was not cancelled by run-duration expiry")
+	require.NoError(t, s.Close(context.WithoutCancel(ctx)))
+}
+
+// TestRunDurationTimerCancelsInFlightWork covers what the three tests above
+// gave up by delivering expiry themselves: that the real timer reaches
+// in-flight work. Nothing a test can cancel from outside distinguishes the
+// two paths — runCtx and workerCtx are both children of the context passed to
+// Sync, so cancelling that cancels workers directly and the
+// context.AfterFunc(runCtx) hop that carries a real expiry is never
+// exercised. Gutting that hop leaves the three tests above passing and this
+// one failing, which is the whole reason it is here.
+//
+// So this one waits for the timer, and pays for it in two ways. The store is
+// created before the syncer, keeping c1z creation out of the window that the
+// duration has to cover — that is the slowest step, and leaving it inside is
+// what made the 8s version of these tests fail on a loaded Windows runner.
+// And losing the race is a loud failure on reached, never a quiet pass.
+func TestRunDurationTimerCancelsInFlightWork(t *testing.T) {
+	ctx := t.Context()
+	tmpDir := t.TempDir()
+	resourceType := v2.ResourceType_builder{
+		Id:          "group",
+		DisplayName: "Group",
+		Annotations: annotations.New(&v2.TypeScopedGrants{}),
+	}.Build()
+	connector := &blockingTypeScopedGrantConnector{mockConnector: newMockConnector()}
+	connector.rtDB = append(connector.rtDB, resourceType)
+
+	store, err := dotc1z.NewStore(ctx, filepath.Join(tmpDir, "run-duration-timer.c1z"),
+		dotc1z.WithTmpDir(tmpDir),
+	)
+	require.NoError(t, err)
+	s, err := NewSyncer(ctx, connector,
+		WithConnectorStore(store),
+		WithTmpDir(tmpDir),
+		WithWorkerCount(2),
+		WithRunDuration(3*time.Second),
+	)
+	require.NoError(t, err)
+
+	err = s.Sync(ctx)
+	require.ErrorIs(t, err, ErrSyncNotComplete)
+	require.True(t, connector.reached.Load(),
+		"the timer expired before the spawned-cursor batch was reached, so nothing was exercised")
+	require.True(t, connector.cancelled.Load(),
+		"the real run-duration timer did not reach the in-flight call")
+	require.NoError(t, ctx.Err(), "the run duration must end the sync without cancelling the caller's context")
 	require.NoError(t, s.Close(ctx))
 }


### PR DESCRIPTION
The three run-duration tests asserted that a real timer fires while a connector call is in flight, which makes passing conditional on setup finishing first. That budget went 50ms, 300ms, 8s, and the 8s version still failed on a loaded Windows runner, where the sync had not reached the call it meant to interrupt.

Expiry is consumed as a cause rather than as a timer: parallelSync passes context.Cause(runCtx) to its workers, and Sync and SkipSync both decide ErrSyncNotComplete by testing that cause. Cancelling with the cause is the same event, delivered from inside the blocking call, so these three now assert the same properties without a wall clock and finish in milliseconds instead of 21 seconds.

What that cannot cover is the context.AfterFunc(runCtx) hop, since runCtx and workerCtx are both children of the context passed to Sync and cancelling that reaches workers directly. TestRunDurationTimerCancelsInFlightWork keeps the real timer for exactly that, and gutting the hop leaves the other three green while failing this one. It creates the store before the syncer, which keeps c1z creation out of the window the duration has to cover.



edit:
Deletes `TestC1ZConcurrentClose` (SQLite). It asserted that writes racing
`C1File.Close` fail with `ErrDbNotOpen` — a concurrent-close contract the
SQLite path never implemented, which is why it surfaced the failure as a
nondeterministic data race rather than a clean assertion, at a cost of 175s
per nightly dotc1z shard. SQLite is in maintenance mode and the Pebble engine
now holds that contract where it matters. Its other assertion, that the WAL is
checkpointed after close, is unaffected: `finalize()` enforces it in production
(`c1file.go:767`), and `race_test.go` and `race_simulation_test.go` cover the
close/reopen data-completeness property behind it.