### PR TITLE
dotc1z: batch external-principal grant deletes into chunked commits

### DIFF
--- a/pkg/dotc1z/engine/pebble/adapter.go
+++ b/pkg/dotc1z/engine/pebble/adapter.go
@@ -636,6 +636,12 @@ func (e *Engine) DeleteGrantByRefs(ctx context.Context, grant *v2.Grant) error {
 // refs-derived identity per grant, but the whole set is deleted through
 // chunked batches rather than one fsync'd commit per grant. See
 // DeleteGrantsByIdentityRefs for why that matters.
+//
+// Identities are derived in one pass so only the small fixed-size
+// grantIdentity slice is retained: V2GrantToV3 allocates annotation and
+// source slices (and unmarshals GrantExpandable) per grant, and holding N of
+// those alive alongside N identities would be the largest allocation in a
+// 90k-grant delete.
 func (e *Engine) DeleteGrantsByRefs(ctx context.Context, grants ...*v2.Grant) error {
 	if len(grants) == 0 {
 		return nil
@@ -644,15 +650,15 @@ func (e *Engine) DeleteGrantsByRefs(ctx context.Context, grants ...*v2.Grant) er
 	if syncID == "" {
 		return ErrNoCurrentSync
 	}
-	records := make([]*v3.GrantRecord, 0, len(grants))
+	ids := make([]grantIdentity, 0, len(grants))
 	for _, grant := range grants {
-		rec := V2GrantToV3(syncID, grant)
-		if _, err := grantIdentityFromRecord(rec); err != nil {
+		id, err := grantIdentityFromRecord(V2GrantToV3(syncID, grant))
+		if err != nil {
 			return fmt.Errorf("DeleteGrantsByRefs: grant %q: %w", grant.GetId(), err)
 		}
-		records = append(records, rec)
+		ids = append(ids, id)
 	}
-	return e.DeleteGrantsByIdentityRefs(ctx, records...)
+	return e.deleteGrantsByIdentities(ctx, grantDeleteBatchChunk, ids)
 }
 
 // PutAsset writes a single asset row. assetRef carries the

--- a/pkg/dotc1z/engine/pebble/adapter.go
+++ b/pkg/dotc1z/engine/pebble/adapter.go
@@ -632,6 +632,29 @@ func (e *Engine) DeleteGrantByRefs(ctx context.Context, grant *v2.Grant) error {
 	return e.DeleteGrantByIdentityRefs(ctx, rec)
 }
 
+// DeleteGrantsByRefs is the bulk sibling of DeleteGrantByRefs: same exact,
+// refs-derived identity per grant, but the whole set is deleted through
+// chunked batches rather than one fsync'd commit per grant. See
+// DeleteGrantsByIdentityRefs for why that matters.
+func (e *Engine) DeleteGrantsByRefs(ctx context.Context, grants ...*v2.Grant) error {
+	if len(grants) == 0 {
+		return nil
+	}
+	syncID := e.CurrentSyncID()
+	if syncID == "" {
+		return ErrNoCurrentSync
+	}
+	records := make([]*v3.GrantRecord, 0, len(grants))
+	for _, grant := range grants {
+		rec := V2GrantToV3(syncID, grant)
+		if _, err := grantIdentityFromRecord(rec); err != nil {
+			return fmt.Errorf("DeleteGrantsByRefs: grant %q: %w", grant.GetId(), err)
+		}
+		records = append(records, rec)
+	}
+	return e.DeleteGrantsByIdentityRefs(ctx, records...)
+}
+
 // PutAsset writes a single asset row. assetRef carries the
 // (resource_type, resource_id) pair we use as the external_id —
 // joined with a "/" separator since the engine's AssetRecord PK is

--- a/pkg/dotc1z/engine/pebble/grant_batch_delete_test.go
+++ b/pkg/dotc1z/engine/pebble/grant_batch_delete_test.go
@@ -2,6 +2,7 @@ package pebble
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"testing"
 
@@ -294,6 +295,28 @@ func TestDeleteGrantsByRefsCommitsInChunks(t *testing.T) {
 	require.Equal(t, 0, countKeys(t, e, encodeGrantPrefix()), "every grant must be deleted")
 	require.Equal(t, 0, countKeys(t, e, GrantByPrincipalLowerBound()),
 		"by_principal must be emptied alongside the primary rows")
+}
+
+// TestDeleteGrantsByIdentitiesClampsNonPositiveChunk pins the guard against a
+// chunk of 0 or less. The chunking loop advances by chunk, so a non-positive
+// value would never reach the end and would spin forever holding the engine
+// write lock and a writeWG slot — an unkillable hang, not a returned error.
+// No production caller can reach it (both pass the constant), so the guard
+// clamps to the default and the call still deletes everything it was given.
+func TestDeleteGrantsByIdentitiesClampsNonPositiveChunk(t *testing.T) {
+	for _, chunk := range []int{0, -1} {
+		t.Run(fmt.Sprintf("chunk-%d", chunk), func(t *testing.T) {
+			e, recs := batchDeleteScaleFixture(t, 4)
+
+			probe := &chunkProbeCtx{Context: context.Background()}
+			require.NoError(t, deleteBatchedWithChunk(probe, e, chunk, recs...))
+
+			require.Equal(t, 1, probe.checks,
+				"a clamped chunk must commit these grants as a single chunk")
+			require.Equal(t, 0, countKeys(t, e, encodeGrantPrefix()),
+				"every grant must be deleted")
+		})
+	}
 }
 
 // TestDeleteGrantsByRefsHonorsCancellation covers the other half of the chunk

--- a/pkg/dotc1z/engine/pebble/grant_batch_delete_test.go
+++ b/pkg/dotc1z/engine/pebble/grant_batch_delete_test.go
@@ -2,6 +2,7 @@ package pebble
 
 import (
 	"context"
+	"strconv"
 	"testing"
 
 	"github.com/cockroachdb/pebble/v2"
@@ -115,6 +116,20 @@ func deleteSingularly(t *testing.T, e *Engine, records ...*v3.GrantRecord) {
 	}
 }
 
+// deleteBatchedWithChunk is DeleteGrantsByIdentityRefs with the chunk size
+// overridden, for the cases that need to straddle a boundary cheaply.
+func deleteBatchedWithChunk(ctx context.Context, e *Engine, chunk int, records ...*v3.GrantRecord) error {
+	ids := make([]grantIdentity, 0, len(records))
+	for _, r := range records {
+		id, err := grantIdentityFromRecord(r)
+		if err != nil {
+			return err
+		}
+		ids = append(ids, id)
+	}
+	return e.deleteGrantsByIdentities(ctx, chunk, ids)
+}
+
 // TestDeleteGrantsByRefsMatchesSingularPath is the equivalence oracle: the
 // batched delete must leave a store indistinguishable from one where the same
 // grants were deleted one durable commit at a time, across the primary rows,
@@ -127,11 +142,13 @@ func TestDeleteGrantsByRefsMatchesSingularPath(t *testing.T) {
 		makeExpandableGrant("g-b-erin", "ent-B", "erin"),
 	}
 
-	// chunk=2 forces a chunk boundary mid-set with a six-row fixture, so the
-	// production chunking loop is exercised without a 10k-grant fixture.
+	// chunk=1 and chunk=2 straddle boundaries within the six-row fixture;
+	// grantDeleteBatchChunk is the single-chunk case. That the chunking loop
+	// runs at all is pinned separately, by
+	// TestDeleteGrantsByRefsCommitsInChunks.
 	for _, chunk := range []int{1, 2, grantDeleteBatchChunk} {
 		batched := batchDeleteFixture(t)
-		require.NoError(t, batched.deleteGrantsByIdentityRefs(ctx, chunk, victims...))
+		require.NoError(t, deleteBatchedWithChunk(ctx, batched, chunk, victims...))
 
 		singular := batchDeleteFixture(t)
 		deleteSingularly(t, singular, victims...)
@@ -200,7 +217,7 @@ func TestDeleteGrantsByRefsMixedBatch(t *testing.T) {
 	// are covered.
 	for _, chunk := range []int{3, grantDeleteBatchChunk} {
 		batched := batchDeleteFixture(t)
-		require.NoError(t, batched.deleteGrantsByIdentityRefs(ctx, chunk, mixed...))
+		require.NoError(t, deleteBatchedWithChunk(ctx, batched, chunk, mixed...))
 
 		singular := batchDeleteFixture(t)
 		deleteSingularly(t, singular, mixed...)
@@ -209,4 +226,130 @@ func TestDeleteGrantsByRefsMixedBatch(t *testing.T) {
 			"exactly the two present identities must be gone")
 		requireSameGrantKeyspaces(t, batched, singular)
 	}
+}
+
+// chunkProbeCtx counts ctx.Err() calls and optionally starts failing them
+// after a given number. deleteGrantsByIdentities consults ctx exactly once
+// per chunk and nothing else in the call path touches it, so the count IS the
+// number of chunks — which makes the chunking observable without adding any
+// production test seam.
+type chunkProbeCtx struct {
+	context.Context
+	checks     int
+	cancelUpon int
+	// onCheck runs at each boundary, before the sealed re-check that
+	// immediately follows ctx.Err() in the loop — which is how a test can
+	// seal the engine strictly between two chunks.
+	onCheck func(check int)
+}
+
+func (c *chunkProbeCtx) Err() error {
+	c.checks++
+	if c.onCheck != nil {
+		c.onCheck(c.checks)
+	}
+	if c.cancelUpon > 0 && c.checks >= c.cancelUpon {
+		return context.Canceled
+	}
+	return c.Context.Err()
+}
+
+// batchDeleteScaleFixture writes n grants under one entitlement, seals to
+// build digest state, and rebinds the sync — the same shape as
+// batchDeleteFixture but sized to cross the real chunk boundary.
+func batchDeleteScaleFixture(t *testing.T, n int) (*Engine, []*v3.GrantRecord) {
+	t.Helper()
+	ctx := context.Background()
+	e, _ := newTestEngine(t)
+	a := NewAdapter(e)
+
+	_, err := a.StartNewSyncWithID(ctx, connectorstore.SyncTypeFull, batchDeleteSyncID, "")
+	require.NoError(t, err)
+	putEnt(t, e, ctx, "ent-A")
+	recs := make([]*v3.GrantRecord, 0, n)
+	for i := range n {
+		recs = append(recs, makeGrant("", "g-"+strconv.Itoa(i), "ent-A", "user-"+strconv.Itoa(i)))
+	}
+	require.NoError(t, e.PutGrantRecords(ctx, recs...))
+	require.NoError(t, a.EndSync(ctx))
+	require.NoError(t, a.SetCurrentSync(ctx, batchDeleteSyncID))
+	require.Equal(t, n, countKeys(t, e, encodeGrantPrefix()))
+	return e, recs
+}
+
+// TestDeleteGrantsByRefsCommitsInChunks pins that the production entry point
+// actually chunks at grantDeleteBatchChunk, using a record count that crosses
+// the real boundary twice. Without this, a change that ignored the chunk size
+// and staged one unbounded batch — the exact memory blow-up the constant
+// exists to prevent — would pass every other test in this file.
+func TestDeleteGrantsByRefsCommitsInChunks(t *testing.T) {
+	n := grantDeleteBatchChunk*2 + grantDeleteBatchChunk/2 // 2.5 chunks
+	e, recs := batchDeleteScaleFixture(t, n)
+
+	probe := &chunkProbeCtx{Context: context.Background()}
+	require.NoError(t, e.DeleteGrantsByIdentityRefs(probe, recs...))
+
+	require.Equal(t, 3, probe.checks,
+		"%d grants at a chunk of %d must be committed as 3 chunks", n, grantDeleteBatchChunk)
+	require.Equal(t, 0, countKeys(t, e, encodeGrantPrefix()), "every grant must be deleted")
+	require.Equal(t, 0, countKeys(t, e, GrantByPrincipalLowerBound()),
+		"by_principal must be emptied alongside the primary rows")
+}
+
+// TestDeleteGrantsByRefsHonorsCancellation covers the other half of the chunk
+// contract: a cancelled context aborts at the next chunk boundary, and the
+// chunks already committed stay committed. The apply phase this exists for
+// was previously uninterruptible for its whole ~956s.
+func TestDeleteGrantsByRefsHonorsCancellation(t *testing.T) {
+	n := grantDeleteBatchChunk * 3
+	e, recs := batchDeleteScaleFixture(t, n)
+
+	// Pass the first boundary check, fail the second: exactly one chunk
+	// commits.
+	probe := &chunkProbeCtx{Context: context.Background(), cancelUpon: 2}
+	err := e.DeleteGrantsByIdentityRefs(probe, recs...)
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, n-grantDeleteBatchChunk, countKeys(t, e, encodeGrantPrefix()),
+		"the one chunk committed before the cancel must be durable, and no more")
+}
+
+// TestDeleteGrantsByRefsRefusesSealedEngine is the ordinary case: an engine
+// already sealed at entry refuses, via withWrite's own check.
+func TestDeleteGrantsByRefsRefusesSealedEngine(t *testing.T) {
+	ctx := context.Background()
+	e := batchDeleteFixture(t)
+	require.NoError(t, NewAdapter(e).EndSync(ctx))
+
+	err := e.DeleteGrantsByIdentityRefs(ctx, batchDeleteFixtureGrants()...)
+	require.ErrorIs(t, err, ErrEngineSealed)
+	require.Equal(t, 6, countKeys(t, e, encodeGrantPrefix()),
+		"a sealed engine must not have deleted anything")
+}
+
+// TestDeleteGrantsByRefsStopsWhenSealedMidCall pins the fence that holding
+// the write lock across every chunk would otherwise coarsen from per-write to
+// per-call. seal() takes only sealMu and never waits on writeWG, so an
+// in-flight bulk delete CAN be sealed underneath — and the remaining chunks,
+// with the digest invalidations they stage, must not land after finalize has
+// begun rebuilding the deferred by_principal index.
+//
+// Sealing from the boundary hook makes that deterministic: the hook runs
+// immediately before the loop's sealed re-check.
+func TestDeleteGrantsByRefsStopsWhenSealedMidCall(t *testing.T) {
+	n := grantDeleteBatchChunk * 3
+	e, recs := batchDeleteScaleFixture(t, n)
+
+	probe := &chunkProbeCtx{Context: context.Background()}
+	probe.onCheck = func(check int) {
+		if check == 2 {
+			e.seal()
+		}
+	}
+	err := e.DeleteGrantsByIdentityRefs(probe, recs...)
+
+	require.ErrorIs(t, err, ErrEngineSealed,
+		"chunks after the seal must be refused, not committed")
+	require.Equal(t, n-grantDeleteBatchChunk, countKeys(t, e, encodeGrantPrefix()),
+		"only the chunk committed before the seal may have applied")
 }

--- a/pkg/dotc1z/engine/pebble/grant_batch_delete_test.go
+++ b/pkg/dotc1z/engine/pebble/grant_batch_delete_test.go
@@ -1,0 +1,212 @@
+package pebble
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/stretchr/testify/require"
+
+	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+)
+
+// batchDeleteSyncID pins the sync id: grant keys embed it, so two
+// independently-built fixtures are only byte-comparable when they share one.
+const batchDeleteSyncID = "0ujsswThIGTUYm2K8FjOOfXtY1K"
+
+// makeExpandableGrant is makeGrant with needs_expansion set, so a fixture
+// populates by_needs_expansion as well as by_principal — a batched delete
+// that dropped either index obligation must be visible.
+func makeExpandableGrant(externalID, entID, principalID string) *v3.GrantRecord {
+	r := makeGrant("", externalID, entID, principalID)
+	r.SetNeedsExpansion(true)
+	return r
+}
+
+// batchDeleteFixtureGrants spans two entitlement partitions (so a delete
+// invalidates one digest partition and must leave the other intact) and mixes
+// expandable and plain grants.
+func batchDeleteFixtureGrants() []*v3.GrantRecord {
+	return []*v3.GrantRecord{
+		makeGrant("", "g-a-alice", "ent-A", "alice"),
+		makeExpandableGrant("g-a-bob", "ent-A", "bob"),
+		makeGrant("", "g-a-carol", "ent-A", "carol"),
+		makeGrant("", "g-b-dave", "ent-B", "dave"),
+		makeExpandableGrant("g-b-erin", "ent-B", "erin"),
+		makeGrant("", "g-b-frank", "ent-B", "frank"),
+	}
+}
+
+// batchDeleteFixture builds the store shape the syncer's external-principal
+// cleanup deletes into: grants written, EndSync run (which builds the digest
+// state, so deletes owe digest invalidation), then the sync rebound so the
+// engine is writable and NOT fresh.
+func batchDeleteFixture(t *testing.T) *Engine {
+	t.Helper()
+	ctx := context.Background()
+	e, _ := newTestEngine(t)
+	a := NewAdapter(e)
+
+	_, err := a.StartNewSyncWithID(ctx, connectorstore.SyncTypeFull, batchDeleteSyncID, "")
+	require.NoError(t, err)
+	putEnt(t, e, ctx, "ent-A")
+	putEnt(t, e, ctx, "ent-B")
+	require.NoError(t, e.PutGrantRecords(ctx, batchDeleteFixtureGrants()...))
+	require.NoError(t, a.EndSync(ctx))
+	require.NoError(t, a.SetCurrentSync(ctx, batchDeleteSyncID))
+
+	// Non-vacuity: every family the comparison inspects must be populated
+	// before anything is deleted, or "indistinguishable" would be trivial.
+	for name, keys := range grantKeyspaces(t, e) {
+		require.NotEmpty(t, keys, "fixture must populate the %s keyspace", name)
+	}
+	return e
+}
+
+func dumpKeyRange(t testing.TB, e *Engine, lo, hi []byte) map[string][]byte {
+	t.Helper()
+	it, err := e.db.NewIter(&pebble.IterOptions{LowerBound: lo, UpperBound: hi})
+	require.NoError(t, err)
+	defer func() { _ = it.Close() }()
+	out := make(map[string][]byte)
+	for it.First(); it.Valid(); it.Next() {
+		out[string(it.Key())] = append([]byte(nil), it.Value()...)
+	}
+	require.NoError(t, it.Error())
+	return out
+}
+
+// grantKeyspaces dumps every key family a grant delete is obligated to
+// maintain: the primary row, both live secondary indexes, and the digest
+// state (nodes + hash index). Two stores agreeing on all five are
+// indistinguishable as far as grants are concerned — which is the whole risk
+// of batching, since a batched delete that skipped an index or digest
+// obligation would show up here and nowhere else.
+func grantKeyspaces(t testing.TB, e *Engine) map[string]map[string][]byte {
+	t.Helper()
+	grantPrefix := encodeGrantPrefix()
+	return map[string]map[string][]byte{
+		"primary":            dumpKeyRange(t, e, grantPrefix, upperBoundOf(grantPrefix)),
+		"by_principal":       dumpKeyRange(t, e, GrantByPrincipalLowerBound(), GrantByPrincipalUpperBound()),
+		"by_needs_expansion": dumpKeyRange(t, e, GrantByNeedsExpansionLowerBound(), GrantByNeedsExpansionUpperBound()),
+		"digest_nodes":       dumpKeyRange(t, e, DigestLowerBound(), DigestUpperBound()),
+		"digest_hash_index":  dumpKeyRange(t, e, GrantByEntPrincHashLowerBound(), GrantByEntPrincHashUpperBound()),
+	}
+}
+
+func requireSameGrantKeyspaces(t *testing.T, batched, singular *Engine) {
+	t.Helper()
+	got := grantKeyspaces(t, batched)
+	want := grantKeyspaces(t, singular)
+	for name := range want {
+		require.Equal(t, want[name], got[name],
+			"batched delete diverged from the singular delete in the %s keyspace", name)
+	}
+}
+
+// deleteSingularly applies the same records through the one-commit-per-grant
+// path, which is the oracle the batch path must match.
+func deleteSingularly(t *testing.T, e *Engine, records ...*v3.GrantRecord) {
+	t.Helper()
+	ctx := context.Background()
+	for _, r := range records {
+		require.NoError(t, e.DeleteGrantByIdentityRefs(ctx, r))
+	}
+}
+
+// TestDeleteGrantsByRefsMatchesSingularPath is the equivalence oracle: the
+// batched delete must leave a store indistinguishable from one where the same
+// grants were deleted one durable commit at a time, across the primary rows,
+// both secondary indexes, and the digest state.
+func TestDeleteGrantsByRefsMatchesSingularPath(t *testing.T) {
+	ctx := context.Background()
+	victims := []*v3.GrantRecord{
+		makeGrant("", "g-a-alice", "ent-A", "alice"),
+		makeExpandableGrant("g-a-bob", "ent-A", "bob"),
+		makeExpandableGrant("g-b-erin", "ent-B", "erin"),
+	}
+
+	// chunk=2 forces a chunk boundary mid-set with a six-row fixture, so the
+	// production chunking loop is exercised without a 10k-grant fixture.
+	for _, chunk := range []int{1, 2, grantDeleteBatchChunk} {
+		batched := batchDeleteFixture(t)
+		require.NoError(t, batched.deleteGrantsByIdentityRefs(ctx, chunk, victims...))
+
+		singular := batchDeleteFixture(t)
+		deleteSingularly(t, singular, victims...)
+
+		// The deletes must actually have happened, or the comparison below
+		// is between two untouched stores.
+		require.Equal(t, 3, countKeys(t, batched, encodeGrantPrefix()),
+			"three of six grants must remain")
+		require.Equal(t, 0, countKeys(t, batched, encodeGrantByNeedsExpansionPrefix()),
+			"both expandable grants were deleted, so the index must be empty")
+
+		requireSameGrantKeyspaces(t, batched, singular)
+	}
+}
+
+// TestDeleteGrantsByRefsAbsentGrantIsNoOp pins the existence-probe
+// short-circuit: an identity that was never stored must stage nothing, so the
+// batch does not tombstone the digest partition of an entitlement it never
+// touched. Staging unconditionally would pass a "grant is gone" assertion
+// while silently invalidating live digests.
+func TestDeleteGrantsByRefsAbsentGrantIsNoOp(t *testing.T) {
+	ctx := context.Background()
+	absent := []*v3.GrantRecord{
+		makeGrant("", "g-a-nobody", "ent-A", "nobody"),
+		makeGrant("", "g-z-ghost", "ent-Z", "ghost"),
+	}
+
+	e := batchDeleteFixture(t)
+	before := grantKeyspaces(t, e)
+	_, rootPresent, err := e.GetGrantDigestGlobalRoot(ctx)
+	require.NoError(t, err)
+	require.True(t, rootPresent, "fixture premise: the sealed store has a global digest root")
+
+	require.NoError(t, e.DeleteGrantsByIdentityRefs(ctx, absent...))
+
+	for name, keys := range grantKeyspaces(t, e) {
+		require.Equal(t, before[name], keys,
+			"deleting a non-existent grant must not touch the %s keyspace", name)
+	}
+	_, rootPresent, err = e.GetGrantDigestGlobalRoot(ctx)
+	require.NoError(t, err)
+	require.True(t, rootPresent, "an absent-grant delete must not invalidate the global digest root")
+
+	// And the singular path agrees.
+	singular := batchDeleteFixture(t)
+	deleteSingularly(t, singular, absent...)
+	requireSameGrantKeyspaces(t, e, singular)
+}
+
+// TestDeleteGrantsByRefsMixedBatch covers the batch-specific cases the
+// singular path cannot express: present and absent identities interleaved,
+// and the same key staged for deletion twice inside one RecordBatch.
+func TestDeleteGrantsByRefsMixedBatch(t *testing.T) {
+	ctx := context.Background()
+	mixed := []*v3.GrantRecord{
+		makeGrant("", "g-a-alice", "ent-A", "alice"),   // present
+		makeGrant("", "g-a-nobody", "ent-A", "nobody"), // absent
+		makeGrant("", "g-a-alice", "ent-A", "alice"),   // duplicate of a present row
+		makeExpandableGrant("g-b-erin", "ent-B", "erin"),
+		makeGrant("", "g-z-ghost", "ent-Z", "ghost"),     // absent, unknown partition
+		makeExpandableGrant("g-b-erin", "ent-B", "erin"), // duplicate of an expandable row
+	}
+
+	// chunk=3 splits the duplicate pairs across chunks for one of the runs,
+	// so both "duplicate inside one batch" and "duplicate across batches"
+	// are covered.
+	for _, chunk := range []int{3, grantDeleteBatchChunk} {
+		batched := batchDeleteFixture(t)
+		require.NoError(t, batched.deleteGrantsByIdentityRefs(ctx, chunk, mixed...))
+
+		singular := batchDeleteFixture(t)
+		deleteSingularly(t, singular, mixed...)
+
+		require.Equal(t, 4, countKeys(t, batched, encodeGrantPrefix()),
+			"exactly the two present identities must be gone")
+		requireSameGrantKeyspaces(t, batched, singular)
+	}
+}

--- a/pkg/dotc1z/engine/pebble/grants.go
+++ b/pkg/dotc1z/engine/pebble/grants.go
@@ -1013,6 +1013,14 @@ func (e *Engine) deleteGrantsByIdentities(ctx context.Context, chunk int, ids []
 	if len(ids) == 0 {
 		return nil
 	}
+	// A non-positive chunk would make the loop below never advance, spinning
+	// forever while holding the write lock and a writeWG slot — an
+	// unkillable hang. No production caller can reach that (both pass the
+	// constant), so clamp rather than error: the call still does exactly what
+	// it was asked to do, just at the default chunking.
+	if chunk <= 0 {
+		chunk = grantDeleteBatchChunk
+	}
 	// One lock acquisition for the whole call, not one per grant.
 	return e.withWrite(func() error {
 		for start := 0; start < len(ids); start += chunk {

--- a/pkg/dotc1z/engine/pebble/grants.go
+++ b/pkg/dotc1z/engine/pebble/grants.go
@@ -941,12 +941,20 @@ func (e *Engine) DeleteGrantByIdentityRefs(ctx context.Context, r *v3.GrantRecor
 	})
 }
 
-// grantDeleteBatchChunk bounds how many grant deletes ride one
-// RecordBatch. Large enough that the per-commit fsync is amortized to
-// nothing (a 90k-grant call becomes 9 commits, not 90k), small enough
-// that a batch's staged bytes stay bounded — each staged delete is a
-// handful of small tombstones, so a chunk is tens of KB.
-const grantDeleteBatchChunk = 10000
+// grantDeleteBatchChunk bounds how many grant deletes ride one RecordBatch.
+//
+// Sized for peak batch memory, not for fsync count. A staged delete is 6
+// batch ops (primary + by_principal + by_needs_expansion + the two digest
+// DeleteRanges + the global root), and its bytes are dominated by the
+// entitlement id repeated across them: measured on this engine, one grant
+// stages ~225 B at a 16-char entitlement id, ~640 B at 75 chars, and ~1.6 KB
+// at 215 chars. So 1000 grants is ~0.2–1.6 MiB of in-memory batch, while
+// 10000 would be ~2.2–16 MiB and keeps scaling with id length.
+//
+// The fsync count barely cares: against the ~90000 fsyncs the batching
+// removes, 90 commits versus 9 is noise, so the 10x lower peak memory is the
+// better side of that trade.
+const grantDeleteBatchChunk = 1000
 
 // DeleteGrantsByIdentityRefs is the plural sibling of
 // DeleteGrantByIdentityRefs: it removes N grants addressed by their
@@ -965,14 +973,10 @@ const grantDeleteBatchChunk = 10000
 // the existence probe: an absent key stages nothing, so a delete of a
 // non-existent grant stays a true no-op and does not invalidate the
 // entitlement's digest partition.
+//
+// The chunk is also the unit of cancellation and of the sealed re-check —
+// see deleteGrantsByIdentities.
 func (e *Engine) DeleteGrantsByIdentityRefs(ctx context.Context, records ...*v3.GrantRecord) error {
-	return e.deleteGrantsByIdentityRefs(ctx, grantDeleteBatchChunk, records...)
-}
-
-// deleteGrantsByIdentityRefs is DeleteGrantsByIdentityRefs with the chunk
-// size injected, so tests can drive the chunk boundary without a
-// grantDeleteBatchChunk-sized fixture.
-func (e *Engine) deleteGrantsByIdentityRefs(ctx context.Context, chunk int, records ...*v3.GrantRecord) error {
 	if len(records) == 0 {
 		return nil
 	}
@@ -984,9 +988,40 @@ func (e *Engine) deleteGrantsByIdentityRefs(ctx context.Context, chunk int, reco
 		}
 		ids = append(ids, id)
 	}
+	return e.deleteGrantsByIdentities(ctx, grantDeleteBatchChunk, ids)
+}
+
+// deleteGrantsByIdentities commits ids in chunk-sized RecordBatches under a
+// single write-lock acquisition. chunk is a parameter so tests can drive the
+// boundary without a grantDeleteBatchChunk-sized fixture.
+//
+// Two things are re-checked at every chunk boundary, because taking the lock
+// once means the per-write checks withWrite would have made no longer happen
+// per write:
+//
+//   - ctx cancellation. A 90k-grant delete is otherwise uninterruptible.
+//     Aborting mid-way is safe: committed chunks are durable and the caller's
+//     dirty flag is already set, and a resumed sync re-derives its delete set
+//     and re-issues these deletes, which are idempotent.
+//   - e.sealed. withWrite's under-lock sealed re-check is the actual fence
+//     against writing past EndSync (seal() takes only sealMu and does not
+//     wait on writeWG), and it would otherwise run once for the whole call
+//     instead of once per write. Without this, a late chunk — and the digest
+//     invalidations it stages — could land after finalize began rebuilding
+//     the deferred by_principal index.
+func (e *Engine) deleteGrantsByIdentities(ctx context.Context, chunk int, ids []grantIdentity) error {
+	if len(ids) == 0 {
+		return nil
+	}
 	// One lock acquisition for the whole call, not one per grant.
 	return e.withWrite(func() error {
 		for start := 0; start < len(ids); start += chunk {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if e.sealed.Load() {
+				return ErrEngineSealed
+			}
 			end := min(start+chunk, len(ids))
 			if err := e.deleteGrantsByIdentityChunkLocked(ids[start:end]); err != nil {
 				return err

--- a/pkg/dotc1z/engine/pebble/grants.go
+++ b/pkg/dotc1z/engine/pebble/grants.go
@@ -16,6 +16,7 @@ import (
 
 	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/codec"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/rawdb"
 	batonGrant "github.com/conductorone/baton-sdk/pkg/types/grant"
 )
 
@@ -940,9 +941,91 @@ func (e *Engine) DeleteGrantByIdentityRefs(ctx context.Context, r *v3.GrantRecor
 	})
 }
 
-// deleteGrantByIdentityLocked deletes one grant row and its index entries.
-// Caller holds the engine write lock (withWrite).
-func (e *Engine) deleteGrantByIdentityLocked(id grantIdentity) error {
+// grantDeleteBatchChunk bounds how many grant deletes ride one
+// RecordBatch. Large enough that the per-commit fsync is amortized to
+// nothing (a 90k-grant call becomes 9 commits, not 90k), small enough
+// that a batch's staged bytes stay bounded — each staged delete is a
+// handful of small tombstones, so a chunk is tens of KB.
+const grantDeleteBatchChunk = 10000
+
+// DeleteGrantsByIdentityRefs is the plural sibling of
+// DeleteGrantByIdentityRefs: it removes N grants addressed by their
+// structural refs, staging the deletes into chunked RecordBatches instead of
+// one commit per grant.
+//
+// Why this exists: the singular path commits once per grant with
+// pebble.Sync (the engine's default durability), so a bulk caller pays one
+// fsync per grant. On network-attached storage that is ~10ms each — the
+// syncer's external-principal cleanup measured ~956s to delete ~90k grants.
+// Chunking amortizes the fsync across the chunk. Durability is deliberately
+// unchanged: each chunk still commits with writeOpts(e.opts.durability), so
+// crash semantics are identical, only the fsync count drops.
+//
+// Per-grant semantics match deleteGrantByIdentityLocked exactly, including
+// the existence probe: an absent key stages nothing, so a delete of a
+// non-existent grant stays a true no-op and does not invalidate the
+// entitlement's digest partition.
+func (e *Engine) DeleteGrantsByIdentityRefs(ctx context.Context, records ...*v3.GrantRecord) error {
+	return e.deleteGrantsByIdentityRefs(ctx, grantDeleteBatchChunk, records...)
+}
+
+// deleteGrantsByIdentityRefs is DeleteGrantsByIdentityRefs with the chunk
+// size injected, so tests can drive the chunk boundary without a
+// grantDeleteBatchChunk-sized fixture.
+func (e *Engine) deleteGrantsByIdentityRefs(ctx context.Context, chunk int, records ...*v3.GrantRecord) error {
+	if len(records) == 0 {
+		return nil
+	}
+	ids := make([]grantIdentity, 0, len(records))
+	for _, r := range records {
+		id, err := grantIdentityFromRecord(r)
+		if err != nil {
+			return fmt.Errorf("DeleteGrantsByIdentityRefs: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	// One lock acquisition for the whole call, not one per grant.
+	return e.withWrite(func() error {
+		for start := 0; start < len(ids); start += chunk {
+			end := min(start+chunk, len(ids))
+			if err := e.deleteGrantsByIdentityChunkLocked(ids[start:end]); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// deleteGrantsByIdentityChunkLocked stages one chunk of grant deletes into a
+// single RecordBatch and commits it once. Caller holds the engine write lock.
+func (e *Engine) deleteGrantsByIdentityChunkLocked(ids []grantIdentity) error {
+	batch := e.db.NewRecordBatch()
+	defer batch.Close()
+
+	staged := 0
+	for _, id := range ids {
+		ok, err := e.stageGrantDeleteIfPresentLocked(batch, id)
+		if err != nil {
+			return err
+		}
+		if ok {
+			staged++
+		}
+	}
+	if staged == 0 {
+		return nil
+	}
+	return batch.Commit(writeOpts(e.opts.durability))
+}
+
+// stageGrantDeleteIfPresentLocked stages one grant row's removal (and the
+// index/digest obligations the typed op derives) into batch, reporting
+// whether anything was staged. A missing row stages nothing — staging
+// unconditionally would emit digest invalidations for identities that never
+// existed. Caller holds the engine write lock.
+//
+// Shared by the singular and batched delete paths so they cannot drift.
+func (e *Engine) stageGrantDeleteIfPresentLocked(batch *rawdb.RecordBatch, id grantIdentity) (bool, error) {
 	key := encodeGrantIdentityKey(id)
 
 	// Existence probe only: delete of non-existent stays a no-op, and
@@ -950,16 +1033,30 @@ func (e *Engine) deleteGrantByIdentityLocked(id grantIdentity) error {
 	_, closer, err := e.db.Get(key)
 	if err != nil {
 		if errors.Is(err, pebble.ErrNotFound) {
-			return nil
+			return false, nil
 		}
-		return err
+		return false, err
 	}
 	closer.Close()
 
+	if err := batch.StageGrantDelete(key); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// deleteGrantByIdentityLocked deletes one grant row and its index entries.
+// Caller holds the engine write lock (withWrite).
+func (e *Engine) deleteGrantByIdentityLocked(id grantIdentity) error {
 	batch := e.db.NewRecordBatch()
 	defer batch.Close()
-	if err := batch.StageGrantDelete(key); err != nil {
+
+	staged, err := e.stageGrantDeleteIfPresentLocked(batch, id)
+	if err != nil {
 		return err
+	}
+	if !staged {
+		return nil
 	}
 	return batch.Commit(writeOpts(e.opts.durability))
 }

--- a/pkg/dotc1z/pebble_store.go
+++ b/pkg/dotc1z/pebble_store.go
@@ -568,8 +568,17 @@ func (s *pebbleStore) DeleteGrantByRefs(ctx context.Context, grant *v2.Grant) er
 // DeleteGrantsByRefs is the bulk form of DeleteGrantByRefs: identical
 // per-grant semantics, but the deletes are committed in chunked batches so a
 // bulk caller does not pay one fsync per grant.
+//
+// Unlike its siblings this marks dirty UNCONDITIONALLY rather than through
+// markDirty, which only marks on success. One call here can commit many
+// chunks: if a later chunk fails, the earlier ones are already durable in
+// Pebble, and leaving dirty unset would let Close discard the temp dir and
+// silently drop that committed work. Over-marking when nothing was staged
+// only costs an unnecessary flush of an unchanged file; under-marking loses
+// data.
 func (s *pebbleStore) DeleteGrantsByRefs(ctx context.Context, grants ...*v2.Grant) error {
-	return s.markDirty(s.Engine.DeleteGrantsByRefs(ctx, grants...))
+	s.MarkDirty()
+	return s.Engine.DeleteGrantsByRefs(ctx, grants...)
 }
 
 // DeleteResourceRecord removes a resource and marks the envelope dirty so an

--- a/pkg/dotc1z/pebble_store.go
+++ b/pkg/dotc1z/pebble_store.go
@@ -565,6 +565,13 @@ func (s *pebbleStore) DeleteGrantByRefs(ctx context.Context, grant *v2.Grant) er
 	return s.markDirty(s.Engine.DeleteGrantByRefs(ctx, grant))
 }
 
+// DeleteGrantsByRefs is the bulk form of DeleteGrantByRefs: identical
+// per-grant semantics, but the deletes are committed in chunked batches so a
+// bulk caller does not pay one fsync per grant.
+func (s *pebbleStore) DeleteGrantsByRefs(ctx context.Context, grants ...*v2.Grant) error {
+	return s.markDirty(s.Engine.DeleteGrantsByRefs(ctx, grants...))
+}
+
 // DeleteResourceRecord removes a resource and marks the envelope dirty so an
 // explicit reconciliation performed by the syncer is persisted on Close.
 func (s *pebbleStore) DeleteResourceRecord(ctx context.Context, resourceTypeID, resourceID string) error {

--- a/pkg/dotc1z/pebble_store_batch_delete_dirty_test.go
+++ b/pkg/dotc1z/pebble_store_batch_delete_dirty_test.go
@@ -1,0 +1,101 @@
+package dotc1z
+
+import (
+	"context"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
+)
+
+// batchDeleteCancelCtx cancels at the Nth cancellation check. The engine's
+// bulk delete consults ctx once per committed chunk, so this lands the abort
+// strictly between two chunks: earlier chunks are durably committed, later
+// ones never run.
+type batchDeleteCancelCtx struct {
+	context.Context
+	checks     int
+	cancelUpon int
+}
+
+func (c *batchDeleteCancelCtx) Err() error {
+	c.checks++
+	if c.checks >= c.cancelUpon {
+		return context.Canceled
+	}
+	return c.Context.Err()
+}
+
+func countStoredGrants(t *testing.T, ctx context.Context, store c1zstore.Store) int {
+	t.Helper()
+	n := 0
+	for _, err := range store.Grants().ListWithAnnotations(ctx) {
+		require.NoError(t, err)
+		n++
+	}
+	return n
+}
+
+// TestPebbleStoreDeleteGrantsByRefsMarksDirtyOnPartialFailure pins the
+// partial-progress contract of the bulk delete. The singular
+// DeleteGrantByRefs routes through markDirty, which only marks on success —
+// harmless there because each call is one commit, so a failure means nothing
+// was written. The bulk form commits many chunks per call, so a mid-way
+// failure leaves earlier chunks durable in Pebble; if the dirty flag stayed
+// unset, Close would skip the envelope save and discard the temp dir,
+// silently dropping committed work.
+//
+// The delete runs in a REOPENED session that has written nothing else, so
+// nothing but the delete itself can set the dirty flag.
+func TestPebbleStoreDeleteGrantsByRefsMarksDirtyOnPartialFailure(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "batch-delete-dirty.c1z")
+
+	// The engine chunks at 1000; 2500 grants gives three chunks so the abort
+	// can land with one chunk already committed.
+	const total = 2500
+	grants := make([]*v2.Grant, 0, total)
+	for i := range total {
+		grants = append(grants, mkV2Grant("", "ent", "user", "user-"+strconv.Itoa(i)))
+	}
+
+	store, err := NewStore(ctx, path, WithEngine(c1zstore.EnginePebble))
+	require.NoError(t, err)
+	syncID, err := store.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, store.PutGrants(ctx, grants...))
+	require.NoError(t, store.EndSync(ctx))
+	require.NoError(t, store.Close(ctx))
+
+	// Fresh session: dirty starts false and only the delete below can set it.
+	reopened, err := NewStore(ctx, path, WithEngine(c1zstore.EnginePebble))
+	require.NoError(t, err)
+	require.NoError(t, reopened.SetCurrentSync(ctx, syncID))
+	require.Equal(t, total, countStoredGrants(t, ctx, reopened), "premise: all grants present")
+
+	batchDeleter, ok := reopened.(interface {
+		DeleteGrantsByRefs(context.Context, ...*v2.Grant) error
+	})
+	require.True(t, ok, "premise: the pebble store offers the bulk delete")
+
+	// Pass the first boundary, abort at the second: exactly one chunk commits.
+	cancelling := &batchDeleteCancelCtx{Context: ctx, cancelUpon: 2}
+	err = batchDeleter.DeleteGrantsByRefs(cancelling, grants...)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, 2, cancelling.checks, "premise: aborted at the second chunk boundary")
+
+	// Close must SAVE, not discard: the committed chunk is real work.
+	require.NoError(t, reopened.Close(ctx))
+
+	verify, err := NewStore(ctx, path, WithEngine(c1zstore.EnginePebble))
+	require.NoError(t, err)
+	require.NoError(t, verify.SetCurrentSync(ctx, syncID))
+	require.Equal(t, total-1000, countStoredGrants(t, ctx, verify),
+		"the chunk committed before the abort must have survived Close")
+	require.NoError(t, verify.Close(ctx))
+}

--- a/pkg/sync/chaos_external_principal_test.go
+++ b/pkg/sync/chaos_external_principal_test.go
@@ -3,6 +3,7 @@ package sync
 import (
 	"context"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"sync/atomic"
 	"testing"
@@ -42,6 +43,61 @@ func (s *chaosExternalPrincipalCutStore) DeleteGrantByRefs(
 	return deleter.DeleteGrantByRefs(ctx, grant)
 }
 
+// DeleteGrantsByRefs puts this wrapper on the batched production path that
+// processGrantsWithExternalPrincipals now prefers. Without it the type
+// assertion for grantsByRefsBatchDeleter fails and the syncer silently falls
+// back to the singular loop, so the crash-resume corpus would stop covering
+// the code path it is meant to cut.
+//
+// The cut stays per-GRANT, counted in the same order and at the same
+// granularity the singular DeleteGrantByRefs would use: deleteCalls advances
+// once per grant, the failDeleteAt-th grant returns before its delete is
+// issued, and every grant before it is committed by its own call into the
+// real store. That keeps "everything before the cut is durable, the cut grant
+// and everything after it is not" — the interruption shape the resume-to-
+// baseline oracle asserts on — byte-identical to the pre-batching behavior.
+//
+// With no delete cut armed there is nothing to interleave, so the batch is
+// handed to the store whole and actually exercises multi-grant chunking.
+//
+// The syncer asserts grantsByRefsBatchDeleter on THIS wrapper, so declaring
+// the method routes every engine here — including SQLite, which has no
+// batched delete. Degrade to the wrapped store's singular delete in that case
+// instead of advertising batch support it does not have, so the SQLite
+// scenarios keep the one-commit-per-grant shape production would give them.
+func (s *chaosExternalPrincipalCutStore) DeleteGrantsByRefs(
+	ctx context.Context,
+	grants ...*v2.Grant,
+) error {
+	batchDeleter, canBatch := s.Store.(grantsByRefsBatchDeleter)
+	if canBatch && s.failDeleteAt <= 0 {
+		s.deleteCalls.Add(int64(len(grants)))
+		return batchDeleter.DeleteGrantsByRefs(ctx, grants...)
+	}
+	for _, grant := range grants {
+		// Count and cut BEFORE resolving the wrapped store's capability, the
+		// same order DeleteGrantByRefs uses. SQLite implements neither delete
+		// interface, so its scenarios only ever get past this line for grants
+		// the cut does not claim.
+		if s.deleteCalls.Add(1) == s.failDeleteAt {
+			return errChaosExternalPrincipalCut
+		}
+		var err error
+		switch singularDeleter, canSingular := s.Store.(grantByRefsDeleter); {
+		case canBatch:
+			err = batchDeleter.DeleteGrantsByRefs(ctx, grant)
+		case canSingular:
+			err = singularDeleter.DeleteGrantByRefs(ctx, grant)
+		default:
+			err = errors.New("chaos: store lacks refs-based grant deletion")
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (s *chaosExternalPrincipalCutStore) DeleteResourceRecord(
 	ctx context.Context,
 	resourceTypeID string,
@@ -69,6 +125,88 @@ func (s *chaosExternalPrincipalCutStore) DeleteEntitlementByRefs(
 		return errors.New("chaos: store lacks entitlement-record deletion")
 	}
 	return deleter.DeleteEntitlementByRefs(ctx, entitlement)
+}
+
+// recordingBatchDeleteStore records the batches it is handed so the cut
+// granularity above can be asserted without a chaos scenario.
+type recordingBatchDeleteStore struct {
+	c1zstore.Store
+	batches [][]string
+}
+
+func (s *recordingBatchDeleteStore) DeleteGrantsByRefs(_ context.Context, grants ...*v2.Grant) error {
+	ids := make([]string, 0, len(grants))
+	for _, grant := range grants {
+		ids = append(ids, grant.GetId())
+	}
+	s.batches = append(s.batches, ids)
+	return nil
+}
+
+// recordingSingularDeleteStore supports only the singular delete, standing in
+// for an engine (SQLite) that never implements grantsByRefsBatchDeleter.
+type recordingSingularDeleteStore struct {
+	c1zstore.Store
+	deleted []string
+}
+
+func (s *recordingSingularDeleteStore) DeleteGrantByRefs(_ context.Context, grant *v2.Grant) error {
+	s.deleted = append(s.deleted, grant.GetId())
+	return nil
+}
+
+func chaosCutTestGrants(n int) []*v2.Grant {
+	grants := make([]*v2.Grant, 0, n)
+	for i := 0; i < n; i++ {
+		grants = append(grants, v2.Grant_builder{Id: fmt.Sprintf("grant-%d", i)}.Build())
+	}
+	return grants
+}
+
+// TestChaosExternalPrincipalCutStoreBatchDeleteKeepsCutPerGrant guards the
+// property the crash-resume corpus depends on but cannot itself observe: its
+// fixtures only ever produce a single pending delete per call, so a batched
+// wrapper that collapsed N grants into one opaque store call would still pass
+// every scenario above while silently losing the per-grant cut point.
+func TestChaosExternalPrincipalCutStoreBatchDeleteKeepsCutPerGrant(t *testing.T) {
+	t.Run("cut armed stops between grants", func(t *testing.T) {
+		underlying := &recordingBatchDeleteStore{}
+		cutStore := &chaosExternalPrincipalCutStore{Store: underlying, failDeleteAt: 2}
+
+		err := cutStore.DeleteGrantsByRefs(t.Context(), chaosCutTestGrants(3)...)
+
+		require.ErrorIs(t, err, errChaosExternalPrincipalCut)
+		require.Equal(t, int64(2), cutStore.deleteCalls.Load(),
+			"the cut must be counted per grant, not per batch")
+		require.Equal(t, [][]string{{"grant-0"}}, underlying.batches,
+			"only grants before the cut may reach the store, each in its own durable call")
+	})
+
+	t.Run("no cut armed delegates the whole batch", func(t *testing.T) {
+		underlying := &recordingBatchDeleteStore{}
+		cutStore := &chaosExternalPrincipalCutStore{Store: underlying}
+
+		require.NoError(t, cutStore.DeleteGrantsByRefs(t.Context(), chaosCutTestGrants(3)...))
+		require.Equal(t, int64(3), cutStore.deleteCalls.Load())
+		require.Equal(t, [][]string{{"grant-0", "grant-1", "grant-2"}}, underlying.batches,
+			"an unarmed wrapper must exercise real multi-grant chunking")
+	})
+
+	// Declaring DeleteGrantsByRefs on the wrapper routes every engine through
+	// it, so a store without batch support must degrade to its singular
+	// delete rather than surface a "store lacks batching" error where the
+	// SQLite scenarios expect the injected cut.
+	t.Run("degrades to singular deletes without batch support", func(t *testing.T) {
+		underlying := &recordingSingularDeleteStore{}
+		cutStore := &chaosExternalPrincipalCutStore{Store: underlying, failDeleteAt: 2}
+
+		err := cutStore.DeleteGrantsByRefs(t.Context(), chaosCutTestGrants(3)...)
+
+		require.ErrorIs(t, err, errChaosExternalPrincipalCut,
+			"the injected cut must still be what surfaces on a non-batching store")
+		require.Equal(t, int64(2), cutStore.deleteCalls.Load())
+		require.Equal(t, []string{"grant-0"}, underlying.deleted)
+	})
 }
 
 func TestChaosConnectorExternalPrincipalCorpus(t *testing.T) {

--- a/pkg/sync/external_principal_batch_delete_test.go
+++ b/pkg/sync/external_principal_batch_delete_test.go
@@ -1,0 +1,186 @@
+package sync //nolint:revive,nolintlint // backwards-compatible package name
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
+)
+
+// batchDeleteRouteStore records which delete surface the apply phase of
+// processGrantsWithExternalPrincipals reached. The embedded nil Store is
+// deliberate: any surface the code path is not supposed to touch panics
+// rather than silently succeeding.
+type batchDeleteRouteStore struct {
+	c1zstore.Store
+	grants cleanupScaleGrantStore
+
+	batchDeleted   [][]string
+	refsDeleted    []string
+	byIDDeleted    []string
+	putGrantsSizes []int
+}
+
+func (s *batchDeleteRouteStore) Grants() c1zstore.GrantStore { return &s.grants }
+
+func (s *batchDeleteRouteStore) PutGrants(_ context.Context, grants ...*v2.Grant) error {
+	s.putGrantsSizes = append(s.putGrantsSizes, len(grants))
+	return nil
+}
+
+func (s *batchDeleteRouteStore) DeleteGrant(_ context.Context, grantID string) error {
+	s.byIDDeleted = append(s.byIDDeleted, grantID)
+	return nil
+}
+
+// idOnlyDeleteStore implements neither optional delete interface — the SQLite
+// shape, which must keep working through the plain DeleteGrant loop.
+type idOnlyDeleteStore struct{ *batchDeleteRouteStore }
+
+// refsDeleteStore implements only the singular refs delete.
+type refsDeleteStore struct{ *batchDeleteRouteStore }
+
+func (s *refsDeleteStore) DeleteGrantByRefs(_ context.Context, grant *v2.Grant) error {
+	s.refsDeleted = append(s.refsDeleted, grant.GetId())
+	return nil
+}
+
+// batchDeleteStore implements both, as the Pebble store does.
+type batchDeleteStore struct{ *batchDeleteRouteStore }
+
+func (s *batchDeleteStore) DeleteGrantByRefs(_ context.Context, grant *v2.Grant) error {
+	s.refsDeleted = append(s.refsDeleted, grant.GetId())
+	return nil
+}
+
+func (s *batchDeleteStore) DeleteGrantsByRefs(_ context.Context, grants ...*v2.Grant) error {
+	ids := make([]string, 0, len(grants))
+	for _, g := range grants {
+		ids = append(ids, g.GetId())
+	}
+	s.batchDeleted = append(s.batchDeleted, ids)
+	return nil
+}
+
+// newBatchDeleteRouteStore seeds grants carrying an ExternalResourceMatchID
+// for a principal that does not exist, which is the "delete the carrier, emit
+// nothing" case — every grant lands in the apply phase's delete set. It
+// returns the store and the grant ids the apply phase must delete, in order.
+func newBatchDeleteRouteStore(size int) (*batchDeleteRouteStore, []string) {
+	store := &batchDeleteRouteStore{}
+	want := make([]string, 0, size)
+	for i := 0; i < size; i++ {
+		grant := v2.Grant_builder{
+			Id: fmt.Sprintf("grant-%d", i),
+			Entitlement: v2.Entitlement_builder{
+				Id: fmt.Sprintf("entitlement-%d", i),
+			}.Build(),
+			Principal: v2.Resource_builder{
+				Id: v2.ResourceId_builder{
+					ResourceType: "group",
+					Resource:     fmt.Sprintf("group-%d", i),
+				}.Build(),
+			}.Build(),
+			Annotations: annotations.New(v2.ExternalResourceMatchID_builder{
+				Id: fmt.Sprintf("no-such-principal-%d", i),
+			}.Build()),
+		}.Build()
+		store.grants.rows = append(store.grants.rows, c1zstore.GrantAnnotation{Grant: grant})
+		want = append(want, grant.GetId())
+	}
+	return store, want
+}
+
+func newExternalMatchSyncer(store c1zstore.Store) *syncer {
+	st := newState()
+	st.SetHasExternalResourcesGrants()
+	return &syncer{store: store, state: st}
+}
+
+// TestProcessGrantsWithExternalPrincipalsDeleteRouting pins the three-way
+// routing of the apply phase: batch when the store offers it, singular refs
+// when it only offers that, and the plain id delete otherwise. Each case must
+// delete exactly the same grants — the batch is an amortization of the loop,
+// not a change to what gets deleted.
+func TestProcessGrantsWithExternalPrincipalsDeleteRouting(t *testing.T) {
+	ctx := t.Context()
+
+	t.Run("batch-capable store uses one batched call", func(t *testing.T) {
+		base, want := newBatchDeleteRouteStore(5)
+		store := &batchDeleteStore{batchDeleteRouteStore: base}
+		require.NoError(t, newExternalMatchSyncer(store).processGrantsWithExternalPrincipals(ctx, nil))
+
+		require.Equal(t, [][]string{want}, base.batchDeleted,
+			"every unmatched carrier must be deleted through a single batched call")
+		require.Empty(t, base.refsDeleted, "the batch path must not also delete grant-by-grant")
+		require.Empty(t, base.byIDDeleted)
+	})
+
+	t.Run("refs-only store falls back to the singular loop", func(t *testing.T) {
+		base, want := newBatchDeleteRouteStore(5)
+		store := &refsDeleteStore{batchDeleteRouteStore: base}
+		require.NoError(t, newExternalMatchSyncer(store).processGrantsWithExternalPrincipals(ctx, nil))
+
+		require.Equal(t, want, base.refsDeleted)
+		require.Empty(t, base.batchDeleted)
+		require.Empty(t, base.byIDDeleted)
+	})
+
+	t.Run("store with neither interface falls back to DeleteGrant", func(t *testing.T) {
+		base, want := newBatchDeleteRouteStore(5)
+		store := &idOnlyDeleteStore{batchDeleteRouteStore: base}
+		require.NoError(t, newExternalMatchSyncer(store).processGrantsWithExternalPrincipals(ctx, nil))
+
+		require.Equal(t, want, base.byIDDeleted)
+		require.Empty(t, base.batchDeleted)
+		require.Empty(t, base.refsDeleted)
+	})
+}
+
+// TestProcessGrantsWithExternalPrincipalsBatchSkipsReissuedGrants pins that
+// the batch path applies the same newGrantIDs filter the loop did: a carrier
+// whose id was re-issued as an expanded grant keeps its row.
+func TestProcessGrantsWithExternalPrincipalsBatchSkipsReissuedGrants(t *testing.T) {
+	ctx := t.Context()
+
+	// A MatchAll carrier whose principal matches produces an expanded grant
+	// keyed by the same (principal, entitlement) pair, so the carrier's id is
+	// re-issued and it must NOT be deleted.
+	principal := v2.Resource_builder{
+		Id: v2.ResourceId_builder{ResourceType: "user", Resource: "alice"}.Build(),
+		Annotations: annotations.New(
+			&v2.BatonID{},
+			&v2.UserTrait{},
+		),
+	}.Build()
+	entitlement := v2.Entitlement_builder{Id: "entitlement-0", Resource: principal}.Build()
+	carrier := v2.Grant_builder{
+		Id:          "grant-reissued",
+		Entitlement: entitlement,
+		Principal:   principal,
+		Annotations: annotations.New(v2.ExternalResourceMatchAll_builder{
+			ResourceType: v2.ResourceType_TRAIT_USER,
+		}.Build()),
+	}.Build()
+	// newGrantForExternalPrincipal derives the expanded grant's id from the
+	// (principal, entitlement) pair, so pin the carrier's id to that value.
+	carrier.SetId(newGrantForExternalPrincipal(carrier, principal).GetId())
+
+	base := &batchDeleteRouteStore{}
+	base.grants.rows = append(base.grants.rows, c1zstore.GrantAnnotation{Grant: carrier})
+	store := &batchDeleteStore{batchDeleteRouteStore: base}
+
+	require.NoError(t, newExternalMatchSyncer(store).processGrantsWithExternalPrincipals(ctx, []*v2.Resource{principal}))
+
+	require.Empty(t, base.batchDeleted,
+		"a carrier whose id was re-issued as an expanded grant must not be deleted")
+	require.Empty(t, base.refsDeleted)
+	require.Empty(t, base.byIDDeleted)
+	require.Equal(t, []int{1}, base.putGrantsSizes,
+		"test premise: exactly one expanded grant was written, so the filter had something to skip")
+}

--- a/pkg/sync/external_principal_cleanup_scale_test.go
+++ b/pkg/sync/external_principal_cleanup_scale_test.go
@@ -68,6 +68,21 @@ func (s *cleanupScaleStore) DeleteGrantByRefs(context.Context, *v2.Grant) error 
 	return nil
 }
 
+// DeleteGrantsByRefs counts per GRANT, not per batch, so the scale assertion
+// below (grantDeletes == number of stale grants) means the same thing on
+// either delete route.
+//
+// deleteStaleExternalPrincipals — the only caller this double is wired to —
+// still deletes stale grants one at a time and never asserts
+// grantsByRefsBatchDeleter, so this method is not reached today. It exists so
+// that if that cleanup is batched the way processGrantsWithExternalPrincipals
+// already was, the double keeps measuring grant deletions rather than
+// silently collapsing them to one.
+func (s *cleanupScaleStore) DeleteGrantsByRefs(_ context.Context, grants ...*v2.Grant) error {
+	s.grantDeletes += len(grants)
+	return nil
+}
+
 func (s *cleanupScaleStore) DeleteEntitlementByRefs(context.Context, *v2.Entitlement) error {
 	s.entitlementDeletes++
 	return nil

--- a/pkg/sync/external_principal_index_verification_test.go
+++ b/pkg/sync/external_principal_index_verification_test.go
@@ -191,8 +191,9 @@ var errVerificationDeleteCut = errors.New("verification: injected delete cut")
 
 // interruptingExternalMatchStore delegates to a real store and injects a
 // process-like stop at a selected delete. Embedding preserves the complete
-// c1zstore.Store contract while the explicit DeleteGrantByRefs method ensures
-// processGrantsWithExternalPrincipals takes the production Pebble fast path.
+// c1zstore.Store contract while the explicit DeleteGrantByRefs and
+// DeleteGrantsByRefs methods ensure processGrantsWithExternalPrincipals takes
+// the production Pebble fast path (which is the batched one).
 type interruptingExternalMatchStore struct {
 	c1zstore.Store
 	failDeleteAt  int64
@@ -215,6 +216,32 @@ func (s *interruptingExternalMatchStore) DeleteGrantByRefs(ctx context.Context, 
 		return fmt.Errorf("verification premise: wrapped store lacks DeleteGrantByRefs")
 	}
 	return deleter.DeleteGrantByRefs(ctx, grant)
+}
+
+// DeleteGrantsByRefs keeps the cut per-GRANT (not per-batch) so the injected
+// stop still lands between two individual deletes: everything before
+// failDeleteAt commits durably, the cut grant and everything after it does
+// not. That is the interruption shape the resume-to-golden assertion needs,
+// and routing through the real store's batch method keeps the wrapper on the
+// production path.
+func (s *interruptingExternalMatchStore) DeleteGrantsByRefs(ctx context.Context, grants ...*v2.Grant) error {
+	deleter, ok := s.Store.(grantsByRefsBatchDeleter)
+	if !ok {
+		return fmt.Errorf("verification premise: wrapped store lacks DeleteGrantsByRefs")
+	}
+	if s.failDeleteAt <= 0 {
+		s.deleteCalls.Add(int64(len(grants)))
+		return deleter.DeleteGrantsByRefs(ctx, grants...)
+	}
+	for _, grant := range grants {
+		if s.deleteCalls.Add(1) == s.failDeleteAt {
+			return errVerificationDeleteCut
+		}
+		if err := deleter.DeleteGrantsByRefs(ctx, grant); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func externalMatchGrantIDs(ctx context.Context, store c1zstore.Store) ([]string, error) {

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -3607,14 +3607,35 @@ func (s *syncer) processGrantsWithExternalPrincipals(ctx context.Context, princi
 		return err
 	}
 
-	// Prefer the refs-based delete (exact structural identity) when the
-	// store supports it; external ids are a lossy external contract and
-	// stores keyed by structural identity cannot always resolve them.
-	refsDeleter, _ := s.store.(grantByRefsDeleter)
+	// A grant that was re-issued against a matched principal keeps its row;
+	// only the unmatched originals are deleted.
+	pendingDeletes := make([]*v2.Grant, 0, len(grantsToDelete))
 	for _, grantToDelete := range grantsToDelete {
 		if newGrantIDs.ContainsOne(grantToDelete.GetId()) {
 			continue
 		}
+		pendingDeletes = append(pendingDeletes, grantToDelete)
+	}
+
+	if len(pendingDeletes) == 0 {
+		return nil
+	}
+
+	// Prefer the bulk refs-based delete when the store supports it: the
+	// per-grant path commits once per grant with pebble.Sync, so on
+	// network-attached storage this loop cost ~956s for ~90k grants. The
+	// batch form amortizes the fsync without weakening durability.
+	// err is the named value the deferred span reports, so assign it.
+	if batchDeleter, ok := s.store.(grantsByRefsBatchDeleter); ok {
+		err = batchDeleter.DeleteGrantsByRefs(ctx, pendingDeletes...)
+		return err
+	}
+
+	// Prefer the refs-based delete (exact structural identity) when the
+	// store supports it; external ids are a lossy external contract and
+	// stores keyed by structural identity cannot always resolve them.
+	refsDeleter, _ := s.store.(grantByRefsDeleter)
+	for _, grantToDelete := range pendingDeletes {
 		if refsDeleter != nil {
 			err = refsDeleter.DeleteGrantByRefs(ctx, grantToDelete)
 		} else {
@@ -3633,6 +3654,14 @@ func (s *syncer) processGrantsWithExternalPrincipals(ctx context.Context, princi
 // it; SQLite resolves ids by exact string and does not need it).
 type grantByRefsDeleter interface {
 	DeleteGrantByRefs(ctx context.Context, grant *v2.Grant) error
+}
+
+// grantsByRefsBatchDeleter is the bulk form of grantByRefsDeleter. Stores
+// that implement it delete N grants in a bounded number of commits instead
+// of one durable commit per grant; stores that do not (SQLite) fall through
+// to the per-grant loop unchanged.
+type grantsByRefsBatchDeleter interface {
+	DeleteGrantsByRefs(ctx context.Context, grants ...*v2.Grant) error
 }
 
 func newGrantForExternalPrincipal(grant *v2.Grant, principal *v2.Resource) *v2.Grant {


### PR DESCRIPTION
## Real-world impact

Validated end-to-end in a real C1 integration environment (service-mode connectors, actual Temporal sync path) — this reflects the shipped fix in production conditions, not the isolated benchmark below.

| Grants | Before (this fix) | After (this fix) | Speedup |
|---:|---:|---:|---:|
| 500 | 1.75 s | 0.09 s | 20x |
| 2,000 | 9.70 s | 0.15 s | 66x |
| 5,000 | 38.06 s | 0.31 s | 122x |
| 50,000 | 5.9 min | 3.19 s | 110x |
| 90,000 | 16.0 min | 9.3 s | 103x |

Correctness identical to pre-fix at every scale (490 / 1,960 / 4,900 / 49,000 / 88,200 grants matched).

## Problem

`processGrantsWithExternalPrincipals` ends with an "apply" phase: one bulk `PutGrants` of the expanded grants, then a loop deleting the placeholder carrier grants. On the Pebble engine that delete loop is the dominant cost of the whole external-principal match.

The two halves are asymmetric. `PutGrantRecords` stages every record into **one** `RecordBatch` and commits it once. The delete path (`deleteGrantByIdentityLocked`) does the opposite: per grant it acquires the engine write lock, does an existence probe, allocates a fresh `RecordBatch`, and commits it with the engine's default durability — `DurabilitySync`, i.e. `pebble.Sync`. So a bulk caller pays **one fsync per grant**.

Measured on a synthetic fixture against a real on-disk Pebble store, at the engine's default durability:

| grants | bulk `PutGrants` | delete loop | delete share of apply |
|---:|---:|---:|---:|
| 5,000 | 34 ms | 13,551 ms | 99.7% |
| 20,000 | 70 ms | 53,239 ms | 99.9% |
| 50,000 | 165 ms | 112,636 ms | 99.9% |
| 90,000 | 425 ms | 220,124 ms | 99.8% |

A durability counterfactual on the same fixture isolates the cause: at 5,000 grants, deletes cost **2712 µs each with `pebble.Sync` vs 4.3 µs with `NoSync`** — **99.84% of the cost is fsync**, not the existence probe (~4 µs including the batch allocation). Per-delete cost is flat across the range (2710 / 2662 / 2253 / 2446 µs), so this is a constant per-grant tax, not superlinear growth.

For scale context, a run against a tenant with ~90k grants on network-attached storage measured this phase at ~956s, implying ~10.6 ms per delete — the same shape with a slower fsync.

Related context: CXP-834. That work removed an O(n·m) matching loop; this is the next cost in the same function, and is independent of it.

## Fix

Add a bulk delete that stages N deletions into chunked `RecordBatch`es under a single write-lock acquisition:

- `Engine.DeleteGrantsByRefs` / `Engine.DeleteGrantsByIdentityRefs` (pebble)
- `pebbleStore.DeleteGrantsByRefs`
- an optional `grantsByRefsBatchDeleter` interface in the syncer

**Durability is deliberately unchanged.** Every chunk still commits with `writeOpts(e.opts.durability)`, so crash semantics are identical — only the fsync *count* drops. The win is amortization, not a weaker guarantee.

Per-grant semantics are unchanged too. The existence probe, the `ErrNotFound` skip (an absent key stages nothing, so deleting a non-existent grant stays a true no-op and does not invalidate the entitlement's digest partition), and the index/digest obligations `StageGrantDelete` derives are shared with the singular path via one helper, `stageGrantDeleteIfPresentLocked`, so the two paths cannot drift.

The syncer applies the same `newGrantIDs` re-issue filter as before, and stores that do not implement the interface fall through to the existing per-grant loop unchanged — SQLite has no `DeleteGrantByRefs` at all and keeps using `DeleteGrant`.

`grantDeleteBatchChunk` is 1000, sized for peak batch memory rather than fsync count. A staged delete is 6 batch ops whose bytes are dominated by the entitlement id repeated across them: measured, one grant stages ~225 B at a 16-char entitlement id, ~640 B at 75 chars, ~1.6 KB at 215. So 1000 is ~0.2–1.6 MiB of live batch where 10000 would be ~2.2–16 MiB and keeps scaling with id length. Against the ~90k fsyncs removed, 90 commits versus 9 is noise.

Because the write lock is now taken once instead of per grant, each chunk boundary re-checks two things that `withWrite` would otherwise have checked per write:

- **`e.sealed`** — the under-lock re-check in `withWrite` is the actual fence against writing past `EndSync` (`seal()` takes only `sealMu` and does not wait on `writeWG`, and `EndSync` seals before finalize). Without a per-chunk re-check, a late chunk and its digest invalidations could land after finalize began rebuilding the deferred `by_principal` index.
- **`ctx`** — a large delete set is otherwise uninterruptible. Aborting mid-way is safe: committed chunks are durable, the dirty flag is set, and a resumed sync re-derives its delete set and re-issues these idempotent deletes.

`pebbleStore.DeleteGrantsByRefs` marks dirty **unconditionally** rather than through `markDirty`, which only marks on success. That is correct for the singular delete (one call, one commit — a failure wrote nothing) but wrong for the bulk form, where one call commits many chunks: if a later chunk fails, earlier ones are already durable in Pebble, and leaving `dirty` unset lets `Close` discard the temp dir and silently drop committed work. There is a regression test that reproduces exactly that data loss against the old routing.

## Testing

- An **equivalence oracle**: a batched delete leaves a store indistinguishable from a singular one across grant primary rows, the `by_principal` and `by_needs_expansion` indexes, and digest node/hash-index state.
- Absent-grant no-op, including that it does not spuriously invalidate digests.
- Mixed batches with duplicate identities staged into one `RecordBatch`.
- Mid-call seal and mid-call cancellation.
- Chunking is **observable**: the boundary consults `ctx` exactly once per chunk, so a counting context pins the chunk count at the production chunk size across a 2500-grant fixture. A mutant that ignores the chunk size and stages one unbounded batch fails this test.
- An end-to-end store test reproducing the dropped-work bug above.
- The syncer's three-way delete routing (batch / refs / id).

Mutation-checked: removing the existence probe, an off-by-one in the chunk loop, dropping the `newGrantIDs` filter, reverting the dirty-flag routing, removing the per-chunk sealed re-check, and collapsing chunking into one batch all fail at least one test.

Full `./pkg/dotc1z/...` and `./pkg/sync/...` suites pass under both `-tags=baton_lambda_support` and `-tags=verification`, plus `-race`.
