### PR TITLE
docs: label source-cache replay surfaces as advanced functionality

### DIFF
--- a/pkg/dotc1z/source_cache.go
+++ b/pkg/dotc1z/source_cache.go
@@ -38,6 +38,11 @@ type sourceCacheStoreTestSeams struct {
 // implemented ONLY by the Pebble engine; the syncer type-asserts for it and
 // treats a store without it as "source cache unsupported" (no-op lookup,
 // no replay). It is deliberately NOT part of c1zstore.Store.
+//
+// Advanced: this interface exists for the SDK's replay orchestration, not
+// for direct use. The correctness obligations (preflight, scope poisoning,
+// compat validation) live in the callers; see pkg/sourcecache for the
+// connector-facing contract.
 type SourceCacheStore interface {
 	// LookupSourceCacheEntry returns this store's manifest entry for
 	// (kind, scopeKey). Backs the connector-facing lookup when this

--- a/pkg/sourcecache/sourcecache.go
+++ b/pkg/sourcecache/sourcecache.go
@@ -1,6 +1,12 @@
 // Package sourcecache defines the connector-facing surface of source-cache
 // replay (see proto/c1/connector/v2/annotation_source_cache.proto).
 //
+// ADVANCED FUNCTIONALITY. Source-cache replay is an advanced, opt-in
+// capability with strict correctness obligations on the connector (scope
+// partitioning, validator lifetime — see the invariants below). Most
+// connectors should not use this package; adopt it only in coordination
+// with the SDK maintainers.
+//
 // NOT YET WIRED. This package describes the intended contract, and the
 // storage and eligibility machinery beneath it is in place, but the syncer
 // does not install a Lookup or consume these annotations yet: SyncOpAttrs

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -4028,6 +4028,9 @@ func WithExternalResourceC1ZPath(path string) SyncOpt {
 // WithPreviousSyncC1ZPath registers a separate c1z holding the previous sync
 // for replay features.
 //
+// Advanced: source-cache replay is advanced, opt-in functionality (see
+// pkg/sourcecache); most callers should not set this option.
+//
 // This is required for the single-sync v3 (Pebble) engine: a Pebble c1z
 // holds exactly one sync by contract, so there is no in-file "previous
 // sync" to replay from (StartNewSync replaces the prior sync). NewSyncer
@@ -4053,7 +4056,8 @@ func WithPreviousSyncC1ZPath(path string) SyncOpt {
 // WithOptionalPreviousSyncC1ZPath is WithPreviousSyncC1ZPath with
 // best-effort semantics: if the file is missing, corrupt, or written by
 // an incompatible SDK, NewSyncer logs and proceeds WITHOUT replay
-// instead of failing. Intended for cache-style replay sources the
+// instead of failing. Advanced, opt-in functionality like its strict
+// twin — see pkg/sourcecache. Intended for cache-style replay sources the
 // caller maintains automatically (the service-mode previous-sync spare)
 // — a bad cache file must never fail a sync. Callers that name a
 // specific file deliberately should use WithPreviousSyncC1ZPath, which


### PR DESCRIPTION
The connector-facing entry points from phase 6a — pkg/sourcecache, the previous-sync syncer options, and the SourceCacheStore capability — now carry an explicit Advanced marker so connector authors don't adopt the surface casually before replay orchestration (6b) lands.