### PR TITLE
feat: add PENDING status for invitation-style principals

### DIFF
--- a/cmd/baton/csv.go
+++ b/cmd/baton/csv.go
@@ -249,6 +249,8 @@ func getUserStatus(r *v2.Resource) string {
 		return "Disabled"
 	case v2.Status_RESOURCE_STATUS_DELETED:
 		return "Deleted"
+	case v2.Status_RESOURCE_STATUS_PENDING:
+		return "Pending"
 	default:
 		return "Unknown"
 	}

--- a/pb/c1/connector/v2/annotation_trait.pb.go
+++ b/pb/c1/connector/v2/annotation_trait.pb.go
@@ -80,6 +80,9 @@ const (
 	UserTrait_Status_STATUS_ENABLED     UserTrait_Status_Status = 1
 	UserTrait_Status_STATUS_DISABLED    UserTrait_Status_Status = 2
 	UserTrait_Status_STATUS_DELETED     UserTrait_Status_Status = 3
+	// Account creation was initiated but the account is not yet usable, such
+	// as an invitation that has not been accepted.
+	UserTrait_Status_STATUS_PENDING UserTrait_Status_Status = 4
 )
 
 // Enum value maps for UserTrait_Status_Status.
@@ -89,12 +92,14 @@ var (
 		1: "STATUS_ENABLED",
 		2: "STATUS_DISABLED",
 		3: "STATUS_DELETED",
+		4: "STATUS_PENDING",
 	}
 	UserTrait_Status_Status_value = map[string]int32{
 		"STATUS_UNSPECIFIED": 0,
 		"STATUS_ENABLED":     1,
 		"STATUS_DISABLED":    2,
 		"STATUS_DELETED":     3,
+		"STATUS_PENDING":     4,
 	}
 )
 
@@ -2957,7 +2962,7 @@ var File_c1_connector_v2_annotation_trait_proto protoreflect.FileDescriptor
 
 const file_c1_connector_v2_annotation_trait_proto_rawDesc = "" +
 	"\n" +
-	"&c1/connector/v2/annotation_trait.proto\x12\x0fc1.connector.v2\x1a\x1bc1/connector/v2/asset.proto\x1a\x1ec1/connector/v2/resource.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1egoogle/protobuf/wrappers.proto\x1a\x17validate/validate.proto\"\x9d\v\n" +
+	"&c1/connector/v2/annotation_trait.proto\x12\x0fc1.connector.v2\x1a\x1bc1/connector/v2/asset.proto\x1a\x1ec1/connector/v2/resource.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1egoogle/protobuf/wrappers.proto\x1a\x17validate/validate.proto\"\xb1\v\n" +
 	"\tUserTrait\x128\n" +
 	"\x06emails\x18\x01 \x03(\v2 .c1.connector.v2.UserTrait.EmailR\x06emails\x12=\n" +
 	"\x06status\x18\x02 \x01(\v2!.c1.connector.v2.UserTrait.StatusB\x02\x18\x01R\x06status\x125\n" +
@@ -2980,16 +2985,17 @@ const file_c1_connector_v2_annotation_trait_proto_rawDesc = "" +
 	"\x05Email\x12!\n" +
 	"\aaddress\x18\x01 \x01(\tB\a\xfaB\x04r\x02`\x01R\aaddress\x12\x1d\n" +
 	"\n" +
-	"is_primary\x18\x02 \x01(\bR\tisPrimary\x1a\xdc\x01\n" +
+	"is_primary\x18\x02 \x01(\bR\tisPrimary\x1a\xf0\x01\n" +
 	"\x06Status\x12J\n" +
 	"\x06status\x18\x01 \x01(\x0e2(.c1.connector.v2.UserTrait.Status.StatusB\b\xfaB\x05\x82\x01\x02\x10\x01R\x06status\x12'\n" +
 	"\adetails\x18\x02 \x01(\tB\r\xfaB\n" +
-	"r\b \x01(\x80\b\xd0\x01\x01R\adetails\"]\n" +
+	"r\b \x01(\x80\b\xd0\x01\x01R\adetails\"q\n" +
 	"\x06Status\x12\x16\n" +
 	"\x12STATUS_UNSPECIFIED\x10\x00\x12\x12\n" +
 	"\x0eSTATUS_ENABLED\x10\x01\x12\x13\n" +
 	"\x0fSTATUS_DISABLED\x10\x02\x12\x12\n" +
-	"\x0eSTATUS_DELETED\x10\x03\x1a,\n" +
+	"\x0eSTATUS_DELETED\x10\x03\x12\x12\n" +
+	"\x0eSTATUS_PENDING\x10\x04\x1a,\n" +
 	"\tMFAStatus\x12\x1f\n" +
 	"\vmfa_enabled\x18\x01 \x01(\bR\n" +
 	"mfaEnabled\x1a,\n" +

--- a/pb/c1/connector/v2/annotation_trait_protoopaque.pb.go
+++ b/pb/c1/connector/v2/annotation_trait_protoopaque.pb.go
@@ -80,6 +80,9 @@ const (
 	UserTrait_Status_STATUS_ENABLED     UserTrait_Status_Status = 1
 	UserTrait_Status_STATUS_DISABLED    UserTrait_Status_Status = 2
 	UserTrait_Status_STATUS_DELETED     UserTrait_Status_Status = 3
+	// Account creation was initiated but the account is not yet usable, such
+	// as an invitation that has not been accepted.
+	UserTrait_Status_STATUS_PENDING UserTrait_Status_Status = 4
 )
 
 // Enum value maps for UserTrait_Status_Status.
@@ -89,12 +92,14 @@ var (
 		1: "STATUS_ENABLED",
 		2: "STATUS_DISABLED",
 		3: "STATUS_DELETED",
+		4: "STATUS_PENDING",
 	}
 	UserTrait_Status_Status_value = map[string]int32{
 		"STATUS_UNSPECIFIED": 0,
 		"STATUS_ENABLED":     1,
 		"STATUS_DISABLED":    2,
 		"STATUS_DELETED":     3,
+		"STATUS_PENDING":     4,
 	}
 )
 
@@ -2902,7 +2907,7 @@ var File_c1_connector_v2_annotation_trait_proto protoreflect.FileDescriptor
 
 const file_c1_connector_v2_annotation_trait_proto_rawDesc = "" +
 	"\n" +
-	"&c1/connector/v2/annotation_trait.proto\x12\x0fc1.connector.v2\x1a\x1bc1/connector/v2/asset.proto\x1a\x1ec1/connector/v2/resource.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1egoogle/protobuf/wrappers.proto\x1a\x17validate/validate.proto\"\x9d\v\n" +
+	"&c1/connector/v2/annotation_trait.proto\x12\x0fc1.connector.v2\x1a\x1bc1/connector/v2/asset.proto\x1a\x1ec1/connector/v2/resource.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1egoogle/protobuf/wrappers.proto\x1a\x17validate/validate.proto\"\xb1\v\n" +
 	"\tUserTrait\x128\n" +
 	"\x06emails\x18\x01 \x03(\v2 .c1.connector.v2.UserTrait.EmailR\x06emails\x12=\n" +
 	"\x06status\x18\x02 \x01(\v2!.c1.connector.v2.UserTrait.StatusB\x02\x18\x01R\x06status\x125\n" +
@@ -2925,16 +2930,17 @@ const file_c1_connector_v2_annotation_trait_proto_rawDesc = "" +
 	"\x05Email\x12!\n" +
 	"\aaddress\x18\x01 \x01(\tB\a\xfaB\x04r\x02`\x01R\aaddress\x12\x1d\n" +
 	"\n" +
-	"is_primary\x18\x02 \x01(\bR\tisPrimary\x1a\xdc\x01\n" +
+	"is_primary\x18\x02 \x01(\bR\tisPrimary\x1a\xf0\x01\n" +
 	"\x06Status\x12J\n" +
 	"\x06status\x18\x01 \x01(\x0e2(.c1.connector.v2.UserTrait.Status.StatusB\b\xfaB\x05\x82\x01\x02\x10\x01R\x06status\x12'\n" +
 	"\adetails\x18\x02 \x01(\tB\r\xfaB\n" +
-	"r\b \x01(\x80\b\xd0\x01\x01R\adetails\"]\n" +
+	"r\b \x01(\x80\b\xd0\x01\x01R\adetails\"q\n" +
 	"\x06Status\x12\x16\n" +
 	"\x12STATUS_UNSPECIFIED\x10\x00\x12\x12\n" +
 	"\x0eSTATUS_ENABLED\x10\x01\x12\x13\n" +
 	"\x0fSTATUS_DISABLED\x10\x02\x12\x12\n" +
-	"\x0eSTATUS_DELETED\x10\x03\x1a,\n" +
+	"\x0eSTATUS_DELETED\x10\x03\x12\x12\n" +
+	"\x0eSTATUS_PENDING\x10\x04\x1a,\n" +
 	"\tMFAStatus\x12\x1f\n" +
 	"\vmfa_enabled\x18\x01 \x01(\bR\n" +
 	"mfaEnabled\x1a,\n" +

--- a/pb/c1/connector/v2/resource.pb.go
+++ b/pb/c1/connector/v2/resource.pb.go
@@ -198,6 +198,9 @@ const (
 	Status_RESOURCE_STATUS_ENABLED     Status_ResourceStatus = 1
 	Status_RESOURCE_STATUS_DISABLED    Status_ResourceStatus = 2
 	Status_RESOURCE_STATUS_DELETED     Status_ResourceStatus = 3
+	// Account creation was initiated but the account is not yet usable, such
+	// as an invitation that has not been accepted.
+	Status_RESOURCE_STATUS_PENDING Status_ResourceStatus = 4
 )
 
 // Enum value maps for Status_ResourceStatus.
@@ -207,12 +210,14 @@ var (
 		1: "RESOURCE_STATUS_ENABLED",
 		2: "RESOURCE_STATUS_DISABLED",
 		3: "RESOURCE_STATUS_DELETED",
+		4: "RESOURCE_STATUS_PENDING",
 	}
 	Status_ResourceStatus_value = map[string]int32{
 		"RESOURCE_STATUS_UNSPECIFIED": 0,
 		"RESOURCE_STATUS_ENABLED":     1,
 		"RESOURCE_STATUS_DISABLED":    2,
 		"RESOURCE_STATUS_DELETED":     3,
+		"RESOURCE_STATUS_PENDING":     4,
 	}
 )
 
@@ -6187,16 +6192,17 @@ const file_c1_connector_v2_resource_proto_rawDesc = "" +
 	"\x0eCreationSource\x12\x1f\n" +
 	"\x1bCREATION_SOURCE_UNSPECIFIED\x10\x00\x12,\n" +
 	"(CREATION_SOURCE_CONNECTOR_LIST_RESOURCES\x10\x01\x127\n" +
-	"3CREATION_SOURCE_CONNECTOR_LIST_GRANTS_PRINCIPAL_JIT\x10\x02\"\x87\x02\n" +
+	"3CREATION_SOURCE_CONNECTOR_LIST_GRANTS_PRINCIPAL_JIT\x10\x02\"\xa4\x02\n" +
 	"\x06Status\x12H\n" +
 	"\x06status\x18\x01 \x01(\x0e2&.c1.connector.v2.Status.ResourceStatusB\b\xfaB\x05\x82\x01\x02\x10\x01R\x06status\x12'\n" +
 	"\adetails\x18\x02 \x01(\tB\r\xfaB\n" +
-	"r\b \x01(\x80\b\xd0\x01\x01R\adetails\"\x89\x01\n" +
+	"r\b \x01(\x80\b\xd0\x01\x01R\adetails\"\xa6\x01\n" +
 	"\x0eResourceStatus\x12\x1f\n" +
 	"\x1bRESOURCE_STATUS_UNSPECIFIED\x10\x00\x12\x1b\n" +
 	"\x17RESOURCE_STATUS_ENABLED\x10\x01\x12\x1c\n" +
 	"\x18RESOURCE_STATUS_DISABLED\x10\x02\x12\x1b\n" +
-	"\x17RESOURCE_STATUS_DELETED\x10\x03\"\xb5\x03\n" +
+	"\x17RESOURCE_STATUS_DELETED\x10\x03\x12\x1b\n" +
+	"\x17RESOURCE_STATUS_PENDING\x10\x04\"\xb5\x03\n" +
 	"$ResourcesServiceListResourcesRequest\x124\n" +
 	"\x10resource_type_id\x18\x01 \x01(\tB\n" +
 	"\xfaB\ar\x05 \x01(\x80\bR\x0eresourceTypeId\x12S\n" +

--- a/pb/c1/connector/v2/resource_protoopaque.pb.go
+++ b/pb/c1/connector/v2/resource_protoopaque.pb.go
@@ -198,6 +198,9 @@ const (
 	Status_RESOURCE_STATUS_ENABLED     Status_ResourceStatus = 1
 	Status_RESOURCE_STATUS_DISABLED    Status_ResourceStatus = 2
 	Status_RESOURCE_STATUS_DELETED     Status_ResourceStatus = 3
+	// Account creation was initiated but the account is not yet usable, such
+	// as an invitation that has not been accepted.
+	Status_RESOURCE_STATUS_PENDING Status_ResourceStatus = 4
 )
 
 // Enum value maps for Status_ResourceStatus.
@@ -207,12 +210,14 @@ var (
 		1: "RESOURCE_STATUS_ENABLED",
 		2: "RESOURCE_STATUS_DISABLED",
 		3: "RESOURCE_STATUS_DELETED",
+		4: "RESOURCE_STATUS_PENDING",
 	}
 	Status_ResourceStatus_value = map[string]int32{
 		"RESOURCE_STATUS_UNSPECIFIED": 0,
 		"RESOURCE_STATUS_ENABLED":     1,
 		"RESOURCE_STATUS_DISABLED":    2,
 		"RESOURCE_STATUS_DELETED":     3,
+		"RESOURCE_STATUS_PENDING":     4,
 	}
 )
 
@@ -6117,16 +6122,17 @@ const file_c1_connector_v2_resource_proto_rawDesc = "" +
 	"\x0eCreationSource\x12\x1f\n" +
 	"\x1bCREATION_SOURCE_UNSPECIFIED\x10\x00\x12,\n" +
 	"(CREATION_SOURCE_CONNECTOR_LIST_RESOURCES\x10\x01\x127\n" +
-	"3CREATION_SOURCE_CONNECTOR_LIST_GRANTS_PRINCIPAL_JIT\x10\x02\"\x87\x02\n" +
+	"3CREATION_SOURCE_CONNECTOR_LIST_GRANTS_PRINCIPAL_JIT\x10\x02\"\xa4\x02\n" +
 	"\x06Status\x12H\n" +
 	"\x06status\x18\x01 \x01(\x0e2&.c1.connector.v2.Status.ResourceStatusB\b\xfaB\x05\x82\x01\x02\x10\x01R\x06status\x12'\n" +
 	"\adetails\x18\x02 \x01(\tB\r\xfaB\n" +
-	"r\b \x01(\x80\b\xd0\x01\x01R\adetails\"\x89\x01\n" +
+	"r\b \x01(\x80\b\xd0\x01\x01R\adetails\"\xa6\x01\n" +
 	"\x0eResourceStatus\x12\x1f\n" +
 	"\x1bRESOURCE_STATUS_UNSPECIFIED\x10\x00\x12\x1b\n" +
 	"\x17RESOURCE_STATUS_ENABLED\x10\x01\x12\x1c\n" +
 	"\x18RESOURCE_STATUS_DISABLED\x10\x02\x12\x1b\n" +
-	"\x17RESOURCE_STATUS_DELETED\x10\x03\"\xb5\x03\n" +
+	"\x17RESOURCE_STATUS_DELETED\x10\x03\x12\x1b\n" +
+	"\x17RESOURCE_STATUS_PENDING\x10\x04\"\xb5\x03\n" +
 	"$ResourcesServiceListResourcesRequest\x124\n" +
 	"\x10resource_type_id\x18\x01 \x01(\tB\n" +
 	"\xfaB\ar\x05 \x01(\x80\bR\x0eresourceTypeId\x12S\n" +

--- a/pb/c1/storage/v3/records.pb.go
+++ b/pb/c1/storage/v3/records.pb.go
@@ -104,6 +104,7 @@ const (
 	StatusRecord_RESOURCE_STATUS_ENABLED     StatusRecord_ResourceStatus = 1
 	StatusRecord_RESOURCE_STATUS_DISABLED    StatusRecord_ResourceStatus = 2
 	StatusRecord_RESOURCE_STATUS_DELETED     StatusRecord_ResourceStatus = 3
+	StatusRecord_RESOURCE_STATUS_PENDING     StatusRecord_ResourceStatus = 4
 )
 
 // Enum value maps for StatusRecord_ResourceStatus.
@@ -113,12 +114,14 @@ var (
 		1: "RESOURCE_STATUS_ENABLED",
 		2: "RESOURCE_STATUS_DISABLED",
 		3: "RESOURCE_STATUS_DELETED",
+		4: "RESOURCE_STATUS_PENDING",
 	}
 	StatusRecord_ResourceStatus_value = map[string]int32{
 		"RESOURCE_STATUS_UNSPECIFIED": 0,
 		"RESOURCE_STATUS_ENABLED":     1,
 		"RESOURCE_STATUS_DISABLED":    2,
 		"RESOURCE_STATUS_DELETED":     3,
+		"RESOURCE_STATUS_PENDING":     4,
 	}
 )
 
@@ -2745,15 +2748,16 @@ var File_c1_storage_v3_records_proto protoreflect.FileDescriptor
 
 const file_c1_storage_v3_records_proto_rawDesc = "" +
 	"\n" +
-	"\x1bc1/storage/v3/records.proto\x12\rc1.storage.v3\x1a\x1bc1/storage/v3/options.proto\x1a\x18c1/storage/v3/refs.proto\x1a\x19google/protobuf/any.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xf8\x01\n" +
+	"\x1bc1/storage/v3/records.proto\x12\rc1.storage.v3\x1a\x1bc1/storage/v3/options.proto\x1a\x18c1/storage/v3/refs.proto\x1a\x19google/protobuf/any.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\x95\x02\n" +
 	"\fStatusRecord\x12B\n" +
 	"\x06status\x18\x01 \x01(\x0e2*.c1.storage.v3.StatusRecord.ResourceStatusR\x06status\x12\x18\n" +
-	"\adetails\x18\x02 \x01(\tR\adetails\"\x89\x01\n" +
+	"\adetails\x18\x02 \x01(\tR\adetails\"\xa6\x01\n" +
 	"\x0eResourceStatus\x12\x1f\n" +
 	"\x1bRESOURCE_STATUS_UNSPECIFIED\x10\x00\x12\x1b\n" +
 	"\x17RESOURCE_STATUS_ENABLED\x10\x01\x12\x1c\n" +
 	"\x18RESOURCE_STATUS_DISABLED\x10\x02\x12\x1b\n" +
-	"\x17RESOURCE_STATUS_DELETED\x10\x03\"\x86\x01\n" +
+	"\x17RESOURCE_STATUS_DELETED\x10\x03\x12\x1b\n" +
+	"\x17RESOURCE_STATUS_PENDING\x10\x04\"\x86\x01\n" +
 	"\x15GrantExpandableRecord\x12'\n" +
 	"\x0fentitlement_ids\x18\x01 \x03(\tR\x0eentitlementIds\x12\x18\n" +
 	"\ashallow\x18\x02 \x01(\bR\ashallow\x12*\n" +

--- a/pb/c1/storage/v3/records_protoopaque.pb.go
+++ b/pb/c1/storage/v3/records_protoopaque.pb.go
@@ -104,6 +104,7 @@ const (
 	StatusRecord_RESOURCE_STATUS_ENABLED     StatusRecord_ResourceStatus = 1
 	StatusRecord_RESOURCE_STATUS_DISABLED    StatusRecord_ResourceStatus = 2
 	StatusRecord_RESOURCE_STATUS_DELETED     StatusRecord_ResourceStatus = 3
+	StatusRecord_RESOURCE_STATUS_PENDING     StatusRecord_ResourceStatus = 4
 )
 
 // Enum value maps for StatusRecord_ResourceStatus.
@@ -113,12 +114,14 @@ var (
 		1: "RESOURCE_STATUS_ENABLED",
 		2: "RESOURCE_STATUS_DISABLED",
 		3: "RESOURCE_STATUS_DELETED",
+		4: "RESOURCE_STATUS_PENDING",
 	}
 	StatusRecord_ResourceStatus_value = map[string]int32{
 		"RESOURCE_STATUS_UNSPECIFIED": 0,
 		"RESOURCE_STATUS_ENABLED":     1,
 		"RESOURCE_STATUS_DISABLED":    2,
 		"RESOURCE_STATUS_DELETED":     3,
+		"RESOURCE_STATUS_PENDING":     4,
 	}
 )
 
@@ -2630,15 +2633,16 @@ var File_c1_storage_v3_records_proto protoreflect.FileDescriptor
 
 const file_c1_storage_v3_records_proto_rawDesc = "" +
 	"\n" +
-	"\x1bc1/storage/v3/records.proto\x12\rc1.storage.v3\x1a\x1bc1/storage/v3/options.proto\x1a\x18c1/storage/v3/refs.proto\x1a\x19google/protobuf/any.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xf8\x01\n" +
+	"\x1bc1/storage/v3/records.proto\x12\rc1.storage.v3\x1a\x1bc1/storage/v3/options.proto\x1a\x18c1/storage/v3/refs.proto\x1a\x19google/protobuf/any.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\x95\x02\n" +
 	"\fStatusRecord\x12B\n" +
 	"\x06status\x18\x01 \x01(\x0e2*.c1.storage.v3.StatusRecord.ResourceStatusR\x06status\x12\x18\n" +
-	"\adetails\x18\x02 \x01(\tR\adetails\"\x89\x01\n" +
+	"\adetails\x18\x02 \x01(\tR\adetails\"\xa6\x01\n" +
 	"\x0eResourceStatus\x12\x1f\n" +
 	"\x1bRESOURCE_STATUS_UNSPECIFIED\x10\x00\x12\x1b\n" +
 	"\x17RESOURCE_STATUS_ENABLED\x10\x01\x12\x1c\n" +
 	"\x18RESOURCE_STATUS_DISABLED\x10\x02\x12\x1b\n" +
-	"\x17RESOURCE_STATUS_DELETED\x10\x03\"\x86\x01\n" +
+	"\x17RESOURCE_STATUS_DELETED\x10\x03\x12\x1b\n" +
+	"\x17RESOURCE_STATUS_PENDING\x10\x04\"\x86\x01\n" +
 	"\x15GrantExpandableRecord\x12'\n" +
 	"\x0fentitlement_ids\x18\x01 \x03(\tR\x0eentitlementIds\x12\x18\n" +
 	"\ashallow\x18\x02 \x01(\bR\ashallow\x12*\n" +

--- a/pkg/dotc1z/engine/pebble/translate_v2_test.go
+++ b/pkg/dotc1z/engine/pebble/translate_v2_test.go
@@ -1,6 +1,7 @@
 package pebble
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -196,6 +197,39 @@ func TestGrantSourcesRoundtrip(t *testing.T) {
 	back := V3GrantToV2(v3rec)
 	require.Len(t, back.GetSources().GetSources(), 2, "source count v2 roundtrip")
 	require.True(t, back.GetSources().GetSources()["direct-source"].GetIsDirect(), "roundtrip direct-source.is_direct should be true")
+}
+
+// The three status enums below are maintained by hand and cast into each
+// other numerically; a value added to one but not the others must fail here
+// rather than mistranslate in stored data.
+func TestStatusEnumMirrorsStayAligned(t *testing.T) {
+	stripPrefix := func(name string) string {
+		return strings.TrimPrefix(strings.TrimPrefix(name, "RESOURCE_"), "STATUS_")
+	}
+
+	require.Equal(t, len(v2.Status_ResourceStatus_name), len(v3.StatusRecord_ResourceStatus_name),
+		"c1.storage.v3.StatusRecord.ResourceStatus must mirror c1.connector.v2.Status.ResourceStatus")
+	require.Equal(t, len(v2.Status_ResourceStatus_name), len(v2.UserTrait_Status_Status_name),
+		"c1.connector.v2.UserTrait.Status.Status must mirror c1.connector.v2.Status.ResourceStatus")
+
+	for num, name := range v2.Status_ResourceStatus_name {
+		v3Name, ok := v3.StatusRecord_ResourceStatus_name[num]
+		require.Truef(t, ok, "Status_ResourceStatus value %d (%s) missing from StatusRecord_ResourceStatus", num, name)
+		require.Equalf(t, name, v3Name, "Status_ResourceStatus value %d name mismatch", num)
+
+		utName, ok := v2.UserTrait_Status_Status_name[num]
+		require.Truef(t, ok, "Status_ResourceStatus value %d (%s) missing from UserTrait_Status_Status", num, name)
+		require.Equalf(t, stripPrefix(name), stripPrefix(utName), "Status_ResourceStatus value %d name mismatch vs UserTrait_Status", num)
+	}
+
+	// AgentTrait_AgentStatus is cast numerically into Status_ResourceStatus.
+	// It is a prefix, not a mirror (READY maps to ENABLED); every AgentStatus
+	// number must exist in ResourceStatus so a new AgentStatus value cannot
+	// silently surface as an unrelated resource status.
+	for num, name := range v2.AgentTrait_AgentStatus_name {
+		_, ok := v2.Status_ResourceStatus_name[num]
+		require.Truef(t, ok, "AgentTrait_AgentStatus value %d (%s) has no Status_ResourceStatus counterpart", num, name)
+	}
 }
 
 func TestV2ResourceStatusPendingRoundtrip(t *testing.T) {

--- a/pkg/dotc1z/engine/pebble/translate_v2_test.go
+++ b/pkg/dotc1z/engine/pebble/translate_v2_test.go
@@ -223,12 +223,22 @@ func TestStatusEnumMirrorsStayAligned(t *testing.T) {
 	}
 
 	// AgentTrait_AgentStatus is cast numerically into Status_ResourceStatus.
-	// It is a prefix, not a mirror (READY maps to ENABLED); every AgentStatus
-	// number must exist in ResourceStatus so a new AgentStatus value cannot
-	// silently surface as an unrelated resource status.
+	// It is a prefix, not a mirror (READY maps to ENABLED). Pin the mapping by
+	// name so a new AgentStatus value cannot silently inherit an unrelated
+	// ResourceStatus meaning — extend this table deliberately when adding one.
+	expectedAgentMirror := map[int32]string{
+		0: "RESOURCE_STATUS_UNSPECIFIED",
+		1: "RESOURCE_STATUS_ENABLED",
+		2: "RESOURCE_STATUS_DISABLED",
+		3: "RESOURCE_STATUS_DELETED",
+	}
+	require.Len(t, v2.AgentTrait_AgentStatus_name, len(expectedAgentMirror),
+		"new AgentTrait_AgentStatus value: confirm its numeric cast into Status_ResourceStatus is still meaningful, then extend expectedAgentMirror")
 	for num, name := range v2.AgentTrait_AgentStatus_name {
-		_, ok := v2.Status_ResourceStatus_name[num]
-		require.Truef(t, ok, "AgentTrait_AgentStatus value %d (%s) has no Status_ResourceStatus counterpart", num, name)
+		want, ok := expectedAgentMirror[num]
+		require.Truef(t, ok, "AgentTrait_AgentStatus value %d (%s) has no reviewed Status_ResourceStatus counterpart", num, name)
+		require.Equalf(t, want, v2.Status_ResourceStatus_name[num],
+			"AgentTrait_AgentStatus value %d (%s) casts to an unexpected Status_ResourceStatus", num, name)
 	}
 }
 

--- a/pkg/dotc1z/engine/pebble/translate_v2_test.go
+++ b/pkg/dotc1z/engine/pebble/translate_v2_test.go
@@ -197,3 +197,23 @@ func TestGrantSourcesRoundtrip(t *testing.T) {
 	require.Len(t, back.GetSources().GetSources(), 2, "source count v2 roundtrip")
 	require.True(t, back.GetSources().GetSources()["direct-source"].GetIsDirect(), "roundtrip direct-source.is_direct should be true")
 }
+
+func TestV2ResourceStatusPendingRoundtrip(t *testing.T) {
+	original := v2.Resource_builder{
+		Id: v2.ResourceId_builder{
+			ResourceType: "user",
+			Resource:     "alice",
+		}.Build(),
+		Status: v2.Status_builder{
+			Status:  v2.Status_RESOURCE_STATUS_PENDING,
+			Details: "invitation not accepted",
+		}.Build(),
+	}.Build()
+
+	v3rec := V2ResourceToV3("sync-1", original)
+	require.Equal(t, v3.StatusRecord_RESOURCE_STATUS_PENDING, v3rec.GetStatus().GetStatus(), "status")
+
+	back := V3ResourceToV2(v3rec)
+	require.Equal(t, v2.Status_RESOURCE_STATUS_PENDING, back.GetStatus().GetStatus(), "roundtrip status")
+	require.Equal(t, "invitation not accepted", back.GetStatus().GetDetails(), "roundtrip status details")
+}

--- a/pkg/types/resource/resource.go
+++ b/pkg/types/resource/resource.go
@@ -171,8 +171,9 @@ func syncAgentTraitToResource(r *v2.Resource, at *v2.AgentTrait) {
 		r.SetProfile(at.GetProfile())
 	}
 	if at.GetStatus() != v2.AgentTrait_AGENT_STATUS_UNSPECIFIED && !r.HasStatus() {
-		// AgentTrait_AgentStatus and Status_ResourceStatus enum values are
-		// identical (READY maps to ENABLED).
+		// AgentTrait_AgentStatus is a numeric prefix of Status_ResourceStatus
+		// (READY maps to ENABLED); new AgentStatus values must not reuse
+		// ResourceStatus numbers with different meanings.
 		r.SetStatus(v2.Status_builder{
 			Status: v2.Status_ResourceStatus(at.GetStatus()),
 		}.Build())

--- a/pkg/types/resource/resource_attrs.go
+++ b/pkg/types/resource/resource_attrs.go
@@ -87,8 +87,9 @@ func GetStatus(r *v2.Resource) *v2.Status {
 		}.Build()
 	}
 	if agt := (&v2.AgentTrait{}); pickTrait(r, agt) && agt.GetStatus() != v2.AgentTrait_AGENT_STATUS_UNSPECIFIED {
-		// AgentTrait_AgentStatus and Status_ResourceStatus enum values are
-		// identical (READY maps to ENABLED).
+		// AgentTrait_AgentStatus is a numeric prefix of Status_ResourceStatus
+		// (READY maps to ENABLED); new AgentStatus values must not reuse
+		// ResourceStatus numbers with different meanings.
 		return v2.Status_builder{
 			Status: v2.Status_ResourceStatus(agt.GetStatus()),
 		}.Build()

--- a/pkg/types/resource/resource_attrs_test.go
+++ b/pkg/types/resource/resource_attrs_test.go
@@ -87,6 +87,21 @@ func TestGetStatusFallsBackToTrait(t *testing.T) {
 	require.Nil(t, GetStatus(v2.Resource_builder{}.Build()))
 }
 
+func TestGetStatusPendingFallsBackToTrait(t *testing.T) {
+	r := resourceWithTrait(t, v2.UserTrait_builder{
+		Status: v2.UserTrait_Status_builder{
+			Status:  v2.UserTrait_Status_STATUS_PENDING,
+			Details: "invitation not accepted",
+		}.Build(),
+	}.Build())
+	st := GetStatus(r)
+	require.Equal(t, v2.Status_RESOURCE_STATUS_PENDING, st.GetStatus())
+	require.Equal(t, "invitation not accepted", st.GetDetails())
+
+	r.SetStatus(v2.Status_builder{Status: v2.Status_RESOURCE_STATUS_PENDING}.Build())
+	require.Equal(t, v2.Status_RESOURCE_STATUS_PENDING, GetStatus(r).GetStatus())
+}
+
 func TestGetCreatedAtFallsBackToTrait(t *testing.T) {
 	createdAt := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
 

--- a/pkg/types/resource/resource_test.go
+++ b/pkg/types/resource/resource_test.go
@@ -325,6 +325,30 @@ func TestDeprecatedTraitOptionsSyncToResource(t *testing.T) {
 		require.Equal(t, v2.Status_RESOURCE_STATUS_ENABLED, ur.GetStatus().GetStatus())
 	})
 
+	t.Run("user trait pending status", func(t *testing.T) {
+		rt := NewResourceType("User", []v2.ResourceType_Trait{v2.ResourceType_TRAIT_USER})
+		ur, err := NewUserResource("test user", rt, 1234, []UserTraitOption{
+			WithDetailedStatus(v2.UserTrait_Status_STATUS_PENDING, "invitation not accepted"),
+		})
+		require.NoError(t, err)
+		require.Equal(t, v2.Status_RESOURCE_STATUS_PENDING, ur.GetStatus().GetStatus())
+		require.Equal(t, "invitation not accepted", ur.GetStatus().GetDetails())
+
+		ut, err := GetUserTrait(ur)
+		require.NoError(t, err)
+		require.Equal(t, v2.UserTrait_Status_STATUS_PENDING, ut.GetStatus().GetStatus())
+	})
+
+	t.Run("resource-level pending status", func(t *testing.T) {
+		rt := NewResourceType("User", []v2.ResourceType_Trait{v2.ResourceType_TRAIT_USER})
+		ur, err := NewUserResource("test user", rt, 1234, nil,
+			WithResourceStatus(v2.Status_RESOURCE_STATUS_PENDING, "invitation not accepted"),
+		)
+		require.NoError(t, err)
+		require.Equal(t, v2.Status_RESOURCE_STATUS_PENDING, ur.GetStatus().GetStatus())
+		require.Equal(t, "invitation not accepted", ur.GetStatus().GetDetails())
+	})
+
 	t.Run("group trait", func(t *testing.T) {
 		rt := NewResourceType("Group", []v2.ResourceType_Trait{v2.ResourceType_TRAIT_GROUP})
 		gr, err := NewGroupResource("test group", rt, 1234, []GroupTraitOption{

--- a/pkg/types/resource/user_trait_test.go
+++ b/pkg/types/resource/user_trait_test.go
@@ -131,3 +131,14 @@ func TestUserTrait(t *testing.T) {
 	require.Equal(t, ut.GetEmails()[1].GetAddress(), "bob@example.com")
 	require.Equal(t, v2.UserTrait_ACCOUNT_TYPE_SERVICE, ut.GetAccountType())
 }
+
+func TestUserTraitPendingStatus(t *testing.T) {
+	ut, err := NewUserTrait(WithStatus(v2.UserTrait_Status_STATUS_PENDING))
+	require.NoError(t, err)
+	require.Equal(t, v2.UserTrait_Status_STATUS_PENDING, ut.GetStatus().GetStatus())
+
+	ut, err = NewUserTrait(WithDetailedStatus(v2.UserTrait_Status_STATUS_PENDING, "invitation not accepted"))
+	require.NoError(t, err)
+	require.Equal(t, v2.UserTrait_Status_STATUS_PENDING, ut.GetStatus().GetStatus())
+	require.Equal(t, "invitation not accepted", ut.GetStatus().GetDetails())
+}

--- a/proto/c1/connector/v2/annotation_trait.proto
+++ b/proto/c1/connector/v2/annotation_trait.proto
@@ -25,6 +25,9 @@ message UserTrait {
       STATUS_ENABLED = 1;
       STATUS_DISABLED = 2;
       STATUS_DELETED = 3;
+      // Account creation was initiated but the account is not yet usable, such
+      // as an invitation that has not been accepted.
+      STATUS_PENDING = 4;
     }
     Status status = 1 [(validate.rules).enum = {defined_only: true}];
     string details = 2 [(validate.rules).string = {

--- a/proto/c1/connector/v2/resource.proto
+++ b/proto/c1/connector/v2/resource.proto
@@ -460,6 +460,9 @@ message Status {
     RESOURCE_STATUS_ENABLED = 1;
     RESOURCE_STATUS_DISABLED = 2;
     RESOURCE_STATUS_DELETED = 3;
+    // Account creation was initiated but the account is not yet usable, such
+    // as an invitation that has not been accepted.
+    RESOURCE_STATUS_PENDING = 4;
   }
   ResourceStatus status = 1 [(validate.rules).enum = {defined_only: true}];
   // Status details, such as "locked by admin" or "deleted by user X".

--- a/proto/c1/storage/v3/records.proto
+++ b/proto/c1/storage/v3/records.proto
@@ -44,6 +44,7 @@ message StatusRecord {
     RESOURCE_STATUS_ENABLED = 1;
     RESOURCE_STATUS_DISABLED = 2;
     RESOURCE_STATUS_DELETED = 3;
+    RESOURCE_STATUS_PENDING = 4;
   }
   ResourceStatus status = 1;
   // Status details, such as "locked by admin" or "deleted by user X".


### PR DESCRIPTION
## Problem

Connectors have no way to say "this principal is a pending invitation, not a usable account." Both status enums stop at `DELETED = 3`, so an invitation-style principal can only be expressed as `STATUS_UNSPECIFIED` — and even that requires the deprecated `WithStatus` option, because `NewUserTrait` force-defaults an unset status to `ENABLED`. Consumers are left inferring "pending" from an absent value, which is indistinguishable from a connector that simply never set a status.

## Change

Additive enum value `4` on both status enums:

- `c1.connector.v2.Status.ResourceStatus` → `RESOURCE_STATUS_PENDING = 4`
- `c1.connector.v2.UserTrait.Status.Status` → `STATUS_PENDING = 4`

`c1.storage.v3.StatusRecord.ResourceStatus` is mirrored as well — that enum documents itself as an explicit mirror of the v2 one, and the pebble translation layer casts between them numerically, so it has to move in lockstep.

Trait ↔ resource status mirroring (`GetStatus`, `syncUserTraitToResource`, `WithResourceStatus` / `WithDetailedStatus` / `WithStatus`) already round-trips by numeric cast, so `PENDING` flows through unchanged with no new branches. The one enumerating switch, `getUserStatus` in the CSV exporter, gains a `Pending` case.

`NewUserTrait`'s enabled-by-default behavior for an unset status is unchanged; an explicitly-set `PENDING` is not overwritten, and there's a test proving it.

## Wire compatibility

Proto3 enums are open, so this is additive and existing values are untouched — nothing is renumbered or reused. The one caveat: the status fields carry `(validate.rules).enum = {defined_only: true}`, which is enforced against the generated `_name` map. A consumer running an older generated `.pb.validate.go` will reject value `4` until it regenerates. Consumers should upgrade before connectors start emitting `PENDING`.

## Testing

`go test -tags=baton_lambda_support ./...` and `golangci-lint run` both clean. Protos regenerated with `buf generate` (no hand edits); `buf lint` and `buf breaking --against origin/main` pass.

Refs IGA-1212.

🤖 Generated with [Claude Code](https://claude.com/claude-code)