### PR TITLE
fix(pebble): preserve resource icon asset refs

### DIFF
--- a/pb/c1/storage/v3/records.pb.go
+++ b/pb/c1/storage/v3/records.pb.go
@@ -591,8 +591,10 @@ type ResourceRecord struct {
 	// to 12 when profile/status/created_at (9-11) landed on main first.
 	// No artifact was ever written with the old number.
 	SourceScopeKey string `protobuf:"bytes,12,opt,name=source_scope_key,json=sourceScopeKey,proto3" json:"source_scope_key,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// External ID of the resource icon asset. This must point to an asset that is an image.
+	IconAssetExternalId string `protobuf:"bytes,13,opt,name=icon_asset_external_id,json=iconAssetExternalId,proto3" json:"icon_asset_external_id,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
 }
 
 func (x *ResourceRecord) Reset() {
@@ -697,6 +699,13 @@ func (x *ResourceRecord) GetSourceScopeKey() string {
 	return ""
 }
 
+func (x *ResourceRecord) GetIconAssetExternalId() string {
+	if x != nil {
+		return x.IconAssetExternalId
+	}
+	return ""
+}
+
 func (x *ResourceRecord) SetResourceTypeId(v string) {
 	x.ResourceTypeId = v
 }
@@ -739,6 +748,10 @@ func (x *ResourceRecord) SetCreatedAt(v *timestamppb.Timestamp) {
 
 func (x *ResourceRecord) SetSourceScopeKey(v string) {
 	x.SourceScopeKey = v
+}
+
+func (x *ResourceRecord) SetIconAssetExternalId(v string) {
+	x.IconAssetExternalId = v
 }
 
 func (x *ResourceRecord) HasParent() bool {
@@ -818,6 +831,8 @@ type ResourceRecord_builder struct {
 	// to 12 when profile/status/created_at (9-11) landed on main first.
 	// No artifact was ever written with the old number.
 	SourceScopeKey string
+	// External ID of the resource icon asset. This must point to an asset that is an image.
+	IconAssetExternalId string
 }
 
 func (b0 ResourceRecord_builder) Build() *ResourceRecord {
@@ -835,6 +850,7 @@ func (b0 ResourceRecord_builder) Build() *ResourceRecord {
 	x.Status = b.Status
 	x.CreatedAt = b.CreatedAt
 	x.SourceScopeKey = b.SourceScopeKey
+	x.IconAssetExternalId = b.IconAssetExternalId
 	return m0
 }
 
@@ -2756,7 +2772,7 @@ const file_c1_storage_v3_records_proto_rawDesc = "" +
 	"\rdiscovered_at\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\fdiscoveredAt\x12 \n" +
 	"\vdescription\x18\a \x01(\tR\vdescription\x12-\n" +
 	"\x12sourced_externally\x18\b \x01(\bR\x11sourcedExternally:!\x82\xf9+\x1d\n" +
-	"\x0eresource_types\x12\vexternal_idJ\x04\b\x01\x10\x02R\async_id\"\xb8\x05\n" +
+	"\x0eresource_types\x12\vexternal_idJ\x04\b\x01\x10\x02R\async_id\"\xed\x05\n" +
 	"\x0eResourceRecord\x12(\n" +
 	"\x10resource_type_id\x18\x02 \x01(\tR\x0eresourceTypeId\x12\x1f\n" +
 	"\vresource_id\x18\x03 \x01(\tR\n" +
@@ -2773,7 +2789,8 @@ const file_c1_storage_v3_records_proto_rawDesc = "" +
 	"\n" +
 	"created_at\x18\v \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x12W\n" +
 	"\x10source_scope_key\x18\f \x01(\tB-\x8a\xf9+)\n" +
-	"\x0fby_source_scope\"\x16source_scope_key != ''R\x0esourceScopeKey:.\x82\xf9+*\n" +
+	"\x0fby_source_scope\"\x16source_scope_key != ''R\x0esourceScopeKey\x123\n" +
+	"\x16icon_asset_external_id\x18\r \x01(\tR\x13iconAssetExternalId:.\x82\xf9+*\n" +
 	"\tresources\x12\x10resource_type_id\x12\vresource_idJ\x04\b\x01\x10\x02R\async_id\"\xd7\x04\n" +
 	"\x11EntitlementRecord\x12\x1f\n" +
 	"\vexternal_id\x18\x02 \x01(\tR\n" +

--- a/pb/c1/storage/v3/records.pb.validate.go
+++ b/pb/c1/storage/v3/records.pb.validate.go
@@ -736,6 +736,8 @@ func (m *ResourceRecord) validate(all bool) error {
 
 	// no validation rules for SourceScopeKey
 
+	// no validation rules for IconAssetExternalId
+
 	if len(errors) > 0 {
 		return ResourceRecordMultiError(errors)
 	}

--- a/pb/c1/storage/v3/records_protoopaque.pb.go
+++ b/pb/c1/storage/v3/records_protoopaque.pb.go
@@ -564,20 +564,21 @@ func (b0 ResourceTypeRecord_builder) Build() *ResourceTypeRecord {
 }
 
 type ResourceRecord struct {
-	state                     protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_ResourceTypeId string                 `protobuf:"bytes,2,opt,name=resource_type_id,json=resourceTypeId,proto3"`
-	xxx_hidden_ResourceId     string                 `protobuf:"bytes,3,opt,name=resource_id,json=resourceId,proto3"`
-	xxx_hidden_DisplayName    string                 `protobuf:"bytes,4,opt,name=display_name,json=displayName,proto3"`
-	xxx_hidden_Description    string                 `protobuf:"bytes,5,opt,name=description,proto3"`
-	xxx_hidden_Parent         *ResourceRef           `protobuf:"bytes,6,opt,name=parent,proto3"`
-	xxx_hidden_Annotations    *[]*anypb.Any          `protobuf:"bytes,7,rep,name=annotations,proto3"`
-	xxx_hidden_DiscoveredAt   *timestamppb.Timestamp `protobuf:"bytes,8,opt,name=discovered_at,json=discoveredAt,proto3"`
-	xxx_hidden_Profile        *structpb.Struct       `protobuf:"bytes,9,opt,name=profile,proto3"`
-	xxx_hidden_Status         *StatusRecord          `protobuf:"bytes,10,opt,name=status,proto3"`
-	xxx_hidden_CreatedAt      *timestamppb.Timestamp `protobuf:"bytes,11,opt,name=created_at,json=createdAt,proto3"`
-	xxx_hidden_SourceScopeKey string                 `protobuf:"bytes,12,opt,name=source_scope_key,json=sourceScopeKey,proto3"`
-	unknownFields             protoimpl.UnknownFields
-	sizeCache                 protoimpl.SizeCache
+	state                          protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_ResourceTypeId      string                 `protobuf:"bytes,2,opt,name=resource_type_id,json=resourceTypeId,proto3"`
+	xxx_hidden_ResourceId          string                 `protobuf:"bytes,3,opt,name=resource_id,json=resourceId,proto3"`
+	xxx_hidden_DisplayName         string                 `protobuf:"bytes,4,opt,name=display_name,json=displayName,proto3"`
+	xxx_hidden_Description         string                 `protobuf:"bytes,5,opt,name=description,proto3"`
+	xxx_hidden_Parent              *ResourceRef           `protobuf:"bytes,6,opt,name=parent,proto3"`
+	xxx_hidden_Annotations         *[]*anypb.Any          `protobuf:"bytes,7,rep,name=annotations,proto3"`
+	xxx_hidden_DiscoveredAt        *timestamppb.Timestamp `protobuf:"bytes,8,opt,name=discovered_at,json=discoveredAt,proto3"`
+	xxx_hidden_Profile             *structpb.Struct       `protobuf:"bytes,9,opt,name=profile,proto3"`
+	xxx_hidden_Status              *StatusRecord          `protobuf:"bytes,10,opt,name=status,proto3"`
+	xxx_hidden_CreatedAt           *timestamppb.Timestamp `protobuf:"bytes,11,opt,name=created_at,json=createdAt,proto3"`
+	xxx_hidden_SourceScopeKey      string                 `protobuf:"bytes,12,opt,name=source_scope_key,json=sourceScopeKey,proto3"`
+	xxx_hidden_IconAssetExternalId string                 `protobuf:"bytes,13,opt,name=icon_asset_external_id,json=iconAssetExternalId,proto3"`
+	unknownFields                  protoimpl.UnknownFields
+	sizeCache                      protoimpl.SizeCache
 }
 
 func (x *ResourceRecord) Reset() {
@@ -684,6 +685,13 @@ func (x *ResourceRecord) GetSourceScopeKey() string {
 	return ""
 }
 
+func (x *ResourceRecord) GetIconAssetExternalId() string {
+	if x != nil {
+		return x.xxx_hidden_IconAssetExternalId
+	}
+	return ""
+}
+
 func (x *ResourceRecord) SetResourceTypeId(v string) {
 	x.xxx_hidden_ResourceTypeId = v
 }
@@ -726,6 +734,10 @@ func (x *ResourceRecord) SetCreatedAt(v *timestamppb.Timestamp) {
 
 func (x *ResourceRecord) SetSourceScopeKey(v string) {
 	x.xxx_hidden_SourceScopeKey = v
+}
+
+func (x *ResourceRecord) SetIconAssetExternalId(v string) {
+	x.xxx_hidden_IconAssetExternalId = v
 }
 
 func (x *ResourceRecord) HasParent() bool {
@@ -805,6 +817,8 @@ type ResourceRecord_builder struct {
 	// to 12 when profile/status/created_at (9-11) landed on main first.
 	// No artifact was ever written with the old number.
 	SourceScopeKey string
+	// External ID of the resource icon asset. This must point to an asset that is an image.
+	IconAssetExternalId string
 }
 
 func (b0 ResourceRecord_builder) Build() *ResourceRecord {
@@ -822,6 +836,7 @@ func (b0 ResourceRecord_builder) Build() *ResourceRecord {
 	x.xxx_hidden_Status = b.Status
 	x.xxx_hidden_CreatedAt = b.CreatedAt
 	x.xxx_hidden_SourceScopeKey = b.SourceScopeKey
+	x.xxx_hidden_IconAssetExternalId = b.IconAssetExternalId
 	return m0
 }
 
@@ -2646,7 +2661,7 @@ const file_c1_storage_v3_records_proto_rawDesc = "" +
 	"\rdiscovered_at\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\fdiscoveredAt\x12 \n" +
 	"\vdescription\x18\a \x01(\tR\vdescription\x12-\n" +
 	"\x12sourced_externally\x18\b \x01(\bR\x11sourcedExternally:!\x82\xf9+\x1d\n" +
-	"\x0eresource_types\x12\vexternal_idJ\x04\b\x01\x10\x02R\async_id\"\xb8\x05\n" +
+	"\x0eresource_types\x12\vexternal_idJ\x04\b\x01\x10\x02R\async_id\"\xed\x05\n" +
 	"\x0eResourceRecord\x12(\n" +
 	"\x10resource_type_id\x18\x02 \x01(\tR\x0eresourceTypeId\x12\x1f\n" +
 	"\vresource_id\x18\x03 \x01(\tR\n" +
@@ -2663,7 +2678,8 @@ const file_c1_storage_v3_records_proto_rawDesc = "" +
 	"\n" +
 	"created_at\x18\v \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x12W\n" +
 	"\x10source_scope_key\x18\f \x01(\tB-\x8a\xf9+)\n" +
-	"\x0fby_source_scope\"\x16source_scope_key != ''R\x0esourceScopeKey:.\x82\xf9+*\n" +
+	"\x0fby_source_scope\"\x16source_scope_key != ''R\x0esourceScopeKey\x123\n" +
+	"\x16icon_asset_external_id\x18\r \x01(\tR\x13iconAssetExternalId:.\x82\xf9+*\n" +
 	"\tresources\x12\x10resource_type_id\x12\vresource_idJ\x04\b\x01\x10\x02R\async_id\"\xd7\x04\n" +
 	"\x11EntitlementRecord\x12\x1f\n" +
 	"\vexternal_id\x18\x02 \x01(\tR\n" +

--- a/pkg/dotc1z/engine/pebble/records_test.go
+++ b/pkg/dotc1z/engine/pebble/records_test.go
@@ -104,12 +104,12 @@ func TestResourceWithParentIndex(t *testing.T) {
 	require.Equal(t, 9, total, "IterateResourcesBySync")
 }
 
-// TestResourceProfileStatusCreatedAtPersistence verifies profile,
-// status, and created_at survive the full v2 write path (Adapter
+// TestResourceAttributesPersistence verifies profile, status, created_at,
+// and icon survive the full v2 write path (Adapter
 // PutResources → v3 record marshaled into Pebble) and hydrate back
 // out on read. The translate-only round trip is covered in
 // translate_v2_test.go; this pins the on-disk persistence.
-func TestResourceProfileStatusCreatedAtPersistence(t *testing.T) {
+func TestResourceAttributesPersistence(t *testing.T) {
 	ctx := context.Background()
 	e, _ := newTestEngine(t)
 	syncID := ksuid.New().String()
@@ -132,6 +132,9 @@ func TestResourceProfileStatusCreatedAtPersistence(t *testing.T) {
 			Details: "locked by admin",
 		},
 		CreatedAt: created,
+		Icon: v2.AssetRef_builder{
+			Id: "icon-alice",
+		}.Build(),
 	}.Build()
 	require.NoError(t, e.PutResources(ctx, res))
 
@@ -141,12 +144,14 @@ func TestResourceProfileStatusCreatedAtPersistence(t *testing.T) {
 	require.Equal(t, v3.StatusRecord_RESOURCE_STATUS_DISABLED, rec.GetStatus().GetStatus(), "stored status")
 	require.Equal(t, "locked by admin", rec.GetStatus().GetDetails(), "stored status details")
 	require.Equal(t, int64(1716393600), rec.GetCreatedAt().GetSeconds(), "stored created_at")
+	require.Equal(t, "icon-alice", rec.GetIconAssetExternalId(), "stored icon")
 
 	back := V3ResourceToV2(rec)
 	require.Equal(t, "alice@example.com", back.GetProfile().GetFields()["email"].GetStringValue(), "hydrated profile")
 	require.Equal(t, v2.Status_RESOURCE_STATUS_DISABLED, back.GetStatus().GetStatus(), "hydrated status")
 	require.Equal(t, "locked by admin", back.GetStatus().GetDetails(), "hydrated status details")
 	require.Equal(t, created.GetSeconds(), back.GetCreatedAt().GetSeconds(), "hydrated created_at")
+	require.Equal(t, "icon-alice", back.GetIcon().GetId(), "hydrated icon")
 }
 
 func TestEntitlementByResourceIndex(t *testing.T) {

--- a/pkg/dotc1z/engine/pebble/translate_v2.go
+++ b/pkg/dotc1z/engine/pebble/translate_v2.go
@@ -341,15 +341,32 @@ func V2ResourceToV3(syncID string, r *v2.Resource) *v3.ResourceRecord {
 		}.Build()
 	}
 	return v3.ResourceRecord_builder{
-		ResourceTypeId: r.GetId().GetResourceType(),
-		ResourceId:     r.GetId().GetResource(),
-		DisplayName:    r.GetDisplayName(),
-		Description:    r.GetDescription(),
-		Parent:         parent,
-		Annotations:    r.GetAnnotations(),
-		CreatedAt:      r.GetCreatedAt(),
-		Profile:        r.GetProfile(),
-		Status:         v2StatusToV3(r.GetStatus()),
+		ResourceTypeId:      r.GetId().GetResourceType(),
+		ResourceId:          r.GetId().GetResource(),
+		DisplayName:         r.GetDisplayName(),
+		Description:         r.GetDescription(),
+		Parent:              parent,
+		Annotations:         r.GetAnnotations(),
+		CreatedAt:           r.GetCreatedAt(),
+		Profile:             r.GetProfile(),
+		Status:              v2StatusToV3(r.GetStatus()),
+		IconAssetExternalId: v2AssetExternalID(r.GetIcon()),
+	}.Build()
+}
+
+func v2AssetExternalID(a *v2.AssetRef) string {
+	if a == nil {
+		return ""
+	}
+	return a.GetId()
+}
+
+func assetExternalIDToV2AssetRef(assetExternalID string) *v2.AssetRef {
+	if assetExternalID == "" {
+		return nil
+	}
+	return v2.AssetRef_builder{
+		Id: assetExternalID,
 	}.Build()
 }
 
@@ -401,6 +418,7 @@ func V3ResourceToV2(r *v3.ResourceRecord) *v2.Resource {
 		Profile:          r.GetProfile(),
 		Status:           v3StatusToV2(r.GetStatus()),
 		CreatedAt:        r.GetCreatedAt(),
+		Icon:             assetExternalIDToV2AssetRef(r.GetIconAssetExternalId()),
 	}.Build()
 }
 

--- a/pkg/dotc1z/engine/pebble/translate_v2_test.go
+++ b/pkg/dotc1z/engine/pebble/translate_v2_test.go
@@ -69,6 +69,9 @@ func TestV2ResourceRoundtrip(t *testing.T) {
 			Seconds: 1716393600,
 			Nanos:   0,
 		},
+		Icon: v2.AssetRef_builder{
+			Id: "icon-alice",
+		}.Build(),
 	}.Build()
 
 	v3rec := V2ResourceToV3("sync-1", original)
@@ -78,6 +81,7 @@ func TestV2ResourceRoundtrip(t *testing.T) {
 	require.Equal(t, v3.StatusRecord_RESOURCE_STATUS_ENABLED, v3rec.GetStatus().GetStatus(), "status")
 	require.Equal(t, "unlocked by admin", v3rec.GetStatus().GetDetails(), "status details")
 	require.Equal(t, int64(1716393600), v3rec.GetCreatedAt().GetSeconds(), "created_at")
+	require.Equal(t, "icon-alice", v3rec.GetIconAssetExternalId(), "icon")
 
 	back := V3ResourceToV2(v3rec)
 	require.Equal(t, "alice", back.GetId().GetResource(), "roundtrip resource")
@@ -87,6 +91,7 @@ func TestV2ResourceRoundtrip(t *testing.T) {
 	require.Equal(t, v2.Status_RESOURCE_STATUS_ENABLED, back.GetStatus().GetStatus(), "roundtrip status")
 	require.Equal(t, "unlocked by admin", back.GetStatus().GetDetails(), "roundtrip status details")
 	require.Equal(t, int64(1716393600), back.GetCreatedAt().GetSeconds(), "roundtrip created_at")
+	require.Equal(t, "icon-alice", back.GetIcon().GetId(), "roundtrip icon")
 }
 
 func TestV2ResourceTypeRoundtrip(t *testing.T) {

--- a/pkg/dotc1z/engine/pebble/translate_v2_test.go
+++ b/pkg/dotc1z/engine/pebble/translate_v2_test.go
@@ -94,6 +94,23 @@ func TestV2ResourceRoundtrip(t *testing.T) {
 	require.Equal(t, "icon-alice", back.GetIcon().GetId(), "roundtrip icon")
 }
 
+func TestV2ResourceWithoutIconRoundtrip(t *testing.T) {
+	original := v2.Resource_builder{
+		Id: v2.ResourceId_builder{
+			ResourceType: "user",
+			Resource:     "alice",
+		}.Build(),
+		DisplayName: "Alice",
+	}.Build()
+
+	v3rec := V2ResourceToV3("sync-1", original)
+	require.Empty(t, v3rec.GetIconAssetExternalId(), "icon")
+
+	back := V3ResourceToV2(v3rec)
+	require.False(t, back.HasIcon(), "roundtrip icon presence")
+	require.Nil(t, back.GetIcon(), "roundtrip icon")
+}
+
 func TestV2ResourceTypeRoundtrip(t *testing.T) {
 	original := v2.ResourceType_builder{
 		Id:          "user",

--- a/proto/c1/storage/v3/records.proto
+++ b/proto/c1/storage/v3/records.proto
@@ -136,6 +136,8 @@ message ResourceRecord {
     name: "by_source_scope"
     partial: "source_scope_key != ''"
   }];
+  // External ID of the resource icon asset. This must point to an asset that is an image.
+  string icon_asset_external_id = 13;
 }
 
 message EntitlementRecord {


### PR DESCRIPTION
Pebble v3 stored ResourceRecord as decomposed fields but had no storage slot for the top-level v2.Resource.icon field. As a result, resource-level icon references were dropped during v2-to-v3 translation and could not be restored when hydrating resources back out of Pebble.

Add icon_asset_external_id to ResourceRecord so the storage shape keeps the asset external ID directly, matching AssetRecord.external_id without adding a one-field v3 ref type. Map v2.Resource.icon.id into that field on write and rebuild v2.AssetRef from it on read.

Extend both the translation round-trip test and the full Pebble persistence path test so profile, status, created_at, and icon all survive the resource write/read flow. Regenerate the storage v3 protobuf outputs.