### PR TITLE
fix(synccompactor): use ResumeSync when reopening the merged sync

### DIFF
--- a/pkg/dotc1z/engine/pebble/resume_sync_test.go
+++ b/pkg/dotc1z/engine/pebble/resume_sync_test.go
@@ -1,0 +1,105 @@
+package pebble
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+)
+
+// The compactor's incremental expansion reopens a sync it just merged into, so
+// "resume failed" and "no such sync, start fresh" must never be conflated:
+// starting fresh wipes the merged records. These two tests pin the difference
+// between the verbs, which is why pkg/synccompactor calls ResumeSync directly.
+
+// TestResumeSyncUnknownIDFailsClosed: an unresolvable sync id must produce an
+// error and leave the destination's records intact.
+func TestResumeSyncUnknownIDFailsClosed(t *testing.T) {
+	ctx := context.Background()
+	e, _ := newTestEngine(t)
+	a := NewAdapter(e)
+
+	syncID, err := a.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, a.PutResourceTypes(ctx,
+		v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()))
+	require.NoError(t, a.EndSync(ctx))
+	require.NotEmpty(t, syncID)
+
+	_, err = a.ResumeSync(ctx, connectorstore.SyncTypeFull, "no-such-sync")
+	require.Error(t, err, "ResumeSync must reject an unresolvable sync id")
+
+	// The failure must not have cost us the data.
+	require.NoError(t, a.SetCurrentSync(ctx, syncID))
+	resp, err := a.ListResourceTypes(ctx, v2.ResourceTypesServiceListResourceTypesRequest_builder{}.Build())
+	require.NoError(t, err)
+	require.Len(t, resp.GetList(), 1, "ResumeSync failure must leave records intact")
+}
+
+// TestResumeSyncOnEndedSyncAllowsWrites pins the contract the compactor's
+// incremental expansion actually depends on: the merge leaves the sync ENDED,
+// and expansion must reopen it and write grants into it. Resuming an ended sync
+// therefore has to unseal the engine, not just rebind the current sync id.
+// Without this, a change separating rebind from unseal would surface as
+// ErrEngineSealed on the first grant write, caught only by the much slower
+// pkg/synccompactor integration tests.
+func TestResumeSyncOnEndedSyncAllowsWrites(t *testing.T) {
+	ctx := context.Background()
+	e, _ := newTestEngine(t)
+	a := NewAdapter(e)
+
+	syncID, err := a.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, a.PutResourceTypes(ctx,
+		v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()))
+	require.NoError(t, a.EndSync(ctx))
+
+	resumed, err := a.ResumeSync(ctx, connectorstore.SyncTypeFull, syncID)
+	require.NoError(t, err, "resuming an ended sync must succeed")
+	require.Equal(t, syncID, resumed)
+
+	// The write is the point: a rebind that left the engine sealed would fail here.
+	require.NoError(t, a.PutResourceTypes(ctx,
+		v2.ResourceType_builder{Id: "user", DisplayName: "User"}.Build()),
+		"resumed ended sync must accept writes")
+
+	resp, err := a.ListResourceTypes(ctx, v2.ResourceTypesServiceListResourceTypesRequest_builder{}.Build())
+	require.NoError(t, err)
+	require.Len(t, resp.GetList(), 2, "the resumed write must land alongside the originals")
+}
+
+// TestStartOrResumeSyncUnknownIDWipesRecords documents the hazard the compactor
+// avoids: StartOrResumeSync treats an unresolvable id as "nothing to resume"
+// and starts a new sync, whose ResetForNewSync excises the record range. Correct
+// for the syncer, which passes an empty id; destructive for a caller that knows
+// the sync exists.
+//
+// This documents current behavior, not desired behavior. SQLite's C1File
+// (sync_runs.go:704) returns NotFound instead of starting a new sync when an
+// explicit id fails to resolve, so the two engines diverge here despite
+// adapter.go's claim to mirror the SQLite cascade. If Pebble is ever aligned,
+// invert the assertions below — a failure here is that alignment landing, not a
+// regression.
+func TestStartOrResumeSyncUnknownIDWipesRecords(t *testing.T) {
+	ctx := context.Background()
+	e, _ := newTestEngine(t)
+	a := NewAdapter(e)
+
+	syncID, err := a.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+	require.NoError(t, a.PutResourceTypes(ctx,
+		v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build()))
+	require.NoError(t, a.EndSync(ctx))
+
+	newID, startedNew, err := a.StartOrResumeSync(ctx, connectorstore.SyncTypeFull, "no-such-sync")
+	require.NoError(t, err)
+	require.True(t, startedNew, "unresolvable id falls through to StartNewSync")
+	require.NotEqual(t, syncID, newID)
+
+	resp, err := a.ListResourceTypes(ctx, v2.ResourceTypesServiceListResourceTypesRequest_builder{}.Build())
+	require.NoError(t, err)
+	require.Empty(t, resp.GetList(), "StartNewSync's reset drops the prior records")
+}

--- a/pkg/synccompactor/compactor.go
+++ b/pkg/synccompactor/compactor.go
@@ -676,7 +676,11 @@ func (c *Compactor) expandGrantsIncremental(ctx context.Context, newSyncId strin
 		return false, fmt.Errorf("incremental expansion: get sync: %w", err)
 	}
 	syncType := connectorstore.SyncType(syncResp.GetSync().GetSyncType())
-	if _, _, err := c.compactedC1z.StartOrResumeSync(walkCtx, syncType, newSyncId); err != nil {
+	// ResumeSync, never StartOrResumeSync: the merge just produced this sync, so
+	// a failed lookup is an error, not a cue to start a fresh one. On Pebble,
+	// StartOrResumeSync's fallback runs ResetForNewSync, which would wipe
+	// everything the merge wrote.
+	if _, err := c.compactedC1z.ResumeSync(walkCtx, syncType, newSyncId); err != nil {
 		return false, fmt.Errorf("incremental expansion: resume sync: %w", err)
 	}
 


### PR DESCRIPTION
Follow-up to #1013, blocker #4 from the approval review.

## The problem

After the merge, incremental grant expansion reopens the compacted sync so it can write derived grants. It did that with `StartOrResumeSync`:

```go
// pkg/dotc1z/engine/pebble/adapter.go:175
if syncID != "" {
    if _, err := e.GetSyncRunRecord(ctx, syncID); err == nil {
        return e.ResumeSync(...)      // happy path
    }
}
// any lookup error at all falls through to:
e.StartNewSync(ctx, syncType, "")
```

`StartNewSync` calls `ResetForNewSync`, which excises the key range from `typeResourceType` to `typeEngineMeta` — everything the merge just wrote.

So a transient failure looking up a sync id that demonstrably exists (the merge produced it moments earlier) discards the compacted output and returns an empty artifact, with the compaction reporting success.

## The fix

Call `ResumeSync` directly. It is already on `connectorstore.Writer`, and it has no "start a new one" branch: a lookup error returns an error and leaves the destination untouched.

That keeps the existing error classification correct. The failure stays a plain error rather than `errIncrementalFatal`, and `ResumeSync` returns before binding anything, so the store is still in the ended state the full-expansion fallback expects — no `restoreEndedSync` needed.

## Tests

New `pkg/dotc1z/engine/pebble/resume_sync_test.go`:

- `TestResumeSyncUnknownIDFailsClosed` — unresolvable id errors, records survive.
- `TestResumeSyncOnEndedSyncAllowsWrites` — resuming an *ended* sync succeeds and accepts writes. This is the contract the compactor actually depends on (the merge leaves the sync ended), and nothing pinned it before.
- `TestStartOrResumeSyncUnknownIDWipesRecords` — pins the destructive fallback so the reason for this change stays visible.

## Note for a separate issue

That last test documents current behavior, not desired behavior. SQLite's `C1File.StartOrResumeSync` (`pkg/dotc1z/sync_runs.go:704`) returns `NotFound` rather than starting a new sync when an explicit id fails to resolve, so the engines diverge — despite `adapter.go`'s comment claiming the Pebble path mirrors the SQLite cascade. Out of scope here, since incremental expansion is Pebble-only, but worth aligning. After this change no production caller passes a non-empty id to `StartOrResumeSync` at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)