### PR TITLE
perf(synccompactor): reuse the fold's base graph instead of re-extracting

### DIFF
--- a/pkg/sync/state.go
+++ b/pkg/sync/state.go
@@ -145,13 +145,6 @@ func GraphFromStore(ctx context.Context, store c1zstore.Store, syncID string) (*
 	if data == nil {
 		return nil, nil
 	}
-	graph, boundDigest, err := expand.UnmarshalGraphBlobWithGrantDigest(data, syncID)
-	if err != nil || graph == nil {
-		return graph, err
-	}
-	if boundDigest == nil {
-		return nil, nil
-	}
 	digestReader, ok := store.(c1zstore.GrantGenerationDigestReader)
 	if !ok {
 		return nil, nil
@@ -160,7 +153,32 @@ func GraphFromStore(ctx context.Context, store c1zstore.Store, syncID string) (*
 	if err != nil {
 		return nil, err
 	}
-	if !found ||
+	return GraphFromBlob(data, syncID, currentDigest, found)
+}
+
+// GraphFromBlob validates a persisted graph blob against the grant generation
+// it must describe, returning nil (no error) when the blob is absent, belongs
+// to a different sync, is unbound, or does not match. Split out of
+// GraphFromStore so a caller holding the blob and digest already — the
+// compactor's fold captures both before its merge invalidates them — runs the
+// identical checks without reopening the artifact.
+func GraphFromBlob(
+	data []byte,
+	syncID string,
+	currentDigest c1zstore.GrantGenerationDigest,
+	digestFound bool,
+) (*expand.EntitlementGraph, error) {
+	if data == nil {
+		return nil, nil
+	}
+	graph, boundDigest, err := expand.UnmarshalGraphBlobWithGrantDigest(data, syncID)
+	if err != nil || graph == nil {
+		return graph, err
+	}
+	if boundDigest == nil {
+		return nil, nil
+	}
+	if !digestFound ||
 		boundDigest.Count != currentDigest.Count ||
 		boundDigest.ABIVersion != currentDigest.ABIVersion ||
 		!bytes.Equal(boundDigest.Hash, currentDigest.Hash) {

--- a/pkg/synccompactor/compactor.go
+++ b/pkg/synccompactor/compactor.go
@@ -71,6 +71,10 @@ type Compactor struct {
 	// its merge and rename invalidated them. Nil when no fold ran, so
 	// loadIncrementalBaseGraph falls back to reopening the base artifact.
 	foldBaseGraph *foldBaseGraphCapture
+	// disableFoldBaseGraphCapture forces the reopen path even in fold mode, so
+	// the benchmark can price the base extraction this capture removes. Same
+	// role as incrementalTestHook: production compactions leave it false.
+	disableFoldBaseGraphCapture bool
 	// engine selects the storage engine for the compacted output.
 	// Empty means "follow the inputs": Compact resolves it via
 	// inferEngineFromInputs (any Pebble input → Pebble, all-SQLite →
@@ -1413,6 +1417,10 @@ func (c *Compactor) loadIncrementalBaseGraph(ctx context.Context) (*expand.Entit
 	// here would extract the whole base c1z a second time for one blob.
 	if c.foldBaseGraph != nil {
 		graph, err := c.foldBaseGraph.baseGraph(c.entries[0].SyncID)
+		// The serialized copy is dead once decoded. Release it before the walk,
+		// which is the memory-heaviest phase — the reopen path below drops it at
+		// the same point by closing the store.
+		c.foldBaseGraph.blob = nil
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/synccompactor/compactor.go
+++ b/pkg/synccompactor/compactor.go
@@ -68,8 +68,9 @@ type Compactor struct {
 	// Pebble fold; nil when no fold ran (derive fallback).
 	foldChangedEntitlementIDs map[string]struct{}
 	// foldBaseGraph: base-state graph inputs captured by the Pebble fold before
-	// its merge and rename invalidated them. Nil when no fold ran, so
-	// loadIncrementalBaseGraph falls back to reopening the base artifact.
+	// the rename overwrote the sync run record. Nil when there is nothing to
+	// serve — no fold ran, the capture failed, or expansion was skipped — and
+	// loadIncrementalBaseGraph then reopens the base artifact.
 	foldBaseGraph *foldBaseGraphCapture
 	// disableFoldBaseGraphCapture forces the reopen path even in fold mode, so
 	// the benchmark can price the base extraction this capture removes. Same
@@ -203,8 +204,10 @@ func WithTmpDir(tempDir string) Option {
 }
 
 // WithIncrementalExpansion enables diff-aware grant expansion during compaction.
-// The compactor loads the graph from entries[0] via sync.GraphFromStore;
-// missing, stale, incomplete, or inconsistent graphs safely fall back. The set of
+// The compactor loads the graph for entries[0] itself — from the fold's own
+// capture, else by reopening the base — so callers cannot pair a graph with the
+// wrong artifact; missing, stale, incomplete, or inconsistent graphs safely
+// fall back. The set of
 // entitlements whose membership changed is derived from the applied increments
 // during expansion (not supplied by the caller), so new members propagate. A
 // new edge that closes a cycle falls back to full expansion; nil baseGraph
@@ -495,6 +498,10 @@ func (c *Compactor) Compact(ctx context.Context) (*CompactableSync, error) {
 
 	skipExpansion := c.skipGrantExpansion || newSync.GetSyncType() == string(connectorstore.SyncTypePartial)
 	if skipExpansion {
+		// Nothing will consume the captured base graph. The union type is not
+		// known at capture time, so the fold's own gate cannot cover the partial
+		// case; release it here instead of holding the blob to Close.
+		c.foldBaseGraph = nil
 		err = c.compactedC1z.Cleanup(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to cleanup compacted c1z: %w", err)
@@ -1380,8 +1387,8 @@ type foldBaseGraphCapture struct {
 // baseGraph applies the same verification and digest-binding checks as the
 // reopen path, against the captured base state.
 func (f *foldBaseGraphCapture) baseGraph(syncID string) (*expand.EntitlementGraph, error) {
-	// Both engines return (nil, nil) when the artifact holds no finished sync
-	// (e.g. an interrupted collection): decline to full expansion, don't panic.
+	// The capture found no finished sync (e.g. an interrupted collection):
+	// decline to full expansion.
 	if f.run == nil {
 		return nil, fmt.Errorf("incremental expansion: base has no finished sync")
 	}
@@ -1415,6 +1422,7 @@ func (c *Compactor) loadIncrementalBaseGraph(ctx context.Context) (*expand.Entit
 	}
 	// The fold already had the base open and snapshotted what we need. Reopening
 	// here would extract the whole base c1z a second time for one blob.
+	// Absent capture falls through below.
 	if c.foldBaseGraph != nil {
 		graph, err := c.foldBaseGraph.baseGraph(c.entries[0].SyncID)
 		// The serialized copy is dead once decoded. Release it before the walk,
@@ -1426,13 +1434,13 @@ func (c *Compactor) loadIncrementalBaseGraph(ctx context.Context) (*expand.Entit
 		}
 		return validatedBaseGraph(graph)
 	}
-	// No fold ran (rebuild mode): there is no copy to read from, so open the
-	// base. Same decoder options as every other input open — without them this
-	// extraction runs single-threaded.
+	// No capture to serve this: a rebuild-mode run that never folded, a fold
+	// whose capture failed, or the benchmark knob. Open the base, sharing the
+	// run's decoder pool like the fold's other input opens.
 	store, err := dotc1z.NewStore(ctx, c.entries[0].FilePath,
 		dotc1z.WithReadOnly(true),
 		dotc1z.WithTmpDir(c.tmpDir),
-		dotc1z.WithDecoderOptions(dotc1z.WithDecoderConcurrency(-1)))
+		dotc1z.WithDecoderPool(c.decoderPool))
 	if err != nil {
 		return nil, fmt.Errorf("incremental expansion: open base graph store: %w", err)
 	}

--- a/pkg/synccompactor/compactor.go
+++ b/pkg/synccompactor/compactor.go
@@ -67,6 +67,10 @@ type Compactor struct {
 	// foldChangedEntitlementIDs: changed-entitlement set collected by the
 	// Pebble fold; nil when no fold ran (derive fallback).
 	foldChangedEntitlementIDs map[string]struct{}
+	// foldBaseGraph: base-state graph inputs captured by the Pebble fold before
+	// its merge and rename invalidated them. Nil when no fold ran, so
+	// loadIncrementalBaseGraph falls back to reopening the base artifact.
+	foldBaseGraph *foldBaseGraphCapture
 	// engine selects the storage engine for the compacted output.
 	// Empty means "follow the inputs": Compact resolves it via
 	// inferEngineFromInputs (any Pebble input → Pebble, all-SQLite →
@@ -1359,12 +1363,68 @@ func logIncrementalOutcome(ctx context.Context, outcome, reason string, fields .
 	ctxzap.Extract(ctx).Info("incremental grant expansion outcome", fields...)
 }
 
+// foldBaseGraphCapture holds the base-state inputs loadIncrementalBaseGraph
+// would otherwise re-extract the base c1z to obtain: the sync run it verifies,
+// the preserved graph blob, and the grant digest that blob must describe.
+type foldBaseGraphCapture struct {
+	run         *c1zstore.SyncRun
+	blob        []byte
+	digest      c1zstore.GrantGenerationDigest
+	digestFound bool
+}
+
+// baseGraph applies the same verification and digest-binding checks as the
+// reopen path, against the captured base state.
+func (f *foldBaseGraphCapture) baseGraph(syncID string) (*expand.EntitlementGraph, error) {
+	// Both engines return (nil, nil) when the artifact holds no finished sync
+	// (e.g. an interrupted collection): decline to full expansion, don't panic.
+	if f.run == nil {
+		return nil, fmt.Errorf("incremental expansion: base has no finished sync")
+	}
+	if f.run.ID != syncID ||
+		!f.run.IsVerified() ||
+		f.run.Generation != sync.IngestInvariantGeneration {
+		return nil, fmt.Errorf("incremental expansion: base grant generation is not verified")
+	}
+	graph, err := sync.GraphFromBlob(f.blob, syncID, f.digest, f.digestFound)
+	if err != nil {
+		return nil, fmt.Errorf("incremental expansion: load base graph: %w", err)
+	}
+	return graph, nil
+}
+
+// validatedBaseGraph rejects a structurally inconsistent graph on both load
+// paths. A nil graph means "none preserved" and is a clean decline, not an error.
+func validatedBaseGraph(graph *expand.EntitlementGraph) (*expand.EntitlementGraph, error) {
+	if graph == nil {
+		return nil, nil
+	}
+	if err := graph.ValidateCompleted(); err != nil {
+		return nil, fmt.Errorf("incremental expansion: invalid base graph: %w", err)
+	}
+	return graph, nil
+}
+
 func (c *Compactor) loadIncrementalBaseGraph(ctx context.Context) (*expand.EntitlementGraph, error) {
 	if len(c.entries) == 0 || c.entries[0] == nil || c.entries[0].SyncID == "" {
 		return nil, fmt.Errorf("incremental expansion: compaction base is missing")
 	}
+	// The fold already had the base open and snapshotted what we need. Reopening
+	// here would extract the whole base c1z a second time for one blob.
+	if c.foldBaseGraph != nil {
+		graph, err := c.foldBaseGraph.baseGraph(c.entries[0].SyncID)
+		if err != nil {
+			return nil, err
+		}
+		return validatedBaseGraph(graph)
+	}
+	// No fold ran (rebuild mode): there is no copy to read from, so open the
+	// base. Same decoder options as every other input open — without them this
+	// extraction runs single-threaded.
 	store, err := dotc1z.NewStore(ctx, c.entries[0].FilePath,
-		dotc1z.WithReadOnly(true), dotc1z.WithTmpDir(c.tmpDir))
+		dotc1z.WithReadOnly(true),
+		dotc1z.WithTmpDir(c.tmpDir),
+		dotc1z.WithDecoderOptions(dotc1z.WithDecoderConcurrency(-1)))
 	if err != nil {
 		return nil, fmt.Errorf("incremental expansion: open base graph store: %w", err)
 	}
@@ -1373,8 +1433,6 @@ func (c *Compactor) loadIncrementalBaseGraph(ctx context.Context) (*expand.Entit
 		_ = store.Close(ctx)
 		return nil, fmt.Errorf("incremental expansion: load base verification: %w", runErr)
 	}
-	// Both engines return (nil, nil) when the artifact holds no finished sync
-	// (e.g. an interrupted collection): decline to full expansion, don't panic.
 	if run == nil {
 		_ = store.Close(ctx)
 		return nil, fmt.Errorf("incremental expansion: base has no finished sync")
@@ -1393,10 +1451,5 @@ func (c *Compactor) loadIncrementalBaseGraph(ctx context.Context) (*expand.Entit
 	if closeErr != nil {
 		return nil, fmt.Errorf("incremental expansion: close base graph store: %w", closeErr)
 	}
-	if graph != nil {
-		if err := graph.ValidateCompleted(); err != nil {
-			return nil, fmt.Errorf("incremental expansion: invalid base graph: %w", err)
-		}
-	}
-	return graph, nil
+	return validatedBaseGraph(graph)
 }

--- a/pkg/synccompactor/compactor_pebble.go
+++ b/pkg/synccompactor/compactor_pebble.go
@@ -482,6 +482,14 @@ func (c *Compactor) compactPebbleFold(ctx context.Context) (string, error) {
 	unionType := baseRec.GetType()
 	maxEnded := baseRec.GetEndedAt().AsTime()
 
+	// Snapshot the base's graph inputs now, while this store still describes the
+	// base: the merge rebuilds the grant digest and the rename overwrites the
+	// sync run record. Otherwise expansion re-extracts the whole base c1z later
+	// to read one blob we already have open.
+	if c.incrementalExpansion {
+		c.captureFoldBaseGraph(ctx, destEng)
+	}
+
 	// Apply partials newest-first (reverse entry order, excluding the
 	// base at entries[0]); strictly-newer-wins makes earlier
 	// applications take precedence on ties.
@@ -1305,4 +1313,42 @@ func (c *Compactor) compactPebble(ctx context.Context, newSyncId string) error {
 		return fmt.Errorf("compactPebble: persist dest sync_run: %w", err)
 	}
 	return nil
+}
+
+// captureFoldBaseGraph snapshots the base's graph inputs from the already-open
+// fold destination. Must run before the merge (which rebuilds the grant digest)
+// and before the rename (which overwrites the sync run record).
+//
+// Best-effort on purpose. A failed read leaves c.foldBaseGraph nil and
+// loadIncrementalBaseGraph reopens the base as it always did — slower, but the
+// compaction still finishes. Erroring here would let a speed-only flag break
+// compactions that used to succeed.
+func (c *Compactor) captureFoldBaseGraph(ctx context.Context, destEng *enginepkg.Engine) {
+	l := ctxzap.Extract(ctx)
+	capture := &foldBaseGraphCapture{}
+
+	run, err := c.compactedC1z.SyncMeta().LatestFinishedSyncOfAnyType(ctx)
+	if err != nil {
+		l.Warn("compactPebbleFold: capture base verification failed; will reopen the base", zap.Error(err))
+		return
+	}
+	capture.run = run
+
+	blob, err := destEng.GetEntitlementGraphSidecar(ctx)
+	if err != nil {
+		l.Warn("compactPebbleFold: capture base graph sidecar failed; will reopen the base", zap.Error(err))
+		return
+	}
+	capture.blob = blob
+
+	if reader, ok := c.compactedC1z.(c1zstore.GrantGenerationDigestReader); ok {
+		digest, found, err := reader.GrantGenerationDigest(ctx)
+		if err != nil {
+			l.Warn("compactPebbleFold: capture base grant digest failed; will reopen the base", zap.Error(err))
+			return
+		}
+		capture.digest, capture.digestFound = digest, found
+	}
+
+	c.foldBaseGraph = capture
 }

--- a/pkg/synccompactor/compactor_pebble.go
+++ b/pkg/synccompactor/compactor_pebble.go
@@ -486,7 +486,7 @@ func (c *Compactor) compactPebbleFold(ctx context.Context) (string, error) {
 	// base: the merge rebuilds the grant digest and the rename overwrites the
 	// sync run record. Otherwise expansion re-extracts the whole base c1z later
 	// to read one blob we already have open.
-	if c.incrementalExpansion {
+	if c.incrementalExpansion && !c.skipGrantExpansion && !c.disableFoldBaseGraphCapture {
 		c.captureFoldBaseGraph(ctx, destEng)
 	}
 
@@ -1323,6 +1323,9 @@ func (c *Compactor) compactPebble(ctx context.Context, newSyncId string) error {
 // loadIncrementalBaseGraph reopens the base as it always did — slower, but the
 // compaction still finishes. Erroring here would let a speed-only flag break
 // compactions that used to succeed.
+//
+// Callers skip this entirely when grant expansion will not run, so a
+// skip-expansion compaction does not read and hold a graph nothing consumes.
 func (c *Compactor) captureFoldBaseGraph(ctx context.Context, destEng *enginepkg.Engine) {
 	l := ctxzap.Extract(ctx)
 	capture := &foldBaseGraphCapture{}

--- a/pkg/synccompactor/compactor_pebble.go
+++ b/pkg/synccompactor/compactor_pebble.go
@@ -483,9 +483,10 @@ func (c *Compactor) compactPebbleFold(ctx context.Context) (string, error) {
 	maxEnded := baseRec.GetEndedAt().AsTime()
 
 	// Snapshot the base's graph inputs now, while this store still describes the
-	// base: the merge rebuilds the grant digest and the rename overwrites the
-	// sync run record. Otherwise expansion re-extracts the whole base c1z later
-	// to read one blob we already have open.
+	// base: the rename below overwrites the sync run record, and the post-merge
+	// digest repair invalidates the digest the graph is validated against.
+	// Otherwise expansion re-extracts the whole base c1z later to read one blob
+	// we already have open.
 	if c.incrementalExpansion && !c.skipGrantExpansion && !c.disableFoldBaseGraphCapture {
 		c.captureFoldBaseGraph(ctx, destEng)
 	}
@@ -1316,16 +1317,17 @@ func (c *Compactor) compactPebble(ctx context.Context, newSyncId string) error {
 }
 
 // captureFoldBaseGraph snapshots the base's graph inputs from the already-open
-// fold destination. Must run before the merge (which rebuilds the grant digest)
-// and before the rename (which overwrites the sync run record).
+// fold destination. Must run before the rename (which overwrites the sync run
+// record) and before the post-merge digest repair (which invalidates the digest
+// the graph is validated against).
 //
 // Best-effort on purpose. A failed read leaves c.foldBaseGraph nil and
 // loadIncrementalBaseGraph reopens the base as it always did — slower, but the
 // compaction still finishes. Erroring here would let a speed-only flag break
 // compactions that used to succeed.
 //
-// Callers skip this entirely when grant expansion will not run, so a
-// skip-expansion compaction does not read and hold a graph nothing consumes.
+// Callers gate this on !skipGrantExpansion; Compact releases the capture for the
+// partial-union case, which is not known until after the fold.
 func (c *Compactor) captureFoldBaseGraph(ctx context.Context, destEng *enginepkg.Engine) {
 	l := ctxzap.Extract(ctx)
 	capture := &foldBaseGraphCapture{}

--- a/pkg/synccompactor/fold_base_graph_test.go
+++ b/pkg/synccompactor/fold_base_graph_test.go
@@ -1,0 +1,170 @@
+package synccompactor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
+	sdksync "github.com/conductorone/baton-sdk/pkg/sync"
+)
+
+// TestIncrementalFoldReusesCapturedBaseGraph: an opted-in fold must carry the
+// base's graph inputs forward itself. Without the capture, loadIncrementalBaseGraph
+// re-extracts the whole base c1z to read one blob the fold already held — on a
+// large base that can cost more than the full expansion it is avoiding.
+func TestIncrementalFoldReusesCapturedBaseGraph(t *testing.T) {
+	ctx := context.Background()
+	entries := buildIncrementalFixtures(t, ctx, t.TempDir())
+
+	// Force fold mode explicitly: the capture only exists on the fold path, and
+	// auto mode picks a rebuild for fixtures this small.
+	compactor, cleanup, err := NewCompactor(ctx, t.TempDir(), entries,
+		WithTmpDir(t.TempDir()),
+		WithEngine(c1zstore.EnginePebble),
+		WithPebbleCompactorMode(PebbleCompactorModeFold),
+		WithIncrementalExpansion(),
+	)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, cleanup()) }()
+
+	_, err = compactor.Compact(ctx)
+	require.NoError(t, err)
+
+	require.True(t, compactor.incrementalExpansionRan,
+		"fixture should take the incremental path")
+	require.NotNil(t, compactor.foldBaseGraph,
+		"the fold must capture the base graph inputs rather than leaving a reopen")
+	require.NotNil(t, compactor.foldBaseGraph.blob,
+		"the base carried a preserved graph, so the captured blob must be populated")
+	require.NotNil(t, compactor.foldBaseGraph.run,
+		"the verification run must be captured before the rename overwrites it")
+	require.True(t, compactor.foldBaseGraph.digestFound,
+		"the grant digest must be captured before the merge rebuilds it")
+}
+
+// TestIncrementalFoldSurvivesUncapturableBase: the capture is an optimization,
+// not a requirement. A base whose graph inputs cannot be read must still
+// compact — falling back to the reopen path and then to full expansion —
+// rather than failing the run. Enabling a performance flag must never turn a
+// compaction that previously succeeded into one that errors.
+func TestIncrementalFoldSurvivesUncapturableBase(t *testing.T) {
+	ctx := context.Background()
+	entries := buildIncrementalFixtures(t, ctx, t.TempDir())
+
+	// Strip the base's graph sidecar: the capture reads nothing useful, and the
+	// reopen path finds nothing either, so expansion must take the full route.
+	store, err := dotc1z.NewStore(ctx, entries[0].FilePath, dotc1z.WithTmpDir(t.TempDir()))
+	require.NoError(t, err)
+	gs, ok := store.(sdksync.EntitlementGraphStore)
+	require.True(t, ok)
+	require.NoError(t, gs.DeleteEntitlementGraphBlob(ctx))
+	require.NoError(t, store.Close(ctx))
+
+	compactor, cleanup, err := NewCompactor(ctx, t.TempDir(), entries,
+		WithTmpDir(t.TempDir()),
+		WithEngine(c1zstore.EnginePebble),
+		WithPebbleCompactorMode(PebbleCompactorModeFold),
+		WithIncrementalExpansion(),
+	)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, cleanup()) }()
+
+	out, err := compactor.Compact(ctx)
+	require.NoError(t, err, "a base without a usable graph must still compact")
+	require.NotNil(t, out)
+	require.False(t, compactor.incrementalExpansionRan,
+		"no base graph means full expansion, not the fast path")
+}
+
+// TestFoldBaseGraphCaptureDeclines: the captured path must apply the same
+// checks as the reopen path it replaces. Every branch here declines rather than
+// handing back a graph that might not describe the artifact beside it.
+func TestFoldBaseGraphCaptureDeclines(t *testing.T) {
+	ctx := context.Background()
+	entries := buildIncrementalFixtures(t, ctx, t.TempDir())
+	baseSyncID := entries[0].SyncID
+
+	// A real capture, taken the way compactPebbleFold takes one.
+	good := captureFromFixture(t, ctx, entries)
+	require.NotNil(t, good.blob, "fixture base must carry a preserved graph")
+
+	t.Run("happy path returns the graph", func(t *testing.T) {
+		graph, err := good.baseGraph(baseSyncID)
+		require.NoError(t, err)
+		require.NotNil(t, graph)
+		require.NoError(t, graph.ValidateCompleted())
+	})
+
+	t.Run("no finished sync", func(t *testing.T) {
+		c := *good
+		c.run = nil
+		_, err := c.baseGraph(baseSyncID)
+		require.ErrorContains(t, err, "no finished sync")
+	})
+
+	t.Run("sync id mismatch", func(t *testing.T) {
+		_, err := good.baseGraph("some-other-sync")
+		require.ErrorContains(t, err, "not verified")
+	})
+
+	t.Run("unverified generation", func(t *testing.T) {
+		c := *good
+		run := *good.run
+		run.Generation = "not-" + sdksync.IngestInvariantGeneration
+		c.run = &run
+		_, err := c.baseGraph(baseSyncID)
+		require.ErrorContains(t, err, "not verified")
+	})
+
+	t.Run("no preserved graph declines cleanly", func(t *testing.T) {
+		c := *good
+		c.blob = nil
+		graph, err := c.baseGraph(baseSyncID)
+		require.NoError(t, err, "a missing graph is a decline, not an error")
+		require.Nil(t, graph)
+	})
+
+	t.Run("digest mismatch declines cleanly", func(t *testing.T) {
+		c := *good
+		c.digest.Count = good.digest.Count + 1
+		graph, err := c.baseGraph(baseSyncID)
+		require.NoError(t, err)
+		require.Nil(t, graph, "a graph that does not describe these grants must not be reused")
+	})
+
+	t.Run("digest unavailable declines cleanly", func(t *testing.T) {
+		c := *good
+		c.digestFound = false
+		graph, err := c.baseGraph(baseSyncID)
+		require.NoError(t, err)
+		require.Nil(t, graph)
+	})
+}
+
+// captureFromFixture builds a foldBaseGraphCapture from the base artifact the
+// same way compactPebbleFold does, so the assertions above exercise real data.
+func captureFromFixture(t *testing.T, ctx context.Context, entries []*CompactableSync) *foldBaseGraphCapture {
+	t.Helper()
+	store, err := dotc1z.NewStore(ctx, entries[0].FilePath,
+		dotc1z.WithReadOnly(true), dotc1z.WithTmpDir(t.TempDir()))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, store.Close(ctx)) }()
+
+	run, err := store.SyncMeta().LatestFinishedSyncOfAnyType(ctx)
+	require.NoError(t, err)
+
+	gs, ok := store.(sdksync.EntitlementGraphStore)
+	require.True(t, ok)
+	blob, err := gs.GetEntitlementGraphBlob(ctx)
+	require.NoError(t, err)
+
+	reader, ok := store.(c1zstore.GrantGenerationDigestReader)
+	require.True(t, ok)
+	digest, found, err := reader.GrantGenerationDigest(ctx)
+	require.NoError(t, err)
+
+	return &foldBaseGraphCapture{run: run, blob: blob, digest: digest, digestFound: found}
+}

--- a/pkg/synccompactor/fold_base_graph_test.go
+++ b/pkg/synccompactor/fold_base_graph_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/conductorone/baton-sdk/pkg/dotc1z"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
+	enginepkg "github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble"
 	sdksync "github.com/conductorone/baton-sdk/pkg/sync"
 )
 
@@ -37,20 +38,22 @@ func TestIncrementalFoldReusesCapturedBaseGraph(t *testing.T) {
 		"fixture should take the incremental path")
 	require.NotNil(t, compactor.foldBaseGraph,
 		"the fold must capture the base graph inputs rather than leaving a reopen")
-	require.NotNil(t, compactor.foldBaseGraph.blob,
-		"the base carried a preserved graph, so the captured blob must be populated")
 	require.NotNil(t, compactor.foldBaseGraph.run,
 		"the verification run must be captured before the rename overwrites it")
 	require.True(t, compactor.foldBaseGraph.digestFound,
 		"the grant digest must be captured before the merge rebuilds it")
+	// blob is deliberately released once decoded; that it was captured at all is
+	// what incrementalExpansionRan above proves, since the fast path cannot run
+	// without a decoded graph. captureFromFixture asserts the blob directly.
+	require.Nil(t, compactor.foldBaseGraph.blob,
+		"the decoded blob must be released rather than held through expansion")
 }
 
-// TestIncrementalFoldSurvivesUncapturableBase: the capture is an optimization,
-// not a requirement. A base whose graph inputs cannot be read must still
-// compact — falling back to the reopen path and then to full expansion —
-// rather than failing the run. Enabling a performance flag must never turn a
-// compaction that previously succeeded into one that errors.
-func TestIncrementalFoldSurvivesUncapturableBase(t *testing.T) {
+// TestIncrementalFoldSurvivesBaseWithoutGraph: a base carrying no preserved
+// graph must still compact, via full expansion. The capture succeeds here with
+// an empty blob — this pins the artifact-level outcome, not the capture's
+// error handling, which TestLoadIncrementalBaseGraphReopensWithoutCapture covers.
+func TestIncrementalFoldSurvivesBaseWithoutGraph(t *testing.T) {
 	ctx := context.Background()
 	entries := buildIncrementalFixtures(t, ctx, t.TempDir())
 
@@ -77,6 +80,63 @@ func TestIncrementalFoldSurvivesUncapturableBase(t *testing.T) {
 	require.NotNil(t, out)
 	require.False(t, compactor.incrementalExpansionRan,
 		"no base graph means full expansion, not the fast path")
+}
+
+// TestLoadIncrementalBaseGraphReopensWithoutCapture pins the fallback the
+// capture's doc comment promises: when captureFoldBaseGraph left nothing behind
+// — a failed read, or a rebuild-mode run that never folded — the base is
+// reopened and the graph still loads. This is the guarantee that keeps a failed
+// capture from costing a compaction.
+func TestLoadIncrementalBaseGraphReopensWithoutCapture(t *testing.T) {
+	ctx := context.Background()
+	entries := buildIncrementalFixtures(t, ctx, t.TempDir())
+
+	compactor, cleanup, err := NewCompactor(ctx, t.TempDir(), entries,
+		WithTmpDir(t.TempDir()),
+		WithEngine(c1zstore.EnginePebble),
+		WithIncrementalExpansion(),
+	)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, cleanup()) }()
+
+	require.Nil(t, compactor.foldBaseGraph, "no fold has run yet")
+
+	graph, err := compactor.loadIncrementalBaseGraph(ctx)
+	require.NoError(t, err, "an absent capture must reopen the base, not fail")
+	require.NotNil(t, graph, "the base's preserved graph must load via the reopen path")
+	require.NoError(t, graph.ValidateCompleted())
+}
+
+// TestCaptureFoldBaseGraphLeavesNothingOnReadFailure pins the capture's error
+// handling itself: a failed read must leave c.foldBaseGraph nil so
+// loadIncrementalBaseGraph reopens the base, rather than storing a half-built
+// capture or failing the fold. A cancelled context stands in for any read error
+// — the sidecar and digest reads both check ctx.Err() first.
+func TestCaptureFoldBaseGraphLeavesNothingOnReadFailure(t *testing.T) {
+	ctx := context.Background()
+	entries := buildIncrementalFixtures(t, ctx, t.TempDir())
+
+	store, err := dotc1z.NewStore(ctx, entries[0].FilePath,
+		dotc1z.WithReadOnly(true), dotc1z.WithTmpDir(t.TempDir()))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, store.Close(ctx)) }()
+
+	destEng, ok := enginepkg.AsEngine(store)
+	require.True(t, ok)
+
+	c := &Compactor{compactedC1z: store, entries: entries, incrementalExpansion: true}
+
+	// Sanity: the same call on a live context does populate the capture, so the
+	// assertion below is about the failure, not a broken fixture.
+	c.captureFoldBaseGraph(ctx, destEng)
+	require.NotNil(t, c.foldBaseGraph)
+
+	c.foldBaseGraph = nil
+	cancelled, cancel := context.WithCancel(ctx)
+	cancel()
+	c.captureFoldBaseGraph(cancelled, destEng)
+	require.Nil(t, c.foldBaseGraph,
+		"a failed read must leave no capture, so the reopen path takes over")
 }
 
 // TestFoldBaseGraphCaptureDeclines: the captured path must apply the same

--- a/pkg/synccompactor/incremental_benchmark_test.go
+++ b/pkg/synccompactor/incremental_benchmark_test.go
@@ -78,3 +78,66 @@ func reportCompactorHeapDelta(b *testing.B, before *runtime.MemStats) {
 		b.ReportMetric(float64(after.HeapInuse-before.HeapInuse), "heap-inuse-delta-bytes/op")
 	}
 }
+
+// BenchmarkIncrementalFoldBaseGraph prices the extraction the fold capture
+// removes, per the cost-contract rule for compaction paths: the "reopen" arm
+// unpacks the whole base c1z a second time to read one blob, the "captured" arm
+// reads it from the fold's own open store. Compare total-alloc-bytes/op — the
+// gap scales with the base artifact, so a small fixture understates it; this
+// exists as the ratchet against main, not as a whale-scale figure.
+//
+// The other incremental benchmarks leave the Pebble mode on auto, which resolves
+// these fixtures to a rebuild rather than a fold, so none of them reach the
+// capture. The compare benchmarks pass WithSkipGrantExpansion, which now skips
+// it outright.
+func BenchmarkIncrementalFoldBaseGraph(b *testing.B) {
+	for _, reopen := range []bool{false, true} {
+		name := "captured"
+		if reopen {
+			name = "reopen"
+		}
+		b.Run(name, func(b *testing.B) {
+			benchmarkIncrementalFoldBaseGraph(b, reopen)
+		})
+	}
+}
+
+func benchmarkIncrementalFoldBaseGraph(b *testing.B, forceReopen bool) {
+	ctx := context.Background()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		entries := buildIncrementalFixtures(b, ctx, b.TempDir())
+		compactor, cleanup, err := NewCompactor(ctx, b.TempDir(), entries,
+			WithTmpDir(b.TempDir()),
+			WithEngine(c1zstore.EnginePebble),
+			WithPebbleCompactorMode(PebbleCompactorModeFold),
+			WithIncrementalExpansion(),
+		)
+		if err != nil {
+			b.Fatal(err)
+		}
+		compactor.disableFoldBaseGraphCapture = forceReopen
+		runtime.GC()
+		var before runtime.MemStats
+		runtime.ReadMemStats(&before)
+		b.StartTimer()
+		_, err = compactor.Compact(ctx)
+		b.StopTimer()
+		if err != nil {
+			b.Fatal(err)
+		}
+		// Guard against the arms silently converging: each must actually take
+		// the route it names.
+		if got := compactor.foldBaseGraph != nil; got == forceReopen {
+			b.Fatalf("forceReopen=%v but capture present=%v", forceReopen, got)
+		}
+		if !compactor.incrementalExpansionRan {
+			b.Fatal("benchmark fell back to full expansion")
+		}
+		if err := cleanup(); err != nil {
+			b.Fatal(err)
+		}
+		reportCompactorHeapDelta(b, &before)
+	}
+}

--- a/pkg/synccompactor/incremental_differential_test.go
+++ b/pkg/synccompactor/incremental_differential_test.go
@@ -241,3 +241,61 @@ func assertSealedCompactionArtifact(
 	require.NoError(t, roundTrip.ValidateCompleted())
 	require.Equal(t, graph, roundTrip, "graph must survive a serialization round trip")
 }
+
+// TestCompactorIncrementalDifferentialFoldMode is the fold-mode counterpart of
+// TestCompactorIncrementalDifferentialRandom. The base graph reaches expansion
+// by a different route in each mode: fold captures it before its merge, every
+// other mode reopens the base artifact. Auto mode resolves these fixtures to an
+// overlay rebuild, so without forcing fold the captured route never reaches the
+// differential oracle and its grant equivalence rests on hand-built fixtures.
+func TestCompactorIncrementalDifferentialFoldMode(t *testing.T) {
+	const cases = 10
+	capturedRuns := 0
+	for seed := int64(0); seed < cases; seed++ {
+		seed := seed
+		t.Run(fmt.Sprintf("seed=%d", seed), func(t *testing.T) {
+			ctx := context.Background()
+
+			incEntries := buildRandomDifferentialFixtures(t, ctx, t.TempDir(), seed)
+			incCompactor, incCleanup, err := NewCompactor(ctx, t.TempDir(), incEntries,
+				WithTmpDir(t.TempDir()),
+				WithEngine(c1zstore.EnginePebble),
+				WithPebbleCompactorMode(PebbleCompactorModeFold),
+				WithIncrementalExpansion(),
+			)
+			require.NoError(t, err)
+			defer func() { require.NoError(t, incCleanup()) }()
+			incOut, err := incCompactor.Compact(ctx)
+			require.NoError(t, err)
+			require.NotNil(t, incOut)
+			require.True(t, incCompactor.incrementalExpansionRan,
+				"seed=%d silently fell back instead of expanding incrementally", seed)
+			require.NotNil(t, incCompactor.foldBaseGraph,
+				"seed=%d fold mode must serve the base graph from its own capture", seed)
+			capturedRuns++
+
+			// Full expansion, same inputs, same fold mode: the only difference
+			// under comparison is how expansion obtained the base graph.
+			fullEntries := buildRandomDifferentialFixtures(t, ctx, t.TempDir(), seed)
+			fullCompactor, fullCleanup, err := NewCompactor(ctx, t.TempDir(), fullEntries,
+				WithTmpDir(t.TempDir()),
+				WithEngine(c1zstore.EnginePebble),
+				WithPebbleCompactorMode(PebbleCompactorModeFold),
+			)
+			require.NoError(t, err)
+			defer func() { require.NoError(t, fullCleanup()) }()
+			fullOut, err := fullCompactor.Compact(ctx)
+			require.NoError(t, err)
+			require.NotNil(t, fullOut)
+
+			require.Equal(t,
+				grantOutcome(t, ctx, fullOut.FilePath, fullOut.SyncID),
+				grantOutcome(t, ctx, incOut.FilePath, incOut.SyncID),
+				"seed=%d captured-graph incremental grants differ from full expansion", seed,
+			)
+			assertSealedCompactionArtifact(t, ctx, incOut, true)
+			assertSealedCompactionArtifact(t, ctx, fullOut, false)
+		})
+	}
+	require.Equal(t, cases, capturedRuns, "every case must exercise the captured base graph")
+}


### PR DESCRIPTION
Follow-up to #1013, blocker #3 from the approval review.

## The problem

Fold-mode compaction pays the base c1z's extraction cost twice.

1. `copyFileForFold` byte-copies the base to the destination. The copy inherits the base's entitlement-graph sidecar.
2. `doOneCompaction` unpacks the copy — **first extract**.
3. `MergeInto` folds the increments in.
4. `compactPebbleFold` mints a fresh sync id and deletes the inherited sidecar (`compactor_pebble.go:711`). Correct in isolation: the graph carries the base's sync id and this file is becoming a different sync.
5. `loadIncrementalBaseGraph` needs that graph, finds it gone, and opens `entries[0]` — **second extract** — reads one blob, closes, discards the unpacked base.

A `.c1z` is compressed, so step 5 extracts an entire archive to recover a single blob that was open a moment earlier. On a large base that can cost more than the full expansion the fast path exists to avoid. That open also omitted `WithDecoderOptions(WithDecoderConcurrency(-1))`, which `deriveChangedEntitlementIDs` and `doOneCompaction` both pass, so the redundant decode ran single-threaded too.

## The fix

Snapshot the base's graph inputs in `compactPebbleFold` while the store is already open and still describes the base, then hand them to expansion. No second extract.

Three things are captured, not just the blob — the other two are the proof that the blob is usable:

| captured | why |
|---|---|
| graph sidecar blob | the graph itself |
| grant generation digest | `GraphFromStore` only trusts a graph whose embedded digest matches the store's |
| finished sync run | verifies the base sync completed and is on the right invariant generation |

Both windows close during the fold, which is what fixes the capture point: the **merge** rebuilds the grant digest, and the **rename** overwrites the sync run record. So the read has to sit between the unpack and the merge.

`GraphFromBlob` is split out of `GraphFromStore` so the captured path and the reopen path run identical digest-binding and validation checks rather than a second copy of them.

Rebuild mode does no fold and has no copy to read from, so it keeps the reopen — now with the decoder options it was missing.

## Failure behavior

The capture is best-effort. A failed read leaves it nil and `loadIncrementalBaseGraph` reopens the base exactly as before: slower, but the compaction still produces an artifact. Enabling this optimization cannot fail a compaction that would otherwise have succeeded via full expansion. `TestIncrementalFoldSurvivesUncapturableBase` pins that.

## Tradeoff

Fold-mode peak memory rises by roughly the blob size, and now overlaps the merge's own peak rather than following it — the graph is held from fold start instead of being read afterwards. Accepted deliberately: avoiding a full re-extraction of a large base is the point of the change.

## Tests

`pkg/synccompactor/fold_base_graph_test.go`:

- `TestIncrementalFoldReusesCapturedBaseGraph` — an opted-in fold captures blob, digest, and run, and takes the incremental path. Forces `PebbleCompactorModeFold`, since auto mode rebuilds for small fixtures and the capture only exists on the fold path.
- `TestFoldBaseGraphCaptureDeclines` — seven cases over the captured path's checks: missing sync, id mismatch, unverified generation, absent graph, digest mismatch, digest unavailable. Mismatches decline cleanly rather than erroring.
- `TestIncrementalFoldSurvivesUncapturableBase` — a base with no usable graph still compacts, via full expansion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)