### PR TITLE
Gate external-principal indexing behind an opt-in sync option

### DIFF
--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -432,6 +432,14 @@ func MakeMainCommand[T field.Configurable](
 			opts = append(opts, connectorrunner.WithSkipGrants(v.GetBool("skip-grants")))
 		}
 
+		// --external-principal-index / BATON_EXTERNAL_PRINCIPAL_INDEX opts
+		// external-resource grant matching into indexed principal lookups.
+		// Off by default: the linear scan stays the shipped behavior until
+		// the indexed path is validated in production.
+		if v.GetBool(field.ExternalPrincipalIndexField.GetName()) {
+			opts = append(opts, connectorrunner.WithExternalPrincipalIndex(true))
+		}
+
 		httpTimeout := v.GetInt(field.HttpTimeoutField.GetName())
 		if httpTimeout <= 0 {
 			return fmt.Errorf("field %s: value must be greater than or equal to 1 but got %d", field.HttpTimeoutField.GetName(), httpTimeout)

--- a/pkg/connectorrunner/runner.go
+++ b/pkg/connectorrunner/runner.go
@@ -1156,6 +1156,7 @@ func NewConnectorRunner(ctx context.Context, c types.ConnectorServer, opts ...Op
 		cfg.externalResourceC1Z,
 		cfg.externalResourceEntitlementIdFilter,
 		cfg.externalResourceTraits,
+		cfg.externalPrincipalIndex,
 		resources,
 		cfg.syncResourceTypeIDs,
 		cfg.workerCount,

--- a/pkg/connectorrunner/runner.go
+++ b/pkg/connectorrunner/runner.go
@@ -432,6 +432,7 @@ type runnerConfig struct {
 	keepPreviousSyncC1ZEnabled            bool
 	skipEntitlementsAndGrants             bool
 	skipGrants                            bool
+	externalPrincipalIndex                bool
 	sessionStoreEnabled                   bool
 	syncResourceTypeIDs                   []string
 	defaultCapabilitiesConnectorBuilder   connectorbuilder.ConnectorBuilder
@@ -862,6 +863,17 @@ func WithSkipGrants(skip bool) Option {
 	}
 }
 
+// WithExternalPrincipalIndex enables the indexed external-principal matcher in
+// the sync engine's external-resource grant matching. Off by default, which
+// keeps the original per-grant linear scan; see sync.WithExternalPrincipalIndex
+// for why the faster path ships opt-in.
+func WithExternalPrincipalIndex(enabled bool) Option {
+	return func(ctx context.Context, cfg *runnerConfig) error {
+		cfg.externalPrincipalIndex = enabled
+		return nil
+	}
+}
+
 // WithDefaultCapabilitiesConnectorBuilder sets the default connector builder for the runner
 // This is used by the "capabilities" sub-command to instantiate the connector.
 func WithDefaultCapabilitiesConnectorBuilder(t connectorbuilder.ConnectorBuilder) Option {
@@ -1103,6 +1115,7 @@ func NewConnectorRunner(ctx context.Context, c types.ConnectorServer, opts ...Op
 				local.WithTargetedSyncResources(resources),
 				local.WithSkipEntitlementsAndGrants(cfg.skipEntitlementsAndGrants),
 				local.WithSkipGrants(cfg.skipGrants),
+				local.WithExternalPrincipalIndex(cfg.externalPrincipalIndex),
 				local.WithSyncResourceTypeIDs(cfg.syncResourceTypeIDs),
 				local.WithWorkerCount(cfg.workerCount),
 				local.WithStorageEngine(cfg.storageEngine),

--- a/pkg/connectorrunner/runner_test.go
+++ b/pkg/connectorrunner/runner_test.go
@@ -271,3 +271,21 @@ func TestExtractDefaultCapabilitiesConnectorFactory(t *testing.T) {
 		require.ErrorIs(t, gotErr, sentinel)
 	})
 }
+
+// The runner is where the CLI flag lands before it is handed to a task
+// manager. Both halves of that trip are covered: this asserts the Option
+// reaches the config, and the task packages assert the config reaches the
+// engine.
+func TestWithExternalPrincipalIndexOption(t *testing.T) {
+	ctx := context.Background()
+
+	for _, enabled := range []bool{false, true} {
+		cfg := &runnerConfig{}
+		require.NoError(t, WithExternalPrincipalIndex(enabled)(ctx, cfg))
+		require.Equal(t, enabled, cfg.externalPrincipalIndex)
+	}
+
+	// The default is what a connector gets when the flag is never passed.
+	require.False(t, (&runnerConfig{}).externalPrincipalIndex,
+		"external principal indexing must stay opt-in")
+}

--- a/pkg/field/defaults.go
+++ b/pkg/field/defaults.go
@@ -274,6 +274,20 @@ var (
 		WithPersistent(true),
 		WithExportTarget(ExportTargetNone))
 
+	// ExternalPrincipalIndexField opts the external-resource grant matcher
+	// into indexed principal lookups instead of the original per-grant
+	// linear scan. Off by default: the indexed path is a large speedup on
+	// tenants with many external principals, but it is new code in
+	// security-relevant grant-matching logic and ships opt-in until it has
+	// been validated in production. Both paths must produce identical
+	// grants.
+	ExternalPrincipalIndexField = BoolField("external-principal-index",
+		WithDescription("Match external-resource grants using an indexed principal lookup instead of a linear scan "+
+			"(much faster on tenants with many external principals)"),
+		WithDefaultValue(false),
+		WithPersistent(true),
+		WithExportTarget(ExportTargetNone))
+
 	// KeepPreviousSyncC1ZField is the CUSTOMER's runtime half of the
 	// service-mode ETag-replay opt-in: keep the last successfully
 	// uploaded c1z on disk as a spare and feed it to the next full sync
@@ -438,6 +452,7 @@ var DefaultFields = append([]SchemaField{
 	externalResourceC1ZField,
 	externalResourceEntitlementIdFilter,
 	externalResourceTraitsField,
+	ExternalPrincipalIndexField,
 	KeepPreviousSyncC1ZField,
 	diffSyncsField,
 	diffSyncsBaseSyncField,

--- a/pkg/sync/external_match_folding_test.go
+++ b/pkg/sync/external_match_folding_test.go
@@ -2,6 +2,7 @@ package sync //nolint:revive,nolintlint // matches the existing package name
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -34,6 +35,23 @@ import (
 //
 // Every case below states its expectation and then pins that expectation to
 // strings.EqualFold, so a case added later cannot quietly encode a divergence.
+//
+// The contract binds both external-principal matchers. The linear scan
+// satisfies the folding cases for free -- it calls strings.EqualFold directly
+// -- so running only the default path would leave the indexed matcher's
+// bucketing, which is where a fold can actually be gotten wrong, unpinned.
+// Every case therefore runs in both modes.
+
+// forEachExternalMatchMode runs fn once per external-principal matcher: the
+// default linear scan, then the indexed lookup (WithExternalPrincipalIndex).
+func forEachExternalMatchMode(t *testing.T, fn func(t *testing.T, indexed bool)) {
+	t.Helper()
+	for _, indexed := range []bool{false, true} {
+		t.Run(fmt.Sprintf("indexed=%t", indexed), func(t *testing.T) {
+			fn(t, indexed)
+		})
+	}
+}
 
 // externalMatchFoldCase is one (stored value, queried value) pair together with
 // whether external matching must pair them.
@@ -80,12 +98,14 @@ func TestExternalResourceMatchProfileFoldingContract(t *testing.T) {
 			require.Equal(t, tc.matches, strings.EqualFold(tc.stored, tc.query),
 				"premise: external matching compares with strings.EqualFold")
 
-			principal := externalMatchPrincipal(t, "external-user-1",
-				map[string]any{"upn": tc.stored})
-			matched := runExternalMatchFold(t, principal, "upn", tc.query)
+			forEachExternalMatchMode(t, func(t *testing.T, indexed bool) {
+				principal := externalMatchPrincipal(t, "external-user-1",
+					map[string]any{"upn": tc.stored})
+				matched := runExternalMatchFold(t, principal, "upn", tc.query, indexed)
 
-			require.Equal(t, tc.matches, matched,
-				"profile %q vs match value %q: expected matched=%t", tc.stored, tc.query, tc.matches)
+				require.Equal(t, tc.matches, matched,
+					"profile %q vs match value %q: expected matched=%t", tc.stored, tc.query, tc.matches)
+			})
 		})
 	}
 }
@@ -96,12 +116,14 @@ func TestExternalResourceMatchEmailFoldingContract(t *testing.T) {
 			require.Equal(t, tc.matches, strings.EqualFold(tc.stored, tc.query),
 				"premise: external matching compares with strings.EqualFold")
 
-			principal := externalMatchPrincipal(t, "external-user-1", nil,
-				rs.WithEmail(tc.stored, true))
-			matched := runExternalMatchFold(t, principal, "email", tc.query)
+			forEachExternalMatchMode(t, func(t *testing.T, indexed bool) {
+				principal := externalMatchPrincipal(t, "external-user-1", nil,
+					rs.WithEmail(tc.stored, true))
+				matched := runExternalMatchFold(t, principal, "email", tc.query, indexed)
 
-			require.Equal(t, tc.matches, matched,
-				"user-trait email %q vs match value %q: expected matched=%t", tc.stored, tc.query, tc.matches)
+				require.Equal(t, tc.matches, matched,
+					"user-trait email %q vs match value %q: expected matched=%t", tc.stored, tc.query, tc.matches)
+			})
 		})
 	}
 }
@@ -134,11 +156,13 @@ func TestExternalResourceMatchEmitsOneGrantPerPrincipal(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			principals := []*v2.Resource{tc.principal(t)}
-			observed := observeExternalMatch(t, principals, "email", "shared@example.com")
-			require.Equal(t, []string{"external-user-1"}, observed.principalIDs,
-				"a principal reachable by two routes must still receive one grant")
-			require.Zero(t, observed.carriers, "the carrier must not survive")
+			forEachExternalMatchMode(t, func(t *testing.T, indexed bool) {
+				principals := []*v2.Resource{tc.principal(t)}
+				observed := observeExternalMatch(t, principals, "email", "shared@example.com", indexed)
+				require.Equal(t, []string{"external-user-1"}, observed.principalIDs,
+					"a principal reachable by two routes must still receive one grant")
+				require.Zero(t, observed.carriers, "the carrier must not survive")
+			})
 		})
 	}
 }
@@ -168,9 +192,9 @@ func externalMatchPrincipal(
 
 // runExternalMatchFold reports whether the single supplied principal received a
 // rewritten grant, and asserts the carrier was consumed either way.
-func runExternalMatchFold(t *testing.T, principal *v2.Resource, key, value string) bool {
+func runExternalMatchFold(t *testing.T, principal *v2.Resource, key, value string, indexed bool) bool {
 	t.Helper()
-	observed := observeExternalMatch(t, []*v2.Resource{principal}, key, value)
+	observed := observeExternalMatch(t, []*v2.Resource{principal}, key, value, indexed)
 	require.Zero(t, observed.carriers,
 		"the carrier is consumed whether or not it matched")
 	require.LessOrEqual(t, len(observed.principalIDs), 1, "one principal cannot yield two grants")
@@ -189,6 +213,7 @@ func observeExternalMatch(
 	t *testing.T,
 	principals []*v2.Resource,
 	key, value string,
+	indexed bool,
 ) externalMatchObservation {
 	t.Helper()
 	ctx := t.Context()
@@ -223,7 +248,7 @@ func observeExternalMatch(
 	state.SetHasExternalResourcesGrants()
 	state.PushAction(ctx, Action{Op: SyncExternalResourcesOp})
 
-	syncer := &syncer{store: store, state: state}
+	syncer := &syncer{store: store, state: state, externalPrincipalIndexEnabled: indexed}
 	require.NoError(t, syncer.processGrantsWithExternalPrincipals(ctx, principals))
 
 	return readExternalMatchGrants(t, ctx, store)

--- a/pkg/sync/external_principal_index_verification_test.go
+++ b/pkg/sync/external_principal_index_verification_test.go
@@ -345,7 +345,16 @@ func grantDigest(t *testing.T, path, syncID string) []string {
 	return digest
 }
 
+// The crash-cut / resume / same-checkpoint-twice seam is shared by both
+// external-principal matchers, but the matcher still runs inside it, so the
+// cell is exercised in both modes. Without this the indexed path -- the one
+// being rolled out -- would never be resumed or replayed by any test, since
+// the linear scan is the default a bare &syncer{} gets.
 func TestVerificationExternalPrincipalMatchDeleteCutResumesToGolden(t *testing.T) {
+	forEachExternalMatchMode(t, verifyExternalPrincipalMatchDeleteCutResumesToGolden)
+}
+
+func verifyExternalPrincipalMatchDeleteCutResumesToGolden(t *testing.T, indexed bool) {
 	ctx := t.Context()
 	tmpDir := t.TempDir()
 
@@ -354,7 +363,7 @@ func TestVerificationExternalPrincipalMatchDeleteCutResumesToGolden(t *testing.T
 	goldenState := newState()
 	goldenState.SetHasExternalResourcesGrants()
 	goldenState.PushAction(ctx, Action{Op: SyncExternalResourcesOp})
-	goldenSyncer := &syncer{store: goldenStore, state: goldenState}
+	goldenSyncer := &syncer{store: goldenStore, state: goldenState, externalPrincipalIndexEnabled: indexed}
 	require.NoError(t, goldenSyncer.processGrantsWithExternalPrincipals(ctx, principals))
 	finishExternalMatchVerificationSync(t, goldenStore, goldenState)
 	goldenDigest := grantDigest(t, goldenPath, goldenSyncID)
@@ -369,7 +378,7 @@ func TestVerificationExternalPrincipalMatchDeleteCutResumesToGolden(t *testing.T
 	currentToken, err := cutStore.CurrentSyncStep(ctx)
 	require.NoError(t, err)
 	require.NoError(t, cutState.Unmarshal(currentToken))
-	cutSyncer := &syncer{store: cutWrapper, state: cutState}
+	cutSyncer := &syncer{store: cutWrapper, state: cutState, externalPrincipalIndexEnabled: indexed}
 	err = cutSyncer.processGrantsWithExternalPrincipals(ctx, principals)
 	require.ErrorIs(t, err, errVerificationDeleteCut)
 	require.Equal(t, []int{9}, cutWrapper.putBatchSizes, "test premise: cut happened after the bulk put")
@@ -388,7 +397,7 @@ func TestVerificationExternalPrincipalMatchDeleteCutResumesToGolden(t *testing.T
 	require.NotNil(t, resumedState.Current(), "unfinished action must survive the cut")
 
 	resumedWrapper := &interruptingExternalMatchStore{Store: resumedStore}
-	resumedSyncer := &syncer{store: resumedWrapper, state: resumedState}
+	resumedSyncer := &syncer{store: resumedWrapper, state: resumedState, externalPrincipalIndexEnabled: indexed}
 	require.NoError(t, resumedSyncer.processGrantsWithExternalPrincipals(ctx, principals))
 	require.Equal(t, []int{33}, resumedWrapper.putBatchSizes,
 		"resume scans two remaining carriers plus nine expanded grants, each matching three principals")

--- a/pkg/sync/external_principal_match_parity_test.go
+++ b/pkg/sync/external_principal_match_parity_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 
@@ -358,4 +359,105 @@ func TestExternalPrincipalMatchParitySkipsUnreadableUserTrait(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestExternalPrincipalMatchDedupesAtTheMatcher asserts on the grants the
+// matchers RETURN rather than on store contents. A principal matched twice
+// produces two grants carrying the same generated grant id, which PutGrants
+// upserts into a single row -- so a lost dedup is invisible to every
+// assertion made after the store write, including the parity digest above.
+func TestExternalPrincipalMatchDedupesAtTheMatcher(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		principal func(*testing.T) *v2.Resource
+	}{
+		{
+			name: "two trait addresses folding alike",
+			principal: func(t *testing.T) *v2.Resource {
+				return parityPrincipal(t, testUserPrincipal(t, "user_dupe", nil,
+					rs.WithEmail("shared@example.com", true),
+					rs.WithEmail("SHARED@example.com", false),
+				))
+			},
+		},
+		{
+			name: "trait address and profile email",
+			principal: func(t *testing.T) *v2.Resource {
+				return parityPrincipal(t, testUserPrincipal(t, "user_dupe",
+					map[string]any{"email": "shared@example.com"},
+					rs.WithEmail("SHARED@example.com", true),
+				))
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := t.Context()
+			l := zap.NewNop()
+
+			principals := []*v2.Resource{tc.principal(t)}
+			matchTraits := map[v2.ResourceType_Trait]bool{
+				v2.ResourceType_TRAIT_USER:  true,
+				v2.ResourceType_TRAIT_GROUP: true,
+			}
+			principalsByTrait := map[v2.ResourceType_Trait][]*v2.Resource{
+				v2.ResourceType_TRAIT_USER: principals,
+			}
+			indexByTrait := map[v2.ResourceType_Trait]*externalPrincipalIndex{
+				v2.ResourceType_TRAIT_USER: newExternalUserPrincipalIndex(principals, l),
+			}
+			match := v2.ExternalResourceMatch_builder{
+				Key:          "email",
+				Value:        "shared@example.com",
+				ResourceType: v2.ResourceType_TRAIT_USER,
+			}.Build()
+			carrier := gt.NewGrant(
+				testGroupPrincipal(t, "source_group", map[string]any{"external_id": "source"}),
+				"member",
+				v2.ResourceId_builder{
+					ResourceType: userResourceType.GetId(),
+					Resource:     "placeholder_user",
+				}.Build(),
+				gt.WithAnnotation(match),
+			)
+
+			// No store: a TRAIT_USER match never reaches one, so both matchers
+			// can be called directly on a bare syncer.
+			s := &syncer{}
+
+			legacy, err := s.matchExternalPrincipalsLegacy(
+				ctx, l, carrier, match, matchTraits, principalsByTrait, nil, nil)
+			require.NoError(t, err)
+			indexed, err := s.matchExternalPrincipalsIndexed(
+				ctx, l, carrier, match, matchTraits, indexByTrait, nil, nil)
+			require.NoError(t, err)
+
+			require.Len(t, legacy, 1, "linear scan emitted a principal twice")
+			require.Len(t, indexed, 1, "indexed matcher emitted a principal twice")
+			require.Equal(t, legacy[0].GetId(), indexed[0].GetId())
+			require.Equal(t, "user_dupe", indexed[0].GetPrincipal().GetId().GetResource())
+		})
+	}
+}
+
+// The option is the whole product of this change, so the wiring between the
+// public SyncOpt and the field the matcher branches on is worth a test of its
+// own: a NewSyncer that silently stopped applying it would leave every caller
+// on the default with no other test noticing.
+func TestWithExternalPrincipalIndexOptionWiring(t *testing.T) {
+	ctx := t.Context()
+
+	newWith := func(t *testing.T, opts ...SyncOpt) *syncer {
+		t.Helper()
+		opts = append([]SyncOpt{WithC1ZPath(filepath.Join(t.TempDir(), "sync.c1z"))}, opts...)
+		created, err := NewSyncer(ctx, nil, opts...)
+		require.NoError(t, err)
+		s, ok := created.(*syncer)
+		require.True(t, ok)
+		return s
+	}
+
+	require.False(t, newWith(t).externalPrincipalIndexEnabled,
+		"the linear scan must stay the default for callers that pass no options")
+	require.False(t, newWith(t, WithExternalPrincipalIndex(false)).externalPrincipalIndexEnabled)
+	require.True(t, newWith(t, WithExternalPrincipalIndex(true)).externalPrincipalIndexEnabled)
 }

--- a/pkg/sync/external_principal_match_parity_test.go
+++ b/pkg/sync/external_principal_match_parity_test.go
@@ -1,0 +1,361 @@
+package sync //nolint:revive,nolintlint // matches the existing package name
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/bid"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
+	et "github.com/conductorone/baton-sdk/pkg/types/entitlement"
+	gt "github.com/conductorone/baton-sdk/pkg/types/grant"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+)
+
+// The external-principal index (WithExternalPrincipalIndex) is a drop-in
+// replacement for the linear scan that preceded it: same grants, found a
+// faster way. That claim is the entire basis for being willing to flip the
+// flag on a live tenant, so it is asserted directly here -- one fixture, run
+// through processGrantsWithExternalPrincipals once in each mode, with the
+// resulting store contents required to be byte-identical.
+//
+// The fixture deliberately covers every arm of both matchers:
+//
+//   - a user matched on a profile key that is not "email"
+//   - a user matched on a user-trait email address
+//   - a user matched BOTH ways at once, which must still yield one grant
+//   - a user whose user trait cannot be read, which must be skipped outright
+//     (including for the profile key it would otherwise match)
+//   - group principals matched on a profile key, case-insensitively, one with
+//     a resolvable expandable entitlement and one without
+//   - a match key no principal carries
+//   - a match against a trait that is not configured for matching
+//   - ExternalResourceMatchAll and ExternalResourceMatchID grants, which the
+//     flag does not fork and which must therefore also come out identical
+
+// parityPrincipal marks a resource as an external principal. Only resources
+// carrying a BatonID annotation are considered by the matcher.
+func parityPrincipal(t *testing.T, principal *v2.Resource) *v2.Resource {
+	t.Helper()
+	annos := annotations.Annotations(principal.GetAnnotations())
+	annos.Update(&v2.BatonID{})
+	principal.SetAnnotations(annos)
+	return principal
+}
+
+// parityUnreadableUserTrait replaces the resource's user-trait annotation with
+// one that still claims to be a UserTrait but cannot be unmarshalled, which is
+// the shape resource.GetUserTrait fails on in production. The resource stays a
+// candidate principal (the annotation is still present and of the right type)
+// but neither matcher may match it.
+func parityUnreadableUserTrait(t *testing.T, principal *v2.Resource) *v2.Resource {
+	t.Helper()
+	annos := principal.GetAnnotations()
+	replaced := false
+	for i, anno := range annos {
+		if !anno.MessageIs(&v2.UserTrait{}) {
+			continue
+		}
+		annos[i] = &anypb.Any{TypeUrl: anno.GetTypeUrl(), Value: []byte{0xff, 0xff}}
+		replaced = true
+	}
+	require.True(t, replaced, "fixture premise: principal must carry a user trait annotation")
+	principal.SetAnnotations(annos)
+
+	_, err := rs.GetUserTrait(principal)
+	require.Error(t, err, "fixture premise: user trait must be unreadable")
+	return principal
+}
+
+func parityPrincipals(t *testing.T) []*v2.Resource {
+	t.Helper()
+	return []*v2.Resource{
+		// Matches "upn"/target@example.com, differing in case.
+		parityPrincipal(t, testUserPrincipal(t, "user_profile", map[string]any{"upn": "Target@Example.com"})),
+		// Matches "email"/trait@example.com via the user trait only.
+		parityPrincipal(t, testUserPrincipal(t, "user_trait", nil,
+			rs.WithEmail("trait@example.com", true),
+			rs.WithEmail("secondary@example.com", false),
+		)),
+		// Matches "email"/shared@example.com both ways: one grant, not two.
+		parityPrincipal(t, testUserPrincipal(t, "user_both", map[string]any{"email": "shared@example.com"},
+			rs.WithEmail("SHARED@example.com", true),
+		)),
+		// Would match "upn"/target@example.com, but its user trait is
+		// unreadable, so it is skipped before the profile is considered.
+		parityPrincipal(t, parityUnreadableUserTrait(t,
+			testUserPrincipal(t, "user_unreadable", map[string]any{"upn": "target@example.com"}))),
+		// Matches nothing.
+		parityPrincipal(t, testUserPrincipal(t, "user_none", map[string]any{"upn": "nobody@example.com"})),
+
+		parityPrincipal(t, testGroupPrincipal(t, "group_expandable", map[string]any{"external_id": "ext_123"})),
+		// Same value in different case: matched, but with no entitlement to
+		// remap the expandable annotation onto.
+		parityPrincipal(t, testGroupPrincipal(t, "group_unexpandable", map[string]any{"external_id": "EXT_123"})),
+		parityPrincipal(t, testGroupPrincipal(t, "group_none", map[string]any{"external_id": "ext_999"})),
+	}
+}
+
+// parityCarrierGrants builds the grants the matcher scans. Each one is
+// annotated so it is a candidate, and each targets its own entitlement so the
+// digest attributes every produced grant to the carrier that produced it.
+func parityCarrierGrants(t *testing.T, expandableEntitlementBID string) []*v2.Grant {
+	t.Helper()
+
+	placeholderUser := v2.ResourceId_builder{
+		ResourceType: userResourceType.GetId(),
+		Resource:     "placeholder_user",
+	}.Build()
+	placeholderGroup := v2.ResourceId_builder{
+		ResourceType: groupResourceType.GetId(),
+		Resource:     "placeholder_group",
+	}.Build()
+
+	sourceGroup := testGroupPrincipal(t, "source_group", map[string]any{"external_id": "source"})
+
+	match := func(slug string, principalID *v2.ResourceId, anno *v2.ExternalResourceMatch, extra ...gt.GrantOption) *v2.Grant {
+		opts := append([]gt.GrantOption{gt.WithAnnotation(anno)}, extra...)
+		return gt.NewGrant(sourceGroup, slug, principalID, opts...)
+	}
+
+	return []*v2.Grant{
+		match("user-profile-key", placeholderUser, v2.ExternalResourceMatch_builder{
+			Key: "upn", Value: "target@example.com", ResourceType: v2.ResourceType_TRAIT_USER,
+		}.Build()),
+		match("user-trait-email", placeholderUser, v2.ExternalResourceMatch_builder{
+			Key: "email", Value: "TRAIT@example.com", ResourceType: v2.ResourceType_TRAIT_USER,
+		}.Build()),
+		match("user-email-both-ways", placeholderUser, v2.ExternalResourceMatch_builder{
+			Key: "email", Value: "shared@example.com", ResourceType: v2.ResourceType_TRAIT_USER,
+		}.Build()),
+		match("user-unknown-key", placeholderUser, v2.ExternalResourceMatch_builder{
+			Key: "employeeNumber", Value: "12345", ResourceType: v2.ResourceType_TRAIT_USER,
+		}.Build()),
+		match("group-profile", placeholderGroup, v2.ExternalResourceMatch_builder{
+			Key: "external_id", Value: "ext_123", ResourceType: v2.ResourceType_TRAIT_GROUP,
+		}.Build()),
+		// Same match, but expandable: the new grant's GrantExpandable
+		// annotation is remapped onto whichever matched principal actually has
+		// the entitlement.
+		match("group-profile-expandable", placeholderGroup, v2.ExternalResourceMatch_builder{
+			Key: "external_id", Value: "ext_123", ResourceType: v2.ResourceType_TRAIT_GROUP,
+		}.Build(), gt.WithAnnotation(v2.GrantExpandable_builder{
+			EntitlementIds: []string{expandableEntitlementBID},
+		}.Build())),
+		// A trait nobody is configured to match on: logged and dropped.
+		match("unconfigured-trait", placeholderUser, v2.ExternalResourceMatch_builder{
+			Key: "external_id", Value: "ext_123", ResourceType: v2.ResourceType_TRAIT_SECRET,
+		}.Build()),
+
+		// Neither of the following is forked by the flag; they are here so the
+		// digest would catch a refactor that disturbed them.
+		gt.NewGrant(sourceGroup, "match-all-groups", placeholderGroup,
+			gt.WithAnnotation(v2.ExternalResourceMatchAll_builder{
+				ResourceType: v2.ResourceType_TRAIT_GROUP,
+			}.Build())),
+		gt.NewGrant(sourceGroup, "match-by-id", placeholderUser,
+			gt.WithAnnotation(v2.ExternalResourceMatchID_builder{
+				Id: "user_none",
+			}.Build())),
+	}
+}
+
+// parityRun seeds a store, runs the external-principal match once in the
+// requested mode, and returns the resulting grants both as a deterministic
+// digest (proto bytes, sorted) and as a readable entitlement -> principals map.
+func parityRun(
+	t *testing.T,
+	engine c1zstore.Engine,
+	traits []v2.ResourceType_Trait,
+	indexed bool,
+) ([]string, map[string][]string) {
+	t.Helper()
+	ctx := t.Context()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "parity.c1z")
+	store, err := dotc1z.NewStore(ctx, path,
+		dotc1z.WithEngine(engine),
+		dotc1z.WithTmpDir(dir),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close(ctx) })
+
+	syncID, err := store.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NotEmpty(t, syncID)
+
+	principals := parityPrincipals(t)
+
+	// The expandable carrier grant points at an entitlement on the group it
+	// was granted from; only group_expandable has the matching entitlement, so
+	// the other matched group exercises the not-found arm.
+	sourceGroup := testGroupPrincipal(t, "source_group", map[string]any{"external_id": "source"})
+	sourceEntitlement := et.NewAssignmentEntitlement(sourceGroup, "member")
+	expandableBID, err := bid.MakeBid(sourceEntitlement)
+	require.NoError(t, err)
+
+	var expandableTarget *v2.Resource
+	for _, principal := range principals {
+		if principal.GetId().GetResource() == "group_expandable" {
+			expandableTarget = principal
+		}
+	}
+	require.NotNil(t, expandableTarget)
+	require.NoError(t, store.PutEntitlements(ctx,
+		sourceEntitlement,
+		et.NewAssignmentEntitlement(expandableTarget, "member"),
+	))
+
+	require.NoError(t, store.PutGrants(ctx, parityCarrierGrants(t, expandableBID)...))
+
+	state := newState()
+	state.SetHasExternalResourcesGrants()
+	state.PushAction(ctx, Action{Op: SyncExternalResourcesOp})
+
+	s := &syncer{
+		store:                         store,
+		state:                         state,
+		externalResourceTraits:        traits,
+		externalPrincipalIndexEnabled: indexed,
+	}
+	require.NoError(t, s.processGrantsWithExternalPrincipals(ctx, principals))
+
+	return parityGrantDigest(ctx, t, store)
+}
+
+func parityGrantDigest(ctx context.Context, t *testing.T, store c1zstore.Store) ([]string, map[string][]string) {
+	t.Helper()
+
+	digest := make([]string, 0)
+	byEntitlement := make(map[string][]string)
+	pageToken := ""
+	for {
+		resp, err := store.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{
+			PageToken: pageToken,
+		}.Build())
+		require.NoError(t, err)
+		for _, grant := range resp.GetList() {
+			wire, err := (proto.MarshalOptions{Deterministic: true}).Marshal(grant)
+			require.NoError(t, err)
+			digest = append(digest, hex.EncodeToString(wire))
+
+			slug := grant.GetEntitlement().GetSlug()
+			if slug == "" {
+				slug = grant.GetEntitlement().GetId()
+			}
+			byEntitlement[slug] = append(byEntitlement[slug], fmt.Sprintf("%s:%s",
+				grant.GetPrincipal().GetId().GetResourceType(),
+				grant.GetPrincipal().GetId().GetResource(),
+			))
+		}
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			break
+		}
+	}
+	slices.Sort(digest)
+	for slug := range byEntitlement {
+		slices.Sort(byEntitlement[slug])
+	}
+	return digest, byEntitlement
+}
+
+// TestExternalPrincipalMatchLegacyIndexedParity is the safety proof for
+// WithExternalPrincipalIndex: flipping the flag must not change a single
+// grant. It is not a substitute for the unit tests of either matcher -- it
+// asserts they agree, and separately pins what they agree ON, so that a change
+// breaking both in the same direction still fails.
+func TestExternalPrincipalMatchLegacyIndexedParity(t *testing.T) {
+	for _, engine := range []c1zstore.Engine{c1zstore.EngineSQLite, c1zstore.EnginePebble} {
+		t.Run(string(engine), func(t *testing.T) {
+			for _, tc := range []struct {
+				name   string
+				traits []v2.ResourceType_Trait
+			}{
+				// TRAIT_USER/TRAIT_GROUP, the default when a connector never
+				// calls WithExternalResourceTraits.
+				{name: "default_traits"},
+				// A TRAIT_USER match arrives for a trait that is not configured
+				// for matching: the legacy scan walks an empty principal slice,
+				// the indexed path has no index to consult. Neither matches.
+				{name: "group_trait_only", traits: []v2.ResourceType_Trait{v2.ResourceType_TRAIT_GROUP}},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					legacyDigest, legacyGrants := parityRun(t, engine, tc.traits, false)
+					indexedDigest, indexedGrants := parityRun(t, engine, tc.traits, true)
+
+					require.Equal(t, legacyGrants, indexedGrants,
+						"indexed matcher produced a different grant set than the linear scan")
+					require.Equal(t, legacyDigest, indexedDigest,
+						"indexed matcher produced grants that differ in their bytes")
+					require.NotEmpty(t, legacyDigest, "fixture premise: the run must produce grants")
+				})
+			}
+		})
+	}
+}
+
+// TestExternalPrincipalMatchParityFixtureExpectations pins what both matchers
+// are expected to agree on. Without it the parity assertion above could be
+// satisfied by two matchers that are equally wrong.
+func TestExternalPrincipalMatchParityFixtureExpectations(t *testing.T) {
+	// Keyed by entitlement id ("<resource type>:<resource>:<slug>"), which is
+	// how the carrier grants above are addressed.
+	expected := map[string][]string{
+		"group:source_group:user-profile-key":     {"user:user_profile"},
+		"group:source_group:user-trait-email":     {"user:user_trait"},
+		"group:source_group:user-email-both-ways": {"user:user_both"},
+		"group:source_group:group-profile": {
+			"group:group_expandable",
+			"group:group_unexpandable",
+		},
+		"group:source_group:group-profile-expandable": {
+			"group:group_expandable",
+			"group:group_unexpandable",
+		},
+		"group:source_group:match-all-groups": {
+			"group:group_expandable",
+			"group:group_none",
+			"group:group_unexpandable",
+		},
+		"group:source_group:match-by-id": {"user:user_none"},
+		// user-unknown-key and unconfigured-trait match nothing, so their
+		// carrier grants are deleted and leave no entry at all.
+	}
+
+	for _, indexed := range []bool{false, true} {
+		t.Run(fmt.Sprintf("indexed=%t", indexed), func(t *testing.T) {
+			_, grants := parityRun(t, c1zstore.EngineSQLite, nil, indexed)
+			require.Equal(t, expected, grants)
+		})
+	}
+}
+
+// A user principal whose user trait cannot be read is skipped by both
+// matchers even when its profile would have matched -- the behavior the
+// linear scan had, preserved by the index's skip list. It is asserted
+// separately because it is an absence, and an absence is exactly what a
+// digest comparison of two identically-broken matchers would not catch.
+func TestExternalPrincipalMatchParitySkipsUnreadableUserTrait(t *testing.T) {
+	for _, indexed := range []bool{false, true} {
+		t.Run(fmt.Sprintf("indexed=%t", indexed), func(t *testing.T) {
+			_, grants := parityRun(t, c1zstore.EngineSQLite, nil, indexed)
+			for slug, principals := range grants {
+				require.NotContains(t, principals, "user:user_unreadable",
+					"principal with an unreadable user trait must not be granted %q", slug)
+			}
+		})
+	}
+}

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -151,12 +151,17 @@ type syncer struct {
 	// set via WithExternalResourceTraits). When left empty the matcher
 	// falls back to TRAIT_USER/TRAIT_GROUP, preserving pre-CE-975 behavior
 	// for callers that never opt in.
-	externalResourceTraits      []v2.ResourceType_Trait
-	previousSyncC1ZPath         string
-	previousSyncC1ZPathOptional bool
-	store                       c1zstore.Store
-	externalResourceReader      connectorstore.Reader
-	previousSyncReader          connectorstore.Reader
+	externalResourceTraits []v2.ResourceType_Trait
+	// externalPrincipalIndexEnabled selects the indexed external-principal
+	// matcher (see processGrantsWithExternalPrincipals) over the original
+	// per-grant linear scan. Off by default; set via
+	// WithExternalPrincipalIndex.
+	externalPrincipalIndexEnabled bool
+	previousSyncC1ZPath           string
+	previousSyncC1ZPathOptional   bool
+	store                         c1zstore.Store
+	externalResourceReader        connectorstore.Reader
+	previousSyncReader            connectorstore.Reader
 	// Ingestion-invariant state (see ingest_invariants.go):
 	// childSchedule is the monotone record backing invariant I4;
 	// resourcesPhaseRanHere gates I4 to processes that actually ran the
@@ -3296,9 +3301,11 @@ func (s *syncer) listExternalResourceTypes(ctx context.Context) ([]*v2.ResourceT
 // expansion originally written for TRAIT_GROUP, now shared by GROUP and any
 // additional trait configured via WithExternalResourceTraits (e.g.
 // TRAIT_APP). The caller must have already confirmed principal matches the
-// grant's key/value pair via externalPrincipalIndex.matchProfile -- this
-// helper does not re-check the profile, so calling it with an unconfirmed
-// principal will unconditionally produce a grant for it. GrantExpandable
+// grant's key/value pair -- this helper does not check the profile, so
+// calling it with an unconfirmed principal will unconditionally produce a
+// grant for it. The indexed matcher confirms the match via
+// externalPrincipalIndex.matchProfile; the legacy matcher confirms it inline
+// in matchProfileAndExpandLegacy, which wraps this one. GrantExpandable
 // remapping is optional: a matching non-expandable grant must still be
 // rewritten to the external principal, just without a remapped
 // GrantExpandable annotation.
@@ -3346,6 +3353,183 @@ func (s *syncer) matchProfileAndExpand(
 	return newGrant, nil
 }
 
+// matchProfileAndExpandLegacy is the pre-index spelling of
+// matchProfileAndExpand: it confirms the principal's profile value for key
+// equals value before building anything, returning a nil grant (and nil
+// error) when it doesn't. The confirmation lives here rather than in the
+// caller because the legacy matcher has no index to pre-filter with.
+func (s *syncer) matchProfileAndExpandLegacy(
+	ctx context.Context,
+	l *zap.Logger,
+	grant *v2.Grant,
+	principal *v2.Resource,
+	key, value string,
+	expandableAnno *v2.GrantExpandable,
+	expandableEntitlementsResourceMap map[string][]string,
+) (*v2.Grant, error) {
+	profileVal, ok := resource.GetProfileStringValue(resource.GetProfile(principal), key)
+	if !ok || !strings.EqualFold(profileVal, value) {
+		return nil, nil
+	}
+	return s.matchProfileAndExpand(ctx, l, grant, principal, expandableAnno, expandableEntitlementsResourceMap)
+}
+
+func userTraitContainsEmail(emails []*v2.UserTrait_Email, address string) bool {
+	return slices.ContainsFunc(emails, func(e *v2.UserTrait_Email) bool {
+		return strings.EqualFold(e.GetAddress(), address)
+	})
+}
+
+// matchExternalPrincipalsLegacy resolves one grant's ExternalResourceMatch
+// (key/val) annotation by scanning every external principal carrying the
+// grant's trait, unmarshalling that principal's user trait and profile on each
+// visit. It is O(grants x principals) and is the default until the indexed
+// matcher below has been validated against live tenants -- see
+// WithExternalPrincipalIndex.
+//
+// This is the behavior every caller had before the index existed and must stay
+// byte-for-byte equivalent to matchExternalPrincipalsIndexed; the parity test
+// in external_principal_match_parity_test.go is what pins that.
+func (s *syncer) matchExternalPrincipalsLegacy(
+	ctx context.Context,
+	l *zap.Logger,
+	grant *v2.Grant,
+	matchExternalResource *v2.ExternalResourceMatch,
+	matchTraits map[v2.ResourceType_Trait]bool,
+	principalsByTrait map[v2.ResourceType_Trait][]*v2.Resource,
+	expandableAnno *v2.GrantExpandable,
+	expandableEntitlementsResourceMap map[string][]string,
+) ([]*v2.Grant, error) {
+	trait := matchExternalResource.GetResourceType()
+	matchKey := matchExternalResource.GetKey()
+	matchValue := matchExternalResource.GetValue()
+
+	expandedGrants := make([]*v2.Grant, 0)
+	switch {
+	case trait == v2.ResourceType_TRAIT_USER:
+		for _, userPrincipal := range principalsByTrait[v2.ResourceType_TRAIT_USER] {
+			userTrait, err := resource.GetUserTrait(userPrincipal)
+			if err != nil {
+				// Identifiers only: logging the resource serializes its whole
+				// profile, which is where a directory keeps email addresses,
+				// employee numbers and the like.
+				l.Error("error getting user trait",
+					zap.String("principal_resource_type_id", userPrincipal.GetId().GetResourceType()),
+					zap.String("principal_resource_id", userPrincipal.GetId().GetResource()),
+					zap.Error(err),
+				)
+				continue
+			}
+			if matchKey == "email" {
+				if userTraitContainsEmail(userTrait.GetEmails(), matchValue) {
+					newGrant := newGrantForExternalPrincipal(grant, userPrincipal)
+					expandedGrants = append(expandedGrants, newGrant)
+					// continue to next principal since we found an email match
+					continue
+				}
+			}
+			profileVal, ok := resource.GetProfileStringValue(resource.GetProfile(userPrincipal), matchKey)
+			if ok && strings.EqualFold(profileVal, matchValue) {
+				newGrant := newGrantForExternalPrincipal(grant, userPrincipal)
+				expandedGrants = append(expandedGrants, newGrant)
+			}
+		}
+	case matchTraits[trait]:
+		// Generic profile match, shared by TRAIT_GROUP and any additional
+		// trait opted into via WithExternalResourceTraits (e.g. TRAIT_APP).
+		for _, principal := range principalsByTrait[trait] {
+			newGrant, err := s.matchProfileAndExpandLegacy(
+				ctx, l, grant, principal,
+				matchKey, matchValue,
+				expandableAnno, expandableEntitlementsResourceMap,
+			)
+			if err != nil {
+				return nil, err
+			}
+			if newGrant != nil {
+				expandedGrants = append(expandedGrants, newGrant)
+			}
+		}
+	default:
+		l.Error("unexpected external resource type trait", zap.Any("trait", trait))
+	}
+
+	return expandedGrants, nil
+}
+
+// matchExternalPrincipalsIndexed resolves one grant's ExternalResourceMatch
+// (key/val) annotation through the per-trait externalPrincipalIndex built once
+// for the whole scan, turning each grant into a bucket lookup instead of a
+// full principal rescan. Opt-in via WithExternalPrincipalIndex; see
+// matchExternalPrincipalsLegacy for the behavior it must reproduce.
+func (s *syncer) matchExternalPrincipalsIndexed(
+	ctx context.Context,
+	l *zap.Logger,
+	grant *v2.Grant,
+	matchExternalResource *v2.ExternalResourceMatch,
+	matchTraits map[v2.ResourceType_Trait]bool,
+	indexByTrait map[v2.ResourceType_Trait]*externalPrincipalIndex,
+	expandableAnno *v2.GrantExpandable,
+	expandableEntitlementsResourceMap map[string][]string,
+) ([]*v2.Grant, error) {
+	trait := matchExternalResource.GetResourceType()
+	matchKey := matchExternalResource.GetKey()
+	matchValue := matchExternalResource.GetValue()
+
+	expandedGrants := make([]*v2.Grant, 0)
+	switch {
+	case trait == v2.ResourceType_TRAIT_USER:
+		// A user matches on its profile value for the key, or -- when the key
+		// is "email" -- on a user-trait email address. Merging the two
+		// ascending position sets preserves principal order and emits at most
+		// one grant per user, as the per-principal scan this replaces did.
+		idx := indexByTrait[v2.ResourceType_TRAIT_USER]
+		if idx == nil {
+			// A grant can carry a TRAIT_USER match even when USER is not among
+			// the configured match traits. The legacy path scans an empty
+			// slice here; match nothing.
+			break
+		}
+		positions := idx.matchProfile(matchKey, matchValue)
+		if matchKey == "email" {
+			positions = mergePositions(idx.matchUserTraitEmail(matchValue), positions)
+		}
+		for _, i := range positions {
+			newGrant := newGrantForExternalPrincipal(grant, idx.principalAt(i))
+			expandedGrants = append(expandedGrants, newGrant)
+		}
+	case matchTraits[trait]:
+		// Generic profile match, shared by TRAIT_GROUP and any
+		// additional trait opted into via WithExternalResourceTraits
+		// (e.g. TRAIT_APP). A key/val match yields a grant whether or
+		// not the source grant is expandable: expandableAnno only
+		// controls whether the new grant also gets a remapped
+		// GrantExpandable annotation (see matchProfileAndExpand).
+		// No nil check: this case only fires when matchTraits[trait]
+		// is true, and indexByTrait is populated for every key of
+		// matchTraits. The guard in the TRAIT_USER case above is not
+		// the same situation -- that case fires on the trait named by
+		// the grant, which need not be a configured match trait.
+		idx := indexByTrait[trait]
+		for _, i := range idx.matchProfile(matchKey, matchValue) {
+			newGrant, err := s.matchProfileAndExpand(
+				ctx, l, grant, idx.principalAt(i),
+				expandableAnno, expandableEntitlementsResourceMap,
+			)
+			if err != nil {
+				return nil, err
+			}
+			if newGrant != nil {
+				expandedGrants = append(expandedGrants, newGrant)
+			}
+		}
+	default:
+		l.Error("unexpected external resource type trait", zap.Any("trait", trait))
+	}
+
+	return expandedGrants, nil
+}
+
 // externalMatchProgressLogInterval is how many grants the external-principal
 // match scan processes between progress logs. The scan can cover every grant in
 // the store, and without progress output a slow one is indistinguishable from a
@@ -3387,26 +3571,37 @@ func (s *syncer) processGrantsWithExternalPrincipals(ctx context.Context, princi
 		principalMap[principalID] = principal
 	}
 
+	principalCounts := make(map[string]int, len(matchTraits))
+	for trait := range matchTraits {
+		principalCounts[trait.String()] = len(principalsByTrait[trait])
+	}
+
 	// Index each trait's principals once. Matching each grant against every
 	// principal is O(grants x principals) proto unmarshals, which on large
 	// tenants runs for hours and never finishes inside the sync deadline.
 	// TRAIT_USER gets the user-trait-aware index so an "email" key can match a
 	// user-trait address as well as a profile field; every other opted-in trait
 	// matches on profile alone.
-	indexByTrait := make(map[v2.ResourceType_Trait]*externalPrincipalIndex, len(matchTraits))
-	principalCounts := make(map[string]int, len(matchTraits))
-	for trait := range matchTraits {
-		traitPrincipals := principalsByTrait[trait]
-		if trait == v2.ResourceType_TRAIT_USER {
-			indexByTrait[trait] = newExternalUserPrincipalIndex(traitPrincipals, l)
-		} else {
-			indexByTrait[trait] = newExternalPrincipalIndex(traitPrincipals)
+	//
+	// Built only when the indexed matcher is selected: with the linear scan
+	// nothing would ever look anything up in it, and indexing every principal
+	// is exactly the work the legacy path is being kept to avoid changing.
+	var indexByTrait map[v2.ResourceType_Trait]*externalPrincipalIndex
+	if s.externalPrincipalIndexEnabled {
+		indexByTrait = make(map[v2.ResourceType_Trait]*externalPrincipalIndex, len(matchTraits))
+		for trait := range matchTraits {
+			traitPrincipals := principalsByTrait[trait]
+			if trait == v2.ResourceType_TRAIT_USER {
+				indexByTrait[trait] = newExternalUserPrincipalIndex(traitPrincipals, l)
+			} else {
+				indexByTrait[trait] = newExternalPrincipalIndex(traitPrincipals)
+			}
 		}
-		principalCounts[trait.String()] = len(traitPrincipals)
 	}
 
 	l.Info("matching grants against external principals",
 		zap.Any("principals_by_trait", principalCounts),
+		zap.Bool("indexed", s.externalPrincipalIndexEnabled),
 	)
 
 	grantsToDelete := make([]*v2.Grant, 0)
@@ -3532,59 +3727,27 @@ func (s *syncer) processGrantsWithExternalPrincipals(ctx context.Context, princi
 		}
 
 		if matchExternalResource != nil {
-			trait := matchExternalResource.GetResourceType()
-			matchKey := matchExternalResource.GetKey()
-			matchValue := matchExternalResource.GetValue()
-			switch {
-			case trait == v2.ResourceType_TRAIT_USER:
-				// A user matches on its profile value for the key, or -- when
-				// the key is "email" -- on a user-trait email address. Merging
-				// the two ascending position sets preserves principal order and
-				// emits at most one grant per user, as the per-principal scan
-				// this replaces did.
-				idx := indexByTrait[v2.ResourceType_TRAIT_USER]
-				if idx == nil {
-					// A grant can carry a TRAIT_USER match even when USER is
-					// not among the configured match traits. The pre-index
-					// code scanned an empty slice here; match nothing.
-					break
-				}
-				positions := idx.matchProfile(matchKey, matchValue)
-				if matchKey == "email" {
-					positions = mergePositions(idx.matchUserTraitEmail(matchValue), positions)
-				}
-				for _, i := range positions {
-					newGrant := newGrantForExternalPrincipal(grant, idx.principalAt(i))
-					expandedGrants = append(expandedGrants, newGrant)
-				}
-			case matchTraits[trait]:
-				// Generic profile match, shared by TRAIT_GROUP and any
-				// additional trait opted into via WithExternalResourceTraits
-				// (e.g. TRAIT_APP). A key/val match yields a grant whether or
-				// not the source grant is expandable: expandableAnno only
-				// controls whether the new grant also gets a remapped
-				// GrantExpandable annotation (see matchProfileAndExpand).
-				// No nil check: this case only fires when matchTraits[trait]
-				// is true, and indexByTrait is populated for every key of
-				// matchTraits. The guard in the TRAIT_USER case above is not
-				// the same situation -- that case fires on the trait named by
-				// the grant, which need not be a configured match trait.
-				idx := indexByTrait[trait]
-				for _, i := range idx.matchProfile(matchKey, matchValue) {
-					newGrant, err := s.matchProfileAndExpand(
-						ctx, l, grant, idx.principalAt(i),
-						expandableAnno, expandableEntitlementsResourceMap,
-					)
-					if err != nil {
-						return err
-					}
-					if newGrant != nil {
-						expandedGrants = append(expandedGrants, newGrant)
-					}
-				}
-			default:
-				l.Error("unexpected external resource type trait", zap.Any("trait", trait))
+			// The two matchers must agree on every input; only how they find
+			// the matching principals differs. See WithExternalPrincipalIndex.
+			var (
+				matchedGrants []*v2.Grant
+				matchErr      error
+			)
+			if s.externalPrincipalIndexEnabled {
+				matchedGrants, matchErr = s.matchExternalPrincipalsIndexed(
+					ctx, l, grant, matchExternalResource, matchTraits, indexByTrait,
+					expandableAnno, expandableEntitlementsResourceMap,
+				)
+			} else {
+				matchedGrants, matchErr = s.matchExternalPrincipalsLegacy(
+					ctx, l, grant, matchExternalResource, matchTraits, principalsByTrait,
+					expandableAnno, expandableEntitlementsResourceMap,
+				)
 			}
+			if matchErr != nil {
+				return matchErr
+			}
+			expandedGrants = append(expandedGrants, matchedGrants...)
 
 			// We still want to delete the grant even if there are no matches
 			grantsToDelete = append(grantsToDelete, grant)
@@ -4074,6 +4237,23 @@ func WithSkipEntitlementsAndGrants(skip bool) SyncOpt {
 func WithSkipGrants(skip bool) SyncOpt {
 	return func(s *syncer) {
 		s.skipGrants = skip
+	}
+}
+
+// WithExternalPrincipalIndex controls whether external-resource grant
+// matching (see processGrantsWithExternalPrincipals) uses an indexed lookup
+// or falls back to the original per-grant linear scan of external principals.
+// Defaults to false (linear scan) to preserve behavior for existing callers;
+// the indexed path is a purely internal performance optimization but is new
+// code touching security-relevant grant-matching logic, so it ships opt-in
+// until validated in production.
+//
+// The two paths are required to produce identical grants — that equivalence
+// is what the flag is for, letting a fleet roll the index out per tenant
+// rather than flipping every connector at once on an SDK bump.
+func WithExternalPrincipalIndex(enabled bool) SyncOpt {
+	return func(s *syncer) {
+		s.externalPrincipalIndexEnabled = enabled
 	}
 }
 

--- a/pkg/sync/syncer_test.go
+++ b/pkg/sync/syncer_test.go
@@ -1326,7 +1326,17 @@ func TestExternalResourceUserProfileMatch(t *testing.T) {
 		require.NoError(t, err)
 
 		internalC1zpath := filepath.Join(tempDir, "internal.c1z")
-		internalOpts := append([]SyncOpt{WithC1ZPath(internalC1zpath), WithTmpDir(tempDir), WithExternalResourceC1ZPath(externalC1zpath)}, extraOpts...)
+		// This test was written for the indexed matcher, which is opt-in
+		// (WithExternalPrincipalIndex) -- the linear scan is what a caller
+		// gets by default. The equivalent default-path coverage lives in
+		// TestExternalPrincipalMatchParityFixtureExpectations, which runs the
+		// same profile-key match through both matchers.
+		internalOpts := append([]SyncOpt{
+			WithC1ZPath(internalC1zpath),
+			WithTmpDir(tempDir),
+			WithExternalResourceC1ZPath(externalC1zpath),
+			WithExternalPrincipalIndex(true),
+		}, extraOpts...)
 		internalSyncer, err := NewSyncer(ctx, internalMc, internalOpts...)
 		require.NoError(t, err)
 		err = internalSyncer.Sync(ctx)

--- a/pkg/tasks/c1api/full_sync.go
+++ b/pkg/tasks/c1api/full_sync.go
@@ -162,16 +162,13 @@ func fileExists(path string) bool {
 	return err == nil && fi.Mode().IsRegular()
 }
 
-func (c *fullSyncTaskHandler) sync(ctx context.Context, c1zPath string) error {
-	ctx, span := tracer.Start(ctx, "fullSyncTaskHandler.sync")
-	var err error
-	defer func() { uotel.EndSpanWithError(span, err) }()
-	l := ctxzap.Extract(ctx).With(zap.String("task_id", c.task.GetId()), zap.Stringer("task_type", tasks.GetType(c.task)))
-
-	if c.task.GetSyncFull() == nil {
-		return errors.New("task is not a full sync task")
-	}
-
+// syncOpts assembles the sync engine options for this task. Split out of
+// sync() so the translation from handler configuration to sdkSync.SyncOpt is
+// reachable from a test: every option here arrives through a long positional
+// constructor chain from connectorrunner, and a value silently dropped
+// somewhere along it produces a sync that runs with the wrong settings and no
+// other signal.
+func (c *fullSyncTaskHandler) syncOpts(l *zap.Logger, c1zPath string, cc types.ConnectorClient) []sdkSync.SyncOpt {
 	syncOpts := []sdkSync.SyncOpt{
 		sdkSync.WithC1ZPath(c1zPath),
 		sdkSync.WithTmpDir(c.helpers.TempDir()),
@@ -246,8 +243,6 @@ func (c *fullSyncTaskHandler) sync(ctx context.Context, c1zPath string) error {
 	if len(c.targetedSyncResources) > 0 {
 		syncOpts = append(syncOpts, sdkSync.WithTargetedSyncResources(c.targetedSyncResources))
 	}
-	cc := c.helpers.ConnectorClient()
-
 	// Prefer the task's resource type IDs (from the server/UI) over local config.
 	// The UI is the authoritative source when set; local config is the fallback.
 	syncResourceTypeIDs := c.task.GetSyncFull().GetSyncResourceTypeIds()
@@ -262,7 +257,23 @@ func (c *fullSyncTaskHandler) sync(ctx context.Context, c1zPath string) error {
 		syncOpts = append(syncOpts, sdkSync.WithSessionStore(setSessionStore))
 	}
 
-	syncer, err := sdkSync.NewSyncer(ctx, c.helpers.ConnectorClient(), syncOpts...)
+	return syncOpts
+}
+
+func (c *fullSyncTaskHandler) sync(ctx context.Context, c1zPath string) error {
+	ctx, span := tracer.Start(ctx, "fullSyncTaskHandler.sync")
+	var err error
+	defer func() { uotel.EndSpanWithError(span, err) }()
+	l := ctxzap.Extract(ctx).With(zap.String("task_id", c.task.GetId()), zap.Stringer("task_type", tasks.GetType(c.task)))
+
+	if c.task.GetSyncFull() == nil {
+		return errors.New("task is not a full sync task")
+	}
+
+	cc := c.helpers.ConnectorClient()
+	syncOpts := c.syncOpts(l, c1zPath, cc)
+
+	syncer, err := sdkSync.NewSyncer(ctx, cc, syncOpts...)
 	if err != nil {
 		l.Error("failed to create syncer", zap.Error(err))
 		return err

--- a/pkg/tasks/c1api/full_sync.go
+++ b/pkg/tasks/c1api/full_sync.go
@@ -54,10 +54,14 @@ type fullSyncTaskHandler struct {
 	externalResourceC1ZPath             string
 	externalResourceEntitlementIdFilter string
 	externalResourceTraits              []v2.ResourceType_Trait
-	targetedSyncResources               []*v2.Resource
-	syncResourceTypeIDs                 []string
-	workerCount                         int
-	storageEngine                       c1zstore.Engine
+	// externalPrincipalIndex opts external-resource grant matching into
+	// indexed principal lookups; off by default, see
+	// sdkSync.WithExternalPrincipalIndex.
+	externalPrincipalIndex bool
+	targetedSyncResources  []*v2.Resource
+	syncResourceTypeIDs    []string
+	workerCount            int
+	storageEngine          c1zstore.Engine
 
 	// previousSyncSparePath is the connector's ETag-replay opt-in: when
 	// non-empty, the handler retains one spare c1z (the last successfully
@@ -205,6 +209,10 @@ func (c *fullSyncTaskHandler) sync(ctx context.Context, c1zPath string) error {
 
 	if len(c.externalResourceTraits) > 0 {
 		syncOpts = append(syncOpts, sdkSync.WithExternalResourceTraits(c.externalResourceTraits...))
+	}
+
+	if c.externalPrincipalIndex {
+		syncOpts = append(syncOpts, sdkSync.WithExternalPrincipalIndex(true))
 	}
 
 	// ETag replay (opt-in): feed the spare retained from the last
@@ -376,6 +384,7 @@ func newFullSyncTaskHandler(
 	externalResourceC1ZPath string,
 	externalResourceEntitlementIdFilter string,
 	externalResourceTraits []v2.ResourceType_Trait,
+	externalPrincipalIndex bool,
 	targetedSyncResources []*v2.Resource,
 	syncResourceTypeIDs []string,
 	workerCount int,
@@ -389,6 +398,7 @@ func newFullSyncTaskHandler(
 		externalResourceC1ZPath:             externalResourceC1ZPath,
 		externalResourceEntitlementIdFilter: externalResourceEntitlementIdFilter,
 		externalResourceTraits:              externalResourceTraits,
+		externalPrincipalIndex:              externalPrincipalIndex,
 		targetedSyncResources:               targetedSyncResources,
 		syncResourceTypeIDs:                 syncResourceTypeIDs,
 		workerCount:                         workerCount,

--- a/pkg/tasks/c1api/full_sync_opts_test.go
+++ b/pkg/tasks/c1api/full_sync_opts_test.go
@@ -1,0 +1,171 @@
+package c1api
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	v1 "github.com/conductorone/baton-sdk/pb/c1/connectorapi/baton/v1"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	sdkSync "github.com/conductorone/baton-sdk/pkg/sync"
+	"github.com/conductorone/baton-sdk/pkg/types"
+)
+
+// Service-mode configuration reaches the sync engine through a chain of long
+// positional constructors: connectorrunner -> NewC1TaskManager ->
+// c1ApiTaskManager -> newFullSyncTaskHandler -> fullSyncTaskHandler.syncOpts.
+// A value dropped anywhere along that chain compiles, runs, and silently syncs
+// with the wrong settings -- which is exactly what happened to
+// externalPrincipalIndex on this branch's first pass. These tests walk the
+// handler half of the chain for real.
+
+type syncOptsTestHelpers struct {
+	tempDir string
+}
+
+func (h *syncOptsTestHelpers) ConnectorClient() types.ConnectorClient { return nil }
+func (h *syncOptsTestHelpers) Upload(ctx context.Context, r io.ReadSeeker) error {
+	return nil
+}
+
+func (h *syncOptsTestHelpers) FinishTask(ctx context.Context, resp proto.Message, annos annotations.Annotations, err error) error {
+	return nil
+}
+
+func (h *syncOptsTestHelpers) HeartbeatTask(ctx context.Context, annos annotations.Annotations) (context.Context, error) {
+	return ctx, nil
+}
+func (h *syncOptsTestHelpers) TempDir() string { return h.tempDir }
+
+// syncerUnderOpts applies a handler's assembled options to a real sync engine
+// and returns it for inspection.
+//
+// The fields the options set are unexported, and deliberately so -- there is no
+// public accessor to assert against. Reading them reflectively is a test-only
+// coupling to pkg/sync's internals, taken because the alternative is asserting
+// nothing: a SyncOpt is an opaque closure that cannot be identified or applied
+// from outside its own package, so the only way to prove an option survived the
+// plumbing is to let it act on an engine and look at the result.
+func syncerUnderOpts(t *testing.T, opts []sdkSync.SyncOpt) reflect.Value {
+	t.Helper()
+
+	created, err := sdkSync.NewSyncer(t.Context(), nil, opts...)
+	require.NoError(t, err)
+
+	value := reflect.ValueOf(created)
+	require.Equal(t, reflect.Ptr, value.Kind(), "NewSyncer must return a pointer to inspect")
+	return value.Elem()
+}
+
+// syncerField reads one field off the engine by name, failing with an
+// actionable message if pkg/sync renamed it.
+func syncerField(t *testing.T, engine reflect.Value, name string) reflect.Value {
+	t.Helper()
+
+	field := engine.FieldByName(name)
+	require.True(t, field.IsValid(),
+		"pkg/sync syncer has no field %q: this test reads it by name to prove service-mode "+
+			"configuration reaches the sync engine, so a rename needs updating here too", name)
+	return field
+}
+
+func newSyncOptsTestHandler(t *testing.T, externalPrincipalIndex bool, traits []v2.ResourceType_Trait) *fullSyncTaskHandler {
+	t.Helper()
+
+	task := v1.Task_builder{
+		Id:       "task-1",
+		SyncFull: &v1.Task_SyncFullTask{},
+	}.Build()
+
+	// Built through the production constructor, not a struct literal: the
+	// positional argument list is itself part of what these tests guard.
+	handler := newFullSyncTaskHandler(
+		task,
+		&syncOptsTestHelpers{tempDir: t.TempDir()},
+		false, // skipFullSync
+		"",    // externalResourceC1ZPath
+		"",    // externalResourceEntitlementIdFilter
+		traits,
+		externalPrincipalIndex,
+		nil, // targetedSyncResources
+		nil, // syncResourceTypeIDs
+		1,   // workerCount
+		"",  // storageEngine
+		"",  // previousSyncSparePath
+	)
+
+	fullSync, ok := handler.(*fullSyncTaskHandler)
+	require.True(t, ok)
+	return fullSync
+}
+
+// engineUnder builds a handler the way service mode does and runs its assembled
+// options through a real sync engine.
+func engineUnder(t *testing.T, externalPrincipalIndex bool, traits []v2.ResourceType_Trait) reflect.Value {
+	t.Helper()
+	handler := newSyncOptsTestHandler(t, externalPrincipalIndex, traits)
+	c1zPath := filepath.Join(t.TempDir(), "sync.c1z")
+	return syncerUnderOpts(t, handler.syncOpts(zap.NewNop(), c1zPath, nil))
+}
+
+func TestFullSyncTaskHandlerThreadsExternalPrincipalIndex(t *testing.T) {
+	t.Run("enabled", func(t *testing.T) {
+		handler := newSyncOptsTestHandler(t, true, nil)
+		require.True(t, handler.externalPrincipalIndex,
+			"the constructor must carry the flag onto the handler")
+
+		engine := engineUnder(t, true, nil)
+		require.True(t, syncerField(t, engine, "externalPrincipalIndexEnabled").Bool(),
+			"a service-mode task configured for the indexed matcher must reach the engine with it enabled")
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		handler := newSyncOptsTestHandler(t, false, nil)
+		require.False(t, handler.externalPrincipalIndex)
+
+		engine := engineUnder(t, false, nil)
+		require.False(t, syncerField(t, engine, "externalPrincipalIndexEnabled").Bool(),
+			"the linear scan is the default and must not be opted out of implicitly")
+	})
+}
+
+// externalResourceTraits reaches the engine through the same chain and had the
+// same untested gap; it is cheap to cover here alongside.
+// The manager -> handler hop is the other half of the chain, and the one that
+// silently dropped the value the first time. It is asserted here rather than
+// through Process(), which needs a live task queue and service client.
+func TestC1TaskManagerThreadsExternalPrincipalIndexToHandler(t *testing.T) {
+	for _, enabled := range []bool{false, true} {
+		t.Run(fmt.Sprintf("enabled=%t", enabled), func(t *testing.T) {
+			manager := &c1ApiTaskManager{externalPrincipalIndex: enabled}
+			task := v1.Task_builder{Id: "task-1", SyncFull: &v1.Task_SyncFullTask{}}.Build()
+
+			handler, ok := manager.newFullSyncHandler(task, &syncOptsTestHelpers{tempDir: t.TempDir()}).(*fullSyncTaskHandler)
+			require.True(t, ok)
+			require.Equal(t, enabled, handler.externalPrincipalIndex,
+				"the manager must hand its own configuration to the handler")
+		})
+	}
+}
+
+func TestFullSyncTaskHandlerThreadsExternalResourceTraits(t *testing.T) {
+	t.Run("configured", func(t *testing.T) {
+		engine := engineUnder(t, false, []v2.ResourceType_Trait{v2.ResourceType_TRAIT_APP})
+		traits := syncerField(t, engine, "externalResourceTraits")
+		require.Equal(t, 1, traits.Len())
+		require.Equal(t, int64(v2.ResourceType_TRAIT_APP), traits.Index(0).Int())
+	})
+
+	t.Run("unset", func(t *testing.T) {
+		engine := engineUnder(t, false, nil)
+		require.Zero(t, syncerField(t, engine, "externalResourceTraits").Len())
+	})
+}

--- a/pkg/tasks/c1api/full_sync_opts_test.go
+++ b/pkg/tasks/c1api/full_sync_opts_test.go
@@ -137,8 +137,6 @@ func TestFullSyncTaskHandlerThreadsExternalPrincipalIndex(t *testing.T) {
 	})
 }
 
-// externalResourceTraits reaches the engine through the same chain and had the
-// same untested gap; it is cheap to cover here alongside.
 // The manager -> handler hop is the other half of the chain, and the one that
 // silently dropped the value the first time. It is asserted here rather than
 // through Process(), which needs a live task queue and service client.
@@ -156,6 +154,8 @@ func TestC1TaskManagerThreadsExternalPrincipalIndexToHandler(t *testing.T) {
 	}
 }
 
+// externalResourceTraits reaches the engine through the same chain and had the
+// same untested gap; it is cheap to cover here alongside.
 func TestFullSyncTaskHandlerThreadsExternalResourceTraits(t *testing.T) {
 	t.Run("configured", func(t *testing.T) {
 		engine := engineUnder(t, false, []v2.ResourceType_Trait{v2.ResourceType_TRAIT_APP})

--- a/pkg/tasks/c1api/manager.go
+++ b/pkg/tasks/c1api/manager.go
@@ -66,6 +66,7 @@ type c1ApiTaskManager struct {
 	externalResourceC1Z                 string
 	externalResourceEntitlementIdFilter string
 	externalResourceTraits              []v2.ResourceType_Trait
+	externalPrincipalIndex              bool
 	targetedSyncResources               []*v2.Resource
 	syncResourceTypeIDs                 []string
 	workerCount                         int
@@ -431,6 +432,7 @@ func (c *c1ApiTaskManager) Process(ctx context.Context, task *v1.Task, cc types.
 			c.externalResourceC1Z,
 			c.externalResourceEntitlementIdFilter,
 			c.externalResourceTraits,
+			c.externalPrincipalIndex,
 			c.targetedSyncResources,
 			c.syncResourceTypeIDs,
 			c.workerCount,
@@ -502,6 +504,7 @@ func NewC1TaskManager(
 	externalC1Z string,
 	externalResourceEntitlementIdFilter string,
 	externalResourceTraits []v2.ResourceType_Trait,
+	externalPrincipalIndex bool,
 	targetedSyncResources []*v2.Resource,
 	syncResourceTypeIDs []string,
 	workerCount int,
@@ -531,6 +534,7 @@ func NewC1TaskManager(
 		externalResourceC1Z:                 externalC1Z,
 		externalResourceEntitlementIdFilter: externalResourceEntitlementIdFilter,
 		externalResourceTraits:              externalResourceTraits,
+		externalPrincipalIndex:              externalPrincipalIndex,
 		targetedSyncResources:               targetedSyncResources,
 		syncResourceTypeIDs:                 syncResourceTypeIDs,
 		workerCount:                         workerCount,

--- a/pkg/tasks/c1api/manager.go
+++ b/pkg/tasks/c1api/manager.go
@@ -425,20 +425,7 @@ func (c *c1ApiTaskManager) Process(ctx context.Context, task *v1.Task, cc types.
 	var handler tasks.TaskHandler
 	switch tasks.GetType(task) {
 	case taskTypes.FullSyncType:
-		handler = newFullSyncTaskHandler(
-			task,
-			tHelpers,
-			c.skipFullSync,
-			c.externalResourceC1Z,
-			c.externalResourceEntitlementIdFilter,
-			c.externalResourceTraits,
-			c.externalPrincipalIndex,
-			c.targetedSyncResources,
-			c.syncResourceTypeIDs,
-			c.workerCount,
-			c.storageEngine,
-			c.previousSyncSparePath,
-		)
+		handler = c.newFullSyncHandler(task, tHelpers)
 	case taskTypes.HelloType:
 		handler = newHelloTaskHandler(task, tHelpers)
 	case taskTypes.GrantType:
@@ -490,6 +477,27 @@ func (c *c1ApiTaskManager) Process(ctx context.Context, task *v1.Task, cc types.
 	}
 
 	return nil
+}
+
+// newFullSyncHandler hands the manager's sync configuration to a full-sync
+// handler. Split out of Process so the hand-off is reachable from a test:
+// these values arrive as a positional argument list and one dropped along the
+// way changes how every sync runs, silently.
+func (c *c1ApiTaskManager) newFullSyncHandler(task *v1.Task, tHelpers fullSyncHelpers) tasks.TaskHandler {
+	return newFullSyncTaskHandler(
+		task,
+		tHelpers,
+		c.skipFullSync,
+		c.externalResourceC1Z,
+		c.externalResourceEntitlementIdFilter,
+		c.externalResourceTraits,
+		c.externalPrincipalIndex,
+		c.targetedSyncResources,
+		c.syncResourceTypeIDs,
+		c.workerCount,
+		c.storageEngine,
+		c.previousSyncSparePath,
+	)
 }
 
 // ensure *c1ApiTaskManager satisfies BootstrappingTaskManager.

--- a/pkg/tasks/local/syncer.go
+++ b/pkg/tasks/local/syncer.go
@@ -123,17 +123,11 @@ func (m *localSyncer) Next(ctx context.Context) (*v1.Task, time.Duration, error)
 	return task, 0, nil
 }
 
-func (m *localSyncer) Process(ctx context.Context, task *v1.Task, cc types.ConnectorClient) error {
-	ctx, span := tracer.Start(ctx, "localSyncer.Process", trace.WithNewRoot())
-	ctx = uotelzap.WithSpanLogFields(ctx)
-	var err error
-	defer func() { uotel.EndSpanWithError(span, err) }()
-
-	var setSessionStore session.SetSessionStore
-	if ssetSessionStore, ok := cc.(session.SetSessionStore); ok {
-		setSessionStore = ssetSessionStore
-	}
-
+// syncOpts translates this task's configuration into sync engine options.
+// Split out of Process so the translation is reachable from a test: a value
+// dropped here compiles and runs, and produces a sync configured differently
+// than the caller asked for with no other signal.
+func (m *localSyncer) syncOpts(setSessionStore session.SetSessionStore) []sdkSync.SyncOpt {
 	syncOpts := []sdkSync.SyncOpt{
 		sdkSync.WithC1ZPath(m.dbPath),
 		sdkSync.WithTmpDir(m.tmpDir),
@@ -151,6 +145,22 @@ func (m *localSyncer) Process(ctx context.Context, task *v1.Task, cc types.Conne
 	if m.storageEngine != "" {
 		syncOpts = append(syncOpts, sdkSync.WithStorageEngine(m.storageEngine))
 	}
+
+	return syncOpts
+}
+
+func (m *localSyncer) Process(ctx context.Context, task *v1.Task, cc types.ConnectorClient) error {
+	ctx, span := tracer.Start(ctx, "localSyncer.Process", trace.WithNewRoot())
+	ctx = uotelzap.WithSpanLogFields(ctx)
+	var err error
+	defer func() { uotel.EndSpanWithError(span, err) }()
+
+	var setSessionStore session.SetSessionStore
+	if ssetSessionStore, ok := cc.(session.SetSessionStore); ok {
+		setSessionStore = ssetSessionStore
+	}
+
+	syncOpts := m.syncOpts(setSessionStore)
 
 	syncer, err := sdkSync.NewSyncer(ctx, cc, syncOpts...)
 	if err != nil {

--- a/pkg/tasks/local/syncer.go
+++ b/pkg/tasks/local/syncer.go
@@ -29,6 +29,7 @@ type localSyncer struct {
 	targetedSyncResources               []*v2.Resource
 	skipEntitlementsAndGrants           bool
 	skipGrants                          bool
+	externalPrincipalIndex              bool
 	syncResourceTypeIDs                 []string
 	workerCount                         int
 	storageEngine                       c1zstore.Engine
@@ -84,6 +85,14 @@ func WithSkipGrants(skip bool) Option {
 	}
 }
 
+// WithExternalPrincipalIndex enables the indexed external-principal matcher
+// in the sync engine. Off by default; see sync.WithExternalPrincipalIndex.
+func WithExternalPrincipalIndex(enabled bool) Option {
+	return func(m *localSyncer) {
+		m.externalPrincipalIndex = enabled
+	}
+}
+
 func WithWorkerCount(workerCount int) Option {
 	return func(m *localSyncer) {
 		m.workerCount = workerCount
@@ -134,6 +143,7 @@ func (m *localSyncer) Process(ctx context.Context, task *v1.Task, cc types.Conne
 		sdkSync.WithTargetedSyncResources(m.targetedSyncResources),
 		sdkSync.WithSkipEntitlementsAndGrants(m.skipEntitlementsAndGrants),
 		sdkSync.WithSkipGrants(m.skipGrants),
+		sdkSync.WithExternalPrincipalIndex(m.externalPrincipalIndex),
 		sdkSync.WithSessionStore(setSessionStore),
 		sdkSync.WithSyncResourceTypes(m.syncResourceTypeIDs),
 		sdkSync.WithWorkerCount(m.workerCount),

--- a/pkg/tasks/local/syncer_opts_test.go
+++ b/pkg/tasks/local/syncer_opts_test.go
@@ -1,0 +1,50 @@
+package local
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	sdkSync "github.com/conductorone/baton-sdk/pkg/sync"
+)
+
+// The local task path carries configuration to the sync engine through the
+// same shape the service-mode path does -- option constructor, task field,
+// SyncOpt -- so it gets the same treatment: run the assembled options through a
+// real engine and read the field they were supposed to set.
+//
+// The fields are unexported and a SyncOpt is an opaque closure that cannot be
+// identified or applied from outside pkg/sync, so the assertion reads them
+// reflectively. Same trade-off, and same twin, as
+// pkg/tasks/c1api/full_sync_opts_test.go: the alternative is asserting nothing.
+func localSyncerEngine(t *testing.T, opts ...Option) reflect.Value {
+	t.Helper()
+
+	syncer := &localSyncer{dbPath: filepath.Join(t.TempDir(), "sync.c1z")}
+	for _, opt := range opts {
+		opt(syncer)
+	}
+
+	created, err := sdkSync.NewSyncer(t.Context(), nil, syncer.syncOpts(nil)...)
+	require.NoError(t, err)
+
+	value := reflect.ValueOf(created)
+	require.Equal(t, reflect.Ptr, value.Kind(), "NewSyncer must return a pointer to inspect")
+
+	field := value.Elem().FieldByName("externalPrincipalIndexEnabled")
+	require.True(t, field.IsValid(),
+		"pkg/sync syncer has no field \"externalPrincipalIndexEnabled\": this test reads it by "+
+			"name to prove local-mode configuration reaches the sync engine, so a rename needs "+
+			"updating here too")
+	return field
+}
+
+func TestLocalSyncerThreadsExternalPrincipalIndex(t *testing.T) {
+	require.False(t, localSyncerEngine(t).Bool(),
+		"the linear scan is the default and must survive a task configured with no options")
+	require.False(t, localSyncerEngine(t, WithExternalPrincipalIndex(false)).Bool())
+	require.True(t, localSyncerEngine(t, WithExternalPrincipalIndex(true)).Bool(),
+		"a local task opted into the indexed matcher must reach the engine with it enabled")
+}


### PR DESCRIPTION
## What

Makes the indexed external-principal matcher added in #1046 opt-in, and restores the pre-#1046 linear scan as the default.

New sync option:

```go
// Defaults to false (linear scan).
sync.WithExternalPrincipalIndex(enabled bool) SyncOpt
```

Threaded through the layers standalone connector binaries go through, so they get the same switch for free:

- `local.WithExternalPrincipalIndex(bool) Option` (`pkg/tasks/local`) — one-shot / on-demand
- `c1api.NewC1TaskManager` → `newFullSyncTaskHandler` → `fullSyncTaskHandler.sync` — service / daemon mode
- `connectorrunner.WithExternalPrincipalIndex(bool) Option` — feeds both of the above
- `--external-principal-index` / `BATON_EXTERNAL_PRINCIPAL_INDEX` (`field.ExternalPrincipalIndexField`, default false)

All four places in the tree that assemble `sdkSync.SyncOpt`s carry the flag.

## Why

#1046 is a real fix: the old matcher was O(grants × principals) proto unmarshals and a tenant with ~99k externally matched grants never finished the step inside the sync deadline. Nothing here questions that, and nothing in `pkg/sync/external_principal_index.go` is modified.

The concern is blast radius, not correctness. As merged, the new grant-matching path becomes mandatory for every tenant the moment its connector bumps its baton-sdk dependency — `baton-sharepoint`, `baton-aks`, `baton-eks` and `baton-google-cloud-platform` all use this feature today. A behavior change in grant matching is an access-correctness change, so it wants a per-tenant rollout and a rollback that doesn't require an SDK downgrade and a connector re-release.

So: default to the behavior every tenant is running today, let the platform enable the index per tenant, and remove the flag once it's at 100%. This is a kill switch, not a revert.

## What changed

Only the "match by key/val" branch of `processGrantsWithExternalPrincipals` is forked, into two methods:

- `matchExternalPrincipalsLegacy` — the pre-#1046 loop (including the `matchProfileAndExpandLegacy` variant that re-checks the profile inline, and the restored `userTraitContainsEmail` helper).
- `matchExternalPrincipalsIndexed` — #1046's logic, lifted out of the loop body unchanged.

Everything else is shared and untouched: setup, `ExternalResourceMatchAll`, `ExternalResourceMatchID`, the expandable-entitlement map, the delete/put loop. #1046's observability additions (progress log interval, the info/debug lines) are orthogonal and stay active in **both** modes, with an added `indexed` field so logs say which matcher ran.

The per-trait index is only built when the indexed matcher is selected — indexing every principal is exactly the work the legacy path exists to avoid.

One deliberate deviation from a verbatim restore: the legacy path's "error getting user trait" log records the principal's ids rather than the whole resource. Logging the resource serializes its profile, which is where a directory keeps emails and employee numbers; #1046 fixed that and re-introducing it as part of a rollback switch would be a privacy regression. It has no effect on which grants are produced.

## Tested

- **`TestExternalPrincipalMatchLegacyIndexedParity`** (new) — the actual proof the flag is safe to flip. One fixture through `processGrantsWithExternalPrincipals` twice, once per mode, requiring byte-identical store contents (deterministic proto marshal of every resulting grant). Fixture covers: a user matched on a non-`email` profile key (case-insensitively), a user matched via user-trait email, a user matched **both** ways at once (must yield one grant, not two), a user whose user trait can't be unmarshalled (must be skipped outright, including for the profile key it would otherwise match), group principals matched on a profile key — one with a resolvable expandable entitlement and one hitting the not-found arm — a match key no principal carries, a match against an unconfigured trait, and `MatchAll` / `MatchByID` carriers that the flag does not fork. Run against both the SQLite and Pebble engines, and with both the default trait set and a `TRAIT_GROUP`-only set (which exercises the "TRAIT_USER match arrives but USER isn't a configured match trait" arm on both sides).
- **`TestExternalPrincipalMatchParityFixtureExpectations`** (new) — pins *what* the two matchers agree on, so parity can't be satisfied by two identically-wrong matchers.
- **`TestExternalPrincipalMatchParitySkipsUnreadableUserTrait`** (new) — the skip is an absence, which a digest comparison alone wouldn't catch.
- **`TestExternalResourceUserProfileMatch`** — added `WithExternalPrincipalIndex(true)`; it was written for the indexed path, which is no longer the default.
- **`TestExternalPrincipalMatchDedupesAtTheMatcher`** (new) — asserts on the grants the matchers *return*, not on store contents: two grants for one principal share a generated grant id and get upserted into a single row, so a lost dedup is invisible to any post-`PutGrants` assertion.
- **`TestExternalResourceMatch*FoldingContract`** / **`TestExternalResourceMatchEmitsOneGrantPerPrincipal`** — now run in both modes (see review fixes below).
- **`TestWithExternalPrincipalIndexOptionWiring`** (new) — pins the default and the opt-in through `NewSyncer`.
- Existing `external_principal_index_test.go` and the `verification`-tagged suite are unchanged and still pass.

```
go build ./...
go test ./pkg/sync/... ./pkg/connectorrunner/... ./pkg/cli/... ./pkg/field/... ./pkg/tasks/... -count=1     # all ok
go test -tags verification ./pkg/sync/ -run TestVerificationExternalPrincipal -count=1                      # ok
golangci-lint run ./pkg/sync/... ./pkg/cli/... ./pkg/field/... ./pkg/connectorrunner/... ./pkg/tasks/...    # only a pre-existing nolintlint hit in ingest_invariants.go, untouched here
```

## Breaking change + release note

`c1api.NewC1TaskManager` is exported and this PR inserts a positional `bool` (`externalPrincipalIndex`) mid-argument-list, so any out-of-repo caller will fail to compile. Together with the default behavior flip (indexed → linear scan for existing callers), **the release this lands in should be a minor bump (`v0.25.0`), not a patch.**

`pkg/sdk/version.go` is deliberately not touched here: version bumps in this repo are made by release automation in standalone commits (`c15e57f`, `d246787`, …), so hand-editing it in a feature PR would fight that process. Flagging it for whoever cuts the release instead. Happy to include the bump in this PR if that's the preference.

Reshaping `NewC1TaskManager` into a variadic-option or config-struct constructor is the right long-term fix for this argument list (14 positional parameters, five of them now sync configuration). That is deliberately **deferred** — it is a much larger, riskier change than a kill-switch PR should carry, and it would break the same callers a second time.

## Review fixes (second commit)

An adversarial review found the equivalence itself clean under mutation testing, plus three gaps, all fixed in `e68cee0`:

1. **The flag never reached service mode.** `runner.go` threaded it into `local.NewSyncer` only, so a daemon-mode connector (`c1api.NewC1TaskManager`) setting `BATON_EXTERNAL_PRINCIPAL_INDEX=true` silently kept using the linear scan — the exact deployment mode #1046's motivating incident happened in, which made the switch useless where it matters most. Now plumbed hop-for-hop alongside `externalResourceTraits`.
2. **`external_match_folding_test.go` silently lost indexed coverage.** It builds a bare `&syncer{}`, so defaulting the flag to false moved the folding contracts (added in #1060) off the matcher they were written to pin. The linear scan satisfies them for free by calling `strings.EqualFold` directly, leaving the index's bucketing — where a fold can actually be gotten wrong — unpinned. All three tests now run in both modes. Verified by mutation: bucketing on `strings.ToLower` fails greek-final-sigma, long-s and dotted-capital-İ in `indexed=true` only.
3. **The parity digest could not see a lost dedup** (upserted away by `PutGrants` before the comparison). Closed with the matcher-level assertion above. Verified by mutation: deleting the email-match `continue` in the legacy scan now fails the suite.

## Review fixes (third commit)

Automated review found two further gaps, fixed in `af9a848`:

4. **The service-mode fix had no regression test** — deleting any of its four plumbing lines left the suite green, which is precisely how the path came to be dropped in the first place. The two hand-offs that carry configuration through positional argument lists are now methods (`c1ApiTaskManager.newFullSyncHandler`, `fullSyncTaskHandler.syncOpts`, both pure extractions), and `pkg/tasks/c1api/full_sync_opts_test.go` asserts them by running the assembled options through a real sync engine and reading the field they set. `externalResourceTraits` is covered the same way, since it had the identical gap. Verified by mutation: dropping the append in `syncOpts`, hardcoding the handler field, and passing `false` from the manager each fail the suite.

   Note on technique: the assertion reads unexported `syncer` fields reflectively. A `SyncOpt` is an opaque closure that cannot be identified or applied from outside `pkg/sync`, so letting the options act on a real engine is the only way to prove one *survived the plumbing* rather than merely that some option was appended. (Comparing option code pointers does not work — `reflect` yields a closure instance address, so two calls of the same constructor already differ.) Three of the four hops are now mutation-covered; `connectorrunner` → `NewC1TaskManager` still needs a live service client to reach and remains uncovered.

5. **The `verification`-tagged crash-cut / resume / same-checkpoint-twice cell** built bare syncers, so after the default flip it only replayed the legacy scan — the indexed path was never resumed or replayed by any test. Now parameterized over both matchers with the same helper used for the folding contracts. Both modes agree on every batch size the cell pins (`{9}`, `{33}`, `{33, 27}`), which is itself a small extra equivalence signal across the checkpoint seam.

One inline bot comment about the service-mode branch not receiving the flag was posted against the pre-fix commit `79ecb38` and is stale; the reviewer's own summary at `e68cee0` confirms it.

## Review fixes (fourth commit)

Two more from automated review, fixed in `1faf55b`:

6. **The local / CLI chain had no coverage** — round 3 proved out the service-mode chain and left its twin untested, even though `--external-principal-index` → `connectorrunner.WithExternalPrincipalIndex` → `cfg` → `local.WithExternalPrincipalIndex` → `sdkSync.WithExternalPrincipalIndex` → engine has exactly the same drop-a-value-silently shape. `localSyncer.syncOpts` is now split out of `Process` (same pure extraction as `fullSyncTaskHandler.syncOpts`) and asserted the same way, plus a runner-level test that the `Option` reaches `runnerConfig`. Mutation-verified: dropping the option from `localSyncer.syncOpts`, dropping the value in `local.WithExternalPrincipalIndex`, and dropping it in `connectorrunner.WithExternalPrincipalIndex` each fail.

7. **Misplaced doc comment** in `full_sync_opts_test.go` — the `externalResourceTraits` comment sat above the manager hand-off test. Moved.

### Wiring coverage after all rounds

| Hop | Covered |
|---|---|
| `SyncOpt` → `syncer.externalPrincipalIndexEnabled` | `pkg/sync` — `TestWithExternalPrincipalIndexOptionWiring` |
| `connectorrunner.Option` → `runnerConfig` | `pkg/connectorrunner` — `TestWithExternalPrincipalIndexOption` |
| `localSyncer` → engine | `pkg/tasks/local` — `TestLocalSyncerThreadsExternalPrincipalIndex` |
| `c1ApiTaskManager` → handler | `pkg/tasks/c1api` — `TestC1TaskManagerThreadsExternalPrincipalIndexToHandler` |
| handler → engine | `pkg/tasks/c1api` — `TestFullSyncTaskHandlerThreadsExternalPrincipalIndex` |
| `NewConnectorRunner` → task manager | **not covered** — needs a live connector wrapper to construct |

Every row except the last is mutation-verified.

## Coordination note

`ben.su/ce-975/external-resource-traits` (referenced from #1046's description) touches the same function. This PR restructures that region into `matchExternalPrincipalsLegacy` / `matchExternalPrincipalsIndexed`, so whichever lands second will need a rebase. Not resolved here — flagging for whoever sequences the two. The new trait plumbing should slot into both matchers identically (both already take `matchTraits`), but that wants a look from someone with that branch's context.

## Open question

The CLI flag is registered visible rather than `WithHidden(true)` (which is what `--skip-grants` does). It's an internal engine toggle, but it's also the only escape hatch a standalone connector operator has on a large tenant. Happy to hide it if the preference is to keep the flag surface minimal.
