### PR TITLE
[CE-1250] fix: hydrate full Resource before local Grant/Revoke calls

### DIFF
--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
@@ -135,16 +136,9 @@ func (p *Provisioner) Close(ctx context.Context) error {
 // Grant/Revoke, or the connector never sees the resource's Profile,
 // DisplayName, etc.
 func hydrateEntitlementResource(e *v2.Entitlement, resource *v2.Resource) *v2.Entitlement {
-	return v2.Entitlement_builder{
-		Resource:    resource,
-		Id:          e.GetId(),
-		DisplayName: e.GetDisplayName(),
-		Description: e.GetDescription(),
-		GrantableTo: e.GetGrantableTo(),
-		Annotations: e.GetAnnotations(),
-		Purpose:     e.GetPurpose(),
-		Slug:        e.GetSlug(),
-	}.Build()
+	clone := proto.Clone(e).(*v2.Entitlement)
+	clone.SetResource(resource)
+	return clone
 }
 
 func (p *Provisioner) grant(ctx context.Context) error {

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -135,10 +135,21 @@ func (p *Provisioner) Close(ctx context.Context) error {
 // splice it back in before handing the entitlement to a connector's
 // Grant/Revoke, or the connector never sees the resource's Profile,
 // DisplayName, etc.
+//
+// GrantableTo is untouched: V3EntitlementToV2 also stubs it down to
+// ResourceType id-only entries, and this helper does not re-hydrate those —
+// a connector reading entitlement.GrantableTo display names/traits in
+// Grant/Revoke still sees stubs on the Pebble engine.
 func hydrateEntitlementResource(e *v2.Entitlement, resource *v2.Resource) *v2.Entitlement {
-	clone := proto.Clone(e).(*v2.Entitlement)
-	clone.SetResource(resource)
-	return clone
+	if e == nil {
+		return nil
+	}
+	hydrated, ok := proto.Clone(e).(*v2.Entitlement)
+	if !ok {
+		return e
+	}
+	hydrated.SetResource(resource)
+	return hydrated
 }
 
 func (p *Provisioner) grant(ctx context.Context) error {

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -126,6 +126,27 @@ func (p *Provisioner) Close(ctx context.Context) error {
 	return nil
 }
 
+// hydrateEntitlementResource returns a copy of e with Resource replaced by
+// resource. The store's entitlement read (GetEntitlement, via
+// V3EntitlementToV2 on the Pebble engine) returns Resource as an
+// identity-only stub; callers that already fetched the full Resource
+// separately (e.g. for the external-resource annotation check) must
+// splice it back in before handing the entitlement to a connector's
+// Grant/Revoke, or the connector never sees the resource's Profile,
+// DisplayName, etc.
+func hydrateEntitlementResource(e *v2.Entitlement, resource *v2.Resource) *v2.Entitlement {
+	return v2.Entitlement_builder{
+		Resource:    resource,
+		Id:          e.GetId(),
+		DisplayName: e.GetDisplayName(),
+		Description: e.GetDescription(),
+		GrantableTo: e.GetGrantableTo(),
+		Annotations: e.GetAnnotations(),
+		Purpose:     e.GetPurpose(),
+		Slug:        e.GetSlug(),
+	}.Build()
+}
+
 func (p *Provisioner) grant(ctx context.Context) error {
 	ctx, span := tracer.Start(ctx, "Provisioner.grant")
 	var err error
@@ -165,18 +186,9 @@ func (p *Provisioner) grant(ctx context.Context) error {
 		return err
 	}
 
-	resource := v2.Resource_builder{
-		Id:               principal.GetResource().GetId(),
-		DisplayName:      principal.GetResource().GetDisplayName(),
-		Annotations:      principal.GetResource().GetAnnotations(),
-		Description:      principal.GetResource().GetDescription(),
-		ExternalId:       principal.GetResource().GetExternalId(), //nolint:staticcheck // Deprecated.
-		ParentResourceId: principal.GetResource().GetParentResourceId(),
-	}.Build()
-
 	_, err = p.connector.Grant(ctx, v2.GrantManagerServiceGrantRequest_builder{
-		Entitlement: entitlement.GetEntitlement(),
-		Principal:   resource,
+		Entitlement: hydrateEntitlementResource(entitlement.GetEntitlement(), entitlementResource.GetResource()),
+		Principal:   principal.GetResource(),
 	}.Build())
 	if err != nil {
 		return err
@@ -228,20 +240,11 @@ func (p *Provisioner) revoke(ctx context.Context) error {
 		return errors.New("cannot revoke grant on external resource")
 	}
 
-	resource := v2.Resource_builder{
-		Id:               principal.GetResource().GetId(),
-		DisplayName:      principal.GetResource().GetDisplayName(),
-		Annotations:      principal.GetResource().GetAnnotations(),
-		Description:      principal.GetResource().GetDescription(),
-		ExternalId:       principal.GetResource().GetExternalId(), //nolint:staticcheck // Deprecated.
-		ParentResourceId: principal.GetResource().GetParentResourceId(),
-	}.Build()
-
 	_, err = p.connector.Revoke(ctx, v2.GrantManagerServiceRevokeRequest_builder{
 		Grant: v2.Grant_builder{
 			Id:          grant.GetGrant().GetId(),
-			Entitlement: entitlement.GetEntitlement(),
-			Principal:   resource,
+			Entitlement: hydrateEntitlementResource(entitlement.GetEntitlement(), entitlementResource.GetResource()),
+			Principal:   principal.GetResource(),
 			Annotations: grant.GetGrant().GetAnnotations(),
 		}.Build(),
 	}.Build())

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -1,0 +1,162 @@
+package provisioner
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
+	"github.com/conductorone/baton-sdk/pkg/types"
+)
+
+// fakeGrantConnectorClient captures the requests handed to Grant/Revoke so
+// tests can inspect exactly what the connector received. All other
+// ConnectorClient methods are left as the nil embedded interface and must
+// not be called by these tests.
+type fakeGrantConnectorClient struct {
+	types.ConnectorClient
+
+	grantReq  *v2.GrantManagerServiceGrantRequest
+	revokeReq *v2.GrantManagerServiceRevokeRequest
+}
+
+func (f *fakeGrantConnectorClient) Grant(ctx context.Context, in *v2.GrantManagerServiceGrantRequest, opts ...grpc.CallOption) (*v2.GrantManagerServiceGrantResponse, error) {
+	f.grantReq = in
+	return v2.GrantManagerServiceGrantResponse_builder{}.Build(), nil
+}
+
+func (f *fakeGrantConnectorClient) Revoke(ctx context.Context, in *v2.GrantManagerServiceRevokeRequest, opts ...grpc.CallOption) (*v2.GrantManagerServiceRevokeResponse, error) {
+	f.revokeReq = in
+	return v2.GrantManagerServiceRevokeResponse_builder{}.Build(), nil
+}
+
+// buildHydrationTestStore writes a group resource (the entitlement's
+// resource), a user resource (the grant principal) and one entitlement +
+// grant connecting them, each carrying Profile data that only a fully
+// hydrated v2.Resource would preserve. It returns a freshly reopened
+// read/write store so reads go through the same code path a real
+// `baton grant`/`baton revoke` invocation would use.
+func buildHydrationTestStore(t *testing.T, ctx context.Context, engine c1zstore.Engine) connectorstore.Reader {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "test.c1z")
+
+	store, err := dotc1z.NewStore(ctx, path, dotc1z.WithEngine(engine))
+	require.NoError(t, err)
+
+	_, err = store.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+
+	userRT := v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()
+	groupRT := v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()
+	require.NoError(t, store.PutResourceTypes(ctx, userRT, groupRT))
+
+	groupProfile, err := structpb.NewStruct(map[string]interface{}{"href": "https://example.com/folders/g1"})
+	require.NoError(t, err)
+	group := v2.Resource_builder{
+		Id:          v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(),
+		DisplayName: "Group One",
+		Profile:     groupProfile,
+	}.Build()
+
+	userProfile, err := structpb.NewStruct(map[string]interface{}{"email": "alice@example.com"})
+	require.NoError(t, err)
+	user := v2.Resource_builder{
+		Id:          v2.ResourceId_builder{ResourceType: "user", Resource: "alice"}.Build(),
+		DisplayName: "Alice",
+		Profile:     userProfile,
+	}.Build()
+	require.NoError(t, store.PutResources(ctx, group, user))
+
+	member := v2.Entitlement_builder{
+		Id:          "member",
+		Resource:    group,
+		DisplayName: "Member",
+		Slug:        "member",
+		Purpose:     v2.Entitlement_PURPOSE_VALUE_ASSIGNMENT,
+	}.Build()
+	require.NoError(t, store.PutEntitlements(ctx, member))
+
+	grant := v2.Grant_builder{
+		Id:          "grant1",
+		Principal:   user,
+		Entitlement: member,
+	}.Build()
+	require.NoError(t, store.PutGrants(ctx, grant))
+
+	require.NoError(t, store.EndSync(ctx))
+	require.NoError(t, store.Close(ctx))
+
+	reopened, err := dotc1z.NewStore(ctx, path, dotc1z.WithReadOnly(true))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = reopened.Close(ctx) })
+
+	return reopened
+}
+
+func TestProvisionerGrantHydratesResources(t *testing.T) {
+	for _, engine := range []c1zstore.Engine{c1zstore.EngineSQLite, c1zstore.EnginePebble} {
+		t.Run(string(engine), func(t *testing.T) {
+			ctx := context.Background()
+			store := buildHydrationTestStore(t, ctx, engine)
+
+			cc := &fakeGrantConnectorClient{}
+			p := &Provisioner{
+				store:              store,
+				connector:          cc,
+				grantEntitlementID: "member",
+				grantPrincipalID:   "alice",
+				grantPrincipalType: "user",
+			}
+
+			require.NoError(t, p.grant(ctx))
+			require.NotNil(t, cc.grantReq)
+
+			principal := cc.grantReq.GetPrincipal()
+			require.Equal(t, "Alice", principal.GetDisplayName())
+			require.Equal(t, "alice@example.com", principal.GetProfile().GetFields()["email"].GetStringValue())
+
+			entResource := cc.grantReq.GetEntitlement().GetResource()
+			require.Equal(t, "Group One", entResource.GetDisplayName(),
+				"entitlement.Resource must be the fully hydrated group, not an identity-only stub")
+			require.Equal(t, "https://example.com/folders/g1", entResource.GetProfile().GetFields()["href"].GetStringValue(),
+				"entitlement.Resource.Profile must survive so a connector's Grant() can read it")
+		})
+	}
+}
+
+func TestProvisionerRevokeHydratesResources(t *testing.T) {
+	for _, engine := range []c1zstore.Engine{c1zstore.EngineSQLite, c1zstore.EnginePebble} {
+		t.Run(string(engine), func(t *testing.T) {
+			ctx := context.Background()
+			store := buildHydrationTestStore(t, ctx, engine)
+
+			cc := &fakeGrantConnectorClient{}
+			p := &Provisioner{
+				store:         store,
+				connector:     cc,
+				revokeGrantID: "grant1",
+			}
+
+			require.NoError(t, p.revoke(ctx))
+			require.NotNil(t, cc.revokeReq)
+
+			principal := cc.revokeReq.GetGrant().GetPrincipal()
+			require.Equal(t, "Alice", principal.GetDisplayName())
+			require.Equal(t, "alice@example.com", principal.GetProfile().GetFields()["email"].GetStringValue())
+
+			entResource := cc.revokeReq.GetGrant().GetEntitlement().GetResource()
+			require.Equal(t, "Group One", entResource.GetDisplayName(),
+				"entitlement.Resource must be the fully hydrated group, not an identity-only stub")
+			require.Equal(t, "https://example.com/folders/g1", entResource.GetProfile().GetFields()["href"].GetStringValue(),
+				"entitlement.Resource.Profile must survive so a connector's Revoke() can read it")
+		})
+	}
+}

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -123,11 +123,17 @@ func TestProvisionerGrantHydratesResources(t *testing.T) {
 			require.Equal(t, "Alice", principal.GetDisplayName())
 			require.Equal(t, "alice@example.com", principal.GetProfile().GetFields()["email"].GetStringValue())
 
-			entResource := cc.grantReq.GetEntitlement().GetResource()
+			hydratedEntitlement := cc.grantReq.GetEntitlement()
+			entResource := hydratedEntitlement.GetResource()
 			require.Equal(t, "Group One", entResource.GetDisplayName(),
 				"entitlement.Resource must be the fully hydrated group, not an identity-only stub")
 			require.Equal(t, "https://example.com/folders/g1", entResource.GetProfile().GetFields()["href"].GetStringValue(),
 				"entitlement.Resource.Profile must survive so a connector's Grant() can read it")
+
+			require.Equal(t, "member", hydratedEntitlement.GetSlug(),
+				"hydrateEntitlementResource must preserve the entitlement's own fields, not just splice in Resource")
+			require.Equal(t, "Member", hydratedEntitlement.GetDisplayName())
+			require.Equal(t, v2.Entitlement_PURPOSE_VALUE_ASSIGNMENT, hydratedEntitlement.GetPurpose())
 		})
 	}
 }
@@ -152,11 +158,17 @@ func TestProvisionerRevokeHydratesResources(t *testing.T) {
 			require.Equal(t, "Alice", principal.GetDisplayName())
 			require.Equal(t, "alice@example.com", principal.GetProfile().GetFields()["email"].GetStringValue())
 
-			entResource := cc.revokeReq.GetGrant().GetEntitlement().GetResource()
+			hydratedEntitlement := cc.revokeReq.GetGrant().GetEntitlement()
+			entResource := hydratedEntitlement.GetResource()
 			require.Equal(t, "Group One", entResource.GetDisplayName(),
 				"entitlement.Resource must be the fully hydrated group, not an identity-only stub")
 			require.Equal(t, "https://example.com/folders/g1", entResource.GetProfile().GetFields()["href"].GetStringValue(),
 				"entitlement.Resource.Profile must survive so a connector's Revoke() can read it")
+
+			require.Equal(t, "member", hydratedEntitlement.GetSlug(),
+				"hydrateEntitlementResource must preserve the entitlement's own fields, not just splice in Resource")
+			require.Equal(t, "Member", hydratedEntitlement.GetDisplayName())
+			require.Equal(t, v2.Entitlement_PURPOSE_VALUE_ASSIGNMENT, hydratedEntitlement.GetPurpose())
 		})
 	}
 }

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -172,3 +172,39 @@ func TestProvisionerRevokeHydratesResources(t *testing.T) {
 		})
 	}
 }
+
+// TestHydrateEntitlementResource pins the nil-guard contract directly: the
+// end-to-end Grant/Revoke tests above never pass a nil entitlement (both
+// call sites derive it from a store read that errors instead of returning
+// nil), so they can't exercise these branches.
+func TestHydrateEntitlementResource(t *testing.T) {
+	group := v2.Resource_builder{
+		Id: v2.ResourceId_builder{ResourceType: "group", Resource: "g1"}.Build(),
+	}.Build()
+	entitlement := v2.Entitlement_builder{
+		Id:          "member",
+		Resource:    v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "group", Resource: "stub"}.Build()}.Build(),
+		DisplayName: "Member",
+		Slug:        "member",
+	}.Build()
+
+	t.Run("nil entitlement returns nil", func(t *testing.T) {
+		require.Nil(t, hydrateEntitlementResource(nil, group))
+	})
+
+	t.Run("nil resource clears Resource but keeps other fields", func(t *testing.T) {
+		got := hydrateEntitlementResource(entitlement, nil)
+		require.Nil(t, got.GetResource())
+		require.Equal(t, "member", got.GetSlug())
+		require.Equal(t, "Member", got.GetDisplayName())
+	})
+
+	t.Run("non-nil inputs produce an independent clone", func(t *testing.T) {
+		got := hydrateEntitlementResource(entitlement, group)
+		require.NotSame(t, entitlement, got, "hydrateEntitlementResource must return a clone, not mutate or alias its input")
+		require.Equal(t, group.GetId().GetResource(), got.GetResource().GetId().GetResource())
+		require.Equal(t, "member", got.GetSlug())
+		require.Equal(t, "stub", entitlement.GetResource().GetId().GetResource(),
+			"the original entitlement must be untouched by hydration")
+	})
+}


### PR DESCRIPTION
## Summary

`Provisioner.grant`/`revoke` (the local `baton grant`/`baton revoke` CLI path — also what `baton-test run all`'s grant/revoke lifecycle test drives in CI) already fetch a fully-hydrated `v2.Resource` for both the principal and the entitlement's resource, but discard the hydration before calling the connector:

- **Entitlement**: `entitlementResource` is fetched (to check the `BatonID` external-resource annotation) but never spliced back in — `entitlement.GetEntitlement()` is passed through with `Resource` as an identity-only stub (on the Pebble engine, `V3EntitlementToV2` documents this by design; see `pkg/dotc1z/engine/pebble/translate_v2.go:508`).
- **Principal**: rebuilt via a hand-copied field list (`Id, DisplayName, Annotations, Description, ExternalId, ParentResourceId`) that predates `Profile`/`Status`/`CreatedAt` on `v2.Resource`. Git history (`866f6618`, `#764`) shows this list has always been an incrementally-patched allowlist (e.g. `ParentResourceId` was added back in `#764` after initially being stripped) — `Profile` was simply never revisited, not deliberately excluded.

Net effect: a connector's `Grant`/`Revoke` implementation never receives `Profile` data for either the principal or the entitlement's resource via this path — even when the store already has it — because it's thrown away one line before the RPC call. Regression tests below fail against the pre-fix code on **both** storage engines (SQLite and Pebble), confirming this isn't Pebble-specific.

## Scope note

This fixes the **local/CLI provisioning path** (`pkg/provisioner/provisioner.go`), which is the only Grant/Revoke call site in this repo with access to a local store. The platform-driven production path (`pkg/tasks/c1api/grant.go`/`revoke.go`) builds its request from an incoming task payload the C1 platform already constructed server-side — it never touches a local store, so there's nothing to hydrate here; if a similar gap exists there, the fix is out of this repo's reach.

`pkg/connectorbuilder/resource_provisioner.go` (the connector-side gRPC handler) was also checked and ruled out as a fix site: it's a pure forwarding handler with no store reference in either topology, so it architecturally cannot hydrate anything itself.

## Edge case: resource not in store

No new failure mode is introduced. `entitlementResource` was already fetched unconditionally before this change (for the `BatonID` check), so a missing/deleted resource already hard-errors `grant()`/`revoke()` today. This PR only reuses data that was already a hard requirement.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./pkg/provisioner/...` / `golangci-lint run ./pkg/provisioner/...` — clean
- [x] New tests in `pkg/provisioner/provisioner_test.go`: `TestProvisionerGrantHydratesResources` / `TestProvisionerRevokeHydratesResources`, each run against both SQLite and Pebble engines via a real `.c1z` store (not a mock) — write a group resource + user resource with `Profile` data, an entitlement, and a grant, then assert the connector-bound request carries the full principal and entitlement resource, Profile included.
- [x] Verified both tests fail against the pre-fix code (confirmed via `git stash` before committing) and pass after.
- [x] `go test ./pkg/provisioner/... ./pkg/tasks/local/... ./pkg/connectorbuilder/...` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)