### PR TITLE
CE-1315 Map failed OAuth2 token exchange to a grpc status in uhttp

### DIFF
--- a/pkg/uhttp/errors.go
+++ b/pkg/uhttp/errors.go
@@ -115,13 +115,29 @@ func wrapTransientNetworkError(err error) error {
 // oauthTokenErrorCode maps an RFC 6749 §5.2 token-error "error" parameter to
 // a grpc code. ok is false when errCode is empty or not one of the values
 // the spec defines, signaling the caller to fall back to the HTTP status.
+//
+//   - invalid_client and unauthorized_client both name the client's
+//     credential/identity as the problem — RFC 6749 defines invalid_client as
+//     "Client authentication failed", and unauthorized_client as "The
+//     authenticated client is not authorized to use this authorization grant
+//     type" (authenticated, but not entitled) — PermissionDenied, not
+//     Unauthenticated, since re-presenting a different secret won't fix a
+//     grant-type mismatch.
+//   - invalid_grant explicitly covers "resource owner credentials" (a wrong
+//     username/password under the password grant) alongside an expired or
+//     revoked authorization code/refresh token — a genuine credential
+//     failure, so it maps with invalid_client rather than the InvalidArgument
+//     bucket.
+//   - access_denied, invalid_scope, invalid_request, unsupported_grant_type,
+//     and unsupported_response_type describe a malformed or disallowed
+//     request rather than a rejected identity.
 func oauthTokenErrorCode(errCode string) (codes.Code, bool) {
 	switch errCode {
-	case "invalid_client", "unauthorized_client":
+	case "invalid_client", "invalid_grant":
 		return codes.Unauthenticated, true
-	case "access_denied":
+	case "unauthorized_client", "access_denied":
 		return codes.PermissionDenied, true
-	case "invalid_grant", "invalid_scope", "invalid_request", "unsupported_grant_type", "unsupported_response_type":
+	case "invalid_scope", "invalid_request", "unsupported_grant_type", "unsupported_response_type":
 		return codes.InvalidArgument, true
 	default:
 		return codes.Unknown, false

--- a/pkg/uhttp/errors.go
+++ b/pkg/uhttp/errors.go
@@ -13,6 +13,8 @@ import (
 	"golang.org/x/oauth2"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/conductorone/baton-sdk/pkg/ratelimit"
 )
 
 // wrapTransientNetworkError mirrors Baton HTTP retry classification for callers
@@ -28,11 +30,11 @@ func wrapTransientNetworkError(err error) error {
 	// servers report it on a 200 and 400 is the spec default for
 	// invalid_client/invalid_grant, both of which GrpcCodeFromHTTPStatus
 	// alone would misclassify. This branch is total once errors.As matches,
-	// so a RetrieveError never reaches the err.Error() calls below it.
+	// so a RetrieveError is never run through the network-error checks below.
 	var retrieveErr *oauth2.RetrieveError
 	if errors.As(err, &retrieveErr) {
 		if retrieveErr.Response != nil && isTransientHTTPStatus(retrieveErr.Response.StatusCode) {
-			return WrapErrors(GrpcCodeFromHTTPStatus(retrieveErr.Response.StatusCode), transientOAuthTokenMessage(retrieveErr), err)
+			return wrapTransientOAuthTokenError(retrieveErr, err)
 		}
 		if code, ok := oauthTokenErrorCode(retrieveErr.ErrorCode); ok {
 			return WrapErrors(code, oauthTokenErrorMessage(retrieveErr), err)
@@ -113,21 +115,34 @@ func wrapTransientNetworkError(err error) error {
 }
 
 // isTransientHTTPStatus reports whether GrpcCodeFromHTTPStatus maps
-// statusCode to codes.Unavailable, so a transient token-endpoint failure
+// statusCode to a code retry.Retryer.ShouldWaitAndRetry treats as retryable
+// (Unavailable or DeadlineExceeded), so a transient token-endpoint failure
 // stays retryable regardless of what error param the body also carries.
 func isTransientHTTPStatus(statusCode int) bool {
-	return GrpcCodeFromHTTPStatus(statusCode) == codes.Unavailable
+	switch GrpcCodeFromHTTPStatus(statusCode) {
+	case codes.Unavailable, codes.DeadlineExceeded:
+		return true
+	default:
+		return false
+	}
 }
 
-// transientOAuthTokenMessage leads with the HTTP status, since that's what
-// drove the Unavailable classification, but keeps ErrorDescription when the
-// server sent one alongside it (e.g. a rate-limit message).
-func transientOAuthTokenMessage(retrieveErr *oauth2.RetrieveError) string {
+// wrapTransientOAuthTokenError mirrors WrapErrorsWithRateLimitInfo's detail
+// attachment (retry.Retryer reads it for rate-limit-aware backoff), while
+// keeping ErrorDescription in the message the way oauthTokenErrorMessage
+// does elsewhere in this file.
+func wrapTransientOAuthTokenError(retrieveErr *oauth2.RetrieveError, err error) error {
 	msg := retrieveErr.Response.Status
 	if retrieveErr.ErrorDescription != "" {
 		msg = fmt.Sprintf("%s: %s", msg, retrieveErr.ErrorDescription)
 	}
-	return msg
+	st := status.New(GrpcCodeFromHTTPStatus(retrieveErr.Response.StatusCode), msg)
+	if description, rlErr := ratelimit.ExtractRateLimitData(retrieveErr.Response.StatusCode, &retrieveErr.Response.Header); rlErr == nil {
+		if withDetails, detailsErr := st.WithDetails(description); detailsErr == nil {
+			st = withDetails
+		}
+	}
+	return errors.Join(st.Err(), err)
 }
 
 // oauthTokenErrorCode maps an RFC 6749 §5.2 token-error "error" parameter to

--- a/pkg/uhttp/errors.go
+++ b/pkg/uhttp/errors.go
@@ -22,18 +22,26 @@ func wrapTransientNetworkError(err error) error {
 		return nil
 	}
 
-	// The RFC 6749 §5.2 error param takes priority over the HTTP status:
-	// some servers report it on a 200, and 400 is the spec default for
-	// invalid_client/invalid_grant, which GrpcCodeFromHTTPStatus alone
-	// would otherwise misclassify.
+	// A transient token-endpoint status (429/5xx) stays retryable even if
+	// the body also carries a recognized RFC 6749 error param; otherwise
+	// the error param takes priority over the HTTP status, since some
+	// servers report it on a 200 and 400 is the spec default for
+	// invalid_client/invalid_grant, both of which GrpcCodeFromHTTPStatus
+	// alone would misclassify. This branch is total once errors.As matches,
+	// so a RetrieveError never reaches the err.Error() calls below it.
 	var retrieveErr *oauth2.RetrieveError
 	if errors.As(err, &retrieveErr) {
+		if retrieveErr.Response != nil && isTransientHTTPStatus(retrieveErr.Response.StatusCode) {
+			return WrapErrors(GrpcCodeFromHTTPStatus(retrieveErr.Response.StatusCode), retrieveErr.Response.Status, err)
+		}
 		if code, ok := oauthTokenErrorCode(retrieveErr.ErrorCode); ok {
 			return WrapErrors(code, oauthTokenErrorMessage(retrieveErr), err)
 		}
+		code := codes.Unknown
 		if retrieveErr.Response != nil {
-			return WrapErrors(GrpcCodeFromHTTPStatus(retrieveErr.Response.StatusCode), oauthTokenErrorMessage(retrieveErr), err)
+			code = GrpcCodeFromHTTPStatus(retrieveErr.Response.StatusCode)
 		}
+		return WrapErrors(code, oauthTokenErrorMessage(retrieveErr), err)
 	}
 
 	if errors.Is(err, io.ErrUnexpectedEOF) {
@@ -102,6 +110,13 @@ func wrapTransientNetworkError(err error) error {
 	}
 
 	return err
+}
+
+// isTransientHTTPStatus mirrors the statuses GrpcCodeFromHTTPStatus maps to
+// codes.Unavailable, so a transient token-endpoint failure stays retryable
+// regardless of what error param the body also carries.
+func isTransientHTTPStatus(statusCode int) bool {
+	return statusCode == http.StatusTooManyRequests || statusCode >= 500
 }
 
 // oauthTokenErrorCode maps an RFC 6749 §5.2 token-error "error" parameter to

--- a/pkg/uhttp/errors.go
+++ b/pkg/uhttp/errors.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"strings"
 
+	"golang.org/x/oauth2"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -20,6 +21,19 @@ func wrapTransientNetworkError(err error) error {
 	if err == nil {
 		return nil
 	}
+
+	// A failed OAuth2 token exchange (rejected client credentials, wrong
+	// scope, expired secret, etc.) surfaces here as *oauth2.RetrieveError
+	// wrapping the token endpoint's real HTTP response — not as a network
+	// blip. Map its status code the same way a normal API response would
+	// be mapped, instead of falling through to codes.Unknown: callers
+	// (e.g. exit.LogExit) rely on that mapping to tell a real auth failure
+	// apart from an unclassified error.
+	var retrieveErr *oauth2.RetrieveError
+	if errors.As(err, &retrieveErr) && retrieveErr.Response != nil {
+		return WrapErrors(GrpcCodeFromHTTPStatus(retrieveErr.Response.StatusCode), retrieveErr.Response.Status, err)
+	}
+
 	if errors.Is(err, io.ErrUnexpectedEOF) {
 		return WrapErrors(codes.Unavailable, "unexpected EOF", err)
 	}

--- a/pkg/uhttp/errors.go
+++ b/pkg/uhttp/errors.go
@@ -24,14 +24,24 @@ func wrapTransientNetworkError(err error) error {
 
 	// A failed OAuth2 token exchange (rejected client credentials, wrong
 	// scope, expired secret, etc.) surfaces here as *oauth2.RetrieveError
-	// wrapping the token endpoint's real HTTP response — not as a network
-	// blip. Map its status code the same way a normal API response would
-	// be mapped, instead of falling through to codes.Unknown: callers
-	// (e.g. exit.LogExit) rely on that mapping to tell a real auth failure
+	// wrapping the token endpoint's real response — not as a network blip.
+	// RFC 6749 §5.2's "error" parameter is the authoritative signal: some
+	// servers report it on an HTTP 200 (x/oauth2 still treats that as a
+	// RetrieveError), and the spec's own default status for invalid_client/
+	// invalid_grant is 400, which GrpcCodeFromHTTPStatus maps to
+	// InvalidArgument — not the Unauthenticated/PermissionDenied a bad-
+	// credentials rejection should produce. Only fall back to the HTTP
+	// status when the server didn't send a recognized error code. Callers
+	// (e.g. exit.LogExit) rely on this mapping to tell a real auth failure
 	// apart from an unclassified error.
 	var retrieveErr *oauth2.RetrieveError
-	if errors.As(err, &retrieveErr) && retrieveErr.Response != nil {
-		return WrapErrors(GrpcCodeFromHTTPStatus(retrieveErr.Response.StatusCode), retrieveErr.Response.Status, err)
+	if errors.As(err, &retrieveErr) {
+		if code, ok := oauthTokenErrorCode(retrieveErr.ErrorCode); ok {
+			return WrapErrors(code, oauthTokenErrorMessage(retrieveErr), err)
+		}
+		if retrieveErr.Response != nil {
+			return WrapErrors(GrpcCodeFromHTTPStatus(retrieveErr.Response.StatusCode), oauthTokenErrorMessage(retrieveErr), err)
+		}
 	}
 
 	if errors.Is(err, io.ErrUnexpectedEOF) {
@@ -100,6 +110,38 @@ func wrapTransientNetworkError(err error) error {
 	}
 
 	return err
+}
+
+// oauthTokenErrorCode maps an RFC 6749 §5.2 token-error "error" parameter to
+// a grpc code. ok is false when errCode is empty or not one of the values
+// the spec defines, signaling the caller to fall back to the HTTP status.
+func oauthTokenErrorCode(errCode string) (code codes.Code, ok bool) {
+	switch errCode {
+	case "invalid_client", "unauthorized_client":
+		return codes.Unauthenticated, true
+	case "access_denied":
+		return codes.PermissionDenied, true
+	case "invalid_grant", "invalid_scope", "invalid_request", "unsupported_grant_type", "unsupported_response_type":
+		return codes.InvalidArgument, true
+	default:
+		return codes.Unknown, false
+	}
+}
+
+// oauthTokenErrorMessage prefers the RFC 6749 error/error_description pair
+// the token endpoint sent, since that survives even when the HTTP status
+// alone would be misleading (e.g. a 200 response carrying an error body).
+func oauthTokenErrorMessage(retrieveErr *oauth2.RetrieveError) string {
+	switch {
+	case retrieveErr.ErrorCode != "" && retrieveErr.ErrorDescription != "":
+		return fmt.Sprintf("%s: %s", retrieveErr.ErrorCode, retrieveErr.ErrorDescription)
+	case retrieveErr.ErrorCode != "":
+		return retrieveErr.ErrorCode
+	case retrieveErr.Response != nil:
+		return retrieveErr.Response.Status
+	default:
+		return "oauth2 token request failed"
+	}
 }
 
 func isHTTP2ClientConnectionLost(err error) bool {

--- a/pkg/uhttp/errors.go
+++ b/pkg/uhttp/errors.go
@@ -32,7 +32,7 @@ func wrapTransientNetworkError(err error) error {
 	var retrieveErr *oauth2.RetrieveError
 	if errors.As(err, &retrieveErr) {
 		if retrieveErr.Response != nil && isTransientHTTPStatus(retrieveErr.Response.StatusCode) {
-			return WrapErrors(GrpcCodeFromHTTPStatus(retrieveErr.Response.StatusCode), retrieveErr.Response.Status, err)
+			return WrapErrors(GrpcCodeFromHTTPStatus(retrieveErr.Response.StatusCode), transientOAuthTokenMessage(retrieveErr), err)
 		}
 		if code, ok := oauthTokenErrorCode(retrieveErr.ErrorCode); ok {
 			return WrapErrors(code, oauthTokenErrorMessage(retrieveErr), err)
@@ -112,11 +112,22 @@ func wrapTransientNetworkError(err error) error {
 	return err
 }
 
-// isTransientHTTPStatus mirrors the statuses GrpcCodeFromHTTPStatus maps to
-// codes.Unavailable, so a transient token-endpoint failure stays retryable
-// regardless of what error param the body also carries.
+// isTransientHTTPStatus reports whether GrpcCodeFromHTTPStatus maps
+// statusCode to codes.Unavailable, so a transient token-endpoint failure
+// stays retryable regardless of what error param the body also carries.
 func isTransientHTTPStatus(statusCode int) bool {
-	return statusCode == http.StatusTooManyRequests || statusCode >= 500
+	return GrpcCodeFromHTTPStatus(statusCode) == codes.Unavailable
+}
+
+// transientOAuthTokenMessage leads with the HTTP status, since that's what
+// drove the Unavailable classification, but keeps ErrorDescription when the
+// server sent one alongside it (e.g. a rate-limit message).
+func transientOAuthTokenMessage(retrieveErr *oauth2.RetrieveError) string {
+	msg := retrieveErr.Response.Status
+	if retrieveErr.ErrorDescription != "" {
+		msg = fmt.Sprintf("%s: %s", msg, retrieveErr.ErrorDescription)
+	}
+	return msg
 }
 
 // oauthTokenErrorCode maps an RFC 6749 §5.2 token-error "error" parameter to

--- a/pkg/uhttp/errors.go
+++ b/pkg/uhttp/errors.go
@@ -115,7 +115,7 @@ func wrapTransientNetworkError(err error) error {
 // oauthTokenErrorCode maps an RFC 6749 §5.2 token-error "error" parameter to
 // a grpc code. ok is false when errCode is empty or not one of the values
 // the spec defines, signaling the caller to fall back to the HTTP status.
-func oauthTokenErrorCode(errCode string) (code codes.Code, ok bool) {
+func oauthTokenErrorCode(errCode string) (codes.Code, bool) {
 	switch errCode {
 	case "invalid_client", "unauthorized_client":
 		return codes.Unauthenticated, true

--- a/pkg/uhttp/errors.go
+++ b/pkg/uhttp/errors.go
@@ -22,18 +22,10 @@ func wrapTransientNetworkError(err error) error {
 		return nil
 	}
 
-	// A failed OAuth2 token exchange (rejected client credentials, wrong
-	// scope, expired secret, etc.) surfaces here as *oauth2.RetrieveError
-	// wrapping the token endpoint's real response — not as a network blip.
-	// RFC 6749 §5.2's "error" parameter is the authoritative signal: some
-	// servers report it on an HTTP 200 (x/oauth2 still treats that as a
-	// RetrieveError), and the spec's own default status for invalid_client/
-	// invalid_grant is 400, which GrpcCodeFromHTTPStatus maps to
-	// InvalidArgument — not the Unauthenticated/PermissionDenied a bad-
-	// credentials rejection should produce. Only fall back to the HTTP
-	// status when the server didn't send a recognized error code. Callers
-	// (e.g. exit.LogExit) rely on this mapping to tell a real auth failure
-	// apart from an unclassified error.
+	// The RFC 6749 §5.2 error param takes priority over the HTTP status:
+	// some servers report it on a 200, and 400 is the spec default for
+	// invalid_client/invalid_grant, which GrpcCodeFromHTTPStatus alone
+	// would otherwise misclassify.
 	var retrieveErr *oauth2.RetrieveError
 	if errors.As(err, &retrieveErr) {
 		if code, ok := oauthTokenErrorCode(retrieveErr.ErrorCode); ok {
@@ -113,24 +105,8 @@ func wrapTransientNetworkError(err error) error {
 }
 
 // oauthTokenErrorCode maps an RFC 6749 §5.2 token-error "error" parameter to
-// a grpc code. ok is false when errCode is empty or not one of the values
-// the spec defines, signaling the caller to fall back to the HTTP status.
-//
-//   - invalid_client and unauthorized_client both name the client's
-//     credential/identity as the problem — RFC 6749 defines invalid_client as
-//     "Client authentication failed", and unauthorized_client as "The
-//     authenticated client is not authorized to use this authorization grant
-//     type" (authenticated, but not entitled) — PermissionDenied, not
-//     Unauthenticated, since re-presenting a different secret won't fix a
-//     grant-type mismatch.
-//   - invalid_grant explicitly covers "resource owner credentials" (a wrong
-//     username/password under the password grant) alongside an expired or
-//     revoked authorization code/refresh token — a genuine credential
-//     failure, so it maps with invalid_client rather than the InvalidArgument
-//     bucket.
-//   - access_denied, invalid_scope, invalid_request, unsupported_grant_type,
-//     and unsupported_response_type describe a malformed or disallowed
-//     request rather than a rejected identity.
+// a grpc code. ok is false when errCode is empty or unrecognized, signaling
+// the caller to fall back to the HTTP status.
 func oauthTokenErrorCode(errCode string) (codes.Code, bool) {
 	switch errCode {
 	case "invalid_client", "invalid_grant":

--- a/pkg/uhttp/errors_test.go
+++ b/pkg/uhttp/errors_test.go
@@ -424,6 +424,14 @@ func TestWrapTransientNetworkError_OAuthTokenEndpointTransientIsRetried(t *testi
 	require.True(t, newRetryer().ShouldWaitAndRetry(t.Context(), rateLimited),
 		"a rate-limited token endpoint must still be retried")
 
+	timedOut := wrapTransientNetworkError(wrapAsTokenRequestError(&oauth2.RetrieveError{
+		ErrorCode: "invalid_request",
+		Response:  &http.Response{StatusCode: http.StatusRequestTimeout, Status: "408 Request Timeout"},
+	}))
+	require.Equal(t, codes.DeadlineExceeded, status.Code(timedOut))
+	require.True(t, newRetryer().ShouldWaitAndRetry(t.Context(), timedOut),
+		"a token endpoint timeout must still be retried")
+
 	rejected := wrapTransientNetworkError(wrapAsTokenRequestError(&oauth2.RetrieveError{
 		ErrorCode: "invalid_client",
 		Response:  &http.Response{StatusCode: http.StatusUnauthorized, Status: "401 Unauthorized"},

--- a/pkg/uhttp/errors_test.go
+++ b/pkg/uhttp/errors_test.go
@@ -19,6 +19,14 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/retry"
 )
 
+// wrapAsTokenRequestError mirrors the shape wrapTransientNetworkError
+// actually receives in production: oauth2.Transport's RoundTrip returns the
+// token-source error unwrapped, and http.Client.Do wraps it in *url.Error
+// before BaseHttpClient.Do ever sees it.
+func wrapAsTokenRequestError(retrieveErr *oauth2.RetrieveError) error {
+	return &url.Error{Op: "Post", URL: "https://example.com/oauth/token", Err: retrieveErr}
+}
+
 func TestWrapTransientNetworkError(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -175,19 +183,71 @@ func TestWrapTransientNetworkError(t *testing.T) {
 			wantMsg:  "http2 client connection lost",
 		},
 		{
-			name: "oauth2 token exchange rejected (401)",
-			err: &oauth2.RetrieveError{
-				Response: &http.Response{StatusCode: http.StatusUnauthorized, Status: "401 Unauthorized"},
-				Body:     []byte(`{"error":"invalid_client"}`),
-			},
+			// Production always delivers *oauth2.RetrieveError wrapped in
+			// *url.Error (http.Client.Do's own wrapping), so this — not a
+			// bare RetrieveError — is the shape the errors.As unwrap in
+			// wrapTransientNetworkError actually has to see through.
+			name: "oauth2 invalid_client (RFC 6749 error param, 401)",
+			err: wrapAsTokenRequestError(&oauth2.RetrieveError{
+				ErrorCode:        "invalid_client",
+				ErrorDescription: "client authentication failed",
+				Response:         &http.Response{StatusCode: http.StatusUnauthorized, Status: "401 Unauthorized"},
+			}),
 			wantCode: codes.Unauthenticated,
-			wantMsg:  "401 Unauthorized",
+			wantMsg:  "invalid_client: client authentication failed",
 		},
 		{
-			name: "oauth2 token exchange forbidden (403)",
-			err: &oauth2.RetrieveError{
+			// RFC 6749 §5.2 makes 400 the default status for invalid_client/
+			// invalid_grant (401 is only a MAY for invalid_client). Relying on
+			// GrpcCodeFromHTTPStatus(400) alone would produce InvalidArgument
+			// for exactly the credentials-rejected case this exists to catch;
+			// the "error" param must take priority over the HTTP status.
+			name: "oauth2 invalid_client on the RFC default status (400)",
+			err: wrapAsTokenRequestError(&oauth2.RetrieveError{
+				ErrorCode: "invalid_client",
+				Response:  &http.Response{StatusCode: http.StatusBadRequest, Status: "400 Bad Request"},
+			}),
+			wantCode: codes.Unauthenticated,
+			wantMsg:  "invalid_client",
+		},
+		{
+			// Some token endpoints report the RFC 6749 error param on a 2xx
+			// response. GrpcCodeFromHTTPStatus(200) would silently map this to
+			// Unknown with a misleading "200 OK" message if the error param
+			// weren't consulted first.
+			name: "oauth2 error param on a 200 response",
+			err: wrapAsTokenRequestError(&oauth2.RetrieveError{
+				ErrorCode: "invalid_client",
+				Response:  &http.Response{StatusCode: http.StatusOK, Status: "200 OK"},
+			}),
+			wantCode: codes.Unauthenticated,
+			wantMsg:  "invalid_client",
+		},
+		{
+			name: "oauth2 access_denied",
+			err: wrapAsTokenRequestError(&oauth2.RetrieveError{
+				ErrorCode: "access_denied",
+				Response:  &http.Response{StatusCode: http.StatusForbidden, Status: "403 Forbidden"},
+			}),
+			wantCode: codes.PermissionDenied,
+			wantMsg:  "access_denied",
+		},
+		{
+			name: "oauth2 invalid_grant maps to InvalidArgument, not an auth failure",
+			err: wrapAsTokenRequestError(&oauth2.RetrieveError{
+				ErrorCode: "invalid_grant",
+				Response:  &http.Response{StatusCode: http.StatusBadRequest, Status: "400 Bad Request"},
+			}),
+			wantCode: codes.InvalidArgument,
+			wantMsg:  "invalid_grant",
+		},
+		{
+			// No RFC 6749 error param at all (a non-compliant or proxy-mangled
+			// response) falls back to the plain HTTP status.
+			name: "oauth2 token request rejected with no error param (403)",
+			err: wrapAsTokenRequestError(&oauth2.RetrieveError{
 				Response: &http.Response{StatusCode: http.StatusForbidden, Status: "403 Forbidden"},
-			},
+			}),
 			wantCode: codes.PermissionDenied,
 			wantMsg:  "403 Forbidden",
 		},

--- a/pkg/uhttp/errors_test.go
+++ b/pkg/uhttp/errors_test.go
@@ -286,6 +286,28 @@ func TestWrapTransientNetworkError(t *testing.T) {
 			wantCode: codes.Unknown,
 			wantMsg:  "oauth2 token request failed",
 		},
+		{
+			name: "oauth2 transient status keeps the error_description, not just the status",
+			err: wrapAsTokenRequestError(&oauth2.RetrieveError{
+				ErrorCode:        "invalid_request",
+				ErrorDescription: "rate limit exceeded, retry after 3600 seconds",
+				Response:         &http.Response{StatusCode: http.StatusTooManyRequests, Status: "429 Too Many Requests"},
+			}),
+			wantCode: codes.Unavailable,
+			wantMsg:  "429 Too Many Requests: rate limit exceeded, retry after 3600 seconds",
+		},
+		{
+			// 501 is Unimplemented, not part of GrpcCodeFromHTTPStatus's
+			// Unavailable set, even though it's >= 500 — isTransientHTTPStatus
+			// must consult the mapping, not approximate it with a numeric range.
+			name: "oauth2 501 is not transient (Unimplemented, not Unavailable)",
+			err: wrapAsTokenRequestError(&oauth2.RetrieveError{
+				ErrorCode: "invalid_client",
+				Response:  &http.Response{StatusCode: http.StatusNotImplemented, Status: "501 Not Implemented"},
+			}),
+			wantCode: codes.Unauthenticated,
+			wantMsg:  "invalid_client",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/uhttp/errors_test.go
+++ b/pkg/uhttp/errors_test.go
@@ -269,6 +269,23 @@ func TestWrapTransientNetworkError(t *testing.T) {
 			wantCode: codes.InvalidArgument,
 			wantMsg:  "some_vendor_specific_error",
 		},
+		{
+			name: "oauth2 transient status wins over a recognized error param",
+			err: wrapAsTokenRequestError(&oauth2.RetrieveError{
+				ErrorCode: "invalid_request",
+				Response:  &http.Response{StatusCode: http.StatusTooManyRequests, Status: "429 Too Many Requests"},
+			}),
+			wantCode: codes.Unavailable,
+			wantMsg:  "429 Too Many Requests",
+		},
+		{
+			name: "oauth2 retrieve error with no error param and no response still maps, not falls through",
+			err: wrapAsTokenRequestError(&oauth2.RetrieveError{
+				ErrorCode: "",
+			}),
+			wantCode: codes.Unknown,
+			wantMsg:  "oauth2 token request failed",
+		},
 	}
 
 	for _, tt := range tests {
@@ -321,6 +338,31 @@ func TestWrapTransientNetworkError_NXDOMAINIsTerminal(t *testing.T) {
 	require.Equal(t, codes.Unavailable, status.Code(temporary))
 	require.True(t, newRetryer().ShouldWaitAndRetry(t.Context(), temporary),
 		"a temporary resolver failure must still be retried")
+}
+
+func TestWrapTransientNetworkError_OAuthTokenEndpointTransientIsRetried(t *testing.T) {
+	newRetryer := func() *retry.Retryer {
+		return retry.NewRetryer(t.Context(), retry.RetryConfig{
+			MaxAttempts:  3,
+			InitialDelay: time.Millisecond,
+			MaxDelay:     time.Millisecond,
+		})
+	}
+
+	rateLimited := wrapTransientNetworkError(wrapAsTokenRequestError(&oauth2.RetrieveError{
+		Response: &http.Response{StatusCode: http.StatusTooManyRequests, Status: "429 Too Many Requests"},
+	}))
+	require.Equal(t, codes.Unavailable, status.Code(rateLimited))
+	require.True(t, newRetryer().ShouldWaitAndRetry(t.Context(), rateLimited),
+		"a rate-limited token endpoint must still be retried")
+
+	rejected := wrapTransientNetworkError(wrapAsTokenRequestError(&oauth2.RetrieveError{
+		ErrorCode: "invalid_client",
+		Response:  &http.Response{StatusCode: http.StatusUnauthorized, Status: "401 Unauthorized"},
+	}))
+	require.Equal(t, codes.Unauthenticated, status.Code(rejected))
+	require.False(t, newRetryer().ShouldWaitAndRetry(t.Context(), rejected),
+		"rejected credentials must not be retried")
 }
 
 func TestWrapTransientNetworkError_LeavesNonTransientAlone(t *testing.T) {

--- a/pkg/uhttp/errors_test.go
+++ b/pkg/uhttp/errors_test.go
@@ -19,10 +19,8 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/retry"
 )
 
-// wrapAsTokenRequestError mirrors the shape wrapTransientNetworkError
-// actually receives in production: oauth2.Transport's RoundTrip returns the
-// token-source error unwrapped, and http.Client.Do wraps it in *url.Error
-// before BaseHttpClient.Do ever sees it.
+// wrapAsTokenRequestError mirrors the *url.Error wrapping http.Client.Do
+// actually produces in production, not a bare *oauth2.RetrieveError.
 func wrapAsTokenRequestError(retrieveErr *oauth2.RetrieveError) error {
 	return &url.Error{Op: "Post", URL: "https://example.com/oauth/token", Err: retrieveErr}
 }
@@ -183,10 +181,6 @@ func TestWrapTransientNetworkError(t *testing.T) {
 			wantMsg:  "http2 client connection lost",
 		},
 		{
-			// Production always delivers *oauth2.RetrieveError wrapped in
-			// *url.Error (http.Client.Do's own wrapping), so this — not a
-			// bare RetrieveError — is the shape the errors.As unwrap in
-			// wrapTransientNetworkError actually has to see through.
 			name: "oauth2 invalid_client (RFC 6749 error param, 401)",
 			err: wrapAsTokenRequestError(&oauth2.RetrieveError{
 				ErrorCode:        "invalid_client",
@@ -197,11 +191,6 @@ func TestWrapTransientNetworkError(t *testing.T) {
 			wantMsg:  "invalid_client: client authentication failed",
 		},
 		{
-			// RFC 6749 §5.2 makes 400 the default status for invalid_client/
-			// invalid_grant (401 is only a MAY for invalid_client). Relying on
-			// GrpcCodeFromHTTPStatus(400) alone would produce InvalidArgument
-			// for exactly the credentials-rejected case this exists to catch;
-			// the "error" param must take priority over the HTTP status.
 			name: "oauth2 invalid_client on the RFC default status (400)",
 			err: wrapAsTokenRequestError(&oauth2.RetrieveError{
 				ErrorCode: "invalid_client",
@@ -211,10 +200,6 @@ func TestWrapTransientNetworkError(t *testing.T) {
 			wantMsg:  "invalid_client",
 		},
 		{
-			// Some token endpoints report the RFC 6749 error param on a 2xx
-			// response. GrpcCodeFromHTTPStatus(200) would silently map this to
-			// Unknown with a misleading "200 OK" message if the error param
-			// weren't consulted first.
 			name: "oauth2 error param on a 200 response",
 			err: wrapAsTokenRequestError(&oauth2.RetrieveError{
 				ErrorCode: "invalid_client",
@@ -233,10 +218,6 @@ func TestWrapTransientNetworkError(t *testing.T) {
 			wantMsg:  "access_denied",
 		},
 		{
-			// RFC 6749 §5.2 names "resource owner credentials" (a wrong
-			// username/password under the password grant) as one of the
-			// things invalid_grant covers — a genuine credential failure,
-			// not a malformed request, so it belongs with invalid_client.
 			name: "oauth2 invalid_grant is a credential failure, not InvalidArgument",
 			err: wrapAsTokenRequestError(&oauth2.RetrieveError{
 				ErrorCode: "invalid_grant",
@@ -246,11 +227,6 @@ func TestWrapTransientNetworkError(t *testing.T) {
 			wantMsg:  "invalid_grant",
 		},
 		{
-			// RFC 6749 §5.2: "The authenticated client is not authorized to
-			// use this authorization grant type" — the identity was
-			// accepted, so PermissionDenied fits better than
-			// Unauthenticated (re-presenting a different secret can't fix a
-			// grant-type mismatch).
 			name: "oauth2 unauthorized_client is authenticated but not entitled",
 			err: wrapAsTokenRequestError(&oauth2.RetrieveError{
 				ErrorCode: "unauthorized_client",
@@ -269,8 +245,6 @@ func TestWrapTransientNetworkError(t *testing.T) {
 			wantMsg:  "invalid_scope",
 		},
 		{
-			// No RFC 6749 error param at all (a non-compliant or proxy-mangled
-			// response) falls back to the plain HTTP status.
 			name: "oauth2 token request rejected with no error param (403)",
 			err: wrapAsTokenRequestError(&oauth2.RetrieveError{
 				Response: &http.Response{StatusCode: http.StatusForbidden, Status: "403 Forbidden"},
@@ -279,12 +253,6 @@ func TestWrapTransientNetworkError(t *testing.T) {
 			wantMsg:  "403 Forbidden",
 		},
 		{
-			// A transient failure at the token endpoint (rate limited or the
-			// server having trouble) has no RFC 6749 error param to key off,
-			// so it falls back to the HTTP status like any other API
-			// response — including retry eligibility: this becomes
-			// Unavailable, which retry.Retryer.ShouldWaitAndRetry treats as
-			// retryable, same as a 503 on a normal API call.
 			name: "oauth2 token endpoint rate limited (429) falls back to status and is retryable",
 			err: wrapAsTokenRequestError(&oauth2.RetrieveError{
 				Response: &http.Response{StatusCode: http.StatusTooManyRequests, Status: "429 Too Many Requests"},
@@ -293,9 +261,6 @@ func TestWrapTransientNetworkError(t *testing.T) {
 			wantMsg:  "429 Too Many Requests",
 		},
 		{
-			// An error code the RFC doesn't define (a non-compliant server,
-			// or a future extension this package doesn't know about) also
-			// falls back to the HTTP status rather than being dropped.
 			name: "oauth2 unrecognized error param falls back to status code, keeps the error param in the message",
 			err: wrapAsTokenRequestError(&oauth2.RetrieveError{
 				ErrorCode: "some_vendor_specific_error",

--- a/pkg/uhttp/errors_test.go
+++ b/pkg/uhttp/errors_test.go
@@ -16,6 +16,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/retry"
 )
 
@@ -270,6 +271,14 @@ func TestWrapTransientNetworkError(t *testing.T) {
 			wantMsg:  "some_vendor_specific_error",
 		},
 		{
+			name: "oauth2 retrieve error with no error param and no response still maps, not falls through",
+			err: wrapAsTokenRequestError(&oauth2.RetrieveError{
+				ErrorCode: "",
+			}),
+			wantCode: codes.Unknown,
+			wantMsg:  "oauth2 token request failed",
+		},
+		{
 			name: "oauth2 transient status wins over a recognized error param",
 			err: wrapAsTokenRequestError(&oauth2.RetrieveError{
 				ErrorCode: "invalid_request",
@@ -277,14 +286,6 @@ func TestWrapTransientNetworkError(t *testing.T) {
 			}),
 			wantCode: codes.Unavailable,
 			wantMsg:  "429 Too Many Requests",
-		},
-		{
-			name: "oauth2 retrieve error with no error param and no response still maps, not falls through",
-			err: wrapAsTokenRequestError(&oauth2.RetrieveError{
-				ErrorCode: "",
-			}),
-			wantCode: codes.Unknown,
-			wantMsg:  "oauth2 token request failed",
 		},
 		{
 			name: "oauth2 transient status keeps the error_description, not just the status",
@@ -308,6 +309,19 @@ func TestWrapTransientNetworkError(t *testing.T) {
 			wantCode: codes.Unauthenticated,
 			wantMsg:  "invalid_client",
 		},
+		{
+			// 408 maps to DeadlineExceeded, which retry.Retryer also treats
+			// as retryable — isTransientHTTPStatus must catch this too, not
+			// just Unavailable, or the same status flips outcome depending
+			// on whether an error param happens to be present.
+			name: "oauth2 408 (DeadlineExceeded) is also transient",
+			err: wrapAsTokenRequestError(&oauth2.RetrieveError{
+				ErrorCode: "invalid_request",
+				Response:  &http.Response{StatusCode: http.StatusRequestTimeout, Status: "408 Request Timeout"},
+			}),
+			wantCode: codes.DeadlineExceeded,
+			wantMsg:  "408 Request Timeout",
+		},
 	}
 
 	for _, tt := range tests {
@@ -320,6 +334,38 @@ func TestWrapTransientNetworkError(t *testing.T) {
 			require.ErrorIs(t, got, tt.err)
 		})
 	}
+}
+
+func TestWrapTransientNetworkError_OAuthTransientAttachesRateLimitDetails(t *testing.T) {
+	header := http.Header{}
+	header.Set("Retry-After", "120")
+	got := wrapTransientNetworkError(wrapAsTokenRequestError(&oauth2.RetrieveError{
+		Response: &http.Response{StatusCode: http.StatusTooManyRequests, Status: "429 Too Many Requests", Header: header},
+	}))
+
+	st, ok := status.FromError(got)
+	require.True(t, ok)
+	require.Equal(t, codes.Unavailable, st.Code())
+
+	var found *v2.RateLimitDescription
+	for _, detail := range st.Details() {
+		if rl, ok := detail.(*v2.RateLimitDescription); ok {
+			found = rl
+		}
+	}
+	require.NotNil(t, found, "expected a RateLimitDescription detail from the Retry-After header")
+}
+
+func TestWrapTransientNetworkError_OAuthNilResponseDoesNotPanicOnFormat(t *testing.T) {
+	got := wrapTransientNetworkError(wrapAsTokenRequestError(&oauth2.RetrieveError{}))
+
+	require.NotPanics(t, func() {
+		_ = got.Error()
+	})
+	st, ok := status.FromError(got)
+	require.True(t, ok)
+	require.Equal(t, codes.Unknown, st.Code())
+	require.Contains(t, st.Message(), "oauth2 token request failed")
 }
 
 // NXDOMAIN is the one classification here that is deliberately terminal: a

--- a/pkg/uhttp/errors_test.go
+++ b/pkg/uhttp/errors_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/http"
 	"net/url"
 	"os"
 	"syscall"
@@ -11,6 +12,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -171,6 +173,23 @@ func TestWrapTransientNetworkError(t *testing.T) {
 			err:      fmt.Errorf(`Get "https://example.com": http2: client connection lost`),
 			wantCode: codes.Unavailable,
 			wantMsg:  "http2 client connection lost",
+		},
+		{
+			name: "oauth2 token exchange rejected (401)",
+			err: &oauth2.RetrieveError{
+				Response: &http.Response{StatusCode: http.StatusUnauthorized, Status: "401 Unauthorized"},
+				Body:     []byte(`{"error":"invalid_client"}`),
+			},
+			wantCode: codes.Unauthenticated,
+			wantMsg:  "401 Unauthorized",
+		},
+		{
+			name: "oauth2 token exchange forbidden (403)",
+			err: &oauth2.RetrieveError{
+				Response: &http.Response{StatusCode: http.StatusForbidden, Status: "403 Forbidden"},
+			},
+			wantCode: codes.PermissionDenied,
+			wantMsg:  "403 Forbidden",
 		},
 	}
 

--- a/pkg/uhttp/errors_test.go
+++ b/pkg/uhttp/errors_test.go
@@ -233,13 +233,40 @@ func TestWrapTransientNetworkError(t *testing.T) {
 			wantMsg:  "access_denied",
 		},
 		{
-			name: "oauth2 invalid_grant maps to InvalidArgument, not an auth failure",
+			// RFC 6749 §5.2 names "resource owner credentials" (a wrong
+			// username/password under the password grant) as one of the
+			// things invalid_grant covers — a genuine credential failure,
+			// not a malformed request, so it belongs with invalid_client.
+			name: "oauth2 invalid_grant is a credential failure, not InvalidArgument",
 			err: wrapAsTokenRequestError(&oauth2.RetrieveError{
 				ErrorCode: "invalid_grant",
 				Response:  &http.Response{StatusCode: http.StatusBadRequest, Status: "400 Bad Request"},
 			}),
-			wantCode: codes.InvalidArgument,
+			wantCode: codes.Unauthenticated,
 			wantMsg:  "invalid_grant",
+		},
+		{
+			// RFC 6749 §5.2: "The authenticated client is not authorized to
+			// use this authorization grant type" — the identity was
+			// accepted, so PermissionDenied fits better than
+			// Unauthenticated (re-presenting a different secret can't fix a
+			// grant-type mismatch).
+			name: "oauth2 unauthorized_client is authenticated but not entitled",
+			err: wrapAsTokenRequestError(&oauth2.RetrieveError{
+				ErrorCode: "unauthorized_client",
+				Response:  &http.Response{StatusCode: http.StatusBadRequest, Status: "400 Bad Request"},
+			}),
+			wantCode: codes.PermissionDenied,
+			wantMsg:  "unauthorized_client",
+		},
+		{
+			name: "oauth2 invalid_scope is a malformed request, not a credential failure",
+			err: wrapAsTokenRequestError(&oauth2.RetrieveError{
+				ErrorCode: "invalid_scope",
+				Response:  &http.Response{StatusCode: http.StatusBadRequest, Status: "400 Bad Request"},
+			}),
+			wantCode: codes.InvalidArgument,
+			wantMsg:  "invalid_scope",
 		},
 		{
 			// No RFC 6749 error param at all (a non-compliant or proxy-mangled
@@ -250,6 +277,32 @@ func TestWrapTransientNetworkError(t *testing.T) {
 			}),
 			wantCode: codes.PermissionDenied,
 			wantMsg:  "403 Forbidden",
+		},
+		{
+			// A transient failure at the token endpoint (rate limited or the
+			// server having trouble) has no RFC 6749 error param to key off,
+			// so it falls back to the HTTP status like any other API
+			// response — including retry eligibility: this becomes
+			// Unavailable, which retry.Retryer.ShouldWaitAndRetry treats as
+			// retryable, same as a 503 on a normal API call.
+			name: "oauth2 token endpoint rate limited (429) falls back to status and is retryable",
+			err: wrapAsTokenRequestError(&oauth2.RetrieveError{
+				Response: &http.Response{StatusCode: http.StatusTooManyRequests, Status: "429 Too Many Requests"},
+			}),
+			wantCode: codes.Unavailable,
+			wantMsg:  "429 Too Many Requests",
+		},
+		{
+			// An error code the RFC doesn't define (a non-compliant server,
+			// or a future extension this package doesn't know about) also
+			// falls back to the HTTP status rather than being dropped.
+			name: "oauth2 unrecognized error param falls back to status code, keeps the error param in the message",
+			err: wrapAsTokenRequestError(&oauth2.RetrieveError{
+				ErrorCode: "some_vendor_specific_error",
+				Response:  &http.Response{StatusCode: http.StatusBadRequest, Status: "400 Bad Request"},
+			}),
+			wantCode: codes.InvalidArgument,
+			wantMsg:  "some_vendor_specific_error",
 		},
 	}
 


### PR DESCRIPTION
## Summary
- A rejected OAuth2 client-credentials token exchange surfaces as `*oauth2.RetrieveError` wrapping the token endpoint's real HTTP response, but `wrapTransientNetworkError` had no case for it — the error fell through unclassified, so callers (including `exit.LogExit`) saw `codes.Unknown` instead of `Unauthenticated`/`PermissionDenied`.
- Adds a case to `wrapTransientNetworkError`, checked in this order once `errors.As` matches a `*oauth2.RetrieveError`:
  1. A transient HTTP status always wins, regardless of what error param the body also carries — "transient" means `GrpcCodeFromHTTPStatus(Response.StatusCode)` is `Unavailable` or `DeadlineExceeded` (the two codes `retry.Retryer.ShouldWaitAndRetry` treats as retryable), checked by consulting the mapping directly rather than approximating it with a numeric range (501 is `Unimplemented`, not part of this set, even though it's ≥ 500). The message keeps `Response.Status` (it explains the classification) and appends `ErrorDescription` when the server sent one, so an actionable detail like a rate-limit retry hint isn't dropped. Rate-limit detail from the response headers (`Retry-After`, etc.) is attached to the status the same way `WrapErrorsWithRateLimitInfo` does for a normal API response, so the retryer can compute rate-limit-aware backoff for a throttled token endpoint too.
  2. Otherwise, RFC 6749 §5.2's `error` parameter is consulted: `invalid_client`/`invalid_grant` → `Unauthenticated` (both name a rejected credential — the latter explicitly covers "resource owner credentials" under the password grant, not just an authorization code/refresh token); `unauthorized_client`/`access_denied` → `PermissionDenied` (`unauthorized_client` per RFC 6749 is "the **authenticated** client is not authorized to use this authorization grant type" — the identity was accepted, so this isn't an auth failure); `invalid_scope`/`invalid_request`/`unsupported_grant_type`/`unsupported_response_type` → `InvalidArgument` (malformed/disallowed request, not a rejected identity).
  3. Otherwise, falls back to `GrpcCodeFromHTTPStatus(Response.StatusCode)`, or `codes.Unknown` if there's no `Response` at all.
  The branch is total once `errors.As` matches — it always returns a wrapped error, so a `*oauth2.RetrieveError` is never run through the network-error checks below it (see "Nil-Response" below for why this is a code-quality choice, not a panic-safety one).
- Affects any connector using `clientcredentials.Config`-based auth through `BaseHttpClient`, whether hand-rolled (as `baton-kyriba` does) or via this package's own `OAuth2ClientCredentials` helper — verified both produce the same unmapped `codes.Unknown` today.

CE-1315

## Why the error param takes priority over the HTTP status (for non-transient statuses)
Two real-world shapes break a status-code-only mapping:
- Some token endpoints report the RFC 6749 `error` param on an HTTP **200** response. Mapping by status alone would map that to `codes.Unknown` with a misleading `"200 OK"` message.
- RFC 6749 §5.2 makes **400**, not 401, the default status for `invalid_client`/`invalid_grant` (401 is only a MAY for `invalid_client`). `GrpcCodeFromHTTPStatus(400)` returns `InvalidArgument`, which would misclassify exactly the credentials-rejected case this PR exists to fix.

## Why a transient status overrides the error param
A 429/5xx token-endpoint response has no RFC 6749 error param that reliably indicates a request-level rejection — some providers report throttling using an `error` value like `invalid_request` alongside a 429. Letting the error param win there would turn a transient failure into `InvalidArgument`, which isn't retried, discarding a request that would have succeeded on retry.

## Nil-Response
`*oauth2.RetrieveError.Response` is a plain nullable field; the vendored `x/oauth2` always populates it when it constructs a `RetrieveError` from a real HTTP round trip, but nothing in the type's contract guarantees that for every caller or future version. `RetrieveError.Error()` unconditionally dereferences `Response.Status` when `ErrorCode` is empty, which looks like a panic risk on a nil `Response` — an earlier revision of this PR made the branch total and stopped joining the raw error into the result specifically to avoid that. Verified (not assumed) that neither was actually necessary for safety: the panic only ever occurs while `RetrieveError.Error()` is being formatted via a `%s`/`%v` verb — which is exactly how `url.Error.Error()` invokes it internally (`fmt.Sprintf("%s %q: %s", ..., e.Err)`) — and Go's `fmt` package recovers a panicking `Error()`/`String()` method during its own formatting, substituting `%!s(PANIC=...)` instead of propagating. Confirmed this holds through `errors.Join` too (its `Error()` method calls each joined error's `Error()` directly, but that call is `url.Error.Error()`, which is itself `fmt.Sprintf`-based and therefore self-protecting). The branch stays total for cleaner control flow (an oauth2-specific error shouldn't be run through unrelated network-error heuristics), and the result still joins the raw `err` — a `TestWrapTransientNetworkError_OAuthNilResponseDoesNotPanicOnFormat` test pins the no-panic behavior directly rather than relying on this reasoning alone.

## Downstream behavior changes
- `pkg/sync/syncer.go`'s `IsSyncPreservable` (frozen per RFC 0009) treats `Unauthenticated` and `PermissionDenied` as preservable. A token-exchange failure that previously produced `codes.Unknown` had its sync artifact discarded; after this change it's preserved, matching how a `401`/`403` on a normal API call already behaves.
- A transient token-endpoint failure (429/5xx) now maps to `codes.Unavailable`. `retry.Retryer.ShouldWaitAndRetry` only retries `Unavailable`/`DeadlineExceeded`, and the syncer's retryer is configured with `MaxAttempts: 0` (`pkg/sync/parallel_syncer.go:151`, meaning unlimited attempts), so a persistently 5xx-ing token endpoint now retries with backoff instead of failing fast on an unclassified error.

Both look like the correct, intended consequence of the fix (matching how a normal API response already behaves) rather than regressions, but are called out here since they're real behavior changes for any runner relying on artifact retention or fail-fast behavior around token-endpoint failures.

## Verification
- Table-driven test cases in `TestWrapTransientNetworkError` covering: `invalid_client` on 401, `invalid_client` on the RFC-default 400, an `error` param on a 200 response, `access_denied`, `invalid_grant` (credential failure, not `InvalidArgument`), `unauthorized_client` (authenticated-but-not-entitled, `PermissionDenied`), `invalid_scope` (`InvalidArgument`), a status-only fallback with no error param (403), a 429 rate-limit falling back to `Unavailable`/retryable, an unrecognized vendor-specific error param falling back to the HTTP status while keeping the error param in the message, a `RetrieveError` with no error param and no `Response` still mapping cleanly instead of falling through, a transient status (429) overriding a recognized error param, a transient status keeping `ErrorDescription` alongside `Response.Status` in the message, 501 correctly excluded from the transient set (it's `Unimplemented`, not `Unavailable`), and 408 correctly included (it's `DeadlineExceeded`, also retryable). Each case wraps the `*oauth2.RetrieveError` in `*url.Error`, the shape `http.Client.Do` actually produces in production, so the `errors.As` unwrap this fix depends on is exercised against real-world shape rather than a bare struct.
- `TestWrapTransientNetworkError_OAuthTransientAttachesRateLimitDetails` asserts a `Retry-After` header on a 429 produces a `*v2.RateLimitDescription` detail on the returned status.
- `TestWrapTransientNetworkError_OAuthNilResponseDoesNotPanicOnFormat` asserts calling `.Error()` on the result of a nil-`Response`/empty-`ErrorCode` `RetrieveError` doesn't panic (see "Nil-Response" above).
- Two dedicated retry-liveness tests (`TestWrapTransientNetworkError_OAuthTokenEndpointTransientIsRetried`, mirroring the existing `TestWrapTransientNetworkError_NXDOMAINIsTerminal` pattern) assert against a real `retry.Retryer`, not just the grpc code: a rate-limited token endpoint is retried, rejected credentials are not.
- Full `pkg/uhttp` test suite passes.
- `golangci-lint run ./pkg/uhttp/... --new-from-rev=<base>` reports 0 issues on the diff.
- End-to-end against a real `baton-kyriba` binary (patched via a local `replace` directive), re-verified after each revision: bad credentials went from exit code `2` (`Unknown`) to `16` (`Unauthenticated`); valid credentials still completed a normal sync with exit `0`; a synthetic 400-status `invalid_client` response (matching a real-world provider's RFC-default behavior) also correctly mapped to `Unauthenticated` rather than `InvalidArgument`.

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/uhttp/...`
- [x] `golangci-lint run ./pkg/uhttp/...`
- [x] Verified against a downstream connector binary (`baton-kyriba`) via local module replace, including a 400-status `invalid_client` scenario

