### PR TITLE
perf(pebble): unlink spill chunks during merge, sort resources on import

### DIFF
--- a/cmd/baton/sanitize.go
+++ b/cmd/baton/sanitize.go
@@ -28,6 +28,7 @@ func sanitizeCmd() *cobra.Command {
 	cmd.Flags().String("secret-file", "", "Path to a per-c1z HMAC secret (>=32 random bytes). If unset, a fresh secret is generated and written next to --out.")
 	cmd.Flags().String("anchor", "", "RFC3339 timestamp the newest source timestamp lands on. Defaults to now.")
 	cmd.Flags().Bool("allow-unknown-annotations", false, "Pass annotations of unknown type through unchanged instead of dropping. Dangerous on real customer data.")
+	cmd.Flags().String("tmp-dir", "", "The temporary directory to use while sanitizing")
 
 	return cmd
 }
@@ -60,6 +61,10 @@ func runSanitize(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	outEngineRaw, err := cmd.Flags().GetString("out-engine")
+	if err != nil {
+		return err
+	}
+	tmpDir, err := cmd.Flags().GetString("tmp-dir")
 	if err != nil {
 		return err
 	}
@@ -103,7 +108,11 @@ func runSanitize(cmd *cobra.Command, args []string) error {
 			zap.String("path", c1zsanitize.SecretPath(secretFile, outPath)))
 	}
 
-	src, err := openReadOnlyC1ZStore(ctx, inPath)
+	var srcOpts []dotc1z.C1ZOption
+	if tmpDir != "" {
+		srcOpts = append(srcOpts, dotc1z.WithTmpDir(tmpDir))
+	}
+	src, err := openReadOnlyC1ZStore(ctx, inPath, srcOpts...)
 	if err != nil {
 		return fmt.Errorf("open source c1z: %w", err)
 	}
@@ -136,6 +145,9 @@ func runSanitize(cmd *cobra.Command, args []string) error {
 	// These pragmas are scoped to THIS writer instance; normal connector
 	// syncs open their own store and are unaffected.
 	dstOpts := []dotc1z.C1ZOption{dotc1z.WithEngine(dstEngine)}
+	if tmpDir != "" {
+		dstOpts = append(dstOpts, dotc1z.WithTmpDir(tmpDir))
+	}
 	if dstEngine == c1zstore.EngineSQLite {
 		dstOpts = append(dstOpts,
 			dotc1z.WithPragma("journal_mode", "OFF"),
@@ -165,6 +177,7 @@ func runSanitize(cmd *cobra.Command, args []string) error {
 		Secret:                  secret,
 		TimestampAnchor:         anchor,
 		AllowUnknownAnnotations: allowUnknown,
+		TmpDir:                  tmpDir,
 	}
 
 	log.Info("c1zsanitize: starting",

--- a/cmd/baton/store.go
+++ b/cmd/baton/store.go
@@ -10,8 +10,8 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
 )
 
-func openReadOnlyC1ZStore(ctx context.Context, path string) (c1zstore.Store, error) {
-	c1zStore, err := dotc1z.NewStore(ctx, path, dotc1z.WithReadOnly(true))
+func openReadOnlyC1ZStore(ctx context.Context, path string, extraOpts ...dotc1z.C1ZOption) (c1zstore.Store, error) {
+	c1zStore, err := dotc1z.NewStore(ctx, path, append([]dotc1z.C1ZOption{dotc1z.WithReadOnly(true)}, extraOpts...)...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/c1zsanitize/assets.go
+++ b/pkg/c1zsanitize/assets.go
@@ -97,12 +97,16 @@ func closeIfCloser(r io.Reader) error {
 	return nil
 }
 
+// copyAssets returns the number of assets written, which the pebble bulk
+// path stashes into the sync's stats sidecar (assets ride outside the bulk
+// import, so its ComputedStats cannot count them).
 func (s *sanitizer) copyAssets(
 	ctx context.Context,
 	src connectorstore.Reader,
 	dst connectorstore.Writer,
 	refs *assetRefSet,
-) error {
+) (int64, error) {
+	var written int64
 	ids := refs.drain()
 	for _, srcID := range ids {
 		req := v2.AssetServiceGetAssetRequest_builder{
@@ -119,12 +123,13 @@ func (s *sanitizer) copyAssets(
 			continue
 		}
 		if err := closeIfCloser(r); err != nil {
-			return fmt.Errorf("close source asset %s: %w", srcID, err)
+			return 0, fmt.Errorf("close source asset %s: %w", srcID, err)
 		}
 		dstID := s.id(srcID)
 		if err := dst.PutAsset(ctx, v2.AssetRef_builder{Id: dstID}.Build(), contentType, placeholderForContentType(contentType)); err != nil {
-			return fmt.Errorf("put dst asset %s: %w", dstID, err)
+			return 0, fmt.Errorf("put dst asset %s: %w", dstID, err)
 		}
+		written++
 	}
-	return nil
+	return written, nil
 }

--- a/pkg/c1zsanitize/bulk_sink.go
+++ b/pkg/c1zsanitize/bulk_sink.go
@@ -39,11 +39,6 @@ type bulkImportSink struct {
 	bi     *pebble.BulkSyncImport
 	shard  *pebble.BulkGrantShard
 	syncID string
-
-	// finished gates abort(): after a successful finish() there is nothing
-	// to tear down, while any earlier exit (including a failed Finish) must
-	// abort to discard staged spill files and the partial ingest.
-	finished bool
 }
 
 // startBulkImportSink opens a bulk import on the destination's current
@@ -84,20 +79,14 @@ func (s *bulkImportSink) PutGrants(ctx context.Context, grants ...*v2.Grant) err
 // writer path (PutAsset, EndSync) may be used again.
 func (s *bulkImportSink) finish(ctx context.Context) error {
 	s.shard.Close()
-	if err := s.bi.Finish(ctx); err != nil {
-		return err
-	}
-	s.finished = true
-	return nil
+	return s.bi.Finish(ctx)
 }
 
-// abort discards the import unless finish succeeded. Deferred by
-// sanitizeSync so any error exit between start and finish tears down
-// staged spill files and the partial ingest.
+// abort discards a still-open import's staged spill files. Deferred by
+// sanitizeSync to cover error exits before finish is reached; once Finish
+// has run — success or failure — it has marked the import done and torn
+// down its own staging, and Abort is a no-op.
 func (s *bulkImportSink) abort() {
-	if s.finished {
-		return
-	}
 	s.bi.Abort()
 }
 

--- a/pkg/c1zsanitize/bulk_sink.go
+++ b/pkg/c1zsanitize/bulk_sink.go
@@ -1,0 +1,112 @@
+package c1zsanitize
+
+import (
+	"context"
+	"fmt"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble"
+)
+
+// recordSink is where sanitizeSync's copy loops write the four record
+// families. It is exactly the method subset of connectorstore.Writer those
+// loops use, so a sqlite destination satisfies it as-is (upserting Put*
+// path); a pebble destination substitutes bulkImportSink so the same
+// transform loops feed the engine's bulk-import fast path instead.
+type recordSink interface {
+	PutResourceTypes(ctx context.Context, resourceTypes ...*v2.ResourceType) error
+	PutResources(ctx context.Context, resources ...*v2.Resource) error
+	PutEntitlements(ctx context.Context, entitlements ...*v2.Entitlement) error
+	PutGrants(ctx context.Context, grants ...*v2.Grant) error
+}
+
+// bulkImportSink adapts a pebble BulkSyncImport to recordSink. The bulk
+// contract (fresh sync, nothing else writes until Finish) holds on the
+// sanitize path by construction: StartNewSync marked the destination sync
+// fresh, resumable+pebble is rejected up front so every checkpoint call is
+// a no-op, and assets are copied only after finish() has ingested.
+//
+// Semantics vs. the Put* path: Put* upserts, the bulk path does not. A
+// source sync carrying two records with the same sanitized external id now
+// fails the import (resource types/resources/entitlements) or folds with a
+// warning (grants) instead of silently last-write-wins. A valid c1z has
+// unique external ids per sync, so this only surfaces on corrupt input.
+//
+// Grants flow through a single shard: the sanitizer's grant loop is
+// sequential, so shard fan-out would add nothing.
+type bulkImportSink struct {
+	eng    *pebble.Engine
+	bi     *pebble.BulkSyncImport
+	shard  *pebble.BulkGrantShard
+	syncID string
+
+	// finished gates abort(): after a successful finish() there is nothing
+	// to tear down, while any earlier exit (including a failed Finish) must
+	// abort to discard staged spill files and the partial ingest.
+	finished bool
+}
+
+// startBulkImportSink opens a bulk import on the destination's current
+// fresh sync. tmpDir stages spill files ("" = system temp dir).
+func startBulkImportSink(ctx context.Context, eng *pebble.Engine, syncID string, tmpDir string) (*bulkImportSink, error) {
+	bi, err := eng.StartBulkSyncImport(ctx, syncID, tmpDir)
+	if err != nil {
+		return nil, fmt.Errorf("start bulk import: %w", err)
+	}
+	shard, err := bi.NewGrantShard()
+	if err != nil {
+		bi.Abort()
+		return nil, fmt.Errorf("open grant shard: %w", err)
+	}
+	return &bulkImportSink{eng: eng, bi: bi, shard: shard, syncID: syncID}, nil
+}
+
+func (s *bulkImportSink) PutResourceTypes(ctx context.Context, resourceTypes ...*v2.ResourceType) error {
+	// copyResourceTypes writes the full set once, sorted by output id,
+	// which is the sorted-by-external-id arrival AddResourceTypes requires.
+	return s.bi.AddResourceTypes(ctx, resourceTypes...)
+}
+
+func (s *bulkImportSink) PutResources(ctx context.Context, resources ...*v2.Resource) error {
+	return s.bi.AddResources(ctx, resources...)
+}
+
+func (s *bulkImportSink) PutEntitlements(ctx context.Context, entitlements ...*v2.Entitlement) error {
+	return s.bi.AddEntitlements(ctx, entitlements...)
+}
+
+func (s *bulkImportSink) PutGrants(ctx context.Context, grants ...*v2.Grant) error {
+	return s.shard.AddGrants(ctx, grants...)
+}
+
+// finish seals the grant shard and ingests the import. After it returns
+// nil the destination sync holds every record the sink received and the
+// writer path (PutAsset, EndSync) may be used again.
+func (s *bulkImportSink) finish(ctx context.Context) error {
+	s.shard.Close()
+	if err := s.bi.Finish(ctx); err != nil {
+		return err
+	}
+	s.finished = true
+	return nil
+}
+
+// abort discards the import unless finish succeeded. Deferred by
+// sanitizeSync so any error exit between start and finish tears down
+// staged spill files and the partial ingest.
+func (s *bulkImportSink) abort() {
+	if s.finished {
+		return
+	}
+	s.bi.Abort()
+}
+
+// stashStats hands the import's record counts (plus the asset count, which
+// rides outside the import) to the engine as the sync's stats sidecar, so
+// EndSync persists stats directly instead of re-scanning the freshly
+// ingested keyspaces.
+func (s *bulkImportSink) stashStats(assetCount int64) {
+	rec := s.bi.ComputedStats()
+	rec.SetAssets(assetCount)
+	s.eng.StashComputedSyncStats(s.syncID, rec)
+}

--- a/pkg/c1zsanitize/bulk_sink.go
+++ b/pkg/c1zsanitize/bulk_sink.go
@@ -42,9 +42,10 @@ type bulkImportSink struct {
 }
 
 // startBulkImportSink opens a bulk import on the destination's current
-// fresh sync. tmpDir stages spill files ("" = system temp dir).
+// fresh sync. tmpDir stages spill files ("" = system temp dir). The
+// import is sized for the single grant shard this sink opens.
 func startBulkImportSink(ctx context.Context, eng *pebble.Engine, syncID string, tmpDir string) (*bulkImportSink, error) {
-	bi, err := eng.StartBulkSyncImport(ctx, syncID, tmpDir)
+	bi, err := eng.StartBulkSyncImport(ctx, syncID, tmpDir, 1)
 	if err != nil {
 		return nil, fmt.Errorf("start bulk import: %w", err)
 	}

--- a/pkg/c1zsanitize/bulk_sink.go
+++ b/pkg/c1zsanitize/bulk_sink.go
@@ -26,11 +26,18 @@ type recordSink interface {
 // fresh, resumable+pebble is rejected up front so every checkpoint call is
 // a no-op, and assets are copied only after finish() has ingested.
 //
-// Semantics vs. the Put* path: Put* upserts, the bulk path does not. A
-// source sync carrying two records with the same sanitized external id now
-// fails the import (resource types/resources/entitlements) or folds with a
-// warning (grants) instead of silently last-write-wins. A valid c1z has
-// unique external ids per sync, so this only surfaces on corrupt input.
+// Semantics vs. the Put* path: Put* upserts, the bulk path does not. For
+// resource types, resources, and entitlements a source sync carrying two
+// records with the same sanitized external id now fails the import
+// instead of silently last-write-wins; a valid c1z has unique external ids
+// per sync, so that only surfaces on corrupt input. Grants are keyed by
+// structural identity (entitlement + principal refs), which SQLite's
+// UNIQUE(external_id, sync_id) does not cover, so a legacy source can
+// legitimately hold two grants with distinct external ids and identical
+// refs. Those now fold at Finish with a warning — keeping the
+// earliest-discovered external id and OR-ing needs_expansion — where
+// PutGrants on pebble kept whichever arrived last. Same row count, but the
+// surviving transformed grant id can differ from the previous path's.
 //
 // Grants flow through a single shard: the sanitizer's grant loop is
 // sequential, so shard fan-out would add nothing.

--- a/pkg/c1zsanitize/expansion_parity_test.go
+++ b/pkg/c1zsanitize/expansion_parity_test.go
@@ -279,18 +279,24 @@ func fullRecordSets(t *testing.T, ctx context.Context, store c1zstore.Store) ful
 		ress: map[string]*v2.Resource{},
 		ents: map[string]*v2.Entitlement{},
 	}
+	// Single-page reads: if a fixture ever outgrows the page, both arms
+	// would truncate identically and the oracle would silently narrow, so
+	// fail loudly instead of paginating.
 	rts, err := store.ListResourceTypes(ctx, v2.ResourceTypesServiceListResourceTypesRequest_builder{PageSize: 1000}.Build())
 	require.NoError(t, err)
+	require.Empty(t, rts.GetNextPageToken(), "resource-type fixture outgrew one page; oracle would silently truncate")
 	for _, rt := range rts.GetList() {
 		fr.rts[rt.GetId()] = rt
 	}
 	ress, err := store.ListResources(ctx, v2.ResourcesServiceListResourcesRequest_builder{PageSize: 1000}.Build())
 	require.NoError(t, err)
+	require.Empty(t, ress.GetNextPageToken(), "resource fixture outgrew one page; oracle would silently truncate")
 	for _, r := range ress.GetList() {
 		fr.ress[r.GetId().GetResourceType()+"/"+r.GetId().GetResource()] = r
 	}
 	ents, err := store.ListEntitlements(ctx, v2.EntitlementsServiceListEntitlementsRequest_builder{PageSize: 1000}.Build())
 	require.NoError(t, err)
+	require.Empty(t, ents.GetNextPageToken(), "entitlement fixture outgrew one page; oracle would silently truncate")
 	for _, e := range ents.GetList() {
 		fr.ents[e.GetId()] = normalizeEntitlementForParity(e)
 	}

--- a/pkg/c1zsanitize/expansion_parity_test.go
+++ b/pkg/c1zsanitize/expansion_parity_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/prototext"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
@@ -258,6 +260,89 @@ func entitlementCount(t *testing.T, ctx context.Context, store c1zstore.Store) i
 	return len(resp.GetList())
 }
 
+// fullRecords holds every resource-type, resource, and entitlement record
+// keyed by transformed id. These three families now ride different write
+// paths per destination engine (upserting Put* on sqlite, the non-upserting
+// bulk import on pebble), so the parity oracle pins full record identity —
+// not just cardinality and graph shape — to catch a row one path drops,
+// folds, or mangles field-by-field.
+type fullRecords struct {
+	rts  map[string]*v2.ResourceType
+	ress map[string]*v2.Resource
+	ents map[string]*v2.Entitlement
+}
+
+func fullRecordSets(t *testing.T, ctx context.Context, store c1zstore.Store) fullRecords {
+	t.Helper()
+	fr := fullRecords{
+		rts:  map[string]*v2.ResourceType{},
+		ress: map[string]*v2.Resource{},
+		ents: map[string]*v2.Entitlement{},
+	}
+	rts, err := store.ListResourceTypes(ctx, v2.ResourceTypesServiceListResourceTypesRequest_builder{PageSize: 1000}.Build())
+	require.NoError(t, err)
+	for _, rt := range rts.GetList() {
+		fr.rts[rt.GetId()] = rt
+	}
+	ress, err := store.ListResources(ctx, v2.ResourcesServiceListResourcesRequest_builder{PageSize: 1000}.Build())
+	require.NoError(t, err)
+	for _, r := range ress.GetList() {
+		fr.ress[r.GetId().GetResourceType()+"/"+r.GetId().GetResource()] = r
+	}
+	ents, err := store.ListEntitlements(ctx, v2.EntitlementsServiceListEntitlementsRequest_builder{PageSize: 1000}.Build())
+	require.NoError(t, err)
+	for _, e := range ents.GetList() {
+		fr.ents[e.GetId()] = normalizeEntitlementForParity(e)
+	}
+	return fr
+}
+
+// normalizeEntitlementForParity slims the two fields pebble's v3 schema
+// stores as identity-only refs: the embedded resource and the grantable_to
+// types are "hydrated as a stub (identity only)" on read (V3EntitlementToV2),
+// while sqlite returns the writer's full embedded copies. Both are derived
+// data — the resource's and resource types' own records are compared in full
+// separately — so slimming them costs no coverage.
+func normalizeEntitlementForParity(e *v2.Entitlement) *v2.Entitlement {
+	out, ok := proto.Clone(e).(*v2.Entitlement)
+	if !ok {
+		panic("clone changed type")
+	}
+	if r := out.GetResource(); r != nil {
+		out.SetResource(v2.Resource_builder{Id: r.GetId()}.Build())
+	}
+	if gs := out.GetGrantableTo(); len(gs) > 0 {
+		slim := make([]*v2.ResourceType, 0, len(gs))
+		for _, rt := range gs {
+			slim = append(slim, v2.ResourceType_builder{Id: rt.GetId()}.Build())
+		}
+		out.SetGrantableTo(slim)
+	}
+	return out
+}
+
+// requireRecordSetEqual asserts got holds exactly want's keys and that each
+// record is proto-equal, printing the diverging pair on failure.
+func requireRecordSetEqual[P proto.Message](t *testing.T, want, got map[string]P, arm, family string) {
+	t.Helper()
+	wantKeys := sortedKeys(want)
+	require.Equalf(t, wantKeys, sortedKeys(got), "%s %s id set", arm, family)
+	for _, id := range wantKeys {
+		require.Truef(t, proto.Equal(want[id], got[id]),
+			"%s %s %q diverged\nbase: %s\narm:  %s",
+			arm, family, id, prototext.Format(want[id]), prototext.Format(got[id]))
+	}
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
 // resourceParentChains maps each resource id to its parent resource id.
 func resourceParentChains(t *testing.T, ctx context.Context, store c1zstore.Store) map[string]string {
 	t.Helper()
@@ -388,6 +473,7 @@ func TestSanitizeCrossEnginePebbleParity(t *testing.T) {
 		parents, entOwn, refs                   map[string]string
 		sources                                 map[string][]string
 		blobs                                   map[string]expandBlob
+		records                                 fullRecords
 		assetCT                                 string
 		assetBytes                              []byte
 	}
@@ -405,6 +491,7 @@ func TestSanitizeCrossEnginePebbleParity(t *testing.T) {
 			refs:       grantRefs(t, ctx, ro),
 			sources:    grantSourcesCanonical(t, ctx, ro),
 			blobs:      pendingExpansionBlobs(t, ctx, ro),
+			records:    fullRecordSets(t, ctx, ro),
 			assetCT:    ct,
 			assetBytes: ab,
 		}
@@ -429,6 +516,9 @@ func TestSanitizeCrossEnginePebbleParity(t *testing.T) {
 		require.Equalf(t, base.refs, snaps[i].refs, "%s grant entitlement/principal refs", arms[i].name)
 		require.Equalf(t, base.sources, snaps[i].sources, "%s expansion-source edges", arms[i].name)
 		require.Equalf(t, base.blobs, snaps[i].blobs, "%s GrantExpandable blobs + needs_expansion enumeration", arms[i].name)
+		requireRecordSetEqual(t, base.records.rts, snaps[i].records.rts, arms[i].name, "resource type")
+		requireRecordSetEqual(t, base.records.ress, snaps[i].records.ress, arms[i].name, "resource")
+		requireRecordSetEqual(t, base.records.ents, snaps[i].records.ents, arms[i].name, "entitlement")
 	}
 
 	// (3) needs_expansion membership: the multi-expand and divergence-trigger

--- a/pkg/c1zsanitize/expansion_parity_test.go
+++ b/pkg/c1zsanitize/expansion_parity_test.go
@@ -1,6 +1,7 @@
 package c1zsanitize
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"path/filepath"
@@ -260,24 +261,30 @@ func entitlementCount(t *testing.T, ctx context.Context, store c1zstore.Store) i
 	return len(resp.GetList())
 }
 
-// fullRecords holds every resource-type, resource, and entitlement record
-// keyed by transformed id. These three families now ride different write
-// paths per destination engine (upserting Put* on sqlite, the non-upserting
-// bulk import on pebble), so the parity oracle pins full record identity —
-// not just cardinality and graph shape — to catch a row one path drops,
-// folds, or mangles field-by-field.
+// fullRecords holds every resource-type, resource, entitlement, and grant
+// record keyed by transformed id (grants by parityGrantRef, their identity
+// on both engines). These families now ride different write paths per
+// destination engine (upserting Put* on sqlite, the non-upserting bulk
+// import on pebble), so the parity oracle pins full record identity — not
+// just cardinality and graph shape — to catch a row one path drops, folds,
+// or mangles field-by-field. For grants this is the only oracle that sees
+// the grant's own transformed external id and its non-expansion
+// annotations; grantRefs/grantSourcesCanonical/pendingExpansionBlobs all
+// key by ref and never look at them.
 type fullRecords struct {
-	rts  map[string]*v2.ResourceType
-	ress map[string]*v2.Resource
-	ents map[string]*v2.Entitlement
+	rts    map[string]*v2.ResourceType
+	ress   map[string]*v2.Resource
+	ents   map[string]*v2.Entitlement
+	grants map[string]*v2.Grant
 }
 
 func fullRecordSets(t *testing.T, ctx context.Context, store c1zstore.Store) fullRecords {
 	t.Helper()
 	fr := fullRecords{
-		rts:  map[string]*v2.ResourceType{},
-		ress: map[string]*v2.Resource{},
-		ents: map[string]*v2.Entitlement{},
+		rts:    map[string]*v2.ResourceType{},
+		ress:   map[string]*v2.Resource{},
+		ents:   map[string]*v2.Entitlement{},
+		grants: map[string]*v2.Grant{},
 	}
 	// Single-page reads: if a fixture ever outgrows the page, both arms
 	// would truncate identically and the oracle would silently narrow, so
@@ -300,7 +307,57 @@ func fullRecordSets(t *testing.T, ctx context.Context, store c1zstore.Store) ful
 	for _, e := range ents.GetList() {
 		fr.ents[e.GetId()] = normalizeEntitlementForParity(e)
 	}
+	grs, err := store.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{PageSize: 1000}.Build())
+	require.NoError(t, err)
+	require.Empty(t, grs.GetNextPageToken(), "grant fixture outgrew one page; oracle would silently truncate")
+	for _, g := range grs.GetList() {
+		ref := parityGrantRef(g)
+		_, dup := fr.grants[ref]
+		require.Falsef(t, dup, "grant ref %q listed twice; the oracle would silently keep one", ref)
+		fr.grants[ref] = normalizeGrantForParity(g)
+	}
 	return fr
+}
+
+// normalizeGrantForParity slims the embedded entitlement and principal to
+// the identity-only stubs pebble's V3GrantToV2 hydrates (entitlement id +
+// owning resource id; principal id + parent id), drops the GrantExpandable
+// annotation, and sorts the remaining annotations by (type_url, value).
+// GrantExpandable is dropped because the engines disagree on plain
+// ListGrants independently of the sanitizer: both store it in a side
+// column, but only pebble re-attaches it on read (sqlite exposes it via
+// ListWithAnnotationsPage). Its content is compared separately through
+// pendingExpansionBlobs. The grant's own id, sources, and every other
+// annotation payload are kept verbatim.
+func normalizeGrantForParity(g *v2.Grant) *v2.Grant {
+	out, ok := proto.Clone(g).(*v2.Grant)
+	if !ok {
+		panic("clone changed type")
+	}
+	if e := out.GetEntitlement(); e != nil {
+		out.SetEntitlement(v2.Entitlement_builder{
+			Id:       e.GetId(),
+			Resource: v2.Resource_builder{Id: e.GetResource().GetId()}.Build(),
+		}.Build())
+	}
+	if p := out.GetPrincipal(); p != nil {
+		out.SetPrincipal(v2.Resource_builder{Id: p.GetId(), ParentResourceId: p.GetParentResourceId()}.Build())
+	}
+	expandableURL := "type.googleapis.com/" + string((&v2.GrantExpandable{}).ProtoReflect().Descriptor().FullName())
+	anns := make([]*anypb.Any, 0, len(out.GetAnnotations()))
+	for _, a := range out.GetAnnotations() {
+		if a.GetTypeUrl() != expandableURL {
+			anns = append(anns, a)
+		}
+	}
+	sort.Slice(anns, func(i, j int) bool {
+		if anns[i].GetTypeUrl() != anns[j].GetTypeUrl() {
+			return anns[i].GetTypeUrl() < anns[j].GetTypeUrl()
+		}
+		return bytes.Compare(anns[i].GetValue(), anns[j].GetValue()) < 0
+	})
+	out.SetAnnotations(anns)
+	return out
 }
 
 // normalizeEntitlementForParity slims the two fields pebble's v3 schema
@@ -525,6 +582,7 @@ func TestSanitizeCrossEnginePebbleParity(t *testing.T) {
 		requireRecordSetEqual(t, base.records.rts, snaps[i].records.rts, arms[i].name, "resource type")
 		requireRecordSetEqual(t, base.records.ress, snaps[i].records.ress, arms[i].name, "resource")
 		requireRecordSetEqual(t, base.records.ents, snaps[i].records.ents, arms[i].name, "entitlement")
+		requireRecordSetEqual(t, base.records.grants, snaps[i].records.grants, arms[i].name, "grant")
 	}
 
 	// (3) needs_expansion membership: the multi-expand and divergence-trigger

--- a/pkg/c1zsanitize/sanitize.go
+++ b/pkg/c1zsanitize/sanitize.go
@@ -12,6 +12,8 @@
 // Sanitize is engine-agnostic: it reads and writes through
 // connectorstore.Reader / Writer, so a source or destination may be
 // either the v1/v2 sqlite-zstd engine or the v3 Pebble engine. A
+// Pebble destination's record writes are routed through the engine's
+// bulk-import fast path instead of Put upserts (see recordSink). A
 // Pebble c1z holds exactly one sync by contract, so a multi-sync
 // source cannot be sanitized into a Pebble destination; that
 // combination is rejected up front (see Sanitize).
@@ -37,6 +39,7 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble"
 )
 
 // syncRunMetadataReader is the optional source capability for reading
@@ -110,6 +113,12 @@ type Options struct {
 	// The rejection is an explicit destination-engine check, so it holds even
 	// though pebble implements ListSyncRuns.
 	Resumable bool
+
+	// TmpDir stages the bulk import's spill files when the destination is
+	// a pebble store ("" = system temp dir). Peak staging usage is on the
+	// order of the destination's record data, so point it at a volume
+	// sized for the output when the system temp dir is small.
+	TmpDir string
 }
 
 // Sanitize copies records from src to dst, transforming identifiers,
@@ -174,6 +183,7 @@ func Sanitize(ctx context.Context, src connectorstore.Reader, dst connectorstore
 		anchor:                 anchor,
 		anchorExplicit:         anchorExplicit,
 		tMax:                   tMax,
+		tmpDir:                 opts.TmpDir,
 	}
 	s.fingerprint = s.checkpointFingerprint()
 
@@ -274,6 +284,14 @@ type sanitizer struct {
 	anchor         time.Time
 	anchorExplicit bool
 	tMax           time.Time
+
+	// sink receives the four record families for the sync currently being
+	// copied. sanitizeSync points it at dst (upserting Put* path) or, for a
+	// pebble destination, at a bulkImportSink over the engine's bulk-import
+	// fast path. Per-sync, not per-run: each destination sync gets its own
+	// import session. tmpDir stages that import's spill files.
+	sink   recordSink
+	tmpDir string
 }
 
 // Checkpoint phases recorded in a destination sync's token. The value names
@@ -580,6 +598,26 @@ func (s *sanitizer) sanitizeSync(ctx context.Context, src connectorstore.Reader,
 	}
 	s.syncIDMap[srcSyncID] = dstSyncID
 
+	// Pick the write path for this sync's records. A pebble destination
+	// routes the four record families through the engine's bulk import
+	// (sorted SST construction + ingest) instead of per-batch Put upserts.
+	// The bulk contract — fresh sync, nothing else writes until Finish —
+	// holds here by construction: StartNewSync above marked the sync fresh
+	// (the resume branch never runs for pebble, since resumable+pebble is
+	// rejected in Sanitize, which also makes every checkpoint call below a
+	// no-op), and assets are copied only after the import is finished.
+	s.sink = dst
+	var bulk *bulkImportSink
+	if eng, ok := pebble.AsEngine(dst); ok {
+		b, err := startBulkImportSink(ctx, eng, dstSyncID, s.tmpDir)
+		if err != nil {
+			return fmt.Errorf("bulk import: %w", err)
+		}
+		bulk = b
+		s.sink = b
+		defer bulk.abort()
+	}
+
 	assetRefs := newAssetRefSet()
 
 	// Per-sync memo cache for the embedded Entitlement/Principal transforms
@@ -591,7 +629,7 @@ func (s *sanitizer) sanitizeSync(ctx context.Context, src connectorstore.Reader,
 	// (which the id transform consults), so it must be rebuilt even when its
 	// rows were already written in a prior run. PutResourceTypes upserts, so the
 	// re-write is idempotent.
-	if err := s.copyResourceTypes(ctx, src, dst, srcSyncID, assetRefs); err != nil {
+	if err := s.copyResourceTypes(ctx, src, srcSyncID, assetRefs); err != nil {
 		return err
 	}
 
@@ -603,7 +641,7 @@ func (s *sanitizer) sanitizeSync(ctx context.Context, src connectorstore.Reader,
 	// re-writing rows that are already durable in the destination. This mirrors
 	// copyResourceTypes, which always runs to rebuild knownResourceTypes.
 	writeResources := phaseAtOrBefore(startPhase, phaseResources)
-	if err := s.copyResources(ctx, src, dst, srcSyncID, assetRefs, writeResources); err != nil {
+	if err := s.copyResources(ctx, src, srcSyncID, assetRefs, writeResources); err != nil {
 		return err
 	}
 	if writeResources {
@@ -613,7 +651,7 @@ func (s *sanitizer) sanitizeSync(ctx context.Context, src connectorstore.Reader,
 	}
 
 	writeEntitlements := phaseAtOrBefore(startPhase, phaseEntitlements)
-	if err := s.copyEntitlements(ctx, src, dst, srcSyncID, assetRefs, writeEntitlements); err != nil {
+	if err := s.copyEntitlements(ctx, src, srcSyncID, assetRefs, writeEntitlements); err != nil {
 		return err
 	}
 	if writeEntitlements {
@@ -632,8 +670,25 @@ func (s *sanitizer) sanitizeSync(ctx context.Context, src connectorstore.Reader,
 		}
 	}
 
-	if err := s.copyAssets(ctx, src, dst, assetRefs); err != nil {
+	// All four record families are in. Seal the bulk import before assets:
+	// PutAsset writes through the writer, which the bulk contract forbids
+	// until Finish has ingested.
+	if bulk != nil {
+		if err := bulk.finish(ctx); err != nil {
+			return fmt.Errorf("bulk import finish: %w", err)
+		}
+	}
+
+	assetCount, err := s.copyAssets(ctx, src, dst, assetRefs)
+	if err != nil {
 		return err
+	}
+
+	// The import counted every record it wrote; stash that (plus the asset
+	// count, which rode outside the import) so EndSync persists the stats
+	// sidecar directly instead of re-scanning the ingested keyspaces.
+	if bulk != nil {
+		bulk.stashStats(assetCount)
 	}
 
 	if err := dst.EndSync(ctx); err != nil {

--- a/pkg/c1zsanitize/sanitize.go
+++ b/pkg/c1zsanitize/sanitize.go
@@ -115,9 +115,10 @@ type Options struct {
 	Resumable bool
 
 	// TmpDir stages the bulk import's spill files when the destination is
-	// a pebble store ("" = system temp dir). Peak staging usage is on the
-	// order of the destination's record data, so point it at a volume
-	// sized for the output when the system temp dir is small.
+	// a pebble store ("" = system temp dir). Peak staging usage is ~2x the
+	// destination's record data — at the merge tail the sorted runs and
+	// the SSTs built from them coexist — so point it at a volume sized
+	// accordingly when the system temp dir is small.
 	TmpDir string
 }
 

--- a/pkg/c1zsanitize/sanitize_pebble_test.go
+++ b/pkg/c1zsanitize/sanitize_pebble_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/connectorstore"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble"
 	sdksync "github.com/conductorone/baton-sdk/pkg/sync"
 	"github.com/conductorone/baton-sdk/pkg/sync/expand"
 )
@@ -74,6 +75,20 @@ func TestSanitizePebbleEndToEnd(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, dstRuns, 1)
 	require.True(t, dstRuns[0].SupportsDiff, "supports_diff marker must carry to the pebble output")
+
+	// Stats sidecar matches the listed cardinalities. The bulk-import path
+	// stashes its own computed counts (plus the asset count, which rides
+	// outside the import) instead of letting EndSync re-scan the keyspaces;
+	// a wrong stash would persist silently, so pin every family here.
+	eng, ok := pebble.AsEngine(ro)
+	require.True(t, ok, "pebble output must expose its engine")
+	stats, err := eng.Stats(ctx, connectorstore.SyncTypeAny, dstRuns[0].ID)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), stats["resource_types"])
+	require.Equal(t, int64(6), stats["resources"])
+	require.Equal(t, int64(2), stats["entitlements"])
+	require.Equal(t, int64(5), stats["grants"])
+	require.Equal(t, int64(1), stats["assets"], "asset count is stashed explicitly by the sanitizer, not counted by the import")
 }
 
 func TestSanitizeDropsEntitlementGraphSidecar(t *testing.T) {

--- a/pkg/c1zsanitize/transform.go
+++ b/pkg/c1zsanitize/transform.go
@@ -118,7 +118,6 @@ func (s *sanitizer) isKnownResourceType(token string) bool {
 func (s *sanitizer) copyResourceTypes(
 	ctx context.Context,
 	src connectorstore.Reader,
-	dst connectorstore.Writer,
 	srcSyncID string,
 	refs *assetRefSet,
 ) error {
@@ -162,11 +161,13 @@ func (s *sanitizer) copyResourceTypes(
 	out := make([]*v2.ResourceType, len(rows))
 	parallelTransform(len(rows), func(i int) { out[i] = s.transformResourceType(rows[i], refs) })
 	xformDur := time.Since(xformStart)
-	// Sort by output id for destination unique-index locality.
+	// Sort by output id for destination unique-index locality. The bulk
+	// sink requires it: this is the single sorted-by-external-id write
+	// AddResourceTypes' ordered writer needs.
 	sort.Slice(out, func(i, j int) bool { return out[i].GetId() < out[j].GetId() })
 	putStart := time.Now()
 	if len(out) > 0 {
-		if err := dst.PutResourceTypes(ctx, out...); err != nil {
+		if err := s.sink.PutResourceTypes(ctx, out...); err != nil {
 			return fmt.Errorf("put resource types: %w", err)
 		}
 	}
@@ -176,14 +177,14 @@ func (s *sanitizer) copyResourceTypes(
 
 // copyResources walks the source resources for srcSyncID, transforming each
 // (which registers its trait icon/logo asset refs into refs). When write is
-// true the transformed rows are written to dst; when false the walk runs purely
-// to repopulate refs — the resume path where resources were already written in
-// a prior run but their asset refs (lost with the prior process) must be
-// re-collected before copyAssets, mirroring how copyResourceTypes always runs.
+// true the transformed rows are written through s.sink; when false the walk
+// runs purely to repopulate refs — the resume path where resources were
+// already written in a prior run but their asset refs (lost with the prior
+// process) must be re-collected before copyAssets, mirroring how
+// copyResourceTypes always runs.
 func (s *sanitizer) copyResources(
 	ctx context.Context,
 	src connectorstore.Reader,
-	dst connectorstore.Writer,
 	srcSyncID string,
 	refs *assetRefSet,
 	write bool,
@@ -210,7 +211,7 @@ func (s *sanitizer) copyResources(
 		sortByResourceID(out)
 		putStart := time.Now()
 		if write && len(out) > 0 {
-			if err := dst.PutResources(ctx, out...); err != nil {
+			if err := s.sink.PutResources(ctx, out...); err != nil {
 				return fmt.Errorf("put resources: %w", err)
 			}
 		}
@@ -229,7 +230,6 @@ func (s *sanitizer) copyResources(
 func (s *sanitizer) copyEntitlements(
 	ctx context.Context,
 	src connectorstore.Reader,
-	dst connectorstore.Writer,
 	srcSyncID string,
 	refs *assetRefSet,
 	write bool,
@@ -256,7 +256,7 @@ func (s *sanitizer) copyEntitlements(
 		sort.Slice(out, func(i, j int) bool { return out[i].GetId() < out[j].GetId() })
 		putStart := time.Now()
 		if write && len(out) > 0 {
-			if err := dst.PutEntitlements(ctx, out...); err != nil {
+			if err := s.sink.PutEntitlements(ctx, out...); err != nil {
 				return fmt.Errorf("put entitlements: %w", err)
 			}
 		}
@@ -313,7 +313,7 @@ func (s *sanitizer) copyGrants(
 		sort.Slice(out, func(i, j int) bool { return out[i].GetId() < out[j].GetId() })
 		putStart := time.Now()
 		if len(out) > 0 {
-			if err := dst.PutGrants(ctx, out...); err != nil {
+			if err := s.sink.PutGrants(ctx, out...); err != nil {
 				return fmt.Errorf("put grants: %w", err)
 			}
 		}

--- a/pkg/dotc1z/engine/pebble/bulk_import.go
+++ b/pkg/dotc1z/engine/pebble/bulk_import.go
@@ -124,20 +124,21 @@ func (w *bulkSSTWriter) finish() error {
 // is written once into its final table — no WAL append, no L0 flush, no
 // background compaction debt.
 //
-// Resource types and resources stream straight into one SST per bucket
-// and must arrive in strictly increasing encoded-key order (SQLite BINARY
-// collation order on the key's tuple columns — the tuple key codec is
-// order-preserving; violations fail with ErrBulkImportOutOfOrder). These
-// add methods are single-threaded.
+// Resource types stream straight into one SST and must arrive in strictly
+// increasing encoded-key order (SQLite BINARY collation order on the key's
+// tuple columns — the tuple key codec is order-preserving; violations fail
+// with ErrBulkImportOutOfOrder). AddResourceTypes is single-threaded.
 //
-// Entitlements and grants are keyed by structural identity, whose tuple
-// order does NOT match the converter's external-id scan order, so they go
-// through spill sorters instead (entitlements single-threaded on the
-// parent; grants scale across goroutines, each scanning goroutine taking
-// its own shard via NewGrantShard so the grant hot path acquires no
-// shared lock at all). The secondary index families are derived
-// internally from the translated records — the same nil-guards and key
-// shapes as the engine's canonical writeXxxIndexes paths — and are
+// Every other bucket is re-sorted on the way in and imposes no ordering
+// requirement on its caller. Resources are keyed (resource_type_id,
+// resource_id); entitlements and grants are keyed by structural identity,
+// whose tuple order does NOT match a converter's external-id scan order.
+// All three go through spill sorters (resources and entitlements
+// single-threaded on the parent; grants scale across goroutines, each
+// scanning goroutine taking its own shard via NewGrantShard so the grant
+// hot path acquires no shared lock at all). The secondary index families
+// are derived internally from the translated records — the same nil-guards
+// and key shapes as the engine's canonical writeXxxIndexes paths — and are
 // key-only spill-sorted. Spill chunks sort and flush to disk in the
 // background while the scans keep streaming; Finish k-way merges each
 // family's sorted runs (across all shards) into one SST per family, in
@@ -1131,10 +1132,17 @@ func readSpillEntry(r io.Reader, key, val *[]byte, lenBuf *[4]byte) (bool, error
 // and the SST being written hold the same entries, so a merge that keeps
 // every chunk until teardown needs staging space for both copies at once;
 // releasing at exhaustion bounds the overlap to the chunks still in
-// flight. This matters well beyond one merge: the same helpers back the
-// bulk import, the deferred grant index, the id-index migration, the
-// segment layer, and the digest build, and the index builds run at
-// EndSync on every pebble sync.
+// flight. This matters well beyond one merge: all four of the engine's
+// k-way merges read their chunks through this type —
+// mergeSortedSpillChunksToSST, mergeSpillChunksToSSTResolvingDuplicates,
+// mergeGrantHashChunksToSST and mergeGrantPrimaryMigrationChunksToSST —
+// which between them cover the bulk import, the segment layer, the
+// deferred grant index, the digest build and the id-index migration, and
+// the index builds run at EndSync on every pebble sync. Every one of
+// those except the bulk import spills 128MiB chunks
+// (deferredIndexSpillChunkBytes) rather than 8MiB, which is where the
+// doubling costs most. advance is readSpillEntry's only caller, which is
+// what keeps that list from going stale.
 //
 // Unlinking is deliberately confined to the exhausted-chunk path, where
 // the file is provably fully consumed. A merge that fails partway closes
@@ -1158,7 +1166,7 @@ func openSpillChunks(chunks []string) (*spillChunkCursors, error) {
 		valBufs: make([][]byte, len(chunks)),
 	}
 	for i, chunk := range chunks {
-		f, err := os.Open(chunk) // #nosec G304 - staged under the import's MkdirTemp dir.
+		f, err := os.Open(chunk) // #nosec G304 - engine-private scratch, staged under the caller's MkdirTemp dir.
 		if err != nil {
 			c.closeAll()
 			return nil, err
@@ -1172,7 +1180,15 @@ func openSpillChunks(chunks []string) (*spillChunkCursors, error) {
 // advance reads the next entry of chunk i into that chunk's reusable
 // buffers, reachable via key/val. It reports false once the chunk is
 // exhausted, having already closed and unlinked it.
+//
+// Advancing an already-exhausted chunk keeps reporting false rather than
+// faulting on the released reader. Callers that re-push onto the heap only
+// after a true never reach that, but the inline readSpillEntry calls this
+// replaced were idempotent at EOF and several merges now depend on it.
 func (c *spillChunkCursors) advance(i int) (bool, error) {
+	if c.bufs[i] == nil {
+		return false, nil
+	}
 	ok, err := readSpillEntry(c.bufs[i], &c.keyBufs[i], &c.valBufs[i], &c.lenBuf)
 	if err != nil {
 		return false, err

--- a/pkg/dotc1z/engine/pebble/bulk_import.go
+++ b/pkg/dotc1z/engine/pebble/bulk_import.go
@@ -39,10 +39,13 @@ import (
 // past it and must be Abort()ed.
 var ErrBulkImportOutOfOrder = errors.New("bulk sync import: keys are not strictly increasing")
 
-// ErrBulkImportDuplicateKey is returned from Finish when a spill merge
-// finds two records with the same key. Duplicates are impossible for
-// well-formed sources (the importer requires global uniqueness), so
-// hitting this means corrupt input, not a caller ordering bug.
+// ErrBulkImportDuplicateKey is returned when a spill merge finds two
+// records with the same key — from BulkSyncImport.Finish, and from the
+// engine's other spill merges (the deferred index and digest builds at
+// EndSync, the synth-grant layer, the open-time id-index migration).
+// Duplicates are impossible for well-formed sources (every producer
+// requires global uniqueness), so hitting this means corrupt input,
+// not a caller ordering bug.
 var ErrBulkImportDuplicateKey = errors.New("bulk sync import: duplicate key in spill merge")
 
 // bulkSpillKeyChunkBytes sizes the shared spill arena pool

--- a/pkg/dotc1z/engine/pebble/bulk_import.go
+++ b/pkg/dotc1z/engine/pebble/bulk_import.go
@@ -30,11 +30,13 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/rawdb"
 )
 
-// ErrBulkImportOutOfOrder is returned by BulkSyncImport's ordered add
-// methods when a primary key arrives that does not sort strictly after
-// the previous key in the same bucket. It means the caller's
-// sorted-source contract was violated; the import cannot continue and
-// must be Abort()ed.
+// ErrBulkImportOutOfOrder is returned when a key arrives at an ordered
+// SST writer without sorting strictly after its predecessor. Callers can
+// only trigger it through AddResourceTypes, the one add method with a
+// sorted-arrival contract; resources, entitlements, and grants re-sort
+// internally, and their duplicate keys surface at Finish as corrupt
+// input (errBulkImportDuplicateKey) instead. The import cannot continue
+// past it and must be Abort()ed.
 var ErrBulkImportOutOfOrder = errors.New("bulk sync import: keys are not strictly increasing")
 
 // errBulkImportDuplicateKey is the spill-merge guard against duplicate
@@ -175,6 +177,20 @@ type BulkSyncImport struct {
 	// every producer on one path rather than making sortedness a
 	// precondition each one has to re-establish, and it holds when a single
 	// resource type is too large to sort in memory.
+	//
+	// Both carry full marshaled records, so both use the record-carrying
+	// chunk size (deferredIndexSpillChunkBytes), not the key-sized default:
+	// Finish's merge holds every chunk open behind a bulkSpillBufferSize
+	// reader, and key-sized chunks over whale record volumes mean thousands
+	// of open chunks and gigabytes of read buffers (grants.go records the
+	// synth-layer incident). These two are single sorters filled in
+	// sequential phases, so the larger arenas do not multiply; grant shards
+	// and the index sorters stay key-sized because shards × families arenas
+	// are alive there at once. Spill-sorting also stages these families
+	// transiently at ~2x (sorted runs plus the SST merged from them, and
+	// the runs' ranges overlap uniformly, so release-on-exhaustion frees
+	// little before the merge tail); the ordered writer resources used
+	// before staged ~1x but pushed sortedness onto every producer.
 	resources    *spillSorter
 	entitlements *spillSorter
 
@@ -253,8 +269,8 @@ func (e *Engine) StartBulkSyncImport(ctx context.Context, syncID string, tmpDir 
 		return nil, err
 	}
 	b.resourceTypes = sw
-	b.resources = newSpillSorter(dir, "resources", b.sortSem, bulkSpillKeyChunkBytes)
-	b.entitlements = newSpillSorter(dir, "entitlements", b.sortSem, bulkSpillKeyChunkBytes)
+	b.resources = newSpillSorter(dir, "resources", b.sortSem, deferredIndexSpillChunkBytes)
+	b.entitlements = newSpillSorter(dir, "entitlements", b.sortSem, deferredIndexSpillChunkBytes)
 	b.idxResourceByParent = newSpillSorter(dir, fmt.Sprintf("index-%02x-p", idxResourceByParent), b.sortSem, bulkSpillKeyChunkBytes)
 	return b, nil
 }
@@ -430,8 +446,10 @@ func (b *BulkSyncImport) AddResourceTypesWithDiscoveredAt(ctx context.Context, r
 
 // AddResources translates and appends resources. Rows are keyed by
 // (resource_type_id, resource_id) and re-sorted through a spill sorter, so
-// arrival order does not matter. by_parent index keys are derived and
-// spilled with the same parent guard as writeResourceIndexes.
+// arrival order does not matter; a duplicate key is corrupt input and
+// surfaces at Finish from the spill merge rather than here. by_parent
+// index keys are derived and spilled with the same parent guard as
+// writeResourceIndexes.
 func (b *BulkSyncImport) AddResources(ctx context.Context, resources ...*v2.Resource) error {
 	return b.AddResourcesWithDiscoveredAt(ctx, resources, nil)
 }

--- a/pkg/dotc1z/engine/pebble/bulk_import.go
+++ b/pkg/dotc1z/engine/pebble/bulk_import.go
@@ -44,9 +44,11 @@ var ErrBulkImportOutOfOrder = errors.New("bulk sync import: keys are not strictl
 // requires global uniqueness); hitting this means corrupt input.
 var errBulkImportDuplicateKey = errors.New("bulk sync import: duplicate key in spill merge")
 
-// bulkSpillKeyChunkBytes bounds the in-memory arena of one spill chunk.
-// Chunks are sorted and written as sorted runs in the background while
-// records keep streaming in, then k-way merged into SSTs at Finish.
+// bulkSpillKeyChunkBytes sizes the shared spill arena pool
+// (getSpillArena) and the deferred build's translate-batch arenas.
+// Production spill sorters all cut chunks at
+// deferredIndexSpillChunkBytes with explicit freelists; see that
+// constant for the sizing trade-off.
 const bulkSpillKeyChunkBytes = 8 << 20
 
 // bulkSpillBufferSize is the bufio size for spill-chunk IO.
@@ -178,25 +180,30 @@ type BulkSyncImport struct {
 	// precondition each one has to re-establish, and it holds when a single
 	// resource type is too large to sort in memory.
 	//
-	// Both carry full marshaled records, so both use the record-carrying
-	// chunk size (deferredIndexSpillChunkBytes), not the key-sized default:
-	// Finish's merge holds every chunk open behind a bulkSpillBufferSize
-	// reader, and key-sized chunks over whale record volumes mean thousands
-	// of open chunks and gigabytes of read buffers (grants.go records the
-	// synth-layer incident). These two are single sorters filled in
-	// sequential phases, so the larger arenas do not multiply; grant shards
-	// and the index sorters stay key-sized because shards × families arenas
-	// are alive there at once. Spill-sorting also stages these families
-	// transiently at ~2x (sorted runs plus the SST merged from them, and
-	// the runs' ranges overlap uniformly, so release-on-exhaustion frees
-	// little before the merge tail); the ordered writer resources used
-	// before staged ~1x but pushed sortedness onto every producer.
+	// Spill-sorting stages each family transiently at ~2x (sorted runs
+	// plus the SST merged from them; the runs' ranges overlap uniformly,
+	// so release-on-exhaustion frees little before the merge tail). The
+	// ordered writer resources used before staged ~1x but pushed
+	// sortedness onto every producer.
 	resources    *spillSorter
 	entitlements *spillSorter
 
 	// sortSem bounds concurrently running background chunk sorts
 	// across all sorters and shards.
 	sortSem chan struct{}
+
+	// Every sorter in the import — resources, entitlements, the parent
+	// index, and each shard's grant and index sorters — cuts chunks at
+	// deferredIndexSpillChunkBytes and recycles arenas through this
+	// import-wide freelist (see newSorter). Chunk size sets Finish's merge
+	// fan-in: every chunk stays open behind a bulkSpillBufferSize reader
+	// for the whole merge, so key-sized (8MiB) chunks over a whale's grant
+	// volume mean thousands of open files and gigabytes of read buffers
+	// (grants.go records the synth-layer incident). The large arenas do
+	// not multiply into RSS: a fresh arena's pages commit only as it
+	// fills, sorts in flight are capped by sortSem, and idle arenas are
+	// capped by the freelist.
+	arenaFree *spillArenaFreeList
 
 	// Parent-level sorter for the (single-threaded) resource index keys.
 	idxResourceByParent *spillSorter
@@ -263,16 +270,25 @@ func (e *Engine) StartBulkSyncImport(ctx context.Context, syncID string, tmpDir 
 		entitlementsByRT:    map[string]int64{},
 		grantDupRowsByEntRT: map[string]int64{},
 	}
+	b.arenaFree = newSpillArenaFreeList(deferredIndexSpillChunkBytes, sorters+2)
 	sw, err := newBulkSSTWriter(e.fs(), dir, "resource-types")
 	if err != nil {
 		b.Abort()
 		return nil, err
 	}
 	b.resourceTypes = sw
-	b.resources = newSpillSorter(dir, "resources", b.sortSem, deferredIndexSpillChunkBytes)
-	b.entitlements = newSpillSorter(dir, "entitlements", b.sortSem, deferredIndexSpillChunkBytes)
-	b.idxResourceByParent = newSpillSorter(dir, fmt.Sprintf("index-%02x-p", idxResourceByParent), b.sortSem, bulkSpillKeyChunkBytes)
+	b.resources = b.newSorter("resources")
+	b.entitlements = b.newSorter("entitlements")
+	b.idxResourceByParent = b.newSorter(fmt.Sprintf("index-%02x-p", idxResourceByParent))
 	return b, nil
+}
+
+// newSorter creates a spill sorter wired to the import's shared sort
+// semaphore and arena freelist (see arenaFree for the sizing rationale).
+func (b *BulkSyncImport) newSorter(name string) *spillSorter {
+	s := newSpillSorter(b.dir, name, b.sortSem, deferredIndexSpillChunkBytes)
+	s.free = b.arenaFree
+	return s
 }
 
 // BulkGrantShard is one goroutine's private view of the grant import:
@@ -308,12 +324,12 @@ func (b *BulkSyncImport) NewGrantShard() (*BulkGrantShard, error) {
 	b.shardSeq++
 	s := &BulkGrantShard{
 		b:      b,
-		grants: newSpillSorter(b.dir, fmt.Sprintf("grants-s%03d", id), b.sortSem, bulkSpillKeyChunkBytes),
+		grants: b.newSorter(fmt.Sprintf("grants-s%03d", id)),
 		idx:    map[byte]*spillSorter{},
 		entRT:  map[string]int64{},
 	}
 	for _, idx := range grantIndexFamilies {
-		s.idx[idx] = newSpillSorter(b.dir, fmt.Sprintf("index-%02x-s%03d", idx, id), b.sortSem, bulkSpillKeyChunkBytes)
+		s.idx[idx] = b.newSorter(fmt.Sprintf("index-%02x-s%03d", idx, id))
 	}
 	b.shards = append(b.shards, s)
 	return s, nil

--- a/pkg/dotc1z/engine/pebble/bulk_import.go
+++ b/pkg/dotc1z/engine/pebble/bulk_import.go
@@ -49,11 +49,40 @@ var ErrBulkImportOutOfOrder = errors.New("bulk sync import: keys are not strictl
 var ErrBulkImportDuplicateKey = errors.New("bulk sync import: duplicate key in spill merge")
 
 // bulkSpillKeyChunkBytes sizes the shared spill arena pool
-// (getSpillArena) and the deferred build's translate-batch arenas.
-// Production spill sorters all cut chunks at
-// deferredIndexSpillChunkBytes with explicit freelists; see that
-// constant for the sizing trade-off.
+// (getSpillArena) and the deferred build's translate-batch arenas. The
+// engine's single-producer spill sorters cut chunks at
+// deferredIndexSpillChunkBytes with explicit freelists (see that
+// constant for the sizing trade-off); the bulk import derives its chunk
+// size from bulkImportSortBudgetBytes instead, because its sorter count
+// scales with the caller's scan fan-out.
 const bulkSpillKeyChunkBytes = 8 << 20
+
+// bulkImportSortBudgetBytes bounds the anonymous memory the bulk import's
+// spill arenas can hold at once. Chunk size is derived from it, not
+// hard-coded: chunkBytes = budget / liveArenas, where liveArenas counts
+// every arena that can be committed simultaneously — one per sorter
+// (resources, entitlements, the parent index, and per grant shard one
+// primary plus one per index family) plus one per background sort slot.
+// Adding an index family or raising the shard count therefore shrinks
+// the chunks instead of silently raising peak RSS.
+//
+// Chunk size sets Finish's merge fan-in: every chunk stays open behind a
+// bulkSpillBufferSize reader for the whole merge, so the derived value is
+// clamped to [bulkImportMinChunkBytes, deferredIndexSpillChunkBytes] —
+// the floor keeps a whale-sized grant family (~17GB) to a few hundred
+// chunks rather than the thousands 8MiB chunks produced (grants.go
+// records the synth-layer incident), and the ceiling is the size the
+// single-producer builds already validated.
+//
+// Worked examples with three grant index families and 4 sort slots: the
+// sanitizer (1 shard, 11 arenas) derives ~93MiB; the converter at 4 lanes
+// (23 arenas) ~44MiB; at 8 lanes (39 arenas) ~26MiB. The freelist
+// recycles arenas within the same budget, so idle arenas never add to it.
+const bulkImportSortBudgetBytes = 1 << 30
+
+// bulkImportMinChunkBytes is the floor on the derived bulk-import chunk
+// size; see bulkImportSortBudgetBytes.
+const bulkImportMinChunkBytes = 16 << 20
 
 // bulkSpillBufferSize is the bufio size for spill-chunk IO.
 const bulkSpillBufferSize = 1 << 20
@@ -198,16 +227,17 @@ type BulkSyncImport struct {
 
 	// Every sorter in the import — resources, entitlements, the parent
 	// index, and each shard's grant and index sorters — cuts chunks at
-	// deferredIndexSpillChunkBytes and recycles arenas through this
-	// import-wide freelist (see newSorter). Chunk size sets Finish's merge
-	// fan-in: every chunk stays open behind a bulkSpillBufferSize reader
-	// for the whole merge, so key-sized (8MiB) chunks over a whale's grant
-	// volume mean thousands of open files and gigabytes of read buffers
-	// (grants.go records the synth-layer incident). The large arenas do
-	// not multiply into RSS: a fresh arena's pages commit only as it
-	// fills, sorts in flight are capped by sortSem, and idle arenas are
-	// capped by the freelist.
-	arenaFree *spillArenaFreeList
+	// chunkBytes and recycles arenas through this import-wide freelist
+	// (see newSorter). chunkBytes is derived from
+	// bulkImportSortBudgetBytes and the caller's expected shard count so
+	// the arenas' aggregate stays under the budget: sorts in flight are
+	// capped by sortSem, and idle arenas are capped by the freelist, so
+	// the live set is exactly the arena count the derivation counted.
+	// (A fresh arena's pages also commit only as it fills, so small
+	// imports stay well under the budget; recycled arenas are fully
+	// committed, which is why the budget counts them all.)
+	chunkBytes int
+	arenaFree  *spillArenaFreeList
 
 	// Parent-level sorter for the (single-threaded) resource index keys.
 	idxResourceByParent *spillSorter
@@ -245,7 +275,13 @@ type BulkSyncImport struct {
 // the engine's current FRESH sync (see BulkSyncImport contract). Working
 // files are staged in a fresh directory under tmpDir ("" = system temp
 // dir) and removed by Finish/Abort.
-func (e *Engine) StartBulkSyncImport(ctx context.Context, syncID string, tmpDir string) (*BulkSyncImport, error) {
+//
+// expectedShards is the number of grant shards the caller intends to open
+// via NewGrantShard (values < 1 are treated as 1). It is a sizing hint,
+// not a limit: the import derives its spill chunk size from it so the
+// arenas' aggregate stays within bulkImportSortBudgetBytes. Opening more
+// shards than declared still works but raises peak memory proportionally.
+func (e *Engine) StartBulkSyncImport(ctx context.Context, syncID string, tmpDir string, expectedShards int) (*BulkSyncImport, error) {
 	if !e.IsFreshSync() {
 		return nil, errors.New("StartBulkSyncImport: sync is not fresh")
 	}
@@ -270,11 +306,12 @@ func (e *Engine) StartBulkSyncImport(ctx context.Context, syncID string, tmpDir 
 		syncID:              syncID,
 		dir:                 dir,
 		sortSem:             make(chan struct{}, sorters),
+		chunkBytes:          bulkImportChunkBytes(expectedShards, sorters),
 		resourcesByRT:       map[string]int64{},
 		entitlementsByRT:    map[string]int64{},
 		grantDupRowsByEntRT: map[string]int64{},
 	}
-	b.arenaFree = newSpillArenaFreeList(deferredIndexSpillChunkBytes, sorters+2)
+	b.arenaFree = newSpillArenaFreeList(b.chunkBytes, sorters+2)
 	sw, err := newBulkSSTWriter(e.fs(), dir, "resource-types")
 	if err != nil {
 		b.Abort()
@@ -287,10 +324,23 @@ func (e *Engine) StartBulkSyncImport(ctx context.Context, syncID string, tmpDir 
 	return b, nil
 }
 
+// bulkImportChunkBytes derives the spill chunk size that keeps the
+// import's simultaneously-live arenas within bulkImportSortBudgetBytes.
+// The live set is one arena per sorter — the three lane-independent
+// sorters plus, per grant shard, one primary and one per index family —
+// plus one per background sort slot (a sorter that just cut a chunk
+// fills a fresh arena while the cut one sorts). See
+// bulkImportSortBudgetBytes for the clamp rationale.
+func bulkImportChunkBytes(expectedShards, sortSlots int) int {
+	expectedShards = max(1, expectedShards)
+	liveArenas := 3 + (1+len(grantIndexFamilies))*expectedShards + sortSlots
+	return min(deferredIndexSpillChunkBytes, max(bulkImportMinChunkBytes, bulkImportSortBudgetBytes/liveArenas))
+}
+
 // newSorter creates a spill sorter wired to the import's shared sort
 // semaphore and arena freelist (see arenaFree for the sizing rationale).
 func (b *BulkSyncImport) newSorter(name string) *spillSorter {
-	s := newSpillSorter(b.dir, name, b.sortSem, deferredIndexSpillChunkBytes)
+	s := newSpillSorter(b.dir, name, b.sortSem, b.chunkBytes)
 	s.free = b.arenaFree
 	return s
 }
@@ -941,6 +991,17 @@ func (s *spillSorter) add(key, val []byte) error {
 	}
 	if err := s.takeErr(); err != nil {
 		return err
+	}
+	// Cut BEFORE an entry would overflow the arena's capacity, not after.
+	// Appending past cap makes Go reallocate the arena at ~1.25x with a
+	// full copy — a 128MiB memcpy per fresh arena — and the freelist then
+	// keeps the oversized copy, so every recycled arena would carry that
+	// growth for the rest of the build. Cutting early keeps arenas at
+	// exactly their allocated size and makes the budget arithmetic in
+	// bulkImportSortBudgetBytes true. (An arena holding nothing yet is
+	// left to grow: a single entry larger than a chunk is legal.)
+	if len(s.views) > 0 && len(s.arena)+len(key)+len(val) > cap(s.arena) {
+		s.cutAndDispatch()
 	}
 	if s.arena == nil {
 		if s.free != nil {

--- a/pkg/dotc1z/engine/pebble/bulk_import.go
+++ b/pkg/dotc1z/engine/pebble/bulk_import.go
@@ -160,19 +160,21 @@ type BulkSyncImport struct {
 	resourceTypes *bulkSSTWriter
 
 	// resources and entitlements go through spill sorters, not ordered SST
-	// writers: the structural key does not sort the way a producer's natural
-	// scan order does (for entitlements, tuple separators sort below
-	// printable bytes and the flag component reorders stripped vs opaque
-	// ids), so the stream must be re-sorted before it can become an SST.
+	// writers, so neither imposes an ordering precondition on its caller.
+	// For entitlements the mismatch is unconditional: the structural key
+	// never sorts the way an external-id scan does (tuple separators sort
+	// below printable bytes, and the flag component reorders stripped vs
+	// opaque ids), so the stream must be re-sorted before it can become an
+	// SST.
 	//
-	// Resources are keyed (resource_type_id, resource_id). A converter
-	// scanning SQLite with ORDER BY on that tuple already arrives sorted and
-	// paid nothing for an ordered writer, but a producer that rewrites
-	// resource ids — the c1z sanitizer HMACs them — emits an order unrelated
-	// to the destination key. Sorting here keeps every producer on one path
-	// rather than making sortedness a precondition each one has to
-	// re-establish, and it holds when a single resource type is too large to
-	// sort in memory.
+	// For resources, keyed (resource_type_id, resource_id), it depends on
+	// the producer. A converter scanning SQLite with ORDER BY on that tuple
+	// already arrives sorted and paid nothing for an ordered writer, but a
+	// producer that rewrites resource ids — the c1z sanitizer HMACs them —
+	// emits an order unrelated to the destination key. Sorting here keeps
+	// every producer on one path rather than making sortedness a
+	// precondition each one has to re-establish, and it holds when a single
+	// resource type is too large to sort in memory.
 	resources    *spillSorter
 	entitlements *spillSorter
 
@@ -567,13 +569,12 @@ func (b *BulkSyncImport) Finish(ctx context.Context) error {
 	}
 	b.done = true
 	// Full teardown, not a bare RemoveAll: Finish's error paths can return
-	// with the ordered SST writers still open (finish() failing on one
-	// leaves the other's file handle live) and with background chunk sorts
-	// still writing into the staging dir (nothing finalized the sorters
-	// yet). Removing the dir while a sort races its os.Create can strand
-	// the dir on disk, and Abort is a no-op once done is set — so this
-	// defer must do the closing and waiting itself. On success everything
-	// is already finished/finalized and teardown reduces to the RemoveAll.
+	// with background chunk sorts still writing into the staging dir
+	// (nothing finalized the sorters yet), and removing the dir while a
+	// sort races its os.Create can strand the dir on disk. Abort is a
+	// no-op once done is set, so this defer must do the waiting itself.
+	// On success everything is already finished/finalized and teardown
+	// reduces to the RemoveAll.
 	defer b.teardown()
 	start := time.Now()
 
@@ -1132,17 +1133,9 @@ func readSpillEntry(r io.Reader, key, val *[]byte, lenBuf *[4]byte) (bool, error
 // and the SST being written hold the same entries, so a merge that keeps
 // every chunk until teardown needs staging space for both copies at once;
 // releasing at exhaustion bounds the overlap to the chunks still in
-// flight. This matters well beyond one merge: all four of the engine's
-// k-way merges read their chunks through this type —
-// mergeSortedSpillChunksToSST, mergeSpillChunksToSSTResolvingDuplicates,
-// mergeGrantHashChunksToSST and mergeGrantPrimaryMigrationChunksToSST —
-// which between them cover the bulk import, the segment layer, the
-// deferred grant index, the digest build and the id-index migration, and
-// the index builds run at EndSync on every pebble sync. Every one of
-// those except the bulk import spills 128MiB chunks
-// (deferredIndexSpillChunkBytes) rather than 8MiB, which is where the
-// doubling costs most. advance is readSpillEntry's only caller, which is
-// what keeps that list from going stale.
+// flight. All of the engine's k-way merges read their chunks through this
+// type (advance is readSpillEntry's only caller), so the bound holds for
+// every spill merge, not just the bulk import's.
 //
 // Unlinking is deliberately confined to the exhausted-chunk path, where
 // the file is provably fully consumed. A merge that fails partway closes
@@ -1182,9 +1175,10 @@ func openSpillChunks(chunks []string) (*spillChunkCursors, error) {
 // exhausted, having already closed and unlinked it.
 //
 // Advancing an already-exhausted chunk keeps reporting false rather than
-// faulting on the released reader. Callers that re-push onto the heap only
-// after a true never reach that, but the inline readSpillEntry calls this
-// replaced were idempotent at EOF and several merges now depend on it.
+// faulting on the released reader. The merges re-push a chunk onto the
+// heap only after a true, so none of them reach this today; the guard
+// preserves the EOF idempotency of the inline readSpillEntry calls this
+// replaced.
 func (c *spillChunkCursors) advance(i int) (bool, error) {
 	if c.bufs[i] == nil {
 		return false, nil

--- a/pkg/dotc1z/engine/pebble/bulk_import.go
+++ b/pkg/dotc1z/engine/pebble/bulk_import.go
@@ -69,10 +69,10 @@ const bulkSpillKeyChunkBytes = 8 << 20
 // Chunk size sets Finish's merge fan-in: every chunk stays open behind a
 // bulkSpillBufferSize reader for the whole merge, so the derived value is
 // clamped to [bulkImportMinChunkBytes, deferredIndexSpillChunkBytes] —
-// the floor keeps a whale-sized grant family (~17GB) to a few hundred
-// chunks rather than the thousands 8MiB chunks produced (grants.go
-// records the synth-layer incident), and the ceiling is the size the
-// single-producer builds already validated.
+// the floor caps the run count at half what 8MiB chunks produce (a
+// whale-sized ~17GB grant family is ~1,100 runs at the floor versus
+// ~2,200 at 8MiB; grants.go records the synth-layer incident), and the
+// ceiling is the size the single-producer builds already validated.
 //
 // Worked examples with three grant index families and 4 sort slots: the
 // sanitizer (1 shard, 11 arenas) derives ~93MiB; the converter at 4 lanes

--- a/pkg/dotc1z/engine/pebble/bulk_import.go
+++ b/pkg/dotc1z/engine/pebble/bulk_import.go
@@ -35,14 +35,15 @@ import (
 // only trigger it through AddResourceTypes, the one add method with a
 // sorted-arrival contract; resources, entitlements, and grants re-sort
 // internally, and their duplicate keys surface at Finish as corrupt
-// input (errBulkImportDuplicateKey) instead. The import cannot continue
+// input (ErrBulkImportDuplicateKey) instead. The import cannot continue
 // past it and must be Abort()ed.
 var ErrBulkImportOutOfOrder = errors.New("bulk sync import: keys are not strictly increasing")
 
-// errBulkImportDuplicateKey is the spill-merge guard against duplicate
-// keys. Duplicates are impossible for well-formed sources (the importer
-// requires global uniqueness); hitting this means corrupt input.
-var errBulkImportDuplicateKey = errors.New("bulk sync import: duplicate key in spill merge")
+// ErrBulkImportDuplicateKey is returned from Finish when a spill merge
+// finds two records with the same key. Duplicates are impossible for
+// well-formed sources (the importer requires global uniqueness), so
+// hitting this means corrupt input, not a caller ordering bug.
+var ErrBulkImportDuplicateKey = errors.New("bulk sync import: duplicate key in spill merge")
 
 // bulkSpillKeyChunkBytes sizes the shared spill arena pool
 // (getSpillArena) and the deferred build's translate-batch arenas.
@@ -1287,7 +1288,7 @@ func mergeSortedSpillChunksToSST(ctx context.Context, fs vfs.FS, sstPath, name s
 	for len(*h) > 0 {
 		item := h.pop()
 		if bytes.Equal(item.key, last) {
-			return fmt.Errorf("%w: bucket %s key %x", errBulkImportDuplicateKey, name, item.key)
+			return fmt.Errorf("%w: bucket %s key %x", ErrBulkImportDuplicateKey, name, item.key)
 		}
 		var v []byte
 		if len(item.val) > 0 {

--- a/pkg/dotc1z/engine/pebble/bulk_import.go
+++ b/pkg/dotc1z/engine/pebble/bulk_import.go
@@ -157,13 +157,22 @@ type BulkSyncImport struct {
 	done   bool
 
 	resourceTypes *bulkSSTWriter
-	resources     *bulkSSTWriter
 
-	// entitlements go through a spill sorter, not an ordered SST writer:
-	// the converter scans in external-id order, but the structural identity
-	// key does not sort the same way (tuple separators sort below printable
-	// bytes, and the flag component reorders stripped vs opaque ids), so the
-	// stream must be re-sorted before it can become an SST.
+	// resources and entitlements go through spill sorters, not ordered SST
+	// writers: the structural key does not sort the way a producer's natural
+	// scan order does (for entitlements, tuple separators sort below
+	// printable bytes and the flag component reorders stripped vs opaque
+	// ids), so the stream must be re-sorted before it can become an SST.
+	//
+	// Resources are keyed (resource_type_id, resource_id). A converter
+	// scanning SQLite with ORDER BY on that tuple already arrives sorted and
+	// paid nothing for an ordered writer, but a producer that rewrites
+	// resource ids — the c1z sanitizer HMACs them — emits an order unrelated
+	// to the destination key. Sorting here keeps every producer on one path
+	// rather than making sortedness a precondition each one has to
+	// re-establish, and it holds when a single resource type is too large to
+	// sort in memory.
+	resources    *spillSorter
 	entitlements *spillSorter
 
 	// sortSem bounds concurrently running background chunk sorts
@@ -235,20 +244,13 @@ func (e *Engine) StartBulkSyncImport(ctx context.Context, syncID string, tmpDir 
 		entitlementsByRT:    map[string]int64{},
 		grantDupRowsByEntRT: map[string]int64{},
 	}
-	for _, w := range []struct {
-		slot **bulkSSTWriter
-		name string
-	}{
-		{&b.resourceTypes, "resource-types"},
-		{&b.resources, "resources"},
-	} {
-		sw, err := newBulkSSTWriter(e.fs(), dir, w.name)
-		if err != nil {
-			b.Abort()
-			return nil, err
-		}
-		*w.slot = sw
+	sw, err := newBulkSSTWriter(e.fs(), dir, "resource-types")
+	if err != nil {
+		b.Abort()
+		return nil, err
 	}
+	b.resourceTypes = sw
+	b.resources = newSpillSorter(dir, "resources", b.sortSem, bulkSpillKeyChunkBytes)
 	b.entitlements = newSpillSorter(dir, "entitlements", b.sortSem, bulkSpillKeyChunkBytes)
 	b.idxResourceByParent = newSpillSorter(dir, fmt.Sprintf("index-%02x-p", idxResourceByParent), b.sortSem, bulkSpillKeyChunkBytes)
 	return b, nil
@@ -423,9 +425,10 @@ func (b *BulkSyncImport) AddResourceTypesWithDiscoveredAt(ctx context.Context, r
 	return nil
 }
 
-// AddResources translates and appends resources, which must arrive
-// sorted by (resource_type_id, resource_id). by_parent index keys are
-// derived and spilled with the same parent guard as writeResourceIndexes.
+// AddResources translates and appends resources. Rows are keyed by
+// (resource_type_id, resource_id) and re-sorted through a spill sorter, so
+// arrival order does not matter. by_parent index keys are derived and
+// spilled with the same parent guard as writeResourceIndexes.
 func (b *BulkSyncImport) AddResources(ctx context.Context, resources ...*v2.Resource) error {
 	return b.AddResourcesWithDiscoveredAt(ctx, resources, nil)
 }
@@ -540,7 +543,7 @@ func (b *BulkSyncImport) ComputedStats() *v3.SyncStatsRecord {
 	rec := &v3.SyncStatsRecord{
 		SyncId:                          b.syncID,
 		ResourceTypes:                   int64(b.resourceTypes.count),
-		Resources:                       int64(b.resources.count),
+		Resources:                       b.resources.count,
 		Entitlements:                    b.entitlements.count,
 		Grants:                          grants,
 		ResourcesByResourceType:         b.resourcesByRT,
@@ -574,13 +577,11 @@ func (b *BulkSyncImport) Finish(ctx context.Context) error {
 	start := time.Now()
 
 	paths := make([]string, 0, 4+len(grantIndexFamilies))
-	for _, w := range []*bulkSSTWriter{b.resourceTypes, b.resources} {
-		if err := w.finish(); err != nil {
-			return err
-		}
-		if w.count > 0 {
-			paths = append(paths, w.path)
-		}
+	if err := b.resourceTypes.finish(); err != nil {
+		return err
+	}
+	if b.resourceTypes.count > 0 {
+		paths = append(paths, b.resourceTypes.path)
 	}
 
 	b.mu.Lock()
@@ -607,6 +608,7 @@ func (b *BulkSyncImport) Finish(ctx context.Context) error {
 	}
 	units := []mergeUnit{
 		{name: "grants", resolve: b.resolveDuplicateGrants},
+		{name: "resources", sorters: []*spillSorter{b.resources}},
 		{name: "entitlements", sorters: []*spillSorter{b.entitlements}},
 		{name: fmt.Sprintf("index-%02x", idxResourceByParent), sorters: []*spillSorter{b.idxResourceByParent}},
 	}
@@ -753,17 +755,15 @@ func (b *BulkSyncImport) Abort() {
 	b.teardown()
 }
 
-// teardown closes both ordered SST writers, waits out every spill
+// teardown closes the ordered SST writer, waits out every spill
 // sorter's in-flight background chunk sorts, and then removes the
 // staging directory. The waits must precede the RemoveAll: a chunk
 // sort racing the removal can re-create a file mid-walk and strand the
-// directory. Idempotent against already-finished writers and
+// directory. Idempotent against an already-finished writer and
 // already-finalized sorters, so Finish can run it unconditionally.
 func (b *BulkSyncImport) teardown() {
-	for _, w := range []*bulkSSTWriter{b.resourceTypes, b.resources} {
-		if w != nil {
-			_ = w.finish()
-		}
+	if b.resourceTypes != nil {
+		_ = b.resourceTypes.finish()
 	}
 	b.mu.Lock()
 	shards := b.shards
@@ -775,7 +775,7 @@ func (b *BulkSyncImport) teardown() {
 			w.abort()
 		}
 	}
-	for _, w := range []*spillSorter{b.entitlements, b.idxResourceByParent} {
+	for _, w := range []*spillSorter{b.resources, b.entitlements, b.idxResourceByParent} {
 		if w != nil {
 			w.abort()
 		}
@@ -1126,6 +1126,83 @@ func readSpillEntry(r io.Reader, key, val *[]byte, lenBuf *[4]byte) (bool, error
 	return true, nil
 }
 
+// spillChunkCursors owns the open chunk files for one merge pass and
+// unlinks each chunk as soon as its last entry has been read. The chunks
+// and the SST being written hold the same entries, so a merge that keeps
+// every chunk until teardown needs staging space for both copies at once;
+// releasing at exhaustion bounds the overlap to the chunks still in
+// flight. This matters well beyond one merge: the same helpers back the
+// bulk import, the deferred grant index, the id-index migration, the
+// segment layer, and the digest build, and the index builds run at
+// EndSync on every pebble sync.
+//
+// Unlinking is deliberately confined to the exhausted-chunk path, where
+// the file is provably fully consumed. A merge that fails partway closes
+// its remaining descriptors and leaves those files for the staging-dir
+// teardown that already owns them.
+type spillChunkCursors struct {
+	paths   []string
+	files   []*os.File
+	bufs    []*bufio.Reader
+	keyBufs [][]byte
+	valBufs [][]byte
+	lenBuf  [4]byte
+}
+
+func openSpillChunks(chunks []string) (*spillChunkCursors, error) {
+	c := &spillChunkCursors{
+		paths:   chunks,
+		files:   make([]*os.File, len(chunks)),
+		bufs:    make([]*bufio.Reader, len(chunks)),
+		keyBufs: make([][]byte, len(chunks)),
+		valBufs: make([][]byte, len(chunks)),
+	}
+	for i, chunk := range chunks {
+		f, err := os.Open(chunk) // #nosec G304 - staged under the import's MkdirTemp dir.
+		if err != nil {
+			c.closeAll()
+			return nil, err
+		}
+		c.files[i] = f
+		c.bufs[i] = bufio.NewReaderSize(f, bulkSpillBufferSize)
+	}
+	return c, nil
+}
+
+// advance reads the next entry of chunk i into that chunk's reusable
+// buffers, reachable via key/val. It reports false once the chunk is
+// exhausted, having already closed and unlinked it.
+func (c *spillChunkCursors) advance(i int) (bool, error) {
+	ok, err := readSpillEntry(c.bufs[i], &c.keyBufs[i], &c.valBufs[i], &c.lenBuf)
+	if err != nil {
+		return false, err
+	}
+	if !ok {
+		c.closeChunk(i)
+		_ = os.Remove(c.paths[i])
+	}
+	return ok, nil
+}
+
+func (c *spillChunkCursors) key(i int) []byte { return c.keyBufs[i] }
+func (c *spillChunkCursors) val(i int) []byte { return c.valBufs[i] }
+
+func (c *spillChunkCursors) closeChunk(i int) {
+	if c.files[i] == nil {
+		return
+	}
+	_ = c.files[i].Close()
+	c.files[i] = nil
+	c.bufs[i] = nil
+}
+
+// closeAll releases descriptors without unlinking; see the type comment.
+func (c *spillChunkCursors) closeAll() {
+	for i := range c.files {
+		c.closeChunk(i)
+	}
+}
+
 // mergeSortedSpillChunksToSST heap-merges the sorted chunk files into a
 // single SST. Duplicate keys are corruption (the importer requires
 // globally unique tuples) and fail the merge. fs is the engine FS the
@@ -1133,30 +1210,19 @@ func readSpillEntry(r io.Reader, key, val *[]byte, lenBuf *[4]byte) (bool, error
 func mergeSortedSpillChunksToSST(ctx context.Context, fs vfs.FS, sstPath, name string, chunks []string) error {
 	start := time.Now()
 	l := ctxzap.Extract(ctx)
-	readers := make([]*os.File, 0, len(chunks))
-	defer func() {
-		for _, r := range readers {
-			_ = r.Close()
-		}
-	}()
-	bufReaders := make([]*bufio.Reader, len(chunks))
-	keyBufs := make([][]byte, len(chunks))
-	valBufs := make([][]byte, len(chunks))
+	cursors, err := openSpillChunks(chunks)
+	if err != nil {
+		return err
+	}
+	defer cursors.closeAll()
 	h := &spillChunkHeap{}
-	var lenBuf [4]byte
-	for i, chunk := range chunks {
-		f, err := os.Open(chunk) // #nosec G304 - staged under the import's MkdirTemp dir.
-		if err != nil {
-			return err
-		}
-		readers = append(readers, f)
-		bufReaders[i] = bufio.NewReaderSize(f, bulkSpillBufferSize)
-		ok, err := readSpillEntry(bufReaders[i], &keyBufs[i], &valBufs[i], &lenBuf)
+	for i := range chunks {
+		ok, err := cursors.advance(i)
 		if err != nil {
 			return err
 		}
 		if ok {
-			h.push(spillChunkItem{chunkIdx: i, key: keyBufs[i], val: valBufs[i]})
+			h.push(spillChunkItem{chunkIdx: i, key: cursors.key(i), val: cursors.val(i)})
 		}
 	}
 
@@ -1205,12 +1271,12 @@ func mergeSortedSpillChunksToSST(ctx context.Context, fs vfs.FS, sstPath, name s
 			}
 		}
 		last = append(last[:0], item.key...)
-		ok, err := readSpillEntry(bufReaders[item.chunkIdx], &keyBufs[item.chunkIdx], &valBufs[item.chunkIdx], &lenBuf)
+		ok, err := cursors.advance(item.chunkIdx)
 		if err != nil {
 			return err
 		}
 		if ok {
-			h.push(spillChunkItem{chunkIdx: item.chunkIdx, key: keyBufs[item.chunkIdx], val: valBufs[item.chunkIdx]})
+			h.push(spillChunkItem{chunkIdx: item.chunkIdx, key: cursors.key(item.chunkIdx), val: cursors.val(item.chunkIdx)})
 		}
 	}
 	if err := writer.finish(); err != nil {
@@ -1247,30 +1313,19 @@ func mergeSpillChunksToSSTResolvingDuplicates(
 ) (int64, error) {
 	start := time.Now()
 	l := ctxzap.Extract(ctx)
-	readers := make([]*os.File, 0, len(chunks))
-	defer func() {
-		for _, r := range readers {
-			_ = r.Close()
-		}
-	}()
-	bufReaders := make([]*bufio.Reader, len(chunks))
-	keyBufs := make([][]byte, len(chunks))
-	valBufs := make([][]byte, len(chunks))
+	cursors, err := openSpillChunks(chunks)
+	if err != nil {
+		return 0, err
+	}
+	defer cursors.closeAll()
 	h := &spillChunkHeap{}
-	var lenBuf [4]byte
-	for i, chunk := range chunks {
-		f, err := os.Open(chunk) // #nosec G304 - staged under the import's MkdirTemp dir.
-		if err != nil {
-			return 0, err
-		}
-		readers = append(readers, f)
-		bufReaders[i] = bufio.NewReaderSize(f, bulkSpillBufferSize)
-		ok, err := readSpillEntry(bufReaders[i], &keyBufs[i], &valBufs[i], &lenBuf)
+	for i := range chunks {
+		ok, err := cursors.advance(i)
 		if err != nil {
 			return 0, err
 		}
 		if ok {
-			h.push(spillChunkItem{chunkIdx: i, key: keyBufs[i], val: valBufs[i]})
+			h.push(spillChunkItem{chunkIdx: i, key: cursors.key(i), val: cursors.val(i)})
 		}
 	}
 
@@ -1359,12 +1414,12 @@ func mergeSpillChunksToSSTResolvingDuplicates(
 		// Advance the popped chunk only AFTER the entry was consumed into
 		// the group scratch: readSpillEntry overwrites the buffers item
 		// aliases.
-		ok, err := readSpillEntry(bufReaders[item.chunkIdx], &keyBufs[item.chunkIdx], &valBufs[item.chunkIdx], &lenBuf)
+		ok, err := cursors.advance(item.chunkIdx)
 		if err != nil {
 			return dupGroups, err
 		}
 		if ok {
-			h.push(spillChunkItem{chunkIdx: item.chunkIdx, key: keyBufs[item.chunkIdx], val: valBufs[item.chunkIdx]})
+			h.push(spillChunkItem{chunkIdx: item.chunkIdx, key: cursors.key(item.chunkIdx), val: cursors.val(item.chunkIdx)})
 		}
 	}
 	if err := flushCur(); err != nil {

--- a/pkg/dotc1z/engine/pebble/bulk_import_budget_test.go
+++ b/pkg/dotc1z/engine/pebble/bulk_import_budget_test.go
@@ -1,0 +1,98 @@
+package pebble
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestBulkImportChunkBytesStaysWithinBudget pins the property the chunk
+// derivation exists for: across the shard counts callers actually use, the
+// simultaneously-live arenas (one per sorter plus one per sort slot) fit
+// in bulkImportSortBudgetBytes, except where the fan-in floor deliberately
+// wins. Written against len(grantIndexFamilies) rather than a literal so
+// adding an index family shrinks the chunks instead of failing the test.
+func TestBulkImportChunkBytesStaysWithinBudget(t *testing.T) {
+	sortSlots := 4
+	for _, shards := range []int{0, 1, 2, 4, 8, 16, 64} {
+		chunk := bulkImportChunkBytes(shards, sortSlots)
+		liveArenas := 3 + (1+len(grantIndexFamilies))*max(1, shards) + sortSlots
+		require.LessOrEqual(t, chunk, deferredIndexSpillChunkBytes, "shards=%d: chunk above the validated ceiling", shards)
+		require.GreaterOrEqual(t, chunk, bulkImportMinChunkBytes, "shards=%d: chunk below the fan-in floor", shards)
+		if chunk > bulkImportMinChunkBytes {
+			require.LessOrEqual(t, chunk*liveArenas, bulkImportSortBudgetBytes,
+				"shards=%d: %d live arenas x %d bytes exceeds the budget", shards, liveArenas, chunk)
+		}
+	}
+
+	// Monotone: more shards never means bigger chunks.
+	prev := bulkImportChunkBytes(1, sortSlots)
+	for shards := 2; shards <= 32; shards++ {
+		cur := bulkImportChunkBytes(shards, sortSlots)
+		require.LessOrEqual(t, cur, prev, "shards=%d grew the chunk size", shards)
+		prev = cur
+	}
+
+	// Non-positive hints size for one shard, not zero (which would divide
+	// the budget across the lane-independent sorters alone and overshoot
+	// once the first shard opens).
+	require.Equal(t, bulkImportChunkBytes(1, sortSlots), bulkImportChunkBytes(0, sortSlots))
+	require.Equal(t, bulkImportChunkBytes(1, sortSlots), bulkImportChunkBytes(-3, sortSlots))
+}
+
+// TestSpillSorterCutsBeforeArenaOverflow pins that add() cuts a chunk
+// before an entry would push the arena past its capacity, so arenas never
+// append-grow. Without the pre-check every fresh arena's first cut
+// reallocates at ~1.25x with a full copy and the freelist keeps the larger
+// buffer; the budget derivation assumes arenas stay at chunkBytes.
+func TestSpillSorterCutsBeforeArenaOverflow(t *testing.T) {
+	const chunkBytes = 1024
+	const entryBytes = 100 // 60-byte key + 40-byte value; ten fit, an eleventh would overflow.
+	const entries = 55
+
+	dir := t.TempDir()
+	s := newSpillSorter(dir, "budget", make(chan struct{}, 1), chunkBytes)
+	s.free = newSpillArenaFreeList(chunkBytes, 2)
+
+	for i := 0; i < entries; i++ {
+		key := []byte(fmt.Sprintf("%060d", i))
+		val := make([]byte, 40)
+		require.NoError(t, s.add(key, val))
+		if s.arena != nil {
+			require.Equal(t, chunkBytes, cap(s.arena), "arena grew past its allocation after entry %d", i)
+			require.LessOrEqual(t, len(s.arena), chunkBytes)
+		}
+	}
+
+	chunks, err := s.finalize()
+	require.NoError(t, err)
+	// 55 entries at 10 per full chunk: five full chunks plus a 5-entry tail.
+	require.Len(t, chunks, 6)
+
+	var total int
+	for _, path := range chunks {
+		f, err := os.Open(path)
+		require.NoError(t, err)
+		r := bufio.NewReader(f)
+		var key, val []byte
+		var lenBuf [4]byte
+		n := 0
+		for {
+			ok, err := readSpillEntry(r, &key, &val, &lenBuf)
+			require.NoError(t, err)
+			if !ok {
+				break
+			}
+			require.Len(t, key, 60)
+			require.Len(t, val, 40)
+			n++
+		}
+		require.NoError(t, f.Close())
+		require.LessOrEqual(t, n*entryBytes, chunkBytes, "chunk %s holds more than one arena's worth", path)
+		total += n
+	}
+	require.Equal(t, entries, total, "every entry must land in exactly one chunk")
+}

--- a/pkg/dotc1z/engine/pebble/bulk_import_dedupe_test.go
+++ b/pkg/dotc1z/engine/pebble/bulk_import_dedupe_test.go
@@ -20,7 +20,7 @@ func startBulkImport(t *testing.T, ctx context.Context) (*Adapter, *BulkSyncImpo
 	store := NewAdapter(e)
 	syncID, err := store.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
 	require.NoError(t, err, "StartNewSync")
-	b, err := e.StartBulkSyncImport(ctx, syncID, t.TempDir())
+	b, err := e.StartBulkSyncImport(ctx, syncID, t.TempDir(), 1)
 	require.NoError(t, err, "StartBulkSyncImport")
 	return store, b
 }

--- a/pkg/dotc1z/engine/pebble/bulk_import_dedupe_test.go
+++ b/pkg/dotc1z/engine/pebble/bulk_import_dedupe_test.go
@@ -93,6 +93,70 @@ func TestBulkImportEntitlementIdentityOrderDivergesFromExternalID(t *testing.T) 
 	require.Equal(t, map[string]int64{"app": 2, "group": 2}, stats.GetEntitlementsByResourceType())
 }
 
+// TestBulkImportAcceptsResourcesOutOfKeyOrder pins that resources no longer
+// have to arrive in destination-key order. Two producers reach AddResources
+// unsorted: one that rewrites resource ids (the c1z sanitizer HMACs them, so
+// its output order is unrelated to the order it read), and a converter
+// hitting the same separator trap that bit entitlements — external-id string
+// order puts "app-x:a" before "app:dev" ('-' 0x2D < ':' 0x3A) while the tuple
+// order is the reverse, because the tuple separator sorts below printable
+// bytes. Both previously aborted with ErrBulkImportOutOfOrder.
+func TestBulkImportAcceptsResourcesOutOfKeyOrder(t *testing.T) {
+	ctx := context.Background()
+	store, b := startBulkImport(t, ctx)
+	defer b.Abort()
+
+	require.NoError(t, b.AddResourceTypes(ctx,
+		v2.ResourceType_builder{Id: "app"}.Build(),
+		v2.ResourceType_builder{Id: "app-x"}.Build(),
+	))
+	appDev := v2.ResourceId_builder{ResourceType: "app", Resource: "dev"}.Build()
+
+	// Scrambled against (resource_type_id, resource_id) on every axis the
+	// key has: the "app-x" type leads but sorts last, "z" precedes "a", and
+	// both children are added before their parent.
+	require.NoError(t, b.AddResources(ctx,
+		v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "app-x", Resource: "a"}.Build()}.Build(),
+		v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "app", Resource: "z"}.Build(), ParentResourceId: appDev}.Build(),
+		v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "app", Resource: "a"}.Build(), ParentResourceId: appDev}.Build(),
+		v2.Resource_builder{Id: v2.ResourceId_builder{ResourceType: "app", Resource: "dev"}.Build()}.Build(),
+	), "AddResources must accept rows out of destination-key order")
+
+	shard, err := b.NewGrantShard()
+	require.NoError(t, err)
+	shard.Close()
+	require.NoError(t, b.Finish(ctx), "Finish")
+
+	resp, err := store.ListResources(ctx, v2.ResourcesServiceListResourcesRequest_builder{PageSize: 100}.Build())
+	require.NoError(t, err)
+	got := make([]string, 0, len(resp.GetList()))
+	for _, r := range resp.GetList() {
+		got = append(got, r.GetId().GetResourceType()+"/"+r.GetId().GetResource())
+	}
+	// Unsorted, this is an assertion that all four rows landed; because the
+	// primary keyspace is scanned in key order it also pins that the merge
+	// really sorted them, "app-x" last rather than first as submitted.
+	require.Equal(t, []string{"app/a", "app/dev", "app/z", "app-x/a"}, got)
+
+	// The by_parent index is spilled from the same unsorted stream and has
+	// to agree with the primary.
+	children, err := store.ListResources(ctx, v2.ResourcesServiceListResourcesRequest_builder{
+		ParentResourceId: appDev,
+		PageSize:         100,
+	}.Build())
+	require.NoError(t, err)
+	kids := make([]string, 0, len(children.GetList()))
+	for _, r := range children.GetList() {
+		kids = append(kids, r.GetId().GetResource())
+	}
+	sort.Strings(kids)
+	require.Equal(t, []string{"a", "z"}, kids)
+
+	stats := b.ComputedStats()
+	require.Equal(t, int64(4), stats.GetResources())
+	require.Equal(t, map[string]int64{"app": 3, "app-x": 1}, stats.GetResourcesByResourceType())
+}
+
 // TestBulkImportMergesDuplicateIdentityGrants pins the merge-and-warn
 // behavior for legacy rows with distinct external ids that fold to one
 // structural identity: the conversion must merge them (like the in-place

--- a/pkg/dotc1z/engine/pebble/deferred_index.go
+++ b/pkg/dotc1z/engine/pebble/deferred_index.go
@@ -18,11 +18,14 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/rawdb"
 )
 
-// deferredIndexSpillChunkBytes is the spill-chunk arena size for the deferred
-// index build's sorters. The shared bulkSpillKeyChunkBytes (8MiB) is sized
-// for the bulk import, where lanes × index-families sorters are alive at once
-// and small arenas bound aggregate memory. The deferred build is the opposite
-// shape — one producer, at most two sorter families, nothing else running —
+// deferredIndexSpillChunkBytes is the spill-chunk arena size for
+// record-carrying and low-fanout sorters. The shared bulkSpillKeyChunkBytes
+// (8MiB) is sized for the bulk import's sharded grant and index sorters,
+// where shards × index-families sorters are alive at once and small arenas
+// bound aggregate memory (the import's single-instance resources and
+// entitlements sorters use this size instead). The deferred build is the
+// opposite shape — one producer, at most two sorter families, nothing else
+// running —
 // and with 8MiB chunks a whale (57M+ index keys ≈ 6.4GB) produced an 801-way
 // final merge: ~10 heap comparisons per entry plus 801 open chunk files with
 // 1MiB readers (~800MB of buffers). 128MiB chunks cut that to ~50 runs.

--- a/pkg/dotc1z/engine/pebble/deferred_index.go
+++ b/pkg/dotc1z/engine/pebble/deferred_index.go
@@ -18,16 +18,19 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/rawdb"
 )
 
-// deferredIndexSpillChunkBytes is the spill-chunk arena size used by every
-// production spill sorter (the deferred build, the bulk import, the synth
-// layer, the digest build, the id-index migration). Chunk size sets the
-// final merge's fan-in — every chunk stays open behind a 1MiB reader for
-// the whole merge — and with 8MiB chunks a whale (57M+ index keys ≈ 6.4GB)
-// produced an 801-way final merge: ~10 heap comparisons per entry plus 801
-// open chunk files (~800MB of buffers). 128MiB chunks cut that to ~50 runs.
-// Large arenas stay affordable because each subsystem pairs them with a
-// bounded spillArenaFreeList and a sort semaphore, and a fresh arena's
-// pages commit only as it fills.
+// deferredIndexSpillChunkBytes is the spill-chunk arena size used by the
+// engine's single-producer spill sorters (the deferred build, the synth
+// layer, the digest build, the id-index migration), and the ceiling for
+// the bulk import's budget-derived size (bulkImportSortBudgetBytes — its
+// sorter count scales with the caller's fan-out, so it cannot use a fixed
+// size). Chunk size sets the final merge's fan-in — every chunk stays
+// open behind a 1MiB reader for the whole merge — and with 8MiB chunks a
+// whale (57M+ index keys ≈ 6.4GB) produced an 801-way final merge: ~10
+// heap comparisons per entry plus 801 open chunk files (~800MB of
+// buffers). 128MiB chunks cut that to ~50 runs. Large arenas stay
+// affordable here because each of these builds has one or two producers,
+// pairs them with a bounded spillArenaFreeList and a sort semaphore, and
+// a fresh arena's pages commit only as it fills.
 //
 // Memory budget (revised for the second family): with the grant digest
 // index enabled the scan feeds TWO sorter families — by_principal

--- a/pkg/dotc1z/engine/pebble/deferred_index.go
+++ b/pkg/dotc1z/engine/pebble/deferred_index.go
@@ -18,17 +18,16 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/rawdb"
 )
 
-// deferredIndexSpillChunkBytes is the spill-chunk arena size for
-// record-carrying and low-fanout sorters. The shared bulkSpillKeyChunkBytes
-// (8MiB) is sized for the bulk import's sharded grant and index sorters,
-// where shards × index-families sorters are alive at once and small arenas
-// bound aggregate memory (the import's single-instance resources and
-// entitlements sorters use this size instead). The deferred build is the
-// opposite shape — one producer, at most two sorter families, nothing else
-// running —
-// and with 8MiB chunks a whale (57M+ index keys ≈ 6.4GB) produced an 801-way
-// final merge: ~10 heap comparisons per entry plus 801 open chunk files with
-// 1MiB readers (~800MB of buffers). 128MiB chunks cut that to ~50 runs.
+// deferredIndexSpillChunkBytes is the spill-chunk arena size used by every
+// production spill sorter (the deferred build, the bulk import, the synth
+// layer, the digest build, the id-index migration). Chunk size sets the
+// final merge's fan-in — every chunk stays open behind a 1MiB reader for
+// the whole merge — and with 8MiB chunks a whale (57M+ index keys ≈ 6.4GB)
+// produced an 801-way final merge: ~10 heap comparisons per entry plus 801
+// open chunk files (~800MB of buffers). 128MiB chunks cut that to ~50 runs.
+// Large arenas stay affordable because each subsystem pairs them with a
+// bounded spillArenaFreeList and a sort semaphore, and a fresh arena's
+// pages commit only as it fills.
 //
 // Memory budget (revised for the second family): with the grant digest
 // index enabled the scan feeds TWO sorter families — by_principal

--- a/pkg/dotc1z/engine/pebble/entitlement_stats_test.go
+++ b/pkg/dotc1z/engine/pebble/entitlement_stats_test.go
@@ -70,7 +70,7 @@ func TestBulkImportComputedStatsEntitlementsByResourceType(t *testing.T) {
 	syncID, err := store.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
 	require.NoError(t, err, "StartNewSync")
 
-	b, err := e.StartBulkSyncImport(ctx, syncID, t.TempDir())
+	b, err := e.StartBulkSyncImport(ctx, syncID, t.TempDir(), 1)
 	require.NoError(t, err, "StartBulkSyncImport")
 	defer b.Abort()
 

--- a/pkg/dotc1z/engine/pebble/fast_path_proof_verification_test.go
+++ b/pkg/dotc1z/engine/pebble/fast_path_proof_verification_test.go
@@ -119,7 +119,7 @@ func TestVerificationBulkImportFinishDisarmsAllFastPathProofs(t *testing.T) {
 	syncID, err := a.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
 	require.NoError(t, err)
 	e := a.PebbleEngine()
-	bulk, err := e.StartBulkSyncImport(ctx, syncID, t.TempDir())
+	bulk, err := e.StartBulkSyncImport(ctx, syncID, t.TempDir(), 1)
 	require.NoError(t, err)
 	defer bulk.Abort()
 

--- a/pkg/dotc1z/engine/pebble/grant_digest_build.go
+++ b/pkg/dotc1z/engine/pebble/grant_digest_build.go
@@ -376,7 +376,7 @@ func mergeGrantHashChunksToSST(ctx context.Context, fs vfs.FS, sstPath, name str
 	for len(*h) > 0 {
 		item := h.pop()
 		if bytes.Equal(item.key, last) {
-			return fmt.Errorf("%w: bucket %s key %x", errBulkImportDuplicateKey, name, item.key)
+			return fmt.Errorf("%w: bucket %s key %x", ErrBulkImportDuplicateKey, name, item.key)
 		}
 		partition, bucket, ok := splitGrantHashIndexKey(item.key)
 		if !ok {

--- a/pkg/dotc1z/engine/pebble/grant_digest_build.go
+++ b/pkg/dotc1z/engine/pebble/grant_digest_build.go
@@ -1,13 +1,11 @@
 package pebble
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"runtime"
 	"time"
@@ -345,30 +343,19 @@ func splitGrantHashIndexKey(key []byte) ([]byte, uint16, bool) {
 func mergeGrantHashChunksToSST(ctx context.Context, fs vfs.FS, sstPath, name string, chunks []string, fold *grantDigestFold) error {
 	start := time.Now()
 	l := ctxzap.Extract(ctx)
-	readers := make([]*os.File, 0, len(chunks))
-	defer func() {
-		for _, r := range readers {
-			_ = r.Close()
-		}
-	}()
-	bufReaders := make([]*bufio.Reader, len(chunks))
-	keyBufs := make([][]byte, len(chunks))
-	valBufs := make([][]byte, len(chunks))
+	cursors, err := openSpillChunks(chunks)
+	if err != nil {
+		return err
+	}
+	defer cursors.closeAll()
 	h := &spillChunkHeap{}
-	var lenBuf [4]byte
-	for i, chunk := range chunks {
-		f, err := os.Open(chunk) // #nosec G304 - staged under the build's MkdirTemp dir.
-		if err != nil {
-			return err
-		}
-		readers = append(readers, f)
-		bufReaders[i] = bufio.NewReaderSize(f, bulkSpillBufferSize)
-		ok, err := readSpillEntry(bufReaders[i], &keyBufs[i], &valBufs[i], &lenBuf)
+	for i := range chunks {
+		ok, err := cursors.advance(i)
 		if err != nil {
 			return err
 		}
 		if ok {
-			h.push(spillChunkItem{chunkIdx: i, key: keyBufs[i], val: valBufs[i]})
+			h.push(spillChunkItem{chunkIdx: i, key: cursors.key(i), val: cursors.val(i)})
 		}
 	}
 
@@ -419,12 +406,12 @@ func mergeGrantHashChunksToSST(ctx context.Context, fs vfs.FS, sstPath, name str
 			}
 		}
 		last = append(last[:0], item.key...)
-		ok, err := readSpillEntry(bufReaders[item.chunkIdx], &keyBufs[item.chunkIdx], &valBufs[item.chunkIdx], &lenBuf)
+		ok, err := cursors.advance(item.chunkIdx)
 		if err != nil {
 			return err
 		}
 		if ok {
-			h.push(spillChunkItem{chunkIdx: item.chunkIdx, key: keyBufs[item.chunkIdx], val: valBufs[item.chunkIdx]})
+			h.push(spillChunkItem{chunkIdx: item.chunkIdx, key: cursors.key(item.chunkIdx), val: cursors.val(item.chunkIdx)})
 		}
 	}
 	if err := writer.finish(); err != nil {

--- a/pkg/dotc1z/engine/pebble/grants.go
+++ b/pkg/dotc1z/engine/pebble/grants.go
@@ -564,8 +564,10 @@ func (e *Engine) initSynthLayerSession(ctx context.Context, s *synthGrantLayerSe
 }
 
 // ingestSynthLayerSegment merges one segment's sorted chunks into an SST and
-// ingests it. Chunk files are deleted once merged; the SST path is left for
-// the session's final dir cleanup (Pebble links/copies it on ingest).
+// ingests it. The merge unlinks each chunk as it drains it, so nothing is
+// left to clean up here on success; a merge that fails partway leaves its
+// remaining chunks to the session's final dir cleanup, which also keeps the
+// SST path (Pebble links/copies it on ingest).
 //
 // Runs on the session's background worker, which deliberately bypasses the
 // engine write barrier (an Add holding writeMu can block on the bounded
@@ -580,9 +582,6 @@ func (e *Engine) ingestSynthLayerSegment(ctx context.Context, dir string, seg sy
 	sstPath := filepath.Join(dir, seg.name+".sst")
 	if err := mergeSortedSpillChunksToSST(ctx, e.fs(), sstPath, seg.name, seg.chunks); err != nil {
 		return err
-	}
-	for _, chunk := range seg.chunks {
-		_ = os.Remove(chunk)
 	}
 	e.checkpointMu.RLock()
 	defer e.checkpointMu.RUnlock()

--- a/pkg/dotc1z/engine/pebble/grants.go
+++ b/pkg/dotc1z/engine/pebble/grants.go
@@ -566,8 +566,8 @@ func (e *Engine) initSynthLayerSession(ctx context.Context, s *synthGrantLayerSe
 // ingestSynthLayerSegment merges one segment's sorted chunks into an SST and
 // ingests it. The merge unlinks each chunk as it drains it, so nothing is
 // left to clean up here on success; a merge that fails partway leaves its
-// remaining chunks to the session's final dir cleanup, which also keeps the
-// SST path (Pebble links/copies it on ingest).
+// remaining chunks to the session's final dir cleanup. The SST path is also
+// left to that cleanup (Pebble links/copies it on ingest).
 //
 // Runs on the session's background worker, which deliberately bypasses the
 // engine write barrier (an Add holding writeMu can block on the bounded

--- a/pkg/dotc1z/engine/pebble/id_index_migration.go
+++ b/pkg/dotc1z/engine/pebble/id_index_migration.go
@@ -1,11 +1,9 @@
 package pebble
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"sort"
 	"time"
@@ -281,30 +279,19 @@ func finalizeGrantPrimaryMigrationSorter(ctx context.Context, fs vfs.FS, dir, na
 }
 
 func mergeGrantPrimaryMigrationChunksToSST(ctx context.Context, fs vfs.FS, sstPath, name string, chunks []string, byPrincipal, byNeedsExpansion *spillSorter) error {
-	readers := make([]*os.File, 0, len(chunks))
-	defer func() {
-		for _, r := range readers {
-			_ = r.Close()
-		}
-	}()
-	bufReaders := make([]*bufio.Reader, len(chunks))
-	keyBufs := make([][]byte, len(chunks))
-	valBufs := make([][]byte, len(chunks))
+	cursors, err := openSpillChunks(chunks)
+	if err != nil {
+		return err
+	}
+	defer cursors.closeAll()
 	h := &spillChunkHeap{}
-	var lenBuf [4]byte
-	for i, chunk := range chunks {
-		f, err := os.Open(chunk) // #nosec G304 - staged under migration temp dir.
-		if err != nil {
-			return err
-		}
-		readers = append(readers, f)
-		bufReaders[i] = bufio.NewReaderSize(f, bulkSpillBufferSize)
-		ok, err := readSpillEntry(bufReaders[i], &keyBufs[i], &valBufs[i], &lenBuf)
+	for i := range chunks {
+		ok, err := cursors.advance(i)
 		if err != nil {
 			return err
 		}
 		if ok {
-			h.push(spillChunkItem{chunkIdx: i, key: append([]byte(nil), keyBufs[i]...), val: append([]byte(nil), valBufs[i]...)})
+			h.push(spillChunkItem{chunkIdx: i, key: append([]byte(nil), cursors.key(i)...), val: append([]byte(nil), cursors.val(i)...)})
 		}
 	}
 
@@ -336,13 +323,13 @@ func mergeGrantPrimaryMigrationChunksToSST(ctx context.Context, fs vfs.FS, sstPa
 		first := h.pop()
 		key := first.key
 		values := [][]byte{first.val}
-		if err := advanceMigrationChunk(h, bufReaders, keyBufs, valBufs, &lenBuf, first.chunkIdx); err != nil {
+		if err := advanceMigrationChunk(h, cursors, first.chunkIdx); err != nil {
 			return err
 		}
 		for len(*h) > 0 && bytes.Equal((*h)[0].key, key) {
 			item := h.pop()
 			values = append(values, item.val)
-			if err := advanceMigrationChunk(h, bufReaders, keyBufs, valBufs, &lenBuf, item.chunkIdx); err != nil {
+			if err := advanceMigrationChunk(h, cursors, item.chunkIdx); err != nil {
 				return err
 			}
 		}
@@ -406,13 +393,13 @@ func mergeGrantPrimaryMigrationChunksToSST(ctx context.Context, fs vfs.FS, sstPa
 	return nil
 }
 
-func advanceMigrationChunk(h *spillChunkHeap, readers []*bufio.Reader, keyBufs, valBufs [][]byte, lenBuf *[4]byte, idx int) error {
-	ok, err := readSpillEntry(readers[idx], &keyBufs[idx], &valBufs[idx], lenBuf)
+func advanceMigrationChunk(h *spillChunkHeap, cursors *spillChunkCursors, idx int) error {
+	ok, err := cursors.advance(idx)
 	if err != nil {
 		return err
 	}
 	if ok {
-		h.push(spillChunkItem{chunkIdx: idx, key: append([]byte(nil), keyBufs[idx]...), val: append([]byte(nil), valBufs[idx]...)})
+		h.push(spillChunkItem{chunkIdx: idx, key: append([]byte(nil), cursors.key(idx)...), val: append([]byte(nil), cursors.val(idx)...)})
 	}
 	return nil
 }

--- a/pkg/dotc1z/engine/pebble/id_index_migration.go
+++ b/pkg/dotc1z/engine/pebble/id_index_migration.go
@@ -30,11 +30,11 @@ func (e *Engine) migrateIDIndexFormatToStructuredV1(ctx context.Context) error {
 	defer e.removeStagingDir(dir)
 
 	sortSem := make(chan struct{}, 4)
-	// 128MiB chunks (deferredIndexSpillChunkBytes), not the bulk import's
-	// 8MiB: the merge holds a 1MiB read buffer per chunk, so chunk size
-	// bounds the fan-in. At 8MiB a 150M-grant file would merge ~4,000
-	// chunks (~4GB of buffers); at 128MiB it stays in the low hundreds.
-	// The arena freelist recycles the big chunks across all four sorters.
+	// 128MiB chunks (deferredIndexSpillChunkBytes): the merge holds a
+	// 1MiB read buffer per chunk, so chunk size bounds the fan-in. At
+	// 8MiB a 150M-grant file would merge ~4,000 chunks (~4GB of
+	// buffers); at 128MiB it stays in the low hundreds. The arena
+	// freelist recycles the big chunks across all four sorters.
 	arenaFree := newSpillArenaFreeList(deferredIndexSpillChunkBytes, 6)
 	grantPrimary := newSpillSorter(dir, "grant-primary", sortSem, deferredIndexSpillChunkBytes)
 	entitlementPrimary := newSpillSorter(dir, "entitlement-primary", sortSem, deferredIndexSpillChunkBytes)

--- a/pkg/dotc1z/engine/pebble/os_io_allowlist_test.go
+++ b/pkg/dotc1z/engine/pebble/os_io_allowlist_test.go
@@ -59,17 +59,8 @@ var allowedOSFileIO = map[string]map[string]string{
 	},
 	"bulk_import.go": {
 		"Create": "writeSortedSpillChunk: spill-chunk scratch is engine-private; only readSpillEntry reads it back, never the DB",
-		"Open":   "spill-chunk merge readers (engine-private scratch, see Create)",
-		"Remove": "failed spill-chunk cleanup (engine-private scratch)",
-	},
-	"grants.go": {
-		"Remove": "ingestSynthLayerSegment deletes merged spill chunks (engine-private scratch)",
-	},
-	"grant_digest_build.go": {
-		"Open": "spill-chunk merge readers (engine-private scratch)",
-	},
-	"id_index_migration.go": {
-		"Open": "spill-chunk merge readers (engine-private scratch)",
+		"Open":   "openSpillChunks: the one place any merge opens spill chunks (engine-private scratch, see Create)",
+		"Remove": "spill-chunk release on exhaustion + failed-chunk cleanup (engine-private scratch)",
 	},
 	"adapter_clone_sync.go": {
 		"Stat":      "clone-sync writes a v3 envelope to a caller-supplied host path; the whole save path is host IO by contract (out of engine-FS scope, like the store layer's envelope save)",

--- a/pkg/dotc1z/engine/pebble/source_scope_gate_verification_test.go
+++ b/pkg/dotc1z/engine/pebble/source_scope_gate_verification_test.go
@@ -366,7 +366,7 @@ func TestVerificationBulkImportFinishReprobesSourceScopeGate(t *testing.T) {
 	require.NoError(t, raw.Set(encodeGrantIdentityKey(id), val, nil))
 	require.NoError(t, raw.Set(encodeGrantBySourceScopeIndexKey(scopeA, id), nil, nil))
 
-	bulk, err := e.StartBulkSyncImport(ctx, syncID, t.TempDir())
+	bulk, err := e.StartBulkSyncImport(ctx, syncID, t.TempDir(), 1)
 	require.NoError(t, err)
 	defer bulk.Abort()
 	require.NoError(t, bulk.AddResourceTypes(ctx, v2.ResourceType_builder{Id: "group"}.Build()))

--- a/pkg/dotc1z/engine/pebble/spill_merge_test.go
+++ b/pkg/dotc1z/engine/pebble/spill_merge_test.go
@@ -128,7 +128,7 @@ func TestMergeSortedSpillChunksRejectsDuplicateAcrossChunks(t *testing.T) {
 	}
 
 	err := mergeSortedSpillChunksToSST(ctx, e.fs(), filepath.Join(dir, "dup.sst"), "dup", chunks)
-	require.ErrorIs(t, err, errBulkImportDuplicateKey)
+	require.ErrorIs(t, err, ErrBulkImportDuplicateKey)
 }
 
 // TestMergeSpillChunksResolvingDuplicatesAcrossChunks pins the

--- a/pkg/dotc1z/engine/pebble/spill_merge_test.go
+++ b/pkg/dotc1z/engine/pebble/spill_merge_test.go
@@ -2,23 +2,34 @@ package pebble
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/pebble/v2"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
 )
 
 // The spill merges only interleave once a sorter has cut more than one
 // chunk, which needs bulkSpillKeyChunkBytes (8MiB) or
-// deferredIndexSpillChunkBytes (128MiB) of keys — more than any test in
-// this package drives through them. These tests therefore build the sorted
-// runs directly with writeSortedSpillChunk, which is what the sorter's
-// background goroutine calls, and hand them to the real merges. That is
-// the only coverage of multi-chunk exhaustion, of the k-way interleave
-// itself, and of the release-on-exhaustion behavior in spillChunkCursors.
+// deferredIndexSpillChunkBytes (128MiB) of keys — far more than a test
+// wants to write. These tests therefore build the sorted runs directly
+// with writeSortedSpillChunk, which is what the sorter's background
+// goroutine calls, and hand them to the real merges.
+//
+// TestGrantDigestSpillMerge reaches the same paths from the other side, by
+// forcing a 512-byte chunk size through a real digest build, and so also
+// covers multi-chunk exhaustion and the k-way interleave (and, since the
+// digest merge moved onto spillChunkCursors, release-on-exhaustion). What
+// is only covered here is spillChunkCursors itself and the merges the
+// digest build does not run.
 
 type spillKV struct{ k, v string }
 
@@ -152,6 +163,118 @@ func TestMergeSpillChunksResolvingDuplicatesAcrossChunks(t *testing.T) {
 	require.Equal(t, []spillKV{
 		{k("a"), "a0"}, {k("dup"), "d0+d1+d2"}, {k("z"), "z0"},
 	}, ingestAndDump(t, e, sstPath))
+}
+
+// TestMergeGrantPrimaryMigrationChunksFoldsAcrossChunks covers the merge
+// with the densest advance pattern: advanceMigrationChunk fires once for a
+// duplicate group's leader and again for every same-key follower popped
+// inside the inner loop, so one group can drain several chunks. The
+// existing TestIDIndexMigrationSemantics drives this merge end to end
+// through Open, but with few enough rows to fit a single chunk, so the
+// cross-chunk fold was never exercised. It is worth pinning here rather
+// than elsewhere because this merge runs on the open-time id-index
+// migration, and a row dropped or double-counted by it stays sorted —
+// bulkSSTWriter.add would not notice — and is written into the c1z.
+//
+// The rows are laid out globally sorted and then dealt round-robin, which
+// keeps every chunk internally sorted while guaranteeing the duplicate
+// group spans three of them.
+func TestMergeGrantPrimaryMigrationChunksFoldsAcrossChunks(t *testing.T) {
+	ctx := context.Background()
+	e, dir := newTestEngine(t)
+	chunkDir := t.TempDir()
+
+	older := timestamppb.New(time.Unix(1000, 0).UTC())
+	middle := timestamppb.New(time.Unix(2000, 0).UTC())
+	newer := timestamppb.New(time.Unix(3000, 0).UTC())
+
+	mkRow := func(externalID, entResourceID, entID, principalID string, needsExpansion bool, at *timestamppb.Timestamp) (string, []byte) {
+		rec := v3.GrantRecord_builder{
+			ExternalId: externalID,
+			Entitlement: v3.EntitlementRef_builder{
+				ResourceTypeId: "group", ResourceId: entResourceID, EntitlementId: entID,
+			}.Build(),
+			Principal:      v3.PrincipalRef_builder{ResourceTypeId: "user", ResourceId: principalID}.Build(),
+			DiscoveredAt:   at,
+			NeedsExpansion: needsExpansion,
+		}.Build()
+		id, err := grantIdentityFromRecord(rec)
+		require.NoError(t, err)
+		val, err := marshalRecord(rec)
+		require.NoError(t, err)
+		return string(encodeGrantIdentityKey(id)), val
+	}
+
+	// Three rows with distinct external ids folding to one identity: the
+	// merged row must keep the earliest-discovered external id and OR the
+	// needs_expansion flags. Plus three singleton identities.
+	rows := make([]spillKV, 0, 6)
+	for _, r := range []struct {
+		extID, entRID, entID, principal string
+		needsExpansion                  bool
+		at                              *timestamppb.Timestamp
+	}{
+		{"dup-a", "g1", "member", "u1", false, newer},
+		{"dup-b", "g1", "member", "u1", false, older},
+		{"dup-c", "g1", "member", "u1", true, middle},
+		{"solo-u2", "g1", "member", "u2", false, older},
+		{"solo-u3", "g1", "member", "u3", true, older},
+		{"solo-g2", "g2", "admin", "u1", false, older},
+	} {
+		k, v := mkRow(r.extID, r.entRID, r.entID, r.principal, r.needsExpansion, r.at)
+		rows = append(rows, spillKV{k: k, v: string(v)})
+	}
+	sort.SliceStable(rows, func(i, j int) bool { return rows[i].k < rows[j].k })
+
+	dealt := make([][]spillKV, 3)
+	for i, r := range rows {
+		dealt[i%3] = append(dealt[i%3], r)
+	}
+	chunks := make([]string, 0, len(dealt))
+	dupKey, _ := mkRow("dup-a", "g1", "member", "u1", false, newer)
+	var chunksHoldingDup int
+	for i, entries := range dealt {
+		for _, kv := range entries {
+			if kv.k == dupKey {
+				chunksHoldingDup++
+				break
+			}
+		}
+		chunks = append(chunks, writeTestSpillChunk(t, chunkDir, fmt.Sprintf("grant-primary-%d", i), entries))
+	}
+	// Everything below only tests the cross-chunk fold if the deal actually
+	// split the group; a key-order change upstream could quietly undo that.
+	require.Equal(t, 3, chunksHoldingDup, "duplicate group must span all three chunks")
+
+	sem := make(chan struct{}, 2)
+	byPrincipal := newSpillSorter(chunkDir, "idx-by-principal", sem, bulkSpillKeyChunkBytes)
+	byNeedsExpansion := newSpillSorter(chunkDir, "idx-by-needs-expansion", sem, bulkSpillKeyChunkBytes)
+
+	sstPath := filepath.Join(dir, "grant-primary.sst")
+	require.NoError(t, mergeGrantPrimaryMigrationChunksToSST(ctx, e.fs(), sstPath, "grant-primary", chunks, byPrincipal, byNeedsExpansion))
+	requireChunksReleased(t, chunks)
+
+	require.NoError(t, e.IngestSSTs(ctx, []string{sstPath}))
+	got := map[string]*v3.GrantRecord{}
+	require.NoError(t, e.IterateGrants(ctx, func(r *v3.GrantRecord) bool {
+		got[r.GetExternalId()] = r
+		return true
+	}))
+
+	// Four identities in, four rows out: the three duplicates folded and
+	// nothing was dropped on the way through three chunks.
+	require.Len(t, got, 4)
+	require.Contains(t, got, "dup-b", "fold must keep the earliest-discovered external id")
+	require.NotContains(t, got, "dup-a")
+	require.NotContains(t, got, "dup-c")
+	require.True(t, got["dup-b"].GetNeedsExpansion(), "needs_expansion ORs across the group, including the follower in a later chunk")
+	require.False(t, got["solo-u2"].GetNeedsExpansion())
+
+	// The derived indexes must be emitted per folded identity, not per
+	// input row — one entry per duplicate would leave rows dangling against
+	// a primary that no longer has them.
+	require.Equal(t, int64(4), byPrincipal.count, "by_principal must be one key per folded identity")
+	require.Equal(t, int64(2), byNeedsExpansion.count, "by_needs_expansion covers the folded dup group and solo-u3")
 }
 
 // TestSpillChunkCursorsAdvancePastExhaustion pins that advancing a drained

--- a/pkg/dotc1z/engine/pebble/spill_merge_test.go
+++ b/pkg/dotc1z/engine/pebble/spill_merge_test.go
@@ -254,6 +254,19 @@ func TestMergeGrantPrimaryMigrationChunksFoldsAcrossChunks(t *testing.T) {
 	require.NoError(t, mergeGrantPrimaryMigrationChunksToSST(ctx, e.fs(), sstPath, "grant-primary", chunks, byPrincipal, byNeedsExpansion))
 	requireChunksReleased(t, chunks)
 
+	// Close the index sinks the way production does. teardown() documents
+	// why this has to happen before the staging dir goes away: a chunk sort
+	// racing the removal can re-create a file mid-walk. finalize rather
+	// than abort because it cuts the pending arena and so actually
+	// dispatches the background sort this waits for — abort would leave
+	// these sorters having never spawned one, and the wait would stay a
+	// no-op however far the fixture grew.
+	idxChunks, err := byPrincipal.finalize()
+	require.NoError(t, err)
+	require.NotEmpty(t, idxChunks, "finalize must flush the tail chunk")
+	_, err = byNeedsExpansion.finalize()
+	require.NoError(t, err)
+
 	require.NoError(t, e.IngestSSTs(ctx, []string{sstPath}))
 	got := map[string]*v3.GrantRecord{}
 	require.NoError(t, e.IterateGrants(ctx, func(r *v3.GrantRecord) bool {

--- a/pkg/dotc1z/engine/pebble/spill_merge_test.go
+++ b/pkg/dotc1z/engine/pebble/spill_merge_test.go
@@ -1,0 +1,187 @@
+package pebble
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// The spill merges only interleave once a sorter has cut more than one
+// chunk, which needs bulkSpillKeyChunkBytes (8MiB) or
+// deferredIndexSpillChunkBytes (128MiB) of keys — more than any test in
+// this package drives through them. These tests therefore build the sorted
+// runs directly with writeSortedSpillChunk, which is what the sorter's
+// background goroutine calls, and hand them to the real merges. That is
+// the only coverage of multi-chunk exhaustion, of the k-way interleave
+// itself, and of the release-on-exhaustion behavior in spillChunkCursors.
+
+type spillKV struct{ k, v string }
+
+// writeTestSpillChunk lays entries into an arena the way spillSorter.add
+// does and flushes them as one sorted run. Entries must already be in key
+// order: writeSortedSpillChunk preserves the order it is given, and the
+// sorter is what sorts.
+func writeTestSpillChunk(t *testing.T, dir, name string, entries []spillKV) string {
+	t.Helper()
+	var arena []byte
+	views := make([]kvView, 0, len(entries))
+	for _, e := range entries {
+		off := len(arena)
+		arena = append(arena, e.k...)
+		arena = append(arena, e.v...)
+		views = append(views, kvView{keyOff: off, keyEnd: off + len(e.k), valEnd: off + len(e.k) + len(e.v)})
+	}
+	path := filepath.Join(dir, name+".bin")
+	require.NoError(t, writeSortedSpillChunk(path, arena, views), "writeSortedSpillChunk %s", name)
+	return path
+}
+
+// ingestAndDump ingests the merged SST and reads every key back. Keys in
+// these tests are prefixed 0xFE so they cannot collide with a real family.
+func ingestAndDump(t *testing.T, e *Engine, sstPath string) []spillKV {
+	t.Helper()
+	ctx := context.Background()
+	require.NoError(t, e.IngestSSTs(ctx, []string{sstPath}), "IngestSSTs")
+	iter, err := e.db.NewIter(&pebble.IterOptions{
+		LowerBound: []byte{0xFE},
+		UpperBound: []byte{0xFF},
+	})
+	require.NoError(t, err)
+	defer iter.Close()
+	var got []spillKV
+	for iter.First(); iter.Valid(); iter.Next() {
+		got = append(got, spillKV{k: string(iter.Key()), v: string(iter.Value())})
+	}
+	require.NoError(t, iter.Error())
+	return got
+}
+
+func requireChunksReleased(t *testing.T, chunks []string) {
+	t.Helper()
+	for _, c := range chunks {
+		_, err := os.Stat(c)
+		require.Truef(t, os.IsNotExist(err), "chunk %s should have been unlinked by the merge, stat err = %v", c, err)
+	}
+}
+
+// TestMergeSortedSpillChunksInterleavesAndReleases drives the strict merge
+// across chunks that run dry at different points — one empty, one
+// single-entry, two staggered — and pins both halves of the contract: the
+// SST is the full sorted union, and every chunk is unlinked by the time
+// the merge returns. A successful merge also proves the interleave is
+// globally ordered on its own, because bulkSSTWriter.add rejects any key
+// that is not strictly greater than the last.
+func TestMergeSortedSpillChunksInterleavesAndReleases(t *testing.T) {
+	ctx := context.Background()
+	e, dir := newTestEngine(t)
+	chunkDir := t.TempDir()
+
+	k := func(s string) string { return "\xfe" + s }
+	chunks := []string{
+		// Empty: exhausts on its very first advance, before the heap is built.
+		writeTestSpillChunk(t, chunkDir, "c0", nil),
+		writeTestSpillChunk(t, chunkDir, "c1", []spillKV{{k("b"), "vb"}}),
+		writeTestSpillChunk(t, chunkDir, "c2", []spillKV{{k("a"), "va"}, {k("d"), "vd"}, {k("g"), "vg"}}),
+		// Trailing empty value: the merge maps len 0 to a nil value.
+		writeTestSpillChunk(t, chunkDir, "c3", []spillKV{{k("c"), "vc"}, {k("e"), "ve"}, {k("f"), "vf"}, {k("h"), ""}}),
+	}
+
+	sstPath := filepath.Join(dir, "merged.sst")
+	require.NoError(t, mergeSortedSpillChunksToSST(ctx, e.fs(), sstPath, "merged", chunks))
+	requireChunksReleased(t, chunks)
+
+	require.Equal(t, []spillKV{
+		{k("a"), "va"}, {k("b"), "vb"}, {k("c"), "vc"}, {k("d"), "vd"},
+		{k("e"), "ve"}, {k("f"), "vf"}, {k("g"), "vg"}, {k("h"), ""},
+	}, ingestAndDump(t, e, sstPath))
+}
+
+// TestMergeSortedSpillChunksRejectsDuplicateAcrossChunks pins that a
+// duplicate key is still corruption when the two copies live in different
+// runs — which is the only way the k-way path can see one, and a shape a
+// single-chunk test cannot produce.
+func TestMergeSortedSpillChunksRejectsDuplicateAcrossChunks(t *testing.T) {
+	ctx := context.Background()
+	e, dir := newTestEngine(t)
+	chunkDir := t.TempDir()
+
+	k := func(s string) string { return "\xfe" + s }
+	chunks := []string{
+		writeTestSpillChunk(t, chunkDir, "c0", []spillKV{{k("a"), "v1"}, {k("dup"), "v2"}}),
+		writeTestSpillChunk(t, chunkDir, "c1", []spillKV{{k("dup"), "v3"}, {k("z"), "v4"}}),
+	}
+
+	err := mergeSortedSpillChunksToSST(ctx, e.fs(), filepath.Join(dir, "dup.sst"), "dup", chunks)
+	require.ErrorIs(t, err, errBulkImportDuplicateKey)
+}
+
+// TestMergeSpillChunksResolvingDuplicatesAcrossChunks pins the
+// duplicate-tolerant variant on the same cross-chunk shape: every copy of
+// a key reaches resolve, in a group assembled from more than one run, and
+// the chunks are still released.
+func TestMergeSpillChunksResolvingDuplicatesAcrossChunks(t *testing.T) {
+	ctx := context.Background()
+	e, dir := newTestEngine(t)
+	chunkDir := t.TempDir()
+
+	k := func(s string) string { return "\xfe" + s }
+	chunks := []string{
+		writeTestSpillChunk(t, chunkDir, "c0", []spillKV{{k("a"), "a0"}, {k("dup"), "d0"}}),
+		writeTestSpillChunk(t, chunkDir, "c1", []spillKV{{k("dup"), "d1"}, {k("z"), "z0"}}),
+		writeTestSpillChunk(t, chunkDir, "c2", []spillKV{{k("dup"), "d2"}}),
+	}
+
+	sstPath := filepath.Join(dir, "resolved.sst")
+	dupGroups, err := mergeSpillChunksToSSTResolvingDuplicates(ctx, e.fs(), sstPath, "resolved", chunks,
+		func(_ []byte, values [][]byte) ([]byte, error) {
+			parts := make([]string, 0, len(values))
+			for _, v := range values {
+				parts = append(parts, string(v))
+			}
+			return []byte(strings.Join(parts, "+")), nil
+		})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), dupGroups)
+	requireChunksReleased(t, chunks)
+
+	require.Equal(t, []spillKV{
+		{k("a"), "a0"}, {k("dup"), "d0+d1+d2"}, {k("z"), "z0"},
+	}, ingestAndDump(t, e, sstPath))
+}
+
+// TestSpillChunkCursorsAdvancePastExhaustion pins that advancing a drained
+// chunk keeps reporting false. The merges only re-push a chunk after a
+// true, so none of them reach this today, but releasing the chunk nils the
+// reader and the inline readSpillEntry calls this replaced were idempotent
+// at EOF — this keeps that true for the merges now sharing the cursor.
+func TestSpillChunkCursorsAdvancePastExhaustion(t *testing.T) {
+	chunkDir := t.TempDir()
+	chunks := []string{
+		writeTestSpillChunk(t, chunkDir, "c0", []spillKV{{"k1", "v1"}}),
+		writeTestSpillChunk(t, chunkDir, "c1", nil),
+	}
+	cursors, err := openSpillChunks(chunks)
+	require.NoError(t, err)
+	defer cursors.closeAll()
+
+	ok, err := cursors.advance(0)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "k1", string(cursors.key(0)))
+
+	// Draining chunk 0 releases it; chunk 1 was empty and releases on its
+	// first advance. Both must keep answering false rather than faulting.
+	for _, idx := range []int{0, 1} {
+		for range 3 {
+			ok, err := cursors.advance(idx)
+			require.NoError(t, err)
+			require.False(t, ok)
+		}
+	}
+	requireChunksReleased(t, chunks)
+}

--- a/pkg/dotc1z/engine/pebble/spill_merge_test.go
+++ b/pkg/dotc1z/engine/pebble/spill_merge_test.go
@@ -209,6 +209,7 @@ func TestMergeGrantPrimaryMigrationChunksFoldsAcrossChunks(t *testing.T) {
 	// merged row must keep the earliest-discovered external id and OR the
 	// needs_expansion flags. Plus three singleton identities.
 	rows := make([]spillKV, 0, 6)
+	var dupKey string
 	for _, r := range []struct {
 		extID, entRID, entID, principal string
 		needsExpansion                  bool
@@ -222,6 +223,9 @@ func TestMergeGrantPrimaryMigrationChunksFoldsAcrossChunks(t *testing.T) {
 		{"solo-g2", "g2", "admin", "u1", false, older},
 	} {
 		k, v := mkRow(r.extID, r.entRID, r.entID, r.principal, r.needsExpansion, r.at)
+		if r.extID == "dup-a" {
+			dupKey = k
+		}
 		rows = append(rows, spillKV{k: k, v: string(v)})
 	}
 	sort.SliceStable(rows, func(i, j int) bool { return rows[i].k < rows[j].k })
@@ -231,7 +235,6 @@ func TestMergeGrantPrimaryMigrationChunksFoldsAcrossChunks(t *testing.T) {
 		dealt[i%3] = append(dealt[i%3], r)
 	}
 	chunks := make([]string, 0, len(dealt))
-	dupKey, _ := mkRow("dup-a", "g1", "member", "u1", false, newer)
 	var chunksHoldingDup int
 	for i, entries := range dealt {
 		for _, kv := range entries {

--- a/pkg/dotc1z/engine/pebble/spill_merge_test.go
+++ b/pkg/dotc1z/engine/pebble/spill_merge_test.go
@@ -18,9 +18,9 @@ import (
 )
 
 // The spill merges only interleave once a sorter has cut more than one
-// chunk, which needs bulkSpillKeyChunkBytes (8MiB) or
-// deferredIndexSpillChunkBytes (128MiB) of keys — far more than a test
-// wants to write. These tests therefore build the sorted runs directly
+// chunk, which needs deferredIndexSpillChunkBytes (128MiB) of keys — far
+// more than a test wants to write. These tests therefore build the sorted
+// runs directly
 // with writeSortedSpillChunk, which is what the sorter's background
 // goroutine calls, and hand them to the real merges.
 //

--- a/pkg/dotc1z/to_pebble.go
+++ b/pkg/dotc1z/to_pebble.go
@@ -108,9 +108,12 @@ func WithConvertTmpDir(dir string) ConvertOption {
 // goroutine). The default — min(4, GOMAXPROCS/2) — leaves headroom for
 // shared infrastructure; callers that own the machine can raise it, and
 // 1 fully serializes the grant scan. Values <= 0 are ignored. Memory
-// scales with fan-out: each lane also pins up to three 128MiB spill
-// arenas (its grant sorter plus two index sorters — see the bulk
-// import's arenaFree), so budget ~384MiB of sort memory per lane.
+// scales with fan-out: each lane pins up to three 128MiB spill arenas
+// (its grant sorter plus two index sorters), and the import's three
+// lane-independent sorters (resources, entitlements, parent index) pin
+// another ~384MiB alongside the scan since none finalize until Finish —
+// so budget ~384MiB × (lanes + 1) of sort memory (see the bulk import's
+// arenaFree).
 func WithConvertParallelism(n int) ConvertOption {
 	return func(c *convertConfig) {
 		if n > 0 {

--- a/pkg/dotc1z/to_pebble.go
+++ b/pkg/dotc1z/to_pebble.go
@@ -109,11 +109,14 @@ func WithConvertTmpDir(dir string) ConvertOption {
 // shared infrastructure; callers that own the machine can raise it, and
 // 1 fully serializes the grant scan. Values <= 0 are ignored.
 //
-// Sort memory does not scale with fan-out: the bulk import sizes its
-// spill chunks from a fixed budget divided by the arena count the lane
-// count implies (see pebble's bulkImportSortBudgetBytes), so more lanes
-// mean smaller chunks and a wider final merge — more open chunk files
-// and read buffers at Finish — rather than more RSS during the scan.
+// Sort memory is budgeted, not proportional to fan-out, up to a point:
+// the bulk import sizes its spill chunks from a fixed budget divided by
+// the arena count the lane count implies (see pebble's
+// bulkImportSortBudgetBytes), so up to ~14 lanes more lanes mean smaller
+// chunks and a wider final merge — more open chunk files and read buffers
+// at Finish — rather than more RSS during the scan. Past that the chunk
+// size hits its 16MiB floor and sort memory grows again, by roughly four
+// 16MiB arenas per additional lane.
 func WithConvertParallelism(n int) ConvertOption {
 	return func(c *convertConfig) {
 		if n > 0 {
@@ -177,17 +180,23 @@ type syncIDPreservingStarter interface {
 // .c1z written to outPath, which must not already exist.
 //
 // It uses the engine's BulkSyncImport SST fast path: each record table is
-// streamed out of SQLite once, in primary-key order via `ORDER BY` on the
-// key's tuple columns (SQLite BINARY collation is bytewise, and the engine's
-// tuple key codec is order-preserving, so SQL order == encoded-key order —
-// enforced at runtime by the importer's strictly-increasing check). Primary
-// records stream straight into one sorted SST per bucket; secondary index
-// keys are derived from the translated records and externally sorted into
-// one index SST; everything is ingested in a single pebble Ingest. No
-// memtable, no WAL, no L0 flush, no background compaction debt.
+// streamed out of SQLite once. Resource types are scanned in primary-key
+// order via `ORDER BY` on the key column (SQLite BINARY collation is
+// bytewise and the engine's tuple key codec is order-preserving, so SQL
+// order == encoded-key order — enforced at runtime by the importer's
+// strictly-increasing check) and stream straight into one sorted SST.
+// Resources, entitlements, and grants are keyed by tuples whose order the
+// scan cannot cheaply reproduce, so the importer spill-sorts them (and the
+// secondary index keys derived from them) into sorted runs and k-way
+// merges each family into one SST at Finish; everything is ingested in a
+// single pebble Ingest. No memtable, no WAL, no L0 flush, no background
+// compaction debt.
 //
 // SQLite's UNIQUE(external_id, sync_id) indexes provide the no-duplicates
-// guarantee the importer requires.
+// guarantee the importer requires for resource types, resources, and
+// entitlements. Grants are keyed by structural identity (entitlement +
+// principal refs), which that index does not cover; legacy rows sharing an
+// identity under distinct external ids fold at Finish with a warning.
 //
 // syncID selects the source sync to convert; the destination holds that one
 // sync and nothing else, so every other sync in the source is dropped. Those
@@ -829,13 +838,13 @@ type rawGrantRow struct {
 
 // convertGrants streams the sync's grants into the bulk import. The
 // scan shards by EXTERNAL ID range over the UNIQUE(external_id,
-// sync_id) index: each lane's ordered range scan yields rows already in
-// the shard's final pebble key order, so grant primaries stream
-// straight into one final SST per lane — no spill, no external sort, no
-// merge (see BulkGrantShard). Range boundaries come from sampling
-// external ids at random rowids and taking quantiles; uneven lanes only
-// cost balance, never correctness, and pebble's Ingest rejects
-// overlapping shard SSTs outright.
+// sync_id) index purely to spread the SQLite read and decode work across
+// lanes: grants are keyed by structural identity, whose order the
+// external-id scan does not reproduce, so each shard spill-sorts its
+// primaries and index keys and Finish k-way merges every shard's runs
+// into one grants SST (see BulkGrantShard). Range boundaries come from
+// sampling external ids at random rowids and taking quantiles; uneven
+// lanes only cost balance, never correctness.
 //
 // Each lane is a two-stage pipeline: a reader goroutine does nothing
 // but step rows and memcpy the raw (data, expansion) column bytes into

--- a/pkg/dotc1z/to_pebble.go
+++ b/pkg/dotc1z/to_pebble.go
@@ -107,13 +107,13 @@ func WithConvertTmpDir(dir string) ConvertOption {
 // lane holds one sqlite connection plus a reader and a decode/encode
 // goroutine). The default — min(4, GOMAXPROCS/2) — leaves headroom for
 // shared infrastructure; callers that own the machine can raise it, and
-// 1 fully serializes the grant scan. Values <= 0 are ignored. Memory
-// scales with fan-out: each lane pins up to three 128MiB spill arenas
-// (its grant sorter plus two index sorters), and the import's three
-// lane-independent sorters (resources, entitlements, parent index) pin
-// another ~384MiB alongside the scan since none finalize until Finish —
-// so budget ~384MiB × (lanes + 1) of sort memory (see the bulk import's
-// arenaFree).
+// 1 fully serializes the grant scan. Values <= 0 are ignored.
+//
+// Sort memory does not scale with fan-out: the bulk import sizes its
+// spill chunks from a fixed budget divided by the arena count the lane
+// count implies (see pebble's bulkImportSortBudgetBytes), so more lanes
+// mean smaller chunks and a wider final merge — more open chunk files
+// and read buffers at Finish — rather than more RSS during the scan.
 func WithConvertParallelism(n int) ConvertOption {
 	return func(c *convertConfig) {
 		if n > 0 {
@@ -338,7 +338,7 @@ func (c *C1File) ToPebble(ctx context.Context, outPath string, syncID string, op
 	if !ok {
 		return nil, errors.New("to-pebble: destination store is not a pebble engine")
 	}
-	bi, err := destEng.StartBulkSyncImport(ctx, destSyncID, cfg.tmpDir)
+	bi, err := destEng.StartBulkSyncImport(ctx, destSyncID, cfg.tmpDir, cfg.grantScanLanes())
 	if err != nil {
 		return nil, fmt.Errorf("to-pebble: start bulk import: %w", err)
 	}
@@ -803,6 +803,20 @@ func (c *C1File) convertEntitlements(ctx context.Context, bi *pebble.BulkSyncImp
 // via WithConvertParallelism.
 const convertGrantScanLanes = 4
 
+// grantScanLanes returns the grant scan fan-out the conversion will
+// attempt: the caller's WithConvertParallelism when set, otherwise half
+// the available CPUs capped at convertGrantScanLanes, never below 1.
+// convertGrants may still fall back to a single lane if the extra sqlite
+// readers cannot attach; the value here is also what the bulk import
+// sizes its spill arenas for, so it is computed once up front.
+func (cfg *convertConfig) grantScanLanes() int {
+	lanes := min(convertGrantScanLanes, max(1, runtime.GOMAXPROCS(0)/2))
+	if cfg.parallelism > 0 {
+		lanes = cfg.parallelism
+	}
+	return max(1, lanes)
+}
+
 // rawGrantRow is one grant row's raw column bytes, copied out of the
 // scan into a batch-owned arena so decoding can happen on another
 // goroutine after the scanner has moved on, plus the row's
@@ -847,13 +861,7 @@ func (c *C1File) convertGrants(ctx context.Context, bi *pebble.BulkSyncImport, s
 		return nil // no grants in this sync
 	}
 
-	lanes := min(convertGrantScanLanes, max(1, runtime.GOMAXPROCS(0)/2))
-	if cfg.parallelism > 0 {
-		lanes = cfg.parallelism
-	}
-	if lanes < 1 {
-		lanes = 1
-	}
+	lanes := cfg.grantScanLanes()
 	// The C1File's own pool is capped at one connection (WAL checkpoint
 	// hygiene — see NewC1File) and defaults to locking_mode=EXCLUSIVE,
 	// which holds its lock indefinitely once acquired and would starve a

--- a/pkg/dotc1z/to_pebble.go
+++ b/pkg/dotc1z/to_pebble.go
@@ -107,7 +107,10 @@ func WithConvertTmpDir(dir string) ConvertOption {
 // lane holds one sqlite connection plus a reader and a decode/encode
 // goroutine). The default — min(4, GOMAXPROCS/2) — leaves headroom for
 // shared infrastructure; callers that own the machine can raise it, and
-// 1 fully serializes the grant scan. Values <= 0 are ignored.
+// 1 fully serializes the grant scan. Values <= 0 are ignored. Memory
+// scales with fan-out: each lane also pins up to three 128MiB spill
+// arenas (its grant sorter plus two index sorters — see the bulk
+// import's arenaFree), so budget ~384MiB of sort memory per lane.
 func WithConvertParallelism(n int) ConvertOption {
 	return func(c *convertConfig) {
 		if n > 0 {


### PR DESCRIPTION
perf(pebble): unlink spill chunks during merge, sort resources on import

The two k-way merge helpers held every sorted chunk file open until the
staging directory was torn down, so for the length of each merge the
staging directory carried the same entries twice: once in the chunks and
once in the SST being built from them. Chunks are now closed and unlinked
as soon as the merge reads their last entry, bounding the overlap to the
chunks still in flight. Unlinking is confined to the exhausted-chunk path,
where the file is provably fully consumed; a merge that fails partway
closes its descriptors and leaves the rest to the staging-dir teardown
that already owned them. Both helpers back the bulk import, the deferred
grant index, the id-index migration, the segment layer, and the digest
build, and the index builds run at EndSync on every pebble sync, so this
bounds peak staging for all of them.

AddResources also no longer requires rows pre-sorted by
(resource_type_id, resource_id); it routes them through the same spill
sorter entitlements already use. A converter scanning SQLite with a
matching ORDER BY satisfied the old precondition for free, but a producer
that rewrites resource ids cannot — the c1z sanitizer HMACs them, so its
output order is unrelated to the order it read. Sorting inside the
importer keeps every producer on one path instead of making sortedness a
precondition each one has to re-establish, and it holds when a single
resource type is too large to sort in memory.