### PR TITLE
dotc1z: make the v3 manifest descriptor closure byte-deterministic

### DIFF
--- a/pkg/dotc1z/format/v3/envelope_test.go
+++ b/pkg/dotc1z/format/v3/envelope_test.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"sort"
 	"testing"
 
 	c1zv3 "github.com/conductorone/baton-sdk/pb/c1/c1z/v3"
@@ -113,6 +114,39 @@ func TestBuildDescriptorClosureIncludesStorageV3(t *testing.T) {
 		}
 	}
 	require.True(t, found, "closure missing %s; got %d files", want, len(set.File))
+}
+
+// TestBuildDescriptorClosureDeterministic pins that the closure — and
+// therefore the manifest bytes that embed it — is byte-deterministic
+// across builds. proto's Deterministic marshal option only sorts map
+// entries; repeated-field order is part of the message value, so the
+// builder must emit a canonical (path-sorted) order itself. The pre-fix
+// builder ranged its collection map, which permuted the set on every
+// call and made two saves of identical content produce different
+// manifest bytes (and a different manifest_xxh64).
+func TestBuildDescriptorClosureDeterministic(t *testing.T) {
+	// Touch the storage.v3 package so its descriptors are registered.
+	_ = &v3pb.GrantRecord{}
+
+	build := func() []byte {
+		set, err := BuildDescriptorClosure()
+		require.NoError(t, err)
+		require.NotEmpty(t, set.File)
+		// The structural property: sorted by path. This catches an
+		// ordering regression deterministically, independent of how
+		// map iteration happens to land in this run.
+		require.True(t, sort.SliceIsSorted(set.File, func(i, j int) bool {
+			return set.File[i].GetName() < set.File[j].GetName()
+		}), "descriptor closure is not sorted by file path")
+		b, err := MarshalManifest(&c1zv3.C1ZManifestV3{Engine: "pebble", Descriptors: set})
+		require.NoError(t, err)
+		return b
+	}
+
+	first := build()
+	for i := 0; i < 20; i++ {
+		require.Equal(t, first, build(), "manifest bytes differ across identical builds (iteration %d)", i)
+	}
 }
 
 // envelope_test helpers below — tiny stand-ins so the test file is self-contained.

--- a/pkg/dotc1z/format/v3/manifest.go
+++ b/pkg/dotc1z/format/v3/manifest.go
@@ -3,6 +3,7 @@ package v3
 import (
 	"errors"
 	"fmt"
+	"sort"
 
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protodesc"
@@ -33,6 +34,16 @@ var (
 // The closure invariant: for every file F in the result, every file F
 // imports is also in the result. Reader-side verification can detect
 // any missing import and return ErrManifestIncompleteDescriptors.
+//
+// The result is sorted by file path so the set — and therefore the
+// marshaled manifest that embeds it — is byte-deterministic across
+// calls. proto's Deterministic marshal option only sorts map entries;
+// repeated-field order is part of the message value, so emitting the
+// closure in Go map-iteration order would make every save produce
+// different manifest bytes (and a different manifest_xxh64) for
+// identical content, defeating any use of the manifest as a content
+// identity. Readers do not depend on any particular order
+// (VerifyDescriptorClosure is set-based).
 func BuildDescriptorClosure() (*descriptorpb.FileDescriptorSet, error) {
 	// Collect all files whose package is c1.storage.v3 OR which any
 	// such file transitively imports.
@@ -56,11 +67,20 @@ func BuildDescriptorClosure() (*descriptorpb.FileDescriptorSet, error) {
 		return true
 	})
 
+	// Sort by path (the map key, so unique — no ties) rather than
+	// ranging the map: Go randomizes map iteration per range statement,
+	// which would permute the repeated field on every call.
+	paths := make([]string, 0, len(seen))
+	for p := range seen {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+
 	set := &descriptorpb.FileDescriptorSet{
 		File: make([]*descriptorpb.FileDescriptorProto, 0, len(seen)),
 	}
-	for _, fd := range seen {
-		set.File = append(set.File, protodesc.ToFileDescriptorProto(fd))
+	for _, p := range paths {
+		set.File = append(set.File, protodesc.ToFileDescriptorProto(seen[p]))
 	}
 	return set, nil
 }


### PR DESCRIPTION
## Summary

`BuildDescriptorClosure` built the v3 manifest's `FileDescriptorSet` by ranging a Go map, so the repeated `file` field came out in a different permutation on every call — including within a single process. proto's `Deterministic` marshal option does not fix this: it only sorts map entries, and repeated-field order is part of the message value.

Consequences before this fix:

- Two saves of byte-identical logical content produced different manifest bytes, and therefore a different `manifest_xxh64` in the indexed-zstd trailer.
- The manifest was unusable as a content identity, and the envelope head never dedups in content-addressed storage.

This PR emits the closure sorted by file path. The path is the collection map's key, so the order is total with no ties.

## Why this is safe

Every consumer was traced before making the change:

- **No production reader touches `descriptors`.** All manifest reads (engine dispatch, compaction source selection, fold-waste cutover, `Metadata()`) consume scalar fields only. The only closure inspector, `VerifyDescriptorClosure`, is set-based (order-independent) and is currently only called from tests.
- **`manifest_xxh64` is intra-file.** It is written and verified against the same file's own bytes (`indexed.go`); it is never compared across files or saves.
- **Splicing and offsets are unaffected.** A permutation preserves the encoded length, so `payloadStart` and every frame offset are unchanged; frame reuse matches by name + content hash, not position.
- **Existing files stay valid.** Old envelopes carry randomly-ordered closures; every read path that accepts them today is order-blind, and no golden fixtures exist.
- **External consumers already tolerate arbitrary order** — the current order varies on every save, so nothing can be depending on a specific one.