### PR TITLE
Add package to exit program with relevant exit code.

### DIFF
--- a/cmd/baton/main.go
+++ b/cmd/baton/main.go
@@ -2,9 +2,8 @@ package main
 
 import (
 	"context"
-	"fmt"
-	"os"
 
+	"github.com/conductorone/baton-sdk/pkg/exit"
 	"github.com/spf13/cobra"
 )
 
@@ -42,7 +41,6 @@ func main() {
 
 	err := cliCmd.ExecuteContext(ctx)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(1)
+		exit.LogExit(err)
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/cli"
 	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
 	"github.com/conductorone/baton-sdk/pkg/connectorrunner"
+	"github.com/conductorone/baton-sdk/pkg/exit"
 	"github.com/conductorone/baton-sdk/pkg/field"
 	"github.com/conductorone/baton-sdk/pkg/types"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
@@ -60,8 +61,7 @@ func RunConnector[T field.Configurable](
 
 	_, cmd, err := DefineConfigurationV2(ctx, connectorName, f, schema, options...)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(1)
+		exit.LogExit(err)
 		return
 	}
 
@@ -69,8 +69,7 @@ func RunConnector[T field.Configurable](
 
 	err = cmd.Execute()
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(1)
+		exit.LogExit(err)
 	}
 }
 

--- a/pkg/exit/exit.go
+++ b/pkg/exit/exit.go
@@ -1,0 +1,53 @@
+package exit
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Exit exits the program with a code based on the error.
+// Exit codes correspond to GRPC status codes.
+// If err is nil, exit code is 0.
+// Common errors such as context cancelled and deadline exceeded exit with the corresponding GRPC status code.
+// Other errors exit with code 2, which is GRPC status code Unknown.
+func Exit(err error) {
+	os.Exit(exitCode(err))
+}
+
+// LogExit logs the error to stderr & calls Exit(), which exits the program with a code based on the error.
+func LogExit(err error) {
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+	}
+	Exit(err)
+}
+
+func exitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+
+	if grpcErr, ok := status.FromError(err); ok {
+		if grpcErr.Code() == codes.OK {
+			// An error with code OK should never happen.
+			return int(codes.Internal)
+		}
+		return int(grpcErr.Code())
+	}
+
+	if errors.Is(err, context.Canceled) {
+		return int(codes.Canceled)
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		return int(codes.DeadlineExceeded)
+	}
+
+	// Otherwise, exit with code 2, which is GRPC status code Unknown.
+	return int(codes.Unknown)
+}

--- a/pkg/exit/exit_test.go
+++ b/pkg/exit/exit_test.go
@@ -1,0 +1,87 @@
+package exit
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type okStatusError struct{}
+
+func (okStatusError) Error() string { return "ok-as-error" }
+
+func (okStatusError) GRPCStatus() *status.Status {
+	return status.New(codes.OK, "ok")
+}
+
+type nilStatusError struct{}
+
+func (nilStatusError) Error() string { return "nil-status" }
+
+func (nilStatusError) GRPCStatus() *status.Status { return nil }
+
+func TestExitCode(t *testing.T) {
+	t.Parallel()
+
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	deadlineCtx, deadlineCancel := context.WithTimeout(context.Background(), 0)
+	t.Cleanup(deadlineCancel)
+	<-deadlineCtx.Done()
+
+	testCases := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{name: "nil", err: nil, want: 0},
+		{name: "status.Error OK is nil", err: status.Error(codes.OK, "ok"), want: 0},
+		{name: "plain error", err: errors.New("boom"), want: int(codes.Unknown)},
+		{name: "wrapped plain error", err: fmt.Errorf("wrap: %w", errors.New("boom")), want: int(codes.Unknown)},
+		{name: "context.Canceled", err: context.Canceled, want: int(codes.Canceled)},
+		{name: "wrapped context.Canceled", err: fmt.Errorf("wrap: %w", context.Canceled), want: int(codes.Canceled)},
+		{name: "canceled context err", err: canceledCtx.Err(), want: int(codes.Canceled)},
+		{name: "context.DeadlineExceeded", err: context.DeadlineExceeded, want: int(codes.DeadlineExceeded)},
+		{name: "wrapped context.DeadlineExceeded", err: fmt.Errorf("wrap: %w", context.DeadlineExceeded), want: int(codes.DeadlineExceeded)},
+		{name: "deadline context err", err: deadlineCtx.Err(), want: int(codes.DeadlineExceeded)},
+		{name: "status Canceled", err: status.Error(codes.Canceled, "canceled"), want: int(codes.Canceled)},
+		{name: "custom GRPCStatus OK", err: okStatusError{}, want: int(codes.Internal)},
+		{name: "wrapped custom GRPCStatus OK", err: fmt.Errorf("wrap: %w", okStatusError{}), want: int(codes.Internal)},
+		{name: "custom GRPCStatus nil", err: nilStatusError{}, want: int(codes.Unknown)},
+		{
+			name: "joined status and cancel prefers status",
+			err:  errors.Join(status.Error(codes.PermissionDenied, "denied"), context.Canceled),
+			want: int(codes.PermissionDenied),
+		},
+		{
+			name: "joined cancel and deadline prefers cancel",
+			err:  errors.Join(context.Canceled, context.DeadlineExceeded),
+			want: int(codes.Canceled),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, exitCode(tc.err))
+		})
+	}
+}
+
+func TestExitCode_AllGRPCCodes(t *testing.T) {
+	t.Parallel()
+
+	for code := codes.Canceled; code <= codes.Unauthenticated; code++ {
+		t.Run(code.String(), func(t *testing.T) {
+			t.Parallel()
+			err := status.Error(code, "msg")
+			require.Equal(t, int(code), exitCode(err))
+			require.Equal(t, int(code), exitCode(fmt.Errorf("wrap: %w", err)))
+		})
+	}
+}


### PR DESCRIPTION
This adds Exit() and LogExit(), which detect if an error is a GRPC error, context cancelled, or context deadline exceeded, and exit with the appropriate exit code.

This lets us add tests to make sure that a connector exits with the correct GRPC status if it hits an auth error.

Getting this behavior requires a small change to each connector. Without it, syncs still exit with status code 1 no matter what. The print/exit behavior in main.go should be change from this:

```golang
func main() {
	ctx := context.Background()

	_, cmd, err := configschema.DefineConfiguration(ctx, "baton-demo", getConnector, config.Config)
	if err != nil {
		fmt.Fprintln(os.Stderr, err.Error())
		os.Exit(1)
	}

	cmd.Version = version

	err = cmd.Execute()
	if err != nil {
		fmt.Fprintln(os.Stderr, err.Error())
		os.Exit(1)
	}
}
```

to this:

```golang
func main() {
	ctx := context.Background()

	_, cmd, err := configschema.DefineConfiguration(ctx, "baton-demo", getConnector, config.Config)
	if err != nil {
		exit.LogExit(err)
	}

	cmd.Version = version

	err = cmd.Execute()
	if err != nil {
		exit.LogExit(err)
	}
}
```
