### PR TITLE
phase 6b replay orchestration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -272,10 +272,11 @@ errorfs-soak: ## Sweep whole-sync Pebble crash points using errorfs.
 chaos-check: ## Run bounded representative chaos checks under race detection.
 	go test -race -count=1 ./internal/chaosconnector/...
 	go test -race -count=1 -timeout=10m -run '^TestChaosConnector(LostResponseThenFilesystemFailureResumes|ResourcesAndEntitlementsFaultMatrix|ListGrantsFaultMatrix|ReservedBatonIDOwnershipIsRejected|MalformedKnownAnnotationFailsWithoutSealing|ClearedNextPageTokenSealsOnlyVisiblePrefix|CancellationTerminatesAndColdResumes|DataPolicyLifecycleCorpus|ExternalPrincipalResumeUsesCurrentExternalAnswer|SQLiteExternalPrincipalResumeDegradesWithoutFailure|ExternalPrincipalCleanupUsesOnePassPerKeyspace)$$' ./pkg/sync
+	go test -race -count=1 -timeout=10m -run '^TestChaosSourceCache(GateMatrix|CollectionSemantics|InterruptResume|GenerationalSteadyState|CompatDriftOnResume|ReplayWithoutHitFailsCold|DriftedResumeRejectsRestoredReplay|DuplicateReplayCursorsParallel|UnsupportedShapesBlockReplaySeed)$$' ./pkg/sync
 
 .PHONY: chaos-full-check
 chaos-full-check: ## Run every deterministic chaos corpus under race detection.
-	BATON_TEST_NIGHTLY=1 go test -race -count=1 -timeout=30m -run '^TestChaosConnector' ./pkg/sync
+	BATON_TEST_NIGHTLY=1 go test -race -count=1 -timeout=30m -run '^TestChaos(Connector|SourceCache)' ./pkg/sync
 
 .PHONY: chaos-soak
 chaos-soak: ## Run extended seeded chaos connector fanout schedules.

--- a/docs/rfcs/0010-sqlite-conversion-only.md
+++ b/docs/rfcs/0010-sqlite-conversion-only.md
@@ -1,0 +1,360 @@
+# RFC 0010: SQLite demotion — conversion-only, one live engine
+
+Status: proposed. Supersedes RFC 0008 §8, whose sizing is stale in three
+material ways (§2).
+
+Risk routing (REVIEW_CHECKLIST §2): this is a behavior change, not a cleanup,
+and it does not route as one thing.
+
+- **Sanitize on Pebble (§4.2) is HIGH.** Relaxing a guard whose whole purpose
+  is preventing silent destination corruption is silent + durable, and the
+  remediation rung is ≥4: a corrupted sanitize output is not re-derivable
+  without a multi-hour re-run against a source that may have rotated.
+  `BUG_CATCHING.md` §5.4 (stored state has a lifecycle contract) and Pass 2
+  (checkpointing & resuming — "resumable twice, the resumer is a different
+  process with a cold cache") govern; the full step-up applies.
+- **Unconditional conversion on open (§4.3) is HIGH.** Conversion keeps one
+  sync and renames over the source. Default-path exposure, durable, and
+  irrecoverable once the rename lands — the top of the consequence scale.
+  `BUG_CATCHING.md` §5.12 (a commit point is a contract) applies to the rename.
+- **Forcing Pebble for compaction output (§4.4) is MEDIUM.** The conversion it
+  relies on already runs in production for mixed-engine inputs.
+- **Retiring explicit SQLite configuration (§4.5) is MEDIUM and loud** — a
+  rejected config fails at startup. Its risk is migration coverage, not
+  silence.
+- **Deleting the SQLite write paths (§4.6) is LOW.** Compile-verified; the risk
+  is in the steps that precede it.
+
+## 1. What this is
+
+Demote SQLite from a live storage engine to a conversion-and-read-only path:
+a newer SDK still opens a v1 `.c1z`, converts it to Pebble, and reads one
+read-only, but nothing syncs into SQLite, compacts through it, expands in it,
+or sanitizes out to it.
+
+The prize is not the deleted lines. It is that `c1zstore.Store` and its family
+stop having two implementors, so the runtime capability probes that currently
+choose between a fast path and a lossier fallback become ordinary method calls
+that fail to compile when the method goes away. That class of silent
+degradation is the most expensive thing about the current arrangement, and it
+is the reason to do this at all.
+
+This RFC covers both repositories, because the sequencing constraint that
+matters most lives in the hosted backend, not the SDK.
+
+## 2. Where we actually are — three corrections to RFC 0008 §8
+
+RFC 0008 §8 sized this work before three things changed. Anyone planning from
+that section will plan the wrong thing.
+
+**The default already flipped in the SDK, and has not reached the backend.**
+`selectStoreDriver` defaults an unset engine to Pebble
+(`pkg/dotc1z/engine_registry.go:246`). But the hosted backend vendors an
+older baton-sdk release where the same line reads `EngineSQLite`. So "new
+files are SQLite today" is false of this repository and true of production.
+§8.3 calls the default flip "step zero"; the real step zero is the SDK bump
+(§4.1).
+
+**Diff is gone, not deferred.** §8.3 calls `GenerateSyncDiff` "the hard one"
+and proposes moving diff up a layer. There is nothing to move: `8bd11917`
+("Remove diff sync support", #1098) deleted the feature, so the method does not
+exist on either engine and `pkg/dotc1z/diff.go`,
+`pkg/tasks/local/differ.go` and `engine/pebble/adapter_diff.go` are absent. The
+removal is recorded as final in
+`docs/rfcs/0004-storage-engine-v4/tracker.md:56-63` — the feature was never
+enabled in production and had no consumer. The backend has no reference to it
+outside `vendor/`. The largest prerequisite on the §8.3 list is therefore
+closed, and closed by deletion rather than by porting.
+
+What survives is a read obligation, already discharged: an old SQLite c1z can
+carry the removed diff-sync shape (a `partial_upserts`/`partial_deletions`
+pair with bidirectional `linked_sync_id` and a cross-file `parent_sync_id`),
+and `pkg/dotc1z/legacy_diff_sync_rows_test.go` pins that those rows list
+cleanly and that `ToPebble` ignores them — failing loudly with "no convertible
+sync found" when they are all the file holds, rather than emitting a silent
+empty artifact. That is the precedent the permanent conversion reader should
+follow for every other legacy shape.
+
+**The capability-probe payoff is real but smaller than claimed.** §8.1 says 28
+non-test sites discover capabilities by type assertion, ~22 of them because one
+engine can do what the other cannot. On the current tree the engine-driven
+probes in `pkg/sync/syncer.go` number about ten (`:289`, `:293`, `:355`,
+`:384`, `:393`, `:421`, `:428`, `:436`, `:444`, `:475`), and the invariant gate
+is `pkg/sync/ingest_invariants.go:507`, where four `requiresStore` invariants
+(`:379`, `:386`, `:393`, `:400`) are skipped when the optional Pebble
+inspection surface is absent — the comment at `:282` states plainly that SQLite
+artifacts never satisfy them. Much of §8.1's inventory has already been cleaned
+up. The argument stands on the invariant gate and the remaining ten; it should
+not be sold on the old numbers.
+
+## 3. The conversion boundary is already right: inline, in place, paid once
+
+An earlier framing of this work proposed converting at ingestion, either in the
+upload RPC or in a dedicated activity. Both are wrong, and the reason is worth
+recording because it is not obvious from the SDK side alone.
+
+Conversion is not a cost added to a budget. It is an investment that shrinks
+it: Pebble is roughly 10× faster on the grant path and produces ~40% smaller
+output (`docs/rfcs/0004-storage-engine-v4/tracker.md:31`), and expansion and
+compaction are exactly the grant-heavy work. Converting first and then
+expanding is a large net win inside a single activity.
+
+It is also paid once, not once per window. The backend's sync activity opens
+the *live* artifact writable with the resolved engine, so a v1 file hits the
+in-place conversion at `pkg/dotc1z/engine_registry.go:280`, which renames the
+converted temp over the artifact path. The same artifact is carried through
+the activity's callers and committed back. The live artifact in object
+storage becomes v3, and every later window reads a v3 header and skips
+conversion entirely. (Backend call sites are tracked in the internal
+ticket.)
+
+The upload RPC is therefore the one place conversion must *not* go — a
+connector-held gRPC stream cannot block on a multi-hour rewrite — and a
+dedicated activity would only add an orchestration hop plus a second multi-GB
+round trip, while separating the cost from the benefit that repays it.
+
+Two consequences follow, and both shape the plan:
+
+1. **Read-only opens must not convert.** The conversion gate at `:280` requires
+   `!options.readOnly`, and that is load-bearing. The backend's file-connector
+   ingest opens uploads read-only, so a v1 upload is
+   served as a SQLite store for a pure read-through with no expansion or
+   compaction downstream to recoup a conversion. Converting there would be
+   paying the cost precisely where nothing recovers it. A read-only SQLite
+   reader has to survive this RFC (§4.7).
+2. **The cost lands on one window.** The first sync after a connector's engine
+   resolves to Pebble pays conversion inside its ordinary budget — 120 minutes
+   for incremental sync (`incremental-sync/incremental_sync.go:185-186`), 210
+   for file-connector sync (`file-connector-sync/activity.go:63-64`). That is a
+   rollout concern (stagger, watch first-window durations), not an
+   architectural one.
+
+## 4. Prerequisites, in dependency order
+
+### 4.1 Step 0 — bump the vendored SDK in the backend
+
+Nothing else on this list changes production behavior until this lands. The
+bump also carries the two things later steps depend on: the diff removal (§2)
+and `2c05c0b9` (#1103), the `ResumeSync` fix whose engine-level tests are the
+scaffolding §4.2 builds on.
+
+Acceptance: the backend's resolved-engine behavior is unchanged for every
+connector — an unset engine with the tenant flag off must keep producing the
+same on-disk format it produces today. This is the step where a silent default
+change would be easiest to ship by accident, because the same source line means
+`EngineSQLite` before and `EnginePebble` after.
+
+### 4.2 Step 1 — sanitize with a Pebble destination
+
+This is the gating item and the hardest one. The backend's sanitize activity is
+the only remaining live-SQLite **writer** in the hosted path: it reads either
+format through `NewStore` but opens its destination with `NewC1ZFile`, because
+the snapshot loop takes the concrete `*C1File`. Explicit SQLite cannot be
+rejected (§4.5) while a production activity requires a SQLite writer.
+
+The SDK has two Pebble guards in `pkg/c1zsanitize/sanitize.go`, and they carry
+different weight.
+
+The **multi-sync source** rejection (`:148`) is likely already unreachable in
+the hosted flow: sanitize's source is a completed artifact, and the backend
+isolates completed artifacts to a single sync when it stores them. Confirm
+against real artifacts before relying on it. Under conversion-only it becomes
+structurally unreachable.
+
+The **resumable** rejection (`:379`, in `isResumableDestination` at `:378`) is
+the real work, and there is a hypothesis worth testing: the guard may be
+broader than its own justification. It says Pebble's "replace-in-place
+`StartNewSync` wipes any prior sync's data", but the resume path does not call
+`StartNewSync` — it rebinds via `SetCurrentSync(rs.dstSyncID)` (`:552`), and
+`StartNewSync` appears only on the fresh-sync branch (`:570`). With a single
+source sync there is exactly one destination sync, so a resume never takes the
+wiping branch. Where the guard genuinely earns its keep is the multi-sync case:
+sanitize iterates source syncs, and calling `StartNewSync` for one that had not
+started in a prior run excises the destination syncs the prior run completed.
+That is real and structural under one-sync-per-file — but it is a function of
+source cardinality, not of resume, and the guard keys on engine alone.
+
+Two changes follow, if the hypothesis survives verification:
+
+- Narrow the resumable guard from "engine is Pebble" to "engine is Pebble **and**
+  the source has more than one sync."
+- Switch the resume rebind from `SetCurrentSync` to `ResumeSync`
+  (`engine/pebble/adapter.go:143`). This is correct independent of engine
+  choice: Pebble's `SetCurrentSync` (`:199`) treats a missing record as legal
+  and binds anyway, so a read failure would bind a sync with no record and then
+  accept writes into it. `ResumeSync` fails closed. This is precisely the bug
+  class #1103 closed in the compactor, where `StartOrResumeSync` (`:176`) fell
+  through to `StartNewSync` on any non-clean lookup and excised the merge
+  output.
+
+Backend-side: `startSnapshotLoop` and `restoreOrStartDst` must work through the
+store interface rather than `*C1File`, and the four SQLite pragmas below
+`sanitize_activity.go:852` become meaningless.
+
+Because this is HIGH: frozen behavioral plan before implementation;
+instruments on the destination-sync lifecycle (fresh, resumed-partial,
+resumed-ended, multi-sync-source rejection); each instrument validated against
+a planted violation, since the failure is silent; acceptance is the crash /
+interrupt harness with resume-twice-from-a-cold-process, not the PR suite. The
+existing 12-hour per-attempt envelope and 24-hour job ceiling
+(`sanitize_activity.go:166`, `:195`) mean a wrong answer here costs a day of
+worker time before it surfaces, which is why detection is not an acceptable
+defense.
+
+### 4.3 Step 2 — decide the conversion policy, then make it unconditional
+
+Today only an explicit Pebble request on a writable v1 file converts
+(`engine_registry.go:280`). Making conversion unconditional for writable opens
+is what "conversion-only" means operationally. It is also HIGH, and not for
+mechanical reasons: conversion keeps exactly one sync and renames over the
+source, so every other sync the file held is gone with only a WARN line as the
+record (`pkg/dotc1z/convert_open.go:64`).
+
+The policy decision belongs here, before the code:
+
+- Does the pre-conversion artifact get retained? The backend still has a
+  multi-sync `CloneSync` branch (`sync/c1z.go:799`), which implies multi-sync
+  files do occur in practice. Retention costs storage and keeps the lossy step
+  reversible; discarding makes the WARN the only record. RFC 0009's
+  preserve-by-default posture for sync artifacts is the closest precedent and
+  argues for retention at least through the migration window.
+- Does the hosted path pass an explicit sync ID instead of relying on
+  resolution? `ToPebble` takes one (`pkg/dotc1z/to_pebble.go:223`); the
+  activity knows which sync the run concerns. Selecting explicitly removes the
+  lossiness question from the hosted path entirely and leaves the
+  "keep newest, WARN the rest" default governing only local and CLI conversion
+  of legacy files, where it is the right tradeoff.
+
+### 4.4 Step 3 — force Pebble for new stores and compaction output
+
+Two spots in the compactor default to SQLite: `resolvedEngine` treats the zero
+value as SQLite (`pkg/synccompactor/compactor.go:106`, returning at `:108`) and
+`inferEngineFromInputs` returns SQLite when no input is Pebble (`:133`,
+returning at `:175` and `:178`). Make the output always Pebble.
+
+The conversion this depends on already ships: `convertSQLiteInputToPebble`
+(`compactor_pebble.go:1046`) converts v1 inputs whenever the output engine is
+Pebble, which after this step is always. Generalize `ErrEnginePolicyConflict`
+from "explicit SQLite with a Pebble input" to "explicit SQLite, ever."
+
+### 4.5 Step 4 — retire explicit SQLite configuration
+
+A breaking config change in three places, all of which need a migration and not
+just tightened validation:
+
+- `StorageEngineField`'s allowed values (`pkg/field/defaults.go:346`).
+- The `storage_engine` in-lookup on the gRPC sync task
+  (`proto/c1/connectorapi/baton/v1/baton.proto:63`, generated into
+  `pb/c1/connectorapi/baton/v1/baton.pb.validate.go:4069`). The task carries the
+  engine to the connector process, so this is a version-pair surface: an old
+  connector receiving an unfamiliar value, and a new connector receiving
+  `sqlite`, both need defined behavior.
+- The backend's per-connector storage-engine setting, which is
+  admin-settable. Any connector currently pinned to SQLite there must be
+  migrated before the value is rejected, and the corresponding tenant
+  feature flag does not override a per-connector setting. (Exact call
+  sites tracked in the internal ticket; they are not part of this
+  repository.)
+
+Also drop the `sqlite` leg of the CI matrix (`.github/workflows/ci.yaml:113`).
+
+### 4.6 Step 5 — delete the SQLite write paths
+
+Compile-verified once the steps above land. The targets:
+
+- The attached compactor (`pkg/synccompactor/attached/attached.go`, 143 lines,
+  asserting `AsSQLiteStore` at `:30` and `:34`) and the SQLite compaction
+  branch.
+- `sqliteDriver` (`engine_registry.go:106`, `:377`) and the driver registry's
+  dual dispatch, along with `EngineDriver` itself once there is one live
+  implementor.
+- The SQLite-only write operations and their CLI entry points:
+  `RollbackExpansion` (`pkg/dotc1z/rollback_expansion.go`, 420 lines, reached
+  from `cmd/baton/rollback_expansion.go:174`), `Vacuum`
+  (`pkg/dotc1z/sync_runs.go:1187`, via `cmd/baton/optimize.go:39-40`), and the
+  `CopyIsolateSync` fast path (`pkg/dotc1z/copy_isolate_sync.go`, 244 lines,
+  reached from `cmd/baton/rollback_expansion.go:145`). These are features
+  dropped on purpose, not dead code.
+- The write halves of the paired implementations: grants, streaming, clone,
+  sessions, sync metadata.
+- The cross-engine parity harness — `pkg/dotc1z/cross_engine_parity_test.go`
+  (422 lines) and `pkg/dotc1z/engine/equivalence/` (548 lines) — plus the
+  SQLite half of the engine-parameterized tests. This is the largest single
+  block and the clearest signal the abstraction has collapsed to one side.
+
+Sizing for scheduling: the goqu-dependent non-test files in `pkg/dotc1z` total
+~8,150 lines, of which `to_pebble.go` (1,202) is retained as the converter;
+`clone_sync.go` (368), `copy_isolate_sync.go` (244),
+`rollback_expansion.go` (420) and `pool.go` (128) sit alongside. Expect the
+write-side deletion to land near the RFC 0008 estimate of ~8,000 production
+lines once the read floor in §4.7 is carved out, but treat that as a range and
+re-derive it at implementation time rather than quoting it: `c1file_attached.go`
+alone went from 462 lines to 188 in `8bd11917`, well after §8 was sized.
+
+### 4.7 Step 6 — define the read-only floor and hold the line
+
+"Retain internal SQLite read code solely for conversion" is not reachable, for
+two reasons, and pretending otherwise will produce a scope surprise late.
+
+It is not internal: `AsSQLiteStore` (`pkg/dotc1z/store.go:16`) and
+`(*C1File).ToPebble` are reached from `pkg/synccompactor`
+(`compactor_pebble.go:1068`), so the conversion reader stays exported unless
+conversion itself moves.
+
+It is not solely for conversion: the backend's file-connector ingest and its
+uplift datasource reader both perform general read-only SQLite reads that no
+conversion would repay (§3).
+
+So the retained surface is *conversion plus read-only ingest*: the open/close
+path in `c1file.go`, sync-run listing in `sync_runs.go`, the raw record list
+paths in `grants.go` / `resources.go` / `entitlements.go` / `resouce_types.go`,
+`sql_helpers.go`, and `to_pebble.go`. Name it explicitly, put a guard test on
+it, and treat any new SQLite write reachable from it as a regression — the
+alternative is that "conversion-only" quietly regrows into a second engine.
+
+## 5. What this does not buy
+
+Unchanged from RFC 0008 §8.2, and worth repeating because the guesses are
+persistent. No dependency or vendor reduction: conversion reads SQLite, so
+`modernc.org/sqlite` stays, and `goqu` stays for both the conversion queries
+and `pkg/uhttp/dbcache.go`'s unrelated HTTP cache. No build simplification:
+there are no SQLite build tags and no cgo requirement. No end to format
+dispatch: `NewStore` must still sniff magic bytes to route v1 files to the
+conversion reader, and the version-skew constraint is unaffected.
+
+## 6. What we are not doing
+
+**Converting in the upload RPC or a dedicated activity.** See §3. Inline at the
+first writable open is both faster and amortized; the alternatives are strictly
+worse.
+
+**Converting on read-only opens.** Pays the cost where nothing recovers it, and
+narrows a multi-sync file to one sync for a reader that could have seen all of
+them.
+
+**Removing the diff-sync read path.** The generator is gone; the ability to
+read a legacy file that contains diff-sync rows is a compatibility obligation
+with a pinned test, and it stays.
+
+**Rejecting `sqlite` configuration before §4.2 lands.** The ordering is not
+cosmetic: the hosted sanitize activity needs a SQLite writer until it doesn't.
+
+## 7. Sequencing summary
+
+Step 0 (SDK bump) gates everything. Step 1 (sanitize on Pebble) gates Steps 3
+and 4, because rejecting SQLite configuration while a production activity
+requires a SQLite writer is not possible. Step 2 (conversion policy) is
+independent of Step 1 and should be decided early, since it is the only
+irreversible decision in the plan. Steps 3 and 4 are ordered before Step 5, and
+Step 5 is mechanical once they land. Step 6 is a standing constraint rather
+than a step, and should be written as a test the day Step 5 starts.
+
+Orthogonal to RFC 0008 steps 1–3, which concern lifecycle and gating inside the
+Pebble stack. Strongly amplified by RFC 0008 step 4: once the protocol face is
+a view over one engine, `connectorstore.Reader` and `Writer` stop being
+dual-engine abstractions and become what they claim to be.
+
+Constraints that apply throughout: a newer SDK must keep opening older `.c1z`
+files, and the connector-facing API cannot change — there are hundreds of
+connector repositories. Every step above is internal or configuration-facing by
+construction; none changes a connector-visible signature.

--- a/docs/verification/sync-replay-6b/evidence.md
+++ b/docs/verification/sync-replay-6b/evidence.md
@@ -1,0 +1,879 @@
+# Sync Replay Phase 6b Verification Evidence
+
+Plan: [`plan.md`](plan.md)
+
+Scope: source-cache replay orchestration — capability parsing, lookup
+install/teardown and delivery, compat record lifecycle and byte-match
+gating, fresh-page recording, replay handling with provenance enforcement,
+the warm/cold `ErrReplayIntegrity` taxonomy, the CO-017 fold fence
+(rider A), and the chaos suites that observe all of it. Gates were run on
+2026-08-27 against the working tree; the committed SHA is recorded at
+commit time. Included change orders: CO-6b-001, CO-6b-002, CO-6b-003,
+CO-6b-004, CO-6b-005, CO-6b-006, CO-6b-007
+(post-review remediation; see Independent reviews).
+
+## Gates
+
+Re-run in full after the post-review remediation (CO-6b-003):
+
+```text
+make lint                                                    -> 0 issues
+go test -count=1 -timeout=25m ./...                          -> pass 876s
+go test -race -count=1 -timeout=15m \
+  -run '^TestChaosSourceCache' ./pkg/sync                    -> ok 227.5s
+go test -race -count=1 -timeout=10m \
+  -run '^(TestSourceCacheReplayVerdictTaxonomy|TestChaosSourceCacheReplayWithoutHitFailsCold|TestChaosSourceCacheCompatDriftOnResume|TestPreviousSyncC1ZPathEnforcesReplayEligibility|TestChaosSourceCacheDriftedResumeRejectsRestoredReplay|TestChaosSourceCacheDuplicateReplayCursorsParallel|TestChaosSourceCacheUnsupportedShapesBlockReplaySeed|TestSourceCacheLookupDeliverabilityProbe|TestSourceCacheReplayOncePerScopeIsAtomic)$' \
+  ./pkg/sync                                                 -> ok 49.1s
+go test -race -count=1 \
+  -run '^TestVerificationReplayVerdictSentinelIdentity$' \
+  ./pkg/dotc1z/engine/pebble                                 -> ok 5.3s
+make chaos-check                                             -> pass
+BATON_TEST_NIGHTLY=1 go test -count=1 \
+  -run '^TestChaosSourceCacheGenerationalLongChain$' \
+  ./pkg/sync                                                 -> pass 4.5s
+```
+
+Note: under the whole-repo run, `pkg/dotc1z` needs more than Go's default
+10-minute per-package timeout when sharing the machine with every other
+package's tests (it passes alone in ~190s); the full-suite gate above runs
+with `-timeout=25m` for that reason.
+
+Re-run after the third re-review remediation (CO-6b-006):
+
+```text
+make lint                                                    -> 0 issues
+go test -count=1 -timeout=20m ./pkg/sync                     -> ok 479s
+go test -count=1 -timeout=25m ./...                          -> pass
+go test -race -count=1 -timeout=10m \
+  -run '^(TestSourceCacheReplayOncePerScopeIsAtomic|TestSourceCacheRecordPageParksBehindReplayCopy|TestChaosSourceCacheDuplicateReplayCursorsParallel|TestChaosSourceCacheDriftedResumeRejectsRestoredReplay)$' \
+  ./pkg/sync                                                 -> ok 5.6s
+make chaos-check                                             -> pass
+```
+
+Mutation checks re-run at this SHA: warm gate deleted -> chaos + unit
+instruments fail; record-page early return restored -> park instrument
+fails; withdrawal block disabled -> capability-withdrawn cell fails;
+scope mutex removed and probe assert disabled -> their CO-6b-005
+instruments fail (verified last round, instruments unchanged).
+
+Re-run after the round-4 remediation (CO-6b-007):
+
+```text
+make lint                                                    -> 0 issues
+go test -count=1 -timeout=40m <all changed packages>         -> 14 pkgs ok
+  (the structural-coverage profile run; includes the full
+  ./pkg/sync and ./pkg/dotc1z/... suites)
+go test -count=1 -timeout=30m <all remaining packages>       -> 51 pkgs ok
+  (together the two runs are the whole repo)
+go test -race -count=1 -timeout=10m \
+  -run '^(TestChaosSourceCacheReplayWithoutHitFailsCold|TestSourceCacheRecordPageParksBehindReplayCopy|TestSourceCacheReplayOncePerScopeIsAtomic|TestSourceCacheLookupDeliverabilityProbe|TestSourceCacheWarmStoreDegradeLadder|TestParseSourceCacheCapabilityUnparsable|TestWarmLookupInputValidationDegradesToMiss|TestSourceCachePageOpsStoreWithoutSurface|TestChaosSourceCacheDriftedResumeRejectsRestoredReplay)$' \
+  ./pkg/sync                                                 -> ok 7.8s
+make chaos-check                                             -> pass (x2)
+```
+
+Mutation checks for the round's new instruments: each handler's
+`defer scOps.release()` removed one at a time -> that handler's
+loud-failure cell fails at the ride-along's held-lock assertion, naming
+the leaked scope (all three sites verified individually).
+
+## Performance evidence
+
+The orchestration's hot-path addition is one `sourceCachePageOps` call per
+list-response page (pure CPU; no store I/O until an annotation is honored).
+For ANNOTATED pages the cost contract also includes the lock hold, not
+just acquisition (noted per round-4 review): since CO-6b-006 the
+per-scope mutex is held from `beforeUpserts` through `afterUpserts`,
+bracketing the page's row writes and — in the grants handler — a
+possible connector RPC (`getResourceFromConnector`). Parallel workers
+serving DISTINCT scopes never contend (one mutex per (rowKind,
+scopeKey)); contention arises only when concurrent cursors carry the
+same scope, which is exactly the interleaving the lock exists to
+serialize. `BenchmarkSourceCacheScopeLocks` measures acquisition cost
+only; no benchmark measures hold time because the held work is the
+page's own ingest, which the sync pays regardless.
+`BenchmarkSourceCachePageOps` (`pkg/sync/source_cache_pageops_bench_test.go`,
+Apple M1):
+
+```text
+disabled-no-annotations            88.8 ns/op   256 B/op   2 allocs/op
+disabled-unrelated-annotations    110.9 ns/op   256 B/op   2 allocs/op
+enabled-no-annotations             94.5 ns/op   256 B/op   2 allocs/op
+enabled-record-annotation         290.2 ns/op   344 B/op   5 allocs/op
+```
+
+The disabled cells are what EVERY production page pays while no connector
+declares the capability: ~100ns and two small allocations per page (a page
+is typically 100+ rows, each costing orders of magnitude more to decode and
+write). Non-capable syncs additionally pay one type-assert and at most one
+compat-record point read per sync attempt; the per-scope lock map, the
+provenance sets, and the produce-guard row scans are only touched by
+annotated pages of capable connectors.
+
+Engine-level costs carried over from the 6a work and re-measured on this
+branch: `BenchmarkSourceCacheReplayResources` copies 100k rows in ~0.46s
+(~217k rows/s, ~210 B allocated per row — the bounded-batch contract also
+pinned by `source_cache_replay_bounds_verification_test.go`); 10k rows in
+~54ms. Scoped-ingest A/B (`BenchmarkScopeIngest*`) and preflight scaling
+(`BenchmarkReplayPreflightScopeScaling`) cover the stamp-and-seal side. A
+warm replay therefore costs milliseconds against the seconds-to-minutes a
+cold refetch of the same scope costs upstream.
+
+Checkpoint cost of the provenance sets (unbounded in scope count, so the
+curve is the documented bound — see `state.sourceCacheHits`):
+`BenchmarkStateMarshalSourceCacheSets` (Apple M1, hit map with validators
+plus replayed set, HashScope-sized keys): 1k scopes → ~0.5ms marshal,
+~151KB token; 10k → ~10ms, ~1.5MB; 100k → ~102ms, ~15MB. Immaterial at
+realistic scope counts; a connector at whale scale should move the sets to
+sidecar persistence (like the entitlement graph) before adopting.
+
+## Criterion closures
+
+Every entry names its instrument(s) and the observed outcome. All
+instruments pass under `-race`.
+
+### R1 — Lookup lifecycle
+
+Instruments: `TestChaosSourceCacheGateMatrix` (OR1 events),
+`TestChaosSourceCacheWarmAcrossTransports`,
+`TestChaosSourceCacheLookupTeardown` (`pkg/sync/chaos_source_cache_gate_test.go`).
+
+- The capability is parsed per attempt; the warm-baseline cell observes a
+  warm consult with the previous validator, every degrade cell observes a
+  cold consult (miss), never an error surfaced to the connector.
+- `requireSourceCacheEvents` asserts on every event passed to it — in
+  every suite that calls the helper, not the suite set as a whole — that
+  `SyncOpAttrs.Lookup` arrived non-nil (`NoopLookup` substitutes when
+  unset) and that no lookup error reached the connector.
+- Transport coverage: the warm consult contract holds on both in-process
+  transports (direct client and in-process gRPC) — both are chaos-harness
+  clients, which wire the lookup setter themselves. NO production
+  transport wires the setter in this phase; the subprocess transport and
+  the absence of a wired production path are a registered exclusion
+  (CO-6b-001, see limitations). The syncer probes deliverability
+  (`sourcecache.LookupDeliverabilityProbe`) and keeps the consume side
+  cold — never logging warm — when the transport cannot deliver.
+  Instrumented by `TestSourceCacheLookupDeliverabilityProbe`
+  (mutation-verified: disabling the probe type-assert fails the
+  undeliverable cell), and the probe is compile-pinned on
+  `internal/connector.connectorClient` so a method rename cannot silently
+  sever it from the syncer's type assertion.
+- Teardown: `TestChaosSourceCacheLookupTeardown` drives a consult through
+  the connector-held lookup AFTER sync exit and observes a miss — the
+  teardown cleared connector-visible state (`SetSourceCache(nil)` on every
+  exit path, including cancellation, via `context.WithoutCancel`).
+- Delivery sites: `pkg/connectorbuilder/resource_syncer.go` populates
+  `SyncOpAttrs.Lookup` at all four sites; consults are observed at the
+  three scoped kinds (resources, entitlements, grants — including the
+  ForResourceType variants). The static-entitlements site receives the
+  lookup identically but its kind is a registered exclusion (B10).
+
+### R2 — Gate decision table
+
+Instruments: `TestChaosSourceCacheGateMatrix` (install-time gates G6/G7 +
+quality), `TestPreviousSyncC1ZPathEnforcesReplayEligibility`
+(`pkg/sync/pebble_etag_replay_test.go`, NewSyncer gates G1–G5).
+
+- Chaos cells: `warm-baseline`, `no-previous-artifact`,
+  `capability-absent`, `capability-disabled`,
+  `compat-cache-generation-mismatch`, `compat-config-fingerprint-mismatch`,
+  `compat-selection-fingerprint-mismatch`, `compat-record-absent`,
+  `quality-blocked-previous`. Each degrade cell produces exactly a cold
+  sync (OR1 miss events) with the artifact converging to cold truth.
+- NewSyncer cells: `pebble-full-synced` (reader installed),
+  `pebble-full-no-quality-stats` (G4 fail-closed), `pebble-partial` (G3),
+  `pebble-compacted-full` (G3 fold-dominates), `sqlite-full` (G2),
+  `pebble-quality-blocked` (G4 reason flag),
+  `pebble-fence-stripped-old-fold-shape` and `pebble-fence-foreign-witness`
+  (G5). Strict `WithPreviousSyncC1ZPath` on an unusable file still fails
+  NewSyncer loudly (`TestOptionalPreviousSyncC1ZPath_SoftFails`).
+- Excluded cell (round-4 review N-3): a connector whose
+  `ListResourceTypes` output SHRINKS between generations while
+  `cache_generation` and `config_fingerprint` stay constant can replay
+  rows referencing types a cold sync's fresh-ingest filter would have
+  dropped — `sync_selection_fingerprint` digests the caller's selection,
+  not the connector's emitted type list, so the compat key does not model
+  this. Excluded rather than gated: the capability contract assigns the
+  connector responsibility for fingerprinting anything that changes what
+  it can see (a shrunk type list without a generation bump is a
+  capability-contract violation, same class as an unstable validator),
+  the ingest invariants (I3/I7/I8/I9) surface the resulting dangling
+  references as warn-class verdicts, and connector type lists are
+  static in practice. Registered in the exclusions registry.
+
+### R3 — Fresh-page semantics
+
+Instrument: `TestChaosSourceCacheFreshPageSemantics`
+(`pkg/sync/chaos_source_cache_collection_test.go`).
+
+- `multi-page-round`: a recording round split across wire pages stamps
+  every page's rows and publishes one entry with the shared validator.
+- `same-page-put-then-tombstone`: within-page order is upserts before
+  deletes (6a C29's orchestration half) — the tombstoned row dies, the
+  other survives stamped.
+- `empty-validator-no-entry-misses-next-sync`: rows stamp, no manifest
+  entry publishes, and the NEXT sync's consult misses and refetches
+  (6a C25's semantics at orchestration level).
+- `static-entitlement-annotation-ignored`: a `SourceCacheRecord` on a
+  static-entitlements response is ignored with a warn; no entry, no
+  stamps, sync stays green (registered exclusion B10).
+- Zero-row scope entries are additionally pinned by the collection
+  suite's zero-row replay cell (OR3 asserts the entry with zero stamps).
+- Unreplayable shapes block the seed (CO-6b-003):
+  `TestChaosSourceCacheUnsupportedShapesBlockReplaySeed`
+  (`pkg/sync/source_cache_orchestration_test.go`) — a record-annotated
+  resources page whose rows declare child resource types, and a grants
+  page carrying `InsertResourceGrants`, complete green but seal the
+  artifact `source_cache_replay_blocked`
+  (`source_cache_shape_unsupported`), so the next sync's G4 gate refuses
+  it: replaying such a scope would silently lose the derived rows.
+
+### R4 — Compat lifecycle (closes 6a C30)
+
+Instruments: `TestSourceCacheCompatRecordLifecycle`
+(`pkg/dotc1z/engine/pebble/source_cache_compat_lifecycle_test.go`),
+`TestChaosSourceCacheCompatDriftOnResume`
+(`pkg/sync/source_cache_orchestration_test.go`).
+
+- Engine lifecycle (replaces the `C30-compatibility-record-lifecycle`
+  exclusion): round-trip forces the singleton id; replay-state
+  invalidation and replacement-sync reset both wipe the record; the
+  cleanup range list covers the compat key; leak accounting rides along in
+  every cell.
+- Record bytes: the gate matrix's compat cells (R2/R5) read the stored
+  record back through the oracle and match it field-for-field against the
+  capability that produced it.
+- Resume idempotence: `TestChaosSourceCacheInterruptResume`'s warm-resume
+  cells re-run the install sequence over the checkpointed store with an
+  unchanged capability — the existing record verifies silently and the
+  resume stays warm.
+- Drift-on-resume (plan B4): the capability's cache generation changes
+  between an interrupted attempt and its resume. The resume completes
+  green, every consult goes cold despite a fully eligible previous
+  artifact, the ORIGINAL compat record is preserved (never overwritten),
+  and the artifact seals with `source_cache_replay_blocked` set so it
+  cannot seed the next generation.
+
+### R5 — Compat byte-match
+
+Instrument: `TestChaosSourceCacheGateMatrix` compat cells (within R2).
+
+- Each mismatching field degrades in isolation: cache generation, config
+  fingerprint, and selection fingerprint cells each flip exactly one field.
+- Missing record degrades (`compat-record-absent`).
+- Empty-matches-only-empty: the warm baseline's selection fingerprint is
+  empty on both sides (unrestricted syncs) and matches; the
+  selection-fingerprint cell declares an explicit selection against the
+  stored empty value and degrades — both directions of the rule.
+
+### R6 — Quality consume gate
+
+Instruments: gate matrix `quality-blocked-previous` cell;
+`TestPreviousSyncC1ZPathEnforcesReplayEligibility`
+(`pebble-quality-blocked`, `pebble-full-no-quality-stats`);
+`TestChaosSourceCacheGenerationalQualityLossBlocksC`
+(`pkg/sync/chaos_source_cache_generational_test.go`).
+
+- The generational cell is the end-to-end shape the criterion names: a
+  chaos run trips a real ingest-filter drop, seals green with the
+  replay-blocked reason, is offered as the previous source, and the next
+  generation degrades to cold (OR1) rather than replaying lossy rows.
+- Stats-absent artifacts fail closed (G4 conservatism cell).
+
+### R7 — Replay semantics (closes 6a C29 at orchestration)
+
+Instrument: `TestChaosSourceCacheCollectionSemantics`
+(`pkg/sync/chaos_source_cache_collection_test.go`).
+
+- Frozen page order (copy → upserts → tombstones) and cross-page order:
+  delta-overlay cells apply upserts and tombstones over the replayed base
+  and converge to the cold truth of the current epoch (OR2 full-proto
+  fingerprint against an independent cold baseline).
+- Copy dedup per scope: the duplicate-annotation cell proves the
+  replacement copy runs once (a second copy would wipe overlay upserts,
+  which OR2 catches).
+- `overlay=false` pages carrying rows: applied as overlay upserts with a
+  warn (transitional tolerance pinning 6a C34's contract).
+- Validator publish on both paths (record wins over replay; zero-row
+  scopes still publish); cross-kind non-aliasing (same scope key on
+  different RPC kinds stays partitioned) — OR3 manifest/stamp snapshots.
+
+### R8 — Provenance enforcement
+
+Instruments: `TestChaosSourceCacheReplayWithoutHitFailsCold`,
+`TestChaosSourceCacheDriftedResumeRejectsRestoredReplay`
+(`pkg/sync/source_cache_orchestration_test.go`);
+`TestChaosSourceCacheOrderingAdversary/spawned-duplicate-replay-cursors`;
+`TestChaosSourceCacheDuplicateReplayCursorsParallel`;
+`TestChaosSourceCacheInterruptResume`; `TestChaosSourceCacheLookupTeardown`.
+
+- Replay-while-cold fails loudly: a connector emitting `SourceCacheReplay`
+  with no this-sync lookup hit (cold sync, `NoopLookup`) fails the sync
+  with `ErrReplayIntegrity`, cold verdict, correct row kind and scope key
+  via `errors.As` — never a silent degrade (OR4). One cell per collection
+  handler (resources, entitlements, grants; CO-6b-007), so each handler's
+  own `sourceCachePageOps` error seam is exercised, not just the grants
+  seam the coverage triage originally found covered.
+- Planning-call → spawned-cursor handoff: the ordering suite's spawned
+  cell consults at the root and honors replay annotations on spawned
+  cursors (single copy, OR2 equivalence).
+- Hit/replayed sets survive interrupt/resume: the resume suite checkpoints
+  after every page (`checkpointInterval = 0`) and resumes with a NEW
+  syncer instance over the checkpointed state — the cross-process-shaped
+  resume the criterion requires. The replayed-set guard skips the
+  replacement copy on the re-walked page. Durability granularity
+  (CO-6b-006): provenance recorded during a dispatch batch becomes
+  durable at the checkpoint atop the NEXT loop iteration; hits recorded
+  in the batch that crashes are lost with the batch, whose actions
+  re-run from the pre-batch checkpoint and re-consult on resume
+  (at-least-once, safe in both warm and cold resume permutations).
+- Restored hits do not outrank the attempt's own gates (CO-6b-003;
+  premise corrected under CO-6b-006 after the third re-review proved the
+  original two-team scenario never checkpointed its hit): the
+  drifted-resume instrument spans two dispatch batches (102 grants
+  actions against the batch cap of 100), captures the surviving
+  checkpoint, and asserts IN-BAND that it contains both the batch-1 hit
+  and the pending batch-2 replay-carrier action. The resume under a
+  drifted capability restores that hit-set, re-serves the replay — and
+  the warm gate (`sourceCacheWarm`, set only on actual warm install)
+  rejects it with a cold `ErrReplayIntegrity` instead of copying rows
+  from an artifact the resume's gates just refused. Mutation-verified:
+  deleting the warm gate lets the restored hit and the still-eligible
+  seed base drive the copy, and the test fails.
+- Hits bind to the base they came from (CO-6b-004): each recorded hit
+  carries the validator the lookup returned, and the copy runs only if
+  the CURRENT replay base's manifest entry byte-matches it — a previous
+  artifact swapped between attempts for a gate-identical sibling
+  (identical compat key) fails cold instead of importing rows the
+  connector never revalidated. Cells: `swapped-base-validator-mismatch`,
+  `swapped-base-entry-missing`, `base-entry-read-failure`,
+  `base-without-entry-surface`.
+- Once-per-scope copy is atomic under parallelism (CO-6b-003): the
+  overlap instrument `TestSourceCacheReplayOncePerScopeIsAtomic` holds
+  one replay copy mid-flight in the store and drives a second
+  `beforeUpserts` for the same scope — with the lock the second parks
+  and takes the already-replayed skip; exactly one copy lands
+  (mutation-verified: removing the scope mutex fails it). The
+  end-to-end shape is `TestChaosSourceCacheDuplicateReplayCursorsParallel`
+  (duplicate replay annotations at `WithWorkerCount(4)`, OR2 against the
+  cold baseline); note the chaos test's spawned cursors are admitted
+  after the parent page marked the scope, so the overlap instrument —
+  not the chaos test — is what pins the race itself.
+- Record-only pages serialize against in-flight copies (CO-6b-006):
+  every scoped page — not just replay pages — holds the scope lock from
+  `beforeUpserts` through `afterUpserts`, so a record page's row puts,
+  tombstones, and manifest publish cannot interleave with another
+  action's REPLACEMENT copy for the same scope (which deletes the
+  scope's rows before copying the base — silent wipe of the fresh rows,
+    or a validator published over an incomplete scope). Interleaving
+  instrument `TestSourceCacheRecordPageParksBehindReplayCopy`,
+  mutation-verified against restoring the record-page early return.
+- The release backstop is a distinct obligation with its own instruments
+  (CO-6b-007, closing the round-4 MAJOR that found it uninstrumented —
+  the bullet above previously misattributed its coverage to the parking
+  test, which only exercises `afterUpserts`): error paths between
+  `beforeUpserts` and `afterUpserts` release through an idempotent
+  `release()` deferred at all three handler call sites; losing any one
+  defer leaves the lock held, and because `syncOneAction` retries a
+  failed action in the SAME goroutine and `sync.Mutex` is not reentrant,
+  a retryable connector error would hang the sync permanently. Two
+  layers, per the recurrence rule (third resource-release obligation on
+  this branch — the ladder climb, not a fourth point test):
+  - A held-lock ride-along bound to the chaos fixture itself
+    (`newChaosHarness` registers a cleanup that walks
+    `sourceCacheScopeLocks` and fails the test if any lock is still held
+    at sync end), so EVERY present and future chaos suite — success or
+    failure path — evaluates the invariant, including any fourth call
+    site added later.
+  - Per-site killing scenarios: the loud-failure suite's three cells
+    error a scoped page inside each handler's lock window.
+    Mutation-verified per site: removing the resources, entitlements, or
+    grants handler's `defer scOps.release()` fails that handler's cell
+    at the ride-along assertion, naming the held scope.
+- Post-sync teardown: R1's teardown instrument.
+
+### R9 — Verdict taxonomy
+
+Instruments: `TestSourceCacheReplayVerdictTaxonomy`
+(`pkg/sync/source_cache_orchestration_test.go`) — a bounded enumeration of
+every failure path named in plan B7, driven through the real page-ops
+pipeline against a fake store — and
+`TestVerificationReplayVerdictSentinelIdentity`
+(`pkg/dotc1z/engine/pebble/source_scope_verification_test.go`):
+
+- Cold: unparsable record annotation, unparsable replay annotation,
+  duplicate same-type annotations on one page, invalid replay scope key,
+  invalid record scope key (over-length), two scopes on one page,
+  principal tombstones on an entitlements page, malformed (non-BID)
+  resource tombstones, replay on a store without the source-cache
+  surface, replay without a this-sync hit, replay with a hit but no
+  previous artifact, replay while the attempt is not warm (drifted/cold
+  resume), source-side replay-copy failure.
+- Warm: destination-commit replay-copy failure
+  (`dotc1z.ErrSourceCacheReplayDestination`), cancellation mid-replay
+  (ERROR CHAIN only — ambient `ctx.Err()` no longer promotes, so a
+  sibling action's failure cannot launder a genuine integrity error into
+  warm), canonical-tombstone failure, principal-tombstone failure,
+  manifest-publish failure, row-put failure on an annotated page
+  (`wrapPageRowPutError`; the helper's classification is unit-pinned —
+  its wiring at the three collection-handler put sites is code-reviewed
+  but has no store-fault instrument, a known verification gap recorded
+  under limitations).
+- Identity (OR4): every cell asserts `errors.Is(…, ErrReplayIntegrity)`
+  and `errors.As` → verdict/row-kind/scope through an extra `fmt.Errorf`
+  wrap, and that the underlying cause stays reachable via `Unwrap`.
+- Engine-side sentinel identity (closes the review's overfit finding):
+  the engine instrument injects failures at the REAL commit and read
+  sites (the enumerated commit-point seams) and asserts a
+  destination-commit failure arrives carrying
+  `ErrReplayDestinationCommit` while a source-side read failure arrives
+  without it — deleting the engine's wrapping can no longer pass the
+  suite.
+
+### R10 — CO-017 fence (rider A)
+
+Instrument: `TestPreviousSyncC1ZPathEnforcesReplayEligibility` fence cells.
+
+- New saves carry the witness: the fence-stripped cell first asserts the
+  freshly synced artifact's envelope manifest equals
+  `sourcecache.MaterializationPolicyGeneration` (the strip would otherwise
+  be a vacuous no-op).
+- Old-fold shape: payload intact (manifest entries, indexes, compat record
+  survive; `compacted` false), witness absent — rejected by the fence
+  alone (`pebble-fence-stripped-old-fold-shape`).
+- Witness mismatch: a foreign generation (future bump) is rejected the
+  same way — the fence is exact-match, never presence-only
+  (`pebble-fence-foreign-witness`).
+
+### R11 — Interruption/resume
+
+Instruments: `TestChaosSourceCacheInterruptResume`,
+`TestChaosSourceCacheReplayStripsExpanderSources`
+(`pkg/sync/chaos_source_cache_resume_test.go`).
+
+- Cut enumeration: crashes before the warm root, after the replay copy,
+  after overlay pages, and around manifest publish all resume and converge
+  to the cold baseline (OR2), with no manifest entry vouching for an
+  incomplete scope (OR3 checked at every seal).
+- Withdrawn-at-resume: a previous artifact that disappears between attempt
+  and resume degrades the resume to cold and still converges.
+- Resume granularity is pinned as CO-6b-002: interrupted paginated actions
+  restart from their ROOT page token (at-least-once page processing); the
+  checkpointed hit/replayed sets act as idempotency guards, asserted
+  explicitly per cell (`grantsTraceHas` on served tokens, exact re-consult
+  counts).
+- Expansion composition: the expansion-enabled scenario proves
+  expander-written `Sources` on direct grants are stripped at replay copy
+  and recomputed, while connector-set `Sources` survive byte-for-byte;
+  OR3 stamp counts exclude the expander-created grant (derived rows stay
+  unscoped — registered boundary B10).
+
+### R12 — Ordering/pagination adversary
+
+Instrument: `TestChaosSourceCacheOrderingAdversary`
+(`pkg/sync/chaos_source_cache_order_test.go`).
+
+- `lost-response-reconsults`: a warm root answered but lost in flight is
+  re-consulted on retry (the warm branch is not burned by an unlanded
+  response); the replay round completes on attempt two.
+- `epoch-drift-between-retries`: the upstream moves between attempts; the
+  retry's consult re-decides (stale → fresh fetch) and the artifact equals
+  the DRIFT epoch's cold truth, never a blend.
+- `spawned-duplicate-replay-cursors`: duplicate replay annotations across
+  spawned cursors produce exactly one copy; the last replay page's
+  validator wins the manifest entry.
+- `TestChaosSourceCacheDuplicateReplayCursorsParallel` re-runs the
+  duplicate-cursors shape at `WithWorkerCount(4)` (CO-6b-003): the
+  per-scope lock serializes the decide-copy-mark sequence, exactly one
+  copy lands, and OR2/OR3 hold under `-race`.
+- Every cell closes with OR2 against the answering epoch's independent
+  cold baseline and OR3 on the final manifest/stamp state.
+
+### R13 — Generational steady state (first-class)
+
+Instruments: `TestChaosSourceCacheGenerationalSteadyState`,
+`TestChaosSourceCacheGenerationalResumedBSeedsC`,
+`TestChaosSourceCacheGenerationalQualityLossBlocksC` (per-PR), and
+`TestChaosSourceCacheGenerationalLongChain` (nightly, six generations)
+(`pkg/sync/chaos_source_cache_generational_test.go`).
+
+- OR5(a) hit-rate parity: all four scopes (etag-style resources,
+  delta-style entitlements, etag-style grants, delta-style grants) consult
+  warm in B and again in C — no per-scope delta.
+- OR5(b) zero fresh fetches for unchanged scopes: every C consult takes
+  the warm branch; no fresh-fetch page is served.
+- OR5(c) manifest parity: every scope entry in B's artifact is present in
+  C's (OR3 snapshots per generation), zero-row scopes included.
+- OR5(d) validator provenance: delta-style validators rotate once per
+  generation; etag-style validators carry unchanged. The long chain holds
+  all four properties across six hops and still equals the cold truth.
+- Adversarial: an interrupted-and-resumed B still seeds a warm C (routine
+  resumes are not chain breaks); a B with genuine quality loss blocks C
+  loudly with the reason in the trace, and C's artifact converges cold.
+- This suite observes the producer half of replay: a replayed scope that
+  failed to republish its entry would alternate hit/miss per generation —
+  the steady-state warm-event assertions would catch it in B→C.
+
+### R14 — Degradation composition
+
+Instruments: `TestChaosSourceCacheStaleValidatorFetchesFresh`,
+`TestChaosSourceCachePoisonedScopeColdInsideWarmSync`
+(`pkg/sync/chaos_source_cache_stale_test.go`).
+
+- Stale validators (upstream changed between generations) consult, fail to
+  match, fresh-fetch, and converge to the cold baseline — warm machinery
+  never replays stale rows.
+- A poisoned scope (CO-015/CO-016 shape: a cross-scope tombstone poisons
+  the stamped scope) reads as a lookup miss inside an otherwise-warm sync
+  and cold-fetches, while sibling scopes stay warm — the graceful
+  composition the CO-016 documentation in `pkg/sourcecache/sourcecache.go`
+  describes.
+
+## Closure-rule items
+
+- The two skipped ETag replay tests were REMOVED from
+  `pkg/sync/pebble_etag_replay_test.go` with a pointer comment; their
+  intent is subsumed by R7/R13 instruments (validator carry: gate matrix +
+  generational; row carry-forward: collection + generational OR2).
+- The 6a `C30-compatibility-record-lifecycle` exclusion is replaced by
+  `TestSourceCacheCompatRecordLifecycle`; the 6a
+  `C25-transitional-empty-overlay-validator`,
+  `C34-transitional-overlay-annotation`, and `source-compatibility-policy`
+  exclusions are closed by the R3/R7/R2 instruments named above and
+  removed from `pkg/dotc1z/engine/pebble/source_cache_exclusions_verification_test.go`
+  with pointer comments.
+- The Phase 6b exclusions registry
+  (`pkg/sync/source_cache_exclusions_verification_test.go`) registers:
+  lambda ask/answer continuation (deferred to 6c), subprocess transport
+  lookup delivery (CO-6b-001), resource-targeted sync and event feeds
+  (B10), and the shrunk-resource-type-list permutation (round-4 N-3,
+  CO-6b-007); and names the instruments for the static-entitlement and
+  derived-row boundaries.
+- The `NOT YET WIRED` block in `pkg/sourcecache/sourcecache.go` is
+  rewritten as current behavior (wiring, CO-6b-001 boundary, CO-016
+  composition) — after R1–R9 instruments passed, and corrected
+  post-review to state the delivery limitation honestly (no wired
+  production transport; deliverability probe keeps unwired paths cold).
+- Tiering: `make chaos-check` gained named source-cache representatives
+  (gate matrix, collection, interrupt/resume, generational steady state,
+  compat drift, replay-without-hit, drifted-resume warm gate, parallel
+  duplicate cursors, unsupported shapes); `make chaos-full-check` runs
+  every `TestChaos(Connector|SourceCache)` suite nightly-tier; the
+  six-generation chain requires `BATON_TEST_NIGHTLY=1`.
+
+## Structural-coverage triage (CO-6b-007)
+
+Method (handbook coverage-driven step for HIGH changes): one combined
+profile over every changed package —
+`go test -coverprofile -coverpkg=<changed packages> ./pkg/sync
+./pkg/sourcecache/... ./pkg/connectorbuilder/... ./pkg/dotc1z/...
+./internal/connector/... ./internal/chaosconnector/...
+./pkg/types/resource/...` — merged per block across test binaries (max
+count; a multi-binary profile repeats every block once per binary),
+intersected with the non-test, non-generated lines this branch changed
+against merge-base `72939098`. Standard tier (no nightly flag), so the
+triage covers what a per-PR run exercises.
+
+At the reviewed SHA `c33f698e`: 87 uncovered changed blocks across 11
+files. Triage produced three instruments for branches judged worth real
+tests, plus three more cells while writing the ledger:
+
+- `TestParseSourceCacheCapabilityUnparsable` — corrupt capability
+  annotation reads as NOT DECLARED (plain cold sync, no error).
+- `TestWarmLookupInputValidationDegradesToMiss` — invalid row kind,
+  invalid scope key, and store read failure each degrade to a miss
+  without failing the connector's call or recording a hit.
+- `TestSourceCachePageOpsStoreWithoutSurface` — record ignored with a
+  warn / replay loud-cold on a store with no source-cache surface.
+- Loud-failure cells for the resources and entitlements handlers
+  (previously grants-only — the profile confirmed the round-4 review's
+  observation that the sibling handlers' identical error seams were
+  unexercised).
+- `TestConnectorClientSourceCacheDelivery` (`internal/connector`) — the
+  production client's setter/probe/delivery trio, previously covered
+  only by the compile pin.
+- `TestSourceCacheWarmStoreDegradeLadder` and the
+  `client-without-setlookup-stays-cold` cell — install-time degrade
+  rungs for structurally unusable previous stores and clients.
+
+Residual uncovered changed blocks: 71 (re-profiled at the final tree).
+Dispositions, every block in one of three groups (42 + 24 + 5):
+
+1. **Store/IO fault propagation with no injection seam** (42 blocks) —
+   compat record read/write failures (orchestration and
+   `pkg/dotc1z/source_cache.go`), batch-commit error wrapping at the
+   Pebble replay loops' mid-loop commit sites
+   (`pkg/dotc1z/engine/pebble/source_cache.go` — the final-batch commit
+   path IS covered via the sentinel-identity test's commit hook, which
+   serves as the representative instrument for the wrapping),
+   `installSourceCacheLookup`/`afterUpserts`/`wrapPageRowPutError`
+   propagation in the three handlers, artifact open/close failures in
+   the eligibility ladder (`syncer.go` fence/quality close-error
+   branches), and `pebble_store.go` file-IO branches. One gap, not
+   forty: uniform two-to-three-line `if err != nil` propagation whose
+   fault cannot be injected without a store-fault seam. Registered under
+   Explicit limitations (the `wrapPageRowPutError` entry now stands for
+   the class); carried to 6c.
+2. **Dead-defensive branches** (24 blocks) — double-checked gates
+   (`sourceCacheWarmStore`'s enabled check, re-verified defensively
+   duplicated by its only caller), nil guards, empty-set normalization
+   in token serialization (`state.go`), protowire malformed-field
+   branches for the witness (`envelope.go`), and chaos-harness internal
+   validation (`internal/chaosconnector` scenario/spec/oracle guards —
+   test infrastructure that fails loud on malformed fixtures).
+   Unreachable by construction; kept fail-closed.
+3. **Warn-only boundary branches, sampled** (5 blocks) — the
+   `EnqueuePageTokens`-on-resources warn (registered boundary), the
+   non-FULL-shape warn when the capability is declared (the gate
+   behavior itself is cell-covered; the warn line is not), and page-ops
+   parse-error propagation through the handlers (the classification is
+   unit-enumerated in the taxonomy; the handlers' `return err` shape is
+   chaos-covered per handler via the beforeUpserts seam, which shares
+   the same two lines).
+
+## Change orders
+
+- **CO-6b-001** — lookup delivery is in-process only (subprocess-wrapped
+  connectors observe `NoopLookup` and sync cold; the ask/answer
+  continuation in 6c is the cross-process mechanism). Amended
+  post-review: NO production transport wires the setter in this phase —
+  in-tree delivery is the chaos harness's clients only — and the syncer's
+  deliverability probe keeps unwired transports cold rather than logging
+  warm. Registered as an executable exclusion; R1 transport coverage is
+  direct + in-process gRPC via those clients.
+- **CO-6b-002** — interrupted paginated actions restart from their root
+  page token (at-least-once page processing); the checkpointed provenance
+  sets are idempotency guards, not mid-chain resume state. Pinned by the
+  resume suite's per-cell trace assertions.
+- **CO-6b-003** — post-review contract tightening: untargeted-FULL-only
+  sync-shape gate (with artifact blocking when produce state predates a
+  capability/shape change on resume), the `sourceCacheWarm` provenance
+  gate in replay enforcement, per-scope atomic decide-copy-mark,
+  unreplayable-shape produce guards (child resource types,
+  `InsertResourceGrants`), and verdict-classification tightening
+  (error-chain-only cancellation, row-put wrapping, duplicate
+  annotations, BID-validated resource tombstones). Full mechanism and
+  instrument list in `plan.md`.
+- **CO-6b-004** — hit-validator binding: recorded hits carry the
+  validator the lookup returned, and the replay copy requires the
+  current base's manifest entry to byte-match it, closing the
+  swapped-previous-artifact hole the eligibility gates cannot see
+  (identical compat keys). Checkpoint hit shape changed to
+  scope → validator. Full entry in `plan.md`.
+- **CO-6b-005** — re-review remediation: mutation-adequate instruments
+  for the deliverability probe and the per-scope replay lock, the probe
+  interface promoted to `pkg/sourcecache` with a compile pin on the
+  production client, the capability-withdrawal-on-resume cell, and the
+  lock-map/scope-set cost benchmarks. Full entry in `plan.md`.
+- **CO-6b-006** — third re-review remediation: the drifted-resume
+  instrument's premise corrected (batch-split scenario with in-band
+  checkpoint assertions; the warm gate is now genuinely
+  mutation-verified end to end), record-only pages hold the scope lock
+  through `afterUpserts` (closing the residual copy-versus-record
+  interleaving race), and the sync-token schema fence (reshaped hit map
+  takes a new JSON key; versioned tokens that fail to parse error
+  loudly instead of silently downgrading to the v0 format and dropping
+  the action stack) with round-trip and fence tests. Full entry in
+  `plan.md`.
+- **CO-6b-007** — round-4 remediation: the held-lock ride-along bound to
+  the chaos fixture plus per-handler loud-failure cells (closing the
+  uninstrumented `release()` backstop, mutation-verified per call
+  site), the structural-coverage triage section below, the
+  `MaterializationWitnessReader` compile pin, the syncer's probe
+  assertion switched to the exported interface, the
+  shrunk-resource-type-list exclusion, and the wording corrections the
+  round requested (token fence scope, lock-hold cost contract, lock
+  cardinality comment). Full entry in `plan.md`.
+
+## Explicit limitations
+
+- Lookup delivery: NO production transport wires the lookup setter this
+  phase (CO-6b-001) — the standard runner path spawns the connector as a
+  subprocess and has no backchannel, and no production in-process
+  constructor wires the setter either. Delivery is verified on the chaos
+  harness's direct and in-process gRPC clients; production syncs run the
+  produce side (stamping, validator publish) but consume cold, with the
+  deliverability probe preventing a false warm log.
+- Lambda ask/answer continuation (`SourceCacheLookupOffer/Ask/Answers`)
+  is unimplemented and deferred to Phase 6c.
+- `overlay=false` replay pages carrying rows are tolerated with a warn and
+  overlay semantics (transitional; hardening to an error is future work).
+- CO-016 (non-destructive external-resource reconciliation) is NOT
+  implemented; connectors using `ExternalResourceMatch*` annotations have
+  their placeholder-grant scopes poisoned every sync and cold-fetch those
+  scopes inside warm syncs, as documented in `pkg/sourcecache`.
+- OR5(b) is observed through consult decisions and served-page shapes,
+  not a dedicated connector-side fetch counter.
+- `wrapPageRowPutError`'s warm classification is unit-pinned, but its
+  wiring at the three collection-handler put sites has no store-fault
+  instrument (the chaos store has no put-failure injection seam);
+  deleting a call site would not fail a test. Known verification gap,
+  carried to 6c alongside the runner ladder that consumes the verdicts.
+- R12 corpus breadth beyond the named adversarial cells and the
+  six-generation chain run at nightly tier, not per-PR.
+
+## Independent reviews
+
+Three independent model code reviews ran against the committed phase
+implementation (closure rules). Verdicts: two REJECT, one ACCEPT WITH
+LIMITATIONS. Every load-bearing finding was verified against the code,
+fixed, and instrumented; the remediation is CO-6b-003 plus the CO-6b-001
+amendment. All fixes landed with their instruments before signoff.
+
+Consolidated findings and dispositions:
+
+1. **Lookup delivery never wired on any production path** (BLOCKER, two
+   reviews). `SetSourceCacheSetter` had no callers, so the production
+   client's setter was always nil while `installSourceCacheLookup` logged
+   "installed (warm)" — the feature was inert in production with logs
+   asserting otherwise. Fixed: `sourceCacheLookupDeliverable` probe;
+   consume side stays cold and never logs warm when the transport cannot
+   deliver; CO-6b-001, the exclusions registry, `pkg/sourcecache` docs,
+   and this document's claims corrected (the original "production
+   in-process path is covered" claim was false). Wiring a production
+   transport is Phase 6c scope alongside the ask/answer continuation.
+2. **Checkpoint-restored provenance re-authorized replay on cold/drifted
+   resume** (BLOCKER). `beforeUpserts` trusted the checkpointed hit-set
+   plus `previousSyncReader` and never consulted the attempt's own gate
+   outcome (`sourceCacheWarm` was a dead field). Fixed: the warm gate is
+   enforced in `beforeUpserts`; instrument
+   `TestChaosSourceCacheDriftedResumeRejectsRestoredReplay`.
+3. **Non-atomic once-per-scope replay guard** (MAJOR, all three reviews).
+   Check-then-act between `SourceCacheReplayed` and
+   `MarkSourceCacheReplayed` duplicated replacement copies at
+   `WithWorkerCount > 1`, able to resurrect replaced overlay rows.
+   Fixed: per-`(rowKind, scopeKey)` mutex around decide-copy-mark;
+   instruments `TestSourceCacheReplayOncePerScopeIsAtomic` (overlapping
+   `beforeUpserts` calls for one scope, mutation-verified against mutex
+   removal) and `TestChaosSourceCacheDuplicateReplayCursorsParallel`
+   (end-to-end shape at worker count 4).
+4. **Replayed resource pages never schedule child-resource discovery**
+   (MAJOR, two reviews). Child discovery runs over a page's own rows and
+   replay pages return zero rows, so replaying a parent scope silently
+   dropped all child resources. Fixed as a produce-side guard: pages
+   declaring child resource types (or grants pages carrying
+   `InsertResourceGrants`) block the artifact as a future replay source;
+   instrument `TestChaosSourceCacheUnsupportedShapesBlockReplaySeed`.
+5. **Fail-open verdicts and classification gaps** (MINOR, multiple).
+   Ambient `ctx.Err()` promoted any replay-copy failure to warm; row-put
+   failures on annotated pages carried no verdict; duplicate same-type
+   annotations were silently first-match; targeted/partial syncs were not
+   excluded from source-cache handling; capability withdrawal across a
+   resume left stale produce state trusted. All fixed under CO-6b-003
+   with taxonomy cells.
+6. **Overfit sentinel test** (MINOR). The syncer taxonomy synthesized the
+   destination-commit sentinel by hand, so deleting the engine's wrapping
+   would have passed. Fixed: `TestVerificationReplayVerdictSentinelIdentity`
+   injects at the engine's real commit/read seams and asserts sentinel
+   identity both ways.
+
+Findings reviewed and NOT acted on: none load-bearing — the remaining
+reviewer notes (stale comments, log ordering) were fixed inline as part
+of the batches above.
+
+### Re-review rounds (post-remediation)
+
+Three independent re-reviews audited the CO-6b-003 remediation; all
+three REJECTED, on the shared ground that fixes claimed closed lacked
+mutation-adequate instruments (reverting the fix left the suite green).
+The third also ran an adversarial pass with mutation testing and found
+two genuinely new defects. Dispositions:
+
+1. **Vacuous instruments for the probe and the per-scope mutex** (rounds
+   one and two) — closed under CO-6b-005:
+   `TestSourceCacheLookupDeliverabilityProbe` and
+   `TestSourceCacheReplayOncePerScopeIsAtomic`, both mutation-verified,
+   plus the compile pin on the production client and the
+   capability-withdrawal cell (which also kills the third round's
+   surviving withdrawal-block mutant).
+2. **Drifted-resume instrument premise false** (third round, confirmed
+   by mutation on HEAD: the chaos test passed with the warm gate
+   deleted because no surviving checkpoint ever contained the hit) —
+   closed under CO-6b-006 with the batch-split scenario and in-band
+   premise assertions; the R8 claim this document previously made for
+   the old scenario was withdrawn and replaced. The unit cell had
+   independently killed the mutation throughout; the chaos instrument
+   now does too.
+3. **Record-only pages bypass the scope lock** (third round, N1, MAJOR)
+   — a real residual race of the same class the mutex closed; fixed and
+   instrumented under CO-6b-006.
+4. **Token schema change without a version fence** (third round, N5) —
+   real data-loss hazard (v1-token parse failure silently downgraded to
+   the v0 format, dropping the action stack); fixed and instrumented
+   under CO-6b-006 before any release carried the reshaped field.
+5. **Provenance-set round-trip untested** (third round, N3) — closed:
+   `TestSyncerTokenSourceCacheSetsRoundTrip`; the marshal cost curve was
+   already pinned under CO-6b-004.
+6. **Retained lock map unreclaimed/undocumented** (third round, N4) —
+   already closed under CO-6b-005 (documentation and
+   `BenchmarkSourceCacheScopeLocks`); cardinality note updated for the
+   CO-6b-006 lock-scope extension (one mutex per scoped page's scope,
+   not per replayed scope).
+7. **Produce-guard limitations noted, not blocking** (third round): the
+   unsupported-shape block is artifact-wide (per-sync stats, one
+   hierarchical resource type blocks every scope), and it fires even for
+   child types excluded from the sync — both conservative in the safe
+   direction; recorded here as accepted behavior.
+
+### Round 4 (against `c33f698e`)
+
+Three reviewers; one ACCEPT WITH LIMITATIONS, two REJECT. All three
+independently re-ran the recorded gates clean and confirmed all seven
+CO-6b-006 closure claims mutation-adequate by experiment (each fix
+reverted in an isolated clone; the named instrument failed), and
+confirmed every prior-round finding closed. The rejections rested on two
+new findings, both remediated under CO-6b-007:
+
+1. **The scope-lock `release()` backstop was uninstrumented** (MAJOR,
+   one review) — deleting the grants handler's `defer scOps.release()`
+   left the entire package green, while this document named the
+   record-page parking test as its instrument (which only exercises
+   `afterUpserts`'s release). The reviewer verified the hazard is real:
+   `beforeUpserts` retains the lock on its error returns,
+   `syncOneAction` retries a failed action in the same goroutine, and
+   the grants handler makes a connector RPC inside the lock window — a
+   transient `Unavailable` with the backstop absent hangs the sync
+   permanently. Closed with the ride-along + per-handler cells
+   (mutation-verified per site) as the reviewer prescribed: the class is
+   retired structurally, not point-tested a third time.
+2. **Structural-coverage triage absent** (MAJOR, one review) — the
+   handbook requires per-block dispositions for uncovered changed code
+   in HIGH changes, and this document had none. Closed with the
+   triage section above, including the three unit instruments it
+   produced. The review's spot observation — the loud-failure cells
+   exercised only the grants handler's error seam — was confirmed by
+   the profile and closed by the per-handler cells.
+3. **Minor/low**: witness assertion unpinned (closed: named interface +
+   compile pin); syncer asserted a private duplicate of the exported
+   probe interface (closed: duplicate deleted); shrunk-type-list replay
+   permutation unenumerated (closed: registered exclusion with
+   containment rationale); performance evidence silent on the extended
+   lock hold (closed: cost contract stated); token-fence wording
+   overclaimed (closed: narrowed to parse-failure-only); token fence
+   hard-fails a corrupt same-version token on every resume where the
+   handbook prefers degrading to redone work (accepted as the
+   documented operational contract — same shape as the cold-verdict
+   retry-livelock note, with the in-tree abandon path being 6c's
+   runner ladder); `requireSourceCacheEvents` claim scoped to the
+   suites that call it.
+
+### PR review round (automated, PR #1112)
+
+Zero blocking findings, four suggestions; dispositions (CO-6b-004):
+
+1. **Hit not bound to its artifact** (load-bearing) — a previous artifact
+   swapped between attempts for a gate-identical sibling could satisfy a
+   checkpointed hit and import unrevalidated rows. Fixed: hits record the
+   lookup's validator; `beforeUpserts` requires the current base's
+   manifest entry to byte-match before the copy; four cold cells added.
+2. **Provenance-set checkpoint cost unbounded** — cost curve documented on
+   the field and pinned by `BenchmarkStateMarshalSourceCacheSets`;
+   sidecar persistence named as the whale-scale escape hatch. Not moved
+   to sidecar in this phase.
+3. **Cold verdict has no consumer; degraded mid-sync resumes fail
+   deterministically** — operational contract documented on
+   `beforeUpserts` (loud repeated failure until the caller's retry policy
+   abandons the unfinished sync; 6c's ladder automates the cold
+   fallback). No behavior change.
+4. **Private backend paths in `docs/rfcs/0010-sqlite-conversion-only.md`**
+   — scrubbed to generic descriptions per the public-repo content
+   guidelines; exact call sites stay in the internal ticket.

--- a/docs/verification/sync-replay-6b/plan.md
+++ b/docs/verification/sync-replay-6b/plan.md
@@ -1,0 +1,872 @@
+# Sync Replay Phase 6b Verification Plan — Orchestration
+
+Status: frozen behavioral baseline, with append-only change orders below.
+
+This plan was frozen before writing any Phase 6b orchestration code. The
+pre-existing surfaces it builds on (Phase 6a storage machinery, the annotation
+protos, the chaos harness, the syncer's existing eligibility gate) were read
+first; the behavior specified here for the NEW orchestration is preregistered
+and implementation-blind with respect to that new code. Deviations discovered
+during implementation are logged as change orders, never silently absorbed.
+
+## Guardrails and risk verdict
+
+- Inputs used for the frozen core: `docs/BUG_CATCHING.md`,
+  `docs/REVIEW_CHECKLIST.md`, `docs/verification/sync-replay-6a/plan.md`
+  (especially CO-013..CO-017 and deferred criteria C29/C30),
+  `docs/verification/sync-replay-6a/evidence.md` (signoff scope),
+  `pkg/sourcecache/sourcecache.go` (the connector-facing contract, present
+  tense by design), `proto/c1/connector/v2/annotation_source_cache.proto`,
+  `proto/c1/storage/v3/records.proto`, `proto/c1/c1z/v3/manifest.proto`, the
+  Phase 6b plan's PR 2 section, and the existing seams in `pkg/sync/syncer.go`,
+  `pkg/connectorbuilder/`, `internal/connector/connector.go`,
+  `pkg/dotc1z/source_cache.go`, and `internal/chaosconnector/`.
+- Phase 6b is HIGH risk: failures are silent (a warm sync that quietly loses a
+  scope's rows is green), combinatorial (capability × provenance × compat ×
+  quality × page shape × interruption), and have no single-run oracle (chain
+  continuity is only observable across three or more generations).
+- Replay is Pebble-only by design (`docs/rfcs/0010-sqlite-conversion-only.md`).
+  Non-Pebble previous artifacts degrade to cold inputs through the existing
+  `NewSyncer` gate; nothing SQLite-side is built or verified beyond that
+  degradation.
+- Store-level semantics (copy exactness, scope isolation, tombstone unions,
+  source immutability, poison behavior) were closed in Phase 6a and are NOT
+  re-verified here; 6b verifies the orchestration that drives them and the
+  sync-level equivalences only 6b can make observable.
+- Observed baseline fact: the chaos-level eligibility-gate matrix described in
+  the Phase 6b plan's PR 1 did not land as such on `main` (PR #1045 absorbed
+  the corpora differently; `TestPreviousSyncC1ZPathEnforcesReplayEligibility`
+  is a plain table test). The 6b gate-matrix suite therefore builds its own
+  artifact-provenance helpers and is the first chaos-level instrument for the
+  gate.
+- Out of scope: everything in 6c (runner cold-retry, spare promotion, lambda
+  continuation plumbing, CLI audit command), PR 7 drops, CO-016 reconciliation
+  rework, incremental-expansion Stage A/B.
+
+## Frozen behavioral contract
+
+### B1 — Capability parsing and lookup install/teardown
+
+- The syncer parses `SourceCacheCapability` from the `Validate` response
+  annotations at the start of every sync attempt, including resumes.
+- Absent capability or any mode other than `MODE_READ_WRITE` means every
+  source-cache annotation on every page is ignored for the whole sync (proto
+  contract). No stamping, no manifest writes, no compat record.
+- The syncer delivers the lookup to the connector via
+  `sourcecache.SetLookup.SetSourceCache` at sync start and delivers `nil` at
+  sync end (all exits, including error paths), so a late RPC cannot read stale
+  state. Delivery mirrors the session-store pattern:
+  `internal/connector.connectorClient` forwards to a builder-side setter;
+  `pkg/connectorbuilder`'s builder implements `sourcecache.SetLookup` and
+  populates a new `resource.SyncOpAttrs.Lookup` field at all four list sites
+  (`ListResources`, `ListStaticEntitlements`, `ListEntitlements`,
+  `ListGrants`). When no lookup has been delivered (or `nil` was delivered),
+  the builder populates `sourcecache.NoopLookup{}` — connectors never see a
+  nil Lookup.
+- The installed warm lookup is a syncer-owned wrapper over the previous
+  store's `LookupSourceCacheEntry` that records every HIT `(row_kind,
+  scope_key)` into the sync's durable provenance set (B5). Lookup read errors
+  that leave fresh fetch available are returned as misses, not errors
+  (package contract). Poisoned scopes already read as misses at the store
+  layer; orchestration treats every miss as "fetch cold", never an error.
+
+### B2 — Warm/cold gate decision table
+
+A warm lookup (backed by the previous artifact) is installed if and only if
+ALL of the following hold; otherwise `NoopLookup` is installed and the sync
+proceeds cold with a structured warn naming the first failing condition:
+
+| # | Condition | Where evaluated |
+|---|-----------|-----------------|
+| G1 | A previous artifact was supplied and opens read-only | `NewSyncer` (exists) |
+| G2 | Previous artifact is Pebble-engine | `NewSyncer` (exists) |
+| G3 | Latest finished sync is FULL and not compacted (`UsableAsReplaySource`) | `NewSyncer` (exists) |
+| G4 | Previous artifact's latest usable run has ingest-quality stats present and `source_cache_replay_blocked == false` (`c1zstore.SourceCacheReplayEligible`) | `NewSyncer` (new) |
+| G5 | Previous artifact's envelope manifest carries the materialization witness equal to `sourcecache.MaterializationPolicyGeneration` (CO-017 fence, B8) | `NewSyncer` (new) |
+| G6 | Connector declared `SourceCacheCapability` `MODE_READ_WRITE` on this sync's Validate response | `Sync`, post-Validate (new) |
+| G7 | Previous artifact's stored `SourceCacheCompatRecord` byte-matches the current sync's computed compat key on all four fields (B4) | `Sync`, post-Validate (new) |
+
+- Strict-open failures (explicit `WithPreviousSyncC1ZPath` that cannot be
+  opened) remain hard errors, as today. Every other failure of G1–G7 is
+  optional-degrade: warn with the reason (quality degradation includes the
+  block reason flags), install `NoopLookup`, proceed cold.
+- Degradation applies to the CONSUME side only. When capability is
+  `MODE_READ_WRITE`, the produce side (stamping, manifest publish, compat
+  record — B3/B4) runs regardless of G1–G5/G7, because a cold sync by a
+  capable connector must still seed the next sync (generation A seeds B).
+- A lossy B must never seed C: G4 is evaluated against the same run that G3
+  selected.
+
+### B3 — Fresh-page handling (`SourceCacheRecord`)
+
+Honored on `ListResources`, `ListEntitlements`, and `ListGrants` responses
+when capability is `MODE_READ_WRITE`. Row kind is determined by the RPC,
+never the annotation.
+
+- Scope key is validated (`sourcecache.ValidateScopeKey`); an invalid scope
+  key on an annotated page fails the sync loudly (cold verdict, B7) — the
+  connector asked for caching semantics the SDK cannot key.
+- The page's connector-emitted rows are stamped by wrapping the store puts in
+  `sourcecache.WithScope(ctx, scope_key)`. Only the annotated page's rows are
+  stamped: SDK-derived writes (expansion output, external-principal
+  reconciliation writes, targeted-sync injections) and rows from other pages
+  are not.
+- Tombstones apply AFTER the page's rows commit (proto contract, closes the
+  orchestration half of 6a C29's within-page order):
+  `deleted_ids` → canonical-ID tombstones (`DeleteSourceCacheRows`);
+  `deleted_principal_ids` → principal-scoped tombstones (grants: every grant
+  in scope whose principal id matches; resources: resource rows in scope by
+  resource id). `deleted_principal_ids` on an entitlements page is a loud
+  sync failure (cold verdict): the proto defines no semantics for it.
+- Manifest publish: when a page's `cache_validator` is non-empty, the syncer
+  writes the scope's manifest entry (`PutSourceCacheEntry`) after that page's
+  rows and tombstones complete. A zero-row page with a non-empty validator
+  still publishes (200-with-zero-rows contract). Interim pages with empty
+  validators publish nothing; a scope whose round never supplies a non-empty
+  validator gets no entry and is a miss next sync (6a C25's transitional
+  semantics, at orchestration level).
+- `SourceCacheRecord` on `ListStaticEntitlements` responses is ignored with a
+  warn: static entitlements stay unscoped (registered exclusion).
+
+### B4 — Compat record lifecycle (closes 6a C30)
+
+- When capability is `MODE_READ_WRITE`, the syncer writes the singleton
+  `SourceCacheCompatRecord` (id `"compat"`) into the current store at sync
+  start, after Validate and before the first list action. Fields:
+  - `connector_cache_generation` — from the capability, verbatim.
+  - `connector_config_fingerprint` — from the capability, verbatim.
+  - `sdk_materialization_generation` — the new exported constant
+    `sourcecache.MaterializationPolicyGeneration`. Bumped when the SDK
+    changes how it materializes replayed rows (e.g. the expander-source
+    stripping rule); a bump colds every pre-bump artifact.
+  - `sync_selection_fingerprint` — lowercase-hex sha256 of the canonical
+    string `v1|types=<comma-joined sorted resource-type filter>|skipEG=<bool>|skipG=<bool>`
+    over the sync's selection shape (empty filter list canonicalizes to an
+    empty segment). Any selection change colds the next sync.
+- Byte-match gating (G7): all four fields of the previous artifact's stored
+  record must equal the current sync's computed values byte-for-byte. A
+  missing record on a previous artifact that is otherwise usable is a
+  mismatch (degrade). Empty strings match only empty strings.
+- Resume: the record is recomputed on every attempt. If a record already
+  exists and matches, the write is an idempotent no-op. If it exists and
+  DIFFERS (connector or config changed between resume attempts), the sync's
+  cached rows are mixed-generation: the original record is left in place,
+  the warm lookup (if any) degrades to `NoopLookup` for the remainder, and
+  the artifact is marked replay-blocked through the ingest-quality reason
+  flags so it cannot seed the next sync. The sync itself proceeds.
+- Storage lifecycle: the record lives in the source-cache key family, so the
+  fold compactor's `InvalidateSourceCacheReplayState` and the
+  rebuild/overlay compactors' family drops remove it with the rest of the
+  replay state; cleanup/reset/leak accounting include it (this is the
+  executable closure of the skipped `C30-compatibility-record-lifecycle`
+  cell).
+
+### B5 — Replay handling (`SourceCacheReplay`) and provenance
+
+Honored on `ListResources`, `ListEntitlements`, and `ListGrants` responses.
+Row kind from the RPC. Ordering per page is frozen as: replay copy → page
+upserts (stamped with the scope) → page tombstones (canonical ∪ principal,
+after upserts). Cross-page ordering follows page arrival order exactly;
+cross-page re-adds after a tombstone are the connector's responsibility
+(proto contract).
+
+- Same-sync provenance: a replay is honored only for a `(row_kind,
+  scope_key)` present in this sync's lookup hit-set. The hit-set is recorded
+  by the warm lookup wrapper (B1) and persisted in the sync's checkpoint
+  token state, restored on resume — a planning call may batch-resolve scopes
+  and hand verdicts to sibling cursors via `EnqueuePageTokens` page tokens,
+  and those cursors may run after an interrupt/resume in a different
+  process. A replay for a scope NOT in the hit-set (including any replay
+  while the lookup is `NoopLookup`) fails the sync loudly with a cold
+  verdict: the connector skipped row generation, there is nothing to fall
+  back to.
+- Replay copy runs once per `(row_kind, scope_key)` per sync. The
+  replayed-scope set is persisted in the checkpoint token state alongside
+  the hit-set. A later `SourceCacheReplay` for an already-replayed scope
+  skips the copy (idempotent under duplicate pages and lost-response
+  retries) and applies the page's upserts/tombstones normally.
+- `overlay == false` with rows on the page: transitional tolerance — warn
+  and apply the rows as overlay upserts (pins 6a C34's shape at
+  orchestration level; the proto documents this hardening to an error
+  later).
+- Validator publish: if `SourceCacheReplay.cache_validator` is non-empty,
+  the manifest entry is published after that page's operations complete;
+  otherwise publish is deferred to a later `SourceCacheRecord` page whose
+  `cache_validator` is non-empty (B3 rule). A replayed scope whose round
+  never publishes a validator has no entry and is a miss next sync — the
+  replay itself remains valid (rows are correct; only cacheability is
+  lost).
+- Checkpoint durability: hit-set and replayed-set mutations are recorded in
+  the token state under the syncer's existing state lock and travel with
+  the normal checkpoint cadence. Both sets are monotone within a sync, so
+  a checkpoint cut between a lookup and its page commit is harmless: the
+  worst case re-records a hit or re-runs an idempotent copy.
+
+### B6 — Quality consume-side gate
+
+- G4 of the decision table: `NewSyncer` reads the ingest-quality stats of
+  the run selected by G3 and requires `c1zstore.SourceCacheReplayEligible`
+  (stats present AND `source_cache_replay_blocked == false`). Absent stats
+  degrade (pre-6b artifacts and unknown-checkpoint conservatism), blocked
+  stats degrade with the reason flags in the warn.
+- The produce side is untouched: `ingestFilterStats` continues to decide
+  `SourceCacheReplayBlocked`, with one addition — the compat-drift-on-resume
+  reason (B4).
+
+### B7 — Warm/cold `ErrReplayIntegrity` taxonomy
+
+- A new exported error surface in `pkg/sync`: `ErrReplayIntegrity`, carrying
+  a verdict (`Warm` or `Cold`), the row kind, and the scope key, reachable
+  via `errors.Is`/`errors.As` from the sync error chain. 6c's runner
+  consumes it; 6b attaches it at every orchestration replay failure path.
+- Frozen classification:
+  - **Cold** (discard the spare, cold-retry): provenance violation (replay
+    for an unknown scope, replay while cold); invalid annotation shapes
+    (invalid scope key, principal tombstones on entitlements); source-side
+    integrity failures from the store's replay preflight (poisoned scope,
+    ineligible/inconsistent source, count mismatch) — the previous artifact
+    or the connector's replay decision cannot be trusted.
+  - **Warm** (retryable with replay still armed): destination-side failures
+    after a sound source verdict — replay-copy commit errors past
+    preflight, overlay upsert/tombstone write errors, manifest publish
+    errors, and interruption/cancellation mid-replay. The replay decision
+    remains valid; a retry may succeed warm.
+  - Ambiguous store errors default to cold (fail-closed: a wrong cold
+    wastes a fetch; a wrong warm can loop on a poisoned artifact).
+
+### B8 — CO-017 cross-version fold fence (Rider A decision)
+
+- Hazard (from 6a CO-017): an OLDER pebble3 SDK's fold byte-copies a scoped
+  artifact and rewrites primaries while leaving the source-cache manifest,
+  poison markers, scope indexes, and any byte-copied compat record intact,
+  sets no `compacted` stamp, and invalidates nothing — a stale-but-eligible
+  replay source. A byte-copied payload record can never be the fence.
+- **Frozen decision: a save-time materialization witness in the v3 envelope
+  manifest.** The current engine writes a new `C1ZManifestV3` field carrying
+  `sourcecache.MaterializationPolicyGeneration` on EVERY envelope save. The
+  eligibility gate (G5) requires the previous artifact's witness to equal
+  the current constant before installing a warm lookup.
+- Why this fences: every committed old-SDK write session — fold included —
+  must rewrite the c1z envelope, and it rebuilds the manifest from its own
+  proto descriptors, which do not know the field. The witness is therefore
+  necessarily ABSENT from any old-fold output, and the old fold cannot
+  forge it. The payload compat record's `sdk_materialization_generation`
+  (B4) is still byte-matched, but the envelope witness is the fence. This
+  instantiates CO-017's "fold-disturbance witness" candidate; the engine
+  name stays `pebble3`, so old SDKs retain read access to scoped artifacts.
+- Collateral (accepted): ANY old-SDK write session against a scoped
+  artifact drops the witness and colds the chain — correct, since any
+  old-SDK write makes the source-cache state untrustworthy.
+- Pinned by a test that simulates the old-fold shape: scoped artifact →
+  envelope rewritten without the witness while the payload (manifest
+  entries, indexes, counts, compat record) survives byte-identical and
+  `compacted` stays false → the gate must degrade cold with the fence
+  reason observable.
+
+### B9 — CO-016 graceful degrade (Rider B, no implementation)
+
+- Connectors using `ExternalResourceMatch*` annotations get their
+  placeholder-grant scopes poisoned every sync by design (destructive
+  reconciliation). Orchestration inherits the correct behavior with no new
+  code: poison ⇒ store-level lookup miss ⇒ `NoopLookup`-equivalent verdict
+  for that scope ⇒ cold fetch, which is pre-replay behavior. The rewritten
+  `sourcecache.go` docs and this plan say so explicitly; the non-destructive
+  reconciliation rework is a separate future PR.
+
+### B10 — Explicit exclusions (registered)
+
+- Lambda ask/answer continuation: `SourceCacheLookupOffer` is never attached
+  to requests, `SourceCacheLookupAsk`/`SourceCacheLookupAnswers` are never
+  consumed/produced by 6b orchestration. Deferred to 6c; registered in the
+  executable exclusions registry.
+- Static entitlements stay unscoped (B3); derived rows (expansion output,
+  reconciliation writes) stay unscoped (B3).
+- `ResourceTargetedSyncer.Get` and event feeds carry no source-cache
+  semantics.
+
+## Oracles
+
+- **OR1, gate/trace conformance**: for every gate-matrix cell, the observed
+  outcome (warm vs cold lookup, hit/miss trace events, degradation reason)
+  equals the decision-table row. Instrument: chaos trace lookup events plus
+  gate logs.
+- **OR2, cold-baseline differential**: a warm run's final logical content
+  equals an independent cold baseline of the same final epoch
+  (`CompareLogicalContent` full-proto fingerprints). The sync-level
+  analogue of 6a's O2.
+- **OR3, manifest/stamp observation**: after a sync, every expected scope
+  has exactly the expected manifest entry (validator value, zero-row scopes
+  included) and annotated pages' rows carry the expected stamps; unexpected
+  scopes have none. Instrument: oracle reads over the produced artifact.
+- **OR4, error-identity oracle**: failure cells surface `ErrReplayIntegrity`
+  with the frozen verdict via `errors.As`, and loud-failure cells fail the
+  sync rather than degrade.
+- **OR5, generational parity**: across A→B→C against an unchanged upstream:
+  (a) per-scope lookup hit-rate parity between B and C — any delta is the
+  finding regardless of cause; (b) zero fresh fetches in C for unchanged
+  scopes (connector-side fetch counters); (c) manifest parity — every scope
+  entry in B's artifact present in C's, zero-row scopes included;
+  (d) validator provenance — delta-style validators rotate every
+  generation, etag-style carry unchanged.
+- **OR6, checkpoint/resume conformance**: interruption cuts around every
+  replay stage resume to OR2 equivalence with no manifest entry claiming a
+  validator over an incomplete scope; the provenance/replayed sets restored
+  from the checkpoint behave identically to uninterrupted state.
+
+## Criteria
+
+Each criterion names its oracle(s) and coverage level. R7 closes 6a C29 at
+orchestration level; R4 closes 6a C30.
+
+- **R1 Lookup lifecycle** — capability parsed each attempt; warm/Noop
+  installed per B2; `SetSourceCache(nil)` on every exit; `SyncOpAttrs.Lookup`
+  populated at all four builder sites, `NoopLookup` when unset; a late call
+  after teardown observes no stale lookup. Oracle: OR1 + unit assertions.
+  Coverage: bounded (all four sites; direct and in-memory-gRPC chaos
+  transports).
+- **R2 Gate decision table** — every reachable G1–G7 cell produces exactly
+  the frozen outcome, warm or degrade-with-reason; strict-open stays hard.
+  Oracle: OR1. Coverage: bounded matrix — capability
+  {absent, disabled, read-write} × previous source {none, SQLite,
+  unfinished, non-FULL, compacted, quality-blocked, fence-stripped,
+  usable} × compat {match, each-field-mismatch, record-absent}, pruned to
+  reachable combinations with every gate condition falsified at least once
+  in isolation.
+- **R3 Fresh-page semantics** — stamping exactness (only annotated pages'
+  rows), manifest publish on non-empty validator including zero-row scopes,
+  per-page tombstones after puts, empty-validator rounds publish nothing,
+  static-entitlement annotations ignored with warn. Oracle: OR3 + OR2.
+  Coverage: bounded over row kinds × {single-page, multi-page,
+  zero-row, tombstoned} cells.
+- **R4 Compat lifecycle (closes C30)** — record written at the frozen time
+  with the frozen fields; resume idempotence; drift-on-resume blocks replay
+  and degrades per B4; fold/rebuild/cleanup lifecycle inclusion. Oracle:
+  OR3 (record bytes) + OR1 + lifecycle assertions. Coverage: bounded.
+- **R5 Compat byte-match** — any single-field mismatch degrades; empty
+  matches only empty; missing record degrades. Oracle: OR1. Coverage:
+  bounded per-field cells (inside the R2 matrix).
+- **R6 Quality consume gate** — blocked or stats-absent previous artifact
+  degrades with reason; eligible artifact passes; the run inspected is the
+  run G3 selected; a chaos run that trips an ingest-filter drop, seals, and
+  is offered as the previous source degrades with the block reason in the
+  trace. Oracle: OR1. Coverage: bounded.
+- **R7 Replay semantics (closes C29 at orchestration)** — frozen page order
+  (copy → upserts → tombstones), cross-page order preserved, copy dedup per
+  scope, `overlay=false` tolerance, validator publish on either path,
+  cross-kind non-aliasing driven by RPC kind. Oracle: OR2 + OR3.
+  Coverage: bounded over kinds × {pure replay, replacement, delta overlay +
+  tombstones, zero-row, same scope across kinds} — the collection-semantics
+  range.
+- **R8 Provenance enforcement** — replay without a this-sync hit fails
+  loudly cold (including replay-while-cold); planning-call → spawned-cursor
+  handoff accepted; hit-set and replayed-set survive interrupt/resume;
+  post-sync teardown clears connector-visible lookup. Oracle: OR4 + OR6 +
+  OR1. Coverage: bounded, including at least one cross-process-shaped
+  resume (new syncer instance over the checkpointed state).
+- **R9 Verdict taxonomy** — every orchestration replay failure path carries
+  the frozen warm/cold classification, surfaced via `errors.As`. Oracle:
+  OR4. Coverage: bounded enumeration of every failure path named in B7.
+- **R10 CO-017 fence** — new saves carry the witness; the simulated
+  old-fold shape (payload intact, witness absent, `compacted` false)
+  degrades cold with the fence reason; witness mismatch (future bump)
+  degrades. Oracle: OR1 + artifact inspection. Coverage: bounded.
+- **R11 Interruption/resume** — cuts after replay copy, after overlay,
+  after tombstones, and around manifest publish resume and converge to the
+  cold baseline; a cold resume (previous artifact withdrawn at resume)
+  converges too; one expansion-enabled scenario proves expander-written
+  Sources on direct grants are stripped at copy and recomputed while
+  connector-set Sources survive byte-for-byte. Oracle: OR6 + OR2 + OR3.
+  Coverage: bounded cut enumeration on a deterministic scenario.
+- **R12 Ordering/pagination adversary** — duplicate pages, duplicate
+  cursors, lost-response retries, and epoch drift between retries preserve
+  OR2 equivalence and single-copy semantics. Oracle: OR2 + OR3 + trace.
+  Coverage: bounded adversarial cells; corpus breadth is nightly.
+- **R13 Generational steady state (first-class; own closure entry)** —
+  A cold → B warm → C warm against a deterministic unchanged upstream:
+  OR5(a–d) in full; adversarial cells: B interrupted-and-resumed still
+  seeds C (the conservative replay-blocked default must not convert
+  routine resumes into chain breaks); B with genuine quality loss blocks C
+  loudly (trace shows the reason), never silently. This suite is the only
+  instrument observing replay's producer half — a replayed scope that
+  fails to republish its manifest entry alternates hit/miss per generation
+  with green syncs, and only this criterion catches it. It is not folded
+  into R7's range. Oracle: OR5 + OR1 + OR2. Coverage: bounded
+  three-generation chain per-PR; wider corpora nightly.
+- **R14 Degradation composition** — poisoned scopes (CO-016 shape) read as
+  misses and cold-fetch inside an otherwise-warm sync; stale validators
+  (upstream changed between B and C) produce fresh fetches, not replays,
+  and the artifact converges to the cold baseline. Oracle: OR2 + OR1.
+  Coverage: bounded.
+
+## Closure rules
+
+- Every criterion above needs a closure entry in `evidence.md` naming its
+  instrument(s) and observed outcome; R13 gets its own entry, never merged
+  into R7's.
+- The two skipped ETag tests in `pkg/sync/pebble_etag_replay_test.go` are
+  replaced by the suites above (their intent — validator carry across syncs
+  and previous-sync row carry-forward — is subsumed by R7/R13); the
+  `C30-compatibility-record-lifecycle` exclusion is un-skipped/replaced per
+  R4; the exclusions registry drops orchestration-deferred entries and adds
+  the ask/answer continuation, static-entitlement, and derived-row
+  exclusions (B10).
+- The `NOT YET WIRED` block in `pkg/sourcecache/sourcecache.go` is rewritten
+  as current behavior once — and only once — R1–R9 instruments pass.
+- Tiering: deterministic single-scenario suites run per-PR; large corpora
+  (R12 breadth, extra R13 generations) go nightly via
+  `BATON_TEST_EXTRA`/`BATON_TEST_NIGHTLY`; every new suite family keeps at
+  least a smoke slice in per-PR CI, and `make chaos-check` gains named
+  representatives.
+- Gates before signoff: full suites, `make lint`, focused `-race` on the new
+  orchestration and chaos suites, `make chaos-check`, then three
+  independent model code reviews with findings verified before fixes.
+
+## Baseline placement map (pre-implementation)
+
+- Gate + lookup install: `pkg/sync/syncer.go` — `NewSyncer` previous-artifact
+  gate (G4/G5 additions), `Sync` post-Validate (G6/G7, install), sync-end
+  teardown; hit-set/replayed-set in `pkg/sync/state.go` token state.
+- Delivery: `internal/connector/connector.go` (`connectorClient` forwarder,
+  mirroring `SetSessionStore`); `pkg/connectorbuilder/connectorbuilder.go`
+  (builder implements `sourcecache.SetLookup`);
+  `pkg/connectorbuilder/resource_syncer.go` (4 `SyncOpAttrs` sites);
+  `pkg/types/resource/resource.go` (`SyncOpAttrs.Lookup`).
+- Page handling: `pkg/sync/syncer.go` — `syncResources`,
+  `syncEntitlementsForResource`, `syncGrantsForResource`, static-entitlement
+  path (ignore+warn).
+- Compat record: new key under the source-cache family in
+  `pkg/dotc1z/engine/pebble/internal/rawdb/` + engine/store accessors in
+  `pkg/dotc1z/`; writer in the syncer.
+- Fence witness: `proto/c1/c1z/v3/manifest.proto` field +
+  `pkg/dotc1z/engine/pebble/manifest.go` (write) + gate read via the
+  manifest header path.
+- Verdicts: `pkg/sync` error types near `ingest_invariants.go`'s ladder.
+- Harness: `internal/chaosconnector/` builder capability emission, page
+  model `(kind, scope, validator, mode, tombstones)`, real lookup from
+  `SyncOpAttrs.Lookup` with planning-handoff shape, trace lookup events,
+  oracle manifest/stamp/fetch-count observations.
+- Suites: `pkg/sync/chaos_source_cache_*_test.go`.
+
+## Change-order log
+
+(Append-only. Deviations from the frozen contract discovered during
+implementation are recorded here as CO-6b-NNN entries with mechanism, reason,
+and verification delta.)
+
+### CO-6b-001 — Lookup delivery is in-process only
+
+- Type: scope boundary discovered during implementation; no contract change
+  for in-process connectors.
+- Mechanism: B1 specifies delivery mirroring the session-store pattern
+  (`internal/connector.connectorClient` forwards to a builder-side setter).
+  The session-store pattern works because the wrapper and the builder share
+  a process in the in-process configurations. When the runner spawns the
+  connector as a SUBPROCESS, `SetSourceCache(lookup Lookup)` cannot cross
+  the process boundary — there is no RPC backchannel for an interface
+  value, and building one (a reverse-direction lookup service) is new
+  protocol surface out of 6b's scope.
+- Behavior: subprocess-wrapped connectors observe `NoopLookup` for the
+  whole sync and serve cold, which is the frozen degrade default (B2's
+  optional-degrade). Delivery requires the transport that constructs the
+  connector client to wire a live in-process setter behind
+  `SetSourceCache`; in-tree, only the chaos harness's clients (direct and
+  in-process gRPC) do. There is NO wired production path in this phase —
+  `internal/connector.NewWrapper` never wires the setter (amended per
+  independent review; the original entry overclaimed "the production
+  in-process path").
+- Deliverability probe (amendment, CO-6b-003 remediation): a client can
+  satisfy `sourcecache.SetLookup` structurally while wrapping a transport
+  that cannot forward an interface value. The syncer probes the optional
+  `sourceCacheLookupDeliverable` interface before install and keeps the
+  consume side cold when the transport cannot deliver, so an unwired
+  `SetLookup` is never logged or treated as warm. The produce side
+  (stamping, validator publish) still runs so such syncs seed future warm
+  syncs.
+- Verification delta: R1's transport coverage is direct + in-process gRPC
+  via the chaos harness clients ONLY; the subprocess boundary and the
+  absence of a wired production path are registered in the Phase 6b
+  executable exclusions registry
+  (`pkg/sync/source_cache_exclusions_verification_test.go`). The lambda
+  ask/answer continuation (6c) is the planned mechanism for cross-process
+  lookups.
+
+### CO-6b-002 — Resume granularity: interrupted actions restart at their root
+
+- Type: discovered behavior pinned as contract; no code change.
+- Mechanism: the syncer's checkpoint restores the action stack, and an
+  interrupted paginated action re-executes from its ROOT page token —
+  mid-chain wire tokens are not resume points. Replay-relevant page
+  processing is therefore at-least-once across a resume: the restarted
+  root re-consults the lookup, and the checkpoint-durable hit/replayed
+  sets act as idempotency guards (the re-walked replay pages skip the
+  replacement copy) rather than as mid-chain resume state.
+- Reason: OR6 as frozen said the restored sets "behave identically to
+  uninterrupted state"; the discovered granularity satisfies that oracle
+  but makes one of its motivating shapes (a replay annotation resumed
+  mid-chain with no fresh consult) unreachable in practice.
+- Verification delta: `TestChaosSourceCacheInterruptResume` pins the
+  granularity explicitly (the withdrawn-at-resume cell asserts the warm
+  chain is never revisited; the warm-resume cell asserts exactly one
+  re-consult) alongside OR2 convergence for every cut × resume shape.
+
+### CO-6b-003 — Review remediation: shape gates, warm provenance gate, copy atomicity
+
+- Type: contract tightening in response to three independent correctness
+  reviews (two REJECT, one ACCEPT WITH LIMITATIONS); each item closes a
+  silent-wrong-data or fail-open path the frozen contract implied but the
+  first implementation did not enforce.
+- Sync-shape gate: source-cache handling is untargeted-FULL-sync only.
+  Partial, resources-only, and targeted syncs collect less than the full
+  inventory, so their pages must not stamp rows or publish validators and
+  their lookup stays cold — a warm replay copy would import a whole
+  scope's previous rows into a store that never selected them
+  (`sourceCacheEnabled`). A resume attempt whose capability is withdrawn
+  or whose shape stops qualifying, over a store that already carries
+  produce state from a prior attempt, blocks the artifact as a future
+  replay source (same mixed-generation hazard as compat drift;
+  fail-closed on compat-read errors).
+- Warm provenance gate: `beforeUpserts` consults the attempt-scoped
+  `sourceCacheWarm` flag (set only after a deliverable warm lookup is
+  actually installed) before any replay copy. A checkpointed hit-set
+  restored into a cold or compat-drifted resume no longer re-authorizes
+  replay; the annotation fails cold `ErrReplayIntegrity` (plan B4/B5
+  enforcement the original implementation left as a dead field).
+- Copy atomicity: the decide-copy-mark replay sequence holds a per-
+  `(rowKind, scopeKey)` mutex, closing the check-then-act window that
+  duplicated replacement copies (and could resurrect replaced overlay
+  rows) at `WithWorkerCount > 1`.
+- Unreplayable-shape produce guard: a record-annotated resources page
+  whose rows declare child resource types, and a grants page carrying
+  `InsertResourceGrants`, mark the artifact replay-blocked
+  (`ingestQualityReasonSourceCacheShapeUnsupported`) — replaying such a
+  scope would silently lose the derived rows because replay copies only
+  the scope's own partition. `EnqueuePageTokens` on an annotated
+  resources page warns loudly as a registered boundary.
+- Verdict-classification tightening: ambient `ctx.Err()` no longer
+  promotes replay-copy failures to warm (only the error chain
+  classifies); row-put failures on annotated pages wrap as warm
+  `ErrReplayIntegrity`; duplicate same-type source-cache annotations on
+  one page fail cold; resource tombstones must parse as Baton resource
+  BIDs before deletion.
+- Verification delta: new instruments
+  `TestChaosSourceCacheDriftedResumeRejectsRestoredReplay` (warm gate on
+  drifted resume), `TestChaosSourceCacheDuplicateReplayCursorsParallel`
+  (copy atomicity at worker count 4),
+  `TestChaosSourceCacheUnsupportedShapesBlockReplaySeed` (produce
+  guards), `TestVerificationReplayVerdictSentinelIdentity` (engine-level
+  proof that real destination-commit failures carry the warm sentinel and
+  source-side failures do not), plus taxonomy cells for the sync-shape
+  gates, duplicate annotations, put-failure wrapping, non-BID tombstones,
+  and materialization-only compat mismatch.
+
+### CO-6b-004 — Hit-validator binding: a replay copies only the base its hit came from
+
+- Type: contract tightening from the PR-review round (automated reviewer,
+  zero blocking findings; this was its load-bearing suggestion).
+- Gap: the same-sync provenance rule recorded hits as bare
+  `(rowKind, scopeKey)` pairs, and no consume gate identifies WHICH
+  artifact a hit came from — two artifacts from the same connector and
+  config carry byte-identical compat keys, so a previous artifact swapped
+  between attempts (service-mode spare replaced by a rollback/restore)
+  passes G1–G7 while its rows for a scope may predate the state the
+  connector actually revalidated. A checkpointed hit would then authorize
+  a replacement copy from a base the connector never consulted: silently
+  stale rows in a green sync.
+- Mechanism: the hit map now records the validator the lookup returned
+  (`row kind → scope key → validator`, checkpoint shape changed
+  accordingly), and `beforeUpserts` requires the CURRENT replay base's
+  manifest entry to byte-match the recorded validator before the copy
+  runs. Mismatch, absent entry, read failure, and a base without the
+  entry surface are all cold `ErrReplayIntegrity` — the copy's provenance
+  cannot be established, fail-closed. Validator equality is the right
+  binding: it is exactly the value the connector's replay verdict was
+  computed against.
+- Also recorded from the same round: the stuck-resume operational
+  contract (a cold verdict inside a checkpointed cursor fails every
+  resume deterministically until the caller's retry policy abandons the
+  unfinished sync; 6c's ladder automates the cold fallback) is documented
+  on `beforeUpserts`; the provenance sets' checkpoint cost curve is
+  documented on the state field and pinned by
+  `BenchmarkStateMarshalSourceCacheSets` (~151KB token / ~0.5ms at 1k
+  scopes, ~15MB / ~102ms at 100k — sidecar persistence is the escape
+  hatch at whale scale).
+- Verification delta: taxonomy cells `swapped-base-validator-mismatch`,
+  `swapped-base-entry-missing`, `base-entry-read-failure`,
+  `base-without-entry-surface` (provenance-cold-paths); every existing
+  warm replay instrument now passes THROUGH the binding check against
+  real artifacts, so deleting the check cannot pass the chaos suites
+  vacuously — but the mismatch cells are what fail if the comparison is
+  removed.
+
+### CO-6b-005 — Re-review remediation: mutation-adequate instruments and the probe pin
+
+- Type: verification hardening from the second independent-review round
+  (two reviewers re-audited the CO-6b-003 remediation; both accepted the
+  warm-gate and produce-guard closures and rejected two instruments as
+  vacuous — reverting the fix they claim to pin left the suite green).
+- Deliverability probe (closes the re-review's finding on the original
+  BLOCKER): the probe interface is promoted to
+  `sourcecache.LookupDeliverabilityProbe` so the production client can
+  compile-pin it (`var _` in `internal/connector`) — a method rename can
+  no longer silently sever the probe from the syncer's type assertion.
+  New instrument `TestSourceCacheLookupDeliverabilityProbe`: a
+  structurally-satisfied `SetLookup` client whose probe reports
+  undeliverable receives NO delivery and the sync stays cold; deliverable
+  and probe-less clients receive the (possibly nil) lookup plus teardown.
+  Mutation-verified: disabling the probe type-assert fails the
+  undeliverable cell.
+- Per-scope lock (closes the re-review's finding on the TOCTOU MAJOR):
+  the parallel-cursors chaos test admits its spawned duplicates only
+  after the parent page has marked the scope replayed, so it serializes
+  on the already-replayed skip, not on decide-copy-mark. New instrument
+  `TestSourceCacheReplayOncePerScopeIsAtomic` holds one copy mid-flight
+  in a blocking store and overlaps a second `beforeUpserts` for the same
+  scope: with the mutex the second parks and skips; without it the
+  second reaches the store inside the observation window.
+  Mutation-verified: removing the lock fails the test.
+- Capability withdrawal on resume now has its cell: the compat-drift
+  resume suite gained `capability-withdrawn` (attempt 1 warm under
+  gen-1, resume declares nothing) — the stale produce state blocks the
+  artifact and the resume completes cold.
+- Cost pins requested by the re-review: `BenchmarkSourceCacheScopeLocks`
+  (per-scope mutex: ~326ns/157B first touch, ~42ns steady state;
+  entries retained for the syncer's one-sync lifetime, cardinality equal
+  to the provenance sets) alongside CO-6b-004's
+  `BenchmarkStateMarshalSourceCacheSets`.
+- Honesty deltas: `pkg/sourcecache` seedability claim now carries the
+  quality-block exception; the row-put wrapper's call-site wiring is
+  recorded as an explicit verification gap (no store-fault injection
+  seam this phase) rather than claimed as covered.
+
+### CO-6b-006 — Third re-review remediation: corrected warm-gate premise, record-page lock, token schema fence
+
+- Type: bug fixes and verification hardening from the third independent
+  re-review (adversarial pass with mutation testing against `b617d6d8`).
+- Warm-gate chaos instrument premise was FALSE (review finding, confirmed
+  by mutation on HEAD): in the two-team drifted-resume scenario the
+  consult and the crash sat in the same dispatch batch, and provenance
+  recorded during a batch becomes durable only at the checkpoint atop the
+  NEXT loop iteration — so no surviving checkpoint ever contained the
+  hit, and the resume rejected on the ordinary no-hit gate while the
+  warm gate went untested (the unit cell still killed the mutation; the
+  chaos instrument did not). Corrected: the scenario now spans two
+  dispatch batches (102 per-resource grants actions against
+  `maxPeekActionsCount` = 100, resource ids chosen for the store's
+  lexicographic drain order), and the test CAPTURES the surviving
+  checkpoint and asserts both premise halves in-band — the hit is in it
+  and the carrier's replay action is still pending. Mutation-verified:
+  deleting the warm gate now fails the chaos instrument (the restored
+  hit plus the still-eligible seed base let the copy proceed).
+  This also settles the durability question the review raised: hits DO
+  checkpoint at batch boundaries; hits recorded in the batch that
+  crashes are lost and their actions re-run from the pre-batch
+  checkpoint, re-consulting on resume (at-least-once, safe in both warm
+  and cold resume permutations).
+- Record-only pages now hold the scope lock (review finding N1, MAJOR):
+  `beforeUpserts` returned before locking when the page carried no
+  replay annotation, so a record page's row puts, tombstones, and
+  manifest publish could interleave with another action's in-flight
+  REPLACEMENT copy for the same scope — the copy deletes the scope's
+  rows before copying the base, silently wiping the fresh rows or
+  publishing a validator over an incomplete scope. Fixed: every scoped
+  page acquires the scope lock in `beforeUpserts` and releases it in
+  `afterUpserts`, with an idempotent `release()` deferred at all three
+  handler call sites so error paths between the two cannot leak the
+  lock (a leaked lock would deadlock the action's own retry). New
+  instrument `TestSourceCacheRecordPageParksBehindReplayCopy`
+  (mutation-verified: restoring the early return fails it inside the
+  observation window); the once-per-scope instrument updated for the
+  extended lock lifetime.
+- Sync-token schema fence (review finding N5, process-blocking):
+  CO-6b-004 changed the checkpointed hit map's value shape under the
+  SAME JSON key (`source_cache_hits`), and the token unmarshal fell back
+  to the v0 format on ANY parse error — a token written by the previous
+  commit and read by the new code would misparse as v0 and silently
+  drop the v1 action stack. Fixed twice over: the reshaped map takes a
+  NEW key (`source_cache_hit_validators`; the retired key is ignored,
+  degrading legacy hits to loud cold replays, never corruption), and
+  `state.Unmarshal` no longer falls back to v0 when the input declares a
+  version AND fails to parse as v1 — such tokens now fail loudly. (A
+  token that parses cleanly but carries an unrecognized version still
+  takes the v0 fallback: that is the pre-version token format's
+  compatibility path, unchanged. The fence targets the misparse hazard —
+  a same-key shape change breaking the v1 parse — not version-unknown
+  inputs; wording narrowed per round-4 review.) Instruments:
+  `TestSyncerTokenSourceCacheSetsRoundTrip` (review finding N3 — the
+  provenance sets round-trip Marshal → Unmarshal exactly) and
+  `TestSyncerTokenSchemaFence` (retired key ignored, versioned parse
+  failure loud, version-less v0 fallback preserved).
+- Mutation adequacy re-verified this round: warm gate (chaos + unit),
+  record-page lock, capability-withdrawal block (its cell from
+  CO-6b-005 kills disabling the block — closing the review's surviving
+  mutant), once-per-scope mutex, deliverability probe.
+
+### CO-6b-007 — Round-4 remediation: held-lock ride-along, coverage triage, witness pin
+
+- Type: verification hardening from the fourth independent-review round
+  (three reviewers against `c33f698e`; all seven CO-6b-006 closure claims
+  independently confirmed mutation-adequate by all three).
+- Held-lock ride-along (closes the round's one new MAJOR — the deferred
+  `release()` backstop CO-6b-006 introduced had no instrument, and the
+  evidence misattributed its coverage to the record-page parking test,
+  which only exercises `afterUpserts`): the chaos fixture itself now
+  registers a sync-end cleanup that walks `sourceCacheScopeLocks` and
+  fails any test that ends with a scope lock still held. This is the
+  ladder climb the recurrence rule prescribes (third uninstrumented
+  resource-release obligation on this branch): every present and future
+  chaos suite evaluates the invariant, including call sites added later.
+  The loud-failure suite additionally grew one cell per collection
+  handler (resources, entitlements, grants — previously grants-only), so
+  each handler's `defer scOps.release()` has a killing scenario.
+  Mutation-verified per site: removing any one handler's defer fails
+  that handler's cell at the ride-along assertion.
+- Structural-coverage triage (closes the round's process MAJOR): the
+  handbook's coverage-driven step for HIGH changes — profile across all
+  changed packages, intersect with the diff, disposition every uncovered
+  changed block — is now recorded in evidence.md, with three new unit
+  instruments for the boundary branches the triage judged worth real
+  tests (unparsable capability, warm-lookup input validation, record on
+  a surfaceless store).
+- Witness compile pin (MINOR): the G5 fence's inline anonymous interface
+  is promoted to `sourcecache.MaterializationWitnessReader` with a
+  `var _` pin on the pebble store — same discipline as the CO-6b-005
+  probe promotion; a method rename is now a build break, not a
+  behavioral-test catch.
+- Probe assertion honesty (MINOR): the syncer now asserts the exported
+  `sourcecache.LookupDeliverabilityProbe` directly; the private duplicate
+  interface it actually used (making the compile-pin claim an
+  overstatement) is deleted.
+- Excluded permutation registered (MINOR): a connector whose emitted
+  resource-type list shrinks between generations without a
+  `cache_generation` bump can replay rows the fresh-ingest filter would
+  drop; registered as an executable exclusion with its containment
+  rationale (connector-side capability-contract violation; warn-class
+  ingest invariants surface the dangling references) rather than gated.
+- Wording deltas (LOW): the token fence's claim narrowed to
+  parse-failure-only (a cleanly-parsed unknown version still takes the
+  v0 fallback — the pre-version compatibility path); the performance
+  evidence now states the extended lock-hold contract for annotated
+  pages; the scope-lock doc comment updated to the extended cardinality.
+- Operational note kept as documentation (LOW, review N-5): a genuinely
+  corrupt same-version token now fails every resume attempt loudly
+  rather than degrading to redone work — same operational contract as
+  the cold-verdict retry-livelock note on `beforeUpserts` (the caller's
+  retry policy abandons the token and a fresh sync starts cold); an
+  in-tree abandon-the-token path is Phase 6c runner-ladder scope.
+
+### CO-6b-008 — Record-round grounding: the verdict-flip phantom union, witnessed and fixed
+
+- Type: live defect, predicted by the formal model (walker calibration
+  scenario 1, tc1c flavor — `formal/walker/CALIBRATION.md`), witnessed
+  against the shipped syncer, fixed.
+- Premise (the verdict-flip path): a warm round's replay copy commits,
+  the sync crashes before the round's validator publishes (a round runs
+  inside one batch, so no checkpoint can intervene — CO-6b-002's
+  granularity), upstream moves between attempts, and the resume's
+  consult misses — the connector serves a fresh RECORD round. The
+  record round's upserts landed on the crashed attempt's copied debris;
+  rows departed upstream sealed under the fresh validator, which the
+  NEXT sync's consult validates clean and replays forward (the
+  non-self-healing direction).
+- Fix: a record round is a replacement listing, so before its first
+  write to a scope this attempt, a partition holding rows that no
+  completed round published (no manifest entry this sync) is cleared.
+  Store surface `ClearSourceCacheScope` (the replay unit's clear leg
+  standalone, bounded batches, idempotent); orchestration
+  `groundRecordScope` under the scope lock; attempt-local grounded set
+  (deliberately volatile — a resume re-decides from durable facts) so
+  replay and record pages of one round never re-ground over each other.
+  Published entries exempt the scope, preserving multi-action
+  accumulation into shared scopes.
+- Witness/regression: `TestChaosSourceCacheRecordFlipOverReplayDebris`
+  (fails against the pre-fix code with the union sealed; passes with
+  the fix) pins both the outcome (content oracle: the departed row is
+  absent) and the mechanism (the resumed attempt's trace shows the
+  grounding clear with no replay copy). Trace-visible: record rounds
+  now emit a real clear — "replacement rounds clear first", previously
+  granted structurally by the oracle's renderer, now witnessed
+  (fixtures `cold_record_sync.jsonl`,
+  `warm_replay_sync_record_flip.jsonl`).
+- Scope note: the model's verified V-ATOMIC/V-OVERLAY-UNIT fix family
+  targets designs with durable marker suppression; this code base heals
+  by re-execution (root restart + idempotent re-copy, CO-6b-002), so
+  grounding was the missing piece, not unit-mode commit.
+
+### CO-6b-009 — Session store across resume: hazard analysis; resume-clear REJECTED
+
+- Type: hazard analysis with contractual pins. A mechanical fix
+  (wholesale namespace clear on a participating resume,
+  `groundSessionStoreOnResume`) was briefly shipped and REVERTED —
+  see the rejection rationale below before reintroducing anything
+  like it.
+- Premise: connector session-store writes are durable in the
+  artifact, keyed by sync id, and commit OUTSIDE the checkpoint
+  mechanism (`SessionSet` commits its own batch; `CheckpointSync` is a
+  separate write). After a crash the resumed attempt's cursor rolls
+  back to the last checkpoint while every session write survives — the
+  resumed attempt inherits the dead attempt's session state wholesale,
+  and the connector cannot detect the resume (its process restarted;
+  sessions are the only surviving state).
+- Provenance, corrected: the walker model carried these exact
+  semantics from calibration (MStore's `sessionKV`, "durable at op
+  commit, survives attempts and crashes") and scenario 2's crash cell
+  (`tc2crash_P6A`) was an EXPECTED red containing the zombie
+  mechanism — but it was filed as a future-runtime obligation, not
+  routed as a shipped-code change order, and the checkpoint-relative
+  root cause was never stated as a property. The concrete shipped-code
+  mechanics were then re-found by code reading.
+- Root cause, now mechanically captured in BOTH formal systems plus a
+  real-execution witness:
+  - P: the `P6C` monitor (session-checkpoint consistency, both
+    directions). `tc2crash_P6C` reds `P6-C-ZOMBIE` under shipped
+    semantics; `tc2clear_P6C` reds `P6-C-AMNESIA` under the rejected
+    wholesale resume-clear; `tc2consistent_P6C` greens the
+    checkpoint-consistent fix (`formal/walker/CALIBRATION.md`,
+    decision 25).
+  - Occult: trace policy 6 (`session_ckpt_consistency`) with four
+    fixtures including the correct-rollback green
+    (`formal/occult/src/sync_trace_policies.occult`).
+  - Witnessed: `warm_replay_sync_session_zombie.jsonl`, recorded from
+    the real syncer by the witness test below, is judged
+    `violation: session-zombie-read` by the oracle — a standing
+    expected-RED pin (`formal/occult/host/real_trace_oracle_test.go`)
+    that flips to green when checkpoint-consistent sessions land.
+- The two-sided hazard:
+  - Writes from BEYOND the restored cursor survive into work that
+    re-runs: the re-run window can observe its own dead attempt's
+    "future" writes, so session-based once-only decisions (dedup,
+    "already handled" markers) silently drop work.
+  - Under the protocol, session caches derived from replay-era rounds
+    can feed rounds whose rows a resume re-grounds (CO-6b-008 clears
+    the row partition; nothing re-validates session state derived from
+    it).
+- Why the resume-clear was rejected: resume restores the action queue
+  from the checkpoint and COMPLETED actions never re-run, so a
+  wholesale clear destroys session values whose producing work will
+  not execute again (accumulate-then-consume: an index built during a
+  completed action, consumed by a later one, is unrecoverable). The
+  clear also rewrote the session contract to match the fix
+  ("attempt-scoped") rather than fixing to the contract.
+- Correct mechanical fix (future work, not scheduled): checkpoint-
+  consistent sessions — session mutations land in a volatile overlay,
+  reads merge overlay-over-durable, and the overlay flushes in the
+  SAME batch as the checkpoint write. Crash then restores sessions to
+  exactly the checkpoint's state: future-writes vanish (hazard a),
+  completed-action caches persist, and the re-run window regenerates
+  its own writes as the work re-runs. (Epoch-tagging entries and
+  purging on resume cannot undo deletes/overwrites without a value
+  journal, which converges to the overlay.) Candidate for RFC 0011
+  scope, where session reads become stamped observation points.
+- Current stance — contractual, pinned in `pkg/sourcecache` and
+  `pkg/session/README.md`: session use must be safe under
+  at-least-once re-execution with prior state present (no once-only
+  decisions); replay/record verdicts must come from upstream evidence,
+  never session-cached answers; session state built while generating
+  rows is silently partial for replayed scopes.
+- Witness: `TestChaosSourceCacheSessionPersistsAcrossResume` — a probe
+  key planted in the interrupted sync's session namespace survives the
+  resume with AND without the source-cache capability, pinning the
+  persistence semantics and standing guard against reintroducing a
+  resume-time clear. The participating leg also records the history
+  through the trace-audit recorder (the test as session actor) and
+  exports the session-zombie fixture the oracle judges expected-RED.

--- a/internal/chaosconnector/builder.go
+++ b/internal/chaosconnector/builder.go
@@ -80,6 +80,12 @@ func (b *Builder) Metadata(context.Context) (*v2.ConnectorMetadata, error) {
 }
 
 func (b *Builder) Validate(context.Context) (annotations.Annotations, error) {
+	// Source-cache capability is run state, not builder config: generational
+	// suites rotate generations/fingerprints between the syncs of one run,
+	// and the syncer re-parses the capability on every attempt (plan B1).
+	if capability := b.run.SourceCacheCapability(); capability != nil {
+		return annotations.New(capability), nil
+	}
 	return nil, nil
 }
 

--- a/internal/chaosconnector/client.go
+++ b/internal/chaosconnector/client.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/conductorone/baton-sdk/internal/connector"
 	"github.com/conductorone/baton-sdk/pkg/connectorclient"
+	"github.com/conductorone/baton-sdk/pkg/sourcecache"
 	"github.com/conductorone/baton-sdk/pkg/types"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -23,19 +24,48 @@ import (
 // without serialization. The same fault runtime wraps this and gRPC clients.
 func NewDirectClient(ctx context.Context, server types.ConnectorServer, run *Run) types.ConnectorClient {
 	direct := &directConn{server: server}
-	return connectorclient.NewConnectorClient(ctx, &faultConn{
-		delegate: direct,
-		run:      run,
-	})
+	return &directClient{
+		ConnectorClient: connectorclient.NewConnectorClient(ctx, &faultConn{
+			delegate: direct,
+			run:      run,
+		}),
+		server: server,
+	}
+}
+
+// directClient adds the syncer→connector source-cache lookup delivery
+// (sourcecache.SetLookup) to the direct transport by forwarding to the
+// server-side connectorbuilder, mirroring what the subprocess runner's
+// connectorClient does over its own channel.
+type directClient struct {
+	types.ConnectorClient
+	server types.ConnectorServer
+}
+
+func (c *directClient) SetSourceCache(ctx context.Context, lookup sourcecache.Lookup) {
+	if setter, ok := c.server.(sourcecache.SetLookup); ok {
+		setter.SetSourceCache(ctx, lookup)
+	}
 }
 
 // GRPCClient owns an in-memory gRPC server and its generated connector client.
 type GRPCClient struct {
 	types.ConnectorClient
 
-	conn     *grpc.ClientConn
-	server   *grpc.Server
-	listener *bufconn.Listener
+	conn      *grpc.ClientConn
+	server    *grpc.Server
+	listener  *bufconn.Listener
+	connector types.ConnectorServer
+}
+
+// SetSourceCache delivers the source-cache lookup to the connector-side
+// builder. The lookup is an in-process interface, so it cannot ride the
+// gRPC transport itself; both processes here share memory, and forwarding
+// directly mirrors the delivery a runner would perform out-of-band.
+func (c *GRPCClient) SetSourceCache(ctx context.Context, lookup sourcecache.Lookup) {
+	if setter, ok := c.connector.(sourcecache.SetLookup); ok {
+		setter.SetSourceCache(ctx, lookup)
+	}
 }
 
 // NewGRPCClient starts an in-memory gRPC server. It exercises normal service
@@ -106,6 +136,7 @@ func newGRPCClient(
 		conn:            conn,
 		server:          grpcServer,
 		listener:        listener,
+		connector:       server,
 	}, nil
 }
 

--- a/internal/chaosconnector/oracle/source_cache.go
+++ b/internal/chaosconnector/oracle/source_cache.go
@@ -1,0 +1,115 @@
+package oracle
+
+import (
+	"context"
+	"fmt"
+
+	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
+	enginepebble "github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble"
+	"github.com/conductorone/baton-sdk/pkg/sourcecache"
+)
+
+// Source-cache artifact observations (Phase 6b oracle OR3): exact manifest
+// membership, per-scope stamp counts, and the compat record, read straight
+// from a sealed Pebble artifact. Enumeration — not point reads — is the
+// point: "unexpected scopes have no entries and no stamps" is only
+// observable over the whole keyspace.
+
+// SourceCacheManifestEntry is one scope's manifest entry as stored.
+type SourceCacheManifestEntry struct {
+	Validator   string
+	Invalidated bool
+}
+
+// SourceCacheCompat is the stored replay-compatibility record.
+type SourceCacheCompat struct {
+	ConnectorCacheGeneration     string
+	ConnectorConfigFingerprint   string
+	SDKMaterializationGeneration string
+	SyncSelectionFingerprint     string
+}
+
+// SourceCacheSnapshot is the complete source-cache projection of one
+// sealed artifact.
+type SourceCacheSnapshot struct {
+	// Entries holds every manifest entry, keyed by KindScope.
+	Entries map[string]SourceCacheManifestEntry
+	// StampCounts holds the number of rows stamped per (kind, scope),
+	// keyed by KindScope. Unstamped rows are not counted anywhere.
+	StampCounts map[string]int
+	// Compat is nil when the artifact carries no compat record.
+	Compat *SourceCacheCompat
+}
+
+// KindScope is the snapshot map key for (rowKind, scopeKey).
+func KindScope(kind sourcecache.RowKind, scopeKey string) string {
+	return string(kind) + "\x00" + scopeKey
+}
+
+// ReadSourceCacheSnapshot reads the source-cache surfaces of a sealed
+// Pebble store (a dotc1z store opened over the artifact).
+func ReadSourceCacheSnapshot(ctx context.Context, store c1zstore.Store) (SourceCacheSnapshot, error) {
+	out := SourceCacheSnapshot{
+		Entries:     map[string]SourceCacheManifestEntry{},
+		StampCounts: map[string]int{},
+	}
+	engine, ok := enginepebble.AsEngine(store)
+	if !ok {
+		return out, fmt.Errorf("chaos oracle: store is not a pebble engine")
+	}
+
+	if err := engine.IterateSourceCacheEntries(ctx, func(rec *v3.SourceCacheEntryRecord) bool {
+		out.Entries[rec.GetRowKind()+"\x00"+rec.GetScopeKey()] = SourceCacheManifestEntry{
+			Validator:   rec.GetCacheValidator(),
+			Invalidated: rec.GetInvalidated(),
+		}
+		return true
+	}); err != nil {
+		return out, fmt.Errorf("chaos oracle: iterate source cache entries: %w", err)
+	}
+
+	stamp := func(kind sourcecache.RowKind, scopeKey string) {
+		if scopeKey == "" {
+			return
+		}
+		out.StampCounts[KindScope(kind, scopeKey)]++
+	}
+	if err := engine.IterateResources(ctx, func(rec *v3.ResourceRecord) bool {
+		stamp(sourcecache.RowKindResources, rec.GetSourceScopeKey())
+		return true
+	}); err != nil {
+		return out, fmt.Errorf("chaos oracle: iterate resource stamps: %w", err)
+	}
+	if err := engine.IterateEntitlements(ctx, func(rec *v3.EntitlementRecord) bool {
+		stamp(sourcecache.RowKindEntitlements, rec.GetSourceScopeKey())
+		return true
+	}); err != nil {
+		return out, fmt.Errorf("chaos oracle: iterate entitlement stamps: %w", err)
+	}
+	if err := engine.IterateGrants(ctx, func(rec *v3.GrantRecord) bool {
+		stamp(sourcecache.RowKindGrants, rec.GetSourceScopeKey())
+		return true
+	}); err != nil {
+		return out, fmt.Errorf("chaos oracle: iterate grant stamps: %w", err)
+	}
+
+	compatStore, ok := store.(dotc1z.SourceCacheStore)
+	if !ok {
+		return out, fmt.Errorf("chaos oracle: store exposes no source-cache compat surface")
+	}
+	compat, found, err := compatStore.GetSourceCacheCompat(ctx)
+	if err != nil {
+		return out, fmt.Errorf("chaos oracle: read compat record: %w", err)
+	}
+	if found {
+		out.Compat = &SourceCacheCompat{
+			ConnectorCacheGeneration:     compat.ConnectorCacheGeneration,
+			ConnectorConfigFingerprint:   compat.ConnectorConfigFingerprint,
+			SDKMaterializationGeneration: compat.SDKMaterializationGeneration,
+			SyncSelectionFingerprint:     compat.SyncSelectionFingerprint,
+		}
+	}
+	return out, nil
+}

--- a/internal/chaosconnector/run.go
+++ b/internal/chaosconnector/run.go
@@ -3,6 +3,8 @@ package chaosconnector
 import (
 	"fmt"
 	"sync"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 )
 
 // Run binds immutable scenario truth to mutable execution state.
@@ -13,6 +15,13 @@ type Run struct {
 
 	mu    sync.RWMutex
 	epoch string
+	// sourceCacheCapability is the capability annotation the reference
+	// connector attaches to Validate responses; nil means not declared.
+	// Mutable so generational suites can rotate it between syncs.
+	sourceCacheCapability *v2.SourceCacheCapability
+	// sourceCacheEvents records connector-side lookup consults in serve
+	// order (see source_cache.go).
+	sourceCacheEvents []SourceCacheLookupEvent
 }
 
 // NewRun validates and arms one scenario execution.

--- a/internal/chaosconnector/scenario.go
+++ b/internal/chaosconnector/scenario.go
@@ -31,6 +31,13 @@ type Dataset struct {
 	StaticEntitlements map[string]Pages[*v2.Entitlement]
 	Entitlements       map[string]Pages[*v2.Entitlement]
 	Grants             map[string]Pages[*v2.Grant]
+
+	// SourceCache* declare per-serve-scope source-cache behavior, keyed by
+	// the SAME keys as the page maps above (see SourceCacheSpec). Scopes
+	// without a spec never consult the lookup.
+	SourceCacheResources    map[string]*SourceCacheSpec
+	SourceCacheEntitlements map[string]*SourceCacheSpec
+	SourceCacheGrants       map[string]*SourceCacheSpec
 }
 
 // Scenario is an immutable deterministic connector world. Runtime state such
@@ -76,6 +83,44 @@ func (s *Scenario) Validate() error {
 				return fmt.Errorf("chaosconnector: epoch %q repeats resource type %q", name, resourceType.GetId())
 			}
 			seenTypes[resourceType.GetId()] = struct{}{}
+		}
+		if err := validateSourceCacheSpecs(name, "resources", dataset.SourceCacheResources, dataset.Resources); err != nil {
+			return err
+		}
+		if err := validateSourceCacheSpecs(name, "entitlements", dataset.SourceCacheEntitlements, dataset.Entitlements); err != nil {
+			return err
+		}
+		if err := validateSourceCacheSpecs(name, "grants", dataset.SourceCacheGrants, dataset.Grants); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateSourceCacheSpecs fails fast on specs that would silently serve
+// nothing: an unkeyed spec, a spec for a scope without pages, or a warm
+// root token that no page declares.
+func validateSourceCacheSpecs[T any](
+	epoch, kind string,
+	specs map[string]*SourceCacheSpec,
+	pages map[string]Pages[T],
+) error {
+	for scope, spec := range specs {
+		if spec == nil {
+			return fmt.Errorf("chaosconnector: epoch %q %s source-cache spec for scope %q is nil", epoch, kind, scope)
+		}
+		if spec.ScopeKey == "" {
+			return fmt.Errorf("chaosconnector: epoch %q %s source-cache spec for scope %q has no scope key", epoch, kind, scope)
+		}
+		scopePages, ok := pages[scope]
+		if !ok {
+			return fmt.Errorf("chaosconnector: epoch %q %s source-cache spec for scope %q has no pages", epoch, kind, scope)
+		}
+		if spec.WarmRoot != "" {
+			if _, ok := scopePages[spec.WarmRoot]; !ok {
+				return fmt.Errorf("chaosconnector: epoch %q %s source-cache spec for scope %q names warm root %q which no page declares",
+					epoch, kind, scope, spec.WarmRoot)
+			}
 		}
 	}
 	return nil
@@ -177,6 +222,10 @@ func cloneDataset(dataset *Dataset) *Dataset {
 		StaticEntitlements: clonePageMap(dataset.StaticEntitlements),
 		Entitlements:       clonePageMap(dataset.Entitlements),
 		Grants:             clonePageMap(dataset.Grants),
+
+		SourceCacheResources:    cloneSourceCacheSpecs(dataset.SourceCacheResources),
+		SourceCacheEntitlements: cloneSourceCacheSpecs(dataset.SourceCacheEntitlements),
+		SourceCacheGrants:       cloneSourceCacheSpecs(dataset.SourceCacheGrants),
 	}
 }
 

--- a/internal/chaosconnector/source_cache.go
+++ b/internal/chaosconnector/source_cache.go
@@ -1,0 +1,171 @@
+package chaosconnector
+
+import (
+	"context"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/sourcecache"
+	"google.golang.org/protobuf/proto"
+)
+
+// Source-cache replay support (Phase 6b — see
+// docs/verification/sync-replay-6b/plan.md, "Harness" in the placement map).
+//
+// A scenario opts a scope into source-cache behavior by declaring a
+// SourceCacheSpec for the serve scope alongside its page graph. At serve
+// time the reference connector consults the SDK-provided lookup
+// (SyncOpAttrs.Lookup) exactly the way a real capable connector would:
+// lookup the previous validator for the scope, compare it to the current
+// epoch's validator, and serve either the warm branch (a declared alternate
+// root page, typically carrying a SourceCacheReplay annotation) or the cold
+// branch (the normal root, typically carrying SourceCacheRecord
+// annotations). Every consult is recorded as a SourceCacheLookupEvent so
+// suites can assert hit/miss/served-warm exactly (oracle OR1, OR5).
+//
+// The page annotations themselves are declared data (Page.Annotations),
+// never synthesized here: adversarial suites need full control over shape,
+// including invalid ones.
+
+// SourceCacheSpec drives the reference connector's source-cache behavior
+// for one serve scope (the key of the Resources/Entitlements/Grants page
+// maps). The connector consults the lookup only on the scope's ROOT request
+// (empty page token); non-root tokens address whichever branch's pages.
+type SourceCacheSpec struct {
+	// ScopeKey is the connector-declared source-cache scope key passed to
+	// the lookup and (by convention) carried in the branch pages'
+	// SourceCacheRecord / SourceCacheReplay annotations.
+	ScopeKey string
+
+	// Validator is the current epoch's validator for this scope. A lookup
+	// hit whose stored validator equals it means "upstream unchanged":
+	// serve the warm branch. A miss or a different (stale) validator means
+	// fetch fresh: serve the cold branch.
+	Validator string
+
+	// WarmRoot is the page token served in place of the root when the
+	// lookup hit matched Validator. Empty means the scope declares no warm
+	// branch and always serves cold (lookup outcomes are still recorded).
+	WarmRoot string
+}
+
+// SourceCacheLookupEvent is one connector-side lookup consult, in serve
+// order. It is the instrument for gate conformance (a cold sync shows
+// Hit=false everywhere) and generational fetch accounting (ServedWarm=false
+// on a spec-bearing scope is a fresh fetch).
+type SourceCacheLookupEvent struct {
+	RowKind  sourcecache.RowKind
+	ScopeKey string
+	// Hit is the lookup's found result.
+	Hit bool
+	// PreviousValidator is the stored validator when Hit.
+	PreviousValidator string
+	// Matched reports Hit && PreviousValidator == spec.Validator.
+	Matched bool
+	// ServedWarm reports that the warm branch root replaced the cold root.
+	ServedWarm bool
+	// LookupError is non-empty when the lookup returned an error (the
+	// package contract says implementations return misses instead; a
+	// non-empty value is itself a finding).
+	LookupError string
+	// LookupWasNil reports that SyncOpAttrs.Lookup arrived nil. The
+	// contract says connectors never observe nil (NoopLookup substitutes);
+	// true is itself a finding (criterion R1).
+	LookupWasNil bool
+}
+
+// SetSourceCacheCapability arms (or, with nil, disarms) the capability
+// annotation the reference connector attaches to its Validate response.
+// Mutable run state on purpose: generational suites rotate generations and
+// fingerprints between syncs of one run.
+func (r *Run) SetSourceCacheCapability(capability *v2.SourceCacheCapability) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if capability == nil {
+		r.sourceCacheCapability = nil
+		return
+	}
+	r.sourceCacheCapability = proto.Clone(capability).(*v2.SourceCacheCapability)
+}
+
+// SourceCacheCapability returns an isolated copy of the armed capability,
+// or nil when the connector does not declare one.
+func (r *Run) SourceCacheCapability() *v2.SourceCacheCapability {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.sourceCacheCapability == nil {
+		return nil
+	}
+	return proto.Clone(r.sourceCacheCapability).(*v2.SourceCacheCapability)
+}
+
+// SourceCacheLookupEvents returns an isolated snapshot in serve order.
+func (r *Run) SourceCacheLookupEvents() []SourceCacheLookupEvent {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return append([]SourceCacheLookupEvent(nil), r.sourceCacheEvents...)
+}
+
+// ResetSourceCacheLookupEvents clears the event log. Generational suites
+// call it between syncs so each generation's events read from zero.
+func (r *Run) ResetSourceCacheLookupEvents() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.sourceCacheEvents = nil
+}
+
+func (r *Run) recordSourceCacheLookup(event SourceCacheLookupEvent) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.sourceCacheEvents = append(r.sourceCacheEvents, event)
+}
+
+// consultSourceCache performs the reference connector's per-scope lookup
+// consult and returns the page token to serve. Non-root tokens and scopes
+// without a spec pass through untouched. A nil lookup is treated as
+// NoopLookup — SyncOpAttrs.Lookup is contractually never nil, but the
+// harness must not crash while proving exactly that contract.
+func (r *Run) consultSourceCache(
+	ctx context.Context,
+	lookup sourcecache.Lookup,
+	kind sourcecache.RowKind,
+	spec *SourceCacheSpec,
+	token string,
+) string {
+	if spec == nil || token != "" {
+		return token
+	}
+	event := SourceCacheLookupEvent{RowKind: kind, ScopeKey: spec.ScopeKey}
+	if lookup == nil {
+		event.LookupWasNil = true
+		lookup = sourcecache.NoopLookup{}
+	}
+	entry, found, err := lookup.LookupPreviousSourceCache(ctx, kind, spec.ScopeKey)
+	if err != nil {
+		event.LookupError = err.Error()
+	}
+	event.Hit = found
+	event.PreviousValidator = entry.CacheValidator
+	event.Matched = found && entry.CacheValidator == spec.Validator
+	if event.Matched && spec.WarmRoot != "" {
+		event.ServedWarm = true
+		token = spec.WarmRoot
+	}
+	r.recordSourceCacheLookup(event)
+	return token
+}
+
+func cloneSourceCacheSpecs(in map[string]*SourceCacheSpec) map[string]*SourceCacheSpec {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]*SourceCacheSpec, len(in))
+	for scope, spec := range in {
+		if spec == nil {
+			out[scope] = nil
+			continue
+		}
+		copied := *spec
+		out[scope] = &copied
+	}
+	return out
+}

--- a/internal/chaosconnector/syncer.go
+++ b/internal/chaosconnector/syncer.go
@@ -6,6 +6,7 @@ import (
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/sourcecache"
 	"github.com/conductorone/baton-sdk/pkg/types/resource"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -22,57 +23,71 @@ func (s *resourceSyncer) ResourceType(context.Context) *v2.ResourceType {
 }
 
 func (s *resourceSyncer) List(
-	_ context.Context,
+	ctx context.Context,
 	parent *v2.ResourceId,
 	opts resource.SyncOpAttrs,
 ) ([]*v2.Resource, *resource.SyncOpResults, error) {
-	resources := s.run.dataset().Resources
-	pages, ok := resources[resourcePageScope(s.resourceType.GetId(), parent)]
+	dataset := s.run.dataset()
+	key := resourcePageScope(s.resourceType.GetId(), parent)
+	pages, ok := dataset.Resources[key]
 	if !ok {
-		pages = resources[s.resourceType.GetId()]
+		key = s.resourceType.GetId()
+		pages = dataset.Resources[key]
 	}
-	return servePage(pages, opts.PageToken.Token)
+	token := s.run.consultSourceCache(ctx, opts.Lookup, sourcecache.RowKindResources, dataset.SourceCacheResources[key], opts.PageToken.Token)
+	return servePage(pages, token)
 }
 
 func (s *resourceSyncer) Entitlements(
-	_ context.Context,
+	ctx context.Context,
 	target *v2.Resource,
 	opts resource.SyncOpAttrs,
 ) ([]*v2.Entitlement, *resource.SyncOpResults, error) {
 	scope := target.GetId().GetResource()
-	return servePage(s.run.dataset().Entitlements[scope], opts.PageToken.Token)
+	dataset := s.run.dataset()
+	token := s.run.consultSourceCache(ctx, opts.Lookup, sourcecache.RowKindEntitlements, dataset.SourceCacheEntitlements[scope], opts.PageToken.Token)
+	return servePage(dataset.Entitlements[scope], token)
 }
 
 func (s *resourceSyncer) Grants(
-	_ context.Context,
+	ctx context.Context,
 	target *v2.Resource,
 	opts resource.SyncOpAttrs,
 ) ([]*v2.Grant, *resource.SyncOpResults, error) {
 	scope := target.GetId().GetResource()
-	return servePage(s.run.dataset().Grants[scope], opts.PageToken.Token)
+	dataset := s.run.dataset()
+	token := s.run.consultSourceCache(ctx, opts.Lookup, sourcecache.RowKindGrants, dataset.SourceCacheGrants[scope], opts.PageToken.Token)
+	return servePage(dataset.Grants[scope], token)
 }
 
 func (s *resourceSyncer) StaticEntitlements(
 	_ context.Context,
 	opts resource.SyncOpAttrs,
 ) ([]*v2.Entitlement, *resource.SyncOpResults, error) {
+	// Static entitlements stay unscoped (plan B3, registered exclusion):
+	// no lookup consult; annotations declared on these pages flow through
+	// so the ignore-with-warn contract can be exercised.
 	return servePage(s.run.dataset().StaticEntitlements[s.resourceType.GetId()], opts.PageToken.Token)
 }
 
 func (s *resourceSyncer) EntitlementsForResourceType(
-	_ context.Context,
+	ctx context.Context,
 	resourceTypeID string,
 	opts resource.SyncOpAttrs,
 ) ([]*v2.Entitlement, *resource.SyncOpResults, error) {
-	return servePage(s.run.dataset().Entitlements[resourceTypeID], opts.PageToken.Token)
+	dataset := s.run.dataset()
+	token := s.run.consultSourceCache(ctx, opts.Lookup, sourcecache.RowKindEntitlements, dataset.SourceCacheEntitlements[resourceTypeID], opts.PageToken.Token)
+	return servePage(dataset.Entitlements[resourceTypeID], token)
 }
 
 func (s *resourceSyncer) GrantsForResourceType(
-	_ context.Context,
+	ctx context.Context,
 	resourceTypeID string,
 	opts resource.SyncOpAttrs,
 ) ([]*v2.Grant, *resource.SyncOpResults, error) {
-	return servePage(s.run.dataset().Grants[resourceTypeID], opts.PageToken.Token)
+	dataset := s.run.dataset()
+	token := s.run.consultSourceCache(ctx, opts.Lookup, sourcecache.RowKindGrants, dataset.SourceCacheGrants[resourceTypeID], opts.PageToken.Token)
+	return servePage(dataset.Grants[resourceTypeID], token)
 }
 
 func (s *resourceSyncer) Get(

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -28,6 +28,7 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/bid"
 	ratelimit2 "github.com/conductorone/baton-sdk/pkg/ratelimit"
 	"github.com/conductorone/baton-sdk/pkg/session"
+	"github.com/conductorone/baton-sdk/pkg/sourcecache"
 	"github.com/conductorone/baton-sdk/pkg/types"
 	"github.com/conductorone/baton-sdk/pkg/types/sessions"
 	"github.com/conductorone/baton-sdk/pkg/ugrpc"
@@ -55,10 +56,20 @@ type connectorClient struct {
 	connectorV2.ActionServiceClient
 
 	sessionStoreSetter sessions.SetSessionStore // this is the session store server
+
+	// sourceCacheSetter forwards the sync runner's source-cache lookup to
+	// an in-process connector server (ADVANCED FUNCTIONALITY — see
+	// pkg/sourcecache). It is nil for subprocess connectors: a live Lookup
+	// interface cannot cross the process boundary, so those connectors see
+	// NoopLookup and degrade to cold fetches until the ask/answer
+	// continuation (deferred) provides an RPC path.
+	sourceCacheSetter sourcecache.SetLookup
 }
 
 var _ sessions.SetSessionStore = (*connectorClient)(nil)
 var _ SetSessionStoreSetter = (*connectorClient)(nil)
+var _ sourcecache.SetLookup = (*connectorClient)(nil)
+var _ SetSourceCacheSetter = (*connectorClient)(nil)
 
 type SetSessionStoreSetter interface {
 	SetSessionStoreSetter(setsessionStoreSetter sessions.SetSessionStore)
@@ -66,6 +77,40 @@ type SetSessionStoreSetter interface {
 
 func (c *connectorClient) SetSessionStoreSetter(sessionStoreSetter sessions.SetSessionStore) {
 	c.sessionStoreSetter = sessionStoreSetter
+}
+
+// SetSourceCacheSetter is implemented by connector clients that can forward
+// the syncer's source-cache lookup to an in-process connector server.
+type SetSourceCacheSetter interface {
+	SetSourceCacheSetter(sourceCacheSetter sourcecache.SetLookup)
+}
+
+func (c *connectorClient) SetSourceCacheSetter(sourceCacheSetter sourcecache.SetLookup) {
+	c.sourceCacheSetter = sourceCacheSetter
+}
+
+// Compile pin: the syncer discovers the probe by type assertion, so a
+// method rename here (or on the interface) must fail the build, not
+// silently re-open the false-warm path this probe closes.
+var _ sourcecache.LookupDeliverabilityProbe = (*connectorClient)(nil)
+
+// SourceCacheLookupDeliverable reports whether SetSourceCache reaches a
+// live in-process target. The syncer probes this before treating a lookup
+// install as warm: for subprocess connectors (the runner's default) the
+// setter is nil and delivery would be a silent no-op (CO-6b-001).
+func (c *connectorClient) SourceCacheLookupDeliverable() bool {
+	return c.sourceCacheSetter != nil
+}
+
+func (c *connectorClient) SetSourceCache(ctx context.Context, lookup sourcecache.Lookup) {
+	if c.sourceCacheSetter == nil {
+		// Normal for every subprocess connector and for connectors that
+		// never opted into source-cache replay; the syncer calls this on
+		// every sync, so anything louder than Debug is noise.
+		ctxzap.Extract(ctx).Debug("connectorClient has no source-cache setter — lookup not delivered; connector degrades to cold fetches")
+		return
+	}
+	c.sourceCacheSetter.SetSourceCache(ctx, lookup)
 }
 
 func (c *connectorClient) SetSessionStore(ctx context.Context, store sessions.SessionStore) {

--- a/internal/connector/source_cache_test.go
+++ b/internal/connector/source_cache_test.go
@@ -1,0 +1,44 @@
+package connector
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/conductorone/baton-sdk/pkg/sourcecache"
+)
+
+type recordingSetLookup struct {
+	delivered []sourcecache.Lookup
+}
+
+func (r *recordingSetLookup) SetSourceCache(_ context.Context, lookup sourcecache.Lookup) {
+	r.delivered = append(r.delivered, lookup)
+}
+
+// TestConnectorClientSourceCacheDelivery pins the production client's half
+// of the deliverability contract (CO-6b-001/CO-6b-007): with no wired
+// setter — every subprocess connector today — the probe reports
+// undeliverable and delivery is a swallowed no-op; with a setter wired,
+// the probe flips and delivery forwards the exact lookup value.
+func TestConnectorClientSourceCacheDelivery(t *testing.T) {
+	ctx := context.Background()
+
+	c := &connectorClient{}
+	require.False(t, c.SourceCacheLookupDeliverable(),
+		"no wired setter must read as undeliverable, or the syncer would log warm into the void")
+	// Delivery without a setter must be a silent no-op, not a panic: the
+	// syncer calls SetSourceCache on every sync regardless of transport.
+	c.SetSourceCache(ctx, sourcecache.NoopLookup{})
+
+	setter := &recordingSetLookup{}
+	c.SetSourceCacheSetter(setter)
+	require.True(t, c.SourceCacheLookupDeliverable())
+	lookup := sourcecache.NoopLookup{}
+	c.SetSourceCache(ctx, lookup)
+	c.SetSourceCache(ctx, nil) // teardown shape
+	require.Len(t, setter.delivered, 2)
+	require.Equal(t, sourcecache.Lookup(lookup), setter.delivered[0])
+	require.Nil(t, setter.delivered[1])
+}

--- a/pb/c1/c1z/v3/manifest.pb.go
+++ b/pb/c1/c1z/v3/manifest.pb.go
@@ -206,8 +206,24 @@ type C1ZManifestV3 struct {
 	// c1/dotc1z/engine/pebble/digest.go's present-means-exact contract.
 	// Additive field: old readers ignore it, old files simply lack it.
 	GrantDigestRoot *GrantDigestRoot `protobuf:"bytes,43,opt,name=grant_digest_root,json=grantDigestRoot,proto3" json:"grant_digest_root,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// Save-time materialization witness (CO-017 cross-version fold fence).
+	// The SDK's replayed-row materialization-policy generation
+	// (sourcecache.MaterializationPolicyGeneration) as of the save that
+	// produced this envelope; written on EVERY save by a witness-aware SDK.
+	//
+	// Why this fences: an OLDER SDK that folds a scoped artifact rewrites
+	// the envelope and rebuilds this manifest fresh from its own
+	// compiled-in descriptors, which do not know this field — so the
+	// witness is necessarily ABSENT from any old-fold output and cannot be
+	// forged by one, even though the old fold byte-copies the payload's
+	// source-cache manifest, indexes, and compat record intact. A replay
+	// consumer requires the witness to byte-match its own generation and
+	// treats absence as ineligible (degrade to a cold sync), which closes
+	// the stale-but-eligible window that a byte-copied payload compat
+	// record alone cannot close.
+	SdkMaterializationGeneration string `protobuf:"bytes,44,opt,name=sdk_materialization_generation,json=sdkMaterializationGeneration,proto3" json:"sdk_materialization_generation,omitempty"`
+	unknownFields                protoimpl.UnknownFields
+	sizeCache                    protoimpl.SizeCache
 }
 
 func (x *C1ZManifestV3) Reset() {
@@ -305,6 +321,13 @@ func (x *C1ZManifestV3) GetGrantDigestRoot() *GrantDigestRoot {
 	return nil
 }
 
+func (x *C1ZManifestV3) GetSdkMaterializationGeneration() string {
+	if x != nil {
+		return x.SdkMaterializationGeneration
+	}
+	return ""
+}
+
 func (x *C1ZManifestV3) SetEngine(v string) {
 	x.Engine = v
 }
@@ -343,6 +366,10 @@ func (x *C1ZManifestV3) SetPebbleIdIndexFormat(v PebbleIdIndexFormat) {
 
 func (x *C1ZManifestV3) SetGrantDigestRoot(v *GrantDigestRoot) {
 	x.GrantDigestRoot = v
+}
+
+func (x *C1ZManifestV3) SetSdkMaterializationGeneration(v string) {
+	x.SdkMaterializationGeneration = v
 }
 
 func (x *C1ZManifestV3) HasEngineConfig() bool {
@@ -438,6 +465,22 @@ type C1ZManifestV3_builder struct {
 	// c1/dotc1z/engine/pebble/digest.go's present-means-exact contract.
 	// Additive field: old readers ignore it, old files simply lack it.
 	GrantDigestRoot *GrantDigestRoot
+	// Save-time materialization witness (CO-017 cross-version fold fence).
+	// The SDK's replayed-row materialization-policy generation
+	// (sourcecache.MaterializationPolicyGeneration) as of the save that
+	// produced this envelope; written on EVERY save by a witness-aware SDK.
+	//
+	// Why this fences: an OLDER SDK that folds a scoped artifact rewrites
+	// the envelope and rebuilds this manifest fresh from its own
+	// compiled-in descriptors, which do not know this field — so the
+	// witness is necessarily ABSENT from any old-fold output and cannot be
+	// forged by one, even though the old fold byte-copies the payload's
+	// source-cache manifest, indexes, and compat record intact. A replay
+	// consumer requires the witness to byte-match its own generation and
+	// treats absence as ineligible (degrade to a cold sync), which closes
+	// the stale-but-eligible window that a byte-copied payload compat
+	// record alone cannot close.
+	SdkMaterializationGeneration string
 }
 
 func (b0 C1ZManifestV3_builder) Build() *C1ZManifestV3 {
@@ -454,6 +497,7 @@ func (b0 C1ZManifestV3_builder) Build() *C1ZManifestV3 {
 	x.FoldDeadBytes = b.FoldDeadBytes
 	x.PebbleIdIndexFormat = b.PebbleIdIndexFormat
 	x.GrantDigestRoot = b.GrantDigestRoot
+	x.SdkMaterializationGeneration = b.SdkMaterializationGeneration
 	return m0
 }
 
@@ -1236,7 +1280,7 @@ var File_c1_c1z_v3_manifest_proto protoreflect.FileDescriptor
 
 const file_c1_c1z_v3_manifest_proto_rawDesc = "" +
 	"\n" +
-	"\x18c1/c1z/v3/manifest.proto\x12\tc1.c1z.v3\x1a\x1bc1/storage/v3/records.proto\x1a\x19google/protobuf/any.proto\x1a google/protobuf/descriptor.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xde\x04\n" +
+	"\x18c1/c1z/v3/manifest.proto\x12\tc1.c1z.v3\x1a\x1bc1/storage/v3/records.proto\x1a\x19google/protobuf/any.proto\x1a google/protobuf/descriptor.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xa4\x05\n" +
 	"\rC1ZManifestV3\x12\x16\n" +
 	"\x06engine\x18\x01 \x01(\tR\x06engine\x122\n" +
 	"\x15engine_schema_version\x18\x02 \x01(\rR\x13engineSchemaVersion\x129\n" +
@@ -1248,7 +1292,8 @@ const file_c1_c1z_v3_manifest_proto_rawDesc = "" +
 	"\tsync_runs\x18( \x03(\v2\x19.c1.c1z.v3.SyncRunSummaryR\bsyncRuns\x12&\n" +
 	"\x0ffold_dead_bytes\x18) \x01(\x03R\rfoldDeadBytes\x12S\n" +
 	"\x16pebble_id_index_format\x18* \x01(\x0e2\x1e.c1.c1z.v3.PebbleIdIndexFormatR\x13pebbleIdIndexFormat\x12F\n" +
-	"\x11grant_digest_root\x18+ \x01(\v2\x1a.c1.c1z.v3.GrantDigestRootR\x0fgrantDigestRoot\"g\n" +
+	"\x11grant_digest_root\x18+ \x01(\v2\x1a.c1.c1z.v3.GrantDigestRootR\x0fgrantDigestRoot\x12D\n" +
+	"\x1esdk_materialization_generation\x18, \x01(\tR\x1csdkMaterializationGeneration\"g\n" +
 	"\x0fGrantDigestRoot\x12\x1d\n" +
 	"\n" +
 	"xor_digest\x18\x01 \x01(\fR\txorDigest\x12\x14\n" +

--- a/pb/c1/c1z/v3/manifest.pb.validate.go
+++ b/pb/c1/c1z/v3/manifest.pb.validate.go
@@ -226,6 +226,8 @@ func (m *C1ZManifestV3) validate(all bool) error {
 		}
 	}
 
+	// no validation rules for SdkMaterializationGeneration
+
 	if len(errors) > 0 {
 		return C1ZManifestV3MultiError(errors)
 	}

--- a/pb/c1/c1z/v3/manifest_protoopaque.pb.go
+++ b/pb/c1/c1z/v3/manifest_protoopaque.pb.go
@@ -148,19 +148,20 @@ func (x PayloadEncoding) Number() protoreflect.EnumNumber {
 }
 
 type C1ZManifestV3 struct {
-	state                          protoimpl.MessageState          `protogen:"opaque.v1"`
-	xxx_hidden_Engine              string                          `protobuf:"bytes,1,opt,name=engine,proto3"`
-	xxx_hidden_EngineSchemaVersion uint32                          `protobuf:"varint,2,opt,name=engine_schema_version,json=engineSchemaVersion,proto3"`
-	xxx_hidden_EngineConfig        *anypb.Any                      `protobuf:"bytes,3,opt,name=engine_config,json=engineConfig,proto3"`
-	xxx_hidden_PayloadEncoding     PayloadEncoding                 `protobuf:"varint,4,opt,name=payload_encoding,json=payloadEncoding,proto3,enum=c1.c1z.v3.PayloadEncoding"`
-	xxx_hidden_Descriptors         *descriptorpb.FileDescriptorSet `protobuf:"bytes,10,opt,name=descriptors,proto3"`
-	xxx_hidden_RecordTypes         *[]*RecordTypeInfo              `protobuf:"bytes,11,rep,name=record_types,json=recordTypes,proto3"`
-	xxx_hidden_SyncRuns            *[]*SyncRunSummary              `protobuf:"bytes,40,rep,name=sync_runs,json=syncRuns,proto3"`
-	xxx_hidden_FoldDeadBytes       int64                           `protobuf:"varint,41,opt,name=fold_dead_bytes,json=foldDeadBytes,proto3"`
-	xxx_hidden_PebbleIdIndexFormat PebbleIdIndexFormat             `protobuf:"varint,42,opt,name=pebble_id_index_format,json=pebbleIdIndexFormat,proto3,enum=c1.c1z.v3.PebbleIdIndexFormat"`
-	xxx_hidden_GrantDigestRoot     *GrantDigestRoot                `protobuf:"bytes,43,opt,name=grant_digest_root,json=grantDigestRoot,proto3"`
-	unknownFields                  protoimpl.UnknownFields
-	sizeCache                      protoimpl.SizeCache
+	state                                   protoimpl.MessageState          `protogen:"opaque.v1"`
+	xxx_hidden_Engine                       string                          `protobuf:"bytes,1,opt,name=engine,proto3"`
+	xxx_hidden_EngineSchemaVersion          uint32                          `protobuf:"varint,2,opt,name=engine_schema_version,json=engineSchemaVersion,proto3"`
+	xxx_hidden_EngineConfig                 *anypb.Any                      `protobuf:"bytes,3,opt,name=engine_config,json=engineConfig,proto3"`
+	xxx_hidden_PayloadEncoding              PayloadEncoding                 `protobuf:"varint,4,opt,name=payload_encoding,json=payloadEncoding,proto3,enum=c1.c1z.v3.PayloadEncoding"`
+	xxx_hidden_Descriptors                  *descriptorpb.FileDescriptorSet `protobuf:"bytes,10,opt,name=descriptors,proto3"`
+	xxx_hidden_RecordTypes                  *[]*RecordTypeInfo              `protobuf:"bytes,11,rep,name=record_types,json=recordTypes,proto3"`
+	xxx_hidden_SyncRuns                     *[]*SyncRunSummary              `protobuf:"bytes,40,rep,name=sync_runs,json=syncRuns,proto3"`
+	xxx_hidden_FoldDeadBytes                int64                           `protobuf:"varint,41,opt,name=fold_dead_bytes,json=foldDeadBytes,proto3"`
+	xxx_hidden_PebbleIdIndexFormat          PebbleIdIndexFormat             `protobuf:"varint,42,opt,name=pebble_id_index_format,json=pebbleIdIndexFormat,proto3,enum=c1.c1z.v3.PebbleIdIndexFormat"`
+	xxx_hidden_GrantDigestRoot              *GrantDigestRoot                `protobuf:"bytes,43,opt,name=grant_digest_root,json=grantDigestRoot,proto3"`
+	xxx_hidden_SdkMaterializationGeneration string                          `protobuf:"bytes,44,opt,name=sdk_materialization_generation,json=sdkMaterializationGeneration,proto3"`
+	unknownFields                           protoimpl.UnknownFields
+	sizeCache                               protoimpl.SizeCache
 }
 
 func (x *C1ZManifestV3) Reset() {
@@ -262,6 +263,13 @@ func (x *C1ZManifestV3) GetGrantDigestRoot() *GrantDigestRoot {
 	return nil
 }
 
+func (x *C1ZManifestV3) GetSdkMaterializationGeneration() string {
+	if x != nil {
+		return x.xxx_hidden_SdkMaterializationGeneration
+	}
+	return ""
+}
+
 func (x *C1ZManifestV3) SetEngine(v string) {
 	x.xxx_hidden_Engine = v
 }
@@ -300,6 +308,10 @@ func (x *C1ZManifestV3) SetPebbleIdIndexFormat(v PebbleIdIndexFormat) {
 
 func (x *C1ZManifestV3) SetGrantDigestRoot(v *GrantDigestRoot) {
 	x.xxx_hidden_GrantDigestRoot = v
+}
+
+func (x *C1ZManifestV3) SetSdkMaterializationGeneration(v string) {
+	x.xxx_hidden_SdkMaterializationGeneration = v
 }
 
 func (x *C1ZManifestV3) HasEngineConfig() bool {
@@ -395,6 +407,22 @@ type C1ZManifestV3_builder struct {
 	// c1/dotc1z/engine/pebble/digest.go's present-means-exact contract.
 	// Additive field: old readers ignore it, old files simply lack it.
 	GrantDigestRoot *GrantDigestRoot
+	// Save-time materialization witness (CO-017 cross-version fold fence).
+	// The SDK's replayed-row materialization-policy generation
+	// (sourcecache.MaterializationPolicyGeneration) as of the save that
+	// produced this envelope; written on EVERY save by a witness-aware SDK.
+	//
+	// Why this fences: an OLDER SDK that folds a scoped artifact rewrites
+	// the envelope and rebuilds this manifest fresh from its own
+	// compiled-in descriptors, which do not know this field — so the
+	// witness is necessarily ABSENT from any old-fold output and cannot be
+	// forged by one, even though the old fold byte-copies the payload's
+	// source-cache manifest, indexes, and compat record intact. A replay
+	// consumer requires the witness to byte-match its own generation and
+	// treats absence as ineligible (degrade to a cold sync), which closes
+	// the stale-but-eligible window that a byte-copied payload compat
+	// record alone cannot close.
+	SdkMaterializationGeneration string
 }
 
 func (b0 C1ZManifestV3_builder) Build() *C1ZManifestV3 {
@@ -411,6 +439,7 @@ func (b0 C1ZManifestV3_builder) Build() *C1ZManifestV3 {
 	x.xxx_hidden_FoldDeadBytes = b.FoldDeadBytes
 	x.xxx_hidden_PebbleIdIndexFormat = b.PebbleIdIndexFormat
 	x.xxx_hidden_GrantDigestRoot = b.GrantDigestRoot
+	x.xxx_hidden_SdkMaterializationGeneration = b.SdkMaterializationGeneration
 	return m0
 }
 
@@ -1145,7 +1174,7 @@ var File_c1_c1z_v3_manifest_proto protoreflect.FileDescriptor
 
 const file_c1_c1z_v3_manifest_proto_rawDesc = "" +
 	"\n" +
-	"\x18c1/c1z/v3/manifest.proto\x12\tc1.c1z.v3\x1a\x1bc1/storage/v3/records.proto\x1a\x19google/protobuf/any.proto\x1a google/protobuf/descriptor.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xde\x04\n" +
+	"\x18c1/c1z/v3/manifest.proto\x12\tc1.c1z.v3\x1a\x1bc1/storage/v3/records.proto\x1a\x19google/protobuf/any.proto\x1a google/protobuf/descriptor.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xa4\x05\n" +
 	"\rC1ZManifestV3\x12\x16\n" +
 	"\x06engine\x18\x01 \x01(\tR\x06engine\x122\n" +
 	"\x15engine_schema_version\x18\x02 \x01(\rR\x13engineSchemaVersion\x129\n" +
@@ -1157,7 +1186,8 @@ const file_c1_c1z_v3_manifest_proto_rawDesc = "" +
 	"\tsync_runs\x18( \x03(\v2\x19.c1.c1z.v3.SyncRunSummaryR\bsyncRuns\x12&\n" +
 	"\x0ffold_dead_bytes\x18) \x01(\x03R\rfoldDeadBytes\x12S\n" +
 	"\x16pebble_id_index_format\x18* \x01(\x0e2\x1e.c1.c1z.v3.PebbleIdIndexFormatR\x13pebbleIdIndexFormat\x12F\n" +
-	"\x11grant_digest_root\x18+ \x01(\v2\x1a.c1.c1z.v3.GrantDigestRootR\x0fgrantDigestRoot\"g\n" +
+	"\x11grant_digest_root\x18+ \x01(\v2\x1a.c1.c1z.v3.GrantDigestRootR\x0fgrantDigestRoot\x12D\n" +
+	"\x1esdk_materialization_generation\x18, \x01(\tR\x1csdkMaterializationGeneration\"g\n" +
 	"\x0fGrantDigestRoot\x12\x1d\n" +
 	"\n" +
 	"xor_digest\x18\x01 \x01(\fR\txorDigest\x12\x14\n" +

--- a/pkg/connectorbuilder/connectorbuilder.go
+++ b/pkg/connectorbuilder/connectorbuilder.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"slices"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/go-jose/go-jose/v4"
@@ -23,6 +24,7 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/retry"
 	"github.com/conductorone/baton-sdk/pkg/sdk"
 	"github.com/conductorone/baton-sdk/pkg/session"
+	"github.com/conductorone/baton-sdk/pkg/sourcecache"
 	"github.com/conductorone/baton-sdk/pkg/types"
 	"github.com/conductorone/baton-sdk/pkg/types/sessions"
 	"github.com/conductorone/baton-sdk/pkg/types/tasks"
@@ -77,6 +79,8 @@ type builder struct {
 	nowFunc                 func() time.Time
 	clientSecret            *jose.JSONWebKey
 	sessionStore            sessions.SessionStore
+	sourceCacheMu           sync.RWMutex
+	sourceCacheLookup       sourcecache.Lookup
 	metadataProvider        MetadataProvider
 	validateProvider        ValidateProvider
 	ticketManager           TicketManagerLimited

--- a/pkg/connectorbuilder/resource_syncer.go
+++ b/pkg/connectorbuilder/resource_syncer.go
@@ -139,7 +139,7 @@ func (b *builder) ListResources(ctx context.Context, request *v2.ResourcesServic
 		Size:  int(request.GetPageSize()),
 		Token: request.GetPageToken(),
 	}
-	opts := resource.SyncOpAttrs{SyncID: request.GetActiveSyncId(), PageToken: token, Session: WithSyncId(b.sessionStore, request.GetActiveSyncId())}
+	opts := resource.SyncOpAttrs{SyncID: request.GetActiveSyncId(), PageToken: token, Session: WithSyncId(b.sessionStore, request.GetActiveSyncId()), Lookup: b.sourceCache()}
 	out, retOptions, err := rb.List(ctx, request.GetParentResourceId(), opts)
 	if retOptions == nil {
 		retOptions = &resource.SyncOpResults{}
@@ -228,7 +228,7 @@ func (b *builder) ListStaticEntitlements(ctx context.Context, request *v2.Entitl
 		Size:  int(request.GetPageSize()),
 		Token: request.GetPageToken(),
 	}
-	opts := resource.SyncOpAttrs{SyncID: request.GetActiveSyncId(), PageToken: token, Session: WithSyncId(b.sessionStore, request.GetActiveSyncId())}
+	opts := resource.SyncOpAttrs{SyncID: request.GetActiveSyncId(), PageToken: token, Session: WithSyncId(b.sessionStore, request.GetActiveSyncId()), Lookup: b.sourceCache()}
 	out, retOptions, err := rbse.StaticEntitlements(ctx, opts)
 	if retOptions == nil {
 		retOptions = &resource.SyncOpResults{}
@@ -283,7 +283,7 @@ func (b *builder) ListEntitlements(ctx context.Context, request *v2.Entitlements
 		Size:  int(request.GetPageSize()),
 		Token: request.GetPageToken(),
 	}
-	opts := resource.SyncOpAttrs{SyncID: request.GetActiveSyncId(), PageToken: token, Session: WithSyncId(b.sessionStore, request.GetActiveSyncId())}
+	opts := resource.SyncOpAttrs{SyncID: request.GetActiveSyncId(), PageToken: token, Session: WithSyncId(b.sessionStore, request.GetActiveSyncId()), Lookup: b.sourceCache()}
 	var out []*v2.Entitlement
 	var retOptions *resource.SyncOpResults
 	reqAnnos := annotations.Annotations(request.GetAnnotations())
@@ -355,7 +355,7 @@ func (b *builder) ListGrants(ctx context.Context, request *v2.GrantsServiceListG
 		Size:  int(request.GetPageSize()),
 		Token: request.GetPageToken(),
 	}
-	opts := resource.SyncOpAttrs{SyncID: request.GetActiveSyncId(), PageToken: token, Session: WithSyncId(b.sessionStore, request.GetActiveSyncId())}
+	opts := resource.SyncOpAttrs{SyncID: request.GetActiveSyncId(), PageToken: token, Session: WithSyncId(b.sessionStore, request.GetActiveSyncId()), Lookup: b.sourceCache()}
 	var out []*v2.Grant
 	var retOptions *resource.SyncOpResults
 	reqAnnos := annotations.Annotations(request.GetAnnotations())

--- a/pkg/connectorbuilder/source_cache.go
+++ b/pkg/connectorbuilder/source_cache.go
@@ -1,0 +1,33 @@
+package connectorbuilder
+
+import (
+	"context"
+
+	"github.com/conductorone/baton-sdk/pkg/sourcecache"
+)
+
+// The builder receives the sync runner's source-cache lookup
+// (ADVANCED FUNCTIONALITY — see pkg/sourcecache) and hands it to resource
+// syncers through SyncOpAttrs.Lookup. Delivery mirrors the session-store
+// pattern: the syncer calls SetSourceCache at sync start and
+// SetSourceCache(nil) at sync end so a late RPC cannot read stale state.
+var _ sourcecache.SetLookup = (*builder)(nil)
+
+// SetSourceCache installs (or, with nil, clears) the source-cache lookup
+// used to populate SyncOpAttrs.Lookup for list calls.
+func (b *builder) SetSourceCache(_ context.Context, lookup sourcecache.Lookup) {
+	b.sourceCacheMu.Lock()
+	defer b.sourceCacheMu.Unlock()
+	b.sourceCacheLookup = lookup
+}
+
+// sourceCache returns the currently installed lookup, or NoopLookup when
+// none is installed: connectors never observe a nil SyncOpAttrs.Lookup.
+func (b *builder) sourceCache() sourcecache.Lookup {
+	b.sourceCacheMu.RLock()
+	defer b.sourceCacheMu.RUnlock()
+	if b.sourceCacheLookup == nil {
+		return sourcecache.NoopLookup{}
+	}
+	return b.sourceCacheLookup
+}

--- a/pkg/dotc1z/engine/pebble/cleanup.go
+++ b/pkg/dotc1z/engine/pebble/cleanup.go
@@ -42,6 +42,7 @@ func scopedRanges() [][2][]byte {
 		{DigestLowerBound(), DigestUpperBound()},
 		{SourceCacheEntryLowerBound(), SourceCacheEntryUpperBound()},
 		{SourceCachePoisonLowerBound(), SourceCachePoisonUpperBound()},
+		{SourceCacheCompatLowerBound(), SourceCacheCompatUpperBound()},
 		{encodeAssetPrefix(), upperBoundOf(encodeAssetPrefix())},
 		// Stats sidecar — single key; the half-open range shape
 		// contains exactly that one key.

--- a/pkg/dotc1z/engine/pebble/internal/rawdb/keyspace.go
+++ b/pkg/dotc1z/engine/pebble/internal/rawdb/keyspace.go
@@ -231,6 +231,7 @@ func SourceScopeIndexPrefix(recordType byte, scopeKey string) ([]byte, bool) {
 const (
 	sourceCacheEntrySubFamily  byte = 0x00
 	sourceCachePoisonSubFamily byte = 0x01
+	sourceCacheCompatSubFamily byte = 0x02
 )
 
 // SourceCacheEntryKey addresses one manifest row.
@@ -266,10 +267,27 @@ func SourceCachePoisonBounds() ([]byte, []byte) {
 	return lo, UpperBound(lo)
 }
 
+// SourceCacheCompatKey addresses the singleton replay-compatibility
+// record (SourceCacheCompatRecord). It lives inside the source-cache
+// family on purpose: replay-state invalidation (fold, overlay rebuild)
+// wipes it together with the manifest entries, so a compat record can
+// never outlive the validators it vouches for.
+func SourceCacheCompatKey() []byte {
+	buf := []byte{VersionV3, TypeSourceCache, sourceCacheCompatSubFamily}
+	return codec.AppendTupleSeparator(buf)
+}
+
+// SourceCacheCompatBounds bounds the compat record's singleton subfamily.
+func SourceCacheCompatBounds() ([]byte, []byte) {
+	lo := []byte{VersionV3, TypeSourceCache, sourceCacheCompatSubFamily}
+	return lo, UpperBound(lo)
+}
+
 // SourceCacheFamilyBounds bounds the whole source-cache family: manifest
-// entries and poison markers. This is the replay-state invalidation
-// range — an artifact whose validators are wiped has nothing left for
-// poison to protect, so the markers go with them.
+// entries, poison markers, and the compat record. This is the
+// replay-state invalidation range — an artifact whose validators are
+// wiped has nothing left for poison or compat to protect, so those
+// records go with them.
 func SourceCacheFamilyBounds() ([]byte, []byte) {
 	lo := []byte{VersionV3, TypeSourceCache}
 	return lo, UpperBound(lo)

--- a/pkg/dotc1z/engine/pebble/keys.go
+++ b/pkg/dotc1z/engine/pebble/keys.go
@@ -420,6 +420,15 @@ func SourceCachePoisonUpperBound() []byte {
 	return hi
 }
 
+func SourceCacheCompatLowerBound() []byte {
+	lo, _ := rawdb.SourceCacheCompatBounds()
+	return lo
+}
+func SourceCacheCompatUpperBound() []byte {
+	_, hi := rawdb.SourceCacheCompatBounds()
+	return hi
+}
+
 // --- ResourceType ---
 
 // encodeResourceTypeKey returns the primary key for a resource_type:

--- a/pkg/dotc1z/engine/pebble/manifest.go
+++ b/pkg/dotc1z/engine/pebble/manifest.go
@@ -11,6 +11,7 @@ import (
 	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
 	formatv3 "github.com/conductorone/baton-sdk/pkg/dotc1z/format/v3"
+	"github.com/conductorone/baton-sdk/pkg/sourcecache"
 )
 
 // BuildManifest assembles the v3 envelope manifest for a Pebble-engine c1z
@@ -30,6 +31,11 @@ func BuildManifest(encoding c1zstore.PayloadEncoding) (*c1zv3.C1ZManifestV3, err
 		EngineSchemaVersion: uint32(SDKPebbleFormat),
 		PayloadEncoding:     payloadEncodingToProto(encoding),
 		Descriptors:         descriptors,
+		// Save-time materialization witness (CO-017 fold fence): written
+		// on EVERY save. An older SDK's fold rebuilds this manifest from
+		// its own descriptors and necessarily omits it, which is what
+		// makes old-fold outputs replay-ineligible. See the proto field.
+		SdkMaterializationGeneration: sourcecache.MaterializationPolicyGeneration,
 	}.Build(), nil
 }
 

--- a/pkg/dotc1z/engine/pebble/manifest_projection_test.go
+++ b/pkg/dotc1z/engine/pebble/manifest_projection_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
 	enginepkg "github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble"
 	formatv3 "github.com/conductorone/baton-sdk/pkg/dotc1z/format/v3"
+	"github.com/conductorone/baton-sdk/pkg/sourcecache"
 )
 
 // TestManifestSyncRunProjection locks in the envelope's sync-run
@@ -77,6 +78,11 @@ func TestManifestSyncRunProjection(t *testing.T) {
 	require.True(t, quality.GetSourceCacheReplayBlocked())
 	require.Equal(t, uint64(2), quality.GetEntitlementsDropped())
 	require.Equal(t, uint64(33), quality.GetReasonFlags())
+	// CO-017 fence witness: every save stamps it AND the hand-rolled
+	// header decoder must surface it — the field was once written but
+	// skipped by the decoder, silently colding every warm sync.
+	require.Equal(t, sourcecache.MaterializationPolicyGeneration, m.GetSdkMaterializationGeneration(),
+		"header sdk_materialization_generation")
 
 	// The engine-dispatch header path must surface the same projection.
 	_, err = f.Seek(0, 0)

--- a/pkg/dotc1z/engine/pebble/source_cache.go
+++ b/pkg/dotc1z/engine/pebble/source_cache.go
@@ -402,6 +402,100 @@ func (e *Engine) GetSourceCacheEntry(ctx context.Context, rowKind, scopeKey stri
 	return rec, nil
 }
 
+// IterateSourceCacheEntries yields every source-cache manifest entry,
+// including invalidated ones (the record carries the flag). Verification
+// oracles use it to assert exact manifest membership — "unexpected scopes
+// have no entries" needs enumeration, not point reads.
+func (e *Engine) IterateSourceCacheEntries(ctx context.Context, yield func(*v3.SourceCacheEntryRecord) bool) error {
+	iter, err := e.db.NewIter(&pebble.IterOptions{
+		LowerBound: SourceCacheEntryLowerBound(),
+		UpperBound: SourceCacheEntryUpperBound(),
+	})
+	if err != nil {
+		return err
+	}
+	defer iter.Close()
+	for iter.First(); iter.Valid(); iter.Next() {
+		rec := &v3.SourceCacheEntryRecord{}
+		if err := unmarshalRecord(iter.Value(), rec); err != nil {
+			return fmt.Errorf("iterate source cache entries: %w", err)
+		}
+		if !yield(rec) {
+			return nil
+		}
+	}
+	return iter.Error()
+}
+
+// ErrReplayDestinationCommit marks a replay-copy failure whose cause is the
+// DESTINATION store's commit path, after the source scope passed preflight.
+// Sync orchestration classifies these as warm (the replay decision was
+// sound; a retry may succeed warm — plan B7 in
+// docs/verification/sync-replay-6b/plan.md), while every unmarked replay
+// failure defaults to cold, fail-closed: a wrong cold wastes one fetch, a
+// wrong warm can loop on an untrustworthy artifact.
+var ErrReplayDestinationCommit = errors.New("source cache replay: destination commit")
+
+func replayDestinationCommitError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%w: %w", ErrReplayDestinationCommit, err)
+}
+
+// sourceCacheCompatID is the fixed singleton id of the replay-compatibility
+// record (the table shape requires a primary key; the keyspace addresses the
+// record without it).
+const sourceCacheCompatID = "compat"
+
+// PutSourceCacheCompatRecord writes the singleton replay-compatibility
+// record. The caller (sync orchestration) writes it when the source-cache
+// write side enables, before any manifest entry, so a crash can never leave
+// manifest entries whose recording conditions were not declared. The id
+// field is forced to the singleton constant.
+func (e *Engine) PutSourceCacheCompatRecord(ctx context.Context, rec *v3.SourceCacheCompatRecord) error {
+	if rec == nil {
+		return errors.New("source cache compat: nil record")
+	}
+	return e.withWrite(func() error {
+		if err := e.requireCurrentSync(); err != nil {
+			return err
+		}
+		stored := &v3.SourceCacheCompatRecord{}
+		stored.SetId(sourceCacheCompatID)
+		stored.SetConnectorCacheGeneration(rec.GetConnectorCacheGeneration())
+		stored.SetConnectorConfigFingerprint(rec.GetConnectorConfigFingerprint())
+		stored.SetSdkMaterializationGeneration(rec.GetSdkMaterializationGeneration())
+		stored.SetSyncSelectionFingerprint(rec.GetSyncSelectionFingerprint())
+		val, err := marshalRecord(stored)
+		if err != nil {
+			return err
+		}
+		opts := writeOpts(e.opts.durability)
+		if e.IsFreshSync() {
+			opts = pebble.NoSync
+		}
+		return e.db.SourceCacheSet(rawdb.SourceCacheCompatKey(), val, opts)
+	})
+}
+
+// GetSourceCacheCompatRecord returns the artifact's singleton
+// replay-compatibility record, or pebble.ErrNotFound when the artifact
+// never declared one (pre-compat SDK, cold-only sync, or invalidated by a
+// compaction fold).
+func (e *Engine) GetSourceCacheCompatRecord(ctx context.Context) (*v3.SourceCacheCompatRecord, error) {
+	val, closer, err := e.db.Get(rawdb.SourceCacheCompatKey())
+	if err != nil {
+		return nil, err
+	}
+	defer closer.Close()
+	rec := &v3.SourceCacheCompatRecord{}
+	if err := unmarshalRecord(val, rec); err != nil {
+		return nil, fmt.Errorf("GetSourceCacheCompatRecord: unmarshal: %w", err)
+	}
+	return rec, nil
+}
+
 // InvalidateSourceCacheReplayState removes upstream validators from a
 // compaction output. Rebuild compactions also drop the source-scope indexes
 // they synthesized while materializing winner rows; fold keeps those indexes
@@ -1164,13 +1258,15 @@ func (e *Engine) clearReplayDestinationScopeLocked(
 		if rowsInBatch == 0 {
 			return nil
 		}
+		// Hook errors take the same warm marking as the real commit: the
+		// hook exists to simulate exactly this failure point.
 		if e.test.sourceCacheReplayClearCommitHook != nil {
 			if err := e.test.sourceCacheReplayClearCommitHook(rowKind, rowsInBatch, final); err != nil {
-				return err
+				return replayDestinationCommitError(err)
 			}
 		}
 		if err := batch.Commit(opts); err != nil {
-			return err
+			return replayDestinationCommitError(err)
 		}
 		deleted += deletedInBatch
 		// Same per-chunk contract as sourceCacheDeleteBatch.onCommit:
@@ -1240,6 +1336,54 @@ func (e *Engine) clearReplayDestinationScopeLocked(
 		return deleted, err
 	}
 	return deleted, nil
+}
+
+// ClearSourceCacheScope removes every destination row stamped with
+// (rowKind, scopeKey) — the replay unit's clear leg exposed standalone.
+// A record round is a replacement listing: orchestration grounds it by
+// clearing a scope whose partition may hold un-attributed rows from a
+// crashed attempt (a replay copy whose round never published) before the
+// round's first write. Composing a record round with such debris is the
+// phantom-union shape (formal/walker/CALIBRATION.md, scenario 1).
+// Deletes commit in the same bounded batches as replay; idempotent, so
+// interruption followed by retry converges. Returns rows deleted.
+func (e *Engine) ClearSourceCacheScope(ctx context.Context, rowKind string, scopeKey string) (int64, error) {
+	var recordType byte
+	var prefix []byte
+	var noteCleared func()
+	switch rowKind {
+	case "grants":
+		recordType, prefix = typeGrant, encodeGrantBySourceScopePrefix(scopeKey)
+		noteCleared = func() { _ = e.takeFreshGrantsEmpty() }
+	case "entitlements":
+		recordType, prefix = typeEntitlement, encodeEntitlementBySourceScopePrefix(scopeKey)
+		noteCleared = func() {
+			e.noteEntitlementKeyspaceWrite()
+			_ = e.takeFreshEntitlementsEmpty()
+		}
+	case "resources":
+		recordType, prefix = typeResource, encodeResourceBySourceScopePrefix(scopeKey)
+		noteCleared = func() { _ = e.takeFreshResourcesEmpty() }
+	default:
+		return 0, fmt.Errorf("source cache clear scope: invalid row kind %q", rowKind)
+	}
+	var deleted int
+	err := e.withWrite(func() error {
+		if err := e.requireCurrentSync(); err != nil {
+			return err
+		}
+		opts := writeOpts(e.opts.durability)
+		if e.IsFreshSync() {
+			opts = pebble.NoSync
+		}
+		var err error
+		deleted, err = e.clearReplayDestinationScopeLocked(ctx, rowKind, recordType, scopeKey, prefix, opts)
+		if deleted > 0 {
+			noteCleared()
+		}
+		return err
+	})
+	return int64(deleted), err
 }
 
 // ReplaySourceCacheGrants copies every grant stamped with scopeKey from
@@ -1404,11 +1548,11 @@ func (e *Engine) ReplaySourceCacheGrants(ctx context.Context, prev *Engine, scop
 			if rowsInBatch >= e.sourceCacheReplayBatchLimit() {
 				if e.test.sourceCacheReplayCommitHook != nil {
 					if err := e.test.sourceCacheReplayCommitHook("grants", rowsInBatch, false); err != nil {
-						return err
+						return replayDestinationCommitError(err)
 					}
 				}
 				if err := batch.Commit(opts); err != nil {
-					return err
+					return replayDestinationCommitError(err)
 				}
 				committedRows += rowsInBatch
 				_ = batch.Close()
@@ -1424,11 +1568,11 @@ func (e *Engine) ReplaySourceCacheGrants(ctx context.Context, prev *Engine, scop
 		}
 		if e.test.sourceCacheReplayCommitHook != nil {
 			if err := e.test.sourceCacheReplayCommitHook("grants", rowsInBatch, true); err != nil {
-				return err
+				return replayDestinationCommitError(err)
 			}
 		}
 		if err := batch.Commit(opts); err != nil {
-			return err
+			return replayDestinationCommitError(err)
 		}
 		// Replay populated the fresh sync's grant keyspace directly. The
 		// first overlay PutGrantRecords must therefore perform its normal
@@ -1570,11 +1714,11 @@ func (e *Engine) ReplaySourceCacheEntitlements(ctx context.Context, prev *Engine
 			if rowsInBatch >= e.sourceCacheReplayBatchLimit() {
 				if e.test.sourceCacheReplayCommitHook != nil {
 					if err := e.test.sourceCacheReplayCommitHook("entitlements", rowsInBatch, false); err != nil {
-						return err
+						return replayDestinationCommitError(err)
 					}
 				}
 				if err := batch.Commit(opts); err != nil {
-					return err
+					return replayDestinationCommitError(err)
 				}
 				committedRows += rowsInBatch
 				// Same per-chunk contract as the clear half above and
@@ -1597,11 +1741,11 @@ func (e *Engine) ReplaySourceCacheEntitlements(ctx context.Context, prev *Engine
 		}
 		if e.test.sourceCacheReplayCommitHook != nil {
 			if err := e.test.sourceCacheReplayCommitHook("entitlements", rowsInBatch, true); err != nil {
-				return err
+				return replayDestinationCommitError(err)
 			}
 		}
 		if err := batch.Commit(opts); err != nil {
-			return err
+			return replayDestinationCommitError(err)
 		}
 		// The defer above covers the FINAL chunk's lookup invalidation
 		// (see lookup.go — later tombstones would silently miss replayed
@@ -1741,11 +1885,11 @@ func (e *Engine) ReplaySourceCacheResources(ctx context.Context, prev *Engine, s
 			if rowsInBatch >= e.sourceCacheReplayBatchLimit() {
 				if e.test.sourceCacheReplayCommitHook != nil {
 					if err := e.test.sourceCacheReplayCommitHook("resources", rowsInBatch, false); err != nil {
-						return err
+						return replayDestinationCommitError(err)
 					}
 				}
 				if err := batch.Commit(opts); err != nil {
-					return err
+					return replayDestinationCommitError(err)
 				}
 				committedRows += rowsInBatch
 				_ = batch.Close()
@@ -1761,11 +1905,11 @@ func (e *Engine) ReplaySourceCacheResources(ctx context.Context, prev *Engine, s
 		}
 		if e.test.sourceCacheReplayCommitHook != nil {
 			if err := e.test.sourceCacheReplayCommitHook("resources", rowsInBatch, true); err != nil {
-				return err
+				return replayDestinationCommitError(err)
 			}
 		}
 		if err := batch.Commit(opts); err != nil {
-			return err
+			return replayDestinationCommitError(err)
 		}
 		// See grant replay above: direct replay writes mean the first
 		// overlay PutResourceRecords must not use the empty-keyspace

--- a/pkg/dotc1z/engine/pebble/source_cache_compat_lifecycle_test.go
+++ b/pkg/dotc1z/engine/pebble/source_cache_compat_lifecycle_test.go
@@ -1,0 +1,111 @@
+package pebble
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/stretchr/testify/require"
+
+	v3 "github.com/conductorone/baton-sdk/pb/c1/storage/v3"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble/internal/rawdb"
+)
+
+// TestSourceCacheCompatRecordLifecycle replaces the Phase 6a
+// `C30-compatibility-record-lifecycle` exclusion: the compat record was
+// schema-only then, and Phase 6b added the Pebble writer/reader
+// (PutSourceCacheCompatRecord / GetSourceCacheCompatRecord). Per 6a C30 the
+// record must be included in reset, cleanup, invalidation, and leak
+// accounting — WITHOUT asserting eligibility/matching semantics, which are
+// orchestration behavior verified by the 6b chaos gate suite.
+//
+// Leak accounting rides along in every cell: the newTestEngine fixture's
+// Close reports leaked iterators, Get closers, and unreleased batches.
+func TestSourceCacheCompatRecordLifecycle(t *testing.T) {
+	newRecord := func(id string) *v3.SourceCacheCompatRecord {
+		return v3.SourceCacheCompatRecord_builder{
+			Id:                           id,
+			ConnectorCacheGeneration:     "gen-1",
+			ConnectorConfigFingerprint:   "cfg-1",
+			SdkMaterializationGeneration: "sdkmat-1",
+			SyncSelectionFingerprint:     "sel-1",
+		}.Build()
+	}
+
+	t.Run("round-trip-forces-singleton-id", func(t *testing.T) {
+		ctx := context.Background()
+		e, _ := newTestEngine(t)
+		a := NewAdapter(e)
+		_, err := a.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+		require.NoError(t, err)
+		// The caller's id is deliberately wrong: the writer must force the
+		// singleton constant so no caller can mint a second record.
+		require.NoError(t, e.PutSourceCacheCompatRecord(ctx, newRecord("not-compat")))
+		require.NoError(t, a.EndSync(ctx))
+
+		got, err := e.GetSourceCacheCompatRecord(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "compat", got.GetId())
+		require.Equal(t, "gen-1", got.GetConnectorCacheGeneration())
+		require.Equal(t, "cfg-1", got.GetConnectorConfigFingerprint())
+		require.Equal(t, "sdkmat-1", got.GetSdkMaterializationGeneration())
+		require.Equal(t, "sel-1", got.GetSyncSelectionFingerprint())
+	})
+
+	t.Run("replay-state-invalidation-wipes-it", func(t *testing.T) {
+		// The compat key lives inside the source-cache family on purpose:
+		// fold/rebuild compactions invalidate replay state with one range
+		// tombstone, and a compat record must never outlive the manifest
+		// entries whose recording conditions it declares.
+		ctx := context.Background()
+		e, _ := newTestEngine(t)
+		a := NewAdapter(e)
+		_, err := a.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+		require.NoError(t, err)
+		require.NoError(t, e.PutSourceCacheCompatRecord(ctx, newRecord("compat")))
+		require.NoError(t, a.EndSync(ctx))
+
+		require.NoError(t, e.InvalidateSourceCacheReplayState(ctx, false))
+		_, err = e.GetSourceCacheCompatRecord(ctx)
+		require.ErrorIs(t, err, pebble.ErrNotFound,
+			"replay-state invalidation must remove the compat record with the manifest entries")
+	})
+
+	t.Run("reset-for-replacement-sync-wipes-it", func(t *testing.T) {
+		ctx := context.Background()
+		e, _ := newTestEngine(t)
+		a := NewAdapter(e)
+		_, err := a.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+		require.NoError(t, err)
+		require.NoError(t, e.PutSourceCacheCompatRecord(ctx, newRecord("compat")))
+		require.NoError(t, a.EndSync(ctx))
+
+		// StartNewSync excises every sync-scoped keyspace before binding
+		// the replacement sync; the compat record must not survive into a
+		// sync whose recording conditions it does not describe.
+		_, err = a.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+		require.NoError(t, err)
+		_, err = e.GetSourceCacheCompatRecord(ctx)
+		require.ErrorIs(t, err, pebble.ErrNotFound,
+			"a replacement sync must not inherit the prior sync's compat record")
+		require.NoError(t, a.EndSync(ctx))
+	})
+
+	t.Run("cleanup-ranges-cover-the-compat-key", func(t *testing.T) {
+		// Same shape as TestSyncScopedRangesCoverEveryWrittenIndex: the
+		// cleanup/reset range list must contain the compat key, so a
+		// future keyspace move fails here instead of leaking the record
+		// past a sync delete.
+		key := rawdb.SourceCacheCompatKey()
+		covered := false
+		for _, r := range scopedRanges() {
+			if bytes.Compare(key, r[0]) >= 0 && bytes.Compare(key, r[1]) < 0 {
+				covered = true
+				break
+			}
+		}
+		require.True(t, covered, "SourceCacheCompatKey not covered by any syncScopedRanges entry: %x", key)
+	})
+}

--- a/pkg/dotc1z/engine/pebble/source_cache_exclusions_verification_test.go
+++ b/pkg/dotc1z/engine/pebble/source_cache_exclusions_verification_test.go
@@ -8,9 +8,12 @@ func TestVerificationPhase6aExecutableExclusions(t *testing.T) {
 	t.Run("C19-scoped-bulk-input", func(t *testing.T) {
 		t.Skip("BulkSyncImport consumes conversion v2 rows and has no source-scope or manifest input; scoped bulk shapes are not representable at the Phase 6a API boundary")
 	})
-	t.Run("C25-transitional-empty-overlay-validator", func(t *testing.T) {
-		t.Skip("SourceCacheStore rejects empty manifest validators and does not receive page-level transitional validators; later-overlay publication belongs to deferred syncer orchestration")
-	})
+	// C25-transitional-empty-overlay-validator: exclusion REMOVED in Phase
+	// 6b. The transitional semantics now exist at orchestration level and
+	// are pinned by pkg/sync's chaos collection suite: a record round with
+	// no validator stamps rows and publishes no entry (fresh-page suite,
+	// empty-validator cell), and a later record's validator wins over a
+	// replay page's (collection suite, record-wins-validator cell).
 	t.Run("C28-invalid-UTF8-protobuf-ID", func(t *testing.T) {
 		t.Skip("protobuf string fields cannot encode invalid UTF-8; the representable hostile-ID corpus covers " +
 			"empty, NUL, normalization neighbors, max/oversized opaque IDs, and malformed resource BIDs")
@@ -18,15 +21,21 @@ func TestVerificationPhase6aExecutableExclusions(t *testing.T) {
 	t.Run("C28-empty-resource-BID-tombstone", func(t *testing.T) {
 		t.Skip("an empty opaque resource id can be stored and replayed, but bid.MakeResourceBid rejects it, so no canonical resource tombstone selector can represent that cell")
 	})
-	t.Run("C30-compatibility-record-lifecycle", func(t *testing.T) {
-		t.Skip("SourceCacheCompatRecord is schema-only in Phase 6a; no Pebble compatibility-family writer or key exists to exercise without implementing deferred compatibility behavior")
-	})
-	t.Run("C34-transitional-overlay-annotation", func(t *testing.T) {
-		t.Skip("overlay=false with emitted rows is a syncer annotation/orchestration shape; SourceCacheStore receives only replay, ordinary puts, and tombstone calls")
-	})
-	t.Run("source-compatibility-policy", func(t *testing.T) {
-		t.Skip("FULL/non-compacted eligibility is implemented by CO-013; cross-version compatibility matching remains deferred")
-	})
+	// C30-compatibility-record-lifecycle: exclusion REMOVED in Phase 6b.
+	// The compat writer/reader now exist and the lifecycle boundary is
+	// verified by TestSourceCacheCompatRecordLifecycle
+	// (source_cache_compat_lifecycle_test.go); eligibility/matching
+	// semantics are verified by the sync-level chaos gate suite.
+	// C34-transitional-overlay-annotation: exclusion REMOVED in Phase 6b.
+	// overlay=false with emitted rows is now an implemented orchestration
+	// shape — tolerated as replacement-plus-page-rows — pinned by pkg/sync's
+	// chaos collection suite (overlay-false-with-rows cell).
+	//
+	// source-compatibility-policy: exclusion REMOVED in Phase 6b.
+	// Cross-version compatibility matching is implemented as the compat
+	// record byte-match gate plus the CO-017 materialization-witness fence,
+	// pinned by pkg/sync's gate-matrix chaos suite and the old-fold-shape
+	// eligibility case in pebble_etag_replay_test.go.
 	t.Run("C37-generate-sync-diff", func(t *testing.T) {
 		t.Skip("GenerateSyncDiff creates a partial delta sync rather than a standalone source artifact; CO-013 separately verifies that non-FULL artifacts are replay-ineligible")
 	})

--- a/pkg/dotc1z/engine/pebble/source_scope_verification_test.go
+++ b/pkg/dotc1z/engine/pebble/source_scope_verification_test.go
@@ -1312,6 +1312,60 @@ func TestVerificationReplayCommitFailureRetryAllKinds(t *testing.T) {
 	}
 }
 
+// TestVerificationReplayVerdictSentinelIdentity pins the warm/cold
+// classification CONTRACT the sync orchestration's B7 taxonomy rides on
+// (docs/verification/sync-replay-6b): a replay failure at a destination
+// commit point arrives at the caller CARRYING ErrReplayDestinationCommit,
+// and a source-side read failure arrives WITHOUT it. The syncer-level
+// taxonomy test synthesizes the sentinel by hand; this cell proves the
+// engine's real failure paths produce it, so deleting the engine's
+// replayDestinationCommitError wrapping cannot pass unnoticed.
+func TestVerificationReplayVerdictSentinelIdentity(t *testing.T) {
+	for _, kind := range []sourcecache.RowKind{
+		sourcecache.RowKindResources,
+		sourcecache.RowKindEntitlements,
+		sourcecache.RowKindGrants,
+	} {
+		t.Run(string(kind), func(t *testing.T) {
+			ctx := t.Context()
+			prev := newAdapter(t)
+			_, err := prev.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+			require.NoError(t, err)
+			driver := newSourceScopeMutationDriver(t, prev, kind)
+			require.NoError(t, driver.put(ctx, "scope-a"))
+			sealReplaySource(ctx, t, prev.PebbleEngine(), kind, "scope-a")
+
+			cur := newAdapter(t)
+			_, err = cur.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+			require.NoError(t, err)
+
+			// A failure at the destination-commit point carries the
+			// warm sentinel through the engine's wrapping.
+			injectedCommit := errors.New("injected destination commit failure")
+			cur.PebbleEngine().test.sourceCacheReplayCommitHook = func(_ string, _ int, _ bool) error {
+				return injectedCommit
+			}
+			_, err = driver.replay(ctx, cur.PebbleEngine(), prev.PebbleEngine(), "scope-a")
+			require.ErrorIs(t, err, injectedCommit)
+			require.ErrorIs(t, err, ErrReplayDestinationCommit,
+				"a destination-commit failure must carry the warm sentinel")
+			cur.PebbleEngine().test.sourceCacheReplayCommitHook = nil
+
+			// A source-side read failure must NOT carry it: the consumer
+			// classifies unmarked replay failures cold, fail-closed.
+			injectedRead := errors.New("injected source read failure")
+			cur.PebbleEngine().test.sourceCacheReplayReadHook = func(_ string, _ int) error {
+				return injectedRead
+			}
+			_, err = driver.replay(ctx, cur.PebbleEngine(), prev.PebbleEngine(), "scope-a")
+			require.ErrorIs(t, err, injectedRead)
+			require.NotErrorIs(t, err, ErrReplayDestinationCommit,
+				"a source-side failure must not read as a destination commit")
+			cur.PebbleEngine().test.sourceCacheReplayReadHook = nil
+		})
+	}
+}
+
 // C10/C25: failure of the terminal manifest write must not publish a false
 // validator claim over the already-materialized scope; retry writes exactly
 // that claim without disturbing rows or indexes.

--- a/pkg/dotc1z/format/v3/envelope.go
+++ b/pkg/dotc1z/format/v3/envelope.go
@@ -577,12 +577,18 @@ func readEnvelope(r io.Reader, headerOnly bool, pool *DecoderPool) (*Envelope, e
 // unmarshalManifestHeader decodes the cheap manifest fields by hand:
 // engine (1), engine_schema_version (2), payload_encoding (4), the
 // sync_runs projection (40), fold_dead_bytes (41),
-// pebble_id_index_format (42), and grant_digest_root (43). The
-// descriptor closure (field 10) — by far
-// the largest field — is skipped, which is what makes header reads
-// cheap enough for engine dispatch on every open. Sync run summaries
-// are small and few (bounded by the sync retention limit), so decoding
-// them here costs a handful of allocations.
+// pebble_id_index_format (42), grant_digest_root (43), and
+// sdk_materialization_generation (44). The descriptor closure (field 10)
+// — by far the largest field — is skipped, which is what makes header
+// reads cheap enough for engine dispatch on every open. Sync run
+// summaries are small and few (bounded by the sync retention limit), so
+// decoding them here costs a handful of allocations.
+//
+// NOTE: any new manifest field a header consumer depends on MUST be
+// added here as well as to the proto — the generated decoder is not
+// used on this path, so an omitted field silently reads as its zero
+// value (the CO-017 witness was briefly invisible for exactly this
+// reason).
 func unmarshalManifestHeader(b []byte) (*c1zv3.C1ZManifestV3, error) {
 	out := &c1zv3.C1ZManifestV3{}
 	for len(b) > 0 {
@@ -678,6 +684,16 @@ func unmarshalManifestHeader(b []byte) (*c1zv3.C1ZManifestV3, error) {
 				return nil, fmt.Errorf("%w: grant_digest_root: %w", ErrManifestInvalid, err)
 			}
 			out.SetGrantDigestRoot(root)
+			b = b[n:]
+		case 44:
+			if typ != protowire.BytesType {
+				return nil, fmt.Errorf("c1z v3: manifest sdk_materialization_generation has wire type %v", typ)
+			}
+			v, n := protowire.ConsumeString(b)
+			if n < 0 {
+				return nil, protowire.ParseError(n)
+			}
+			out.SetSdkMaterializationGeneration(v)
 			b = b[n:]
 		default:
 			n := protowire.ConsumeFieldValue(num, typ, b)

--- a/pkg/dotc1z/pebble_store.go
+++ b/pkg/dotc1z/pebble_store.go
@@ -22,6 +22,7 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble"
 	formatv3 "github.com/conductorone/baton-sdk/pkg/dotc1z/format/v3"
+	"github.com/conductorone/baton-sdk/pkg/sourcecache"
 	batonGrant "github.com/conductorone/baton-sdk/pkg/types/grant"
 )
 
@@ -30,6 +31,12 @@ type pebbleDriver struct{}
 
 var _ c1zstore.Store = (*pebbleStore)(nil)
 var _ connectorstore.Writer = (*pebbleStore)(nil)
+
+// The syncer's G5 fence asserts this optional capability on the previous
+// store; the pin makes a rename on either side a build break instead of a
+// silently-open fence (the behavioral test would still catch it, but the
+// compile-time coupling is the point — see CO-6b-005's probe precedent).
+var _ sourcecache.MaterializationWitnessReader = (*pebbleStore)(nil)
 
 // Local mirrors of the optional capabilities the c1z sanitizer probes on
 // the source/destination store (pkg/c1zsanitize keeps those interfaces
@@ -66,7 +73,7 @@ func (pebbleDriver) OpenStore(ctx context.Context, outputFilePath string, opts S
 	}
 
 	dbDir := filepath.Join(tmpDir, "db")
-	reuse, fileEncoding, foldDeadBytes, err := unpackExistingPebbleC1Z(outputFilePath, dbDir, opts.MaxDecodedPayloadBytes, opts.MaxDecoderMemoryBytes, opts.DecoderPool)
+	reuse, fileEncoding, foldDeadBytes, materializationWitness, err := unpackExistingPebbleC1Z(outputFilePath, dbDir, opts.MaxDecodedPayloadBytes, opts.MaxDecoderMemoryBytes, opts.DecoderPool)
 	if err != nil {
 		return nil, cleanupOnError(err)
 	}
@@ -119,15 +126,16 @@ func (pebbleDriver) OpenStore(ctx context.Context, outputFilePath string, opts S
 	}
 
 	return &pebbleStore{
-		Engine:          e,
-		outputFilePath:  outputFilePath,
-		tmpDir:          tmpDir,
-		readOnly:        opts.ReadOnly,
-		payloadEncoding: encoding,
-		payloadReuse:    reuse,
-		foldDeadBytes:   foldDeadBytes,
-		syncLimit:       opts.SyncLimit,
-		skipCleanup:     opts.SkipCleanup,
+		Engine:                 e,
+		outputFilePath:         outputFilePath,
+		tmpDir:                 tmpDir,
+		readOnly:               opts.ReadOnly,
+		payloadEncoding:        encoding,
+		payloadReuse:           reuse,
+		foldDeadBytes:          foldDeadBytes,
+		materializationWitness: materializationWitness,
+		syncLimit:              opts.SyncLimit,
+		skipCleanup:            opts.SkipCleanup,
 		// A writable open that ran the in-place id-index migration must
 		// save the migrated layout back into the c1z even if the caller
 		// never writes, or every subsequent open re-pays the O(rows)
@@ -142,32 +150,32 @@ func unpackExistingPebbleC1Z(
 	maxDecodedPayloadBytes uint64,
 	maxDecoderMemoryBytes uint64,
 	pool *EnvelopeDecoderPool,
-) (*formatv3.PayloadReuse, c1zstore.PayloadEncoding, int64, error) {
+) (*formatv3.PayloadReuse, c1zstore.PayloadEncoding, int64, string, error) {
 	stat, err := os.Stat(outputFilePath)
 	switch {
 	case errors.Is(err, os.ErrNotExist):
-		return nil, c1zstore.PayloadEncodingUnspecified, 0, nil
+		return nil, c1zstore.PayloadEncodingUnspecified, 0, "", nil
 	case err != nil:
-		return nil, c1zstore.PayloadEncodingUnspecified, 0, err
+		return nil, c1zstore.PayloadEncodingUnspecified, 0, "", err
 	case stat.Size() == 0:
-		return nil, c1zstore.PayloadEncodingUnspecified, 0, nil
+		return nil, c1zstore.PayloadEncodingUnspecified, 0, "", nil
 	}
 
 	f, err := os.Open(outputFilePath)
 	if err != nil {
-		return nil, c1zstore.PayloadEncodingUnspecified, 0, err
+		return nil, c1zstore.PayloadEncodingUnspecified, 0, "", err
 	}
 	defer f.Close()
 
 	header, err := formatv3.ReadManifestHeader(f)
 	if err != nil {
-		return nil, c1zstore.PayloadEncodingUnspecified, 0, err
+		return nil, c1zstore.PayloadEncodingUnspecified, 0, "", err
 	}
 	if e := c1zstore.Engine(header.GetEngine()); e != c1zstore.EnginePebble && e != c1zstore.PebbleManifestEngine && e != c1zstore.PebbleManifestEngineV2 {
-		return nil, c1zstore.PayloadEncodingUnspecified, 0, fmt.Errorf("%w: %s", pebble.ErrUnknownEngine, header.GetEngine())
+		return nil, c1zstore.PayloadEncodingUnspecified, 0, "", fmt.Errorf("%w: %s", pebble.ErrUnknownEngine, header.GetEngine())
 	}
 	if err := os.MkdirAll(dbDir, 0o755); err != nil {
-		return nil, c1zstore.PayloadEncodingUnspecified, 0, err
+		return nil, c1zstore.PayloadEncodingUnspecified, 0, "", err
 	}
 	manifest, reuse, err := formatv3.ExtractEnvelopePayload(f, dbDir,
 		formatv3.WithMaxDecodedPayloadBytes(maxDecodedPayloadBytes),
@@ -175,12 +183,14 @@ func unpackExistingPebbleC1Z(
 		formatv3.WithPayloadDecoderPool(pool),
 	)
 	if err != nil {
-		return nil, c1zstore.PayloadEncodingUnspecified, 0, err
+		return nil, c1zstore.PayloadEncodingUnspecified, 0, "", err
 	}
 	// fold_dead_bytes is inherited from the source file so the waste
 	// accounting survives arbitrary open/save cycles, not just fold
-	// compactions; a fresh file starts at zero.
-	return reuse, payloadEncodingFromProto(manifest.GetPayloadEncoding()), header.GetFoldDeadBytes(), nil
+	// compactions; a fresh file starts at zero. The materialization
+	// witness comes from the header verbatim: absent (older writer or
+	// old-SDK fold) reads as "" and fails the replay fence.
+	return reuse, payloadEncodingFromProto(manifest.GetPayloadEncoding()), header.GetFoldDeadBytes(), header.GetSdkMaterializationGeneration(), nil
 }
 
 func payloadEncodingFromProto(enc c1zv3.PayloadEncoding) c1zstore.PayloadEncoding {
@@ -213,6 +223,12 @@ type pebbleStore struct {
 	// single merge goroutine; the lock just pairs it with save/Close).
 	foldDeadBytes int64
 
+	// materializationWitness is the envelope header's save-time
+	// materialization witness (C1ZManifestV3.sdk_materialization_generation,
+	// the CO-017 fold fence) as read at open; "" when the file predates the
+	// witness or was last saved by an old-SDK fold. Immutable after open.
+	materializationWitness string
+
 	// syncLimit and skipCleanup mirror StoreOptions and feed into
 	// Cleanup. The Adapter intentionally has no awareness of these
 	// — retention policy is an envelope-writer concern, not an
@@ -241,6 +257,15 @@ var _ c1zstore.Store = (*pebbleStore)(nil)
 // Clone/isolate write a separate file, so no dirty-marking is needed.
 func (s *pebbleStore) FileOps() c1zstore.FileOps {
 	return s.FileOpsWithEncoding(s.payloadEncoding)
+}
+
+// SourceCacheMaterializationWitness returns the envelope's save-time
+// materialization witness (CO-017 fold fence) as read at open. The replay
+// consumer requires it to byte-match sourcecache.MaterializationPolicyGeneration;
+// "" (pre-witness file, or an old-SDK fold that rebuilt the envelope
+// without the field) fails the fence and degrades the sync cold.
+func (s *pebbleStore) SourceCacheMaterializationWitness() string {
+	return s.materializationWitness
 }
 
 // SyncMeta overrides the Adapter-level SyncMeta so the MUTATING

--- a/pkg/dotc1z/source_cache.go
+++ b/pkg/dotc1z/source_cache.go
@@ -19,6 +19,12 @@ import (
 // SourceCacheReplayResult reports what one scope's replay copied.
 type SourceCacheReplayResult = pebble.SourceCacheReplayResult
 
+// ErrSourceCacheReplayDestination marks a ReplaySourceCache failure caused
+// by the DESTINATION store's commit path after the source passed preflight.
+// The sync orchestration classifies these as warm-retryable; every unmarked
+// replay failure is treated as a source-side (cold) verdict, fail-closed.
+var ErrSourceCacheReplayDestination = pebble.ErrReplayDestinationCommit
+
 type sourceCacheStoreTestSeams struct {
 	// afterEngineReplay injects a wrapper-level error after the engine has
 	// committed replay work.
@@ -38,6 +44,11 @@ type sourceCacheStoreTestSeams struct {
 // implemented ONLY by the Pebble engine; the syncer type-asserts for it and
 // treats a store without it as "source cache unsupported" (no-op lookup,
 // no replay). It is deliberately NOT part of c1zstore.Store.
+//
+// Advanced: this interface exists for the SDK's replay orchestration, not
+// for direct use. The correctness obligations (preflight, scope poisoning,
+// compat validation) live in the callers; see pkg/sourcecache for the
+// connector-facing contract.
 type SourceCacheStore interface {
 	// LookupSourceCacheEntry returns this store's manifest entry for
 	// (kind, scopeKey). Backs the connector-facing lookup when this
@@ -60,6 +71,15 @@ type SourceCacheStore interface {
 	// row — the safe direction, since arming expansion is idempotent and
 	// add-only.
 	ReplaySourceCache(ctx context.Context, prev connectorstore.Reader, kind sourcecache.RowKind, scopeKey string) (SourceCacheReplayResult, error)
+
+	// ClearSourceCacheScope removes every current-sync row stamped with
+	// (kind, scopeKey) — the replay clear leg standalone. Backs
+	// record-round grounding: a record round is a replacement listing,
+	// so a partition holding rows no completed round published (crashed-
+	// attempt debris) is cleared before the round's first write.
+	// Idempotent; deletes commit in bounded chunks, so retry converges.
+	// Returns rows deleted.
+	ClearSourceCacheScope(ctx context.Context, kind sourcecache.RowKind, scopeKey string) (int64, error)
 
 	// DeleteSourceCacheRows removes rows by public canonical ID from the
 	// current sync, after replay + overlay (delta-query tombstones).
@@ -97,6 +117,18 @@ type SourceCacheStore interface {
 	// no matching rows are no-ops. Deletes commit in bounded chunks; on
 	// error, the returned count reports rows already committed.
 	DeleteSourceCacheGrantsByIDInScope(ctx context.Context, scopeKey string, ids []string) (int64, error)
+
+	// PutSourceCacheCompat writes the current sync's replay-compatibility
+	// key. Orchestration writes it when the source-cache write side
+	// enables, BEFORE any manifest entry, so a crash can never leave
+	// manifest entries whose recording conditions were undeclared.
+	PutSourceCacheCompat(ctx context.Context, compat sourcecache.CompatKey) error
+
+	// GetSourceCacheCompat returns this artifact's stored
+	// replay-compatibility key. found is false when the artifact never
+	// declared one (pre-compat SDK, cold-only sync, or invalidated by a
+	// compaction fold) — the caller must treat that as incompatible.
+	GetSourceCacheCompat(ctx context.Context) (compat sourcecache.CompatKey, found bool, err error)
 }
 
 var _ SourceCacheStore = (*pebbleStore)(nil)
@@ -286,6 +318,55 @@ func (s *pebbleStore) ReplaySourceCache(ctx context.Context, prev connectorstore
 		}
 	}
 	return res, nil
+}
+
+func (s *pebbleStore) PutSourceCacheCompat(ctx context.Context, compat sourcecache.CompatKey) error {
+	rec := &v3.SourceCacheCompatRecord{}
+	rec.SetConnectorCacheGeneration(compat.ConnectorCacheGeneration)
+	rec.SetConnectorConfigFingerprint(compat.ConnectorConfigFingerprint)
+	rec.SetSdkMaterializationGeneration(compat.SDKMaterializationGeneration)
+	rec.SetSyncSelectionFingerprint(compat.SyncSelectionFingerprint)
+	done, err := s.beginSourceCacheMutation()
+	if err != nil {
+		return err
+	}
+	defer done()
+	return s.PutSourceCacheCompatRecord(ctx, rec)
+}
+
+func (s *pebbleStore) GetSourceCacheCompat(ctx context.Context) (sourcecache.CompatKey, bool, error) {
+	rec, err := s.GetSourceCacheCompatRecord(ctx)
+	if err != nil {
+		if errors.Is(err, cdbpebble.ErrNotFound) {
+			return sourcecache.CompatKey{}, false, nil
+		}
+		return sourcecache.CompatKey{}, false, err
+	}
+	return sourcecache.CompatKey{
+		ConnectorCacheGeneration:     rec.GetConnectorCacheGeneration(),
+		ConnectorConfigFingerprint:   rec.GetConnectorConfigFingerprint(),
+		SDKMaterializationGeneration: rec.GetSdkMaterializationGeneration(),
+		SyncSelectionFingerprint:     rec.GetSyncSelectionFingerprint(),
+	}, true, nil
+}
+
+func (s *pebbleStore) ClearSourceCacheScope(ctx context.Context, kind sourcecache.RowKind, scopeKey string) (int64, error) {
+	if err := sourcecache.ValidateRowKind(kind); err != nil {
+		return 0, err
+	}
+	if err := sourcecache.ValidateScopeKey(scopeKey); err != nil {
+		return 0, err
+	}
+	done, err := s.beginSourceCacheMutation()
+	if err != nil {
+		return 0, err
+	}
+	defer done()
+	deleted, err := s.Engine.ClearSourceCacheScope(ctx, string(kind), scopeKey)
+	if err != nil {
+		return deleted, fmt.Errorf("source cache clear scope %q: %w", scopeKey, err)
+	}
+	return deleted, nil
 }
 
 // DeleteSourceCacheRows deletes delta tombstones by public id string.

--- a/pkg/session/README.md
+++ b/pkg/session/README.md
@@ -12,3 +12,39 @@ The session cache is used to store temporary data during sync operations. It pro
 - Prefix support for key organization
 - Context-based configuration
 - An implemention will be chosen at runtime (the grpc interface will be used if the build tag is specified).
+
+## Durability and staleness (what connectors may assume)
+
+Sessions are **scratch cache space**, not durable connector state:
+
+- The namespace is per **sync ID**. Sessions never cross syncs: they are
+  cleared after the sync ends and do not ship in the saved `.c1z`.
+- Session state **persists across crash/resume**, including writes from
+  beyond the restored checkpoint: session writes are durable but commit
+  **independently of the syncer's checkpoints**, so after a crash the
+  resumed attempt's cursor rolls back to the last checkpoint while every
+  session write survives. Two consequences (CO-6b-009 in
+  `docs/verification/sync-replay-6b/plan.md`):
+  - The work between the checkpoint and the crash **re-runs**, and during
+    that window the connector can observe its own dead attempt's "future"
+    writes. Never use sessions for once-only decisions — whether to emit
+    rows, whether a page was "already handled", how to shape a paginated
+    response. At-least-once re-execution must be safe with session state
+    present from the first run.
+  - Conversely, state written during **completed** actions is preserved
+    and legitimately consumable later in the sync — resume never re-runs
+    completed actions, and the SDK deliberately does **not** clear
+    sessions on resume for exactly this reason (an accumulate-then-consume
+    cache would be unrecoverable).
+- Under the **source-cache protocol**, session-derived caches carry extra
+  obligations — see `pkg/sourcecache` (SESSION STORE section), including
+  why replay/record verdicts must never come from session-cached answers.
+
+These semantics are formally captured: the walker model's `P6C` monitor
+(`formal/walker/`) and the trace oracle's `session_ckpt_consistency`
+policy (`formal/occult/`) both state that post-crash session state must
+match the restored checkpoint — the shipped durable-at-op-commit
+behavior violates it in the zombie direction (a standing expected-red
+pin on a real execution's trace), and a resume-time clear violates it in
+the amnesia direction. The registered fix is checkpoint-consistent
+sessions (CO-6b-009).

--- a/pkg/sourcecache/compat.go
+++ b/pkg/sourcecache/compat.go
@@ -1,0 +1,39 @@
+package sourcecache
+
+// MaterializationPolicyGeneration identifies the SDK's replayed-row
+// materialization policy: the rules by which replayed rows are copied,
+// transformed (e.g. expander-written Sources on direct grants are stripped
+// at copy time), and re-indexed. Bump it whenever those rules change in a
+// way that makes rows materialized by a PRIOR SDK unsafe to replay
+// verbatim. Replay is permitted only when the previous artifact recorded a
+// byte-identical generation — both in its stored CompatKey and in the c1z
+// envelope-manifest witness (the CO-017 cross-version fold fence) — so a
+// bump colds every pre-bump artifact exactly once per chain.
+const MaterializationPolicyGeneration = "1"
+
+// CompatKey is a sync's replay-compatibility key (stored as
+// SourceCacheCompatRecord — see proto/c1/storage/v3/records.proto). The
+// current sync computes its own key and byte-compares it against the
+// previous artifact's stored key on lookup install; ANY difference —
+// including a missing record — degrades the sync to a cold run. Empty
+// fields match only empty fields.
+type CompatKey struct {
+	// ConnectorCacheGeneration is SourceCacheCapability.cache_generation,
+	// verbatim: the connector's explicit declaration of scope/validator/row
+	// compatibility.
+	ConnectorCacheGeneration string
+
+	// ConnectorConfigFingerprint is SourceCacheCapability.config_fingerprint,
+	// verbatim: a digest of every configuration input that changes what
+	// upstream data the connector CAN see.
+	ConnectorConfigFingerprint string
+
+	// SDKMaterializationGeneration is MaterializationPolicyGeneration as of
+	// the sync that wrote the record.
+	SDKMaterializationGeneration string
+
+	// SyncSelectionFingerprint digests the sync's selection shape (resource
+	// type filter, skip flags): a sync that intentionally collects less
+	// must not serve as the replay base for one that collects more.
+	SyncSelectionFingerprint string
+}

--- a/pkg/sourcecache/sourcecache.go
+++ b/pkg/sourcecache/sourcecache.go
@@ -1,14 +1,52 @@
 // Package sourcecache defines the connector-facing surface of source-cache
 // replay (see proto/c1/connector/v2/annotation_source_cache.proto).
 //
-// NOT YET WIRED. This package describes the intended contract, and the
-// storage and eligibility machinery beneath it is in place, but the syncer
-// does not install a Lookup or consume these annotations yet: SyncOpAttrs
-// carries no source-cache field, and nothing outside this package references
-// Lookup, SetLookup, or NoopLookup. A connector written against the surface
-// below will compile and do nothing until the orchestration lands. The
-// wiring described here is present tense on purpose — it is the contract the
-// orchestration must satisfy, not a description of today's behavior.
+// ADVANCED FUNCTIONALITY. Source-cache replay is an advanced, opt-in
+// capability with strict correctness obligations on the connector (scope
+// partitioning, validator lifetime — see the invariants below). Most
+// connectors should not use this package; adopt it only in coordination
+// with the SDK maintainers.
+//
+// WIRING. The syncer parses SourceCacheCapability from the Validate
+// response at the start of every sync attempt (including resumes). When the
+// capability is MODE_READ_WRITE and the previous-sync artifact passes the
+// eligibility gates (Pebble engine, finished non-compacted FULL sync, clean
+// ingest quality, current materialization witness, byte-matching compat
+// record), the syncer installs a warm Lookup via SetLookup.SetSourceCache
+// at sync start and delivers nil on every exit; otherwise connectors
+// observe NoopLookup and every lookup misses. The lookup reaches connector
+// code through SyncOpAttrs.Lookup at the four list sites (resources, static
+// entitlements, entitlements, grants).
+//
+// DELIVERY LIMITATION (CO-6b-001 in
+// docs/verification/sync-replay-6b/plan.md). SetSourceCache is only a
+// conduit: the transport that constructs the connector client must also
+// wire a live in-process setter behind it. The standard subprocess wrapper
+// (internal/connector.NewWrapper) has no RPC backchannel for an interface
+// value and never wires one, so subprocess-run connectors observe
+// NoopLookup in this phase; in-tree, only the chaos harness's in-process
+// clients deliver. The syncer probes deliverability before install
+// (LookupDeliverabilityProbe) and keeps the consume side cold when the
+// transport cannot deliver — no warm lookup, and any SourceCacheReplay
+// annotation fails loud — so a structurally-satisfied but unwired
+// SetLookup is never reported warm. The produce side (row stamping,
+// validator publish) still runs, so such syncs build artifacts that can
+// seed a warm sync once a delivering transport exists — unless the
+// artifact was quality-blocked as a replay source (unreplayable page
+// shapes such as child resource types or InsertResourceGrants, compat
+// drift or capability withdrawal across a resume, or row-partition
+// violations), in which case it seeds nothing and the next sync runs
+// cold.
+//
+// Composition with external-resource reconciliation (CO-016): connectors
+// using ExternalResourceMatch* annotations get their placeholder-grant
+// scopes poisoned every sync by design — destructive reconciliation
+// deletes match-annotated placeholder grants and re-issues derived grants
+// unscoped, which the row-partition contract records as poison. Poison
+// reads as a lookup miss, so those scopes cold-fetch inside an
+// otherwise-warm sync: graceful, pre-replay behavior. Replay for such
+// scopes cannot engage until the non-destructive reconciliation rework
+// lands.
 //
 // A connector that can cheaply revalidate upstream data — HTTP conditional
 // requests (GitHub), delta queries (Microsoft Graph) — opts in by attaching
@@ -33,6 +71,30 @@
 // disabled or degraded (no capability, no usable previous sync, unsupported
 // storage engine) the SDK installs NoopLookup, every lookup misses, and a
 // well-behaved connector naturally falls back to full fetch.
+//
+// SESSION STORE (CO-6b-009 in docs/verification/sync-replay-6b/plan.md).
+// The connector session store carries the same discipline. Sessions
+// persist across crash/resume — including writes from beyond the restored
+// checkpoint, since session writes commit outside the checkpoint
+// mechanism (the SDK does NOT clear them on resume: completed actions
+// never re-run, so a clear would destroy caches whose producing work
+// will not execute again). The obligations that follow:
+//
+//   - Replay/record verdicts must be derived from upstream evidence
+//     (conditional requests, delta tokens), never from session-cached
+//     verdicts — a session-cached MATCH is exactly the "validator that
+//     outlives its evidence" shape above, and it launders staleness past
+//     every SDK gate. This holds doubly across a resume: a cached verdict
+//     may predate rounds whose rows the resume re-grounds.
+//   - A replayed scope's rows never pass through the connector, so
+//     session state built while GENERATING rows ("principals I emitted
+//     this sync") is silently partial for scopes the connector chose to
+//     replay. Do not consume such state for cross-scope decisions unless
+//     every contributing scope was fetched fresh this sync.
+//   - The window between the last checkpoint and a crash RE-RUNS on
+//     resume, with the dead attempt's session writes still present.
+//     Session use must be safe under at-least-once re-execution — no
+//     once-only dedup, no "already handled" markers.
 //
 // Replay equivalence: a cached sync must reproduce what a full resync
 // would produce. Replayed rows are verbatim copies of the previous sync's
@@ -137,6 +199,35 @@ func (NoopLookup) LookupPreviousSourceCache(context.Context, RowKind, string) (E
 // when the sync ends so a late RPC can't read stale state.
 type SetLookup interface {
 	SetSourceCache(ctx context.Context, lookup Lookup)
+}
+
+// LookupDeliverabilityProbe is optionally implemented by connector clients
+// whose SetSourceCache may be a structural no-op — a wrapper that satisfies
+// SetLookup while forwarding to a transport that cannot carry an interface
+// value (the runner's subprocess wrapper, CO-6b-001). False means the
+// connector will observe NoopLookup no matter what the syncer delivers, so
+// lookup install must not report warm. Clients that do not implement the
+// probe are presumed deliverable: they own their SetSourceCache and are
+// expected to satisfy SetLookup only when delivery is real.
+//
+// This interface is defined here — rather than privately in pkg/sync — so
+// implementing clients can compile-pin it (var _ LookupDeliverabilityProbe
+// = ...) and a method rename cannot silently sever the probe from the
+// syncer's type assertion.
+type LookupDeliverabilityProbe interface {
+	SourceCacheLookupDeliverable() bool
+}
+
+// MaterializationWitnessReader is the optional store capability behind the
+// G5 / CO-017 cross-version fold fence: the previous artifact's envelope
+// must carry the save-time materialization witness byte-equal to this SDK's
+// MaterializationPolicyGeneration or the sync degrades cold. Named here —
+// rather than asserted inline in pkg/sync — so the implementing store can
+// compile-pin it (var _ MaterializationWitnessReader = ...) and a method
+// rename cannot silently sever the fence from the syncer's type assertion
+// (same discipline as LookupDeliverabilityProbe).
+type MaterializationWitnessReader interface {
+	SourceCacheMaterializationWitness() string
 }
 
 // HashScope returns the lowercase-hex sha256 of a canonical scope string.

--- a/pkg/sync/chaos_external_principal_test.go
+++ b/pkg/sync/chaos_external_principal_test.go
@@ -457,6 +457,7 @@ func TestChaosConnectorExternalPrincipalResumeUsesCurrentExternalAnswer(t *testi
 		WithExternalResourceC1ZPath(firstExternalPath),
 		WithConnectorStore(cutStore),
 	)
+	attempt1Audit := attachSyncTraceAudit(t, cutHarness)
 	require.ErrorIs(t, cutHarness.Syncer.Sync(ctx), errChaosExternalPrincipalCut)
 	require.NoError(t, cutHarness.Close(ctx))
 	seedStaleExternalPrincipalDependencies(t, internalPath, tmpDir)
@@ -505,6 +506,7 @@ func TestChaosConnectorExternalPrincipalResumeUsesCurrentExternalAnswer(t *testi
 		WithExternalResourceC1ZPath(resumeExternalPath),
 		WithConnectorStore(dependencyCutStore),
 	)
+	attempt2Audit := attachSyncTraceAudit(t, resumeHarness)
 	require.ErrorIs(t, resumeHarness.Syncer.Sync(ctx), errChaosExternalPrincipalCut)
 	require.NoError(t, resumeHarness.Close(ctx))
 	require.Equal(t, int64(2), dependencyCutStore.deleteCalls.Load(),
@@ -514,15 +516,19 @@ func TestChaosConnectorExternalPrincipalResumeUsesCurrentExternalAnswer(t *testi
 	require.Equal(t, interruptedSyncID, partiallyCleanedRuns[0].ID)
 	require.Nil(t, partiallyCleanedRuns[0].EndedAt)
 
+	attempt3Audit := &syncTraceAudit{}
 	entitlementCutStore := runExternalPrincipalCleanupCut(
 		t, internalScenario, internalPath, resumeExternalPath, tmpDir,
 		&chaosExternalPrincipalCutStore{failEntitlementAt: 2},
+		attempt3Audit,
 	)
 	require.Equal(t, int64(2), entitlementCutStore.entitlementCalls.Load(),
 		"entitlement cleanup cut must occur after a committed entitlement deletion")
+	attempt4Audit := &syncTraceAudit{}
 	resourceCutStore := runExternalPrincipalCleanupCut(
 		t, internalScenario, internalPath, resumeExternalPath, tmpDir,
 		&chaosExternalPrincipalCutStore{failResourceAt: 1},
+		attempt4Audit,
 	)
 	require.Equal(t, int64(1), resourceCutStore.resourceCalls.Load(),
 		"resource cleanup cut must fire before the stale principal deletion")
@@ -539,6 +545,7 @@ func TestChaosConnectorExternalPrincipalResumeUsesCurrentExternalAnswer(t *testi
 		WithWorkerCount(1),
 		WithExternalResourceC1ZPath(resumeExternalPath),
 	)
+	attempt5Audit := attachSyncTraceAudit(t, finalResumeHarness)
 	finalResumeHarness.SyncAndClose(t, ctx)
 
 	manifest, err := internalScenario.Manifest(internalScenario.InitialEpoch)
@@ -564,6 +571,14 @@ func TestChaosConnectorExternalPrincipalResumeUsesCurrentExternalAnswer(t *testi
 	finalContent := readChaosLogicalContent(t, ctx, internalPath, tmpDir)
 	require.NoError(t, chaosoracle.CompareLogicalContent(baselineContent, finalContent),
 		"resume against changed external data must equal a clean run against that data")
+
+	// Trace-oracle witness (policy 7, external-principal grounding):
+	// the five attempts of this capable-engine history — including the
+	// final resume whose completed reconciliation deletes the dead
+	// attempts' stale principal — must satisfy every policy.
+	exportTraceFixture(t, "external_resume_current_answer",
+		attempt1Audit.snapshot(), attempt2Audit.snapshot(), attempt3Audit.snapshot(),
+		attempt4Audit.snapshot(), attempt5Audit.snapshot())
 }
 
 func TestChaosConnectorSQLiteExternalPrincipalResumeDegradesWithoutFailure(t *testing.T) {
@@ -602,6 +617,7 @@ func TestChaosConnectorSQLiteExternalPrincipalResumeDegradesWithoutFailure(t *te
 		WithExternalResourceC1ZPath(firstExternalPath),
 		WithConnectorStore(cutStore),
 	)
+	attempt1Audit := attachSyncTraceAudit(t, firstHarness)
 	require.ErrorIs(t, firstHarness.Syncer.Sync(ctx), errChaosExternalPrincipalCut)
 	require.NoError(t, firstHarness.Close(ctx))
 
@@ -640,6 +656,7 @@ func TestChaosConnectorSQLiteExternalPrincipalResumeDegradesWithoutFailure(t *te
 		WithExternalResourceC1ZPath(resumeExternalPath),
 		WithStorageEngine(c1zstore.EngineSQLite),
 	)
+	attempt2Audit := attachSyncTraceAudit(t, resumeHarness)
 	resumeHarness.SyncAndClose(t, ctx)
 
 	finalStore, err := dotc1z.NewStore(
@@ -673,6 +690,25 @@ func TestChaosConnectorSQLiteExternalPrincipalResumeDegradesWithoutFailure(t *te
 	}
 	require.True(t, currentPrincipalPresent,
 		"SQLite degradation must still ingest the current external answer")
+
+	// Trace-oracle witness (policy 7, KNOWN-DEGRADE PIN): the resumed
+	// attempt's principal writes commit with NO completed
+	// reconciliation (SQLite cannot delete), so the oracle must flag
+	// ext-recon-before-copy — the accepted degradation, witnessed as an
+	// expected RED like the session-zombie pin.
+	exportTraceFixture(t, "external_resume_sqlite_degrade",
+		attempt1Audit.snapshot(), attempt2Audit.snapshot())
+}
+
+// attachSyncTraceAudit installs a fresh trace recorder on the harness's
+// concrete syncer (the same wiring every trace-oracle export uses).
+func attachSyncTraceAudit(t *testing.T, h *chaosHarness) *syncTraceAudit {
+	t.Helper()
+	concrete, ok := h.Syncer.(*syncer)
+	require.True(t, ok, "chaos harness syncer is not the concrete *syncer")
+	audit := &syncTraceAudit{}
+	concrete.testSyncTraceAudit = audit
+	return audit
 }
 
 func runExternalPrincipalCleanupCut(
@@ -682,6 +718,7 @@ func runExternalPrincipalCleanupCut(
 	externalPath string,
 	tmpDir string,
 	cutStore *chaosExternalPrincipalCutStore,
+	audit *syncTraceAudit,
 ) *chaosExternalPrincipalCutStore {
 	t.Helper()
 	ctx := t.Context()
@@ -706,6 +743,11 @@ func runExternalPrincipalCleanupCut(
 		WithExternalResourceC1ZPath(externalPath),
 		WithConnectorStore(cutStore),
 	)
+	if audit != nil {
+		concrete, ok := harness.Syncer.(*syncer)
+		require.True(t, ok, "chaos harness syncer is not the concrete *syncer")
+		concrete.testSyncTraceAudit = audit
+	}
 	require.ErrorIs(t, harness.Syncer.Sync(ctx), errChaosExternalPrincipalCut)
 	require.NoError(t, harness.Close(ctx))
 	return cutStore

--- a/pkg/sync/chaos_harness_test.go
+++ b/pkg/sync/chaos_harness_test.go
@@ -3,6 +3,7 @@ package sync //nolint:revive,nolintlint // backwards-compatible package name
 import (
 	"context"
 	"errors"
+	native_sync "sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -58,6 +59,10 @@ func skipChaosInShort(t *testing.T) {
 type chaosHarness struct {
 	Syncer Syncer
 	Run    *chaosconnector.Run
+	// Client is the transport-wrapped connector client the syncer holds.
+	// Source-cache teardown probes invoke it directly after a sync to
+	// verify the connector no longer observes the sync's lookup.
+	Client types.ConnectorClient
 
 	closeAdapter func() error
 }
@@ -105,11 +110,50 @@ func newChaosHarness(
 	}
 	sdkSyncer, err := NewSyncer(ctx, client, append(baseOpts, opts...)...)
 	require.NoError(t, err)
+	// Held-lock ride-along (CO-6b-007): a source-cache scope lock is
+	// acquired in beforeUpserts and released in afterUpserts or by the
+	// handlers' deferred release(); a lock still held once the sync is
+	// over means a release path was lost — and because syncOneAction
+	// retries a failed action in the SAME goroutine and sync.Mutex is not
+	// reentrant, that is a permanently hung sync, not a slow one. Bound
+	// here so EVERY chaos suite — present and future, success or failure
+	// path — evaluates it at test end; any scenario that errors a scoped
+	// page between the lock's acquire and release trips it if a handler
+	// loses its backstop.
+	if concrete, ok := sdkSyncer.(*syncer); ok {
+		t.Cleanup(func() {
+			require.Empty(t, heldSourceCacheScopeLocks(concrete),
+				"source-cache scope locks still held at sync end: a page errored between beforeUpserts and afterUpserts and its release path was lost — this sync would hang its own retry")
+		})
+	}
 	return &chaosHarness{
 		Syncer:       sdkSyncer,
 		Run:          run,
+		Client:       client,
 		closeAdapter: closeAdapter,
 	}
+}
+
+// heldSourceCacheScopeLocks reports which per-scope replay locks are still
+// held. Only safe once the sync has finished (no workers contend the
+// locks); TryLock on a free mutex briefly holds it, so a concurrent worker
+// could see spurious contention.
+func heldSourceCacheScopeLocks(s *syncer) []string {
+	var held []string
+	s.sourceCacheScopeLocks.Range(func(k, v any) bool {
+		mu, ok := v.(*native_sync.Mutex)
+		if !ok {
+			held = append(held, k.(string)+" (non-mutex entry)")
+			return true
+		}
+		if mu.TryLock() {
+			mu.Unlock()
+		} else {
+			held = append(held, k.(string))
+		}
+		return true
+	})
+	return held
 }
 
 func (h *chaosHarness) SyncAndClose(t *testing.T, ctx context.Context) {

--- a/pkg/sync/chaos_source_cache_collection_test.go
+++ b/pkg/sync/chaos_source_cache_collection_test.go
@@ -1,0 +1,750 @@
+package sync //nolint:revive,nolintlint // backwards-compatible package name
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/conductorone/baton-sdk/internal/chaosconnector"
+	chaosoracle "github.com/conductorone/baton-sdk/internal/chaosconnector/oracle"
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/bid"
+	"github.com/conductorone/baton-sdk/pkg/sourcecache"
+	et "github.com/conductorone/baton-sdk/pkg/types/entitlement"
+	gt "github.com/conductorone/baton-sdk/pkg/types/grant"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+)
+
+// Phase 6b collection-semantics suite (plan R7 + the R3 replay-adjacent
+// cells, oracles OR2 + OR3): each cell runs generation A as the cold seed,
+// switches the connector to the "second" epoch, runs generation B warm
+// against A's artifact, and then checks two things:
+//
+//   - OR2: B's logical content equals an INDEPENDENT cold baseline of the
+//     second epoch (a fresh run served the cold branch, never a lookup hit).
+//     Every ordering property — copy before upserts, tombstones after
+//     upserts, replacement wiping earlier fresh rows, dedup skipping the
+//     second copy — is arranged so that violating it changes final content.
+//   - OR3: B's artifact carries exactly the expected manifest entries
+//     (validator values) and per-scope stamp counts; nothing more.
+//
+// R3's cold-only fresh-page cells (multi-page rounds, same-page
+// put-then-tombstone, empty-validator rounds, stamping exactness, the
+// static-entitlement exclusion) live in TestChaosSourceCacheFreshPageSemantics.
+
+const (
+	scValidatorV2     = "validator-v2"
+	scResourceScope   = "resources:sc-user"
+	scSharedScope     = "shared:team-1"
+	scSharedValidator = "validator-shared"
+)
+
+// scCollectionFixture extends the reference fixture with a third user and a
+// grant to it, the "changed upstream" material for delta cells.
+type scCollectionFixture struct {
+	*scFixture
+	User3  *v2.Resource
+	Grant3 *v2.Grant
+}
+
+func newSCCollectionFixture(t *testing.T) *scCollectionFixture {
+	t.Helper()
+	fixture := newSourceCacheFixture(t)
+	user3, err := rs.NewUserResource("User 3", fixture.UserType, "user-3", nil)
+	require.NoError(t, err)
+	return &scCollectionFixture{
+		scFixture: fixture,
+		User3:     user3,
+		Grant3:    gt.NewGrant(fixture.Team, "member", user3),
+	}
+}
+
+// scCollectionBase is the epoch skeleton shared by every cell: both types,
+// the team, all three users, the member entitlement (unannotated), and no
+// grants pages — cells attach their own scoped page graphs.
+func scCollectionBase(fx *scCollectionFixture) *chaosconnector.Dataset {
+	return &chaosconnector.Dataset{
+		ResourceTypes: []*v2.ResourceType{fx.TeamType, fx.UserType},
+		Resources: map[string]chaosconnector.Pages[*v2.Resource]{
+			scTeamTypeID: {"": {List: []*v2.Resource{fx.Team}}},
+			scUserTypeID: {"": {List: []*v2.Resource{fx.Users[0], fx.Users[1], fx.User3}}},
+		},
+		StaticEntitlements: map[string]chaosconnector.Pages[*v2.Entitlement]{
+			scTeamTypeID: {"": {}},
+			scUserTypeID: {"": {}},
+		},
+		Entitlements: map[string]chaosconnector.Pages[*v2.Entitlement]{
+			"team-1": {"": {List: []*v2.Entitlement{fx.Member}}},
+		},
+		Grants: map[string]chaosconnector.Pages[*v2.Grant]{
+			"team-1": {"": {}},
+		},
+	}
+}
+
+func scRecordAnno(scopeKey, validator string) annotations.Annotations {
+	return annotations.New(v2.SourceCacheRecord_builder{
+		ScopeKey:       scopeKey,
+		CacheValidator: validator,
+	}.Build())
+}
+
+func scReplayAnno(scopeKey, validator string, overlay bool, deletedIDs, deletedPrincipalIDs []string) annotations.Annotations {
+	return annotations.New(v2.SourceCacheReplay_builder{
+		ScopeKey:            scopeKey,
+		CacheValidator:      validator,
+		Overlay:             overlay,
+		DeletedIds:          deletedIDs,
+		DeletedPrincipalIds: deletedPrincipalIDs,
+	}.Build())
+}
+
+// scWarmEventFor builds the expected warm-serve event for one consult.
+func scWarmEventFor(kind sourcecache.RowKind, scopeKey, previousValidator string) chaosconnector.SourceCacheLookupEvent {
+	return chaosconnector.SourceCacheLookupEvent{
+		RowKind:           kind,
+		ScopeKey:          scopeKey,
+		Hit:               true,
+		PreviousValidator: previousValidator,
+		Matched:           true,
+		ServedWarm:        true,
+	}
+}
+
+// requireAllColdEvents asserts every consult in a cold sync missed.
+func requireAllColdEvents(t *testing.T, events []chaosconnector.SourceCacheLookupEvent, want int) {
+	t.Helper()
+	require.Len(t, events, want)
+	for i, event := range events {
+		require.Falsef(t, event.LookupWasNil, "event %d: lookup was nil", i)
+		require.Emptyf(t, event.LookupError, "event %d: lookup errored", i)
+		require.Falsef(t, event.Hit, "event %d: cold sync must miss every lookup", i)
+		require.Falsef(t, event.ServedWarm, "event %d: cold sync must never serve warm", i)
+	}
+}
+
+// requireSourceCacheProduceState asserts OR3 exactly: the artifact's full
+// manifest-entry map (validators, nothing invalidated) and full per-scope
+// stamp-count map equal the expectation — unexpected scopes are failures,
+// not noise.
+func requireSourceCacheProduceState(
+	t *testing.T,
+	snapshot chaosoracle.SourceCacheSnapshot,
+	wantEntries map[string]string,
+	wantStamps map[string]int,
+) {
+	t.Helper()
+	gotEntries := map[string]string{}
+	for key, entry := range snapshot.Entries {
+		require.Falsef(t, entry.Invalidated, "manifest entry %q is invalidated", key)
+		gotEntries[key] = entry.Validator
+	}
+	require.Equal(t, wantEntries, gotEntries, "manifest entries (validator by kind+scope)")
+
+	gotStamps := map[string]int{}
+	for key, count := range snapshot.StampCounts {
+		gotStamps[key] = count
+	}
+	require.Equal(t, wantStamps, gotStamps, "stamped-row counts by kind+scope")
+	require.NotNil(t, snapshot.Compat, "capable sync must write the compat record")
+}
+
+func TestChaosSourceCacheCollectionSemantics(t *testing.T) {
+	skipChaosInShort(t)
+
+	grantsScope := chaosoracle.KindScope(sourcecache.RowKindGrants, scGrantsScopeKey)
+
+	type cell struct {
+		name string
+		// build returns the two-epoch scenario ("seed" initial, "second").
+		build func(t *testing.T, fx *scCollectionFixture) *chaosconnector.Scenario
+		// seedConsults is the number of lookup consults generation A makes.
+		seedConsults int
+		// wantWarmEvents is generation B's exact serve-order event list.
+		wantWarmEvents func(fx *scCollectionFixture) []chaosconnector.SourceCacheLookupEvent
+		// wantEntries / wantStamps are B's exact OR3 produce-side state.
+		wantEntries func(fx *scCollectionFixture) map[string]string
+		wantStamps  func(fx *scCollectionFixture) map[string]int
+	}
+
+	// twoEpoch assembles the scenario given each epoch's grants pages+spec.
+	grantsScenario := func(
+		t *testing.T,
+		fx *scCollectionFixture,
+		seedPages, secondPages chaosconnector.Pages[*v2.Grant],
+		seedSpec, secondSpec *chaosconnector.SourceCacheSpec,
+	) *chaosconnector.Scenario {
+		t.Helper()
+		seed := scCollectionBase(fx)
+		seed.Grants["team-1"] = seedPages
+		seed.SourceCacheGrants = map[string]*chaosconnector.SourceCacheSpec{"team-1": seedSpec}
+		second := scCollectionBase(fx)
+		second.Grants["team-1"] = secondPages
+		second.SourceCacheGrants = map[string]*chaosconnector.SourceCacheSpec{"team-1": secondSpec}
+		scenario := &chaosconnector.Scenario{
+			Name:         "source-cache-collection",
+			Seed:         1,
+			InitialEpoch: "seed",
+			Epochs:       map[string]*chaosconnector.Dataset{"seed": seed, "second": second},
+		}
+		require.NoError(t, scenario.Validate())
+		return scenario
+	}
+
+	// seedGrantsV1 is the standard generation-A round: both grants fresh,
+	// validator v1, no warm branch (a seed sync always serves cold).
+	seedGrantsV1 := func(fx *scCollectionFixture) chaosconnector.Pages[*v2.Grant] {
+		return chaosconnector.Pages[*v2.Grant]{
+			"": {List: fx.Grants, Annotations: scRecordAnno(scGrantsScopeKey, scValidatorV1)},
+		}
+	}
+	specV1 := func(warmRoot string) *chaosconnector.SourceCacheSpec {
+		return &chaosconnector.SourceCacheSpec{
+			ScopeKey:  scGrantsScopeKey,
+			Validator: scValidatorV1,
+			WarmRoot:  warmRoot,
+		}
+	}
+	warmGrantsEvent := func(fx *scCollectionFixture) []chaosconnector.SourceCacheLookupEvent {
+		return []chaosconnector.SourceCacheLookupEvent{
+			scWarmEventFor(sourcecache.RowKindGrants, scGrantsScopeKey, scValidatorV1),
+		}
+	}
+
+	cells := []cell{
+		{
+			// Delta overlay + both tombstone families in one page: the
+			// replayed base (g1, g2) is trimmed by a canonical-id tombstone
+			// (g2) and a principal tombstone (user-1 kills g1) AFTER the
+			// page's fresh upsert (g3). Upstream truth is [g3]; any
+			// ordering violation leaves a replayed corpse behind and OR2
+			// catches it.
+			name: "grants-delta-overlay-tombstones",
+			build: func(t *testing.T, fx *scCollectionFixture) *chaosconnector.Scenario {
+				return grantsScenario(t, fx,
+					seedGrantsV1(fx),
+					chaosconnector.Pages[*v2.Grant]{
+						"": {List: []*v2.Grant{fx.Grant3}, Annotations: scRecordAnno(scGrantsScopeKey, scValidatorV2)},
+						"warm": {
+							List: []*v2.Grant{fx.Grant3},
+							Annotations: scReplayAnno(scGrantsScopeKey, scValidatorV2, true,
+								[]string{fx.Grants[1].GetId()}, []string{"user-1"}),
+						},
+					},
+					specV1(""), specV1("warm"),
+				)
+			},
+			seedConsults:   1,
+			wantWarmEvents: warmGrantsEvent,
+			wantEntries: func(fx *scCollectionFixture) map[string]string {
+				return map[string]string{grantsScope: scValidatorV2}
+			},
+			wantStamps: func(fx *scCollectionFixture) map[string]int {
+				return map[string]int{grantsScope: 1}
+			},
+		},
+		{
+			// Replacement across pages: a fresh scoped page lands g3, then
+			// a later replay page for the same scope arrives. Replay is
+			// replacement — the copy must wipe the earlier fresh row and
+			// restore the base [g1, g2], which is the second epoch's truth.
+			name: "grants-replacement-cross-page",
+			build: func(t *testing.T, fx *scCollectionFixture) *chaosconnector.Scenario {
+				return grantsScenario(t, fx,
+					seedGrantsV1(fx),
+					chaosconnector.Pages[*v2.Grant]{
+						"": {List: fx.Grants, Annotations: scRecordAnno(scGrantsScopeKey, scValidatorV1)},
+						"warm": {
+							List:        []*v2.Grant{fx.Grant3},
+							Annotations: scRecordAnno(scGrantsScopeKey, ""),
+							Next:        "warm-2",
+						},
+						"warm-2": {Annotations: scReplayAnno(scGrantsScopeKey, scValidatorV1, false, nil, nil)},
+					},
+					specV1(""), specV1("warm"),
+				)
+			},
+			seedConsults:   1,
+			wantWarmEvents: warmGrantsEvent,
+			wantEntries: func(fx *scCollectionFixture) map[string]string {
+				return map[string]string{grantsScope: scValidatorV1}
+			},
+			wantStamps: func(fx *scCollectionFixture) map[string]int {
+				return map[string]int{grantsScope: 2}
+			},
+		},
+		{
+			// Copy dedup: two replay pages for one scope in one round. The
+			// second copy must be SKIPPED — re-running it would wipe the
+			// first page's overlay upsert (g3) by replacement. Also pins
+			// deferred validator publish: page one carries no validator,
+			// page two publishes v2.
+			name: "grants-copy-dedup",
+			build: func(t *testing.T, fx *scCollectionFixture) *chaosconnector.Scenario {
+				allThree := []*v2.Grant{fx.Grants[0], fx.Grants[1], fx.Grant3}
+				return grantsScenario(t, fx,
+					seedGrantsV1(fx),
+					chaosconnector.Pages[*v2.Grant]{
+						"": {List: allThree, Annotations: scRecordAnno(scGrantsScopeKey, scValidatorV2)},
+						"warm": {
+							List:        []*v2.Grant{fx.Grant3},
+							Annotations: scReplayAnno(scGrantsScopeKey, "", true, nil, nil),
+							Next:        "warm-2",
+						},
+						"warm-2": {Annotations: scReplayAnno(scGrantsScopeKey, scValidatorV2, true, nil, nil)},
+					},
+					specV1(""), specV1("warm"),
+				)
+			},
+			seedConsults:   1,
+			wantWarmEvents: warmGrantsEvent,
+			wantEntries: func(fx *scCollectionFixture) map[string]string {
+				return map[string]string{grantsScope: scValidatorV2}
+			},
+			wantStamps: func(fx *scCollectionFixture) map[string]int {
+				return map[string]int{grantsScope: 3}
+			},
+		},
+		{
+			// C34 transitional tolerance at orchestration level: a
+			// non-overlay replay page carrying rows warns and applies them
+			// as overlay upserts anyway.
+			name: "grants-overlay-false-with-rows",
+			build: func(t *testing.T, fx *scCollectionFixture) *chaosconnector.Scenario {
+				allThree := []*v2.Grant{fx.Grants[0], fx.Grants[1], fx.Grant3}
+				return grantsScenario(t, fx,
+					seedGrantsV1(fx),
+					chaosconnector.Pages[*v2.Grant]{
+						"": {List: allThree, Annotations: scRecordAnno(scGrantsScopeKey, scValidatorV2)},
+						"warm": {
+							List:        []*v2.Grant{fx.Grant3},
+							Annotations: scReplayAnno(scGrantsScopeKey, scValidatorV2, false, nil, nil),
+						},
+					},
+					specV1(""), specV1("warm"),
+				)
+			},
+			seedConsults:   1,
+			wantWarmEvents: warmGrantsEvent,
+			wantEntries: func(fx *scCollectionFixture) map[string]string {
+				return map[string]string{grantsScope: scValidatorV2}
+			},
+			wantStamps: func(fx *scCollectionFixture) map[string]int {
+				return map[string]int{grantsScope: 3}
+			},
+		},
+		{
+			// Record and replay on ONE page (same scope): the record's
+			// validator wins the publish (a delta round's final record
+			// carries the NEW token), never the replay's.
+			name: "grants-record-wins-validator",
+			build: func(t *testing.T, fx *scCollectionFixture) *chaosconnector.Scenario {
+				allThree := []*v2.Grant{fx.Grants[0], fx.Grants[1], fx.Grant3}
+				warmAnnos := scReplayAnno(scGrantsScopeKey, "validator-replay-side", true, nil, nil)
+				warmAnnos.Update(v2.SourceCacheRecord_builder{
+					ScopeKey:       scGrantsScopeKey,
+					CacheValidator: scValidatorV2,
+				}.Build())
+				return grantsScenario(t, fx,
+					seedGrantsV1(fx),
+					chaosconnector.Pages[*v2.Grant]{
+						"":     {List: allThree, Annotations: scRecordAnno(scGrantsScopeKey, scValidatorV2)},
+						"warm": {List: []*v2.Grant{fx.Grant3}, Annotations: warmAnnos},
+					},
+					specV1(""), specV1("warm"),
+				)
+			},
+			seedConsults:   1,
+			wantWarmEvents: warmGrantsEvent,
+			wantEntries: func(fx *scCollectionFixture) map[string]string {
+				return map[string]string{grantsScope: scValidatorV2}
+			},
+			wantStamps: func(fx *scCollectionFixture) map[string]int {
+				return map[string]int{grantsScope: 3}
+			},
+		},
+		{
+			// A replay round that never publishes a validator: rows are
+			// replayed correctly (OR2 holds) but the scope gets NO manifest
+			// entry — a miss next sync, cacheability lost, correctness kept.
+			name: "grants-replay-no-validator-no-entry",
+			build: func(t *testing.T, fx *scCollectionFixture) *chaosconnector.Scenario {
+				return grantsScenario(t, fx,
+					seedGrantsV1(fx),
+					chaosconnector.Pages[*v2.Grant]{
+						"":     {List: fx.Grants, Annotations: scRecordAnno(scGrantsScopeKey, scValidatorV1)},
+						"warm": {Annotations: scReplayAnno(scGrantsScopeKey, "", false, nil, nil)},
+					},
+					specV1(""), specV1("warm"),
+				)
+			},
+			seedConsults:   1,
+			wantWarmEvents: warmGrantsEvent,
+			wantEntries: func(fx *scCollectionFixture) map[string]string {
+				return map[string]string{}
+			},
+			wantStamps: func(fx *scCollectionFixture) map[string]int {
+				return map[string]int{grantsScope: 2}
+			},
+		},
+		{
+			// Zero-row scope, both halves: the seed publishes an entry for
+			// a scope with no rows (200-with-zero-rows), and the warm
+			// generation replays it — zero rows copied, entry republished.
+			name: "grants-zero-row-replay",
+			build: func(t *testing.T, fx *scCollectionFixture) *chaosconnector.Scenario {
+				return grantsScenario(t, fx,
+					chaosconnector.Pages[*v2.Grant]{
+						"": {Annotations: scRecordAnno(scGrantsScopeKey, scValidatorV1)},
+					},
+					chaosconnector.Pages[*v2.Grant]{
+						"":     {Annotations: scRecordAnno(scGrantsScopeKey, scValidatorV1)},
+						"warm": {Annotations: scReplayAnno(scGrantsScopeKey, scValidatorV1, false, nil, nil)},
+					},
+					specV1(""), specV1("warm"),
+				)
+			},
+			seedConsults:   1,
+			wantWarmEvents: warmGrantsEvent,
+			wantEntries: func(fx *scCollectionFixture) map[string]string {
+				return map[string]string{grantsScope: scValidatorV1}
+			},
+			wantStamps: func(fx *scCollectionFixture) map[string]int {
+				return map[string]int{}
+			},
+		},
+		{
+			// Resources kind, delta overlay: the replayed base (u1, u2) is
+			// trimmed by a resource-BID tombstone (u1) after the fresh
+			// upsert (u3). Upstream truth is [u2, u3]. The user type skips
+			// entitlements/grants, so replayed resources spawn no child
+			// work by construction.
+			name: "resources-delta-overlay",
+			build: func(t *testing.T, fx *scCollectionFixture) *chaosconnector.Scenario {
+				u1BID, err := bid.MakeResourceBid(fx.Users[0])
+				require.NoError(t, err)
+				seed := scCollectionBase(fx)
+				seed.Resources[scUserTypeID] = chaosconnector.Pages[*v2.Resource]{
+					"": {List: []*v2.Resource{fx.Users[0], fx.Users[1]}, Annotations: scRecordAnno(scResourceScope, scValidatorV1)},
+				}
+				seed.SourceCacheResources = map[string]*chaosconnector.SourceCacheSpec{
+					scUserTypeID: {ScopeKey: scResourceScope, Validator: scValidatorV1},
+				}
+				second := scCollectionBase(fx)
+				second.Resources[scUserTypeID] = chaosconnector.Pages[*v2.Resource]{
+					"": {List: []*v2.Resource{fx.Users[1], fx.User3}, Annotations: scRecordAnno(scResourceScope, scValidatorV2)},
+					"warm": {
+						List:        []*v2.Resource{fx.User3},
+						Annotations: scReplayAnno(scResourceScope, scValidatorV2, true, []string{u1BID}, nil),
+					},
+				}
+				second.SourceCacheResources = map[string]*chaosconnector.SourceCacheSpec{
+					scUserTypeID: {ScopeKey: scResourceScope, Validator: scValidatorV1, WarmRoot: "warm"},
+				}
+				scenario := &chaosconnector.Scenario{
+					Name:         "source-cache-collection-resources",
+					Seed:         1,
+					InitialEpoch: "seed",
+					Epochs:       map[string]*chaosconnector.Dataset{"seed": seed, "second": second},
+				}
+				require.NoError(t, scenario.Validate())
+				return scenario
+			},
+			seedConsults: 1,
+			wantWarmEvents: func(fx *scCollectionFixture) []chaosconnector.SourceCacheLookupEvent {
+				return []chaosconnector.SourceCacheLookupEvent{
+					scWarmEventFor(sourcecache.RowKindResources, scResourceScope, scValidatorV1),
+				}
+			},
+			wantEntries: func(fx *scCollectionFixture) map[string]string {
+				return map[string]string{chaosoracle.KindScope(sourcecache.RowKindResources, scResourceScope): scValidatorV2}
+			},
+			wantStamps: func(fx *scCollectionFixture) map[string]int {
+				return map[string]int{chaosoracle.KindScope(sourcecache.RowKindResources, scResourceScope): 2}
+			},
+		},
+		{
+			// Cross-kind non-aliasing: the IDENTICAL scope-key string on an
+			// entitlements scope and a grants scope, same validator. The
+			// manifest keys by (kind, scope) so both entries coexist, each
+			// kind replays only its own rows, and stamp counts stay per-kind.
+			name: "cross-kind-shared-scope",
+			build: func(t *testing.T, fx *scCollectionFixture) *chaosconnector.Scenario {
+				buildEpoch := func(warm bool) *chaosconnector.Dataset {
+					d := scCollectionBase(fx)
+					entPages := chaosconnector.Pages[*v2.Entitlement]{
+						"": {List: []*v2.Entitlement{fx.Member}, Annotations: scRecordAnno(scSharedScope, scSharedValidator)},
+					}
+					grantPages := chaosconnector.Pages[*v2.Grant]{
+						"": {List: fx.Grants, Annotations: scRecordAnno(scSharedScope, scSharedValidator)},
+					}
+					entSpec := &chaosconnector.SourceCacheSpec{ScopeKey: scSharedScope, Validator: scSharedValidator}
+					grantSpec := &chaosconnector.SourceCacheSpec{ScopeKey: scSharedScope, Validator: scSharedValidator}
+					if warm {
+						entPages["warm"] = chaosconnector.Page[*v2.Entitlement]{
+							Annotations: scReplayAnno(scSharedScope, scSharedValidator, false, nil, nil),
+						}
+						grantPages["warm"] = chaosconnector.Page[*v2.Grant]{
+							Annotations: scReplayAnno(scSharedScope, scSharedValidator, false, nil, nil),
+						}
+						entSpec.WarmRoot = "warm"
+						grantSpec.WarmRoot = "warm"
+					}
+					d.Entitlements["team-1"] = entPages
+					d.Grants["team-1"] = grantPages
+					d.SourceCacheEntitlements = map[string]*chaosconnector.SourceCacheSpec{"team-1": entSpec}
+					d.SourceCacheGrants = map[string]*chaosconnector.SourceCacheSpec{"team-1": grantSpec}
+					return d
+				}
+				scenario := &chaosconnector.Scenario{
+					Name:         "source-cache-collection-cross-kind",
+					Seed:         1,
+					InitialEpoch: "seed",
+					Epochs: map[string]*chaosconnector.Dataset{
+						"seed":   buildEpoch(false),
+						"second": buildEpoch(true),
+					},
+				}
+				require.NoError(t, scenario.Validate())
+				return scenario
+			},
+			seedConsults: 2,
+			wantWarmEvents: func(fx *scCollectionFixture) []chaosconnector.SourceCacheLookupEvent {
+				return []chaosconnector.SourceCacheLookupEvent{
+					scWarmEventFor(sourcecache.RowKindEntitlements, scSharedScope, scSharedValidator),
+					scWarmEventFor(sourcecache.RowKindGrants, scSharedScope, scSharedValidator),
+				}
+			},
+			wantEntries: func(fx *scCollectionFixture) map[string]string {
+				return map[string]string{
+					chaosoracle.KindScope(sourcecache.RowKindEntitlements, scSharedScope): scSharedValidator,
+					chaosoracle.KindScope(sourcecache.RowKindGrants, scSharedScope):       scSharedValidator,
+				}
+			},
+			wantStamps: func(fx *scCollectionFixture) map[string]int {
+				return map[string]int{
+					chaosoracle.KindScope(sourcecache.RowKindEntitlements, scSharedScope): 1,
+					chaosoracle.KindScope(sourcecache.RowKindGrants, scSharedScope):       2,
+				}
+			},
+		},
+	}
+
+	for _, tc := range cells {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), 90*time.Second)
+			defer cancel()
+			tmpDir, paths := sourceCachePaths(t, 3)
+			seedPath, warmPath, baselinePath := paths[0], paths[1], paths[2]
+
+			fx := newSCCollectionFixture(t)
+			scenario := tc.build(t, fx)
+			capability := sourceCacheCapabilityRW("gen-1", "cfg-1")
+
+			// Generation A: cold seed of the "seed" epoch.
+			run, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+			require.NoError(t, err)
+			run.SetSourceCacheCapability(capability)
+			seedEvents := runSourceCacheSync(t, ctx, run, chaosTransportDirect, seedPath, tmpDir, "", WithWorkerCount(1))
+			requireAllColdEvents(t, seedEvents, tc.seedConsults)
+
+			// Generation B: warm against A, upstream now at "second".
+			require.NoError(t, run.SetEpoch("second"))
+			warmEvents := runSourceCacheSync(t, ctx, run, chaosTransportDirect, warmPath, tmpDir, seedPath, WithWorkerCount(1))
+			requireSourceCacheEvents(t, warmEvents, tc.wantWarmEvents(fx))
+
+			// Independent cold baseline of the SAME final epoch: a fresh
+			// run misses every lookup and serves the cold branch.
+			baselineRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+			require.NoError(t, err)
+			require.NoError(t, baselineRun.SetEpoch("second"))
+			baselineRun.SetSourceCacheCapability(capability)
+			baselineEvents := runSourceCacheSync(t, ctx, baselineRun, chaosTransportDirect, baselinePath, tmpDir, "", WithWorkerCount(1))
+			requireAllColdEvents(t, baselineEvents, tc.seedConsults)
+
+			// OR2 — warm result must equal the cold truth of the epoch.
+			warmContent := readChaosLogicalContent(t, ctx, warmPath, tmpDir)
+			baselineContent := readChaosLogicalContent(t, ctx, baselinePath, tmpDir)
+			require.NoError(t, chaosoracle.CompareLogicalContent(baselineContent, warmContent),
+				"warm generation's logical content must equal the independent cold baseline")
+
+			// OR3 — exact produce-side state on the warm artifact.
+			requireSourceCacheProduceState(t, readSourceCacheSnapshot(t, ctx, warmPath, tmpDir),
+				tc.wantEntries(fx), tc.wantStamps(fx))
+		})
+	}
+}
+
+// TestChaosSourceCacheFreshPageSemantics pins R3's cold-only fresh-page
+// cells (plan B3, oracle OR3): multi-page rounds, same-page
+// put-then-tombstone ordering, the empty-validator transitional round (6a
+// C25's semantics at orchestration level), and the static-entitlement
+// registered exclusion (B10).
+func TestChaosSourceCacheFreshPageSemantics(t *testing.T) {
+	skipChaosInShort(t)
+
+	grantsScope := chaosoracle.KindScope(sourcecache.RowKindGrants, scGrantsScopeKey)
+
+	t.Run("multi-page-round", func(t *testing.T) {
+		// One recording round split across two wire pages, each carrying
+		// the same record annotation: every page's rows are stamped and
+		// the entry publishes once with the shared validator.
+		ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+		defer cancel()
+		tmpDir, paths := sourceCachePaths(t, 1)
+
+		fx := newSCCollectionFixture(t)
+		d := scCollectionBase(fx)
+		d.Grants["team-1"] = chaosconnector.Pages[*v2.Grant]{
+			"":   {List: []*v2.Grant{fx.Grants[0]}, Annotations: scRecordAnno(scGrantsScopeKey, scValidatorV1), Next: "p2"},
+			"p2": {List: []*v2.Grant{fx.Grants[1]}, Annotations: scRecordAnno(scGrantsScopeKey, scValidatorV1)},
+		}
+		d.SourceCacheGrants = map[string]*chaosconnector.SourceCacheSpec{
+			"team-1": {ScopeKey: scGrantsScopeKey, Validator: scValidatorV1},
+		}
+		scenario := &chaosconnector.Scenario{
+			Name: "source-cache-fresh-multipage", Seed: 1, InitialEpoch: "seed",
+			Epochs: map[string]*chaosconnector.Dataset{"seed": d},
+		}
+		require.NoError(t, scenario.Validate())
+
+		run, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+		require.NoError(t, err)
+		run.SetSourceCacheCapability(sourceCacheCapabilityRW("gen-1", "cfg-1"))
+		events := runSourceCacheSync(t, ctx, run, chaosTransportDirect, paths[0], tmpDir, "", WithWorkerCount(1))
+		requireAllColdEvents(t, events, 1)
+
+		grants := readChaosGrantsByID(t, ctx, paths[0], tmpDir)
+		require.Len(t, grants, 2)
+		requireSourceCacheProduceState(t, readSourceCacheSnapshot(t, ctx, paths[0], tmpDir),
+			map[string]string{grantsScope: scValidatorV1},
+			map[string]int{grantsScope: 2})
+	})
+
+	t.Run("same-page-put-then-tombstone", func(t *testing.T) {
+		// A page that upserts g1 and g2 AND tombstones g1 in its own
+		// record annotation: within-page order is upserts before deletes
+		// (B3, 6a C29's orchestration half), so g1 must be gone and only
+		// g2 stamped. Reversed order would leave both rows standing.
+		ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+		defer cancel()
+		tmpDir, paths := sourceCachePaths(t, 1)
+
+		fx := newSCCollectionFixture(t)
+		d := scCollectionBase(fx)
+		d.Grants["team-1"] = chaosconnector.Pages[*v2.Grant]{
+			"": {
+				List: fx.Grants,
+				Annotations: annotations.New(v2.SourceCacheRecord_builder{
+					ScopeKey:       scGrantsScopeKey,
+					CacheValidator: scValidatorV1,
+					DeletedIds:     []string{fx.Grants[0].GetId()},
+				}.Build()),
+			},
+		}
+		d.SourceCacheGrants = map[string]*chaosconnector.SourceCacheSpec{
+			"team-1": {ScopeKey: scGrantsScopeKey, Validator: scValidatorV1},
+		}
+		scenario := &chaosconnector.Scenario{
+			Name: "source-cache-fresh-put-tombstone", Seed: 1, InitialEpoch: "seed",
+			Epochs: map[string]*chaosconnector.Dataset{"seed": d},
+		}
+		require.NoError(t, scenario.Validate())
+
+		run, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+		require.NoError(t, err)
+		run.SetSourceCacheCapability(sourceCacheCapabilityRW("gen-1", "cfg-1"))
+		events := runSourceCacheSync(t, ctx, run, chaosTransportDirect, paths[0], tmpDir, "", WithWorkerCount(1))
+		requireAllColdEvents(t, events, 1)
+
+		grants := readChaosGrantsByID(t, ctx, paths[0], tmpDir)
+		require.Len(t, grants, 1)
+		require.Contains(t, grants, fx.Grants[1].GetId(), "the tombstoned row must be the one that dies")
+		requireSourceCacheProduceState(t, readSourceCacheSnapshot(t, ctx, paths[0], tmpDir),
+			map[string]string{grantsScope: scValidatorV1},
+			map[string]int{grantsScope: 1})
+	})
+
+	t.Run("empty-validator-no-entry-misses-next-sync", func(t *testing.T) {
+		// The transitional round: a record with rows but NO validator
+		// stamps the rows and publishes NO manifest entry, so the next
+		// sync's lookup for that scope must miss and refetch (6a C25's
+		// semantics at orchestration level).
+		ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+		defer cancel()
+		tmpDir, paths := sourceCachePaths(t, 2)
+		seedPath, secondPath := paths[0], paths[1]
+
+		fx := newSCCollectionFixture(t)
+		seed := scCollectionBase(fx)
+		seed.Grants["team-1"] = chaosconnector.Pages[*v2.Grant]{
+			"": {List: fx.Grants, Annotations: scRecordAnno(scGrantsScopeKey, "")},
+		}
+		second := scCollectionBase(fx)
+		second.Grants["team-1"] = chaosconnector.Pages[*v2.Grant]{
+			"":     {List: fx.Grants, Annotations: scRecordAnno(scGrantsScopeKey, scValidatorV1)},
+			"warm": {Annotations: scReplayAnno(scGrantsScopeKey, scValidatorV1, false, nil, nil)},
+		}
+		second.SourceCacheGrants = map[string]*chaosconnector.SourceCacheSpec{
+			"team-1": {ScopeKey: scGrantsScopeKey, Validator: scValidatorV1, WarmRoot: "warm"},
+		}
+		scenario := &chaosconnector.Scenario{
+			Name: "source-cache-fresh-transitional", Seed: 1, InitialEpoch: "seed",
+			Epochs: map[string]*chaosconnector.Dataset{"seed": seed, "second": second},
+		}
+		require.NoError(t, scenario.Validate())
+		capability := sourceCacheCapabilityRW("gen-1", "cfg-1")
+
+		run, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+		require.NoError(t, err)
+		run.SetSourceCacheCapability(capability)
+		seedEvents := runSourceCacheSync(t, ctx, run, chaosTransportDirect, seedPath, tmpDir, "", WithWorkerCount(1))
+		require.Empty(t, seedEvents, "seed epoch declares no source-cache spec: no consults")
+		// Rows stamped, NO entry: the vacuity guard for the next sync's miss.
+		requireSourceCacheProduceState(t, readSourceCacheSnapshot(t, ctx, seedPath, tmpDir),
+			map[string]string{},
+			map[string]int{grantsScope: 2})
+
+		require.NoError(t, run.SetEpoch("second"))
+		secondEvents := runSourceCacheSync(t, ctx, run, chaosTransportDirect, secondPath, tmpDir, seedPath, WithWorkerCount(1))
+		requireAllColdEvents(t, secondEvents, 1)
+		requireSourceCacheProduceState(t, readSourceCacheSnapshot(t, ctx, secondPath, tmpDir),
+			map[string]string{grantsScope: scValidatorV1},
+			map[string]int{grantsScope: 2})
+	})
+
+	t.Run("static-entitlement-annotation-ignored", func(t *testing.T) {
+		// Registered exclusion (B10): a SourceCacheRecord on a
+		// ListStaticEntitlements response is ignored with a warn — static
+		// entitlements stay unscoped, no entry and no stamps appear, and
+		// the sync stays green.
+		ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+		defer cancel()
+		tmpDir, paths := sourceCachePaths(t, 1)
+
+		fx := newSCCollectionFixture(t)
+		d := scCollectionBase(fx)
+		d.StaticEntitlements[scTeamTypeID] = chaosconnector.Pages[*v2.Entitlement]{
+			"": {
+				List:        []*v2.Entitlement{et.NewEntitlement(fx.Team, "viewer", "assignment")},
+				Annotations: scRecordAnno("static:team", "v-static"),
+			},
+		}
+		scenario := &chaosconnector.Scenario{
+			Name: "source-cache-fresh-static-ents", Seed: 1, InitialEpoch: "seed",
+			Epochs: map[string]*chaosconnector.Dataset{"seed": d},
+		}
+		require.NoError(t, scenario.Validate())
+
+		run, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+		require.NoError(t, err)
+		run.SetSourceCacheCapability(sourceCacheCapabilityRW("gen-1", "cfg-1"))
+		events := runSourceCacheSync(t, ctx, run, chaosTransportDirect, paths[0], tmpDir, "", WithWorkerCount(1))
+		require.Empty(t, events, "static entitlements never consult the lookup")
+		requireSourceCacheProduceState(t, readSourceCacheSnapshot(t, ctx, paths[0], tmpDir),
+			map[string]string{}, map[string]int{})
+	})
+}

--- a/pkg/sync/chaos_source_cache_gate_test.go
+++ b/pkg/sync/chaos_source_cache_gate_test.go
@@ -1,0 +1,298 @@
+package sync //nolint:revive,nolintlint // backwards-compatible package name
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/conductorone/baton-sdk/internal/chaosconnector"
+	chaosoracle "github.com/conductorone/baton-sdk/internal/chaosconnector/oracle"
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/sourcecache"
+	gt "github.com/conductorone/baton-sdk/pkg/types/grant"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+)
+
+// Phase 6b gate-matrix suite (plan R2 + R5 + R6, oracle OR1): each cell
+// runs generation A (the seed sync) and generation B with exactly one gate
+// condition falsified, then asserts the connector-side lookup events show
+// the frozen outcome — warm (hit + matched + served warm) or cold (miss).
+//
+// Artifact-provenance cells that fail in NewSyncer before any connector is
+// involved — non-Pebble (G2), non-FULL / compacted (G3), stats-absent (G4),
+// fence-stripped (G5) — are pinned at that level by
+// TestPreviousSyncC1ZPathEnforcesReplayEligibility; this suite carries the
+// cells that need a real capable connector in the loop.
+
+// scWarmEvent is the expected event for a warm serve of the reference
+// grants scope; scColdEvent for a cold serve (miss).
+func scWarmEvent() chaosconnector.SourceCacheLookupEvent {
+	return chaosconnector.SourceCacheLookupEvent{
+		RowKind:           sourcecache.RowKindGrants,
+		ScopeKey:          scGrantsScopeKey,
+		Hit:               true,
+		PreviousValidator: scValidatorV1,
+		Matched:           true,
+		ServedWarm:        true,
+	}
+}
+
+func scColdEvent() chaosconnector.SourceCacheLookupEvent {
+	return chaosconnector.SourceCacheLookupEvent{
+		RowKind:  sourcecache.RowKindGrants,
+		ScopeKey: scGrantsScopeKey,
+	}
+}
+
+func TestChaosSourceCacheGateMatrix(t *testing.T) {
+	skipChaosInShort(t)
+
+	type cell struct {
+		name string
+		// seedCapability arms generation A; nil means A declares nothing.
+		seedCapability *v2.SourceCacheCapability
+		// mutateDataset adversarially reshapes the scenario before the run
+		// is armed (both generations serve it).
+		mutateDataset func(t *testing.T, fixture *scFixture, dataset *chaosconnector.Dataset)
+		// secondCapability arms generation B.
+		secondCapability *v2.SourceCacheCapability
+		// secondOpts extends generation B's sync options.
+		secondOpts []SyncOpt
+		// noPrevious withholds WithPreviousSyncC1ZPath from B.
+		noPrevious bool
+		// wantWarm is B's expected consume outcome.
+		wantWarm bool
+		// wantSecondProduce asserts whether B's artifact carries produce-side
+		// state (manifest entry + stamps + compat record).
+		wantSecondProduce bool
+	}
+
+	rw := sourceCacheCapabilityRW("gen-1", "cfg-1")
+	cells := []cell{
+		{
+			// All gates pass: the frozen warm baseline.
+			name:              "warm-baseline",
+			seedCapability:    rw,
+			secondCapability:  rw,
+			wantWarm:          true,
+			wantSecondProduce: true,
+		},
+		{
+			// G1: no previous artifact supplied at all.
+			name:              "no-previous-artifact",
+			seedCapability:    rw,
+			secondCapability:  rw,
+			noPrevious:        true,
+			wantSecondProduce: true,
+		},
+		{
+			// G6: capability absent on B's Validate — every source-cache
+			// annotation is ignored wholesale, so B also produces nothing.
+			name:             "capability-absent",
+			seedCapability:   rw,
+			secondCapability: nil,
+		},
+		{
+			// G6: capability declared but not MODE_READ_WRITE.
+			name:           "capability-disabled",
+			seedCapability: rw,
+			secondCapability: v2.SourceCacheCapability_builder{
+				Mode:              v2.SourceCacheCapability_MODE_DISABLED,
+				CacheGeneration:   "gen-1",
+				ConfigFingerprint: "cfg-1",
+			}.Build(),
+		},
+		{
+			// G7: connector cache generation drifted between A and B.
+			name:              "compat-cache-generation-mismatch",
+			seedCapability:    rw,
+			secondCapability:  sourceCacheCapabilityRW("gen-2", "cfg-1"),
+			wantSecondProduce: true,
+		},
+		{
+			// G7: connector config fingerprint drifted.
+			name:              "compat-config-fingerprint-mismatch",
+			seedCapability:    rw,
+			secondCapability:  sourceCacheCapabilityRW("gen-1", "cfg-2"),
+			wantSecondProduce: true,
+		},
+		{
+			// G7: selection fingerprint drifted — B declares an explicit
+			// resource-type filter that happens to collect the same data.
+			// Same rows, different declared selection: still cold.
+			name:              "compat-selection-fingerprint-mismatch",
+			seedCapability:    rw,
+			secondCapability:  rw,
+			secondOpts:        []SyncOpt{WithSyncResourceTypes([]string{scTeamTypeID, scUserTypeID})},
+			wantSecondProduce: true,
+		},
+		{
+			// G7: previous artifact carries no compat record at all (its
+			// sync declared no capability — pre-6b shape).
+			name:              "compat-record-absent",
+			seedCapability:    nil,
+			secondCapability:  rw,
+			wantSecondProduce: true,
+		},
+		{
+			// G4 at chaos level (R6): generation A trips an ingest-filter
+			// drop (a grant to a principal type the sync never schedules),
+			// seals replay-blocked, and must not seed B. The drop happens on
+			// an UNANNOTATED page so A's source-cache state itself is sound
+			// — only quality blocks it.
+			name:           "quality-blocked-previous",
+			seedCapability: rw,
+			mutateDataset: func(t *testing.T, fixture *scFixture, dataset *chaosconnector.Dataset) {
+				ghostType := v2.ResourceType_builder{
+					Id:          "sc-ghost",
+					DisplayName: "SC Ghost",
+					Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_USER},
+				}.Build()
+				ghost, err := rs.NewUserResource("Ghost", ghostType, "ghost-1", nil)
+				require.NoError(t, err)
+				pages := dataset.Grants["team-1"]
+				cold := pages[""]
+				cold.List = append(cold.List, gt.NewGrant(fixture.Team, "member", ghost))
+				pages[""] = cold
+			},
+			secondCapability:  rw,
+			wantSecondProduce: true,
+		},
+	}
+
+	for _, tc := range cells {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+			defer cancel()
+			tmpDir, paths := sourceCachePaths(t, 2)
+
+			fixture := newSourceCacheFixture(t)
+			scenario := newSourceCacheScenario(t, fixture)
+			if tc.mutateDataset != nil {
+				tc.mutateDataset(t, fixture, scenario.Epochs[scenario.InitialEpoch])
+				require.NoError(t, scenario.Validate())
+			}
+			run, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+			require.NoError(t, err)
+
+			// Generation A: always a cold seed — one lookup, one miss.
+			run.SetSourceCacheCapability(tc.seedCapability)
+			seedEvents := runSourceCacheSync(t, ctx, run, chaosTransportDirect, paths[0], tmpDir, "")
+			requireSourceCacheEvents(t, seedEvents, []chaosconnector.SourceCacheLookupEvent{scColdEvent()})
+
+			// Generation B: the cell's gate condition applied.
+			run.SetSourceCacheCapability(tc.secondCapability)
+			prevPath := paths[0]
+			if tc.noPrevious {
+				prevPath = ""
+			}
+			secondEvents := runSourceCacheSync(t, ctx, run, chaosTransportDirect, paths[1], tmpDir, prevPath, tc.secondOpts...)
+			expected := scColdEvent()
+			if tc.wantWarm {
+				expected = scWarmEvent()
+			}
+			requireSourceCacheEvents(t, secondEvents, []chaosconnector.SourceCacheLookupEvent{expected})
+
+			// OR2 — B's logical content must equal A's regardless of how it
+			// was served (replayed or fresh; the epoch never changed).
+			// The quality cell is the exception by design: A contains the
+			// dropped-grant page's survivors, and B (served identically)
+			// matches A anyway, so the comparison still holds.
+			seedContent := readChaosLogicalContent(t, ctx, paths[0], tmpDir)
+			secondContent := readChaosLogicalContent(t, ctx, paths[1], tmpDir)
+			require.NoError(t, chaosoracle.CompareLogicalContent(seedContent, secondContent),
+				"generation B's logical content must equal generation A's")
+
+			// OR3 — produce-side state on B's artifact.
+			snapshot := readSourceCacheSnapshot(t, ctx, paths[1], tmpDir)
+			if tc.wantSecondProduce {
+				entry, ok := snapshot.Entries[grantsKindScope()]
+				require.True(t, ok, "B must publish the grants scope manifest entry")
+				require.Equal(t, scValidatorV1, entry.Validator)
+				require.False(t, entry.Invalidated)
+				require.Equal(t, len(fixture.Grants), snapshot.StampCounts[grantsKindScope()],
+					"every replayed/fresh grant of the scope must carry the scope stamp")
+				require.NotNil(t, snapshot.Compat, "capable sync must write the compat record")
+				require.Equal(t, sourcecache.MaterializationPolicyGeneration, snapshot.Compat.SDKMaterializationGeneration)
+			} else {
+				require.Empty(t, snapshot.Entries, "incapable sync must not publish manifest entries")
+				require.Empty(t, snapshot.StampCounts, "incapable sync must not stamp rows")
+				require.Nil(t, snapshot.Compat, "incapable sync must not write a compat record")
+			}
+		})
+	}
+}
+
+// TestChaosSourceCacheWarmAcrossTransports pins the warm A→B chain on every
+// chaos transport (R1's transport coverage): the direct aggregate and both
+// in-memory gRPC shapes must deliver the lookup and produce identical warm
+// outcomes.
+func TestChaosSourceCacheWarmAcrossTransports(t *testing.T) {
+	skipChaosInShort(t)
+	for _, transport := range chaosFaultTransports() {
+		t.Run(transport.String(), func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+			defer cancel()
+			tmpDir, paths := sourceCachePaths(t, 2)
+
+			fixture := newSourceCacheFixture(t)
+			scenario := newSourceCacheScenario(t, fixture)
+			run, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+			require.NoError(t, err)
+			run.SetSourceCacheCapability(sourceCacheCapabilityRW("gen-1", "cfg-1"))
+
+			seedEvents := runSourceCacheSync(t, ctx, run, transport, paths[0], tmpDir, "")
+			requireSourceCacheEvents(t, seedEvents, []chaosconnector.SourceCacheLookupEvent{scColdEvent()})
+
+			secondEvents := runSourceCacheSync(t, ctx, run, transport, paths[1], tmpDir, paths[0])
+			requireSourceCacheEvents(t, secondEvents, []chaosconnector.SourceCacheLookupEvent{scWarmEvent()})
+
+			seedContent := readChaosLogicalContent(t, ctx, paths[0], tmpDir)
+			secondContent := readChaosLogicalContent(t, ctx, paths[1], tmpDir)
+			require.NoError(t, chaosoracle.CompareLogicalContent(seedContent, secondContent))
+		})
+	}
+}
+
+// TestChaosSourceCacheLookupTeardown pins the R1 teardown contract: after a
+// warm sync ends, a late connector call must observe NoopLookup — never the
+// sync's warm lookup.
+func TestChaosSourceCacheLookupTeardown(t *testing.T) {
+	skipChaosInShort(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+	defer cancel()
+	tmpDir, paths := sourceCachePaths(t, 2)
+
+	fixture := newSourceCacheFixture(t)
+	scenario := newSourceCacheScenario(t, fixture)
+	run, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+	require.NoError(t, err)
+	run.SetSourceCacheCapability(sourceCacheCapabilityRW("gen-1", "cfg-1"))
+
+	seedEvents := runSourceCacheSync(t, ctx, run, chaosTransportDirect, paths[0], tmpDir, "")
+	requireSourceCacheEvents(t, seedEvents, []chaosconnector.SourceCacheLookupEvent{scColdEvent()})
+
+	// Generation B warm, holding the harness open after Sync: teardown runs
+	// at Sync exit, so a late RPC issued before Close must already observe
+	// the cleared (Noop) lookup while the previous artifact is still open —
+	// a hit here would mean the warm lookup leaked past the sync.
+	run.ResetSourceCacheLookupEvents()
+	h := newChaosHarness(t, ctx, run, paths[1], tmpDir, chaosTransportDirect,
+		WithPreviousSyncC1ZPath(paths[0]))
+	require.NoError(t, h.Syncer.Sync(ctx))
+	warmEvents := run.SourceCacheLookupEvents()
+	requireSourceCacheEvents(t, warmEvents, []chaosconnector.SourceCacheLookupEvent{scWarmEvent()})
+
+	run.ResetSourceCacheLookupEvents()
+	_, err = h.Client.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{
+		Resource: fixture.Team,
+	}.Build())
+	require.NoError(t, err)
+	lateEvents := run.SourceCacheLookupEvents()
+	requireSourceCacheEvents(t, lateEvents, []chaosconnector.SourceCacheLookupEvent{scColdEvent()})
+
+	require.NoError(t, h.Close(ctx))
+	require.NoError(t, run.Runtime().VerifyRequired())
+}

--- a/pkg/sync/chaos_source_cache_generational_test.go
+++ b/pkg/sync/chaos_source_cache_generational_test.go
@@ -1,0 +1,461 @@
+package sync //nolint:revive,nolintlint // backwards-compatible package name
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/conductorone/baton-sdk/internal/chaosconnector"
+	chaosoracle "github.com/conductorone/baton-sdk/internal/chaosconnector/oracle"
+	"github.com/conductorone/baton-sdk/internal/testtier"
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/sourcecache"
+	et "github.com/conductorone/baton-sdk/pkg/types/entitlement"
+	gt "github.com/conductorone/baton-sdk/pkg/types/grant"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+)
+
+// Phase 6b generational steady-state suite (plan R13 — first-class
+// criterion with its own closure entry; oracles OR5 + OR1 + OR2): three
+// generations A cold → B warm → C warm against an UNCHANGED upstream. This
+// is the only instrument observing replay's producer half: a replayed
+// scope that fails to republish its manifest entry alternates hit/miss per
+// generation while every individual sync stays green — only C's exact
+// consult trace catches it.
+//
+// Scope shapes covered (all four consulted every generation):
+//   - an etag-style grants scope whose validator carries unchanged (OR5d),
+//   - a delta-style grants scope whose validator rotates every generation
+//     with zero-change overlays (OR5d),
+//   - a zero-row grants scope whose entry must persist with no rows (OR5c),
+//   - an etag-style entitlements scope for cross-kind breadth.
+
+const (
+	scGenEtagScope      = "grants:team-1"
+	scGenEtagValidator  = "validator-etag"
+	scGenDeltaScope     = "grants:team-2"
+	scGenZeroScope      = "grants:team-3"
+	scGenZeroValidator  = "validator-zero"
+	scGenEntsScope      = "ents:team-1"
+	scGenEntsValidator  = "validator-ents"
+	scGenLossyEpochName = "b-lossy"
+)
+
+// scGenEpochName names generation g's epoch: "a", "b", "c", then "gen-3"…
+// for the nightly long chain.
+func scGenEpochName(g int) string {
+	if g < 3 {
+		return []string{"a", "b", "c"}[g]
+	}
+	return fmt.Sprintf("gen-%d", g)
+}
+
+// scGenDeltaValidator is the delta scope's validator CURRENT in
+// generation g; the scope's validator rotates every generation.
+func scGenDeltaValidator(g int) string {
+	return fmt.Sprintf("delta-token-%d", g+1)
+}
+
+type scGenFixture struct {
+	*scCollectionFixture
+	Team2   *v2.Resource
+	Team3   *v2.Resource
+	Member2 *v2.Entitlement
+	H1      *v2.Grant
+}
+
+func newSCGenFixture(t *testing.T) *scGenFixture {
+	t.Helper()
+	fx := newSCCollectionFixture(t)
+	team2, err := rs.NewGroupResource("Team 2", fx.TeamType, "team-2", nil)
+	require.NoError(t, err)
+	team3, err := rs.NewGroupResource("Team 3", fx.TeamType, "team-3", nil)
+	require.NoError(t, err)
+	member2 := et.NewEntitlement(team2, "member", "assignment")
+	return &scGenFixture{
+		scCollectionFixture: fx,
+		Team2:               team2,
+		Team3:               team3,
+		Member2:             member2,
+		H1:                  gt.NewGrant(team2, "member", fx.Users[0]),
+	}
+}
+
+// scGenDeltaValidators returns (previous, current) for the delta scope in
+// generation g.
+func scGenDeltaValidators(g int) (string, string) {
+	if g == 0 {
+		return "", scGenDeltaValidator(0)
+	}
+	return scGenDeltaValidator(g - 1), scGenDeltaValidator(g)
+}
+
+// scGenEpoch builds one generation's dataset. The logical content is
+// IDENTICAL in every generation — only validators and page annotations
+// differ. lossy adds an entitlement with an unknown resource type to an
+// unannotated page, which the ingest filter drops under the skip-report
+// policy, marking the artifact replay-blocked.
+func scGenEpoch(fx *scGenFixture, gen int, lossy bool) *chaosconnector.Dataset {
+	warm := gen != 0
+	deltaPrevious, deltaCurrent := scGenDeltaValidators(gen)
+
+	d := scCollectionBase(fx.scCollectionFixture)
+	d.Resources[scTeamTypeID] = chaosconnector.Pages[*v2.Resource]{
+		"": {List: []*v2.Resource{fx.Team, fx.Team2, fx.Team3}},
+	}
+
+	entsTeam1 := chaosconnector.Pages[*v2.Entitlement]{
+		"": {List: []*v2.Entitlement{fx.Member}, Annotations: scRecordAnno(scGenEntsScope, scGenEntsValidator)},
+	}
+	team2Ents := []*v2.Entitlement{fx.Member2}
+	if lossy {
+		team2Ents = append(team2Ents, v2.Entitlement_builder{
+			Id:          "gen-ghost-entitlement",
+			DisplayName: "Ghost entitlement on an unscheduled type",
+			Resource: v2.Resource_builder{
+				Id: v2.ResourceId_builder{ResourceType: "ghost-type", Resource: "ghost-1"}.Build(),
+			}.Build(),
+		}.Build())
+	}
+	d.Entitlements["team-2"] = chaosconnector.Pages[*v2.Entitlement]{"": {List: team2Ents}}
+	d.Entitlements["team-3"] = chaosconnector.Pages[*v2.Entitlement]{"": {}}
+
+	grantsTeam1 := chaosconnector.Pages[*v2.Grant]{
+		"": {List: fx.Grants, Annotations: scRecordAnno(scGenEtagScope, scGenEtagValidator)},
+	}
+	grantsTeam2 := chaosconnector.Pages[*v2.Grant]{
+		"": {List: []*v2.Grant{fx.H1}, Annotations: scRecordAnno(scGenDeltaScope, deltaCurrent)},
+	}
+	grantsTeam3 := chaosconnector.Pages[*v2.Grant]{
+		"": {Annotations: scRecordAnno(scGenZeroScope, scGenZeroValidator)},
+	}
+	if warm {
+		entsTeam1["warm"] = chaosconnector.Page[*v2.Entitlement]{
+			Annotations: scReplayAnno(scGenEntsScope, scGenEntsValidator, false, nil, nil),
+		}
+		// Etag-style: full replay, validator carries.
+		grantsTeam1["warm"] = chaosconnector.Page[*v2.Grant]{
+			Annotations: scReplayAnno(scGenEtagScope, scGenEtagValidator, false, nil, nil),
+		}
+		// Delta-style: zero-change overlay, validator rotates.
+		grantsTeam2["warm"] = chaosconnector.Page[*v2.Grant]{
+			Annotations: scReplayAnno(scGenDeltaScope, deltaCurrent, true, nil, nil),
+		}
+		// Zero-row scope: replay of nothing still republishes the entry.
+		grantsTeam3["warm"] = chaosconnector.Page[*v2.Grant]{
+			Annotations: scReplayAnno(scGenZeroScope, scGenZeroValidator, false, nil, nil),
+		}
+	}
+	d.Entitlements["team-1"] = entsTeam1
+	d.Grants["team-1"] = grantsTeam1
+	d.Grants["team-2"] = grantsTeam2
+	d.Grants["team-3"] = grantsTeam3
+
+	warmRoot := ""
+	if warm {
+		warmRoot = "warm"
+	}
+	if gen == 0 {
+		deltaPrevious = deltaCurrent // unused: no warm root in generation 0
+	}
+	d.SourceCacheGrants = map[string]*chaosconnector.SourceCacheSpec{
+		"team-1": {ScopeKey: scGenEtagScope, Validator: scGenEtagValidator, WarmRoot: warmRoot},
+		"team-2": {ScopeKey: scGenDeltaScope, Validator: deltaPrevious, WarmRoot: warmRoot},
+		"team-3": {ScopeKey: scGenZeroScope, Validator: scGenZeroValidator, WarmRoot: warmRoot},
+	}
+	d.SourceCacheEntitlements = map[string]*chaosconnector.SourceCacheSpec{
+		"team-1": {ScopeKey: scGenEntsScope, Validator: scGenEntsValidator, WarmRoot: warmRoot},
+	}
+	return d
+}
+
+// scGenScenario builds a generations-long chain of identical-content
+// epochs (plus the lossy variant of generation 1).
+func scGenScenario(t *testing.T, fx *scGenFixture, generations int) *chaosconnector.Scenario {
+	t.Helper()
+	epochs := map[string]*chaosconnector.Dataset{
+		scGenLossyEpochName: scGenEpoch(fx, 1, true),
+	}
+	for g := 0; g < generations; g++ {
+		epochs[scGenEpochName(g)] = scGenEpoch(fx, g, false)
+	}
+	scenario := &chaosconnector.Scenario{
+		Name:         "source-cache-generational",
+		Seed:         1,
+		InitialEpoch: "a",
+		Epochs:       epochs,
+	}
+	require.NoError(t, scenario.Validate())
+	return scenario
+}
+
+// scGenWarmEvents is the exact consult trace of a fully warm generation.
+// Single-worker order: the entitlements phase precedes grants, and grants
+// actions drain in reverse resource order.
+func scGenWarmEvents(deltaPrevious string) []chaosconnector.SourceCacheLookupEvent {
+	return []chaosconnector.SourceCacheLookupEvent{
+		scWarmEventFor(sourcecache.RowKindEntitlements, scGenEntsScope, scGenEntsValidator),
+		scWarmEventFor(sourcecache.RowKindGrants, scGenZeroScope, scGenZeroValidator),
+		scWarmEventFor(sourcecache.RowKindGrants, scGenDeltaScope, deltaPrevious),
+		scWarmEventFor(sourcecache.RowKindGrants, scGenEtagScope, scGenEtagValidator),
+	}
+}
+
+// scGenEntries is the expected manifest-entry map after the given
+// generation; only the delta scope's validator differs per generation.
+func scGenEntries(gen int) map[string]string {
+	_, deltaCurrent := scGenDeltaValidators(gen)
+	return map[string]string{
+		chaosoracle.KindScope(sourcecache.RowKindGrants, scGenEtagScope):       scGenEtagValidator,
+		chaosoracle.KindScope(sourcecache.RowKindGrants, scGenDeltaScope):      deltaCurrent,
+		chaosoracle.KindScope(sourcecache.RowKindGrants, scGenZeroScope):       scGenZeroValidator,
+		chaosoracle.KindScope(sourcecache.RowKindEntitlements, scGenEntsScope): scGenEntsValidator,
+	}
+}
+
+// scGenStamps is the expected stamped-row count map — identical every
+// generation; the zero-row scope never appears.
+func scGenStamps() map[string]int {
+	return map[string]int{
+		chaosoracle.KindScope(sourcecache.RowKindGrants, scGenEtagScope):       2,
+		chaosoracle.KindScope(sourcecache.RowKindGrants, scGenDeltaScope):      1,
+		chaosoracle.KindScope(sourcecache.RowKindEntitlements, scGenEntsScope): 1,
+	}
+}
+
+func TestChaosSourceCacheGenerationalSteadyState(t *testing.T) {
+	skipChaosInShort(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 120*time.Second)
+	defer cancel()
+	tmpDir, paths := sourceCachePaths(t, 4)
+	pathA, pathB, pathC, baselinePath := paths[0], paths[1], paths[2], paths[3]
+
+	fx := newSCGenFixture(t)
+	scenario := scGenScenario(t, fx, 3)
+	capability := sourceCacheCapabilityRW("gen-1", "cfg-1")
+
+	runGeneration := func(epoch, c1zPath, prevPath string) []chaosconnector.SourceCacheLookupEvent {
+		run, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+		require.NoError(t, err)
+		require.NoError(t, run.SetEpoch(epoch))
+		run.SetSourceCacheCapability(capability)
+		return runSourceCacheSync(t, ctx, run, chaosTransportDirect, c1zPath, tmpDir, prevPath, WithWorkerCount(1))
+	}
+
+	// Generation A: cold seed; all four scopes consult and miss.
+	eventsA := runGeneration("a", pathA, "")
+	requireAllColdEvents(t, eventsA, 4)
+	requireSourceCacheProduceState(t, readSourceCacheSnapshot(t, ctx, pathA, tmpDir),
+		scGenEntries(0), scGenStamps())
+
+	// Generation B: fully warm against A.
+	eventsB := runGeneration("b", pathB, pathA)
+	requireSourceCacheEvents(t, eventsB, scGenWarmEvents(scGenDeltaValidator(0)))
+	requireSourceCacheProduceState(t, readSourceCacheSnapshot(t, ctx, pathB, tmpDir),
+		scGenEntries(1), scGenStamps())
+
+	// Generation C: fully warm against B. OR5a/OR5b — the consult trace
+	// must be EXACTLY B's (modulo the rotated delta validator): any scope
+	// whose entry B failed to republish surfaces here as a miss, and any
+	// fresh fetch surfaces as a non-warm serve.
+	eventsC := runGeneration("c", pathC, pathB)
+	requireSourceCacheEvents(t, eventsC, scGenWarmEvents(scGenDeltaValidator(1)))
+	// OR5c/OR5d — manifest parity with rotation/carry provenance: entry
+	// KEYS are identical between B and C (zero-row scope included);
+	// etag/ents/zero validators carry, the delta validator rotates.
+	requireSourceCacheProduceState(t, readSourceCacheSnapshot(t, ctx, pathC, tmpDir),
+		scGenEntries(2), scGenStamps())
+
+	// OR2 — the upstream never changed, so every generation's content
+	// equals one cold baseline.
+	runGeneration("c", baselinePath, "")
+	baselineContent := readChaosLogicalContent(t, ctx, baselinePath, tmpDir)
+	for name, path := range map[string]string{"B": pathB, "C": pathC} {
+		content := readChaosLogicalContent(t, ctx, path, tmpDir)
+		require.NoErrorf(t, chaosoracle.CompareLogicalContent(baselineContent, content),
+			"generation %s must equal the cold truth of the unchanged upstream", name)
+	}
+}
+
+// TestChaosSourceCacheGenerationalLongChain extends R13's steady-state
+// chain to six generations (nightly tier): the same four scopes must stay
+// fully warm through every hop, the delta validator must rotate once per
+// generation, and the final artifact must still equal the cold truth.
+func TestChaosSourceCacheGenerationalLongChain(t *testing.T) {
+	skipChaosInShort(t)
+	testtier.RequireNightly(t)
+	const generations = 6
+	ctx, cancel := context.WithTimeout(t.Context(), 300*time.Second)
+	defer cancel()
+	tmpDir, paths := sourceCachePaths(t, generations+1)
+	baselinePath := paths[generations]
+
+	fx := newSCGenFixture(t)
+	scenario := scGenScenario(t, fx, generations)
+	capability := sourceCacheCapabilityRW("gen-1", "cfg-1")
+
+	runGeneration := func(epoch, c1zPath, prevPath string) []chaosconnector.SourceCacheLookupEvent {
+		run, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+		require.NoError(t, err)
+		require.NoError(t, run.SetEpoch(epoch))
+		run.SetSourceCacheCapability(capability)
+		return runSourceCacheSync(t, ctx, run, chaosTransportDirect, c1zPath, tmpDir, prevPath, WithWorkerCount(1))
+	}
+
+	requireAllColdEvents(t, runGeneration(scGenEpochName(0), paths[0], ""), 4)
+	for g := 1; g < generations; g++ {
+		events := runGeneration(scGenEpochName(g), paths[g], paths[g-1])
+		requireSourceCacheEvents(t, events, scGenWarmEvents(scGenDeltaValidator(g-1)))
+		requireSourceCacheProduceState(t, readSourceCacheSnapshot(t, ctx, paths[g], tmpDir),
+			scGenEntries(g), scGenStamps())
+	}
+
+	runGeneration(scGenEpochName(generations-1), baselinePath, "")
+	require.NoError(t, chaosoracle.CompareLogicalContent(
+		readChaosLogicalContent(t, ctx, baselinePath, tmpDir),
+		readChaosLogicalContent(t, ctx, paths[generations-1], tmpDir)),
+		"the final warm generation must equal the cold truth of the unchanged upstream")
+}
+
+// TestChaosSourceCacheGenerationalResumedBSeedsC pins the adversarial R13
+// cell: a routine interruption-and-resume in generation B must NOT convert
+// into a chain break — the resumed artifact publishes ingest quality
+// without the replay-blocked flag and seeds a fully warm generation C.
+func TestChaosSourceCacheGenerationalResumedBSeedsC(t *testing.T) {
+	skipChaosInShort(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 120*time.Second)
+	defer cancel()
+	tmpDir, paths := sourceCachePaths(t, 4)
+	pathA, pathB, pathC, baselinePath := paths[0], paths[1], paths[2], paths[3]
+
+	fx := newSCGenFixture(t)
+	scenario := scGenScenario(t, fx, 3)
+	capability := sourceCacheCapabilityRW("gen-1", "cfg-1")
+
+	seedRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+	require.NoError(t, err)
+	seedRun.SetSourceCacheCapability(capability)
+	requireAllColdEvents(t,
+		runSourceCacheSync(t, ctx, seedRun, chaosTransportDirect, pathA, tmpDir, "", WithWorkerCount(1)), 4)
+
+	// Generation B, interrupted at the first grants root request.
+	interruptedRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule(chaosconnector.Rule{
+		ID: "cut-first-grants-root",
+		Match: chaosconnector.Matcher{
+			Service:   chaosconnector.ExactString("GrantsService"),
+			Method:    chaosconnector.ExactString("ListGrants"),
+			PageToken: chaosconnector.ExactString(""),
+			Attempt:   1,
+			Phase:     chaosconnector.PhaseBeforeCall,
+		},
+		Effects:  []chaosconnector.Effect{{Kind: chaosconnector.EffectCrash}},
+		MinFires: 1,
+		MaxFires: 1,
+	}))
+	require.NoError(t, err)
+	require.NoError(t, interruptedRun.SetEpoch("b"))
+	interruptedRun.SetSourceCacheCapability(capability)
+	interruptedHarness := newChaosHarness(t, ctx, interruptedRun, pathB, tmpDir, chaosTransportDirect,
+		WithPreviousSyncC1ZPath(pathA), WithWorkerCount(1))
+	require.ErrorIs(t, interruptedHarness.Syncer.Sync(ctx), chaosconnector.ErrInterruptRequested)
+	require.NoError(t, interruptedHarness.Close(t.Context()))
+	require.NoError(t, interruptedRun.Runtime().VerifyRequired())
+
+	// Resume B to completion with a fresh syncer.
+	resumeRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+	require.NoError(t, err)
+	require.NoError(t, resumeRun.SetEpoch("b"))
+	resumeRun.SetSourceCacheCapability(capability)
+	runSourceCacheSync(t, ctx, resumeRun, chaosTransportDirect, pathB, tmpDir, pathA, WithWorkerCount(1))
+
+	// The routine resume must publish quality WITHOUT the replay-blocked
+	// flag — this is exactly the conservative default that must not turn
+	// resumes into generational chain breaks.
+	quality := readLifecycleIngestQuality(t, pathB)
+	require.NotNil(t, quality, "resumed sync must publish ingest quality")
+	require.False(t, quality.GetSourceCacheReplayBlocked(),
+		"a routine resume must not mark the artifact replay-blocked")
+	requireSourceCacheProduceState(t, readSourceCacheSnapshot(t, ctx, pathB, tmpDir),
+		scGenEntries(1), scGenStamps())
+
+	// Generation C over the resumed B: fully warm.
+	genCRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+	require.NoError(t, err)
+	require.NoError(t, genCRun.SetEpoch("c"))
+	genCRun.SetSourceCacheCapability(capability)
+	eventsC := runSourceCacheSync(t, ctx, genCRun, chaosTransportDirect, pathC, tmpDir, pathB, WithWorkerCount(1))
+	requireSourceCacheEvents(t, eventsC, scGenWarmEvents(scGenDeltaValidator(1)))
+	requireSourceCacheProduceState(t, readSourceCacheSnapshot(t, ctx, pathC, tmpDir),
+		scGenEntries(2), scGenStamps())
+
+	baselineRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+	require.NoError(t, err)
+	require.NoError(t, baselineRun.SetEpoch("c"))
+	baselineRun.SetSourceCacheCapability(capability)
+	runSourceCacheSync(t, ctx, baselineRun, chaosTransportDirect, baselinePath, tmpDir, "", WithWorkerCount(1))
+	require.NoError(t, chaosoracle.CompareLogicalContent(
+		readChaosLogicalContent(t, ctx, baselinePath, tmpDir),
+		readChaosLogicalContent(t, ctx, pathC, tmpDir)),
+		"generation C over a resumed B must equal the cold truth")
+}
+
+// TestChaosSourceCacheGenerationalQualityLossBlocksC pins the second
+// adversarial R13 cell: generation B suffers GENUINE quality loss (a
+// dropped entitlement under the skip-report policy), so its artifact is
+// marked replay-blocked and generation C must go fully cold — loudly
+// consulted and missed, never silently blended.
+func TestChaosSourceCacheGenerationalQualityLossBlocksC(t *testing.T) {
+	skipChaosInShort(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 120*time.Second)
+	defer cancel()
+	tmpDir, paths := sourceCachePaths(t, 4)
+	pathA, pathB, pathC, baselinePath := paths[0], paths[1], paths[2], paths[3]
+
+	fx := newSCGenFixture(t)
+	scenario := scGenScenario(t, fx, 3)
+	capability := sourceCacheCapabilityRW("gen-1", "cfg-1")
+
+	seedRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+	require.NoError(t, err)
+	seedRun.SetSourceCacheCapability(capability)
+	requireAllColdEvents(t,
+		runSourceCacheSync(t, ctx, seedRun, chaosTransportDirect, pathA, tmpDir, "", WithWorkerCount(1)), 4)
+
+	// Generation B against the lossy epoch: warm for the annotated scopes,
+	// but the ghost entitlement is dropped and the artifact is marked
+	// replay-blocked.
+	lossyRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+	require.NoError(t, err)
+	require.NoError(t, lossyRun.SetEpoch(scGenLossyEpochName))
+	lossyRun.SetSourceCacheCapability(capability)
+	eventsB := runSourceCacheSync(t, ctx, lossyRun, chaosTransportDirect, pathB, tmpDir, pathA, WithWorkerCount(1))
+	requireSourceCacheEvents(t, eventsB, scGenWarmEvents(scGenDeltaValidator(0)))
+	quality := readLifecycleIngestQuality(t, pathB)
+	require.NotNil(t, quality)
+	require.True(t, quality.GetSourceCacheReplayBlocked(),
+		"vacuity guard: the lossy generation must actually be replay-blocked")
+
+	// Generation C: the consume-side quality gate rejects B's artifact —
+	// every scope consults and misses, and the sync refetches cold.
+	genCRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+	require.NoError(t, err)
+	require.NoError(t, genCRun.SetEpoch("c"))
+	genCRun.SetSourceCacheCapability(capability)
+	eventsC := runSourceCacheSync(t, ctx, genCRun, chaosTransportDirect, pathC, tmpDir, pathB, WithWorkerCount(1))
+	requireAllColdEvents(t, eventsC, 4)
+	requireSourceCacheProduceState(t, readSourceCacheSnapshot(t, ctx, pathC, tmpDir),
+		scGenEntries(2), scGenStamps())
+
+	baselineRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+	require.NoError(t, err)
+	require.NoError(t, baselineRun.SetEpoch("c"))
+	baselineRun.SetSourceCacheCapability(capability)
+	runSourceCacheSync(t, ctx, baselineRun, chaosTransportDirect, baselinePath, tmpDir, "", WithWorkerCount(1))
+	require.NoError(t, chaosoracle.CompareLogicalContent(
+		readChaosLogicalContent(t, ctx, baselinePath, tmpDir),
+		readChaosLogicalContent(t, ctx, pathC, tmpDir)),
+		"the blocked generation must refetch to the cold truth")
+}

--- a/pkg/sync/chaos_source_cache_harness_test.go
+++ b/pkg/sync/chaos_source_cache_harness_test.go
@@ -1,0 +1,226 @@
+package sync //nolint:revive,nolintlint // backwards-compatible package name
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/conductorone/baton-sdk/internal/chaosconnector"
+	chaosoracle "github.com/conductorone/baton-sdk/internal/chaosconnector/oracle"
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
+	"github.com/conductorone/baton-sdk/pkg/sourcecache"
+	et "github.com/conductorone/baton-sdk/pkg/types/entitlement"
+	gt "github.com/conductorone/baton-sdk/pkg/types/grant"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+)
+
+// Shared fixtures for the Phase 6b source-cache chaos suites
+// (chaos_source_cache_*_test.go; plan docs/verification/sync-replay-6b/
+// plan.md). The reference scenario is one team whose grants scope opts into
+// source-cache: the cold branch serves fresh grants tagged with
+// SourceCacheRecord, the warm branch serves a zero-row SourceCacheReplay.
+
+const (
+	scTeamTypeID = "sc-team"
+	scUserTypeID = "sc-user"
+
+	scGrantsScopeKey = "grants:team-1"
+	scValidatorV1    = "validator-v1"
+)
+
+// scFixture bundles the deterministic protos the scenario builders share.
+type scFixture struct {
+	TeamType *v2.ResourceType
+	UserType *v2.ResourceType
+	Team     *v2.Resource
+	Users    []*v2.Resource
+	Member   *v2.Entitlement
+	Grants   []*v2.Grant
+}
+
+func newSourceCacheFixture(t *testing.T) *scFixture {
+	t.Helper()
+	teamType := v2.ResourceType_builder{
+		Id:          scTeamTypeID,
+		DisplayName: "SC Team",
+		Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_GROUP},
+	}.Build()
+	userType := v2.ResourceType_builder{
+		Id:          scUserTypeID,
+		DisplayName: "SC User",
+		Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_USER},
+		Annotations: annotations.New(&v2.SkipEntitlementsAndGrants{}),
+	}.Build()
+
+	team, err := rs.NewGroupResource("Team 1", teamType, "team-1", nil)
+	require.NoError(t, err)
+	user1, err := rs.NewUserResource("User 1", userType, "user-1", nil)
+	require.NoError(t, err)
+	user2, err := rs.NewUserResource("User 2", userType, "user-2", nil)
+	require.NoError(t, err)
+
+	member := et.NewEntitlement(team, "member", "assignment")
+	return &scFixture{
+		TeamType: teamType,
+		UserType: userType,
+		Team:     team,
+		Users:    []*v2.Resource{user1, user2},
+		Member:   member,
+		Grants: []*v2.Grant{
+			gt.NewGrant(team, "member", user1),
+			gt.NewGrant(team, "member", user2),
+		},
+	}
+}
+
+// newSourceCacheScenario builds the reference scenario: a single epoch
+// where team-1's grants scope declares source-cache behavior. The cold
+// root serves the fixture grants with a SourceCacheRecord; the warm root
+// serves zero rows with a non-overlay SourceCacheReplay.
+func newSourceCacheScenario(t *testing.T, fixture *scFixture) *chaosconnector.Scenario {
+	t.Helper()
+	scenario := &chaosconnector.Scenario{
+		Name:         "source-cache-reference",
+		Seed:         1,
+		InitialEpoch: "initial",
+		Epochs: map[string]*chaosconnector.Dataset{
+			"initial": newSourceCacheDataset(fixture),
+		},
+	}
+	require.NoError(t, scenario.Validate())
+	return scenario
+}
+
+// newSourceCacheDataset builds the reference epoch dataset. Callers mutate
+// the returned dataset for adversarial variants before NewRun clones it.
+func newSourceCacheDataset(fixture *scFixture) *chaosconnector.Dataset {
+	return &chaosconnector.Dataset{
+		ResourceTypes: []*v2.ResourceType{fixture.TeamType, fixture.UserType},
+		Resources: map[string]chaosconnector.Pages[*v2.Resource]{
+			scTeamTypeID: {"": {List: []*v2.Resource{fixture.Team}}},
+			scUserTypeID: {"": {List: fixture.Users}},
+		},
+		StaticEntitlements: map[string]chaosconnector.Pages[*v2.Entitlement]{
+			scTeamTypeID: {"": {}},
+			scUserTypeID: {"": {}},
+		},
+		Entitlements: map[string]chaosconnector.Pages[*v2.Entitlement]{
+			"team-1": {"": {List: []*v2.Entitlement{fixture.Member}}},
+		},
+		Grants: map[string]chaosconnector.Pages[*v2.Grant]{
+			"team-1": {
+				"": {
+					List: fixture.Grants,
+					Annotations: annotations.New(v2.SourceCacheRecord_builder{
+						ScopeKey:       scGrantsScopeKey,
+						CacheValidator: scValidatorV1,
+					}.Build()),
+				},
+				"warm": {
+					Annotations: annotations.New(v2.SourceCacheReplay_builder{
+						ScopeKey:       scGrantsScopeKey,
+						CacheValidator: scValidatorV1,
+					}.Build()),
+				},
+			},
+		},
+		SourceCacheGrants: map[string]*chaosconnector.SourceCacheSpec{
+			"team-1": {
+				ScopeKey:  scGrantsScopeKey,
+				Validator: scValidatorV1,
+				WarmRoot:  "warm",
+			},
+		},
+	}
+}
+
+// sourceCacheCapabilityRW builds a MODE_READ_WRITE capability.
+func sourceCacheCapabilityRW(cacheGeneration, configFingerprint string) *v2.SourceCacheCapability {
+	return v2.SourceCacheCapability_builder{
+		Mode:              v2.SourceCacheCapability_MODE_READ_WRITE,
+		CacheGeneration:   cacheGeneration,
+		ConfigFingerprint: configFingerprint,
+	}.Build()
+}
+
+// runSourceCacheSync runs one full sync of the run into c1zPath and returns
+// the connector-side lookup events observed during it. prevPath, when
+// non-empty, arms WithPreviousSyncC1ZPath.
+func runSourceCacheSync(
+	t *testing.T,
+	ctx context.Context,
+	run *chaosconnector.Run,
+	transport chaosTransport,
+	c1zPath string,
+	tmpDir string,
+	prevPath string,
+	opts ...SyncOpt,
+) []chaosconnector.SourceCacheLookupEvent {
+	t.Helper()
+	run.ResetSourceCacheLookupEvents()
+	if prevPath != "" {
+		opts = append(opts, WithPreviousSyncC1ZPath(prevPath))
+	}
+	h := newChaosHarness(t, ctx, run, c1zPath, tmpDir, transport, opts...)
+	h.SyncAndClose(t, ctx)
+	return run.SourceCacheLookupEvents()
+}
+
+// readSourceCacheSnapshot reads a sealed artifact's source-cache surfaces.
+func readSourceCacheSnapshot(
+	t *testing.T,
+	ctx context.Context,
+	path string,
+	tmpDir string,
+) chaosoracle.SourceCacheSnapshot {
+	t.Helper()
+	store, err := dotc1z.NewStore(
+		ctx,
+		path,
+		dotc1z.WithEngine(c1zstore.EnginePebble),
+		dotc1z.WithTmpDir(tmpDir),
+		dotc1z.WithReadOnly(true),
+	)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, store.Close(ctx)) }()
+	snapshot, err := chaosoracle.ReadSourceCacheSnapshot(ctx, store)
+	require.NoError(t, err)
+	return snapshot
+}
+
+// requireSourceCacheEvents asserts the connector-side lookup events match
+// expectations exactly, in serve order, and that no event violates the R1
+// contract (nil lookup, lookup error surfaced to the connector).
+func requireSourceCacheEvents(
+	t *testing.T,
+	events []chaosconnector.SourceCacheLookupEvent,
+	expected []chaosconnector.SourceCacheLookupEvent,
+) {
+	t.Helper()
+	for i, event := range events {
+		require.Falsef(t, event.LookupWasNil, "event %d: SyncOpAttrs.Lookup was nil (contract: NoopLookup substitutes)", i)
+		require.Emptyf(t, event.LookupError, "event %d: lookup surfaced an error to the connector (contract: internal errors read as misses)", i)
+	}
+	require.Equal(t, expected, events)
+}
+
+// grantsKindScope is the snapshot key of the reference grants scope.
+func grantsKindScope() string {
+	return chaosoracle.KindScope(sourcecache.RowKindGrants, scGrantsScopeKey)
+}
+
+// sourceCachePaths allocates the per-generation c1z paths for a chain test.
+func sourceCachePaths(t *testing.T, generations int) (string, []string) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	out := make([]string, generations)
+	for i := range out {
+		out[i] = filepath.Join(tmpDir, "gen-"+string(rune('a'+i))+".c1z")
+	}
+	return tmpDir, out
+}

--- a/pkg/sync/chaos_source_cache_order_test.go
+++ b/pkg/sync/chaos_source_cache_order_test.go
@@ -1,0 +1,320 @@
+package sync //nolint:revive,nolintlint // backwards-compatible package name
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+
+	"github.com/conductorone/baton-sdk/internal/chaosconnector"
+	chaosoracle "github.com/conductorone/baton-sdk/internal/chaosconnector/oracle"
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/sourcecache"
+)
+
+// Phase 6b ordering/pagination adversary suite (plan R12, oracles OR2 +
+// OR1 + OR3): retries, lost responses, epoch drift between retries, and
+// duplicate replay cursors must all preserve equivalence with the cold
+// truth of whatever epoch ultimately answered.
+func TestChaosSourceCacheOrderingAdversary(t *testing.T) {
+	skipChaosInShort(t)
+
+	warmMatchedV1 := scWarmEventFor(sourcecache.RowKindGrants, scGrantsScopeKey, scValidatorV1)
+
+	cells := []struct {
+		name string
+		// epochs builds the scenario's epoch map; generation B always
+		// starts in "second".
+		epochs func(fx *scCollectionFixture) map[string]*chaosconnector.Dataset
+		// schedule is generation B's fault program.
+		schedule chaosconnector.Schedule
+		// baselineEpoch is the epoch whose independent cold sync is the
+		// OR2 truth for generation B's final artifact.
+		baselineEpoch string
+		wantEvents    []chaosconnector.SourceCacheLookupEvent
+	}{
+		{
+			// A lost response on the warm root: the connector served the
+			// warm page (consult hit, warm decision made) but the syncer
+			// never saw it. The retry re-consults — the warm branch must
+			// not be "burned" by a response that never landed — and the
+			// replay round completes normally on attempt two.
+			name: "lost-response-reconsults",
+			epochs: func(fx *scCollectionFixture) map[string]*chaosconnector.Dataset {
+				allThree := []*v2.Grant{fx.Grants[0], fx.Grants[1], fx.Grant3}
+				seed := scCollectionBase(fx)
+				seed.Grants["team-1"] = chaosconnector.Pages[*v2.Grant]{
+					"": {List: fx.Grants, Annotations: scRecordAnno(scGrantsScopeKey, scValidatorV1)},
+				}
+				seed.SourceCacheGrants = map[string]*chaosconnector.SourceCacheSpec{
+					"team-1": {ScopeKey: scGrantsScopeKey, Validator: scValidatorV1},
+				}
+				second := scCollectionBase(fx)
+				second.Grants["team-1"] = chaosconnector.Pages[*v2.Grant]{
+					"": {List: allThree, Annotations: scRecordAnno(scGrantsScopeKey, scValidatorV2)},
+					"warm": {
+						List:        []*v2.Grant{fx.Grant3},
+						Annotations: scReplayAnno(scGrantsScopeKey, scValidatorV2, true, nil, nil),
+					},
+				}
+				second.SourceCacheGrants = map[string]*chaosconnector.SourceCacheSpec{
+					"team-1": {ScopeKey: scGrantsScopeKey, Validator: scValidatorV1, WarmRoot: "warm"},
+				}
+				return map[string]*chaosconnector.Dataset{"seed": seed, "second": second}
+			},
+			schedule: chaosconnector.NewSchedule(chaosconnector.Rule{
+				ID: "lose-warm-root",
+				Match: chaosconnector.Matcher{
+					Service:   chaosconnector.ExactString("GrantsService"),
+					Method:    chaosconnector.ExactString("ListGrants"),
+					PageToken: chaosconnector.ExactString(""),
+					Attempt:   1,
+					Phase:     chaosconnector.PhaseAfterDelegate,
+				},
+				Effects: []chaosconnector.Effect{{
+					Kind:    chaosconnector.EffectLoseResponse,
+					Code:    codes.Unavailable,
+					Message: "warm root lost after delegate",
+				}},
+				MinFires: 1,
+				MaxFires: 1,
+			}),
+			baselineEpoch: "second",
+			wantEvents: []chaosconnector.SourceCacheLookupEvent{
+				warmMatchedV1,
+				warmMatchedV1,
+			},
+		},
+		{
+			// Epoch drift between retries (the temporal-corpus shape
+			// composed with replay): attempt one answers warm from the
+			// "second" epoch but the response is lost and the upstream
+			// moves to "drift", whose validator no longer matches the
+			// stored entry. The retry's consult must re-decide — stale,
+			// fresh fetch — and the artifact must equal the DRIFT epoch's
+			// cold truth, never a blend of both answers.
+			name: "epoch-drift-between-retries",
+			epochs: func(fx *scCollectionFixture) map[string]*chaosconnector.Dataset {
+				allThree := []*v2.Grant{fx.Grants[0], fx.Grants[1], fx.Grant3}
+				seed := scCollectionBase(fx)
+				seed.Grants["team-1"] = chaosconnector.Pages[*v2.Grant]{
+					"": {List: fx.Grants, Annotations: scRecordAnno(scGrantsScopeKey, scValidatorV1)},
+				}
+				seed.SourceCacheGrants = map[string]*chaosconnector.SourceCacheSpec{
+					"team-1": {ScopeKey: scGrantsScopeKey, Validator: scValidatorV1},
+				}
+				second := scCollectionBase(fx)
+				second.Grants["team-1"] = chaosconnector.Pages[*v2.Grant]{
+					"": {List: fx.Grants, Annotations: scRecordAnno(scGrantsScopeKey, scValidatorV1)},
+					"warm": {
+						Annotations: scReplayAnno(scGrantsScopeKey, scValidatorV1, false, nil, nil),
+					},
+				}
+				second.SourceCacheGrants = map[string]*chaosconnector.SourceCacheSpec{
+					"team-1": {ScopeKey: scGrantsScopeKey, Validator: scValidatorV1, WarmRoot: "warm"},
+				}
+				drift := scCollectionBase(fx)
+				drift.Grants["team-1"] = chaosconnector.Pages[*v2.Grant]{
+					"": {List: allThree, Annotations: scRecordAnno(scGrantsScopeKey, scValidatorV2)},
+					"warm": {
+						Annotations: scReplayAnno(scGrantsScopeKey, scValidatorV1, false, nil, nil),
+					},
+				}
+				drift.SourceCacheGrants = map[string]*chaosconnector.SourceCacheSpec{
+					"team-1": {ScopeKey: scGrantsScopeKey, Validator: scValidatorV2, WarmRoot: "warm"},
+				}
+				return map[string]*chaosconnector.Dataset{"seed": seed, "second": second, "drift": drift}
+			},
+			schedule: chaosconnector.NewSchedule(chaosconnector.Rule{
+				ID: "drift-between-retries",
+				Match: chaosconnector.Matcher{
+					Service:   chaosconnector.ExactString("GrantsService"),
+					Method:    chaosconnector.ExactString("ListGrants"),
+					PageToken: chaosconnector.ExactString(""),
+					Attempt:   1,
+					Phase:     chaosconnector.PhaseAfterDelegate,
+				},
+				Effects: []chaosconnector.Effect{
+					{Kind: chaosconnector.EffectSetEpoch, Epoch: "drift"},
+					{Kind: chaosconnector.EffectLoseResponse, Code: codes.Unavailable, Message: "first answer lost"},
+				},
+				MinFires: 1,
+				MaxFires: 1,
+			}),
+			baselineEpoch: "drift",
+			wantEvents: []chaosconnector.SourceCacheLookupEvent{
+				warmMatchedV1,
+				{
+					RowKind:           sourcecache.RowKindGrants,
+					ScopeKey:          scGrantsScopeKey,
+					Hit:               true,
+					PreviousValidator: scValidatorV1,
+					Matched:           false,
+				},
+			},
+		},
+		{
+			// Duplicate replay annotations across SPAWNED cursors: the warm
+			// root fans out two extra cursors that each carry another
+			// replay annotation for the same scope. The copy must run only
+			// once (a second replacement copy would wipe the overlay
+			// upsert g3, which OR2 catches), and the last replay page's
+			// validator wins the manifest entry.
+			name: "spawned-duplicate-replay-cursors",
+			epochs: func(fx *scCollectionFixture) map[string]*chaosconnector.Dataset {
+				allThree := []*v2.Grant{fx.Grants[0], fx.Grants[1], fx.Grant3}
+				seed := scCollectionBase(fx)
+				seed.Grants["team-1"] = chaosconnector.Pages[*v2.Grant]{
+					"": {List: fx.Grants, Annotations: scRecordAnno(scGrantsScopeKey, scValidatorV1)},
+				}
+				seed.SourceCacheGrants = map[string]*chaosconnector.SourceCacheSpec{
+					"team-1": {ScopeKey: scGrantsScopeKey, Validator: scValidatorV1},
+				}
+				second := scCollectionBase(fx)
+				second.Grants["team-1"] = chaosconnector.Pages[*v2.Grant]{
+					"": {List: allThree, Annotations: scRecordAnno(scGrantsScopeKey, scValidatorV2)},
+					"warm": {
+						List:        []*v2.Grant{fx.Grant3},
+						Annotations: scReplayAnno(scGrantsScopeKey, "", true, nil, nil),
+						Spawn:       []string{"dup-a", "dup-b"},
+					},
+					"dup-a": {Annotations: scReplayAnno(scGrantsScopeKey, "", true, nil, nil)},
+					"dup-b": {Annotations: scReplayAnno(scGrantsScopeKey, scValidatorV2, true, nil, nil)},
+				}
+				second.SourceCacheGrants = map[string]*chaosconnector.SourceCacheSpec{
+					"team-1": {ScopeKey: scGrantsScopeKey, Validator: scValidatorV1, WarmRoot: "warm"},
+				}
+				return map[string]*chaosconnector.Dataset{"seed": seed, "second": second}
+			},
+			schedule:      chaosconnector.NewSchedule(),
+			baselineEpoch: "second",
+			wantEvents:    []chaosconnector.SourceCacheLookupEvent{warmMatchedV1},
+		},
+	}
+
+	for _, tc := range cells {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), 90*time.Second)
+			defer cancel()
+			tmpDir, paths := sourceCachePaths(t, 3)
+			seedPath, warmPath, baselinePath := paths[0], paths[1], paths[2]
+
+			fx := newSCCollectionFixture(t)
+			scenario := &chaosconnector.Scenario{
+				Name:         "source-cache-ordering-" + tc.name,
+				Seed:         1,
+				InitialEpoch: "seed",
+				Epochs:       tc.epochs(fx),
+			}
+			require.NoError(t, scenario.Validate())
+			capability := sourceCacheCapabilityRW("gen-1", "cfg-1")
+
+			seedRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+			require.NoError(t, err)
+			seedRun.SetSourceCacheCapability(capability)
+			seedEvents := runSourceCacheSync(t, ctx, seedRun, chaosTransportDirect, seedPath, tmpDir, "", WithWorkerCount(1))
+			requireAllColdEvents(t, seedEvents, 1)
+
+			// Generation B under the adversarial schedule.
+			warmRun, err := chaosconnector.NewRun(scenario, tc.schedule)
+			require.NoError(t, err)
+			require.NoError(t, warmRun.SetEpoch("second"))
+			warmRun.SetSourceCacheCapability(capability)
+			warmEvents := runSourceCacheSync(t, ctx, warmRun, chaosTransportDirect, warmPath, tmpDir, seedPath, WithWorkerCount(1))
+			requireSourceCacheEvents(t, warmEvents, tc.wantEvents)
+
+			// OR2 against the cold truth of the answering epoch.
+			baselineRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+			require.NoError(t, err)
+			require.NoError(t, baselineRun.SetEpoch(tc.baselineEpoch))
+			baselineRun.SetSourceCacheCapability(capability)
+			runSourceCacheSync(t, ctx, baselineRun, chaosTransportDirect, baselinePath, tmpDir, "", WithWorkerCount(1))
+			warmContent := readChaosLogicalContent(t, ctx, warmPath, tmpDir)
+			baselineContent := readChaosLogicalContent(t, ctx, baselinePath, tmpDir)
+			require.NoError(t, chaosoracle.CompareLogicalContent(baselineContent, warmContent),
+				"adversarial sync must equal the answering epoch's cold truth")
+
+			// OR3: every cell ends at validator v2 over exactly 3 stamped
+			// rows regardless of the path taken to get there.
+			requireSourceCacheProduceState(t, readSourceCacheSnapshot(t, ctx, warmPath, tmpDir),
+				map[string]string{grantsKindScope(): scValidatorV2},
+				map[string]int{grantsKindScope(): 3})
+		})
+	}
+}
+
+// TestChaosSourceCacheDuplicateReplayCursorsParallel re-runs the
+// spawned-duplicate-replay-cursors shape at WithWorkerCount(4) (CO-6b-003):
+// the once-per-scope replay guard is a decide-copy-mark sequence that must
+// stay atomic when duplicate replay cursors drain on CONCURRENT workers — a
+// second replacement copy racing past the guard would wipe the overlay
+// upsert g3, which the OR2 differential catches. Run under -race in the
+// focused race gate.
+func TestChaosSourceCacheDuplicateReplayCursorsParallel(t *testing.T) {
+	skipChaosInShort(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 90*time.Second)
+	defer cancel()
+	tmpDir, paths := sourceCachePaths(t, 3)
+	seedPath, warmPath, baselinePath := paths[0], paths[1], paths[2]
+
+	fx := newSCCollectionFixture(t)
+	allThree := []*v2.Grant{fx.Grants[0], fx.Grants[1], fx.Grant3}
+	seed := scCollectionBase(fx)
+	seed.Grants["team-1"] = chaosconnector.Pages[*v2.Grant]{
+		"": {List: fx.Grants, Annotations: scRecordAnno(scGrantsScopeKey, scValidatorV1)},
+	}
+	seed.SourceCacheGrants = map[string]*chaosconnector.SourceCacheSpec{
+		"team-1": {ScopeKey: scGrantsScopeKey, Validator: scValidatorV1},
+	}
+	second := scCollectionBase(fx)
+	second.Grants["team-1"] = chaosconnector.Pages[*v2.Grant]{
+		"": {List: allThree, Annotations: scRecordAnno(scGrantsScopeKey, scValidatorV2)},
+		"warm": {
+			List:        []*v2.Grant{fx.Grant3},
+			Annotations: scReplayAnno(scGrantsScopeKey, "", true, nil, nil),
+			Spawn:       []string{"dup-a", "dup-b"},
+		},
+		"dup-a": {Annotations: scReplayAnno(scGrantsScopeKey, "", true, nil, nil)},
+		"dup-b": {Annotations: scReplayAnno(scGrantsScopeKey, scValidatorV2, true, nil, nil)},
+	}
+	second.SourceCacheGrants = map[string]*chaosconnector.SourceCacheSpec{
+		"team-1": {ScopeKey: scGrantsScopeKey, Validator: scValidatorV1, WarmRoot: "warm"},
+	}
+	scenario := &chaosconnector.Scenario{
+		Name:         "source-cache-duplicate-replay-parallel",
+		Seed:         1,
+		InitialEpoch: "seed",
+		Epochs:       map[string]*chaosconnector.Dataset{"seed": seed, "second": second},
+	}
+	require.NoError(t, scenario.Validate())
+	capability := sourceCacheCapabilityRW("gen-1", "cfg-1")
+
+	seedRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+	require.NoError(t, err)
+	seedRun.SetSourceCacheCapability(capability)
+	requireAllColdEvents(t,
+		runSourceCacheSync(t, ctx, seedRun, chaosTransportDirect, seedPath, tmpDir, "", WithWorkerCount(1)), 1)
+
+	warmRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+	require.NoError(t, err)
+	require.NoError(t, warmRun.SetEpoch("second"))
+	warmRun.SetSourceCacheCapability(capability)
+	warmEvents := runSourceCacheSync(t, ctx, warmRun, chaosTransportDirect, warmPath, tmpDir, seedPath, WithWorkerCount(4))
+	requireSourceCacheEvents(t, warmEvents,
+		[]chaosconnector.SourceCacheLookupEvent{scWarmEventFor(sourcecache.RowKindGrants, scGrantsScopeKey, scValidatorV1)})
+
+	baselineRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+	require.NoError(t, err)
+	require.NoError(t, baselineRun.SetEpoch("second"))
+	baselineRun.SetSourceCacheCapability(capability)
+	runSourceCacheSync(t, ctx, baselineRun, chaosTransportDirect, baselinePath, tmpDir, "", WithWorkerCount(1))
+	require.NoError(t, chaosoracle.CompareLogicalContent(
+		readChaosLogicalContent(t, ctx, baselinePath, tmpDir),
+		readChaosLogicalContent(t, ctx, warmPath, tmpDir)),
+		"parallel duplicate replay cursors must equal the cold truth (a second replacement copy would wipe g3)")
+	requireSourceCacheProduceState(t, readSourceCacheSnapshot(t, ctx, warmPath, tmpDir),
+		map[string]string{grantsKindScope(): scValidatorV2},
+		map[string]int{grantsKindScope(): 3})
+}

--- a/pkg/sync/chaos_source_cache_resume_test.go
+++ b/pkg/sync/chaos_source_cache_resume_test.go
@@ -1,0 +1,726 @@
+package sync //nolint:revive,nolintlint // backwards-compatible package name
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/conductorone/baton-sdk/internal/chaosconnector"
+	chaosoracle "github.com/conductorone/baton-sdk/internal/chaosconnector/oracle"
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
+	"github.com/conductorone/baton-sdk/pkg/sourcecache"
+	et "github.com/conductorone/baton-sdk/pkg/types/entitlement"
+	gt "github.com/conductorone/baton-sdk/pkg/types/grant"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+	"github.com/conductorone/baton-sdk/pkg/types/sessions"
+)
+
+// Phase 6b interruption/resume suite (plan R11 + R8's cross-process resume,
+// oracles OR6 + OR2 + OR3): a warm sync is cut at a connector-call seam,
+// then resumed by a NEW syncer instance over the checkpointed state (the
+// cross-process shape). Every cell must converge to the independent cold
+// baseline. The suite also pins the resume granularity it discovered: an
+// interrupted paginated action restarts from its ROOT token (mid-chain
+// tokens are not resume points), so replay processing is at-least-once.
+// CORRECTED by the sync-trace audit (chaos_trace_oracle_test.go): for a
+// mid-chain cut the replayed-set does NOT restore — checkpoints commit at
+// batch boundaries and the page chain runs inside one batch, so the
+// resume re-runs the replay copy regardless of checkpoint cadence. The
+// guard for the re-run is the copy's own replacement idempotence (B5);
+// the replayed-set's skip role is WITHIN-attempt (a later replay
+// annotation for an already-copied scope skips, e.g. warm-2 below).
+
+// withExpandGrants re-enables grant expansion (the shared chaos harness
+// disables it by default).
+func withExpandGrants() SyncOpt {
+	return func(s *syncer) { s.dontExpandGrants = false }
+}
+
+// grantsTraceHas reports whether the run's fault trace saw a ListGrants
+// request for the given page token finish with the given outcome.
+func grantsTraceHas(run *chaosconnector.Run, pageToken string, outcome chaosconnector.Outcome) bool {
+	for _, event := range run.Trace().Events() {
+		if event.Operation.Method == "ListGrants" &&
+			event.Operation.PageToken == pageToken &&
+			event.Outcome == outcome {
+			return true
+		}
+	}
+	return false
+}
+
+// scResumeScenario: seed epoch serves [g1, g2] fresh at v1. Second epoch's
+// truth is all three grants at v2; its warm branch is a two-page delta
+// round — page one replays with an overlay upsert (g3), page two carries a
+// second replay annotation for the same scope and publishes v2.
+func scResumeScenario(t *testing.T, fx *scCollectionFixture) *chaosconnector.Scenario {
+	t.Helper()
+	allThree := []*v2.Grant{fx.Grants[0], fx.Grants[1], fx.Grant3}
+	seed := scCollectionBase(fx)
+	seed.Grants["team-1"] = chaosconnector.Pages[*v2.Grant]{
+		"": {List: fx.Grants, Annotations: scRecordAnno(scGrantsScopeKey, scValidatorV1)},
+	}
+	seed.SourceCacheGrants = map[string]*chaosconnector.SourceCacheSpec{
+		"team-1": {ScopeKey: scGrantsScopeKey, Validator: scValidatorV1},
+	}
+	second := scCollectionBase(fx)
+	second.Grants["team-1"] = chaosconnector.Pages[*v2.Grant]{
+		"": {List: allThree, Annotations: scRecordAnno(scGrantsScopeKey, scValidatorV2)},
+		"warm": {
+			List:        []*v2.Grant{fx.Grant3},
+			Annotations: scReplayAnno(scGrantsScopeKey, "", true, nil, nil),
+			Next:        "warm-2",
+		},
+		"warm-2": {Annotations: scReplayAnno(scGrantsScopeKey, scValidatorV2, true, nil, nil)},
+	}
+	second.SourceCacheGrants = map[string]*chaosconnector.SourceCacheSpec{
+		"team-1": {ScopeKey: scGrantsScopeKey, Validator: scValidatorV1, WarmRoot: "warm"},
+	}
+	scenario := &chaosconnector.Scenario{
+		Name:         "source-cache-resume",
+		Seed:         1,
+		InitialEpoch: "seed",
+		Epochs:       map[string]*chaosconnector.Dataset{"seed": seed, "second": second},
+	}
+	require.NoError(t, scenario.Validate())
+	return scenario
+}
+
+// scValidatorV3 is the "upstream moved between attempts" validator for
+// the flip scenario below.
+const scValidatorV3 = "validator-v3"
+
+// scFlipScenario extends scResumeScenario with a third epoch: upstream
+// truth moves to [g1, g3] at v3 (g2 departs). A consult offering the
+// seed's v1 misses against it, so the connector serves a fresh RECORD
+// round instead of the warm branch — the verdict-flip path.
+func scFlipScenario(t *testing.T, fx *scCollectionFixture) *chaosconnector.Scenario {
+	t.Helper()
+	scenario := scResumeScenario(t, fx)
+	third := scCollectionBase(fx)
+	third.Grants["team-1"] = chaosconnector.Pages[*v2.Grant]{
+		"": {List: []*v2.Grant{fx.Grants[0], fx.Grant3}, Annotations: scRecordAnno(scGrantsScopeKey, scValidatorV3)},
+	}
+	third.SourceCacheGrants = map[string]*chaosconnector.SourceCacheSpec{
+		"team-1": {ScopeKey: scGrantsScopeKey, Validator: scValidatorV3},
+	}
+	scenario.Epochs["third"] = third
+	require.NoError(t, scenario.Validate())
+	return scenario
+}
+
+// TestChaosSourceCacheRecordFlipOverReplayDebris is the Go-side witness
+// for the formal model's phantom-union family (walker calibration
+// scenario 1, tc1c flavor; see formal/walker/CALIBRATION.md): a warm
+// replay round is cut AFTER its copy commits but BEFORE its validator
+// publishes, upstream moves between attempts, and the resume's consult
+// misses — so the connector flips to a fresh RECORD round. The record
+// round is a replacement listing: it must not compose with the crashed
+// attempt's copied debris. Without record-round grounding the sealed
+// artifact is the union {g1, g2, g3} published under v3 — g2 departed
+// upstream before the record round ran, and the v3 manifest entry
+// launders it into every future warm sync (the non-self-healing
+// direction: the next consult validates v3 clean and replays the
+// mosaic forward).
+func TestChaosSourceCacheRecordFlipOverReplayDebris(t *testing.T) {
+	skipChaosInShort(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 90*time.Second)
+	defer cancel()
+	tmpDir, paths := sourceCachePaths(t, 2)
+	seedPath, warmPath := paths[0], paths[1]
+
+	fx := newSCCollectionFixture(t)
+	scenario := scFlipScenario(t, fx)
+	capability := sourceCacheCapabilityRW("gen-1", "cfg-1")
+
+	// Generation A: cold seed of [g1, g2] at v1.
+	seedRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+	require.NoError(t, err)
+	seedRun.SetSourceCacheCapability(capability)
+	runSourceCacheSync(t, ctx, seedRun, chaosTransportDirect, seedPath, tmpDir, "", WithWorkerCount(1))
+
+	// Generation B, attempt 1: warm sync at epoch "second", cut before
+	// "warm-2" — the replay copy of [g1, g2] and the g3 overlay commit,
+	// the validator never publishes (same premise as the interrupted
+	// trace fixture).
+	interruptedRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule(chaosconnector.Rule{
+		ID: "cut",
+		Match: chaosconnector.Matcher{
+			Service:   chaosconnector.ExactString("GrantsService"),
+			Method:    chaosconnector.ExactString("ListGrants"),
+			PageToken: chaosconnector.ExactString("warm-2"),
+			Attempt:   1,
+			Phase:     chaosconnector.PhaseBeforeCall,
+		},
+		Effects:  []chaosconnector.Effect{{Kind: chaosconnector.EffectCrash}},
+		MinFires: 1,
+		MaxFires: 1,
+	}))
+	require.NoError(t, err)
+	require.NoError(t, interruptedRun.SetEpoch("second"))
+	interruptedRun.SetSourceCacheCapability(capability)
+	interruptedHarness := newChaosHarness(t, ctx, interruptedRun, warmPath, tmpDir, chaosTransportDirect,
+		WithPreviousSyncC1ZPath(seedPath), WithWorkerCount(1))
+	interruptedConcrete, ok := interruptedHarness.Syncer.(*syncer)
+	require.True(t, ok)
+	interruptedConcrete.checkpointInterval = 0
+	attempt1Audit := &syncTraceAudit{}
+	interruptedConcrete.testSyncTraceAudit = attempt1Audit
+	require.ErrorIs(t, interruptedHarness.Syncer.Sync(ctx), chaosconnector.ErrInterruptRequested)
+	require.NoError(t, interruptedHarness.Close(t.Context()))
+
+	// Generation B, resume: upstream has moved to epoch "third" — the
+	// re-consult's v1 offer misses, the connector serves the fresh
+	// record round [g1, g3] @ v3.
+	resumeRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+	require.NoError(t, err)
+	require.NoError(t, resumeRun.SetEpoch("third"))
+	resumeRun.SetSourceCacheCapability(capability)
+	resumeHarness := newChaosHarness(t, ctx, resumeRun, warmPath, tmpDir, chaosTransportDirect,
+		WithPreviousSyncC1ZPath(seedPath), WithWorkerCount(1))
+	resumeConcrete, ok := resumeHarness.Syncer.(*syncer)
+	require.True(t, ok)
+	attempt2Audit := &syncTraceAudit{}
+	resumeConcrete.testSyncTraceAudit = attempt2Audit
+	resumeHarness.SyncAndClose(t, ctx)
+
+	// Mechanism pin: the record round GROUNDS — attempt 2's trace shows
+	// the grounding clear between the consult and the record upserts,
+	// with no replay copy (this is the flip: fresh round, not warm).
+	// This is the trace-visible half of the fix; the content oracle
+	// below is the outcome half.
+	rowKind := "grants"
+	attempt2 := attempt2Audit.snapshot()
+	requireTraceOrder(t, attempt2,
+		syncTraceEvent{Kind: syncTraceConsult, RowKind: rowKind, ScopeKey: scGrantsScopeKey},
+		syncTraceEvent{Kind: syncTraceClear, RowKind: rowKind, ScopeKey: scGrantsScopeKey},
+		syncTraceEvent{Kind: syncTraceUpsert, RowKind: rowKind, ScopeKey: scGrantsScopeKey},
+		syncTraceEvent{Kind: syncTracePublish, RowKind: rowKind, ScopeKey: scGrantsScopeKey},
+		syncTraceEvent{Kind: syncTraceSeal},
+	)
+	require.NotContains(t, kinds(attempt2), syncTraceReplay,
+		"the flip serves a record round: no replay copy may run in attempt 2")
+
+	// Content oracle against epoch "third"'s truth: the record round is
+	// a replacement listing, so the sealed partition must be exactly
+	// what it listed. g2 in the sealed artifact is the phantom — dead
+	// upstream before the round ran, present only as crashed-copy
+	// debris, laundered under the v3 entry.
+	sealed := readChaosGrantsByID(t, ctx, warmPath, tmpDir)
+	require.Contains(t, sealed, fx.Grants[0].GetId(), "g1 is in the record round's listing")
+	require.Contains(t, sealed, fx.Grant3.GetId(), "g3 is in the record round's listing")
+	require.NotContains(t, sealed, fx.Grants[1].GetId(),
+		"g2 departed upstream before the record round: a replacement listing must not compose with crashed-replay debris (phantom union, tc1c flavor)")
+
+	exportTraceFixture(t, "warm_replay_sync_record_flip", attempt1Audit.snapshot(), attempt2)
+}
+
+func TestChaosSourceCacheInterruptResume(t *testing.T) {
+	skipChaosInShort(t)
+
+	warmEvent := scWarmEventFor(sourcecache.RowKindGrants, scGrantsScopeKey, scValidatorV1)
+	coldEvent := chaosconnector.SourceCacheLookupEvent{
+		RowKind:  sourcecache.RowKindGrants,
+		ScopeKey: scGrantsScopeKey,
+	}
+
+	cells := []struct {
+		name string
+		// cutToken is the wire page token whose first request crashes. The
+		// warm branch's wire tokens are "" (serves the warm root's content)
+		// then "warm-2", so "" cuts BEFORE the lookup consult and "warm-2"
+		// cuts AFTER the replay copy and overlay upsert committed.
+		cutToken string
+		// resumeWarm re-supplies the previous artifact on resume; false is
+		// the withdrawn-at-resume cold shape.
+		resumeWarm bool
+		// wantInterruptedEvents / wantResumeEvents are the exact consult
+		// traces of each attempt. Resume semantics discovered and pinned
+		// here: the interrupted action RESTARTS FROM ITS ROOT token —
+		// mid-chain page tokens are not resume points — so page
+		// processing is at-least-once and every post-cut resume
+		// re-consults exactly once.
+		wantInterruptedEvents []chaosconnector.SourceCacheLookupEvent
+		wantResumeEvents      []chaosconnector.SourceCacheLookupEvent
+		// wantResumeServedTokens must appear as successfully returned
+		// ListGrants pages in the RESUME attempt's trace.
+		wantResumeServedTokens []string
+	}{
+		{
+			// Post-copy cut, warm resume: the action restarts at the root,
+			// re-consults (hit, warm), and re-walks the warm chain over
+			// rows the interrupted attempt already committed. The re-run
+			// replay page RE-RUNS the copy (the mid-chain cut left the
+			// replayed-set un-checkpointed — see the suite comment) and
+			// the overlay upsert re-applies, both idempotently; warm-2 is
+			// reached again via the chain, skips via the same-attempt
+			// replayed-set, and publishes the new validator.
+			name:                   "cut-after-copy-resume-warm",
+			cutToken:               "warm-2",
+			resumeWarm:             true,
+			wantInterruptedEvents:  []chaosconnector.SourceCacheLookupEvent{warmEvent},
+			wantResumeEvents:       []chaosconnector.SourceCacheLookupEvent{warmEvent},
+			wantResumeServedTokens: []string{"warm-2"},
+		},
+		{
+			// Post-copy cut, previous artifact withdrawn at resume: the
+			// restarted root consult goes through NoopLookup — miss — and
+			// the cold branch fully refetches OVER the half-written warm
+			// rows from the interrupted attempt. The warm chain (and its
+			// validator-publishing warm-2 page) is never revisited; the
+			// cold root's record annotation republishes instead.
+			name:                  "cut-after-copy-resume-cold",
+			cutToken:              "warm-2",
+			resumeWarm:            false,
+			wantInterruptedEvents: []chaosconnector.SourceCacheLookupEvent{warmEvent},
+			wantResumeEvents:      []chaosconnector.SourceCacheLookupEvent{coldEvent},
+		},
+		{
+			// Pre-consult cut, warm resume: nothing source-cache-related
+			// happened before the cut; the resume re-runs the whole warm
+			// chain from the root.
+			name:                  "cut-before-consult-resume-warm",
+			cutToken:              "",
+			resumeWarm:            true,
+			wantInterruptedEvents: nil,
+			wantResumeEvents:      []chaosconnector.SourceCacheLookupEvent{warmEvent},
+		},
+		{
+			// Pre-consult cut, cold resume: the replay decision is remade
+			// under NoopLookup — miss, cold branch, fresh fetch.
+			name:                  "cut-before-consult-resume-cold",
+			cutToken:              "",
+			resumeWarm:            false,
+			wantInterruptedEvents: nil,
+			wantResumeEvents:      []chaosconnector.SourceCacheLookupEvent{coldEvent},
+		},
+	}
+
+	for _, tc := range cells {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), 90*time.Second)
+			defer cancel()
+			tmpDir, paths := sourceCachePaths(t, 3)
+			seedPath, warmPath, baselinePath := paths[0], paths[1], paths[2]
+
+			fx := newSCCollectionFixture(t)
+			scenario := scResumeScenario(t, fx)
+			capability := sourceCacheCapabilityRW("gen-1", "cfg-1")
+
+			// Generation A: cold seed.
+			seedRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+			require.NoError(t, err)
+			seedRun.SetSourceCacheCapability(capability)
+			seedEvents := runSourceCacheSync(t, ctx, seedRun, chaosTransportDirect, seedPath, tmpDir, "", WithWorkerCount(1))
+			requireAllColdEvents(t, seedEvents, 1)
+
+			// Generation B, attempt 1: warm sync cut at the seam.
+			interruptedRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule(chaosconnector.Rule{
+				ID: "cut",
+				Match: chaosconnector.Matcher{
+					Service:   chaosconnector.ExactString("GrantsService"),
+					Method:    chaosconnector.ExactString("ListGrants"),
+					PageToken: chaosconnector.ExactString(tc.cutToken),
+					Attempt:   1,
+					Phase:     chaosconnector.PhaseBeforeCall,
+				},
+				Effects:  []chaosconnector.Effect{{Kind: chaosconnector.EffectCrash}},
+				MinFires: 1,
+				MaxFires: 1,
+			}))
+			require.NoError(t, err)
+			require.NoError(t, interruptedRun.SetEpoch("second"))
+			interruptedRun.SetSourceCacheCapability(capability)
+			interruptedHarness := newChaosHarness(t, ctx, interruptedRun, warmPath, tmpDir, chaosTransportDirect,
+				WithPreviousSyncC1ZPath(seedPath), WithWorkerCount(1))
+			interruptedConcrete, ok := interruptedHarness.Syncer.(*syncer)
+			require.True(t, ok)
+			// Persist every completed page so the resume proves the
+			// provenance sets restore from the CHECKPOINT, not from luck.
+			interruptedConcrete.checkpointInterval = 0
+			require.ErrorIs(t, interruptedHarness.Syncer.Sync(ctx), chaosconnector.ErrInterruptRequested)
+			require.NoError(t, interruptedHarness.Close(t.Context()))
+			require.NoError(t, interruptedRun.Runtime().VerifyRequired())
+			requireSourceCacheEvents(t, interruptedRun.SourceCacheLookupEvents(), tc.wantInterruptedEvents)
+
+			// Generation B, resume: a NEW syncer instance over the same
+			// artifact (the cross-process shape).
+			resumeRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+			require.NoError(t, err)
+			require.NoError(t, resumeRun.SetEpoch("second"))
+			resumeRun.SetSourceCacheCapability(capability)
+			resumePrev := ""
+			if tc.resumeWarm {
+				resumePrev = seedPath
+			}
+			resumeEvents := runSourceCacheSync(t, ctx, resumeRun, chaosTransportDirect, warmPath, tmpDir, resumePrev, WithWorkerCount(1))
+			requireSourceCacheEvents(t, resumeEvents, tc.wantResumeEvents)
+			for _, token := range tc.wantResumeServedTokens {
+				require.True(t, grantsTraceHas(resumeRun, token, chaosconnector.OutcomeReturned),
+					"resume must serve the checkpointed page token %q", token)
+			}
+
+			// The resume must finish the interrupted sync, not replace it.
+			finalRuns := readChaosSyncRuns(t, ctx, warmPath, tmpDir)
+			require.Len(t, finalRuns, 1, "resume must not create a replacement sync")
+			require.NotNil(t, finalRuns[0].EndedAt, "resume must finish the interrupted sync")
+
+			// OR6/OR2 — convergence to the independent cold baseline.
+			baselineRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+			require.NoError(t, err)
+			require.NoError(t, baselineRun.SetEpoch("second"))
+			baselineRun.SetSourceCacheCapability(capability)
+			runSourceCacheSync(t, ctx, baselineRun, chaosTransportDirect, baselinePath, tmpDir, "", WithWorkerCount(1))
+			warmContent := readChaosLogicalContent(t, ctx, warmPath, tmpDir)
+			baselineContent := readChaosLogicalContent(t, ctx, baselinePath, tmpDir)
+			require.NoError(t, chaosoracle.CompareLogicalContent(baselineContent, warmContent),
+				"resumed sync must equal the uninterrupted cold baseline")
+
+			// OR3 — no manifest entry may vouch for an incomplete scope,
+			// and the completed round publishes exactly v2 over 3 rows.
+			requireSourceCacheProduceState(t, readSourceCacheSnapshot(t, ctx, warmPath, tmpDir),
+				map[string]string{grantsKindScope(): scValidatorV2},
+				map[string]int{grantsKindScope(): 3})
+		})
+	}
+}
+
+// TestChaosSourceCacheSessionPersistsAcrossResume pins the session
+// store's resume semantics (CO-6b-009, hazard analysis): connector
+// session writes are durable in the artifact and commit OUTSIDE the
+// checkpoint mechanism, so a resumed attempt inherits the crashed
+// attempt's session state wholesale — regardless of source-cache
+// participation. Both legs must KEEP the probe.
+//
+// This pins a deliberate rejection: an earlier change cleared the
+// namespace on a participating resume ("attempt-scoped sessions"). That
+// is unsound in the other direction — resume restores the action queue
+// from the checkpoint, completed actions never re-run, so a wholesale
+// clear destroys session values whose producing work will not execute
+// again (the accumulate-then-consume pattern: an index built during a
+// completed action, consumed by a later one). Do not reintroduce it.
+//
+// The inherited-state semantics carries a real two-sided hazard,
+// documented in pkg/session/README.md: (a) writes from beyond the
+// restored cursor survive, so the re-run window can observe its own
+// dead attempt's "future" writes — sessions must not implement
+// once-only dedup; (b) under the source-cache protocol, session-derived
+// caches must never feed replay/record verdicts (pkg/sourcecache,
+// SESSION STORE section). The mechanical fix for (a) is checkpoint-
+// consistent sessions (volatile overlay flushed atomically with the
+// checkpoint), registered as future work in
+// docs/verification/sync-replay-6b/plan.md.
+//
+// Both legs plant a probe key into the interrupted sync's session
+// namespace between attempts (equivalent to a crashed attempt's own
+// write — same keyspace, same durability), then crash the resume after
+// dispatch begins and read the artifact: the probe must survive with
+// and without the source-cache capability.
+func TestChaosSourceCacheSessionPersistsAcrossResume(t *testing.T) {
+	skipChaosInShort(t)
+
+	for _, leg := range []struct {
+		name           string
+		withCapability bool
+	}{
+		{name: "participating-resume-keeps", withCapability: true},
+		{name: "withdrawn-capability-resume-keeps", withCapability: false},
+	} {
+		t.Run(leg.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), 90*time.Second)
+			defer cancel()
+			tmpDir, paths := sourceCachePaths(t, 2)
+			seedPath, warmPath := paths[0], paths[1]
+
+			fx := newSCCollectionFixture(t)
+			scenario := scResumeScenario(t, fx)
+			capability := sourceCacheCapabilityRW("gen-1", "cfg-1")
+
+			seedRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+			require.NoError(t, err)
+			seedRun.SetSourceCacheCapability(capability)
+			runSourceCacheSync(t, ctx, seedRun, chaosTransportDirect, seedPath, tmpDir, "", WithWorkerCount(1))
+
+			// Attempt 1: warm sync cut before "warm-2".
+			interruptedRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule(chaosconnector.Rule{
+				ID: "cut",
+				Match: chaosconnector.Matcher{
+					Service:   chaosconnector.ExactString("GrantsService"),
+					Method:    chaosconnector.ExactString("ListGrants"),
+					PageToken: chaosconnector.ExactString("warm-2"),
+					Attempt:   1,
+					Phase:     chaosconnector.PhaseBeforeCall,
+				},
+				Effects:  []chaosconnector.Effect{{Kind: chaosconnector.EffectCrash}},
+				MinFires: 1,
+				MaxFires: 1,
+			}))
+			require.NoError(t, err)
+			require.NoError(t, interruptedRun.SetEpoch("second"))
+			interruptedRun.SetSourceCacheCapability(capability)
+			interruptedHarness := newChaosHarness(t, ctx, interruptedRun, warmPath, tmpDir, chaosTransportDirect,
+				WithPreviousSyncC1ZPath(seedPath), WithWorkerCount(1))
+			interruptedConcrete, ok := interruptedHarness.Syncer.(*syncer)
+			require.True(t, ok)
+			attempt1Audit := &syncTraceAudit{}
+			interruptedConcrete.testSyncTraceAudit = attempt1Audit
+			require.ErrorIs(t, interruptedHarness.Syncer.Sync(ctx), chaosconnector.ErrInterruptRequested)
+			syncID := interruptedConcrete.syncID
+			require.NotEmpty(t, syncID)
+			require.NoError(t, interruptedHarness.Close(t.Context()))
+
+			// Plant the probe into the unfinished sync's session
+			// namespace. The recorded swrite closes attempt 1's trace
+			// segment: the plant is the dead attempt's own
+			// beyond-checkpoint write (same keyspace, same durability,
+			// same position in the durable history — after the last
+			// checkpoint, before the resume boundary); the test is the
+			// session actor because the chaos connector has no session
+			// plumbing.
+			probeStore, err := dotc1z.NewStore(ctx, warmPath,
+				dotc1z.WithEngine(c1zstore.EnginePebble), dotc1z.WithTmpDir(tmpDir))
+			require.NoError(t, err)
+			require.NoError(t, probeStore.SessionStore().Set(ctx, "probe-key", []byte("stale-premise"),
+				sessions.WithSyncID(syncID)))
+			attempt1Audit.record(syncTraceSessionWrite, "", "probe-key")
+			require.NoError(t, probeStore.Close(ctx))
+
+			// Resume, crashing on the restarted action's first page so the
+			// sync neither seals nor runs connector cleanup (which would
+			// clear sessions and make the read vacuous).
+			resumeRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule(chaosconnector.Rule{
+				ID: "cut-resume",
+				Match: chaosconnector.Matcher{
+					Service:   chaosconnector.ExactString("GrantsService"),
+					Method:    chaosconnector.ExactString("ListGrants"),
+					PageToken: chaosconnector.ExactString(""),
+					Attempt:   1,
+					Phase:     chaosconnector.PhaseBeforeCall,
+				},
+				Effects:  []chaosconnector.Effect{{Kind: chaosconnector.EffectCrash}},
+				MinFires: 1,
+				MaxFires: 1,
+			}))
+			require.NoError(t, err)
+			require.NoError(t, resumeRun.SetEpoch("second"))
+			if leg.withCapability {
+				resumeRun.SetSourceCacheCapability(capability)
+			}
+			resumeHarness := newChaosHarness(t, ctx, resumeRun, warmPath, tmpDir, chaosTransportDirect,
+				WithPreviousSyncC1ZPath(seedPath), WithWorkerCount(1))
+			resumeConcrete, ok := resumeHarness.Syncer.(*syncer)
+			require.True(t, ok)
+			attempt2Audit := &syncTraceAudit{}
+			resumeConcrete.testSyncTraceAudit = attempt2Audit
+			require.ErrorIs(t, resumeHarness.Syncer.Sync(ctx), chaosconnector.ErrInterruptRequested)
+			require.NoError(t, resumeHarness.Close(t.Context()))
+
+			readStore, err := dotc1z.NewStore(ctx, warmPath,
+				dotc1z.WithEngine(c1zstore.EnginePebble), dotc1z.WithTmpDir(tmpDir), dotc1z.WithReadOnly(true))
+			require.NoError(t, err)
+			defer func() { require.NoError(t, readStore.Close(ctx)) }()
+			_, found, err := readStore.SessionStore().Get(ctx, "probe-key", sessions.WithSyncID(syncID))
+			require.NoError(t, err)
+			// The re-run window's read, recorded into attempt 2's trace
+			// segment (again the test as session actor). The exported
+			// fixture is the shipped zombie-read history the oracle's
+			// session-checkpoint-consistency policy must judge RED:
+			// swrite with no later checkpoint, resume, read HIT.
+			if found {
+				attempt2Audit.record(syncTraceSessionReadHit, "", "probe-key")
+			} else {
+				attempt2Audit.record(syncTraceSessionReadMiss, "", "probe-key")
+			}
+			require.True(t, found,
+				"session state must persist across resume: completed actions never re-run, so a "+
+					"resume-time clear destroys values whose producing work will not execute again (CO-6b-009)")
+			if leg.withCapability {
+				exportTraceFixture(t, "warm_replay_sync_session_zombie",
+					attempt1Audit.snapshot(), attempt2Audit.snapshot())
+			}
+		})
+	}
+}
+
+// readChaosGrantsByID collects every stored grant keyed by public id.
+func readChaosGrantsByID(t *testing.T, ctx context.Context, path, tmpDir string) map[string]*v2.Grant {
+	t.Helper()
+	store, err := dotc1z.NewStore(
+		ctx,
+		path,
+		dotc1z.WithEngine(c1zstore.EnginePebble),
+		dotc1z.WithTmpDir(tmpDir),
+		dotc1z.WithReadOnly(true),
+	)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, store.Close(ctx)) }()
+	out := map[string]*v2.Grant{}
+	token := ""
+	for {
+		response, err := store.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{
+			PageToken: token,
+		}.Build())
+		require.NoError(t, err)
+		for _, grant := range response.GetList() {
+			out[grant.GetId()] = grant
+		}
+		token = response.GetNextPageToken()
+		if token == "" {
+			return out
+		}
+	}
+}
+
+// TestChaosSourceCacheReplayStripsExpanderSources pins R11's expansion
+// clause at sync level: a replayed grants scope containing (a) a direct
+// grant whose Sources were EXPANDER-written in the previous sync, (b) a
+// grant-expandable group grant, and (c) a direct grant with CONNECTOR-set
+// Sources must — after replay + re-expansion — equal the cold baseline
+// byte-for-byte: expander Sources are stripped at copy and recomputed from
+// true state, connector Sources survive verbatim, and the expander-created
+// grant (a derived row) is regenerated unstamped.
+func TestChaosSourceCacheReplayStripsExpanderSources(t *testing.T) {
+	skipChaosInShort(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 90*time.Second)
+	defer cancel()
+	tmpDir, paths := sourceCachePaths(t, 3)
+	seedPath, warmPath, baselinePath := paths[0], paths[1], paths[2]
+
+	const (
+		scope2      = "grants:team-2"
+		validatorT2 = "validator-team-2"
+	)
+
+	fx := newSCCollectionFixture(t)
+	team2, err := rs.NewGroupResource("Team 2", fx.TeamType, "team-2", nil)
+	require.NoError(t, err)
+	member2 := et.NewEntitlement(team2, "member", "assignment")
+	// Group grant: holders of team-1#member expand into team-2#member.
+	expandable := gt.NewGrant(team2, "member", fx.Team,
+		gt.WithAnnotation(v2.GrantExpandable_builder{
+			EntitlementIds: []string{fx.Member.GetId()},
+		}.Build()))
+	// user-1 holds team-1#member, so this DIRECT grant receives
+	// expander-written Sources (self-source + contribution) in every sync.
+	directExpanded := gt.NewGrant(team2, "member", fx.Users[0])
+	// user-3 holds nothing on team-1: its connector-set Sources (no
+	// self-source entry) must survive replay byte-for-byte.
+	connectorSourced := gt.NewGrant(team2, "member", fx.User3)
+	connectorSourced.SetSources(v2.GrantSources_builder{
+		Sources: map[string]*v2.GrantSources_GrantSource{
+			fx.Member.GetId(): {},
+		},
+	}.Build())
+	scopeGrants := []*v2.Grant{expandable, directExpanded, connectorSourced}
+
+	buildEpoch := func(warm bool) *chaosconnector.Dataset {
+		d := scCollectionBase(fx)
+		d.Resources[scTeamTypeID] = chaosconnector.Pages[*v2.Resource]{
+			"": {List: []*v2.Resource{fx.Team, team2}},
+		}
+		// Team-1's grants stay unannotated and fresh in every generation:
+		// they are the expansion inputs, not the replayed scope.
+		d.Grants["team-1"] = chaosconnector.Pages[*v2.Grant]{
+			"": {List: fx.Grants},
+		}
+		d.Entitlements["team-2"] = chaosconnector.Pages[*v2.Entitlement]{
+			"": {List: []*v2.Entitlement{member2}},
+		}
+		pages := chaosconnector.Pages[*v2.Grant]{
+			"": {List: scopeGrants, Annotations: scRecordAnno(scope2, validatorT2)},
+		}
+		spec := &chaosconnector.SourceCacheSpec{ScopeKey: scope2, Validator: validatorT2}
+		if warm {
+			pages["warm"] = chaosconnector.Page[*v2.Grant]{
+				Annotations: scReplayAnno(scope2, validatorT2, false, nil, nil),
+			}
+			spec.WarmRoot = "warm"
+		}
+		d.Grants["team-2"] = pages
+		d.SourceCacheGrants = map[string]*chaosconnector.SourceCacheSpec{"team-2": spec}
+		return d
+	}
+	scenario := &chaosconnector.Scenario{
+		Name:         "source-cache-expansion-strip",
+		Seed:         1,
+		InitialEpoch: "seed",
+		Epochs: map[string]*chaosconnector.Dataset{
+			"seed":   buildEpoch(false),
+			"second": buildEpoch(true),
+		},
+	}
+	require.NoError(t, scenario.Validate())
+	capability := sourceCacheCapabilityRW("gen-1", "cfg-1")
+
+	// Generation A: cold seed with expansion enabled.
+	seedRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+	require.NoError(t, err)
+	seedRun.SetSourceCacheCapability(capability)
+	seedEvents := runSourceCacheSync(t, ctx, seedRun, chaosTransportDirect, seedPath, tmpDir, "",
+		WithWorkerCount(1), withExpandGrants())
+	requireAllColdEvents(t, seedEvents, 1)
+
+	// Vacuity guard: the seed artifact must actually carry the
+	// expander-written shape this test claims to strip — a self-source on
+	// the direct grant — and the untouched connector-set Sources.
+	seedGrants := readChaosGrantsByID(t, ctx, seedPath, tmpDir)
+	seedDirect, ok := seedGrants[directExpanded.GetId()]
+	require.True(t, ok, "seed must store the direct grant")
+	require.Contains(t, seedDirect.GetSources().GetSources(), member2.GetId(),
+		"seed expansion must have written a self-source on the direct grant")
+	seedConnectorSourced, ok := seedGrants[connectorSourced.GetId()]
+	require.True(t, ok, "seed must store the connector-sourced grant")
+	require.NotContains(t, seedConnectorSourced.GetSources().GetSources(), member2.GetId(),
+		"connector-set Sources must not gain a self-source (u3 holds no source entitlement)")
+
+	// Generation B: warm replay of team-2's scope, expansion recomputes.
+	warmRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+	require.NoError(t, err)
+	require.NoError(t, warmRun.SetEpoch("second"))
+	warmRun.SetSourceCacheCapability(capability)
+	warmEvents := runSourceCacheSync(t, ctx, warmRun, chaosTransportDirect, warmPath, tmpDir, seedPath,
+		WithWorkerCount(1), withExpandGrants())
+	requireSourceCacheEvents(t, warmEvents, []chaosconnector.SourceCacheLookupEvent{
+		scWarmEventFor(sourcecache.RowKindGrants, scope2, validatorT2),
+	})
+
+	// Independent cold baseline of the same epoch, expansion enabled.
+	baselineRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+	require.NoError(t, err)
+	require.NoError(t, baselineRun.SetEpoch("second"))
+	baselineRun.SetSourceCacheCapability(capability)
+	runSourceCacheSync(t, ctx, baselineRun, chaosTransportDirect, baselinePath, tmpDir, "",
+		WithWorkerCount(1), withExpandGrants())
+
+	// OR2 over full-proto fingerprints: strip-at-copy + re-expansion must
+	// equal fresh + expansion, including every Sources byte.
+	warmContent := readChaosLogicalContent(t, ctx, warmPath, tmpDir)
+	baselineContent := readChaosLogicalContent(t, ctx, baselinePath, tmpDir)
+	require.NoError(t, chaosoracle.CompareLogicalContent(baselineContent, warmContent),
+		"replayed+re-expanded content must equal the cold baseline byte-for-byte")
+
+	// OR3: only the three connector-emitted scope rows are stamped — the
+	// expander-created grant is a derived row and stays unscoped (B10).
+	requireSourceCacheProduceState(t, readSourceCacheSnapshot(t, ctx, warmPath, tmpDir),
+		map[string]string{chaosoracle.KindScope(sourcecache.RowKindGrants, scope2): validatorT2},
+		map[string]int{chaosoracle.KindScope(sourcecache.RowKindGrants, scope2): 3})
+
+	// Direct evidence on the warm artifact (not just fingerprint parity):
+	// the direct grant's Sources were recomputed and the connector-set
+	// Sources survived byte-for-byte.
+	warmGrants := readChaosGrantsByID(t, ctx, warmPath, tmpDir)
+	warmDirect, ok := warmGrants[directExpanded.GetId()]
+	require.True(t, ok)
+	require.Contains(t, warmDirect.GetSources().GetSources(), member2.GetId(),
+		"re-expansion must restore the stripped self-source")
+	warmConnectorSourced, ok := warmGrants[connectorSourced.GetId()]
+	require.True(t, ok)
+	require.Equal(t,
+		seedConnectorSourced.GetSources().GetSources(),
+		warmConnectorSourced.GetSources().GetSources(),
+		"connector-set Sources must survive replay verbatim")
+}

--- a/pkg/sync/chaos_source_cache_stale_test.go
+++ b/pkg/sync/chaos_source_cache_stale_test.go
@@ -1,0 +1,231 @@
+package sync //nolint:revive,nolintlint // backwards-compatible package name
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/conductorone/baton-sdk/internal/chaosconnector"
+	chaosoracle "github.com/conductorone/baton-sdk/internal/chaosconnector/oracle"
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/sourcecache"
+	et "github.com/conductorone/baton-sdk/pkg/types/entitlement"
+	gt "github.com/conductorone/baton-sdk/pkg/types/grant"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+)
+
+// Phase 6b degradation-composition suite (plan R14, oracles OR2 + OR1):
+// per-scope degradations inside an otherwise healthy sync must compose —
+// a stale validator or a poisoned scope colds THAT scope only, the sync
+// stays green, and the artifact converges to the cold truth.
+
+// TestChaosSourceCacheStaleValidatorFetchesFresh pins the stale-validator
+// path: upstream changed between A and B, so B's lookup HITS but the stored
+// validator no longer matches — the connector must fetch fresh, never
+// replay. The warm branch is armed with a deliberately WRONG page (the old
+// row set) so that serving it would fail the OR2 comparison.
+func TestChaosSourceCacheStaleValidatorFetchesFresh(t *testing.T) {
+	skipChaosInShort(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 90*time.Second)
+	defer cancel()
+	tmpDir, paths := sourceCachePaths(t, 3)
+	seedPath, secondPath, baselinePath := paths[0], paths[1], paths[2]
+
+	fx := newSCCollectionFixture(t)
+	allThree := []*v2.Grant{fx.Grants[0], fx.Grants[1], fx.Grant3}
+
+	seed := scCollectionBase(fx)
+	seed.Grants["team-1"] = chaosconnector.Pages[*v2.Grant]{
+		"": {List: fx.Grants, Annotations: scRecordAnno(scGrantsScopeKey, scValidatorV1)},
+	}
+	seed.SourceCacheGrants = map[string]*chaosconnector.SourceCacheSpec{
+		"team-1": {ScopeKey: scGrantsScopeKey, Validator: scValidatorV1},
+	}
+	// Upstream changed: the second epoch's validator is v2 and its truth is
+	// all three grants. The warm branch would replay the STALE base — the
+	// mismatch must keep it unserved.
+	second := scCollectionBase(fx)
+	second.Grants["team-1"] = chaosconnector.Pages[*v2.Grant]{
+		"":     {List: allThree, Annotations: scRecordAnno(scGrantsScopeKey, scValidatorV2)},
+		"warm": {Annotations: scReplayAnno(scGrantsScopeKey, scValidatorV1, false, nil, nil)},
+	}
+	second.SourceCacheGrants = map[string]*chaosconnector.SourceCacheSpec{
+		"team-1": {ScopeKey: scGrantsScopeKey, Validator: scValidatorV2, WarmRoot: "warm"},
+	}
+	scenario := &chaosconnector.Scenario{
+		Name:         "source-cache-stale-validator",
+		Seed:         1,
+		InitialEpoch: "seed",
+		Epochs:       map[string]*chaosconnector.Dataset{"seed": seed, "second": second},
+	}
+	require.NoError(t, scenario.Validate())
+	capability := sourceCacheCapabilityRW("gen-1", "cfg-1")
+
+	run, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+	require.NoError(t, err)
+	run.SetSourceCacheCapability(capability)
+	seedEvents := runSourceCacheSync(t, ctx, run, chaosTransportDirect, seedPath, tmpDir, "", WithWorkerCount(1))
+	requireAllColdEvents(t, seedEvents, 1)
+
+	require.NoError(t, run.SetEpoch("second"))
+	secondEvents := runSourceCacheSync(t, ctx, run, chaosTransportDirect, secondPath, tmpDir, seedPath, WithWorkerCount(1))
+	requireSourceCacheEvents(t, secondEvents, []chaosconnector.SourceCacheLookupEvent{{
+		RowKind:           sourcecache.RowKindGrants,
+		ScopeKey:          scGrantsScopeKey,
+		Hit:               true,
+		PreviousValidator: scValidatorV1,
+		Matched:           false,
+		ServedWarm:        false,
+	}})
+
+	baselineRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+	require.NoError(t, err)
+	require.NoError(t, baselineRun.SetEpoch("second"))
+	baselineRun.SetSourceCacheCapability(capability)
+	runSourceCacheSync(t, ctx, baselineRun, chaosTransportDirect, baselinePath, tmpDir, "", WithWorkerCount(1))
+
+	secondContent := readChaosLogicalContent(t, ctx, secondPath, tmpDir)
+	baselineContent := readChaosLogicalContent(t, ctx, baselinePath, tmpDir)
+	require.NoError(t, chaosoracle.CompareLogicalContent(baselineContent, secondContent),
+		"stale-validator sync must converge to the cold truth of the changed upstream")
+
+	requireSourceCacheProduceState(t, readSourceCacheSnapshot(t, ctx, secondPath, tmpDir),
+		map[string]string{grantsKindScope(): scValidatorV2},
+		map[string]int{grantsKindScope(): 3})
+}
+
+// TestChaosSourceCachePoisonedScopeColdInsideWarmSync pins the CO-016 shape
+// (plan B9 + R14): the seed sync's team-1 page tombstones a row stamped
+// with team-2's scope — a row-partition violation that durably poisons
+// team-2's scope in the seed artifact (CO-015). The next sync is otherwise
+// warm: team-1 replays, but team-2's lookup must MISS (poison reads as
+// miss) and cold-fetch, all inside one green sync.
+//
+// The single-worker grants phase processes team-2 BEFORE team-1 (task-stack
+// order), so team-1's page is the one whose tombstone can reach an
+// already-ingested foreign row.
+func TestChaosSourceCachePoisonedScopeColdInsideWarmSync(t *testing.T) {
+	skipChaosInShort(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 90*time.Second)
+	defer cancel()
+	tmpDir, paths := sourceCachePaths(t, 3)
+	seedPath, secondPath, baselinePath := paths[0], paths[1], paths[2]
+
+	const (
+		scope1     = "grants:team-1"
+		scope2     = "grants:team-2"
+		validator1 = "validator-team-1"
+		validator2 = "validator-team-2"
+	)
+
+	fx := newSCCollectionFixture(t)
+	team2, err := rs.NewGroupResource("Team 2", fx.TeamType, "team-2", nil)
+	require.NoError(t, err)
+	member2 := et.NewEntitlement(team2, "member", "assignment")
+	h1 := gt.NewGrant(team2, "member", fx.Users[1])
+
+	buildEpoch := func(seedShape bool) *chaosconnector.Dataset {
+		d := scCollectionBase(fx)
+		d.Resources[scTeamTypeID] = chaosconnector.Pages[*v2.Resource]{
+			"": {List: []*v2.Resource{fx.Team, team2}},
+		}
+		d.Entitlements["team-2"] = chaosconnector.Pages[*v2.Entitlement]{
+			"": {List: []*v2.Entitlement{member2}},
+		}
+		if seedShape {
+			// Team-2 serves h1 first; team-1's page then tombstones h1
+			// while acting FOR scope1 — deleting a scope2-stamped row, the
+			// poison trigger.
+			d.Grants["team-1"] = chaosconnector.Pages[*v2.Grant]{
+				"": {
+					List: fx.Grants,
+					Annotations: annotations.New(v2.SourceCacheRecord_builder{
+						ScopeKey:       scope1,
+						CacheValidator: validator1,
+						DeletedIds:     []string{h1.GetId()},
+					}.Build()),
+				},
+			}
+			d.Grants["team-2"] = chaosconnector.Pages[*v2.Grant]{
+				"": {List: []*v2.Grant{h1}, Annotations: scRecordAnno(scope2, validator2)},
+			}
+			d.SourceCacheGrants = map[string]*chaosconnector.SourceCacheSpec{
+				"team-1": {ScopeKey: scope1, Validator: validator1},
+				"team-2": {ScopeKey: scope2, Validator: validator2},
+			}
+			return d
+		}
+		// Second epoch: upstream unchanged (h1 remains gone). Both scopes
+		// declare warm branches; only team-1's may be served.
+		d.Grants["team-1"] = chaosconnector.Pages[*v2.Grant]{
+			"":     {List: fx.Grants, Annotations: scRecordAnno(scope1, validator1)},
+			"warm": {Annotations: scReplayAnno(scope1, validator1, false, nil, nil)},
+		}
+		d.Grants["team-2"] = chaosconnector.Pages[*v2.Grant]{
+			"":     {Annotations: scRecordAnno(scope2, validator2)},
+			"warm": {Annotations: scReplayAnno(scope2, validator2, false, nil, nil)},
+		}
+		d.SourceCacheGrants = map[string]*chaosconnector.SourceCacheSpec{
+			"team-1": {ScopeKey: scope1, Validator: validator1, WarmRoot: "warm"},
+			"team-2": {ScopeKey: scope2, Validator: validator2, WarmRoot: "warm"},
+		}
+		return d
+	}
+
+	scenario := &chaosconnector.Scenario{
+		Name:         "source-cache-poisoned-scope",
+		Seed:         1,
+		InitialEpoch: "seed",
+		Epochs: map[string]*chaosconnector.Dataset{
+			"seed":   buildEpoch(true),
+			"second": buildEpoch(false),
+		},
+	}
+	require.NoError(t, scenario.Validate())
+	capability := sourceCacheCapabilityRW("gen-1", "cfg-1")
+
+	run, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+	require.NoError(t, err)
+	run.SetSourceCacheCapability(capability)
+	seedEvents := runSourceCacheSync(t, ctx, run, chaosTransportDirect, seedPath, tmpDir, "", WithWorkerCount(1))
+	requireAllColdEvents(t, seedEvents, 2)
+
+	require.NoError(t, run.SetEpoch("second"))
+	secondEvents := runSourceCacheSync(t, ctx, run, chaosTransportDirect, secondPath, tmpDir, seedPath, WithWorkerCount(1))
+	requireSourceCacheEvents(t, secondEvents, []chaosconnector.SourceCacheLookupEvent{
+		{
+			// Team-2 (served first): poisoned in the seed artifact — the
+			// lookup must read as a MISS even though the entry exists with
+			// a live validator.
+			RowKind:  sourcecache.RowKindGrants,
+			ScopeKey: scope2,
+		},
+		scWarmEventFor(sourcecache.RowKindGrants, scope1, validator1),
+	})
+
+	baselineRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+	require.NoError(t, err)
+	require.NoError(t, baselineRun.SetEpoch("second"))
+	baselineRun.SetSourceCacheCapability(capability)
+	runSourceCacheSync(t, ctx, baselineRun, chaosTransportDirect, baselinePath, tmpDir, "", WithWorkerCount(1))
+
+	secondContent := readChaosLogicalContent(t, ctx, secondPath, tmpDir)
+	baselineContent := readChaosLogicalContent(t, ctx, baselinePath, tmpDir)
+	require.NoError(t, chaosoracle.CompareLogicalContent(baselineContent, secondContent),
+		"poison-composed sync must converge to the cold truth")
+
+	// Both scopes republish; the poisoned scope's fresh zero-row fetch
+	// re-seeds it cleanly (the poison lived in the PREVIOUS artifact, not
+	// this one).
+	requireSourceCacheProduceState(t, readSourceCacheSnapshot(t, ctx, secondPath, tmpDir),
+		map[string]string{
+			chaosoracle.KindScope(sourcecache.RowKindGrants, scope1): validator1,
+			chaosoracle.KindScope(sourcecache.RowKindGrants, scope2): validator2,
+		},
+		map[string]int{
+			chaosoracle.KindScope(sourcecache.RowKindGrants, scope1): 2,
+		})
+}

--- a/pkg/sync/chaos_trace_oracle_test.go
+++ b/pkg/sync/chaos_trace_oracle_test.go
@@ -1,0 +1,391 @@
+package sync //nolint:revive,nolintlint // backwards-compatible package name
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/conductorone/baton-sdk/internal/chaosconnector"
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+)
+
+// The sync-trace oracle bridge (formal/occult/TRACE_BRIDGE.md, mapping 2:
+// real sync executions). These tests record canonical sync traces
+// (sync_trace_audit.go) from the source-cache chaos scenarios —
+// single-attempt cold/warm syncs and crash/resume multi-attempt syncs —
+// sanity-check their shape in-process, and export them as JSONL
+// fixtures for the Occult trace-policy oracle when
+// BATON_SYNC_TRACE_FIXTURE_DIR is set. The committed fixtures live at
+// formal/occult/host/testdata/realtraces/ and are verified against the
+// five deliverable-7 policies by
+// formal/occult/host/real_trace_oracle_test.go; regenerate them with:
+//
+//	BATON_SYNC_TRACE_FIXTURE_DIR=$(pwd)/formal/occult/host/testdata/realtraces \
+//	  go test -run 'TestChaosSyncTraceOracle' ./pkg/sync/
+//
+// The recorder is observational only (commit-order events); rendering
+// conventions live on the oracle side. Every fixture starts at sync
+// birth (resumed=false in the header — the precondition for the
+// renderer's structural-clear convention); crash/resume fixtures carry
+// explicit "resume" marker lines between attempt segments.
+
+// syncTraceFixtureHeader is the first JSONL line of an exported trace.
+type syncTraceFixtureHeader struct {
+	Name    string `json:"name"`
+	Resumed bool   `json:"resumed"`
+}
+
+// scTombstoneScenario: seed epoch serves [g1, g2] fresh at v1. Second
+// epoch's truth is [g1, g3] at v2; its warm branch is a one-page delta
+// round that replays the base, overlay-upserts g3, TOMBSTONES g2
+// (departed upstream), and publishes v2.
+func scTombstoneScenario(t *testing.T, fx *scCollectionFixture) *chaosconnector.Scenario {
+	t.Helper()
+	seed := scCollectionBase(fx)
+	seed.Grants["team-1"] = chaosconnector.Pages[*v2.Grant]{
+		"": {List: fx.Grants, Annotations: scRecordAnno(scGrantsScopeKey, scValidatorV1)},
+	}
+	seed.SourceCacheGrants = map[string]*chaosconnector.SourceCacheSpec{
+		"team-1": {ScopeKey: scGrantsScopeKey, Validator: scValidatorV1},
+	}
+	second := scCollectionBase(fx)
+	second.Grants["team-1"] = chaosconnector.Pages[*v2.Grant]{
+		"": {List: []*v2.Grant{fx.Grants[0], fx.Grant3}, Annotations: scRecordAnno(scGrantsScopeKey, scValidatorV2)},
+		"warm": {
+			List:        []*v2.Grant{fx.Grant3},
+			Annotations: scReplayAnno(scGrantsScopeKey, scValidatorV2, true, []string{fx.Grants[1].GetId()}, nil),
+		},
+	}
+	second.SourceCacheGrants = map[string]*chaosconnector.SourceCacheSpec{
+		"team-1": {ScopeKey: scGrantsScopeKey, Validator: scValidatorV1, WarmRoot: "warm"},
+	}
+	scenario := &chaosconnector.Scenario{
+		Name:         "source-cache-tombstone-trace",
+		Seed:         1,
+		InitialEpoch: "seed",
+		Epochs:       map[string]*chaosconnector.Dataset{"seed": seed, "second": second},
+	}
+	require.NoError(t, scenario.Validate())
+	return scenario
+}
+
+// TestChaosSyncTraceOracleTombstoneFixture records the delta protocol's
+// delete leg: a warm replay round whose page tombstones a row that
+// departed upstream. The trace pins B3's within-page commit order —
+// rows, then tombstones, then the validator publish — and the content
+// oracle proves the tombstone actually deleted (the phantom-union
+// family's fix at the row level: without the delete leg, g2 would
+// survive the replay into the sealed artifact).
+func TestChaosSyncTraceOracleTombstoneFixture(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 90*time.Second)
+	defer cancel()
+	tmpDir, paths := sourceCachePaths(t, 2)
+	seedPath, warmPath := paths[0], paths[1]
+
+	fx := newSCCollectionFixture(t)
+	scenario := scTombstoneScenario(t, fx)
+	capability := sourceCacheCapabilityRW("gen-1", "cfg-1")
+
+	// Generation A: cold seed of [g1, g2] at v1.
+	seedRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+	require.NoError(t, err)
+	seedRun.SetSourceCacheCapability(capability)
+	runSourceCacheSync(t, ctx, seedRun, chaosTransportDirect, seedPath, tmpDir, "", WithWorkerCount(1))
+
+	// Generation B: warm delta round with the tombstone.
+	warmRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+	require.NoError(t, err)
+	require.NoError(t, warmRun.SetEpoch("second"))
+	warmRun.SetSourceCacheCapability(capability)
+	warmHarness := newChaosHarness(t, ctx, warmRun, warmPath, tmpDir, chaosTransportDirect,
+		WithPreviousSyncC1ZPath(seedPath), WithWorkerCount(1))
+	warmConcrete, ok := warmHarness.Syncer.(*syncer)
+	require.True(t, ok)
+	audit := &syncTraceAudit{}
+	warmConcrete.testSyncTraceAudit = audit
+	warmHarness.SyncAndClose(t, ctx)
+	trace := audit.snapshot()
+
+	rowKind := "grants"
+	requireTraceOrder(t, trace,
+		syncTraceEvent{Kind: syncTraceConsult, RowKind: rowKind, ScopeKey: scGrantsScopeKey},
+		syncTraceEvent{Kind: syncTraceClear, RowKind: rowKind, ScopeKey: scGrantsScopeKey},
+		syncTraceEvent{Kind: syncTraceReplay, RowKind: rowKind, ScopeKey: scGrantsScopeKey},
+		syncTraceEvent{Kind: syncTraceUpsert, RowKind: rowKind, ScopeKey: scGrantsScopeKey},
+		syncTraceEvent{Kind: syncTraceDelete, RowKind: rowKind, ScopeKey: scGrantsScopeKey},
+		syncTraceEvent{Kind: syncTracePublish, RowKind: rowKind, ScopeKey: scGrantsScopeKey},
+		syncTraceEvent{Kind: syncTraceSeal},
+	)
+	require.Equal(t, 1, countKind(trace, syncTraceReplay))
+	require.Equal(t, 1, countKind(trace, syncTraceDelete))
+	require.Equal(t, syncTraceSeal, trace[len(trace)-1].Kind)
+
+	// Content oracle: the tombstoned grant is gone, the survivors and
+	// the overlay row are present.
+	sealed := readChaosGrantsByID(t, ctx, warmPath, tmpDir)
+	require.Contains(t, sealed, fx.Grants[0].GetId(), "surviving base row must replay")
+	require.Contains(t, sealed, fx.Grant3.GetId(), "overlay row must land")
+	require.NotContains(t, sealed, fx.Grants[1].GetId(), "tombstoned row must not survive the replay")
+
+	exportTraceFixture(t, "warm_replay_sync_tombstone", trace)
+}
+
+func TestChaosSyncTraceOracleFixtures(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 120*time.Second)
+	defer cancel()
+	tmpDir, paths := sourceCachePaths(t, 2)
+
+	fixture := newSourceCacheFixture(t)
+	scenario := newSourceCacheScenario(t, fixture)
+	run, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+	require.NoError(t, err)
+	run.SetSourceCacheCapability(sourceCacheCapabilityRW("gen-1", "cfg-1"))
+
+	// Generation A: cold record sync (no previous artifact; the lookup is
+	// NoopLookup, so the trace carries no consult events).
+	coldTrace := runTracedSourceCacheSync(t, ctx, run, paths[0], tmpDir, "")
+
+	// Generation B: warm replay sync against A's artifact.
+	warmTrace := runTracedSourceCacheSync(t, ctx, run, paths[1], tmpDir, paths[0])
+
+	rowKind := "grants"
+
+	// In-process sanity only — the real verdicts are the Occult policy
+	// oracle's job. Cold: the scope's page rows landed and its validator
+	// published before the seal; no replay machinery ran.
+	require.NotEmpty(t, coldTrace)
+	requireTraceOrder(t, coldTrace,
+		syncTraceEvent{Kind: syncTraceUpsert, RowKind: rowKind, ScopeKey: scGrantsScopeKey},
+		syncTraceEvent{Kind: syncTracePublish, RowKind: rowKind, ScopeKey: scGrantsScopeKey},
+		syncTraceEvent{Kind: syncTraceSeal},
+	)
+	require.NotContains(t, kinds(coldTrace), syncTraceReplay)
+	require.NotContains(t, kinds(coldTrace), syncTraceConsult)
+
+	// Warm: consult precedes the replay unit's clear+copy legs, exactly
+	// one replay ran, the validator republished, and the seal closed it.
+	requireTraceOrder(t, warmTrace,
+		syncTraceEvent{Kind: syncTraceConsult, RowKind: rowKind, ScopeKey: scGrantsScopeKey},
+		syncTraceEvent{Kind: syncTraceClear, RowKind: rowKind, ScopeKey: scGrantsScopeKey},
+		syncTraceEvent{Kind: syncTraceReplay, RowKind: rowKind, ScopeKey: scGrantsScopeKey},
+		syncTraceEvent{Kind: syncTracePublish, RowKind: rowKind, ScopeKey: scGrantsScopeKey},
+		syncTraceEvent{Kind: syncTraceSeal},
+	)
+	require.Equal(t, 1, countKind(warmTrace, syncTraceReplay))
+
+	// Both traces end at their seal (the recorder stops with the sync).
+	require.Equal(t, syncTraceSeal, coldTrace[len(coldTrace)-1].Kind)
+	require.Equal(t, syncTraceSeal, warmTrace[len(warmTrace)-1].Kind)
+
+	exportTraceFixture(t, "cold_record_sync", coldTrace)
+	exportTraceFixture(t, "warm_replay_sync", warmTrace)
+}
+
+// runTracedSourceCacheSync mirrors runSourceCacheSync but installs the
+// sync-trace audit on the concrete syncer before running.
+func runTracedSourceCacheSync(
+	t *testing.T,
+	ctx context.Context,
+	run *chaosconnector.Run,
+	c1zPath string,
+	tmpDir string,
+	prevPath string,
+) []syncTraceEvent {
+	t.Helper()
+	var opts []SyncOpt
+	if prevPath != "" {
+		opts = append(opts, WithPreviousSyncC1ZPath(prevPath))
+	}
+	h := newChaosHarness(t, ctx, run, c1zPath, tmpDir, chaosTransportDirect, opts...)
+	concrete, ok := h.Syncer.(*syncer)
+	require.True(t, ok, "chaos harness syncer is not the concrete *syncer")
+	audit := &syncTraceAudit{}
+	concrete.testSyncTraceAudit = audit
+	h.SyncAndClose(t, ctx)
+	return audit.snapshot()
+}
+
+// requireTraceOrder asserts the expected events appear in the trace in
+// the given relative order (other events may interleave).
+func requireTraceOrder(t *testing.T, trace []syncTraceEvent, expected ...syncTraceEvent) {
+	t.Helper()
+	i := 0
+	for _, ev := range trace {
+		if i < len(expected) && ev == expected[i] {
+			i++
+		}
+	}
+	require.Equalf(t, len(expected), i,
+		"trace missing expected event order (matched %d of %d): trace=%v expected=%v", i, len(expected), trace, expected)
+}
+
+func kinds(trace []syncTraceEvent) []syncTraceKind {
+	out := make([]syncTraceKind, 0, len(trace))
+	for _, ev := range trace {
+		out = append(out, ev.Kind)
+	}
+	return out
+}
+
+func countKind(trace []syncTraceEvent, kind syncTraceKind) int {
+	n := 0
+	for _, ev := range trace {
+		if ev.Kind == kind {
+			n++
+		}
+	}
+	return n
+}
+
+// exportTraceFixture writes one sync's trace as a JSONL fixture (header
+// line, then one event per line, with a {"kind":"resume"} marker line
+// between attempt segments) when BATON_SYNC_TRACE_FIXTURE_DIR is set.
+func exportTraceFixture(t *testing.T, name string, attempts ...[]syncTraceEvent) {
+	t.Helper()
+	dir := os.Getenv("BATON_SYNC_TRACE_FIXTURE_DIR")
+	if dir == "" {
+		return
+	}
+	// The path is the developer's own updater flag, not external input.
+	require.NoError(t, os.MkdirAll(dir, 0o755)) //nolint:gosec // test-only fixture export
+	var buf []byte
+	header, err := json.Marshal(syncTraceFixtureHeader{Name: name, Resumed: false})
+	require.NoError(t, err)
+	buf = append(buf, header...)
+	buf = append(buf, '\n')
+	total := 0
+	for i, trace := range attempts {
+		if i > 0 {
+			buf = append(buf, []byte(`{"kind":"resume"}`)...)
+			buf = append(buf, '\n')
+		}
+		for _, ev := range trace {
+			line, err := json.Marshal(ev)
+			require.NoError(t, err)
+			buf = append(buf, line...)
+			buf = append(buf, '\n')
+		}
+		total += len(trace)
+	}
+	path := filepath.Join(dir, name+".jsonl")
+	require.NoError(t, os.WriteFile(path, buf, 0o600)) //nolint:gosec // test-only fixture export
+	t.Logf("wrote trace fixture %s (%d attempts, %d events)", path, len(attempts), total)
+}
+
+// TestChaosSyncTraceOracleInterruptedFixtures records a MULTI-ATTEMPT
+// sync trace from the crash/resume scenario pinned by
+// chaos_source_cache_resume_test.go: a warm two-page delta round is cut
+// by an EffectCrash before its second page ("warm-2" — i.e. AFTER the
+// replay copy and the overlay upsert committed), then resumed to seal
+// by a NEW syncer over the same artifact.
+//
+// PINNED DISCOVERY (this recorder is the first instrument that can
+// distinguish a skipped copy from an idempotent re-copy): the resume
+// RE-RUNS the replay copy even when attempt 1 checkpoints at every
+// batch boundary (checkpointInterval=0, the strongest cadence). The
+// main loop checkpoints between BATCHES, and a paginated action's page
+// chain runs inside one batch, so a mid-chain cut leaves
+// MarkSourceCacheReplayed un-checkpointed no matter the interval — the
+// resume restarts the action from its root and re-copies. The
+// across-attempt re-copy is B5-legal at-least-once idempotence, which
+// is exactly what the policy oracle's once-per-scope-resets-at-resume
+// semantics legalize. The replayed-set's skip role is WITHIN-attempt:
+// warm-2's second replay annotation skips because page "" marked the
+// scope replayed in the same attempt — visible below as exactly one
+// replay per attempt.
+func TestChaosSyncTraceOracleInterruptedFixtures(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 90*time.Second)
+	defer cancel()
+	tmpDir, paths := sourceCachePaths(t, 2)
+	seedPath, warmPath := paths[0], paths[1]
+
+	fx := newSCCollectionFixture(t)
+	scenario := scResumeScenario(t, fx)
+	capability := sourceCacheCapabilityRW("gen-1", "cfg-1")
+
+	// Generation A: cold seed (not exported; the sync under trace is
+	// generation B).
+	seedRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+	require.NoError(t, err)
+	seedRun.SetSourceCacheCapability(capability)
+	runSourceCacheSync(t, ctx, seedRun, chaosTransportDirect, seedPath, tmpDir, "", WithWorkerCount(1))
+
+	// Generation B, attempt 1: warm sync cut before "warm-2".
+	interruptedRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule(chaosconnector.Rule{
+		ID: "cut",
+		Match: chaosconnector.Matcher{
+			Service:   chaosconnector.ExactString("GrantsService"),
+			Method:    chaosconnector.ExactString("ListGrants"),
+			PageToken: chaosconnector.ExactString("warm-2"),
+			Attempt:   1,
+			Phase:     chaosconnector.PhaseBeforeCall,
+		},
+		Effects:  []chaosconnector.Effect{{Kind: chaosconnector.EffectCrash}},
+		MinFires: 1,
+		MaxFires: 1,
+	}))
+	require.NoError(t, err)
+	require.NoError(t, interruptedRun.SetEpoch("second"))
+	interruptedRun.SetSourceCacheCapability(capability)
+	interruptedHarness := newChaosHarness(t, ctx, interruptedRun, warmPath, tmpDir, chaosTransportDirect,
+		WithPreviousSyncC1ZPath(seedPath), WithWorkerCount(1))
+	interruptedConcrete, ok := interruptedHarness.Syncer.(*syncer)
+	require.True(t, ok)
+	// The strongest cadence: even per-batch checkpoints cannot make the
+	// mid-chain cut resumable past the copy (see the pin above).
+	interruptedConcrete.checkpointInterval = 0
+	attempt1Audit := &syncTraceAudit{}
+	interruptedConcrete.testSyncTraceAudit = attempt1Audit
+	require.ErrorIs(t, interruptedHarness.Syncer.Sync(ctx), chaosconnector.ErrInterruptRequested)
+	require.NoError(t, interruptedHarness.Close(t.Context()))
+	attempt1 := attempt1Audit.snapshot()
+
+	// Generation B, resume: a new syncer over the same artifact.
+	resumeRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+	require.NoError(t, err)
+	require.NoError(t, resumeRun.SetEpoch("second"))
+	resumeRun.SetSourceCacheCapability(capability)
+	resumeHarness := newChaosHarness(t, ctx, resumeRun, warmPath, tmpDir, chaosTransportDirect,
+		WithPreviousSyncC1ZPath(seedPath), WithWorkerCount(1))
+	resumeConcrete, ok := resumeHarness.Syncer.(*syncer)
+	require.True(t, ok)
+	attempt2Audit := &syncTraceAudit{}
+	resumeConcrete.testSyncTraceAudit = attempt2Audit
+	resumeHarness.SyncAndClose(t, ctx)
+	attempt2 := attempt2Audit.snapshot()
+
+	rowKind := "grants"
+	// Attempt 1 committed the replay unit and the overlay upsert, never
+	// published, never sealed (the cut hit before warm-2).
+	requireTraceOrder(t, attempt1,
+		syncTraceEvent{Kind: syncTraceConsult, RowKind: rowKind, ScopeKey: scGrantsScopeKey},
+		syncTraceEvent{Kind: syncTraceClear, RowKind: rowKind, ScopeKey: scGrantsScopeKey},
+		syncTraceEvent{Kind: syncTraceReplay, RowKind: rowKind, ScopeKey: scGrantsScopeKey},
+		syncTraceEvent{Kind: syncTraceUpsert, RowKind: rowKind, ScopeKey: scGrantsScopeKey},
+	)
+	require.NotContains(t, kinds(attempt1), syncTracePublish)
+	require.NotContains(t, kinds(attempt1), syncTraceSeal)
+	require.Equal(t, 1, countKind(attempt1, syncTraceReplay))
+
+	// Attempt 2 restarts the action from its root: re-consult, re-clear,
+	// re-copy (the pin), the re-applied overlay upsert, warm-2's skip
+	// (one replay only), the validator publish, and the seal.
+	requireTraceOrder(t, attempt2,
+		syncTraceEvent{Kind: syncTraceConsult, RowKind: rowKind, ScopeKey: scGrantsScopeKey},
+		syncTraceEvent{Kind: syncTraceClear, RowKind: rowKind, ScopeKey: scGrantsScopeKey},
+		syncTraceEvent{Kind: syncTraceReplay, RowKind: rowKind, ScopeKey: scGrantsScopeKey},
+		syncTraceEvent{Kind: syncTraceUpsert, RowKind: rowKind, ScopeKey: scGrantsScopeKey},
+		syncTraceEvent{Kind: syncTracePublish, RowKind: rowKind, ScopeKey: scGrantsScopeKey},
+		syncTraceEvent{Kind: syncTraceSeal},
+	)
+	require.Equal(t, 1, countKind(attempt2, syncTraceReplay),
+		"mid-chain cut resume must re-run the replay copy exactly once (root restart + within-attempt skip on warm-2)")
+	require.Equal(t, syncTraceSeal, attempt2[len(attempt2)-1].Kind)
+
+	exportTraceFixture(t, "warm_replay_sync_interrupted", attempt1, attempt2)
+}

--- a/pkg/sync/ingest_filter.go
+++ b/pkg/sync/ingest_filter.go
@@ -45,6 +45,16 @@ const (
 	ingestQualityReasonExpansionDropped
 	ingestQualityReasonRetainedInvalid
 	ingestQualityReasonUnknownPriorCheckpoint
+	// ingestQualityReasonCompatDriftOnResume: the source-cache compat key
+	// changed across resume attempts, so this artifact's cached rows are
+	// mixed-generation (see ensureSourceCacheCompatRecord). Append-only:
+	// these bit values are persisted in sync stats.
+	ingestQualityReasonCompatDriftOnResume
+	// ingestQualityReasonSourceCacheShapeUnsupported: a source-cache-
+	// annotated page carried a shape replay cannot reproduce (child
+	// resource types, InsertResourceGrants discovery), so replaying this
+	// artifact would silently lose the derived rows (CO-6b-003).
+	ingestQualityReasonSourceCacheShapeUnsupported
 )
 
 func (s *ingestFilterStats) markKnown() {

--- a/pkg/sync/ingest_invariants.go
+++ b/pkg/sync/ingest_invariants.go
@@ -322,8 +322,9 @@ type ingestInvariant struct {
 	failFastPromotes bool
 	// ridesReplayLadder: the check's FAIL-class verdicts wrap
 	// ErrReplayIntegrity on warm syncs for the runners' cold-retry
-	// ladder. Always false until source-cache replay lands; the
-	// meta-test pins that so the field cannot silently pre-enable.
+	// ladder. ErrReplayIntegrity exists (Phase 6b) but no invariant rides
+	// it yet — consuming the ladder is Phase 6c's runner work; the
+	// meta-test pins false so the field cannot silently pre-enable.
 	ridesReplayLadder bool
 	// haltStage, when non-empty, names the test-only halt seam fired
 	// AFTER this invariant completes.

--- a/pkg/sync/ingest_invariants_test.go
+++ b/pkg/sync/ingest_invariants_test.go
@@ -121,10 +121,11 @@ func TestIngestInvariantVerdictTable(t *testing.T) {
 			"%s is both a verdict-table row and a documented exclusion; remove one", id)
 	}
 
-	// The replay ladder does not exist yet: no row may pre-enable it.
+	// ErrReplayIntegrity exists (Phase 6b) but the invariant ladder that
+	// rides it is Phase 6c runner work: no row may pre-enable it.
 	for _, inv := range ingestInvariants {
 		require.Falsef(t, inv.ridesReplayLadder,
-			"row %s sets ridesReplayLadder, but the ErrReplayIntegrity ladder arrives with replay", inv.id)
+			"row %s sets ridesReplayLadder, but consuming the ErrReplayIntegrity ladder is Phase 6c work", inv.id)
 	}
 
 	// A fail-fast-only check trivially promotes under fail-fast; the

--- a/pkg/sync/pebble_etag_replay_test.go
+++ b/pkg/sync/pebble_etag_replay_test.go
@@ -16,7 +16,9 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/dotc1z"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
 	enginepkg "github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble"
+	formatv3 "github.com/conductorone/baton-sdk/pkg/dotc1z/format/v3"
 	"github.com/conductorone/baton-sdk/pkg/logging"
+	"github.com/conductorone/baton-sdk/pkg/sourcecache"
 	et "github.com/conductorone/baton-sdk/pkg/types/entitlement"
 	gt "github.com/conductorone/baton-sdk/pkg/types/grant"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
@@ -24,18 +26,10 @@ import (
 
 // etagObservingMockConnector emits an ETag on every ListGrants
 // response and records the ETag the syncer attaches to the resource
-// it sends back on the next sync. The recorded ETag is the load-
-// bearing observation: when etag-replay is working, sync 2's
-// ListGrants request carries the ETag that sync 1 persisted on the
-// resource; when etag-replay is broken, sync 2 sends a bare
-// resource and the connector observes an empty ETag.
-//
-// When `matchOnIncomingETag` is set, the next call carrying a
-// matching incoming ETag returns ETagMatch with an empty grant list
-// (mimicking a real connector that decided the data is unchanged).
-// That drives the syncer's `fetchEtaggedGrantsForResource` path so
-// downstream assertions can verify the previous sync's grants
-// actually get re-written into the current sync.
+// it sends back on the next sync. It remains the fixture for the
+// previous-sync plumbing tests below (soft-fail contract, replay
+// eligibility gates); the replay behavior itself is verified by the
+// source-cache chaos suites.
 type etagObservingMockConnector struct {
 	*mockConnector
 	etagValue     string
@@ -43,7 +37,6 @@ type etagObservingMockConnector struct {
 
 	mu                  sync.Mutex
 	etagsReceivedByCall []string
-	matchOnIncomingETag bool
 }
 
 func newEtagObservingMockConnector(etagValue string) *etagObservingMockConnector {
@@ -81,21 +74,7 @@ func (mc *etagObservingMockConnector) ListGrants(
 	}
 	mc.mu.Lock()
 	mc.etagsReceivedByCall = append(mc.etagsReceivedByCall, incomingETag)
-	matchMode := mc.matchOnIncomingETag
 	mc.mu.Unlock()
-
-	// When configured to match, the FIRST call with a non-empty
-	// incoming ETag matching ours returns ETagMatch + empty list.
-	// This drives the syncer's etag-replay path that pulls the
-	// previous sync's grants into the current sync.
-	if matchMode && incomingETag == mc.etagValue {
-		return v2.GrantsServiceListGrantsResponse_builder{
-			List: []*v2.Grant{},
-			Annotations: annotations.New(&v2.ETagMatch{
-				EntitlementId: mc.entitlementID,
-			}),
-		}.Build(), nil
-	}
 
 	var key string
 	if r := in.GetResource(); r != nil {
@@ -110,219 +89,26 @@ func (mc *etagObservingMockConnector) ListGrants(
 	}.Build(), nil
 }
 
-// TestPebble_EtagReplay_SendsPreviousEtagOnSecondSync is the
-// end-to-end regression guard for ETag-based replay on the single-sync
-// Pebble engine. A Pebble c1z holds exactly one sync, so the previous
-// sync lives in a SEPARATE c1z supplied via WithPreviousSyncC1ZPath —
-// there is no in-file previous sync to replay from.
+// The two skipped ETag replay tests that lived here
+// (TestPebble_EtagReplay_SendsPreviousEtagOnSecondSync and
+// TestPebble_EtagReplay_CarriesPreviousSyncsGrantsForward) were REMOVED in
+// Phase 6b, replaced by the source-cache chaos suites per the frozen plan
+// (docs/verification/sync-replay-6b/plan.md, closure rules):
 //
-// The story:
+//   - "the previous sync's validator is re-presented to the connector on
+//     the next sync" is subsumed by the lookup consult contract — the gate
+//     matrix (chaos_source_cache_gate_test.go) and the generational suite
+//     (chaos_source_cache_generational_test.go, etag-style scope) assert
+//     the exact validator every consult observes across generations;
+//   - "previous-sync rows are carried forward on a validator match" is
+//     subsumed by the collection-semantics suite
+//     (chaos_source_cache_collection_test.go) and the generational
+//     steady-state suite, which compare replayed content against
+//     independent cold baselines by full-proto fingerprint.
 //
-//  1. Sync 1 into file A stores a grant + an ETag annotation on the
-//     resource, then closes.
-//  2. Sync 2 into a fresh file B is configured with
-//     WithPreviousSyncC1ZPath(A). The syncer's
-//     fetchResourceForPreviousSync reads file A's resource, extracts
-//     the ETag, and re-attaches it to the request it sends the
-//     connector.
-//
-// This asserts the contract the optimisation depends on: every sync
-// after the first re-attaches the previous sync's persisted ETag to the
-// resource the syncer sends the connector.
-func TestPebble_EtagReplay_SendsPreviousEtagOnSecondSync(t *testing.T) {
-	// TODO(kans): re-enable when the ETag-replay read path returns. The
-	// previous-sync scaffolding (WithPreviousSyncC1ZPath, previousSyncReader)
-	// and the etag protobufs are intentionally retained for that future
-	// effort, but the syncer no longer resolves/reads the previous sync
-	// (getPreviousFullSyncID / fetchResourceForPreviousSync were removed),
-	// so the connector never receives the prior ETag.
-	t.Skip("etag replay read path not implemented on the single-sync Pebble engine yet")
-
-	ctx := t.Context()
-	ctx, err := logging.Init(ctx)
-	require.NoError(t, err)
-
-	tempDir := t.TempDir()
-	sync1Path := filepath.Join(tempDir, "etag-prev-pebble.c1z")
-	sync2Path := filepath.Join(tempDir, "etag-current-pebble.c1z")
-
-	group, err := rs.NewGroupResource("g1", groupResourceType, "g1", nil)
-	require.NoError(t, err)
-	ent := et.NewAssignmentEntitlement(group, "member", et.WithGrantableTo(groupResourceType, userResourceType))
-	ent.SetSlug("member")
-	user, err := rs.NewUserResource("u1", userResourceType, "u1", nil, rs.WithAnnotation(&v2.SkipEntitlementsAndGrants{}))
-	require.NoError(t, err)
-	grant := gt.NewGrant(group, "member", user)
-
-	mc := newEtagObservingMockConnector("etag-v1")
-	mc.WithData(group, ent, grant)
-
-	// --- Sync 1 into file A ---
-	store1, err := dotc1z.NewStore(ctx, sync1Path,
-		dotc1z.WithEngine(c1zstore.EnginePebble),
-		dotc1z.WithTmpDir(tempDir),
-	)
-	require.NoError(t, err)
-	syncer1, err := NewSyncer(ctx, mc, WithConnectorStore(store1), WithTmpDir(tempDir))
-	require.NoError(t, err)
-	require.NoError(t, syncer1.Sync(ctx))
-	require.NoError(t, syncer1.Close(ctx))
-
-	// --- Sync 2 into a fresh file B, replaying from file A ---
-	store2, err := dotc1z.NewStore(ctx, sync2Path,
-		dotc1z.WithEngine(c1zstore.EnginePebble),
-		dotc1z.WithTmpDir(tempDir),
-	)
-	require.NoError(t, err)
-	syncer2, err := NewSyncer(ctx, mc,
-		WithConnectorStore(store2),
-		WithTmpDir(tempDir),
-		WithPreviousSyncC1ZPath(sync1Path),
-	)
-	require.NoError(t, err)
-	require.NoError(t, syncer2.Sync(ctx))
-	require.NoError(t, syncer2.Close(ctx))
-
-	mc.mu.Lock()
-	calls := append([]string(nil), mc.etagsReceivedByCall...)
-	mc.mu.Unlock()
-
-	require.GreaterOrEqual(t, len(calls), 2,
-		"expected at least two ListGrants calls across the two syncs; got %d", len(calls))
-
-	require.Equal(t, "", calls[0], "sync 1's first ListGrants must not carry an ETag (no previous sync to replay from)")
-
-	// The load-bearing assertion. Sync 2's ListGrants call must have
-	// received the ETag sync 1 persisted on the resource — recovered
-	// from the previous-sync c1z (file A) via WithPreviousSyncC1ZPath.
-	require.Equal(t, "etag-v1", calls[1],
-		"sync 2's ListGrants request must carry the ETag persisted by sync 1 (read from the "+
-			"previous-sync c1z); got %q. The syncer's fetchResourceForPreviousSync reads file A's "+
-			"resource through the previous-sync reader; if that read regresses the connector sees a "+
-			"bare resource and etag-replay is silently defeated",
-		calls[1],
-	)
-}
-
-// TestPebble_EtagReplay_CarriesPreviousSyncsGrantsForward is the
-// downstream half of the etag-replay contract that
-// `SendsPreviousEtagOnSecondSync` (above) gates: when the connector
-// responds with ETagMatch, the syncer's `fetchEtaggedGrantsForResource`
-// (pkg/sync/syncer.go) must read the previous sync's grants for the
-// resource — from the previous-sync c1z (WithPreviousSyncC1ZPath) on
-// the single-sync Pebble engine — and re-write them into the current
-// sync.
-//
-// The read is `previousSyncReadStore().ListGrants(Resource=g1,
-// SyncDetails=sync1)`. `Adapter.ListGrants` must filter `req.Resource`
-// against the entitlement-side resource (matching SQLite's
-// `listGrantsGeneric`) via the `idxGrantByEntitlementResource` index /
-// `PaginateGrantsByEntitlementResource` path; a principal-side filter
-// would return zero grants for membership-style grants and silently
-// drop the carry-forward.
-func TestPebble_EtagReplay_CarriesPreviousSyncsGrantsForward(t *testing.T) {
-	// TODO(kans): re-enable when the ETag-replay read path returns. The
-	// previous-sync scaffolding (WithPreviousSyncC1ZPath, previousSyncReader)
-	// and the etag protobufs are intentionally retained for that future
-	// effort, but the syncer no longer resolves/reads the previous sync
-	// (getPreviousFullSyncID / fetchResourceForPreviousSync were removed),
-	// so grants from the prior sync are not carried forward.
-	t.Skip("etag replay read path not implemented on the single-sync Pebble engine yet")
-
-	ctx := t.Context()
-	ctx, err := logging.Init(ctx)
-	require.NoError(t, err)
-
-	tempDir := t.TempDir()
-	sync1Path := filepath.Join(tempDir, "etag-carryforward-prev.c1z")
-	sync2Path := filepath.Join(tempDir, "etag-carryforward-current.c1z")
-
-	group, err := rs.NewGroupResource("g1", groupResourceType, "g1", nil)
-	require.NoError(t, err)
-	ent := et.NewAssignmentEntitlement(group, "member", et.WithGrantableTo(groupResourceType, userResourceType))
-	ent.SetSlug("member")
-	user, err := rs.NewUserResource("u1", userResourceType, "u1", nil, rs.WithAnnotation(&v2.SkipEntitlementsAndGrants{}))
-	require.NoError(t, err)
-	grant := gt.NewGrant(group, "member", user)
-
-	mc := newEtagObservingMockConnector("etag-v1")
-	mc.WithData(group, ent, grant)
-
-	// --- Sync 1 into file A: stores the grant and the ETag. ---
-	store1, err := dotc1z.NewStore(ctx, sync1Path,
-		dotc1z.WithEngine(c1zstore.EnginePebble),
-		dotc1z.WithTmpDir(tempDir),
-	)
-	require.NoError(t, err)
-	syncer1, err := NewSyncer(ctx, mc, WithConnectorStore(store1), WithTmpDir(tempDir))
-	require.NoError(t, err)
-	require.NoError(t, syncer1.Sync(ctx))
-	require.NoError(t, syncer1.Close(ctx))
-
-	// --- Sync 2 into a fresh file B, replaying from file A. The
-	// connector returns ETagMatch when it sees the previous ETag the
-	// syncer attaches, so the syncer's etag-replay path is responsible
-	// for carrying sync 1's grant forward.
-	mc.mu.Lock()
-	mc.matchOnIncomingETag = true
-	mc.etagsReceivedByCall = nil
-	mc.mu.Unlock()
-
-	store2, err := dotc1z.NewStore(ctx, sync2Path,
-		dotc1z.WithEngine(c1zstore.EnginePebble),
-		dotc1z.WithTmpDir(tempDir),
-	)
-	require.NoError(t, err)
-	syncer2, err := NewSyncer(ctx, mc,
-		WithConnectorStore(store2),
-		WithTmpDir(tempDir),
-		WithPreviousSyncC1ZPath(sync1Path),
-	)
-	require.NoError(t, err)
-	require.NoError(t, syncer2.Sync(ctx))
-	require.NoError(t, syncer2.Close(ctx))
-
-	// Sanity: sync 2 actually sent sync 1's ETag (replay source read OK).
-	mc.mu.Lock()
-	calls := append([]string(nil), mc.etagsReceivedByCall...)
-	mc.mu.Unlock()
-	require.NotEmpty(t, calls)
-	require.Equal(t, "etag-v1", calls[0], "sanity: sync 2's ListGrants must carry sync 1's ETag from the previous-sync c1z")
-
-	// Reopen the current sync's c1z (file B): with etag-replay working
-	// end-to-end, sync 2 carried sync 1's grant forward into its own
-	// grants keyspace.
-	reopen, err := dotc1z.NewStore(ctx, sync2Path,
-		dotc1z.WithEngine(c1zstore.EnginePebble),
-		dotc1z.WithReadOnly(true),
-	)
-	require.NoError(t, err)
-	defer func() { _ = reopen.Close(ctx) }()
-
-	latest, ok := reopen.(interface {
-		LatestFinishedSyncID(ctx context.Context, syncType connectorstore.SyncType) (string, error)
-	})
-	require.True(t, ok)
-	sync2ID, err := latest.LatestFinishedSyncID(ctx, connectorstore.SyncTypeFull)
-	require.NoError(t, err)
-	require.NotEmpty(t, sync2ID)
-	require.NoError(t, reopen.SetCurrentSync(ctx, sync2ID))
-
-	resp, err := reopen.ListGrants(ctx, v2.GrantsServiceListGrantsRequest_builder{}.Build())
-	require.NoError(t, err)
-
-	require.Len(t, resp.GetList(), 1,
-		"sync 2 must carry sync 1's grant forward after ETagMatch; got %d. "+
-			"fetchEtaggedGrantsForResource reads the previous-sync c1z via "+
-			"ListGrants(Resource=g1); if Adapter.ListGrants(req.Resource) reverts to a "+
-			"principal filter (PaginateGrantsByPrincipal) instead of the entitlement-side "+
-			"PaginateGrantsByEntitlementResource path, the read silently returns zero grants "+
-			"and etag-replay drops sync 1's grants entirely",
-		len(resp.GetList()))
-
-	got := resp.GetList()[0]
-	require.Equal(t, grant.GetId(), got.GetId(), "the etag-replayed grant must round-trip its identity")
-}
+// The generalized source-cache annotations replace the ETag/ETagMatch
+// protobufs as the replay contract; the old protobufs remain for wire
+// compatibility only.
 
 // TestOptionalPreviousSyncC1ZPath_SoftFails pins the best-effort
 // contract of WithOptionalPreviousSyncC1ZPath: a missing or corrupt
@@ -388,38 +174,211 @@ func TestOptionalPreviousSyncC1ZPath_SoftFails(t *testing.T) {
 	require.NoError(t, store.Close(ctx))
 }
 
+// buildSyncedPreviousArtifact runs a REAL full sync (group + member
+// entitlement + one grant to an existing user) into a fresh Pebble c1z and
+// returns its path. Unlike a bare StartNewSync/EndSync artifact, the result
+// carries everything the consume gates demand of a replay source: a finished
+// FULL run, ingest-quality stats with no drops (G4), and the save-time
+// materialization witness in the envelope manifest (G5).
+func buildSyncedPreviousArtifact(t *testing.T, extra ...SyncOpt) string {
+	t.Helper()
+	ctx, err := logging.Init(t.Context())
+	require.NoError(t, err)
+
+	tempDir := t.TempDir()
+	path := filepath.Join(tempDir, "previous.c1z")
+
+	group, err := rs.NewGroupResource("g1", groupResourceType, "g1", nil)
+	require.NoError(t, err)
+	ent := et.NewAssignmentEntitlement(group, "member", et.WithGrantableTo(groupResourceType, userResourceType))
+	ent.SetSlug("member")
+	user, err := rs.NewUserResource("u1", userResourceType, "u1", nil, rs.WithAnnotation(&v2.SkipEntitlementsAndGrants{}))
+	require.NoError(t, err)
+	grant := gt.NewGrant(group, "member", user)
+
+	mc := newEtagObservingMockConnector("etag-v1")
+	mc.WithData(group, ent, grant)
+	// The grant's principal must resolve to a synced resource so an
+	// unrestricted sync ends with clean ingest quality.
+	mc.AddResource(ctx, user)
+
+	store, err := dotc1z.NewStore(ctx, path,
+		dotc1z.WithEngine(c1zstore.EnginePebble),
+		dotc1z.WithTmpDir(tempDir),
+	)
+	require.NoError(t, err)
+	opts := append([]SyncOpt{WithConnectorStore(store), WithTmpDir(tempDir)}, extra...)
+	syncer, err := NewSyncer(ctx, mc, opts...)
+	require.NoError(t, err)
+	require.NoError(t, syncer.Sync(ctx))
+	require.NoError(t, syncer.Close(ctx))
+	return path
+}
+
+// buildBarePreviousArtifact writes an artifact with StartNewSync/EndSync
+// only — no syncer, so no ingest-quality stats. Saved by the current SDK it
+// still carries the envelope witness, which makes it the isolation case for
+// G4's absent-stats fail-closed rule.
+func buildBarePreviousArtifact(t *testing.T, engine c1zstore.Engine, syncType connectorstore.SyncType) string {
+	t.Helper()
+	ctx := t.Context()
+	path := filepath.Join(t.TempDir(), "previous.c1z")
+	previous, err := dotc1z.NewStore(ctx, path, dotc1z.WithEngine(engine))
+	require.NoError(t, err)
+	_, err = previous.StartNewSync(ctx, syncType, "")
+	require.NoError(t, err)
+	require.NoError(t, previous.EndSync(ctx))
+	require.NoError(t, previous.Close(ctx))
+	return path
+}
+
+// TestPreviousSyncC1ZPathEnforcesReplayEligibility pins the NewSyncer half
+// of the source-cache gate ladder (docs/verification/sync-replay-6b/plan.md
+// B2, gates G1–G5): which previous-sync artifacts are accepted as warm
+// replay sources (previousSyncReader != nil) and which degrade to a cold
+// sync. The install-time gates (G6 capability, G7 compat byte-match) run at
+// Sync, not NewSyncer, so reader presence here is independent of the
+// connector's declared capability.
 func TestPreviousSyncC1ZPathEnforcesReplayEligibility(t *testing.T) {
 	for _, tc := range []struct {
 		name       string
-		engine     c1zstore.Engine
-		syncType   connectorstore.SyncType
-		compacted  bool
+		build      func(t *testing.T) string
 		wantReader bool
 	}{
-		{name: "pebble-full", engine: c1zstore.EnginePebble, syncType: connectorstore.SyncTypeFull, wantReader: true},
-		{name: "pebble-partial", engine: c1zstore.EnginePebble, syncType: connectorstore.SyncTypePartial},
-		{name: "pebble-compacted-full", engine: c1zstore.EnginePebble, syncType: connectorstore.SyncTypeFull, compacted: true},
-		{name: "sqlite-full", engine: c1zstore.EngineSQLite, syncType: connectorstore.SyncTypeFull},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			ctx := t.Context()
-			previousPath := filepath.Join(t.TempDir(), "previous.c1z")
-			previous, err := dotc1z.NewStore(ctx, previousPath, dotc1z.WithEngine(tc.engine))
-			require.NoError(t, err)
-			syncID, err := previous.StartNewSync(ctx, tc.syncType, "")
-			require.NoError(t, err)
-			require.NoError(t, previous.EndSync(ctx))
-			if tc.compacted {
-				require.Equal(t, c1zstore.EnginePebble, tc.engine)
-				eng, ok := enginepkg.AsEngine(previous)
+		{
+			// Every gate passes: Pebble artifact (G2) holding a finished,
+			// non-compacted FULL sync (G3) produced by a real syncer run, so
+			// ingest-quality stats exist with no drop flags (G4) and the
+			// envelope carries this SDK's materialization witness (G5).
+			name:       "pebble-full-synced",
+			build:      func(t *testing.T) string { return buildSyncedPreviousArtifact(t) },
+			wantReader: true,
+		},
+		{
+			// G4 absent-stats conservatism: a finished FULL Pebble sync
+			// written without the syncer has no ingest-quality stats.
+			// Unknown quality must fail closed — pre-quality artifacts can
+			// never seed a warm sync.
+			name: "pebble-full-no-quality-stats",
+			build: func(t *testing.T) string {
+				return buildBarePreviousArtifact(t, c1zstore.EnginePebble, connectorstore.SyncTypeFull)
+			},
+		},
+		{
+			// G3: partial syncs never serve as replay sources.
+			name: "pebble-partial",
+			build: func(t *testing.T) string {
+				return buildBarePreviousArtifact(t, c1zstore.EnginePebble, connectorstore.SyncTypePartial)
+			},
+		},
+		{
+			// G3: a folded (compacted) artifact is rejected even when its
+			// quality stats and witness are intact — fold retains stale
+			// source-scope indexes, so compacted must dominate.
+			name: "pebble-compacted-full",
+			build: func(t *testing.T) string {
+				path := buildSyncedPreviousArtifact(t)
+				ctx := t.Context()
+				store, err := dotc1z.NewStore(ctx, path,
+					dotc1z.WithEngine(c1zstore.EnginePebble),
+					dotc1z.WithTmpDir(t.TempDir()),
+				)
+				require.NoError(t, err)
+				latest, ok := store.(interface {
+					LatestFinishedSyncID(ctx context.Context, syncType connectorstore.SyncType) (string, error)
+				})
+				require.True(t, ok)
+				syncID, err := latest.LatestFinishedSyncID(ctx, connectorstore.SyncTypeFull)
+				require.NoError(t, err)
+				eng, ok := enginepkg.AsEngine(store)
 				require.True(t, ok)
 				run, err := eng.GetSyncRunRecord(ctx, syncID)
 				require.NoError(t, err)
 				run.SetCompacted(true)
 				require.NoError(t, eng.PutSyncRunRecord(ctx, run))
-				require.True(t, enginepkg.MarkStoreDirty(previous))
-			}
-			require.NoError(t, previous.Close(ctx))
+				require.True(t, enginepkg.MarkStoreDirty(store))
+				require.NoError(t, store.Close(ctx))
+				return path
+			},
+		},
+		{
+			// G2: SQLite is conversion-only (RFC 0010) — always cold.
+			name: "sqlite-full",
+			build: func(t *testing.T) string {
+				return buildBarePreviousArtifact(t, c1zstore.EngineSQLite, connectorstore.SyncTypeFull)
+			},
+		},
+		{
+			// G4 replay-blocked: restricting the sync to the group type
+			// leaves the grant's user principal type unscheduled, so the
+			// ingest filter drops the grant and flags the run
+			// source_cache_replay_blocked. A lossy sync must never seed the
+			// next generation, however healthy it looks structurally.
+			name: "pebble-quality-blocked",
+			build: func(t *testing.T) string {
+				return buildSyncedPreviousArtifact(t, WithSyncResourceTypes([]string{"group"}))
+			},
+		},
+		{
+			// G5 — CO-017 old-fold shape (plan B8). An older SDK's fold
+			// byte-copies the payload intact (source-cache manifest entries,
+			// indexes, compat record survive; compacted stays false on the
+			// surviving run) but rebuilds the ENVELOPE manifest from its own
+			// descriptors, so it cannot carry the materialization witness.
+			// Simulate exactly that: extract the payload of a fully eligible
+			// artifact, clear the witness, and re-wrap the same payload. The
+			// result passes G1–G4 and must be rejected by the fence alone.
+			name: "pebble-fence-stripped-old-fold-shape",
+			build: func(t *testing.T) string {
+				path := buildSyncedPreviousArtifact(t)
+				src, err := os.Open(path)
+				require.NoError(t, err)
+				payloadDir := filepath.Join(t.TempDir(), "payload")
+				require.NoError(t, os.MkdirAll(payloadDir, 0o755))
+				manifest, _, err := formatv3.ExtractEnvelopePayload(src, payloadDir)
+				require.NoError(t, err)
+				require.NoError(t, src.Close())
+				// Sanity: current-SDK saves stamp the witness; without this
+				// the strip below would be a no-op and the case vacuous.
+				require.Equal(t, sourcecache.MaterializationPolicyGeneration, manifest.GetSdkMaterializationGeneration())
+				manifest.SetSdkMaterializationGeneration("")
+				stripped := filepath.Join(t.TempDir(), "old-fold-shape.c1z")
+				out, err := os.Create(stripped)
+				require.NoError(t, err)
+				require.NoError(t, formatv3.WriteEnvelope(out, manifest, payloadDir))
+				require.NoError(t, out.Close())
+				return stripped
+			},
+		},
+		{
+			// G5 — witness MISMATCH (not absence): an artifact whose witness
+			// names a different materialization generation (a future SDK's
+			// save, or any generation bump) must be rejected the same way.
+			// The fence is an exact-match check, never "witness present".
+			name: "pebble-fence-foreign-witness",
+			build: func(t *testing.T) string {
+				path := buildSyncedPreviousArtifact(t)
+				src, err := os.Open(path)
+				require.NoError(t, err)
+				payloadDir := filepath.Join(t.TempDir(), "payload")
+				require.NoError(t, os.MkdirAll(payloadDir, 0o755))
+				manifest, _, err := formatv3.ExtractEnvelopePayload(src, payloadDir)
+				require.NoError(t, err)
+				require.NoError(t, src.Close())
+				manifest.SetSdkMaterializationGeneration(
+					sourcecache.MaterializationPolicyGeneration + "-future")
+				rewrapped := filepath.Join(t.TempDir(), "foreign-witness.c1z")
+				out, err := os.Create(rewrapped)
+				require.NoError(t, err)
+				require.NoError(t, formatv3.WriteEnvelope(out, manifest, payloadDir))
+				require.NoError(t, out.Close())
+				return rewrapped
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := t.Context()
+			previousPath := tc.build(t)
 
 			current, err := dotc1z.NewStore(ctx, filepath.Join(t.TempDir(), "current.c1z"), dotc1z.WithEngine(c1zstore.EnginePebble))
 			require.NoError(t, err)

--- a/pkg/sync/replay_integrity.go
+++ b/pkg/sync/replay_integrity.go
@@ -1,0 +1,63 @@
+package sync //nolint:revive,nolintlint // we can't change the package name for backwards compatibility
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/conductorone/baton-sdk/pkg/sourcecache"
+)
+
+// ErrReplayIntegrity is the errors.Is target for every source-cache replay
+// failure the sync orchestration raises (plan B7 in
+// docs/verification/sync-replay-6b/plan.md). Use errors.As with
+// *ReplayIntegrityError to read the verdict, row kind, and scope key.
+var ErrReplayIntegrity = errors.New("source-cache replay integrity")
+
+// ReplayVerdict tells a retrying runner what a failed replay says about the
+// previous artifact.
+type ReplayVerdict int
+
+const (
+	// ReplayVerdictCold: the previous artifact or the connector's replay
+	// decision cannot be trusted — discard the replay source and retry
+	// cold. This is the fail-closed default: a wrong cold wastes one
+	// fetch, a wrong warm can loop on a poisoned artifact.
+	ReplayVerdictCold ReplayVerdict = iota
+
+	// ReplayVerdictWarm: the replay decision was sound and the failure was
+	// destination-side (copy commit, overlay write, manifest publish) or
+	// an interruption — a retry may succeed with replay still armed.
+	ReplayVerdictWarm
+)
+
+func (v ReplayVerdict) String() string {
+	if v == ReplayVerdictWarm {
+		return "warm"
+	}
+	return "cold"
+}
+
+// ReplayIntegrityError wraps a source-cache replay failure with its retry
+// verdict and the failing (row kind, scope key). It matches
+// ErrReplayIntegrity via errors.Is and unwraps to the underlying cause.
+type ReplayIntegrityError struct {
+	Verdict  ReplayVerdict
+	RowKind  sourcecache.RowKind
+	ScopeKey string
+	Err      error
+}
+
+func (e *ReplayIntegrityError) Error() string {
+	return fmt.Sprintf(
+		"source-cache replay integrity (%s verdict) for %s scope %q: %v",
+		e.Verdict, e.RowKind, e.ScopeKey, e.Err,
+	)
+}
+
+func (e *ReplayIntegrityError) Unwrap() error { return e.Err }
+
+func (e *ReplayIntegrityError) Is(target error) bool { return target == ErrReplayIntegrity }
+
+func newReplayIntegrityError(verdict ReplayVerdict, rowKind sourcecache.RowKind, scopeKey string, err error) *ReplayIntegrityError {
+	return &ReplayIntegrityError{Verdict: verdict, RowKind: rowKind, ScopeKey: scopeKey, Err: err}
+}

--- a/pkg/sync/source_cache_exclusions_verification_test.go
+++ b/pkg/sync/source_cache_exclusions_verification_test.go
@@ -1,0 +1,40 @@
+package sync //nolint:revive,nolintlint // backwards-compatible package name
+
+import "testing"
+
+// TestVerificationPhase6bExecutableExclusions is the Phase 6b registry of
+// executable boundary exclusions for source-cache replay orchestration
+// (docs/verification/sync-replay-6b/plan.md, B10). These are deliberate,
+// registered scope boundaries — not silently omitted coverage. Removing an
+// entry requires replacing it with evidence.
+//
+// Registered boundaries that HAVE instruments (listed here for the
+// registry's completeness, not skipped):
+//
+//   - Static entitlements stay unscoped: SourceCacheRecord on a
+//     ListStaticEntitlements response is ignored with a warn. Pinned by
+//     TestChaosSourceCacheFreshPageSemantics/static-entitlement-annotation-ignored.
+//   - Derived rows stay unscoped: expansion output is regenerated, never
+//     stamped, and expander-written Sources are stripped at replay copy.
+//     Pinned by TestChaosSourceCacheReplayStripsExpanderSources (stamp
+//     counts exclude the expander-created grant).
+func TestVerificationPhase6bExecutableExclusions(t *testing.T) {
+	t.Run("lambda-ask-answer-continuation", func(t *testing.T) {
+		t.Skip("SourceCacheLookupOffer is never attached to requests and SourceCacheLookupAsk/SourceCacheLookupAnswers are never consumed or produced " +
+			"by 6b orchestration; the lambda ask/answer continuation is deferred to Phase 6c")
+	})
+	t.Run("subprocess-transport-lookup-delivery", func(t *testing.T) {
+		t.Skip("CO-6b-001: subprocess-wrapped connectors (internal/connector's runner wrapper) have no RPC backchannel to receive the Lookup interface, " +
+			"so they observe NoopLookup and sync cold; in-process delivery is covered by the gate-matrix suite's transport cells (direct client, in-process gRPC), " +
+			"which are chaos-harness clients — no production transport wires the setter in this phase, and the syncer's deliverability probe keeps such syncs cold rather than logging warm")
+	})
+	t.Run("resource-targeted-sync-and-event-feeds", func(t *testing.T) {
+		t.Skip("ResourceTargetedSyncer.Get and event feeds carry no source-cache semantics in Phase 6b (plan B10)")
+	})
+	t.Run("shrunk-resource-type-list-bypasses-fresh-ingest-filter", func(t *testing.T) {
+		t.Skip("round-4 review N-3: a connector whose ListResourceTypes output shrinks between generations without bumping cache_generation can replay rows " +
+			"referencing types a cold sync's fresh-ingest filter would drop (sync_selection_fingerprint digests the caller's selection, not the emitted type list); " +
+			"excluded because the capability contract makes an unbumped visibility change a connector-side violation (same class as an unstable validator), " +
+			"the ingest invariants (I3/I7/I8/I9) surface the dangling references as warn-class verdicts, and connector type lists are static in practice")
+	})
+}

--- a/pkg/sync/source_cache_orchestration.go
+++ b/pkg/sync/source_cache_orchestration.go
@@ -1,0 +1,855 @@
+package sync
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"sync"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	"github.com/conductorone/baton-sdk/pkg/sourcecache"
+)
+
+// Source-cache replay orchestration (ADVANCED FUNCTIONALITY — see
+// pkg/sourcecache for the connector-facing contract and
+// docs/verification/sync-replay-6b/plan.md for the frozen behavioral
+// contract this file implements).
+//
+// A connector opts in by attaching SourceCacheCapability MODE_READ_WRITE to
+// its Validate response. The syncer then decides warm vs cold: warm installs
+// a lookup backed by the previous sync artifact's source-cache manifest;
+// every degradation installs NoopLookup so a well-behaved connector
+// cold-fetches. The lookup is delivered through the connector client at sync
+// start and cleared at sync end so a late RPC cannot read stale state.
+
+// parseSourceCacheCapability extracts the SourceCacheCapability annotation
+// from a Validate response. Absent or unparsable annotations mean the
+// capability is not declared (unparsable additionally warns): source-cache
+// handling stays off and the connector runs a plain cold sync.
+func parseSourceCacheCapability(ctx context.Context, annos annotations.Annotations) *v2.SourceCacheCapability {
+	capability := &v2.SourceCacheCapability{}
+	ok, err := annos.Pick(capability)
+	if err != nil {
+		ctxzap.Extract(ctx).Warn("failed to parse SourceCacheCapability from Validate response; treating as not declared", zap.Error(err))
+		return nil
+	}
+	if !ok {
+		return nil
+	}
+	return capability
+}
+
+// sourceCacheEnabled reports whether this sync's connector declared
+// SourceCacheCapability MODE_READ_WRITE and this sync's shape supports
+// source-cache handling. Only then are SourceCacheRecord /
+// SourceCacheReplay annotations honored (produce side); the consume side
+// (warm lookup) additionally requires a usable previous artifact.
+//
+// Source-cache handling is untargeted-FULL-sync only (CO-6b-003): a
+// partial, resources-only, or targeted sync intentionally collects less
+// than the full inventory, so its pages must not stamp rows or publish
+// validators, and its lookup must stay cold — a warm replay copy would
+// import a whole scope's previous rows into a store that never selected
+// them.
+func (s *syncer) sourceCacheEnabled() bool {
+	if s.sourceCacheCapability.GetMode() != v2.SourceCacheCapability_MODE_READ_WRITE {
+		return false
+	}
+	return s.syncType == connectorstore.SyncTypeFull && len(s.targetedSyncResources) == 0
+}
+
+// sourceCacheEntryReader is the slice of the previous store's source-cache
+// surface the warm lookup needs (satisfied by dotc1z.SourceCacheStore).
+type sourceCacheEntryReader interface {
+	LookupSourceCacheEntry(ctx context.Context, kind sourcecache.RowKind, scopeKey string) (sourcecache.Entry, bool, error)
+}
+
+// sourceCacheCompatReader is the slice of a store's source-cache surface the
+// consume-side compat gate (G7) needs; sourceCacheCompatWriter adds the
+// produce side (satisfied by dotc1z.SourceCacheStore).
+type sourceCacheCompatReader interface {
+	GetSourceCacheCompat(ctx context.Context) (sourcecache.CompatKey, bool, error)
+}
+
+type sourceCacheCompatWriter interface {
+	sourceCacheCompatReader
+	PutSourceCacheCompat(ctx context.Context, compat sourcecache.CompatKey) error
+}
+
+// sourceCacheSelectionFingerprint digests this sync's selection shape: a
+// sync that intentionally collects less (resource-type filter, skip flags)
+// must never serve as the replay base for one that collects more. Frozen
+// canonical form (plan B4):
+//
+//	v1|types=<comma-joined sorted resource-type filter>|skipEG=<bool>|skipG=<bool>
+//
+// hashed as lowercase-hex sha256. The empty filter (all types) canonicalizes
+// to an empty types segment. skipEG never appears on a FULL sync (it flips
+// the sync type), but it shapes THIS sync's consume decision, so it stays in
+// the canonical string rather than relying on that coupling.
+func (s *syncer) sourceCacheSelectionFingerprint() string {
+	types := slices.Clone(s.syncResourceTypes)
+	slices.Sort(types)
+	canonical := fmt.Sprintf("v1|types=%s|skipEG=%t|skipG=%t", strings.Join(types, ","), s.skipEntitlementsAndGrants, s.skipGrants)
+	digest := sha256.Sum256([]byte(canonical))
+	return hex.EncodeToString(digest[:])
+}
+
+// computeSourceCacheCompatKey builds the current sync's replay-compatibility
+// key (plan B4). Connector components are taken verbatim from the declared
+// capability; empty strings are legitimate values that match only empty.
+func (s *syncer) computeSourceCacheCompatKey() sourcecache.CompatKey {
+	return sourcecache.CompatKey{
+		ConnectorCacheGeneration:     s.sourceCacheCapability.GetCacheGeneration(),
+		ConnectorConfigFingerprint:   s.sourceCacheCapability.GetConfigFingerprint(),
+		SDKMaterializationGeneration: sourcecache.MaterializationPolicyGeneration,
+		SyncSelectionFingerprint:     s.sourceCacheSelectionFingerprint(),
+	}
+}
+
+// ensureSourceCacheCompatRecord runs the produce-side compat lifecycle
+// (plan B4): called once per sync attempt — including resumes — when the
+// capability is MODE_READ_WRITE, after Validate and before the first list
+// action. First attempt writes the record; a resume that recomputes the
+// same key is an idempotent no-op.
+//
+// A resume that recomputes a DIFFERENT key means the connector or its
+// configuration changed mid-sync and the artifact's cached rows are
+// mixed-generation: the original record stays (it described the rows
+// already recorded), the sync is marked replay-blocked through the
+// ingest-quality reason flags so this artifact cannot seed the next sync,
+// and drifted=true tells install to degrade this sync's own lookup to
+// NoopLookup for the remainder.
+//
+// Errors are reads/writes against the sync's OWN store and fail the sync,
+// matching every other current-store write on the sync path.
+func (s *syncer) ensureSourceCacheCompatRecord(ctx context.Context, store sourceCacheCompatWriter) (bool, error) {
+	computed := s.computeSourceCacheCompatKey()
+	existing, found, err := store.GetSourceCacheCompat(ctx)
+	if err != nil {
+		return false, fmt.Errorf("source cache: read current sync compat record: %w", err)
+	}
+	if found {
+		if existing == computed {
+			return false, nil
+		}
+		s.ingestFilterStats.blockReplay(ingestQualityReasonCompatDriftOnResume)
+		ctxzap.Extract(ctx).Warn(
+			"source-cache compat key changed across resume attempts; this sync's rows are mixed-generation — "+
+				"degrading to cold lookups and blocking this artifact as a future replay source",
+			zap.Bool("cache_generation_drifted", existing.ConnectorCacheGeneration != computed.ConnectorCacheGeneration),
+			zap.Bool("config_fingerprint_drifted", existing.ConnectorConfigFingerprint != computed.ConnectorConfigFingerprint),
+			zap.Bool("materialization_generation_drifted", existing.SDKMaterializationGeneration != computed.SDKMaterializationGeneration),
+			zap.Bool("selection_fingerprint_drifted", existing.SyncSelectionFingerprint != computed.SyncSelectionFingerprint),
+		)
+		return true, nil
+	}
+	if err := store.PutSourceCacheCompat(ctx, computed); err != nil {
+		return false, fmt.Errorf("source cache: write compat record: %w", err)
+	}
+	return false, nil
+}
+
+// previousSyncSourceCacheLookup is the warm sourcecache.Lookup installed for
+// a sync whose previous artifact passed every consume-side gate. Hits are
+// reported through onHit so replay provenance (same-sync validator origin)
+// can be enforced when a SourceCacheReplay annotation arrives.
+type previousSyncSourceCacheLookup struct {
+	prev sourceCacheEntryReader
+	// onHit records a lookup hit and its validator for provenance
+	// enforcement. May be nil.
+	onHit func(rowKind sourcecache.RowKind, scopeKey string, cacheValidator string)
+	// onConsult, when non-nil, observes every cleanly resolved lookup
+	// (hit or miss) for the sync-trace audit. Purely observational.
+	onConsult func(rowKind sourcecache.RowKind, scopeKey string)
+}
+
+var _ sourcecache.Lookup = (*previousSyncSourceCacheLookup)(nil)
+
+// LookupPreviousSourceCache resolves a scope's previous-sync validator.
+// Contract (pkg/sourcecache): internal read errors that leave fresh fetch
+// available are misses, never connector-call failures — a miss means "fetch
+// cold", which is always safe. Poisoned scopes already read as misses at the
+// store layer. Invalid connector-supplied arguments are logged and read as
+// misses for the same reason.
+func (p *previousSyncSourceCacheLookup) LookupPreviousSourceCache(
+	ctx context.Context,
+	rowKind sourcecache.RowKind,
+	scopeKey string,
+) (sourcecache.Entry, bool, error) {
+	l := ctxzap.Extract(ctx)
+	if err := sourcecache.ValidateRowKind(rowKind); err != nil {
+		l.Warn("source-cache lookup with invalid row kind; treating as miss",
+			zap.String("row_kind", string(rowKind)),
+			zap.Error(err),
+		)
+		return sourcecache.Entry{}, false, nil
+	}
+	if err := sourcecache.ValidateScopeKey(scopeKey); err != nil {
+		l.Warn("source-cache lookup with invalid scope key; treating as miss",
+			zap.String("row_kind", string(rowKind)),
+			zap.Error(err),
+		)
+		return sourcecache.Entry{}, false, nil
+	}
+	entry, found, err := p.prev.LookupSourceCacheEntry(ctx, rowKind, scopeKey)
+	if err != nil {
+		l.Warn("source-cache lookup read failed; treating as miss",
+			zap.String("row_kind", string(rowKind)),
+			zap.String("scope_key", scopeKey),
+			zap.Error(err),
+		)
+		return sourcecache.Entry{}, false, nil
+	}
+	if found && p.onHit != nil {
+		p.onHit(rowKind, scopeKey, entry.CacheValidator)
+	}
+	if p.onConsult != nil {
+		p.onConsult(rowKind, scopeKey)
+	}
+	return entry, found, nil
+}
+
+// sourceCacheWarmStore evaluates the install-time consume-side gates and
+// returns the previous artifact's lookup surface when ALL pass. NewSyncer
+// already gated artifact provenance (present, Pebble, latest finished sync
+// FULL and non-compacted) before setting previousSyncReader; this adds the
+// capability gate (G6) and the compat byte-match gate (G7). Every
+// degradation warns with the failing condition and returns false: the sync
+// proceeds cold, never errors.
+func (s *syncer) sourceCacheWarmStore(ctx context.Context) (sourceCacheEntryReader, bool) {
+	if !s.sourceCacheEnabled() {
+		return nil, false
+	}
+	l := ctxzap.Extract(ctx)
+	if s.previousSyncReader == nil {
+		l.Warn("source-cache capability declared but no usable previous sync artifact; syncing cold")
+		return nil, false
+	}
+	reader, ok := s.previousSyncReader.(sourceCacheEntryReader)
+	if !ok {
+		l.Warn("source-cache capability declared but previous sync store exposes no source-cache surface; syncing cold")
+		return nil, false
+	}
+	// G7 — the previous artifact's stored compat key must byte-match the
+	// current sync's computed key on every field. Absent or unreadable
+	// records are mismatches: compatibility is declared, never inferred.
+	compatReader, ok := s.previousSyncReader.(sourceCacheCompatReader)
+	if !ok {
+		l.Warn("source-cache capability declared but previous sync store exposes no compat record surface; syncing cold")
+		return nil, false
+	}
+	prevCompat, found, err := compatReader.GetSourceCacheCompat(ctx)
+	if err != nil {
+		l.Warn("failed reading previous artifact's source-cache compat record; syncing cold", zap.Error(err))
+		return nil, false
+	}
+	if !found {
+		l.Warn("previous artifact carries no source-cache compat record; syncing cold")
+		return nil, false
+	}
+	computed := s.computeSourceCacheCompatKey()
+	if prevCompat != computed {
+		l.Warn("previous artifact's source-cache compat key does not match this sync; syncing cold",
+			zap.Bool("cache_generation_match", prevCompat.ConnectorCacheGeneration == computed.ConnectorCacheGeneration),
+			zap.Bool("config_fingerprint_match", prevCompat.ConnectorConfigFingerprint == computed.ConnectorConfigFingerprint),
+			zap.Bool("materialization_generation_match", prevCompat.SDKMaterializationGeneration == computed.SDKMaterializationGeneration),
+			zap.Bool("selection_fingerprint_match", prevCompat.SyncSelectionFingerprint == computed.SyncSelectionFingerprint),
+		)
+		return nil, false
+	}
+	return reader, true
+}
+
+// installSourceCacheLookup runs the per-attempt source-cache install
+// sequence: the produce-side compat lifecycle (write/verify the current
+// store's compat record — plan B4), then lookup delivery to the connector
+// (warm lookup when every consume gate passes, nil otherwise — the builder
+// substitutes NoopLookup). It returns the teardown that clears the
+// connector-held lookup at sync end. Delivery is unconditional when the
+// transport supports it so a long-lived connector server never carries a
+// prior sync's lookup into this one.
+//
+// The returned error is always a current-store failure (compat record
+// read/write); every consume-side gate failure degrades to cold instead.
+func (s *syncer) installSourceCacheLookup(ctx context.Context) (func(), error) {
+	l := ctxzap.Extract(ctx)
+
+	// Produce side first: when the connector is capable and the store can
+	// record replay state, the compat record must exist before any list
+	// action — even on syncs that end up consuming cold. A capable
+	// connector on a store without the source-cache surface runs as if the
+	// capability were absent (replay is Pebble-only by design).
+	s.sourceCacheStore = nil
+	compatDrifted := false
+	if s.sourceCacheEnabled() {
+		store, ok := s.store.(dotc1z.SourceCacheStore)
+		if !ok {
+			l.Warn("source-cache capability declared but this sync's store has no source-cache surface; source-cache handling disabled")
+		} else {
+			var err error
+			compatDrifted, err = s.ensureSourceCacheCompatRecord(ctx, store)
+			if err != nil {
+				return nil, err
+			}
+			s.sourceCacheStore = store
+		}
+	} else if store, ok := s.store.(dotc1z.SourceCacheStore); ok {
+		// Capability withdrawn or sync shape changed across resume
+		// attempts (CO-6b-003): a fresh sync's store can never hold a
+		// compat record (replacement syncs excise the family), so finding
+		// one here means a PRIOR ATTEMPT ran with source-cache enabled and
+		// this attempt does not. The rows recorded before the cut carry
+		// stamps and possibly manifest entries whose recording conditions
+		// this attempt no longer declares — the same mixed-generation
+		// hazard as compat drift, so it gets the same treatment: the
+		// artifact is blocked as a future replay source. Read failures
+		// block too (fail-closed: unknown produce history is untrusted).
+		if s.sourceCacheCapability.GetMode() == v2.SourceCacheCapability_MODE_READ_WRITE {
+			l.Warn("source-cache capability declared but this sync is not an untargeted FULL sync; source-cache handling disabled")
+		}
+		_, found, err := store.GetSourceCacheCompat(ctx)
+		if err != nil || found {
+			s.ingestFilterStats.blockReplay(ingestQualityReasonCompatDriftOnResume)
+			l.Warn("source-cache produce state exists from a prior attempt but this attempt runs without source-cache handling; "+
+				"blocking this artifact as a future replay source",
+				zap.Bool("compat_record_found", found),
+				zap.Error(err),
+			)
+		}
+	}
+
+	setter, canDeliver := s.connector.(sourcecache.SetLookup)
+	if !canDeliver {
+		if s.sourceCacheEnabled() {
+			l.Warn("source-cache capability declared but the connector client cannot receive a lookup; syncing cold")
+		}
+		return func() {}, nil
+	}
+	// A client can satisfy SetLookup structurally while wrapping a
+	// transport that cannot forward an interface value (the runner's
+	// subprocess wrapper, CO-6b-001). Delivery into the void must not
+	// count as warm: the connector would consult NoopLookup while the
+	// syncer believed a warm lookup was live.
+	if probe, ok := s.connector.(sourcecache.LookupDeliverabilityProbe); ok && !probe.SourceCacheLookupDeliverable() {
+		if s.sourceCacheEnabled() {
+			l.Warn("source-cache capability declared but the connector transport cannot deliver a lookup " +
+				"(subprocess connectors have no in-process backchannel, CO-6b-001); syncing cold")
+		}
+		return func() {}, nil
+	}
+
+	var lookup sourcecache.Lookup
+	// Compat drift on resume forces the remainder of the sync cold even
+	// when every consume gate would pass: the drifted capability describes
+	// a different connector than the one whose validators the previous
+	// artifact recorded (plan B4).
+	if s.sourceCacheStore != nil && !compatDrifted {
+		if warmStore, warm := s.sourceCacheWarmStore(ctx); warm {
+			lookup = &previousSyncSourceCacheLookup{
+				prev:  warmStore,
+				onHit: s.recordSourceCacheHit,
+				onConsult: func(rowKind sourcecache.RowKind, scopeKey string) {
+					s.testSyncTraceAudit.record(syncTraceConsult, string(rowKind), scopeKey)
+				},
+			}
+		}
+	}
+	setter.SetSourceCache(ctx, lookup)
+	if lookup != nil {
+		// Warm only after delivery actually happened; this flag is the
+		// provenance gate replay enforcement reads (plan B5, CO-6b-003).
+		s.sourceCacheWarm = true
+		l.Info("source-cache replay lookup installed (warm)")
+	}
+
+	// The teardown must run even when the sync exits because ctx was
+	// canceled; the cleared state is what protects the NEXT sync.
+	teardownCtx := context.WithoutCancel(ctx)
+	return func() {
+		s.sourceCacheWarm = false
+		setter.SetSourceCache(teardownCtx, nil)
+	}, nil
+}
+
+// recordSourceCacheHit records a warm-lookup hit and its validator for
+// same-sync replay provenance. Recording is durable (checkpointed with the
+// sync token) so a planning call's verdicts survive interrupt/resume; see
+// the replay handling for enforcement, including the validator binding
+// against the current replay base.
+func (s *syncer) recordSourceCacheHit(rowKind sourcecache.RowKind, scopeKey string, cacheValidator string) {
+	s.state.RecordSourceCacheHit(rowKind, scopeKey, cacheValidator)
+}
+
+// sourceCacheScopeLock returns the mutex serializing page application for
+// one (rowKind, scopeKey) — every scoped page (record or replay) holds it
+// from beforeUpserts through afterUpserts (CO-6b-006). Locks are per-syncer
+// and never reclaimed: the map is bounded by the number of distinct scoped
+// (rowKind, scopeKey) pairs in one sync.
+func (s *syncer) sourceCacheScopeLock(rowKind sourcecache.RowKind, scopeKey string) *sync.Mutex {
+	key := sourceCacheScopeKey(rowKind, scopeKey)
+	if mu, ok := s.sourceCacheScopeLocks.Load(key); ok {
+		return mu.(*sync.Mutex)
+	}
+	mu, _ := s.sourceCacheScopeLocks.LoadOrStore(key, &sync.Mutex{})
+	return mu.(*sync.Mutex)
+}
+
+// sourceCacheScopeKey is the map key for per-(rowKind, scopeKey) syncer
+// state (scope locks, the attempt-local grounded set).
+func sourceCacheScopeKey(rowKind sourcecache.RowKind, scopeKey string) string {
+	return string(rowKind) + "\x00" + scopeKey
+}
+
+// === Page handling (plan B3 fresh pages, B5 replay pages) ===
+
+// sourceCachePageOps drives one list-response page's source-cache work.
+// The three collection handlers call, in order:
+//
+//	ops, err := s.sourceCachePageOps(ctx, rowKind, respAnnos, pageRows)
+//	defer ops.release()      // scope-lock backstop for error paths
+//	ops.beforeUpserts(ctx)   // scope lock + replay copy (B5), before row puts
+//	ops.stampCtx(ctx)        // ctx for the page's CONNECTOR-row puts only
+//	ops.afterUpserts(ctx)    // tombstones, then validator publish; unlocks
+//
+// A nil *sourceCachePageOps (page without honored annotations) no-ops all
+// four, keeping the handlers' happy path annotation-free.
+type sourceCachePageOps struct {
+	s        *syncer
+	rowKind  sourcecache.RowKind
+	scopeKey string
+	record   *v2.SourceCacheRecord
+	replay   *v2.SourceCacheReplay
+	pageRows int
+	// held is the scope lock acquired by beforeUpserts and released by
+	// afterUpserts (or by the handler's deferred release() on error paths
+	// between the two). See beforeUpserts for why EVERY scoped page holds
+	// it, not just replay pages.
+	held *sync.Mutex
+}
+
+// release unlocks the scope lock if this page still holds it. Idempotent
+// and nil-safe: handlers defer it unconditionally so an error between
+// beforeUpserts and afterUpserts cannot leak the lock (a leaked scope lock
+// would deadlock every later page for the scope, including the action's
+// own retry).
+func (o *sourceCachePageOps) release() {
+	if o == nil || o.held == nil {
+		return
+	}
+	o.held.Unlock()
+	o.held = nil
+}
+
+// sourceCachePageOps parses and gates the page's source-cache annotations.
+// Row kind comes from the RPC, never the annotation (proto contract).
+//
+//   - Capability not MODE_READ_WRITE: annotations are ignored wholesale
+//     (proto contract, B1). Returns nil ops.
+//   - Capability declared but the store has no source-cache surface: a
+//     record is ignored with a warn (nothing can be stamped — cold-sync
+//     behavior); a replay is a loud cold failure, because the connector
+//     skipped row generation and there is nothing to fall back to.
+//   - Honored annotations with invalid shapes — unparsable annotation,
+//     invalid scope key, two different scope keys on one page (a page's
+//     rows can be stamped with only one scope), or principal tombstones on
+//     an entitlements page — fail the sync loudly with a cold verdict (B3).
+func (s *syncer) sourceCachePageOps(
+	ctx context.Context,
+	rowKind sourcecache.RowKind,
+	annos annotations.Annotations,
+	pageRows int,
+) (*sourceCachePageOps, error) {
+	record := &v2.SourceCacheRecord{}
+	hasRecord, recordErr := annos.Pick(record)
+	replay := &v2.SourceCacheReplay{}
+	hasReplay, replayErr := annos.Pick(replay)
+
+	if !s.sourceCacheEnabled() {
+		if hasRecord || hasReplay || recordErr != nil || replayErr != nil {
+			ctxzap.Extract(ctx).Debug("source-cache annotations on page ignored: capability not declared MODE_READ_WRITE")
+		}
+		return nil, nil
+	}
+	if recordErr != nil {
+		return nil, newReplayIntegrityError(ReplayVerdictCold, rowKind, "",
+			fmt.Errorf("unparsable SourceCacheRecord annotation: %w", recordErr))
+	}
+	if replayErr != nil {
+		return nil, newReplayIntegrityError(ReplayVerdictCold, rowKind, "",
+			fmt.Errorf("unparsable SourceCacheReplay annotation: %w", replayErr))
+	}
+	if !hasRecord && !hasReplay {
+		return nil, nil
+	}
+	// Duplicate same-type annotations would silently collapse to the first
+	// (Pick returns the first match), letting a second scope bypass the
+	// one-scope-per-page rule below. Reject them loudly (CO-6b-003).
+	var recordCount, replayCount int
+	for _, a := range annos {
+		switch {
+		case a.MessageIs(record):
+			recordCount++
+		case a.MessageIs(replay):
+			replayCount++
+		}
+	}
+	if recordCount > 1 || replayCount > 1 {
+		return nil, newReplayIntegrityError(ReplayVerdictCold, rowKind, "",
+			fmt.Errorf("page carries %d SourceCacheRecord and %d SourceCacheReplay annotations: at most one of each is defined",
+				recordCount, replayCount))
+	}
+	if s.sourceCacheStore == nil {
+		if hasReplay {
+			return nil, newReplayIntegrityError(ReplayVerdictCold, rowKind, replay.GetScopeKey(),
+				fmt.Errorf("SourceCacheReplay on a store with no source-cache surface: the connector skipped row generation and there is nothing to fall back to"))
+		}
+		ctxzap.Extract(ctx).Warn("SourceCacheRecord ignored: this sync's store has no source-cache surface",
+			zap.String("row_kind", string(rowKind)),
+			zap.String("scope_key", record.GetScopeKey()),
+		)
+		return nil, nil
+	}
+
+	ops := &sourceCachePageOps{s: s, rowKind: rowKind, pageRows: pageRows}
+	if hasReplay {
+		if err := sourcecache.ValidateScopeKey(replay.GetScopeKey()); err != nil {
+			return nil, newReplayIntegrityError(ReplayVerdictCold, rowKind, replay.GetScopeKey(),
+				fmt.Errorf("SourceCacheReplay scope key: %w", err))
+		}
+		ops.replay = replay
+		ops.scopeKey = replay.GetScopeKey()
+	}
+	if hasRecord {
+		if err := sourcecache.ValidateScopeKey(record.GetScopeKey()); err != nil {
+			return nil, newReplayIntegrityError(ReplayVerdictCold, rowKind, record.GetScopeKey(),
+				fmt.Errorf("SourceCacheRecord scope key: %w", err))
+		}
+		if hasReplay && record.GetScopeKey() != replay.GetScopeKey() {
+			return nil, newReplayIntegrityError(ReplayVerdictCold, rowKind, record.GetScopeKey(),
+				fmt.Errorf("page carries SourceCacheRecord scope %q and SourceCacheReplay scope %q: a page's rows can be stamped with only one scope",
+					record.GetScopeKey(), replay.GetScopeKey()))
+		}
+		ops.record = record
+		ops.scopeKey = record.GetScopeKey()
+	}
+	if rowKind == sourcecache.RowKindEntitlements &&
+		(len(record.GetDeletedPrincipalIds()) > 0 || len(replay.GetDeletedPrincipalIds()) > 0) {
+		return nil, newReplayIntegrityError(ReplayVerdictCold, rowKind, ops.scopeKey,
+			fmt.Errorf("deleted_principal_ids on an entitlements page: the proto defines no semantics for it"))
+	}
+	return ops, nil
+}
+
+// warnIgnoredSourceCacheAnnotations covers list surfaces where source-cache
+// annotations are registered exclusions (static entitlements, B3): the
+// annotations are ignored with a warn instead of being honored or failing.
+func warnIgnoredSourceCacheAnnotations(ctx context.Context, surface string, annos annotations.Annotations) {
+	if !annos.ContainsAny(&v2.SourceCacheRecord{}, &v2.SourceCacheReplay{}) {
+		return
+	}
+	ctxzap.Extract(ctx).Warn("source-cache annotations are not supported on this surface; ignored",
+		zap.String("surface", surface),
+	)
+}
+
+// stampCtx returns the context for the page's connector-row puts. Rows of a
+// scope-annotated page (fresh or replay-overlay) are stamped with the scope
+// via sourcecache.WithScope; the Pebble adapter picks the scope up at write
+// time. SDK-derived writes (expansion output, reconciliation, sub-resource
+// or related-resource fetches) must NOT go through this context.
+func (o *sourceCachePageOps) stampCtx(ctx context.Context) context.Context {
+	if o == nil || o.scopeKey == "" {
+		return ctx
+	}
+	return sourcecache.WithScope(ctx, o.scopeKey)
+}
+
+// beforeUpserts acquires the page's scope lock and, for replay pages, runs
+// the replay copy (B5) before the page's row puts, enforcing same-sync
+// provenance and once-per-scope idempotence.
+//
+// EVERY scoped page — record-only included — holds the scope's lock from
+// here through afterUpserts (CO-6b-003, extended per re-review N1): at
+// worker counts above one, two pages carrying replay annotations for the
+// same scope could otherwise both observe "not yet replayed" and both run
+// the REPLACEMENT copy — the second wiping overlay rows the first already
+// applied; and a record-only page's row puts, tombstones, and manifest
+// publish could interleave with another action's in-progress replacement
+// copy for the same scope, which deletes the scope's rows before copying
+// the base — silently wiping the fresh rows or publishing a validator over
+// an incomplete scope. Handlers must defer release() so error paths
+// between beforeUpserts and afterUpserts cannot leak the lock.
+func (o *sourceCachePageOps) beforeUpserts(ctx context.Context) error {
+	if o == nil {
+		return nil
+	}
+	mu := o.s.sourceCacheScopeLock(o.rowKind, o.scopeKey)
+	mu.Lock()
+	o.held = mu
+	if o.replay == nil {
+		// Record-only page: ground the replacement listing before its
+		// first write this attempt.
+		return o.groundRecordScope(ctx)
+	}
+	l := ctxzap.Extract(ctx)
+	// The warm flag gates every replay this attempt (CO-6b-003): the
+	// checkpointed hit-set can authorize a handed-off replay verdict only
+	// while the ATTEMPT that drains it still has the warm lookup installed.
+	// A resume whose gates degraded to cold (compat drift, withdrawn
+	// previous artifact) must not honor hits recorded by an earlier attempt
+	// against a base this attempt never re-validated.
+	//
+	// Operational contract for these cold verdicts until Phase 6c: nothing
+	// in-tree consumes ReplayVerdictCold yet, and the offending replay
+	// verdict may live in a checkpointed cursor, so a sync degraded
+	// mid-flight fails identically on every resume — deterministically and
+	// loudly, like any deterministic connector error — until the caller's
+	// retry policy abandons the unfinished sync and starts a fresh (cold)
+	// one. 6c's runner ladder consumes the verdict to make that fallback
+	// automatic.
+	if !o.s.sourceCacheWarm {
+		return newReplayIntegrityError(ReplayVerdictCold, o.rowKind, o.scopeKey,
+			fmt.Errorf("SourceCacheReplay while this attempt's lookup is not warm: the replay base was not re-validated by this attempt's consume gates"))
+	}
+	// Same-sync provenance: the replayed scope's validator must have come
+	// from THIS sync's lookup (possibly a prior attempt of it — the hit-set
+	// is checkpoint-durable). This is also what rejects every replay while
+	// the lookup is NoopLookup: a cold sync records no hits.
+	hitValidator, hasHit := o.s.state.SourceCacheHitValidator(o.rowKind, o.scopeKey)
+	if !hasHit {
+		return newReplayIntegrityError(ReplayVerdictCold, o.rowKind, o.scopeKey,
+			fmt.Errorf("SourceCacheReplay for a scope with no lookup hit recorded this sync: the validator did not originate from this sync's lookup"))
+	}
+	if o.s.state.SourceCacheReplayed(o.rowKind, o.scopeKey) {
+		// Duplicate page / lost-response retry: the copy already ran this
+		// sync. Replay is replacement, so re-running it would also wipe
+		// overlay rows upserted since. Skip the copy; apply the page's
+		// upserts/tombstones normally.
+		l.Debug("source-cache replay already completed for scope this sync; skipping copy",
+			zap.String("row_kind", string(o.rowKind)),
+			zap.String("scope_key", o.scopeKey),
+		)
+	} else {
+		if o.s.previousSyncReader == nil {
+			return newReplayIntegrityError(ReplayVerdictCold, o.rowKind, o.scopeKey,
+				fmt.Errorf("no previous sync artifact available to replay from"))
+		}
+		// Bind the hit to the CURRENT replay base. The eligibility gates
+		// cannot distinguish two artifacts from the same connector and
+		// config (identical compat keys), so a previous artifact swapped
+		// between attempts — service-mode spare replaced by a
+		// rollback/restore — passes every gate while its rows for this
+		// scope may predate the state the connector actually revalidated.
+		// The recorded validator is the one the connector's verdict was
+		// computed against; the base we copy from must still publish
+		// exactly it. Mismatch, absence, and read failure are all cold:
+		// the copy's provenance cannot be established.
+		reader, ok := o.s.previousSyncReader.(sourceCacheEntryReader)
+		if !ok {
+			return newReplayIntegrityError(ReplayVerdictCold, o.rowKind, o.scopeKey,
+				fmt.Errorf("previous sync artifact exposes no source-cache surface to verify the replay base against the recorded hit"))
+		}
+		baseEntry, found, err := reader.LookupSourceCacheEntry(ctx, o.rowKind, o.scopeKey)
+		if err != nil {
+			return newReplayIntegrityError(ReplayVerdictCold, o.rowKind, o.scopeKey,
+				fmt.Errorf("reading the replay base's manifest entry to verify the recorded hit: %w", err))
+		}
+		if !found {
+			return newReplayIntegrityError(ReplayVerdictCold, o.rowKind, o.scopeKey,
+				fmt.Errorf("replay base has no manifest entry for this scope: the recorded hit came from a different artifact"))
+		}
+		if baseEntry.CacheValidator != hitValidator {
+			return newReplayIntegrityError(ReplayVerdictCold, o.rowKind, o.scopeKey,
+				fmt.Errorf("replay base's validator does not match the one this sync's lookup returned: the previous artifact changed between attempts"))
+		}
+		res, err := o.s.sourceCacheStore.ReplaySourceCache(ctx, o.s.previousSyncReader, o.rowKind, o.scopeKey)
+		if err != nil {
+			return newReplayIntegrityError(replayCopyVerdict(err), o.rowKind, o.scopeKey,
+				fmt.Errorf("replay copy: %w", err))
+		}
+		// Trace-audit the unit's legs in the store's contractual
+		// clear-then-copy order (TRACE_BRIDGE.md unit expansion).
+		o.s.testSyncTraceAudit.record(syncTraceClear, string(o.rowKind), o.scopeKey)
+		o.s.testSyncTraceAudit.record(syncTraceReplay, string(o.rowKind), o.scopeKey)
+		if res.NeedsExpansion && !o.s.dontExpandGrants {
+			o.s.state.SetNeedsExpansion()
+		}
+		o.s.state.MarkSourceCacheReplayed(o.rowKind, o.scopeKey)
+		l.Debug("source-cache replay copied previous sync's scope rows",
+			zap.String("row_kind", string(o.rowKind)),
+			zap.String("scope_key", o.scopeKey),
+			zap.Int64("rows", res.Rows),
+		)
+	}
+	// The scope's base is established this attempt (the copy ran, or a
+	// committed copy was observed via the replayed-set): record pages
+	// later in this attempt must not re-ground over it.
+	o.s.sourceCacheScopeGrounded.Store(sourceCacheScopeKey(o.rowKind, o.scopeKey), struct{}{})
+	if !o.replay.GetOverlay() && o.pageRows > 0 {
+		// TRANSITIONAL tolerance (proto contract, pins 6a C34): a
+		// non-overlay replay page must carry no rows. Warn and apply them
+		// with overlay semantics; this hardens to an error later.
+		l.Warn("SourceCacheReplay page with overlay=false carries rows; applying them as overlay upserts (transitional tolerance)",
+			zap.String("row_kind", string(o.rowKind)),
+			zap.String("scope_key", o.scopeKey),
+			zap.Int("rows", o.pageRows),
+		)
+	}
+	return nil
+}
+
+// groundRecordScope grounds a record round's replacement semantics: before
+// the round's first write to a scope this attempt, a partition holding rows
+// that no completed round published is cleared. Un-published rows are
+// un-attributed debris from a crashed attempt — most dangerously a replay
+// copy whose round never published before a cut, after which upstream moved
+// and the resume's consult missed (the verdict-flip path). Composing the
+// record round's fresh listing with that debris seals a phantom union under
+// the fresh validator, which the NEXT sync's consult validates clean and
+// replays forward — the non-self-healing direction. This is the walker
+// model's scenario-1 family (formal/walker/CALIBRATION.md, tc1c flavor),
+// witnessed against this code by
+// TestChaosSourceCacheRecordFlipOverReplayDebris.
+//
+// The rule fires once per scope per attempt (the grounded set is volatile
+// by design — a resume re-decides from the durable facts) and skips scopes
+// with a manifest entry: a published entry means a completed round owns the
+// partition's rows, so later record pages accumulate exactly as before.
+// The caller holds the scope lock. Clearing an empty partition is a no-op,
+// so the common born-empty case costs one manifest lookup.
+func (o *sourceCachePageOps) groundRecordScope(ctx context.Context) error {
+	key := sourceCacheScopeKey(o.rowKind, o.scopeKey)
+	if _, done := o.s.sourceCacheScopeGrounded.Load(key); done {
+		return nil
+	}
+	_, published, err := o.s.sourceCacheStore.LookupSourceCacheEntry(ctx, o.rowKind, o.scopeKey)
+	if err != nil {
+		return newReplayIntegrityError(ReplayVerdictWarm, o.rowKind, o.scopeKey,
+			fmt.Errorf("record grounding: reading this sync's manifest entry: %w", err))
+	}
+	if !published {
+		deleted, err := o.s.sourceCacheStore.ClearSourceCacheScope(ctx, o.rowKind, o.scopeKey)
+		if err != nil {
+			return newReplayIntegrityError(ReplayVerdictWarm, o.rowKind, o.scopeKey,
+				fmt.Errorf("record grounding: clearing un-attributed rows: %w", err))
+		}
+		o.s.testSyncTraceAudit.record(syncTraceClear, string(o.rowKind), o.scopeKey)
+		if deleted > 0 {
+			ctxzap.Extract(ctx).Warn("record grounding cleared un-attributed rows from a prior attempt",
+				zap.String("row_kind", string(o.rowKind)),
+				zap.String("scope_key", o.scopeKey),
+				zap.Int64("rows", deleted),
+			)
+		}
+	}
+	o.s.sourceCacheScopeGrounded.Store(key, struct{}{})
+	return nil
+}
+
+// replayCopyVerdict classifies a ReplaySourceCache failure per plan B7:
+// destination-commit failures past preflight and interruptions are warm
+// (the replay decision was sound; retry may succeed warm); everything else
+// — preflight/source integrity, eligibility, ambiguous store errors — is
+// cold, fail-closed. Only the ERROR CHAIN classifies: ambient context state
+// must not promote (CO-6b-003) — in parallel mode a sibling action's
+// failure cancels the batch context, and a genuine source-integrity error
+// racing that cancellation would otherwise read as warm, the exact
+// fail-open B7's cold default exists to prevent.
+func replayCopyVerdict(err error) ReplayVerdict {
+	if errors.Is(err, dotc1z.ErrSourceCacheReplayDestination) ||
+		errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) {
+		return ReplayVerdictWarm
+	}
+	return ReplayVerdictCold
+}
+
+// wrapPageRowPutError classifies a failure writing THIS page's own rows on
+// a scope-annotated page. Plan B7 names overlay/record upsert write errors
+// as destination-side failures after a sound decision: warm. Nil ops (page
+// without honored annotations) and nil errors pass through untouched, so
+// the handlers can wrap unconditionally.
+func (o *sourceCachePageOps) wrapPageRowPutError(err error) error {
+	if o == nil || err == nil || o.scopeKey == "" {
+		return err
+	}
+	return newReplayIntegrityError(ReplayVerdictWarm, o.rowKind, o.scopeKey,
+		fmt.Errorf("page row upserts: %w", err))
+}
+
+// afterUpserts applies the page's tombstones (after its rows commit — B3's
+// within-page order, closing 6a C29's orchestration half) and then
+// publishes the scope's manifest entry when the page supplied a validator.
+// Write failures here are destination-side after a sound decision: warm.
+// Deterministic input-shape failures (a malformed tombstone id the store
+// can never resolve) are cold — retrying them warm cannot succeed
+// (CO-6b-003).
+func (o *sourceCachePageOps) afterUpserts(ctx context.Context) error {
+	if o == nil {
+		return nil
+	}
+	defer o.release()
+	if o.pageRows > 0 {
+		// The page's row puts committed between beforeUpserts and here.
+		o.s.testSyncTraceAudit.record(syncTraceUpsert, string(o.rowKind), o.scopeKey)
+	}
+	// Replay tombstones precede record tombstones (the replay annotation
+	// describes the base; the record describes this page), each canonical
+	// before principal-scoped.
+	canonical := append(append([]string{}, o.replay.GetDeletedIds()...), o.record.GetDeletedIds()...)
+	if o.rowKind == sourcecache.RowKindResources {
+		// The store contract requires Baton resource BIDs for resource
+		// tombstones; a malformed id is a connector bug that fails
+		// deterministically before any write, so it must not read warm.
+		for _, id := range canonical {
+			if !strings.HasPrefix(id, "bid:r:") {
+				return newReplayIntegrityError(ReplayVerdictCold, o.rowKind, o.scopeKey,
+					fmt.Errorf("resource tombstone %q is not a Baton resource BID (bid:r:...)", id))
+			}
+		}
+	}
+	if len(canonical) > 0 {
+		if err := o.s.sourceCacheStore.DeleteSourceCacheRows(ctx, o.rowKind, o.scopeKey, canonical); err != nil {
+			return newReplayIntegrityError(ReplayVerdictWarm, o.rowKind, o.scopeKey,
+				fmt.Errorf("canonical-id tombstones: %w", err))
+		}
+		o.s.testSyncTraceAudit.record(syncTraceDelete, string(o.rowKind), o.scopeKey)
+	}
+	principals := append(append([]string{}, o.replay.GetDeletedPrincipalIds()...), o.record.GetDeletedPrincipalIds()...)
+	if len(principals) > 0 {
+		if _, err := o.s.sourceCacheStore.DeleteSourceCacheRowsInScope(ctx, o.rowKind, o.scopeKey, principals); err != nil {
+			return newReplayIntegrityError(ReplayVerdictWarm, o.rowKind, o.scopeKey,
+				fmt.Errorf("principal-scoped tombstones: %w", err))
+		}
+		o.s.testSyncTraceAudit.record(syncTraceDelete, string(o.rowKind), o.scopeKey)
+	}
+	// Validator publish AFTER the page's rows and tombstones: a failed
+	// page can't leave a phantom manifest entry vouching for rows that
+	// never landed. The record's validator wins over the replay's (a delta
+	// round's final record carries the NEW token); interim empty
+	// validators publish nothing (B3 — a scope whose round never supplies
+	// one is a miss next sync).
+	validator := o.record.GetCacheValidator()
+	if validator == "" {
+		validator = o.replay.GetCacheValidator()
+	}
+	if validator != "" {
+		if err := o.s.sourceCacheStore.PutSourceCacheEntry(ctx, o.rowKind, o.scopeKey, validator); err != nil {
+			return newReplayIntegrityError(ReplayVerdictWarm, o.rowKind, o.scopeKey,
+				fmt.Errorf("manifest publish: %w", err))
+		}
+		o.s.testSyncTraceAudit.record(syncTracePublish, string(o.rowKind), o.scopeKey)
+	}
+	return nil
+}

--- a/pkg/sync/source_cache_orchestration_test.go
+++ b/pkg/sync/source_cache_orchestration_test.go
@@ -1,0 +1,1291 @@
+package sync //nolint:revive,nolintlint // backwards-compatible package name
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	native_sync "sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	"github.com/conductorone/baton-sdk/internal/chaosconnector"
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	"github.com/conductorone/baton-sdk/pkg/sourcecache"
+	"github.com/conductorone/baton-sdk/pkg/types"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+)
+
+// fakeSourceCacheStore satisfies dotc1z.SourceCacheStore with configurable
+// failures, for the B7 verdict-taxonomy enumeration.
+type fakeSourceCacheStore struct {
+	replayErr      error
+	deleteRowsErr  error
+	deleteScopeErr error
+	putEntryErr    error
+	clearScopeErr  error
+}
+
+func (f *fakeSourceCacheStore) ClearSourceCacheScope(context.Context, sourcecache.RowKind, string) (int64, error) {
+	return 0, f.clearScopeErr
+}
+
+func (f *fakeSourceCacheStore) LookupSourceCacheEntry(context.Context, sourcecache.RowKind, string) (sourcecache.Entry, bool, error) {
+	return sourcecache.Entry{}, false, nil
+}
+
+func (f *fakeSourceCacheStore) PutSourceCacheEntry(context.Context, sourcecache.RowKind, string, string) error {
+	return f.putEntryErr
+}
+
+func (f *fakeSourceCacheStore) ReplaySourceCache(context.Context, connectorstore.Reader, sourcecache.RowKind, string) (dotc1z.SourceCacheReplayResult, error) {
+	return dotc1z.SourceCacheReplayResult{}, f.replayErr
+}
+
+func (f *fakeSourceCacheStore) DeleteSourceCacheRows(context.Context, sourcecache.RowKind, string, []string) error {
+	return f.deleteRowsErr
+}
+
+func (f *fakeSourceCacheStore) DeleteSourceCacheRowsInScope(context.Context, sourcecache.RowKind, string, []string) (int64, error) {
+	return 0, f.deleteScopeErr
+}
+
+func (f *fakeSourceCacheStore) DeleteSourceCacheGrantsByIDInScope(context.Context, string, []string) (int64, error) {
+	return 0, nil
+}
+
+func (f *fakeSourceCacheStore) PutSourceCacheCompat(context.Context, sourcecache.CompatKey) error {
+	return nil
+}
+
+func (f *fakeSourceCacheStore) GetSourceCacheCompat(context.Context) (sourcecache.CompatKey, bool, error) {
+	return sourcecache.CompatKey{}, false, nil
+}
+
+// stubPreviousReader is a non-nil connectorstore.Reader serving as the
+// replay base. Its Reader methods are never reached (the fake store's
+// ReplaySourceCache ignores it); LookupSourceCacheEntry serves the
+// hit-binding check in beforeUpserts.
+type stubPreviousReader struct {
+	connectorstore.Reader
+	entry    sourcecache.Entry
+	found    bool
+	entryErr error
+}
+
+func (r stubPreviousReader) LookupSourceCacheEntry(context.Context, sourcecache.RowKind, string) (sourcecache.Entry, bool, error) {
+	return r.entry, r.found, r.entryErr
+}
+
+// bareStubPreviousReader is a previous reader WITHOUT the source-cache
+// entry surface, for the binding check's fail-closed cell.
+type bareStubPreviousReader struct{ connectorstore.Reader }
+
+// TestSourceCacheReplayVerdictTaxonomy enumerates every orchestration
+// replay failure path named in plan B7 and pins its frozen warm/cold
+// classification, surfaced via errors.Is/errors.As (oracle OR4, criterion
+// R9). Each cell drives the real page-ops pipeline against a fake store.
+func TestSourceCacheReplayVerdictTaxonomy(t *testing.T) {
+	const scope = "grants:team-1"
+	rw := v2.SourceCacheCapability_builder{
+		Mode:            v2.SourceCacheCapability_MODE_READ_WRITE,
+		CacheGeneration: "gen-1",
+	}.Build()
+
+	newSyncerFixture := func(store dotc1z.SourceCacheStore) *syncer {
+		s := &syncer{
+			sourceCacheCapability: rw,
+			sourceCacheStore:      store,
+			state:                 newState(),
+			syncType:              connectorstore.SyncTypeFull,
+			// The replay cells exercise post-gate behavior: this attempt
+			// installed and delivered a warm lookup. The not-warm gate has
+			// its own dedicated cell below.
+			sourceCacheWarm: true,
+		}
+		if store != nil {
+			// The base publishes the validator the hit cells record, so
+			// the hit-binding check passes and cells reach their target
+			// failure site.
+			s.previousSyncReader = stubPreviousReader{
+				entry: sourcecache.Entry{CacheValidator: "v-hit"},
+				found: true,
+			}
+		}
+		return s
+	}
+
+	corruptAnno := func(typeURL string) annotations.Annotations {
+		return annotations.Annotations{{TypeUrl: "type.googleapis.com/" + typeURL, Value: []byte{0xff, 0xff}}}
+	}
+
+	requireVerdict := func(t *testing.T, err error, want ReplayVerdict, kind sourcecache.RowKind) {
+		t.Helper()
+		require.Error(t, err)
+		// The identity contract 6c's runner depends on: reachable through
+		// arbitrary wrapping via errors.Is / errors.As.
+		wrapped := fmt.Errorf("sync failed: %w", err)
+		require.ErrorIs(t, wrapped, ErrReplayIntegrity)
+		var rie *ReplayIntegrityError
+		require.ErrorAs(t, wrapped, &rie)
+		require.Equal(t, want, rie.Verdict)
+		require.Equal(t, kind, rie.RowKind)
+		require.NotNil(t, rie.Unwrap(), "the underlying cause must stay reachable")
+	}
+
+	ctx := context.Background()
+	kind := sourcecache.RowKindGrants
+
+	t.Run("parse-cold-paths", func(t *testing.T) {
+		s := newSyncerFixture(&fakeSourceCacheStore{})
+		for name, annos := range map[string]annotations.Annotations{
+			"unparsable-record": corruptAnno("c1.connector.v2.SourceCacheRecord"),
+			"unparsable-replay": corruptAnno("c1.connector.v2.SourceCacheReplay"),
+			"invalid-replay-scope-key": annotations.New(
+				v2.SourceCacheReplay_builder{ScopeKey: ""}.Build()),
+			"two-scopes-on-one-page": annotations.New(
+				v2.SourceCacheRecord_builder{ScopeKey: "grants:a", CacheValidator: "v"}.Build(),
+				v2.SourceCacheReplay_builder{ScopeKey: "grants:b", CacheValidator: "v"}.Build()),
+		} {
+			t.Run(name, func(t *testing.T) {
+				_, err := s.sourceCachePageOps(ctx, kind, annos, 0)
+				requireVerdict(t, err, ReplayVerdictCold, kind)
+			})
+		}
+		t.Run("invalid-record-scope-key", func(t *testing.T) {
+			longKey := make([]byte, 300)
+			for i := range longKey {
+				longKey[i] = 'x'
+			}
+			_, err := s.sourceCachePageOps(ctx, kind,
+				annotations.New(v2.SourceCacheRecord_builder{ScopeKey: string(longKey)}.Build()), 0)
+			requireVerdict(t, err, ReplayVerdictCold, kind)
+		})
+		t.Run("principal-tombstones-on-entitlements", func(t *testing.T) {
+			_, err := s.sourceCachePageOps(ctx, sourcecache.RowKindEntitlements,
+				annotations.New(v2.SourceCacheRecord_builder{
+					ScopeKey:            "ents:a",
+					DeletedPrincipalIds: []string{"u1"},
+				}.Build()), 0)
+			requireVerdict(t, err, ReplayVerdictCold, sourcecache.RowKindEntitlements)
+		})
+		t.Run("replay-on-store-without-surface", func(t *testing.T) {
+			bare := newSyncerFixture(nil)
+			_, err := bare.sourceCachePageOps(ctx, kind,
+				annotations.New(v2.SourceCacheReplay_builder{ScopeKey: scope}.Build()), 0)
+			requireVerdict(t, err, ReplayVerdictCold, kind)
+		})
+		t.Run("duplicate-same-type-annotations", func(t *testing.T) {
+			// CO-6b-003: Pick returns the first match, so duplicates would
+			// silently collapse and a second scope could bypass the
+			// one-scope-per-page rule. annotations.New dedupes same-type
+			// messages, but the wire does not (Append/Merge or a remote
+			// connector's raw slice) — build the duplicates with Append.
+			s := newSyncerFixture(&fakeSourceCacheStore{})
+			dupRecords := annotations.Annotations{}
+			dupRecords.Append(
+				v2.SourceCacheRecord_builder{ScopeKey: "grants:a", CacheValidator: "v"}.Build(),
+				v2.SourceCacheRecord_builder{ScopeKey: "grants:b", CacheValidator: "v"}.Build())
+			_, err := s.sourceCachePageOps(ctx, kind, dupRecords, 0)
+			requireVerdict(t, err, ReplayVerdictCold, kind)
+			dupReplays := annotations.Annotations{}
+			dupReplays.Append(
+				v2.SourceCacheReplay_builder{ScopeKey: "grants:a"}.Build(),
+				v2.SourceCacheReplay_builder{ScopeKey: "grants:b"}.Build())
+			_, err = s.sourceCachePageOps(ctx, kind, dupReplays, 0)
+			requireVerdict(t, err, ReplayVerdictCold, kind)
+		})
+	})
+
+	t.Run("sync-shape-gates", func(t *testing.T) {
+		// CO-6b-003: source-cache handling is untargeted-FULL-sync only. A
+		// partial/targeted sync ignores the annotations wholesale (nil ops,
+		// no error) — its pages must not stamp, publish, or replay.
+		for name, mutate := range map[string]func(*syncer){
+			"partial-sync":  func(s *syncer) { s.syncType = connectorstore.SyncTypePartial },
+			"targeted-sync": func(s *syncer) { s.targetedSyncResources = []*v2.Resource{{}} },
+		} {
+			t.Run(name, func(t *testing.T) {
+				s := newSyncerFixture(&fakeSourceCacheStore{})
+				mutate(s)
+				require.False(t, s.sourceCacheEnabled())
+				ops, err := s.sourceCachePageOps(ctx, kind,
+					annotations.New(v2.SourceCacheRecord_builder{ScopeKey: scope, CacheValidator: "v"}.Build()), 0)
+				require.NoError(t, err)
+				require.Nil(t, ops)
+			})
+		}
+	})
+
+	buildReplayOps := func(t *testing.T, s *syncer) *sourceCachePageOps {
+		t.Helper()
+		ops, err := s.sourceCachePageOps(ctx, kind,
+			annotations.New(v2.SourceCacheReplay_builder{ScopeKey: scope, CacheValidator: "v2"}.Build()), 0)
+		require.NoError(t, err)
+		require.NotNil(t, ops)
+		return ops
+	}
+
+	t.Run("provenance-cold-paths", func(t *testing.T) {
+		t.Run("replay-on-attempt-not-warm", func(t *testing.T) {
+			// CO-6b-003: a checkpointed hit-set must not authorize replay
+			// on an attempt whose consume gates degraded to cold (compat
+			// drift, withdrawn/swapped previous artifact). The hit exists;
+			// the warm flag does not; the replay dies cold.
+			s := newSyncerFixture(&fakeSourceCacheStore{})
+			s.sourceCacheWarm = false
+			s.state.RecordSourceCacheHit(kind, scope, "v-hit")
+			err := buildReplayOps(t, s).beforeUpserts(ctx)
+			requireVerdict(t, err, ReplayVerdictCold, kind)
+		})
+		t.Run("replay-without-this-sync-hit", func(t *testing.T) {
+			s := newSyncerFixture(&fakeSourceCacheStore{})
+			err := buildReplayOps(t, s).beforeUpserts(ctx)
+			requireVerdict(t, err, ReplayVerdictCold, kind)
+		})
+		t.Run("replay-with-hit-but-no-previous-artifact", func(t *testing.T) {
+			s := newSyncerFixture(&fakeSourceCacheStore{})
+			s.previousSyncReader = nil
+			s.state.RecordSourceCacheHit(kind, scope, "v-hit")
+			err := buildReplayOps(t, s).beforeUpserts(ctx)
+			requireVerdict(t, err, ReplayVerdictCold, kind)
+		})
+		// Hit-binding cells: the eligibility gates cannot distinguish two
+		// artifacts from the same connector and config (identical compat
+		// keys), so a previous artifact swapped between attempts must be
+		// caught by binding the recorded hit's validator to the CURRENT
+		// base's manifest entry.
+		t.Run("swapped-base-validator-mismatch", func(t *testing.T) {
+			s := newSyncerFixture(&fakeSourceCacheStore{})
+			s.previousSyncReader = stubPreviousReader{
+				entry: sourcecache.Entry{CacheValidator: "v-older-artifact"},
+				found: true,
+			}
+			s.state.RecordSourceCacheHit(kind, scope, "v-hit")
+			err := buildReplayOps(t, s).beforeUpserts(ctx)
+			requireVerdict(t, err, ReplayVerdictCold, kind)
+		})
+		t.Run("swapped-base-entry-missing", func(t *testing.T) {
+			s := newSyncerFixture(&fakeSourceCacheStore{})
+			s.previousSyncReader = stubPreviousReader{found: false}
+			s.state.RecordSourceCacheHit(kind, scope, "v-hit")
+			err := buildReplayOps(t, s).beforeUpserts(ctx)
+			requireVerdict(t, err, ReplayVerdictCold, kind)
+		})
+		t.Run("base-entry-read-failure", func(t *testing.T) {
+			s := newSyncerFixture(&fakeSourceCacheStore{})
+			s.previousSyncReader = stubPreviousReader{entryErr: errors.New("manifest read failed")}
+			s.state.RecordSourceCacheHit(kind, scope, "v-hit")
+			err := buildReplayOps(t, s).beforeUpserts(ctx)
+			requireVerdict(t, err, ReplayVerdictCold, kind)
+		})
+		t.Run("base-without-entry-surface", func(t *testing.T) {
+			s := newSyncerFixture(&fakeSourceCacheStore{})
+			s.previousSyncReader = bareStubPreviousReader{}
+			s.state.RecordSourceCacheHit(kind, scope, "v-hit")
+			err := buildReplayOps(t, s).beforeUpserts(ctx)
+			requireVerdict(t, err, ReplayVerdictCold, kind)
+		})
+	})
+
+	t.Run("replay-copy-classification", func(t *testing.T) {
+		for name, tc := range map[string]struct {
+			err  error
+			want ReplayVerdict
+		}{
+			"source-side-error-is-cold":       {err: errors.New("preflight: poisoned scope"), want: ReplayVerdictCold},
+			"destination-commit-is-warm":      {err: fmt.Errorf("commit: %w", dotc1z.ErrSourceCacheReplayDestination), want: ReplayVerdictWarm},
+			"cancellation-mid-replay-is-warm": {err: fmt.Errorf("copy: %w", context.Canceled), want: ReplayVerdictWarm},
+		} {
+			t.Run(name, func(t *testing.T) {
+				s := newSyncerFixture(&fakeSourceCacheStore{replayErr: tc.err})
+				s.state.RecordSourceCacheHit(kind, scope, "v-hit")
+				err := buildReplayOps(t, s).beforeUpserts(ctx)
+				requireVerdict(t, err, tc.want, kind)
+			})
+		}
+		t.Run("ambient-cancellation-does-not-promote", func(t *testing.T) {
+			// CO-6b-003: only the ERROR CHAIN classifies. In parallel mode
+			// a sibling failure cancels the batch context, and a genuine
+			// source-integrity error racing that cancellation must stay
+			// cold (fail-closed), not read as warm.
+			require.Equal(t, ReplayVerdictCold, replayCopyVerdict(errors.New("preflight: poisoned scope")))
+			require.Equal(t, ReplayVerdictWarm, replayCopyVerdict(fmt.Errorf("copy: %w", context.Canceled)))
+		})
+	})
+
+	t.Run("destination-warm-paths", func(t *testing.T) {
+		buildRecordOps := func(t *testing.T, s *syncer, record *v2.SourceCacheRecord) *sourceCachePageOps {
+			t.Helper()
+			ops, err := s.sourceCachePageOps(ctx, kind, annotations.New(record), 0)
+			require.NoError(t, err)
+			require.NotNil(t, ops)
+			return ops
+		}
+		t.Run("canonical-tombstone-failure", func(t *testing.T) {
+			s := newSyncerFixture(&fakeSourceCacheStore{deleteRowsErr: errors.New("write stall")})
+			ops := buildRecordOps(t, s, v2.SourceCacheRecord_builder{
+				ScopeKey: scope, CacheValidator: "v2", DeletedIds: []string{"g1"},
+			}.Build())
+			requireVerdict(t, ops.afterUpserts(ctx), ReplayVerdictWarm, kind)
+		})
+		t.Run("principal-tombstone-failure", func(t *testing.T) {
+			s := newSyncerFixture(&fakeSourceCacheStore{deleteScopeErr: errors.New("write stall")})
+			ops := buildRecordOps(t, s, v2.SourceCacheRecord_builder{
+				ScopeKey: scope, CacheValidator: "v2", DeletedPrincipalIds: []string{"u1"},
+			}.Build())
+			requireVerdict(t, ops.afterUpserts(ctx), ReplayVerdictWarm, kind)
+		})
+		t.Run("manifest-publish-failure", func(t *testing.T) {
+			s := newSyncerFixture(&fakeSourceCacheStore{putEntryErr: errors.New("write stall")})
+			ops := buildRecordOps(t, s, v2.SourceCacheRecord_builder{
+				ScopeKey: scope, CacheValidator: "v2",
+			}.Build())
+			requireVerdict(t, ops.afterUpserts(ctx), ReplayVerdictWarm, kind)
+		})
+		t.Run("page-row-put-failure-is-warm", func(t *testing.T) {
+			// The put itself happens in the collection handlers; they wrap
+			// through wrapPageRowPutError (B7: overlay/record upsert write
+			// errors are warm). Nil ops and nil errors pass through.
+			s := newSyncerFixture(&fakeSourceCacheStore{})
+			ops := buildRecordOps(t, s, v2.SourceCacheRecord_builder{
+				ScopeKey: scope, CacheValidator: "v2",
+			}.Build())
+			requireVerdict(t, ops.wrapPageRowPutError(errors.New("write stall")), ReplayVerdictWarm, kind)
+			var nilOps *sourceCachePageOps
+			plain := errors.New("plain store error")
+			require.Equal(t, plain, nilOps.wrapPageRowPutError(plain),
+				"a page without honored annotations must not gain a verdict")
+			require.NoError(t, ops.wrapPageRowPutError(nil))
+		})
+		t.Run("malformed-resource-tombstone-is-cold", func(t *testing.T) {
+			// CO-6b-003: resource tombstones must be Baton resource BIDs;
+			// a malformed id fails deterministically before any write, so
+			// retrying it warm can never succeed.
+			s := newSyncerFixture(&fakeSourceCacheStore{})
+			ops, err := s.sourceCachePageOps(ctx, sourcecache.RowKindResources,
+				annotations.New(v2.SourceCacheRecord_builder{
+					ScopeKey: "res:all", CacheValidator: "v2", DeletedIds: []string{"not-a-bid"},
+				}.Build()), 0)
+			require.NoError(t, err)
+			requireVerdict(t, ops.afterUpserts(ctx), ReplayVerdictCold, sourcecache.RowKindResources)
+		})
+	})
+
+	t.Run("compat-materialization-only-mismatch-degrades", func(t *testing.T) {
+		// G7 exact-match with ONLY the stored sdk_materialization_generation
+		// flipped (a corrupt or stale payload field under a current envelope
+		// witness): the warm store must degrade. The chaos gate matrix flips
+		// the connector-controlled fields; this cell covers the one field a
+		// capability cannot reach.
+		s := newSyncerFixture(&fakeSourceCacheStore{})
+		stored := s.computeSourceCacheCompatKey()
+		stored.SDKMaterializationGeneration += "-stale"
+		s.previousSyncReader = &fakeCompatPreviousReader{compat: stored, found: true}
+		_, warm := s.sourceCacheWarmStore(ctx)
+		require.False(t, warm, "a materialization-generation mismatch alone must degrade to cold")
+
+		// Sanity against vacuity: the same reader with the computed key
+		// byte-matched goes warm.
+		s.previousSyncReader = &fakeCompatPreviousReader{compat: s.computeSourceCacheCompatKey(), found: true}
+		_, warm = s.sourceCacheWarmStore(ctx)
+		require.True(t, warm)
+	})
+}
+
+// fakeCompatPreviousReader satisfies the consume-side gate surfaces
+// (sourceCacheEntryReader + sourceCacheCompatReader) with a fixed compat
+// record, for G7 field-isolation cells the chaos capability cannot reach.
+type fakeCompatPreviousReader struct {
+	connectorstore.Reader
+	compat sourcecache.CompatKey
+	found  bool
+}
+
+func (f *fakeCompatPreviousReader) LookupSourceCacheEntry(context.Context, sourcecache.RowKind, string) (sourcecache.Entry, bool, error) {
+	return sourcecache.Entry{}, false, nil
+}
+
+func (f *fakeCompatPreviousReader) GetSourceCacheCompat(context.Context) (sourcecache.CompatKey, bool, error) {
+	return f.compat, f.found, nil
+}
+
+// TestChaosSourceCacheReplayWithoutHitFailsCold pins R8's loud-failure
+// clause at sync level: a connector that emits SourceCacheReplay while the
+// sync is COLD (no previous artifact, so the lookup is NoopLookup and no
+// hit can exist) skipped row generation with nothing to fall back to — the
+// sync must FAIL with a cold ErrReplayIntegrity, never degrade silently.
+func TestChaosSourceCacheReplayWithoutHitFailsCold(t *testing.T) {
+	skipChaosInShort(t)
+
+	fx := newSCCollectionFixture(t)
+	// One cell per collection handler (resources, entitlements, grants):
+	// the loud cold failure must fire from each handler's own
+	// sourceCachePageOps seam, and — with the held-lock ride-along — each
+	// cell also proves that handler's deferred release() backstop frees
+	// the scope lock on the error path (CO-6b-007; removing any one
+	// handler's defer fails its cell at the harness's sync-end assertion).
+	cells := []struct {
+		rowKind  sourcecache.RowKind
+		scopeKey string
+		mutate   func(d *chaosconnector.Dataset)
+	}{
+		{
+			rowKind:  sourcecache.RowKindResources,
+			scopeKey: "resources:user",
+			mutate: func(d *chaosconnector.Dataset) {
+				d.Resources[scUserTypeID] = chaosconnector.Pages[*v2.Resource]{
+					"": {Annotations: scReplayAnno("resources:user", scValidatorV1, false, nil, nil)},
+				}
+			},
+		},
+		{
+			rowKind:  sourcecache.RowKindEntitlements,
+			scopeKey: "entitlements:team-1",
+			mutate: func(d *chaosconnector.Dataset) {
+				d.Entitlements["team-1"] = chaosconnector.Pages[*v2.Entitlement]{
+					"": {Annotations: scReplayAnno("entitlements:team-1", scValidatorV1, false, nil, nil)},
+				}
+			},
+		},
+		{
+			rowKind:  sourcecache.RowKindGrants,
+			scopeKey: scGrantsScopeKey,
+			mutate: func(d *chaosconnector.Dataset) {
+				d.Grants["team-1"] = chaosconnector.Pages[*v2.Grant]{
+					"": {Annotations: scReplayAnno(scGrantsScopeKey, scValidatorV1, false, nil, nil)},
+				}
+			},
+		},
+	}
+	for _, cell := range cells {
+		t.Run(string(cell.rowKind), func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+			defer cancel()
+			tmpDir, paths := sourceCachePaths(t, 1)
+
+			d := scCollectionBase(fx)
+			// The ROOT page itself carries a replay annotation: a
+			// misbehaving connector replaying without ever consulting.
+			cell.mutate(d)
+			scenario := &chaosconnector.Scenario{
+				Name: "source-cache-replay-without-hit-" + string(cell.rowKind), Seed: 1, InitialEpoch: "seed",
+				Epochs: map[string]*chaosconnector.Dataset{"seed": d},
+			}
+			require.NoError(t, scenario.Validate())
+
+			run, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+			require.NoError(t, err)
+			run.SetSourceCacheCapability(sourceCacheCapabilityRW("gen-1", "cfg-1"))
+			harness := newChaosHarness(t, ctx, run, paths[0], tmpDir, chaosTransportDirect, WithWorkerCount(1))
+			syncErr := harness.Syncer.Sync(ctx)
+			require.Error(t, syncErr, "a replay with no this-sync lookup hit must fail the sync")
+			require.ErrorIs(t, syncErr, ErrReplayIntegrity)
+			var rie *ReplayIntegrityError
+			require.ErrorAs(t, syncErr, &rie)
+			require.Equal(t, ReplayVerdictCold, rie.Verdict)
+			require.Equal(t, cell.rowKind, rie.RowKind)
+			require.Equal(t, cell.scopeKey, rie.ScopeKey)
+			require.NoError(t, harness.Close(t.Context()))
+		})
+	}
+}
+
+// TestChaosSourceCacheCompatDriftOnResume pins R4's drift-on-resume clause
+// (plan B4): the connector's capability changes between an interrupted
+// attempt and its resume, so the artifact's cached rows are
+// mixed-generation. The resume must proceed green but degrade its own
+// lookup to cold, leave the ORIGINAL compat record in place, and mark the
+// artifact replay-blocked so it cannot seed the next generation.
+func TestChaosSourceCacheCompatDriftOnResume(t *testing.T) {
+	skipChaosInShort(t)
+
+	cells := []struct {
+		name string
+		// resumeCapability arms the resume attempt; nil withdraws the
+		// capability entirely (CO-6b-003's stale-produce-state branch).
+		resumeCapability *v2.SourceCacheCapability
+	}{
+		{
+			// The recomputed compat key differs from the stored one.
+			name:             "drifted-generation",
+			resumeCapability: sourceCacheCapabilityRW("gen-2", "cfg-1"),
+		},
+		{
+			// The connector stops declaring the capability across the
+			// resume: attempt 1's produce state (compat record, stamps)
+			// was recorded under conditions this attempt no longer
+			// declares — the same mixed-generation hazard as drift.
+			name:             "capability-withdrawn",
+			resumeCapability: nil,
+		},
+	}
+
+	for _, tc := range cells {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), 90*time.Second)
+			defer cancel()
+			tmpDir, paths := sourceCachePaths(t, 2)
+			seedPath, driftPath := paths[0], paths[1]
+
+			fixture := newSourceCacheFixture(t)
+			scenario := newSourceCacheScenario(t, fixture)
+
+			// Generation A: clean cold seed under gen-1.
+			seedRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+			require.NoError(t, err)
+			seedRun.SetSourceCacheCapability(sourceCacheCapabilityRW("gen-1", "cfg-1"))
+			requireSourceCacheEvents(t,
+				runSourceCacheSync(t, ctx, seedRun, chaosTransportDirect, seedPath, tmpDir, "", WithWorkerCount(1)),
+				[]chaosconnector.SourceCacheLookupEvent{scColdEvent()})
+
+			// Generation B, attempt 1 under gen-1: writes the compat record at
+			// sync start, then crashes on the first grants root request.
+			interruptedRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule(chaosconnector.Rule{
+				ID: "cut-grants-root",
+				Match: chaosconnector.Matcher{
+					Service:   chaosconnector.ExactString("GrantsService"),
+					Method:    chaosconnector.ExactString("ListGrants"),
+					PageToken: chaosconnector.ExactString(""),
+					Attempt:   1,
+					Phase:     chaosconnector.PhaseBeforeCall,
+				},
+				Effects:  []chaosconnector.Effect{{Kind: chaosconnector.EffectCrash}},
+				MinFires: 1,
+				MaxFires: 1,
+			}))
+			require.NoError(t, err)
+			interruptedRun.SetSourceCacheCapability(sourceCacheCapabilityRW("gen-1", "cfg-1"))
+			interruptedHarness := newChaosHarness(t, ctx, interruptedRun, driftPath, tmpDir, chaosTransportDirect,
+				WithPreviousSyncC1ZPath(seedPath), WithWorkerCount(1))
+			require.ErrorIs(t, interruptedHarness.Syncer.Sync(ctx), chaosconnector.ErrInterruptRequested)
+			require.NoError(t, interruptedHarness.Close(t.Context()))
+			require.NoError(t, interruptedRun.Runtime().VerifyRequired())
+
+			// Resume under the drifted/withdrawn capability. The sync
+			// proceeds but every consult must go cold even though the
+			// previous artifact would pass the consume gates for gen-1.
+			resumeRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+			require.NoError(t, err)
+			resumeRun.SetSourceCacheCapability(tc.resumeCapability)
+			resumeEvents := runSourceCacheSync(t, ctx, resumeRun, chaosTransportDirect, driftPath, tmpDir, seedPath, WithWorkerCount(1))
+			requireAllColdEvents(t, resumeEvents, 1)
+
+			// The ORIGINAL record stays: it described the rows recorded before
+			// the drift; overwriting it would vouch for mixed-generation rows.
+			snapshot := readSourceCacheSnapshot(t, ctx, driftPath, tmpDir)
+			require.NotNil(t, snapshot.Compat)
+			require.Equal(t, "gen-1", snapshot.Compat.ConnectorCacheGeneration,
+				"drift must not overwrite the original compat record")
+
+			// The artifact is barred from seeding the next generation.
+			quality := readLifecycleIngestQuality(t, driftPath)
+			require.NotNil(t, quality)
+			require.True(t, quality.GetSourceCacheReplayBlocked(),
+				"compat drift on resume must mark the artifact replay-blocked")
+		})
+	}
+}
+
+// TestChaosSourceCacheDriftedResumeRejectsRestoredReplay pins the
+// CO-6b-003 warm gate: a CHECKPOINTED lookup hit must not re-authorize a
+// replay verdict on a resume attempt whose consume gates degraded to cold.
+//
+// PREMISE (corrected per re-review, CO-6b-005): per-resource grants
+// actions dispatch in batches of maxPeekActionsCount (100), and provenance
+// recorded during a batch becomes durable only at the checkpoint atop the
+// NEXT loop iteration — so the consult site and the crash site must sit in
+// DIFFERENT batches or no checkpoint ever contains the hit and the resume
+// dies on the ordinary no-hit gate instead. The test therefore uses 102
+// team resources: the consult team drains first (batch 1, hit for scope S
+// recorded and checkpointed at the top of the batch-2 iteration — the test
+// captures that checkpoint and asserts the hit is IN it), a filler team at
+// the top of batch 2 crashes on its first serve, and the carrier team
+// (batch 2, after the filler) statically holds the SourceCacheReplay for S
+// it never got to serve in attempt 1. The resume runs under gen-2 (compat
+// drift ⇒ cold), restores the hit-set WITH the hit, re-runs the carrier —
+// and must die loudly with a cold ErrReplayIntegrity from the warm gate,
+// not silently copy from a base the drifted attempt never re-validated.
+// Mutation-verified: with the warm gate removed, the restored hit and the
+// still-eligible seed base let the copy proceed and the test fails.
+func TestChaosSourceCacheDriftedResumeRejectsRestoredReplay(t *testing.T) {
+	skipChaosInShort(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 90*time.Second)
+	defer cancel()
+	tmpDir, paths := sourceCachePaths(t, 2)
+	seedPath, warmPath := paths[0], paths[1]
+
+	const consultScopeKey = "grants:team-hit"
+	fixture := newSourceCacheFixture(t)
+	// Resources list order is push order; actions drain in REVERSE, so the
+	// consult team (listed last) drains first and the carrier (listed
+	// first) drains last, with 100 fillers between them forcing the batch
+	// split: batch 1 = consult + fillers 100..02, batch 2 = filler 01 +
+	// carrier.
+	// NOTE: the syncer pushes per-resource grants actions in the STORE's
+	// lexicographic resource-id order, so the ids are chosen to sort the
+	// carrier (team-1) first — draining last — and the consult site
+	// (z-team-hit) last — draining first.
+	teams := []*v2.Resource{fixture.Team} // team-1 is the replay carrier.
+	for i := 1; i <= 100; i++ {
+		filler, err := rs.NewGroupResource(fmt.Sprintf("Filler %03d", i), fixture.TeamType, fmt.Sprintf("u-filler-%03d", i), nil)
+		require.NoError(t, err)
+		teams = append(teams, filler)
+	}
+	consultTeam, err := rs.NewGroupResource("Team Hit", fixture.TeamType, "z-team-hit", nil)
+	require.NoError(t, err)
+	teams = append(teams, consultTeam)
+
+	dataset := newSourceCacheDataset(fixture)
+	dataset.Resources[scTeamTypeID] = chaosconnector.Pages[*v2.Resource]{"": {List: teams}}
+	// team-hit: the consult site. The spec declares no warm branch, so the
+	// hit for S is recorded but the cold root (with its record) is served
+	// either way — the REPLAY verdict for S travels to the carrier.
+	dataset.SourceCacheGrants = map[string]*chaosconnector.SourceCacheSpec{
+		"z-team-hit": {ScopeKey: consultScopeKey, Validator: scValidatorV1},
+	}
+	dataset.Grants["z-team-hit"] = chaosconnector.Pages[*v2.Grant]{
+		"": {
+			Annotations: annotations.New(v2.SourceCacheRecord_builder{
+				ScopeKey:       consultScopeKey,
+				CacheValidator: scValidatorV1,
+			}.Build()),
+		},
+	}
+	// team-1: the handed-off replay carrier for team-hit's scope S.
+	dataset.Grants["team-1"] = chaosconnector.Pages[*v2.Grant]{
+		"": {
+			Annotations: annotations.New(v2.SourceCacheReplay_builder{
+				ScopeKey:       consultScopeKey,
+				CacheValidator: scValidatorV1,
+			}.Build()),
+		},
+	}
+	scenario := &chaosconnector.Scenario{
+		Name:         "source-cache-drifted-resume-replay",
+		Seed:         1,
+		InitialEpoch: "initial",
+		Epochs:       map[string]*chaosconnector.Dataset{"initial": dataset},
+	}
+	require.NoError(t, scenario.Validate())
+
+	// Generation A seeds from a variant whose team-1 root is plain: A has
+	// no previous artifact, so a replay page in A would (correctly) die on
+	// the no-hit check before ever producing the seed.
+	seedDataset := newSourceCacheDataset(fixture)
+	seedDataset.Resources[scTeamTypeID] = dataset.Resources[scTeamTypeID]
+	seedDataset.SourceCacheGrants = dataset.SourceCacheGrants
+	seedDataset.Grants["z-team-hit"] = dataset.Grants["z-team-hit"]
+	seedDataset.Grants["team-1"] = chaosconnector.Pages[*v2.Grant]{"": {List: fixture.Grants}}
+	seedScenario := &chaosconnector.Scenario{
+		Name:         "source-cache-drifted-resume-replay-seed",
+		Seed:         1,
+		InitialEpoch: "initial",
+		Epochs:       map[string]*chaosconnector.Dataset{"initial": seedDataset},
+	}
+	require.NoError(t, seedScenario.Validate())
+	seedRun, err := chaosconnector.NewRun(seedScenario, chaosconnector.NewSchedule())
+	require.NoError(t, err)
+	seedRun.SetSourceCacheCapability(sourceCacheCapabilityRW("gen-1", "cfg-1"))
+	requireAllColdEvents(t,
+		runSourceCacheSync(t, ctx, seedRun, chaosTransportDirect, seedPath, tmpDir, "", WithWorkerCount(1)), 1)
+
+	// Generation B attempt 1 under gen-1: z-team-hit consults in batch 1
+	// (hit recorded); the checkpoint atop the batch-2 iteration makes it
+	// durable; u-filler-001 (top of batch 2) crashes on first serve,
+	// before the carrier's replay page is ever processed.
+	interruptedRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule(chaosconnector.Rule{
+		ID: "cut-batch-two",
+		Match: chaosconnector.Matcher{
+			Service:   chaosconnector.ExactString("GrantsService"),
+			Method:    chaosconnector.ExactString("ListGrants"),
+			Subject:   chaosconnector.ExactString("u-filler-001"),
+			PageToken: chaosconnector.ExactString(""),
+			Attempt:   1,
+			Phase:     chaosconnector.PhaseBeforeCall,
+		},
+		Effects:  []chaosconnector.Effect{{Kind: chaosconnector.EffectCrash}},
+		MinFires: 1,
+		MaxFires: 1,
+	}))
+	require.NoError(t, err)
+	interruptedRun.SetSourceCacheCapability(sourceCacheCapabilityRW("gen-1", "cfg-1"))
+	interruptedHarness := newChaosHarness(t, ctx, interruptedRun, warmPath, tmpDir, chaosTransportDirect,
+		WithPreviousSyncC1ZPath(seedPath), WithWorkerCount(1))
+	interruptedConcrete, ok := interruptedHarness.Syncer.(*syncer)
+	require.True(t, ok)
+	// Persist every loop iteration's checkpoint and capture each token so
+	// the premise is provable, not assumed.
+	interruptedConcrete.checkpointInterval = 0
+	var lastCheckpoint string
+	interruptedConcrete.testCheckpointHook = func(token string) { lastCheckpoint = token }
+	require.ErrorIs(t, interruptedHarness.Syncer.Sync(ctx), chaosconnector.ErrInterruptRequested)
+	require.NoError(t, interruptedHarness.Close(t.Context()))
+	require.NoError(t, interruptedRun.Runtime().VerifyRequired())
+	// The hit for S was recorded before the cut...
+	requireSourceCacheEvents(t, interruptedRun.SourceCacheLookupEvents(),
+		[]chaosconnector.SourceCacheLookupEvent{{
+			RowKind:           sourcecache.RowKindGrants,
+			ScopeKey:          consultScopeKey,
+			Hit:               true,
+			PreviousValidator: scValidatorV1,
+			Matched:           true,
+			ServedWarm:        false,
+		}})
+	// ...and — the premise this test exists for — the DURABLE CHECKPOINT
+	// that survives the crash contains it. Without this the resume would
+	// reject on the ordinary no-hit gate and the warm gate would be
+	// untested vacuously.
+	require.NotEmpty(t, lastCheckpoint)
+	checkpointed := newState()
+	require.NoError(t, checkpointed.Unmarshal(lastCheckpoint))
+	v, hasHit := checkpointed.SourceCacheHitValidator(sourcecache.RowKindGrants, consultScopeKey)
+	require.True(t, hasHit, "the surviving checkpoint must contain the batch-1 hit; if it does not, the batch split regressed and this test is vacuous")
+	require.Equal(t, scValidatorV1, v)
+	// The second premise half: the carrier's grants action is still
+	// PENDING in that same checkpoint — the resume genuinely re-serves a
+	// replay verdict it did not invent.
+	carrierPending := false
+	for cur := checkpointed.Current(); cur != nil; cur = checkpointed.Current() {
+		if cur.Op == SyncGrantsOp && cur.ResourceID == "team-1" {
+			carrierPending = true
+		}
+		checkpointed.FinishAction(ctx, cur)
+	}
+	require.True(t, carrierPending, "the surviving checkpoint must still hold the carrier's grants action; if not, the batch layout regressed and this test is vacuous")
+
+	// Resume under gen-2: gates degrade to cold (compat drift). The
+	// restored hit-set still holds S; the carrier re-runs its root and
+	// re-serves the replay verdict — loud cold death from the warm gate,
+	// not a silent copy from the un-revalidated base.
+	resumeRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+	require.NoError(t, err)
+	resumeRun.SetSourceCacheCapability(sourceCacheCapabilityRW("gen-2", "cfg-1"))
+	resumeHarness := newChaosHarness(t, ctx, resumeRun, warmPath, tmpDir, chaosTransportDirect,
+		WithPreviousSyncC1ZPath(seedPath), WithWorkerCount(1))
+	err = resumeHarness.Syncer.Sync(ctx)
+	require.ErrorIs(t, err, ErrReplayIntegrity,
+		"a drifted resume must reject the restored replay verdict loudly")
+	var rie *ReplayIntegrityError
+	require.ErrorAs(t, err, &rie)
+	require.Equal(t, ReplayVerdictCold, rie.Verdict)
+	require.Equal(t, sourcecache.RowKindGrants, rie.RowKind)
+	require.Equal(t, consultScopeKey, rie.ScopeKey)
+	require.NoError(t, resumeHarness.Close(t.Context()))
+}
+
+// TestChaosSourceCacheUnsupportedShapesBlockReplaySeed pins the CO-6b-003
+// produce-side guard: a source-cache-annotated page whose shape replay
+// cannot reproduce — resource rows declaring child resource types, or a
+// grants response carrying InsertResourceGrants — must mark the sealed
+// artifact replay-blocked so it never seeds a warm generation (the derived
+// rows would silently vanish on replay). Generation B against the blocked
+// artifact must go all-cold through the G4 quality gate.
+func TestChaosSourceCacheUnsupportedShapesBlockReplaySeed(t *testing.T) {
+	skipChaosInShort(t)
+
+	cells := []struct {
+		name    string
+		dataset func(fixture *scFixture) *chaosconnector.Dataset
+	}{
+		{
+			// A record-annotated RESOURCES page whose row declares a child
+			// resource type: child discovery is scheduled from a page's own
+			// rows, which a replayed page never has.
+			name: "child-resource-types",
+			dataset: func(fixture *scFixture) *chaosconnector.Dataset {
+				teamWithChildren := proto.Clone(fixture.Team).(*v2.Resource)
+				annos := annotations.Annotations(teamWithChildren.GetAnnotations())
+				annos.Update(v2.ChildResourceType_builder{ResourceTypeId: scUserTypeID}.Build())
+				teamWithChildren.SetAnnotations(annos)
+				dataset := newSourceCacheDataset(fixture)
+				dataset.Resources[scTeamTypeID] = chaosconnector.Pages[*v2.Resource]{
+					"": {
+						List: []*v2.Resource{teamWithChildren},
+						Annotations: annotations.New(v2.SourceCacheRecord_builder{
+							ScopeKey:       "resources:team",
+							CacheValidator: "rv1",
+						}.Build()),
+					},
+				}
+				return dataset
+			},
+		},
+		{
+			// A record-annotated GRANTS page carrying InsertResourceGrants:
+			// grant-discovered resources are materialized from the page's
+			// own rows and response annotation, which replay never re-runs.
+			name: "insert-resource-grants",
+			dataset: func(fixture *scFixture) *chaosconnector.Dataset {
+				dataset := newSourceCacheDataset(fixture)
+				grantsAnnos := annotations.New(v2.SourceCacheRecord_builder{
+					ScopeKey:       scGrantsScopeKey,
+					CacheValidator: scValidatorV1,
+				}.Build())
+				grantsAnnos.Update(&v2.InsertResourceGrants{})
+				dataset.Grants["team-1"] = chaosconnector.Pages[*v2.Grant]{
+					"": {List: fixture.Grants, Annotations: grantsAnnos},
+				}
+				// Both generations serve cold (G4 blocks B); the spec's
+				// warm branch is unreachable, so don't declare one.
+				dataset.SourceCacheGrants[scGrantsScopeKey] = nil
+				dataset.SourceCacheGrants = map[string]*chaosconnector.SourceCacheSpec{
+					"team-1": {ScopeKey: scGrantsScopeKey, Validator: scValidatorV1},
+				}
+				return dataset
+			},
+		},
+	}
+
+	for _, tc := range cells {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), 90*time.Second)
+			defer cancel()
+			tmpDir, paths := sourceCachePaths(t, 2)
+			seedPath, nextPath := paths[0], paths[1]
+
+			fixture := newSourceCacheFixture(t)
+			scenario := &chaosconnector.Scenario{
+				Name:         "source-cache-unsupported-shape-" + tc.name,
+				Seed:         1,
+				InitialEpoch: "initial",
+				Epochs:       map[string]*chaosconnector.Dataset{"initial": tc.dataset(fixture)},
+			}
+			require.NoError(t, scenario.Validate())
+			capability := sourceCacheCapabilityRW("gen-1", "cfg-1")
+
+			// Generation A syncs green but seals replay-blocked.
+			seedRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+			require.NoError(t, err)
+			seedRun.SetSourceCacheCapability(capability)
+			requireAllColdEvents(t,
+				runSourceCacheSync(t, ctx, seedRun, chaosTransportDirect, seedPath, tmpDir, "", WithWorkerCount(1)), 1)
+			quality := readLifecycleIngestQuality(t, seedPath)
+			require.NotNil(t, quality)
+			require.True(t, quality.GetSourceCacheReplayBlocked(),
+				"an unsupported page shape must mark the artifact replay-blocked")
+
+			// Generation B: the blocked artifact must not seed a warm sync.
+			nextRun, err := chaosconnector.NewRun(scenario, chaosconnector.NewSchedule())
+			require.NoError(t, err)
+			nextRun.SetSourceCacheCapability(capability)
+			requireAllColdEvents(t,
+				runSourceCacheSync(t, ctx, nextRun, chaosTransportDirect, nextPath, tmpDir, seedPath, WithWorkerCount(1)), 1)
+		})
+	}
+}
+
+// deliverabilityProbeClient satisfies sourcecache.SetLookup structurally and
+// implements the deliverability probe. deliverable=false models a wrapper
+// whose transport cannot forward an interface value (the runner's
+// subprocess client, CO-6b-001): SetSourceCache exists but delivers into
+// the void.
+type deliverabilityProbeClient struct {
+	types.ConnectorClient
+	deliverable bool
+	delivered   []sourcecache.Lookup
+}
+
+func (c *deliverabilityProbeClient) SetSourceCache(_ context.Context, lookup sourcecache.Lookup) {
+	c.delivered = append(c.delivered, lookup)
+}
+
+func (c *deliverabilityProbeClient) SourceCacheLookupDeliverable() bool { return c.deliverable }
+
+// structuralSetLookupClient satisfies SetLookup but not the probe — the
+// presumed-deliverable default for clients that own their SetSourceCache.
+type structuralSetLookupClient struct {
+	types.ConnectorClient
+	delivered []sourcecache.Lookup
+}
+
+func (c *structuralSetLookupClient) SetSourceCache(_ context.Context, lookup sourcecache.Lookup) {
+	c.delivered = append(c.delivered, lookup)
+}
+
+// TestSourceCacheLookupDeliverabilityProbe pins the install-side
+// deliverability contract (CO-6b-003, closing the original false-warm
+// BLOCKER): a client that satisfies SetLookup structurally while its probe
+// reports undeliverable receives NOTHING — no delivery call, no warm flag —
+// while deliverable and probe-less clients receive the (possibly nil)
+// lookup unconditionally. Removing the probe type-assert in
+// installSourceCacheLookup fails the undeliverable cell.
+func TestSourceCacheLookupDeliverabilityProbe(t *testing.T) {
+	ctx := context.Background()
+	newFixture := func(client types.ConnectorClient) *syncer {
+		return &syncer{
+			connector:             client,
+			state:                 newState(),
+			syncType:              connectorstore.SyncTypeFull,
+			sourceCacheCapability: sourceCacheCapabilityRW("gen-1", "cfg-1"),
+		}
+	}
+
+	t.Run("undeliverable-transport-gets-no-delivery-and-stays-cold", func(t *testing.T) {
+		client := &deliverabilityProbeClient{deliverable: false}
+		s := newFixture(client)
+		teardown, err := s.installSourceCacheLookup(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, teardown)
+		require.Empty(t, client.delivered,
+			"SetSourceCache must not be called when the transport cannot deliver: the connector would consult NoopLookup while the syncer believed a lookup was live")
+		require.False(t, s.sourceCacheWarm)
+		teardown()
+		require.Empty(t, client.delivered, "teardown must not deliver either")
+	})
+
+	t.Run("deliverable-transport-receives-delivery-and-teardown", func(t *testing.T) {
+		client := &deliverabilityProbeClient{deliverable: true}
+		s := newFixture(client)
+		teardown, err := s.installSourceCacheLookup(ctx)
+		require.NoError(t, err)
+		// No previous artifact in this fixture, so the consume gates are
+		// cold and the delivered lookup is nil (the builder substitutes
+		// NoopLookup); delivery is still unconditional so a long-lived
+		// server never carries a prior sync's lookup.
+		require.Len(t, client.delivered, 1)
+		require.Nil(t, client.delivered[0])
+		require.False(t, s.sourceCacheWarm)
+		teardown()
+		require.Len(t, client.delivered, 2)
+		require.Nil(t, client.delivered[1])
+	})
+
+	t.Run("probe-less-client-is-presumed-deliverable", func(t *testing.T) {
+		client := &structuralSetLookupClient{}
+		s := newFixture(client)
+		teardown, err := s.installSourceCacheLookup(ctx)
+		require.NoError(t, err)
+		require.Len(t, client.delivered, 1)
+		teardown()
+	})
+
+	t.Run("client-without-setlookup-stays-cold", func(t *testing.T) {
+		// A capable connector behind a client that does not satisfy
+		// SetLookup at all (coverage-triage cell, CO-6b-007): install
+		// degrades to cold with a warn, returns a no-op teardown, and the
+		// sync proceeds.
+		s := newFixture(struct{ types.ConnectorClient }{})
+		teardown, err := s.installSourceCacheLookup(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, teardown)
+		require.False(t, s.sourceCacheWarm)
+		teardown()
+	})
+}
+
+// blockingReplayStore parks every ReplaySourceCache call until release is
+// closed, so the test can hold one copy mid-flight and observe whether a
+// second is admitted.
+type blockingReplayStore struct {
+	fakeSourceCacheStore
+	calls   atomic.Int32
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (b *blockingReplayStore) ReplaySourceCache(context.Context, connectorstore.Reader, sourcecache.RowKind, string) (dotc1z.SourceCacheReplayResult, error) {
+	b.calls.Add(1)
+	b.entered <- struct{}{}
+	<-b.release
+	return dotc1z.SourceCacheReplayResult{}, nil
+}
+
+// TestSourceCacheReplayOncePerScopeIsAtomic overlaps two beforeUpserts
+// calls for the SAME (rowKind, scopeKey) — the shape the per-scope lock
+// exists for (CO-6b-003): two workers serving replay annotations for one
+// scope, both past the provenance gates, racing decide-copy-mark. The
+// first copy is held mid-flight; if the second call reaches the store
+// while the first has not yet marked, the once-per-scope guard is not
+// atomic and a REPLACEMENT copy could wipe overlay rows the first already
+// admitted. Removing the scope mutex in beforeUpserts fails this test
+// inside the 300ms window; with the mutex the second call parks on Lock
+// and then takes the already-replayed skip path.
+func TestSourceCacheReplayOncePerScopeIsAtomic(t *testing.T) {
+	ctx := context.Background()
+	const scope = "grants:team-1"
+	kind := sourcecache.RowKindGrants
+
+	store := &blockingReplayStore{
+		entered: make(chan struct{}, 2),
+		release: make(chan struct{}),
+	}
+	releaseOnce := native_sync.OnceFunc(func() { close(store.release) })
+	t.Cleanup(releaseOnce)
+
+	s := &syncer{
+		sourceCacheCapability: sourceCacheCapabilityRW("gen-1", "cfg-1"),
+		sourceCacheStore:      store,
+		state:                 newState(),
+		syncType:              connectorstore.SyncTypeFull,
+		sourceCacheWarm:       true,
+		previousSyncReader: stubPreviousReader{
+			entry: sourcecache.Entry{CacheValidator: "v-hit"},
+			found: true,
+		},
+	}
+	s.state.RecordSourceCacheHit(kind, scope, "v-hit")
+
+	errs := make(chan error, 2)
+	for range 2 {
+		go func() {
+			ops, err := s.sourceCachePageOps(ctx, kind,
+				annotations.New(v2.SourceCacheReplay_builder{ScopeKey: scope, CacheValidator: "v-hit"}.Build()), 0)
+			if err != nil {
+				errs <- err
+				return
+			}
+			err = ops.beforeUpserts(ctx)
+			ops.release() // as the handlers' defer does
+			errs <- err
+		}()
+	}
+
+	// One copy is now mid-flight. Give the second call a generous window
+	// to (incorrectly) reach the store as well before releasing the first.
+	<-store.entered
+	select {
+	case <-store.entered:
+		t.Fatal("second replay copy entered the store while the first was mid-flight: decide-copy-mark is not atomic per scope")
+	case <-time.After(300 * time.Millisecond):
+	}
+	releaseOnce()
+
+	require.NoError(t, <-errs)
+	require.NoError(t, <-errs)
+	require.Equal(t, int32(1), store.calls.Load(), "exactly one replay copy must land per scope per sync")
+	require.True(t, s.state.SourceCacheReplayed(kind, scope))
+}
+
+// TestSourceCacheRecordPageParksBehindReplayCopy pins the record-page half
+// of the scope lock (re-review N1): a RECORD-only page for a scope must not
+// begin its row puts while another action's REPLACEMENT copy for the same
+// scope is mid-flight — the copy deletes the scope's rows before copying
+// the base, so an interleaved record page's fresh rows would be silently
+// wiped (or its validator published over an incomplete scope). The record
+// page's beforeUpserts must park on the scope lock until the copy holder
+// releases at afterUpserts. Reverting beforeUpserts to early-return before
+// the lock for record-only pages fails this test inside the 300ms window.
+func TestSourceCacheRecordPageParksBehindReplayCopy(t *testing.T) {
+	ctx := context.Background()
+	const scope = "grants:team-1"
+	kind := sourcecache.RowKindGrants
+
+	store := &blockingReplayStore{
+		entered: make(chan struct{}, 1),
+		release: make(chan struct{}),
+	}
+	releaseOnce := native_sync.OnceFunc(func() { close(store.release) })
+	t.Cleanup(releaseOnce)
+
+	s := &syncer{
+		sourceCacheCapability: sourceCacheCapabilityRW("gen-1", "cfg-1"),
+		sourceCacheStore:      store,
+		state:                 newState(),
+		syncType:              connectorstore.SyncTypeFull,
+		sourceCacheWarm:       true,
+		previousSyncReader: stubPreviousReader{
+			entry: sourcecache.Entry{CacheValidator: "v-hit"},
+			found: true,
+		},
+	}
+	s.state.RecordSourceCacheHit(kind, scope, "v-hit")
+
+	replayOps, err := s.sourceCachePageOps(ctx, kind,
+		annotations.New(v2.SourceCacheReplay_builder{ScopeKey: scope, CacheValidator: "v-hit"}.Build()), 0)
+	require.NoError(t, err)
+	copyDone := make(chan error, 1)
+	go func() {
+		err := replayOps.beforeUpserts(ctx)
+		replayOps.release()
+		copyDone <- err
+	}()
+	<-store.entered // the replacement copy is now mid-flight, lock held
+
+	recordOps, err := s.sourceCachePageOps(ctx, kind,
+		annotations.New(v2.SourceCacheRecord_builder{ScopeKey: scope, CacheValidator: "v-next"}.Build()), 1)
+	require.NoError(t, err)
+	recordEntered := make(chan error, 1)
+	go func() { recordEntered <- recordOps.beforeUpserts(ctx) }()
+
+	select {
+	case <-recordEntered:
+		t.Fatal("record page proceeded past beforeUpserts while a replacement copy for its scope was mid-flight: its rows could be wiped by the copy")
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	releaseOnce()
+	require.NoError(t, <-copyDone)
+	require.NoError(t, <-recordEntered)
+	// afterUpserts must release the lock — a leak would deadlock every
+	// later page for the scope, including the action's own retry.
+	require.NoError(t, recordOps.afterUpserts(ctx))
+	require.True(t, s.sourceCacheScopeLock(kind, scope).TryLock(),
+		"the scope lock must be free once the record page's afterUpserts returns")
+}
+
+// TestParseSourceCacheCapabilityUnparsable pins the boundary contract for a
+// corrupt SourceCacheCapability annotation (coverage-triage cell,
+// CO-6b-007): unparsable means NOT DECLARED — the sync runs plain cold, it
+// does not error. A capability is an opt-in, so failing to read one must
+// degrade to the opted-out behavior, never block the sync.
+func TestParseSourceCacheCapabilityUnparsable(t *testing.T) {
+	ctx := context.Background()
+
+	corrupt, err := anypb.New(sourceCacheCapabilityRW("gen-1", "cfg-1"))
+	require.NoError(t, err)
+	// A truncated tag byte cannot parse as any proto message.
+	corrupt.Value = []byte{0xff}
+	require.Nil(t, parseSourceCacheCapability(ctx, annotations.Annotations{corrupt}),
+		"an unparsable capability must read as not declared")
+
+	// Control: the same annotation uncorrupted parses.
+	parsed := parseSourceCacheCapability(ctx, annotations.New(sourceCacheCapabilityRW("gen-1", "cfg-1")))
+	require.NotNil(t, parsed)
+	require.Equal(t, v2.SourceCacheCapability_MODE_READ_WRITE, parsed.GetMode())
+}
+
+// countingEntryReader counts LookupSourceCacheEntry consultations so input
+// -validation cells can assert the store is never reached.
+type countingEntryReader struct {
+	stubPreviousReader
+	calls atomic.Int32
+}
+
+func (r *countingEntryReader) LookupSourceCacheEntry(ctx context.Context, kind sourcecache.RowKind, scopeKey string) (sourcecache.Entry, bool, error) {
+	r.calls.Add(1)
+	return r.stubPreviousReader.LookupSourceCacheEntry(ctx, kind, scopeKey)
+}
+
+// TestWarmLookupInputValidationDegradesToMiss pins the warm lookup's
+// input-validation contract (pkg/sourcecache; coverage-triage cells,
+// CO-6b-007): invalid connector-supplied arguments and internal read
+// failures are MISSES, never connector-call errors — a miss means "fetch
+// cold", which is always safe, while an error would fail a page the
+// connector could have served fresh. None of these paths may record a hit.
+func TestWarmLookupInputValidationDegradesToMiss(t *testing.T) {
+	ctx := context.Background()
+
+	newLookup := func(reader sourceCacheEntryReader) (*previousSyncSourceCacheLookup, *int) {
+		hits := 0
+		return &previousSyncSourceCacheLookup{
+			prev: reader,
+			onHit: func(sourcecache.RowKind, string, string) {
+				hits++
+			},
+		}, &hits
+	}
+
+	t.Run("invalid-row-kind-is-a-miss-without-consulting-the-store", func(t *testing.T) {
+		reader := &countingEntryReader{}
+		lookup, hits := newLookup(reader)
+		_, found, err := lookup.LookupPreviousSourceCache(ctx, sourcecache.RowKind("bogus"), "grants:team-1")
+		require.NoError(t, err, "an invalid row kind must not fail the connector's call")
+		require.False(t, found)
+		require.Zero(t, reader.calls.Load(), "invalid input must not reach the store")
+		require.Zero(t, *hits)
+	})
+
+	t.Run("invalid-scope-key-is-a-miss-without-consulting-the-store", func(t *testing.T) {
+		reader := &countingEntryReader{}
+		lookup, hits := newLookup(reader)
+		_, found, err := lookup.LookupPreviousSourceCache(ctx, sourcecache.RowKindGrants, "")
+		require.NoError(t, err, "an invalid scope key must not fail the connector's call")
+		require.False(t, found)
+		require.Zero(t, reader.calls.Load())
+		require.Zero(t, *hits)
+	})
+
+	t.Run("store-read-failure-is-a-miss", func(t *testing.T) {
+		reader := &countingEntryReader{stubPreviousReader: stubPreviousReader{entryErr: errors.New("pebble: sstable checksum mismatch")}}
+		lookup, hits := newLookup(reader)
+		_, found, err := lookup.LookupPreviousSourceCache(ctx, sourcecache.RowKindGrants, "grants:team-1")
+		require.NoError(t, err, "an internal read failure must degrade to a miss while fresh fetch is still available")
+		require.False(t, found)
+		require.Equal(t, int32(1), reader.calls.Load())
+		require.Zero(t, *hits)
+	})
+
+	t.Run("control-valid-hit-is-reported", func(t *testing.T) {
+		reader := &countingEntryReader{stubPreviousReader: stubPreviousReader{entry: sourcecache.Entry{CacheValidator: "v-1"}, found: true}}
+		lookup, hits := newLookup(reader)
+		entry, found, err := lookup.LookupPreviousSourceCache(ctx, sourcecache.RowKindGrants, "grants:team-1")
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, "v-1", entry.CacheValidator)
+		require.Equal(t, 1, *hits)
+	})
+}
+
+// TestSourceCachePageOpsStoreWithoutSurface pins the no-surface page
+// contract (plan B3; coverage-triage cells, CO-6b-007) on a capable
+// connector whose CURRENT store has no source-cache surface: a record is
+// ignored with a warn — nothing can be stamped, cold-sync behavior — while
+// a replay fails loud and cold, because the connector skipped row
+// generation and there is nothing to fall back to.
+func TestSourceCachePageOpsStoreWithoutSurface(t *testing.T) {
+	ctx := context.Background()
+	s := &syncer{
+		state:                 newState(),
+		syncType:              connectorstore.SyncTypeFull,
+		sourceCacheCapability: sourceCacheCapabilityRW("gen-1", "cfg-1"),
+		// sourceCacheStore deliberately nil: the current store exposed no
+		// dotc1z.SourceCacheStore surface at install time.
+	}
+
+	ops, err := s.sourceCachePageOps(ctx, sourcecache.RowKindGrants,
+		scRecordAnno("grants:team-1", "v-1"), 1)
+	require.NoError(t, err, "a record on a surfaceless store is ignored, not an error")
+	require.Nil(t, ops)
+
+	_, err = s.sourceCachePageOps(ctx, sourcecache.RowKindGrants,
+		scReplayAnno("grants:team-1", "v-1", false, nil, nil), 0)
+	require.ErrorIs(t, err, ErrReplayIntegrity)
+	var rie *ReplayIntegrityError
+	require.ErrorAs(t, err, &rie)
+	require.Equal(t, ReplayVerdictCold, rie.Verdict, "no rows were generated and none can be copied: cold")
+}
+
+// compatErrPreviousReader has the entry surface AND the compat surface,
+// but every compat read fails.
+type compatErrPreviousReader struct{ stubPreviousReader }
+
+func (r compatErrPreviousReader) GetSourceCacheCompat(context.Context) (sourcecache.CompatKey, bool, error) {
+	return sourcecache.CompatKey{}, false, errors.New("pebble: compat record read failed")
+}
+
+// TestSourceCacheWarmStoreDegradeLadder pins the install-time consume-gate
+// degradations for a previous store that is PRESENT but structurally or
+// operationally unusable (coverage-triage cells, CO-6b-007): each rung
+// degrades to cold with a warn — the sync proceeds, never errors.
+func TestSourceCacheWarmStoreDegradeLadder(t *testing.T) {
+	ctx := context.Background()
+	cells := []struct {
+		name   string
+		reader connectorstore.Reader
+	}{
+		{name: "previous-store-without-entry-surface", reader: bareStubPreviousReader{}},
+		{name: "previous-store-without-compat-surface", reader: stubPreviousReader{}},
+		{name: "compat-read-failure", reader: compatErrPreviousReader{}},
+	}
+	for _, cell := range cells {
+		t.Run(cell.name, func(t *testing.T) {
+			s := &syncer{
+				state:                 newState(),
+				syncType:              connectorstore.SyncTypeFull,
+				sourceCacheCapability: sourceCacheCapabilityRW("gen-1", "cfg-1"),
+				previousSyncReader:    cell.reader,
+			}
+			reader, warm := s.sourceCacheWarmStore(ctx)
+			require.False(t, warm)
+			require.Nil(t, reader)
+		})
+	}
+}

--- a/pkg/sync/source_cache_pageops_bench_test.go
+++ b/pkg/sync/source_cache_pageops_bench_test.go
@@ -1,0 +1,130 @@
+package sync
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/sourcecache"
+)
+
+// BenchmarkSourceCachePageOps pins the per-page cost source-cache
+// orchestration adds to the collection handlers' hot path (one call per
+// list-response page, before the page's row puts).
+//
+// The disabled cells are the cost EVERY production page pays while no
+// connector declares SourceCacheCapability: two annotation Picks over the
+// page's annotation slice. The enabled cells price the parse-and-gate work
+// for opted-in connectors. All cells are pure CPU — no store I/O happens
+// until beforeUpserts/afterUpserts, whose costs are engine-level and
+// benchmarked in pkg/dotc1z/engine/pebble (BenchmarkSourceCacheReplay*,
+// BenchmarkScopeIngest*).
+func BenchmarkSourceCachePageOps(b *testing.B) {
+	ctx := context.Background()
+	newBenchSyncer := func(capable bool) *syncer {
+		s := &syncer{state: newState(), syncType: connectorstore.SyncTypeFull}
+		if capable {
+			s.sourceCacheCapability = v2.SourceCacheCapability_builder{
+				Mode:            v2.SourceCacheCapability_MODE_READ_WRITE,
+				CacheGeneration: "gen-1",
+			}.Build()
+			s.sourceCacheStore = &fakeSourceCacheStore{}
+		}
+		return s
+	}
+	record := v2.SourceCacheRecord_builder{
+		ScopeKey:       "grants:team-1",
+		CacheValidator: "etag-1",
+	}.Build()
+	unrelated := annotations.New(&v2.ETag{}, &v2.RateLimitDescription{})
+
+	cells := []struct {
+		name    string
+		capable bool
+		annos   annotations.Annotations
+	}{
+		{"disabled-no-annotations", false, nil},
+		{"disabled-unrelated-annotations", false, unrelated},
+		{"enabled-no-annotations", true, nil},
+		{"enabled-record-annotation", true, annotations.New(record)},
+	}
+	for _, cell := range cells {
+		b.Run(cell.name, func(b *testing.B) {
+			s := newBenchSyncer(cell.capable)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				ops, err := s.sourceCachePageOps(ctx, sourcecache.RowKindGrants, cell.annos, 100)
+				if err != nil {
+					b.Fatal(err)
+				}
+				_ = ops
+			}
+		})
+	}
+}
+
+// BenchmarkSourceCacheScopeLocks pins the retained per-scope replay lock
+// cost (CO-6b-003): one mutex per distinct replay-annotated (rowKind,
+// scopeKey), never reclaimed for the syncer's lifetime — the same
+// cardinality as the provenance sets, whose serialized cost curve
+// BenchmarkStateMarshalSourceCacheSets pins. new-scopes prices the
+// first-touch allocation; existing-scope is the steady-state per-page cost.
+func BenchmarkSourceCacheScopeLocks(b *testing.B) {
+	b.Run("new-scopes", func(b *testing.B) {
+		s := &syncer{}
+		keys := make([]string, b.N)
+		for i := range keys {
+			keys[i] = fmt.Sprintf("grants:team-%d", i)
+		}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			s.sourceCacheScopeLock(sourcecache.RowKindGrants, keys[i])
+		}
+	})
+	b.Run("existing-scope", func(b *testing.B) {
+		s := &syncer{}
+		s.sourceCacheScopeLock(sourcecache.RowKindGrants, "grants:team-1")
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			s.sourceCacheScopeLock(sourcecache.RowKindGrants, "grants:team-1")
+		}
+	})
+}
+
+// BenchmarkStateMarshalSourceCacheSets pins the checkpoint-serialization
+// cost curve of the source-cache provenance sets (hit map with validators +
+// replayed set), which are re-serialized into the sync token on EVERY
+// checkpoint. Scope keys here are HashScope-sized (64 hex chars) and
+// validators ETag-sized. The curve is the documented bound on
+// state.sourceCacheHits: a connector whose scope count makes this material
+// should move the sets to sidecar persistence before adopting source cache
+// at that scale.
+func BenchmarkStateMarshalSourceCacheSets(b *testing.B) {
+	for _, scopes := range []int{0, 1_000, 10_000, 100_000} {
+		b.Run(fmt.Sprintf("scopes-%d", scopes), func(b *testing.B) {
+			st := newState()
+			for i := 0; i < scopes; i++ {
+				scope := sourcecache.HashScope(fmt.Sprintf("grants:team-%d", i))
+				st.RecordSourceCacheHit(sourcecache.RowKindGrants, scope, fmt.Sprintf("W/\"etag-%d\"", i))
+				st.MarkSourceCacheReplayed(sourcecache.RowKindGrants, scope)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				token, err := st.Marshal()
+				if err != nil {
+					b.Fatal(err)
+				}
+				if i == 0 {
+					b.ReportMetric(float64(len(token)), "token-bytes")
+				}
+			}
+		})
+	}
+}

--- a/pkg/sync/state.go
+++ b/pkg/sync/state.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
+	"github.com/conductorone/baton-sdk/pkg/sourcecache"
 	"github.com/conductorone/baton-sdk/pkg/sync/expand"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
@@ -65,6 +66,10 @@ type State interface {
 	SessionStoreStats() map[string]SessionStoreStat
 	SetIngestQuality(quality *IngestQualityCheckpoint)
 	IngestQuality() *IngestQualityCheckpoint
+	RecordSourceCacheHit(rowKind sourcecache.RowKind, scopeKey string, cacheValidator string)
+	SourceCacheHitValidator(rowKind sourcecache.RowKind, scopeKey string) (string, bool)
+	MarkSourceCacheReplayed(rowKind sourcecache.RowKind, scopeKey string)
+	SourceCacheReplayed(rowKind sourcecache.RowKind, scopeKey string) bool
 }
 
 func NeedsExpansion(stateStr string) (bool, error) {
@@ -350,6 +355,39 @@ type state struct {
 	// cycles still terminate. Guarded by st.mtx; bounded by total
 	// spawned admissions in the process (32-byte keys).
 	spawnedAdmitted map[parallelActionKey]string
+	// sourceCacheHits records every warm source-cache lookup HIT of this
+	// sync, keyed (row kind → scope key → the validator the lookup
+	// returned). It is the same-sync replay provenance map: a
+	// SourceCacheReplay annotation is honored only for a scope recorded
+	// here, and only while the CURRENT replay base's manifest entry still
+	// byte-matches the recorded validator — the binding that rejects a
+	// previous artifact swapped between attempts for a different one that
+	// passes every eligibility gate (two artifacts from the same connector
+	// and config share a compat key). Checkpointed (unlike spawnedAdmitted)
+	// because the connector contract allows a planning call to
+	// batch-resolve scopes and hand verdicts to sibling cursors through
+	// EnqueuePageTokens page tokens — those cursors may run after an
+	// interrupt/resume in a different process, and rejecting their
+	// legitimate replays would convert routine resumes into loud sync
+	// failures. Monotone within a sync; guarded by st.mtx.
+	//
+	// Cost bound: one entry per distinct warm-consulted scope (scope keys
+	// ≤256 bytes, validators typically ETag/delta-token sized), re-sorted
+	// and re-serialized into the sync token on every checkpoint —
+	// O(scopes·log scopes) per checkpoint, pinned by
+	// BenchmarkStateMarshalSourceCacheSets. A connector whose scope count
+	// makes that material should move the sets to sidecar persistence
+	// (like the entitlement graph) before adopting source cache at that
+	// scale.
+	sourceCacheHits map[sourcecache.RowKind]map[string]string
+	// sourceCacheReplayed records every (row kind, scope) whose replay
+	// copy COMPLETED this sync. Replay copies run once per scope per
+	// sync: duplicate pages and lost-response retries re-deliver the
+	// replay annotation, and re-copying the base over already-applied
+	// overlay pages would resurrect replaced rows. Marked only after the
+	// copy commits, so a cut mid-copy re-runs the copy on resume.
+	// Checkpointed alongside sourceCacheHits; guarded by st.mtx.
+	sourceCacheReplayed map[sourcecache.RowKind]map[string]struct{}
 }
 
 // stateOpt configures a state at construction. Not part of the State
@@ -437,7 +475,23 @@ type serializedTokenV1 struct {
 	SessionStoreStats  map[string]*SessionStoreStat  `json:"session_store_stats,omitempty"`
 	IngestQuality      *IngestQualityCheckpoint      `json:"ingest_quality,omitempty"`
 	Compaction         *CompactionTokenStats         `json:"compaction,omitempty"`
-	Version            uint64                        `json:"version"`
+	// Source-cache replay provenance; see the state struct fields for
+	// semantics. Additive: older parsers ignore the fields, and an older
+	// SDK resuming such a token pairs with an older connector build that
+	// never emits replay annotations.
+	//
+	// SCHEMA FENCE: the hit map is keyed source_cache_hit_validators, NOT
+	// the earlier source_cache_hits (row kind → scope list) — the value
+	// shape changed when hits gained validators (CO-6b-004), and reusing
+	// a key with a new shape makes json.Unmarshal fail the WHOLE v1 token,
+	// which the version-less fallback below would then misparse as v0 and
+	// silently drop the action stack. A token field's shape is frozen the
+	// moment it ships; changed shapes take a new key (old keys are
+	// ignored, so a legacy hit map degrades to loud cold replays, never
+	// to corruption).
+	SourceCacheHits     map[string]map[string]string `json:"source_cache_hit_validators,omitempty"`
+	SourceCacheReplayed map[string][]string          `json:"source_cache_replayed,omitempty"`
+	Version             uint64                       `json:"version"`
 }
 
 func newState(opts ...stateOpt) *state {
@@ -556,8 +610,27 @@ func (st *state) Unmarshal(input string) error {
 
 	if input != "" {
 		err := json.Unmarshal([]byte(input), &token)
-		if err != nil || (token.Version != StateTokenVersion && token.Version != StateTokenVersionTypeScoped) {
-			// Fall back to old serialized token format.
+		if err != nil {
+			// A token that DECLARES a version is a v1+ token whose full
+			// parse failed (corrupt, or a field's shape changed under a
+			// reused key). Falling back to v0 here would misparse it —
+			// the v0 struct ignores the unknown v1 fields, "succeeds"
+			// with an empty action stack, and the resume silently
+			// restarts as a fresh sync. Fail loud instead; only tokens
+			// without a version field are genuinely v0.
+			var probe struct {
+				Version *uint64 `json:"version"`
+			}
+			if probeErr := json.Unmarshal([]byte(input), &probe); probeErr == nil && probe.Version != nil {
+				return fmt.Errorf("syncer token declares version %d but failed to parse: %w", *probe.Version, err)
+			}
+			token, err = unmarshalTokenV0(input)
+			if err != nil {
+				return err
+			}
+		} else if token.Version != StateTokenVersion && token.Version != StateTokenVersionTypeScoped {
+			// Parsed cleanly but with an unrecognized (or absent) version:
+			// the original pre-version token format.
 			token, err = unmarshalTokenV0(input)
 			if err != nil {
 				return err
@@ -609,6 +682,8 @@ func (st *state) Unmarshal(input string) error {
 		}
 		st.ingestQuality = cloneIngestQualityCheckpoint(token.IngestQuality)
 		st.compaction = token.Compaction
+		st.sourceCacheHits = scopeValidatorsFromToken(token.SourceCacheHits)
+		st.sourceCacheReplayed = scopeSetsFromSorted(token.SourceCacheReplayed)
 		// Rebuild the I10 drain-evidence set from the checkpointed
 		// actions: a spawned cursor restored from a token was admitted
 		// by a previous process and must still drain in the process
@@ -641,6 +716,8 @@ func (st *state) Unmarshal(input string) error {
 		st.compaction = nil
 		st.spawnedInFlight = make(map[string]Action)
 		st.spawnedAdmitted = make(map[parallelActionKey]string)
+		st.sourceCacheHits = nil
+		st.sourceCacheReplayed = nil
 	}
 
 	return nil
@@ -754,6 +831,8 @@ func (st *state) Marshal() (string, error) {
 		SessionStoreStats:               st.sessionStoreStats,
 		IngestQuality:                   cloneIngestQualityCheckpoint(st.ingestQuality),
 		Compaction:                      st.compaction,
+		SourceCacheHits:                 scopeValidatorsToToken(st.sourceCacheHits),
+		SourceCacheReplayed:             scopeSetsToSorted(st.sourceCacheReplayed),
 		Version:                         version,
 	})
 	if err != nil {
@@ -918,6 +997,141 @@ func cloneIngestQualityCheckpoint(in *IngestQualityCheckpoint) *IngestQualityChe
 	}
 	out := *in
 	return &out
+}
+
+// RecordSourceCacheHit records a warm source-cache lookup hit and the
+// validator it returned; see the sourceCacheHits field for why the map is
+// checkpointed and what the validator binds. A later hit for the same
+// scope overwrites: the connector's most recent consult is the one whose
+// verdict its cursors carry.
+func (st *state) RecordSourceCacheHit(rowKind sourcecache.RowKind, scopeKey string, cacheValidator string) {
+	st.mtx.Lock()
+	defer st.mtx.Unlock()
+	if st.sourceCacheHits == nil {
+		st.sourceCacheHits = make(map[sourcecache.RowKind]map[string]string)
+	}
+	scopes := st.sourceCacheHits[rowKind]
+	if scopes == nil {
+		scopes = make(map[string]string)
+		st.sourceCacheHits[rowKind] = scopes
+	}
+	scopes[scopeKey] = cacheValidator
+}
+
+// SourceCacheHitValidator returns the validator recorded by this sync's
+// warm lookup hit for (rowKind, scopeKey) — the same-sync replay
+// provenance check. ok is false when no hit was recorded.
+func (st *state) SourceCacheHitValidator(rowKind sourcecache.RowKind, scopeKey string) (string, bool) {
+	st.mtx.RLock()
+	defer st.mtx.RUnlock()
+	validator, ok := st.sourceCacheHits[rowKind][scopeKey]
+	return validator, ok
+}
+
+// MarkSourceCacheReplayed records that (rowKind, scopeKey)'s replay copy
+// completed this sync. Called only after the copy commits.
+func (st *state) MarkSourceCacheReplayed(rowKind sourcecache.RowKind, scopeKey string) {
+	st.mtx.Lock()
+	defer st.mtx.Unlock()
+	if st.sourceCacheReplayed == nil {
+		st.sourceCacheReplayed = make(map[sourcecache.RowKind]map[string]struct{})
+	}
+	scopes := st.sourceCacheReplayed[rowKind]
+	if scopes == nil {
+		scopes = make(map[string]struct{})
+		st.sourceCacheReplayed[rowKind] = scopes
+	}
+	scopes[scopeKey] = struct{}{}
+}
+
+// SourceCacheReplayed reports whether (rowKind, scopeKey) already completed
+// its replay copy this sync (duplicate-page / retry dedup).
+func (st *state) SourceCacheReplayed(rowKind sourcecache.RowKind, scopeKey string) bool {
+	st.mtx.RLock()
+	defer st.mtx.RUnlock()
+	_, ok := st.sourceCacheReplayed[rowKind][scopeKey]
+	return ok
+}
+
+// scopeSetsToSorted projects the in-memory provenance sets into the
+// deterministic token shape (row kind → sorted scope keys).
+func scopeSetsToSorted(in map[sourcecache.RowKind]map[string]struct{}) map[string][]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string][]string, len(in))
+	for rowKind, scopes := range in {
+		if len(scopes) == 0 {
+			continue
+		}
+		sorted := make([]string, 0, len(scopes))
+		for scope := range scopes {
+			sorted = append(sorted, scope)
+		}
+		sort.Strings(sorted)
+		out[string(rowKind)] = sorted
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// scopeSetsFromSorted restores the in-memory provenance sets from a token.
+func scopeSetsFromSorted(in map[string][]string) map[sourcecache.RowKind]map[string]struct{} {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[sourcecache.RowKind]map[string]struct{}, len(in))
+	for rowKind, scopes := range in {
+		set := make(map[string]struct{}, len(scopes))
+		for _, scope := range scopes {
+			set[scope] = struct{}{}
+		}
+		out[sourcecache.RowKind(rowKind)] = set
+	}
+	return out
+}
+
+// scopeValidatorsToToken projects the hit map into the token shape
+// (row kind → scope key → validator). encoding/json marshals map keys in
+// sorted order, so the serialized form is deterministic without an
+// explicit sort.
+func scopeValidatorsToToken(in map[sourcecache.RowKind]map[string]string) map[string]map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]map[string]string, len(in))
+	for rowKind, scopes := range in {
+		if len(scopes) == 0 {
+			continue
+		}
+		copied := make(map[string]string, len(scopes))
+		for scope, validator := range scopes {
+			copied[scope] = validator
+		}
+		out[string(rowKind)] = copied
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// scopeValidatorsFromToken restores the in-memory hit map from a token.
+func scopeValidatorsFromToken(in map[string]map[string]string) map[sourcecache.RowKind]map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[sourcecache.RowKind]map[string]string, len(in))
+	for rowKind, scopes := range in {
+		copied := make(map[string]string, len(scopes))
+		for scope, validator := range scopes {
+			copied[scope] = validator
+		}
+		out[sourcecache.RowKind(rowKind)] = copied
+	}
+	return out
 }
 
 func makeActionID(id uint64) string {

--- a/pkg/sync/state_test.go
+++ b/pkg/sync/state_test.go
@@ -9,6 +9,7 @@ import (
 
 	reader_v2 "github.com/conductorone/baton-sdk/pb/c1/reader/v2"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	"github.com/conductorone/baton-sdk/pkg/sourcecache"
 	"github.com/stretchr/testify/require"
 )
 
@@ -710,4 +711,67 @@ func TestStateLegacyTokenLeavesIngestQualityUnknown(t *testing.T) {
 	st := newState()
 	require.NoError(t, st.Unmarshal(`{"version":1}`))
 	require.Nil(t, st.IngestQuality())
+}
+
+// TestSyncerTokenSourceCacheSetsRoundTrip pins the checkpoint round-trip of
+// the source-cache provenance sets: the hit map (scope → validator,
+// CO-6b-004) and the replayed set must survive Marshal → Unmarshal exactly
+// — they are the same-sync replay authorization a resume restores.
+func TestSyncerTokenSourceCacheSetsRoundTrip(t *testing.T) {
+	st := newState()
+	st.RecordSourceCacheHit(sourcecache.RowKindGrants, "grants:team-1", `W/"etag-1"`)
+	st.RecordSourceCacheHit(sourcecache.RowKindGrants, "grants:team-2", `W/"etag-2"`)
+	st.RecordSourceCacheHit(sourcecache.RowKindResources, "res:all", "delta-9")
+	st.MarkSourceCacheReplayed(sourcecache.RowKindGrants, "grants:team-1")
+
+	tokenString, err := st.Marshal()
+	require.NoError(t, err)
+
+	restored := newState()
+	require.NoError(t, restored.Unmarshal(tokenString))
+
+	v, ok := restored.SourceCacheHitValidator(sourcecache.RowKindGrants, "grants:team-1")
+	require.True(t, ok)
+	require.Equal(t, `W/"etag-1"`, v)
+	v, ok = restored.SourceCacheHitValidator(sourcecache.RowKindGrants, "grants:team-2")
+	require.True(t, ok)
+	require.Equal(t, `W/"etag-2"`, v)
+	v, ok = restored.SourceCacheHitValidator(sourcecache.RowKindResources, "res:all")
+	require.True(t, ok)
+	require.Equal(t, "delta-9", v)
+	_, ok = restored.SourceCacheHitValidator(sourcecache.RowKindEntitlements, "grants:team-1")
+	require.False(t, ok, "row kinds must not alias")
+	require.True(t, restored.SourceCacheReplayed(sourcecache.RowKindGrants, "grants:team-1"))
+	require.False(t, restored.SourceCacheReplayed(sourcecache.RowKindGrants, "grants:team-2"))
+}
+
+// TestSyncerTokenSchemaFence pins the two halves of the token schema fence
+// (review N5): a v1 token carrying the RETIRED source_cache_hits shape (row
+// kind → scope list) parses cleanly with the hits simply absent — never a
+// parse failure — and a v1-versioned token that genuinely fails to parse
+// errors loudly instead of falling back to the v0 format, which would
+// "succeed" with an empty action stack and silently restart the sync.
+func TestSyncerTokenSchemaFence(t *testing.T) {
+	t.Run("retired-hits-key-is-ignored-not-fatal", func(t *testing.T) {
+		st := newState()
+		require.NoError(t, st.Unmarshal(
+			`{"version":1,"actions_map":{"0000000001":{"operation":"init"}},"action_order":["0000000001"],"source_cache_hits":{"grants":["grants:team-1"]}}`))
+		_, ok := st.SourceCacheHitValidator(sourcecache.RowKindGrants, "grants:team-1")
+		require.False(t, ok, "the retired key's hits degrade to cold replays; they must not round-trip into the new shape")
+		require.NotNil(t, st.Current(), "the action stack must survive")
+	})
+	t.Run("versioned-token-that-fails-to-parse-errors-loudly", func(t *testing.T) {
+		st := newState()
+		// A shape conflict on a versioned token (here: hit map value is a
+		// list where an object is expected) must NOT downgrade to v0.
+		err := st.Unmarshal(
+			`{"version":1,"actions_map":{"0000000001":{"operation":"init"}},"source_cache_hit_validators":{"grants":["not-an-object"]}}`)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "declares version 1")
+	})
+	t.Run("version-less-v0-token-still-falls-back", func(t *testing.T) {
+		st := newState()
+		require.NoError(t, st.Unmarshal(`{"actions":[{"operation":"init"}]}`))
+		require.NotNil(t, st.Current())
+	})
 }

--- a/pkg/sync/sync_trace_audit.go
+++ b/pkg/sync/sync_trace_audit.go
@@ -1,0 +1,117 @@
+package sync //nolint:revive,nolintlint // we can't change the package name for backwards compatibility
+
+import (
+	native_sync "sync"
+)
+
+// syncTraceAudit is the test-only canonical-event recorder behind the
+// formal trace-policy oracle (formal/occult/TRACE_BRIDGE.md, "Mapping 2:
+// real sync executions"). The ordering/durability policies verified over
+// the P models' traces (formal/occult/src/sync_trace_policies.occult)
+// consume event lists in a canonical vocabulary; recording at the
+// syncer's source-cache orchestration seams lets chaos tests export real
+// sync traces to the same oracle, closing the model-to-implementation
+// bridge the formal brief requires.
+//
+// The recorder is purely observational: every event corresponds to a
+// store operation that actually committed, in commit order. Rendering
+// conventions (e.g. the structural emptiness of a brand-new sync's
+// partitions standing in for an explicit clear) belong to the trace
+// renderer on the oracle side, never here.
+//
+// Production cost is one nil pointer check per recorded event: the
+// syncer only carries an audit when a test sets testSyncTraceAudit
+// (same pattern as testQueueAudit).
+type syncTraceAudit struct {
+	mu     native_sync.Mutex
+	events []syncTraceEvent
+}
+
+type syncTraceKind string
+
+const (
+	// syncTraceConsult: the previous-artifact source-cache lookup
+	// resolved (hit or miss) for a scope.
+	syncTraceConsult syncTraceKind = "consult"
+	// syncTraceClear: the replay unit's destination-scope clear
+	// committed (recorded with syncTraceReplay in the store's
+	// contractual clear-then-copy leg order).
+	syncTraceClear syncTraceKind = "clear"
+	// syncTraceReplay: a ReplaySourceCache replacement copy committed.
+	syncTraceReplay syncTraceKind = "replay"
+	// syncTraceUpsert: a scoped page's row upserts committed (page
+	// granularity — the policies gate ordering, not row counts).
+	syncTraceUpsert syncTraceKind = "upsert"
+	// syncTraceDelete: a scoped page's tombstones committed (one event
+	// per successful store delete call: canonical-id and
+	// principal-scoped fire separately, in their contractual order).
+	syncTraceDelete syncTraceKind = "delete"
+	// syncTracePublish: the scope's manifest entry (validator) was
+	// written.
+	syncTracePublish syncTraceKind = "publish"
+	// syncTraceCheckpoint: a checkpoint token durably committed.
+	syncTraceCheckpoint syncTraceKind = "checkpoint"
+	// syncTraceSeal: EndSync succeeded.
+	syncTraceSeal syncTraceKind = "seal"
+	// syncTraceSessionWrite: a connector session write committed.
+	// Sessions are durable at op time, OUTSIDE the checkpoint
+	// mechanism — the provenance hazard the oracle's policy 6
+	// (session-checkpoint consistency) judges. The chaos connector has
+	// no session plumbing, so these events are recorded by the test
+	// acting as the session actor, at the moment of its real store
+	// operation (see TestChaosSourceCacheSessionPersistsAcrossResume).
+	syncTraceSessionWrite syncTraceKind = "swrite"
+	// syncTraceSessionReadHit / syncTraceSessionReadMiss: a session
+	// read returning found / not-found. ScopeKey carries the session
+	// key for session events.
+	syncTraceSessionReadHit  syncTraceKind = "sread_hit"
+	syncTraceSessionReadMiss syncTraceKind = "sread_miss"
+	// External-principal events (the oracle's policy 7,
+	// external-principal grounding — the deleteStaleExternalPrincipals
+	// contract). syncTraceExtList: the external source's current answer
+	// finished listing for this phase run. syncTraceExtLive: one
+	// principal is a member of that answer (ScopeKey carries the
+	// principal's resource id). syncTraceExtRecon: reconciliation
+	// COMPLETED — stale principal rows deleted, or nothing stale. The
+	// warn-and-continue degrade of a non-deleting engine records
+	// NOTHING: the pass ran but did not reconcile, and the missing
+	// event is exactly what the oracle's recon-before-copy direction
+	// flags. syncTraceExtCopy: one principal's row write committed.
+	syncTraceExtList  syncTraceKind = "ep_list"
+	syncTraceExtLive  syncTraceKind = "ep_live"
+	syncTraceExtRecon syncTraceKind = "ep_recon"
+	syncTraceExtCopy  syncTraceKind = "ep_copy"
+)
+
+// syncTraceEvent is one canonical event. Scope-less kinds (checkpoint,
+// seal) leave RowKind and ScopeKey empty.
+type syncTraceEvent struct {
+	Kind     syncTraceKind `json:"kind"`
+	RowKind  string        `json:"row_kind,omitempty"`
+	ScopeKey string        `json:"scope_key,omitempty"`
+}
+
+// record appends one event. Nil-receiver safe so call sites need no
+// guard; the mutex serializes concurrent workers, and because every
+// call site sits directly after its operation's commit, the recorded
+// order is a real commit order (one legal linearization of the sync).
+func (a *syncTraceAudit) record(kind syncTraceKind, rowKind, scopeKey string) {
+	if a == nil {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.events = append(a.events, syncTraceEvent{Kind: kind, RowKind: rowKind, ScopeKey: scopeKey})
+}
+
+// snapshot returns a copy of the recorded events.
+func (a *syncTraceAudit) snapshot() []syncTraceEvent {
+	if a == nil {
+		return nil
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	out := make([]syncTraceEvent, len(a.events))
+	copy(out, a.events)
+	return out
+}

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -21,6 +21,7 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/dotc1z"
 	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
 	enginepkg "github.com/conductorone/baton-sdk/pkg/dotc1z/engine/pebble"
+	"github.com/conductorone/baton-sdk/pkg/sourcecache"
 	"github.com/conductorone/baton-sdk/pkg/sync/expand"
 	"github.com/conductorone/baton-sdk/pkg/types/entitlement"
 	batonGrant "github.com/conductorone/baton-sdk/pkg/types/grant"
@@ -207,7 +208,13 @@ type syncer struct {
 	// event (seed/dequeue/commit/abort/done) for post-hoc verification
 	// of the queue contract. Nil in production: one pointer check per
 	// queue operation.
-	testQueueAudit           *queueAudit
+	testQueueAudit *queueAudit
+	// testSyncTraceAudit, when non-nil, records canonical sync-trace
+	// events (consult/clear/replay/upsert/publish/checkpoint/seal) at
+	// their commit sites for the formal trace-policy oracle
+	// (formal/occult/TRACE_BRIDGE.md, mapping 2). Nil in production:
+	// one pointer check per recorded event.
+	testSyncTraceAudit       *syncTraceAudit
 	connector                types.ConnectorClient
 	state                    State
 	runDuration              time.Duration
@@ -244,11 +251,47 @@ type syncer struct {
 	syncType                              connectorstore.SyncType
 	injectSyncIDAnnotation                bool
 	setSessionStore                       sessions.SetSessionStore
-	syncResourceTypes                     []string
-	workerCount                           int // If 1, sync is sequential (default). If > 1, sync operations are done in parallel.
-	metricsHandler                        metrics.Handler
-	syncIdentity                          uotel.SyncIdentity
-	recordStats                           bool
+	// sourceCacheCapability is the SourceCacheCapability parsed from this
+	// sync's Validate response (nil when absent). Only MODE_READ_WRITE
+	// activates source-cache handling; see source_cache_orchestration.go.
+	sourceCacheCapability *v2.SourceCacheCapability
+	// sourceCacheWarm reports whether a warm (previous-artifact-backed)
+	// lookup was installed AND delivered for this sync attempt. When false
+	// and capability is MODE_READ_WRITE, the connector sees NoopLookup and
+	// every scope cold-fetches; replay annotations are provenance
+	// violations, enforced by beforeUpserts (CO-6b-003) — a checkpointed
+	// hit-set must not authorize replay on an attempt whose consume gates
+	// degraded to cold.
+	sourceCacheWarm bool
+	// sourceCacheScopeLocks serializes page application per (rowKind,
+	// scopeKey): the once-per-scope replacement copy stays atomic at
+	// worker counts above one, and a record-only page's puts/tombstones/
+	// publish cannot interleave with another action's in-flight copy for
+	// the same scope (re-review N1); see sourceCachePageOps.beforeUpserts.
+	// Entries are never reclaimed for the syncer's lifetime (a syncer runs
+	// one sync): one mutex per distinct SCOPED page's (rowKind, scopeKey)
+	// — record or replay — the same cardinality as the scope manifest.
+	// Cost pinned by BenchmarkSourceCacheScopeLocks.
+	sourceCacheScopeLocks native_sync.Map
+	// sourceCacheScopeGrounded is the ATTEMPT-LOCAL set of (rowKind,
+	// scopeKey) pairs whose partition base is established this attempt —
+	// by a replay copy (or its within-attempt skip) or by a record
+	// round's grounding (groundRecordScope). Deliberately volatile: a
+	// resume re-decides grounding from the durable facts (this sync's
+	// manifest entries), which is what clears crashed-attempt debris on
+	// the verdict-flip path instead of composing with it.
+	sourceCacheScopeGrounded native_sync.Map
+	// sourceCacheStore is this sync's store viewed through its source-cache
+	// surface, set at lookup install when the capability is MODE_READ_WRITE
+	// and the store is Pebble; nil otherwise. Non-nil is the produce-side
+	// gate: only then are SourceCacheRecord / SourceCacheReplay page
+	// annotations honored.
+	sourceCacheStore  dotc1z.SourceCacheStore
+	syncResourceTypes []string
+	workerCount       int // If 1, sync is sequential (default). If > 1, sync operations are done in parallel.
+	metricsHandler    metrics.Handler
+	syncIdentity      uotel.SyncIdentity
+	recordStats       bool
 	// parallelActionTransitioner atomically commits parent pagination and
 	// spawned work to state and the active worker pool.
 	parallelTransitionMu       native_sync.RWMutex
@@ -508,6 +551,7 @@ func (s *syncer) Checkpoint(ctx context.Context, force bool) error {
 	if s.testCheckpointHook != nil {
 		s.testCheckpointHook(checkpoint)
 	}
+	s.testSyncTraceAudit.record(syncTraceCheckpoint, "", "")
 
 	return nil
 }
@@ -934,6 +978,10 @@ func (s *syncer) Sync(ctx context.Context) error {
 		}
 	}
 
+	// Re-parsed on every attempt, including resumes: the capability is the
+	// produce-side gate for every source-cache annotation this sync serves.
+	s.sourceCacheCapability = parseSourceCacheCapability(ctx, resp.GetAnnotations())
+
 	syncResourceTypeMap := make(map[string]bool)
 	if len(s.syncResourceTypes) > 0 {
 		for _, rt := range s.syncResourceTypes {
@@ -1028,6 +1076,18 @@ func (s *syncer) Sync(ctx context.Context) error {
 		}
 		s.ingestFilterStats.restore(quality)
 	}
+
+	// Deliver this sync's source-cache lookup (warm or nil→NoopLookup)
+	// after the state restore: the warm lookup records hits into the
+	// checkpointed provenance set and the compat drift check layers on the
+	// restored ingest-quality flags. The teardown clears the connector-held
+	// lookup on every exit so a late RPC cannot read stale state.
+	teardownSourceCache, err := s.installSourceCacheLookup(ctx)
+	if err != nil {
+		return err
+	}
+	defer teardownSourceCache()
+
 	if !newSync {
 		currentAction := s.state.Current()
 		currentActionOp := ""
@@ -1137,6 +1197,7 @@ func (s *syncer) Sync(ctx context.Context) error {
 	if err != nil {
 		return s.returnSyncError(l, span, err)
 	}
+	s.testSyncTraceAudit.record(syncTraceSeal, "", "")
 	// EndSync built the authoritative whole-file grant digest. Persisting the
 	// graph now binds it to that exact sealed grant generation. A crash before
 	// this write leaves no reusable graph and therefore fails safe.
@@ -1664,6 +1725,45 @@ func (s *syncer) syncResources(ctx context.Context, action *Action) error {
 		return err
 	}
 
+	respAnnotations := annotations.Annotations(resp.GetAnnotations())
+	if respAnnotations.Contains(&v2.EnqueuePageTokens{}) {
+		// Spawned-cursor fanout is an entitlements/grants surface; a
+		// resources response carrying it would silently drop the spawned
+		// tokens, so say so loudly (CO-6b-003 registered boundary).
+		ctxzap.Extract(ctx).Warn("EnqueuePageTokens on a resources page is not supported; the spawned page tokens were ignored")
+	}
+	scOps, err := s.sourceCachePageOps(ctx, sourcecache.RowKindResources, respAnnotations, len(resp.GetList()))
+	if err != nil {
+		return err
+	}
+	// Backstop: release the scope lock on any error path between
+	// beforeUpserts and afterUpserts (release is idempotent and nil-safe).
+	defer scOps.release()
+	if scOps != nil {
+		// Child-resource discovery is scheduled from a page's OWN rows, so
+		// a replayed resources scope would never re-schedule its children —
+		// silent row loss relative to a cold sync. A scope-annotated page
+		// whose rows declare children therefore blocks this artifact as a
+		// future replay source (CO-6b-003): the scope's shape cannot be
+		// reproduced by replay.
+		for _, r := range resp.GetList() {
+			if s.hasChildResources(r) {
+				s.ingestFilterStats.blockReplay(ingestQualityReasonSourceCacheShapeUnsupported)
+				ctxzap.Extract(ctx).Warn(
+					"source-cache-annotated resources page declares child resource types; replay cannot re-schedule child discovery — "+
+						"blocking this artifact as a future replay source",
+					zap.String("scope_key", scOps.scopeKey),
+				)
+				break
+			}
+		}
+	}
+	// Replay copy precedes the page's own rows (frozen order: replay copy →
+	// page upserts → page tombstones).
+	if err := scOps.beforeUpserts(ctx); err != nil {
+		return err
+	}
+
 	resources, err := filterConnectorData(s, connectorDataResource, resp.GetList(), validateConnectorResource)
 	if err != nil {
 		return err
@@ -1716,10 +1816,15 @@ func (s *syncer) syncResources(ctx context.Context, action *Action) error {
 	}
 
 	if len(bulkPutResoruces) > 0 {
-		err = s.putConnectorResources(ctx, bulkPutResoruces...)
+		// stampCtx scopes ONLY the page's connector rows; sub-resource and
+		// related-resource writes happen through other actions/contexts.
+		err = s.putConnectorResources(scOps.stampCtx(ctx), bulkPutResoruces...)
 		if err != nil {
-			return err
+			return scOps.wrapPageRowPutError(err)
 		}
+	}
+	if err := scOps.afterUpserts(ctx); err != nil {
+		return err
 	}
 
 	s.handleProgress(ctx, action, len(resp.GetList()))
@@ -2115,6 +2220,19 @@ func (s *syncer) syncEntitlementsForResource(ctx context.Context, action *Action
 	if err != nil {
 		return err
 	}
+	scOps, err := s.sourceCachePageOps(ctx, sourcecache.RowKindEntitlements, annotations.Annotations(resp.GetAnnotations()), len(resp.GetList()))
+	if err != nil {
+		return err
+	}
+	// Backstop: release the scope lock on any error path between
+	// beforeUpserts and afterUpserts (release is idempotent and nil-safe).
+	defer scOps.release()
+	// Replay copy precedes the page's own rows (frozen order: replay copy →
+	// page upserts → page tombstones).
+	if err := scOps.beforeUpserts(ctx); err != nil {
+		return err
+	}
+
 	// Filter before the put: a dropped entitlement must never be
 	// ingested (exclusion-group validation happens post-collection over
 	// the STORED keyspace — ingestion invariant I5 — so filtered rows
@@ -2127,8 +2245,11 @@ func (s *syncer) syncEntitlementsForResource(ctx context.Context, action *Action
 	if err != nil {
 		return err
 	}
-	err = s.store.PutEntitlements(ctx, entitlements...)
+	err = s.store.PutEntitlements(scOps.stampCtx(ctx), entitlements...)
 	if err != nil {
+		return scOps.wrapPageRowPutError(err)
+	}
+	if err := scOps.afterUpserts(ctx); err != nil {
 		return err
 	}
 
@@ -2201,6 +2322,10 @@ func (s *syncer) syncStaticEntitlementsForResourceType(ctx context.Context, acti
 
 		return err
 	}
+
+	// Static entitlements stay unscoped: source-cache annotations here are
+	// a registered exclusion (plan B3), ignored with a warn.
+	warnIgnoredSourceCacheAnnotations(ctx, "static entitlements", annotations.Annotations(resp.GetAnnotations()))
 
 	for _, ent := range resp.GetList() {
 		resourcePageToken := ""
@@ -2687,6 +2812,33 @@ func (s *syncer) syncGrantsForResource(ctx context.Context, action *Action) erro
 	respAnnos := annotations.Annotations(resp.GetAnnotations())
 	insertResourceGrants := respAnnos.Contains(&v2.InsertResourceGrants{})
 
+	scOps, err := s.sourceCachePageOps(ctx, sourcecache.RowKindGrants, respAnnos, len(resp.GetList()))
+	if err != nil {
+		return err
+	}
+	// Backstop: release the scope lock on any error path between
+	// beforeUpserts and afterUpserts (release is idempotent and nil-safe).
+	defer scOps.release()
+	if scOps != nil && insertResourceGrants {
+		// Grant-discovered resources are materialized from a page's OWN
+		// rows and response annotation; a replayed grants scope copies the
+		// grants but can never re-run the discovery, so the resources
+		// would silently vanish relative to a cold sync. A scope-annotated
+		// page carrying InsertResourceGrants therefore blocks this
+		// artifact as a future replay source (CO-6b-003).
+		s.ingestFilterStats.blockReplay(ingestQualityReasonSourceCacheShapeUnsupported)
+		l.Warn(
+			"source-cache-annotated grants page carries InsertResourceGrants; replay cannot re-materialize grant-discovered resources — "+
+				"blocking this artifact as a future replay source",
+			zap.String("scope_key", scOps.scopeKey),
+		)
+	}
+	// Replay copy precedes the page's own rows (frozen order: replay copy →
+	// page upserts → page tombstones).
+	if err := scOps.beforeUpserts(ctx); err != nil {
+		return err
+	}
+
 	// Stamp InsertResourceGrants per-grant so the slim-blob writer's
 	// gate sees it. The annotation is response-level, but the writer
 	// needs it per-row to avoid stripping the Resource this path
@@ -2809,9 +2961,15 @@ func (s *syncer) syncGrantsForResource(ctx context.Context, action *Action) erro
 		}
 	}
 
-	err = s.store.PutGrants(ctx, grants...)
+	// stampCtx scopes ONLY the page's grant rows: grant-discovered resources
+	// and related-resource fetches above are resource rows on a grants page
+	// and stay unstamped (a scope partitions one row kind).
+	err = s.store.PutGrants(scOps.stampCtx(ctx), grants...)
 	if err != nil {
-		return fmt.Errorf("sync-grants-for-resource: error putting grants: %w", err)
+		return scOps.wrapPageRowPutError(fmt.Errorf("sync-grants-for-resource: error putting grants: %w", err))
+	}
+	if err := scOps.afterUpserts(ctx); err != nil {
+		return err
 	}
 
 	s.handleProgress(ctx, action, len(grants))
@@ -2956,6 +3114,7 @@ func (s *syncer) SyncExternalResourcesWithGrantToEntitlement(ctx context.Context
 		principals = append(principals, resourceVal)
 	}
 
+	s.recordExternalListTrace(principals)
 	err = s.deleteStaleExternalPrincipals(ctx, principals)
 	if err != nil {
 		return err
@@ -2964,6 +3123,7 @@ func (s *syncer) SyncExternalResourcesWithGrantToEntitlement(ctx context.Context
 	if err != nil {
 		return err
 	}
+	s.recordExternalCopyTrace(principals)
 
 	entsCount := 0
 	ents := make([]*v2.Entitlement, 0)
@@ -3072,6 +3232,7 @@ func (s *syncer) SyncExternalResourcesUsersAndGroups(ctx context.Context) error 
 		}
 	}
 
+	s.recordExternalListTrace(principals)
 	err = s.deleteStaleExternalPrincipals(ctx, principals)
 	if err != nil {
 		return err
@@ -3080,6 +3241,7 @@ func (s *syncer) SyncExternalResourcesUsersAndGroups(ctx context.Context) error 
 	if err != nil {
 		return err
 	}
+	s.recordExternalCopyTrace(principals)
 
 	entsCount := 0
 	principalsCount := len(principals)
@@ -3166,6 +3328,30 @@ type entitlementRecordDeleter interface {
 	DeleteEntitlementByRefs(ctx context.Context, entitlement *v2.Entitlement) error
 }
 
+// recordExternalListTrace records the external phase's listed answer for the
+// trace oracle (policy 7): one ep_list marker, then one ep_live per member.
+// Nil-audit safe; a no-op in production.
+func (s *syncer) recordExternalListTrace(principals []*v2.Resource) {
+	if s.testSyncTraceAudit == nil {
+		return
+	}
+	s.testSyncTraceAudit.record(syncTraceExtList, "", "")
+	for _, principal := range principals {
+		s.testSyncTraceAudit.record(syncTraceExtLive, "", principal.GetId().GetResource())
+	}
+}
+
+// recordExternalCopyTrace records the committed principal writes (ep_copy per
+// principal), after the store accepted them.
+func (s *syncer) recordExternalCopyTrace(principals []*v2.Resource) {
+	if s.testSyncTraceAudit == nil {
+		return
+	}
+	for _, principal := range principals {
+		s.testSyncTraceAudit.record(syncTraceExtCopy, "", principal.GetId().GetResource())
+	}
+}
+
 // deleteStaleExternalPrincipals reconciles principal rows copied by an earlier
 // attempt before writing the external source's current answer. Checkpoint
 // resume deliberately retains completed writes, so without this pass a
@@ -3210,6 +3396,12 @@ func (s *syncer) deleteStaleExternalPrincipals(
 		}
 	}
 	if len(staleIDs) == 0 {
+		// Reconciliation completed: nothing was stale. (ep_recon means
+		// the pass RECONCILED — deletes applied or none needed. The
+		// degrade branch below records nothing: its pass ran but left
+		// the debris in place, which is what the trace oracle's
+		// recon-before-copy direction exists to flag.)
+		s.testSyncTraceAudit.record(syncTraceExtRecon, "", "")
 		return nil
 	}
 	if !canDeleteResources || !canDeleteEntitlements || !canDeleteGrants {
@@ -3280,6 +3472,9 @@ func (s *syncer) deleteStaleExternalPrincipals(
 				id.GetResourceType(), id.GetResource(), err)
 		}
 	}
+	// Reconciliation completed: every stale principal (and its dependent
+	// grants and entitlements) is deleted.
+	s.testSyncTraceAudit.record(syncTraceExtRecon, "", "")
 	return nil
 }
 
@@ -4028,6 +4223,9 @@ func WithExternalResourceC1ZPath(path string) SyncOpt {
 // WithPreviousSyncC1ZPath registers a separate c1z holding the previous sync
 // for replay features.
 //
+// Advanced: source-cache replay is advanced, opt-in functionality (see
+// pkg/sourcecache); most callers should not set this option.
+//
 // This is required for the single-sync v3 (Pebble) engine: a Pebble c1z
 // holds exactly one sync by contract, so there is no in-file "previous
 // sync" to replay from (StartNewSync replaces the prior sync). NewSyncer
@@ -4053,7 +4251,8 @@ func WithPreviousSyncC1ZPath(path string) SyncOpt {
 // WithOptionalPreviousSyncC1ZPath is WithPreviousSyncC1ZPath with
 // best-effort semantics: if the file is missing, corrupt, or written by
 // an incompatible SDK, NewSyncer logs and proceeds WITHOUT replay
-// instead of failing. Intended for cache-style replay sources the
+// instead of failing. Advanced, opt-in functionality like its strict
+// twin — see pkg/sourcecache. Intended for cache-style replay sources the
 // caller maintains automatically (the service-mode previous-sync spare)
 // — a bad cache file must never fail a sync. Callers that name a
 // specific file deliberately should use WithPreviousSyncC1ZPath, which
@@ -4298,7 +4497,8 @@ func NewSyncer(ctx context.Context, c types.ConnectorClient, opts ...SyncOpt) (S
 		)
 		switch {
 		case err == nil:
-			if _, ok := enginepkg.AsEngine(previousSyncStore); !ok {
+			prevEngine, ok := enginepkg.AsEngine(previousSyncStore)
+			if !ok {
 				if closeErr := previousSyncStore.Close(ctx); closeErr != nil {
 					if s.previousSyncC1ZPathOptional {
 						ctxzap.Extract(ctx).Warn("non-Pebble previous-sync c1z could not close cleanly; syncing without source-cache replay",
@@ -4343,6 +4543,67 @@ func NewSyncer(ctx context.Context, c types.ConnectorClient, opts ...SyncOpt) (S
 				}
 				ctxzap.Extract(ctx).Warn("previous-sync c1z is not replay-eligible; syncing without source-cache replay",
 					zap.String("previous_sync_c1z_path", s.previousSyncC1ZPath),
+				)
+				break
+			}
+			// G5 — CO-017 cross-version fold fence (plan B8): the previous
+			// artifact's ENVELOPE manifest must carry the save-time
+			// materialization witness equal to this SDK's generation. An
+			// older pebble3 SDK's fold byte-copies the payload's
+			// source-cache state intact (manifest entries, indexes, compat
+			// record) and sets no compacted stamp, but it rebuilds the
+			// envelope manifest from its own descriptors and so cannot
+			// carry — or forge — the witness. Absence or mismatch means an
+			// old SDK wrote the file last and its replay state is
+			// untrustworthy: degrade to a cold sync.
+			witnessReader, hasWitness := any(previousSyncStore).(sourcecache.MaterializationWitnessReader)
+			if !hasWitness || witnessReader.SourceCacheMaterializationWitness() != sourcecache.MaterializationPolicyGeneration {
+				witness := ""
+				if hasWitness {
+					witness = witnessReader.SourceCacheMaterializationWitness()
+				}
+				if closeErr := previousSyncStore.Close(ctx); closeErr != nil {
+					if s.previousSyncC1ZPathOptional {
+						ctxzap.Extract(ctx).Warn("fence-ineligible previous-sync c1z could not close cleanly; syncing without source-cache replay",
+							zap.String("previous_sync_c1z_path", s.previousSyncC1ZPath),
+							zap.Error(closeErr),
+						)
+						break
+					}
+					return nil, fmt.Errorf("error closing fence-ineligible previous-sync c1z %q: %w", s.previousSyncC1ZPath, closeErr)
+				}
+				ctxzap.Extract(ctx).Warn("previous-sync c1z lacks this SDK's materialization witness (last saved by a pre-witness or older SDK); syncing without source-cache replay",
+					zap.String("previous_sync_c1z_path", s.previousSyncC1ZPath),
+					zap.String("witness", witness),
+					zap.String("required", sourcecache.MaterializationPolicyGeneration),
+				)
+				break
+			}
+			// G4 — quality consume gate (plan B6), evaluated against the SAME
+			// run G3 selected: the replay source must carry ingest-quality
+			// stats and not be replay-blocked. Absent stats fail closed
+			// (pre-quality artifacts and unknown-checkpoint conservatism);
+			// blocked stats degrade with the reason flags visible. A lossy
+			// sync must never seed the next generation. Like the gates
+			// above, failure degrades to a cold sync, never an error.
+			statsRec, statsErr := enginepkg.ReadSyncStatsRecord(ctx, prevEngine, run.ID)
+			if statsErr != nil || !c1zstore.SourceCacheReplayEligible(statsRec) {
+				if closeErr := previousSyncStore.Close(ctx); closeErr != nil {
+					if s.previousSyncC1ZPathOptional {
+						ctxzap.Extract(ctx).Warn("quality-ineligible previous-sync c1z could not close cleanly; syncing without source-cache replay",
+							zap.String("previous_sync_c1z_path", s.previousSyncC1ZPath),
+							zap.Error(errors.Join(statsErr, closeErr)),
+						)
+						break
+					}
+					return nil, fmt.Errorf("error closing quality-ineligible previous-sync c1z %q: %w", s.previousSyncC1ZPath, errors.Join(statsErr, closeErr))
+				}
+				ctxzap.Extract(ctx).Warn("previous-sync c1z failed the source-cache quality gate; syncing without source-cache replay",
+					zap.String("previous_sync_c1z_path", s.previousSyncC1ZPath),
+					zap.Bool("stats_present", statsRec != nil),
+					zap.Bool("replay_blocked", statsRec.GetIngestQuality().GetSourceCacheReplayBlocked()),
+					zap.Uint64("reason_flags", statsRec.GetIngestQuality().GetReasonFlags()),
+					zap.Error(statsErr),
 				)
 				break
 			}

--- a/pkg/types/resource/resource.go
+++ b/pkg/types/resource/resource.go
@@ -9,6 +9,7 @@ import (
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/pagination"
+	"github.com/conductorone/baton-sdk/pkg/sourcecache"
 	"github.com/conductorone/baton-sdk/pkg/types/sessions"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -654,6 +655,13 @@ type SyncOpAttrs struct {
 	Session   sessions.SessionStore
 	SyncID    string
 	PageToken pagination.Token
+
+	// Lookup resolves previous-sync source-cache validators for connectors
+	// that declared SourceCacheCapability MODE_READ_WRITE (ADVANCED
+	// FUNCTIONALITY — see pkg/sourcecache). Never nil: when source-cache
+	// replay is disabled or degraded this is sourcecache.NoopLookup and
+	// every lookup misses.
+	Lookup sourcecache.Lookup
 }
 
 type SyncOpResults struct {

--- a/proto/c1/c1z/v3/manifest.proto
+++ b/proto/c1/c1z/v3/manifest.proto
@@ -87,6 +87,23 @@ message C1ZManifestV3 {
   // c1/dotc1z/engine/pebble/digest.go's present-means-exact contract.
   // Additive field: old readers ignore it, old files simply lack it.
   GrantDigestRoot grant_digest_root = 43;
+
+  // Save-time materialization witness (CO-017 cross-version fold fence).
+  // The SDK's replayed-row materialization-policy generation
+  // (sourcecache.MaterializationPolicyGeneration) as of the save that
+  // produced this envelope; written on EVERY save by a witness-aware SDK.
+  //
+  // Why this fences: an OLDER SDK that folds a scoped artifact rewrites
+  // the envelope and rebuilds this manifest fresh from its own
+  // compiled-in descriptors, which do not know this field — so the
+  // witness is necessarily ABSENT from any old-fold output and cannot be
+  // forged by one, even though the old fold byte-copies the payload's
+  // source-cache manifest, indexes, and compat record intact. A replay
+  // consumer requires the witness to byte-match its own generation and
+  // treats absence as ineligible (degrade to a cold sync), which closes
+  // the stale-but-eligible window that a byte-copied payload compat
+  // record alone cannot close.
+  string sdk_materialization_generation = 44;
 }
 
 // GrantDigestRoot is the whole-file grant digest: present iff the


### PR DESCRIPTION
# sync: source-cache replay orchestration (Phase 6b)

Connectors that can cheaply revalidate upstream data (ETags, delta tokens)
can now skip refetching unchanged scopes: the SDK hands them their previous
validator, and on "unchanged" replays the previous sync's rows locally
instead of paging them from the API.

Core invariant: a warm sync produces the identical artifact a cold sync
would have, or fails loudly with a warm/cold `ErrReplayIntegrity` verdict —
never a silent blend of stale and fresh rows. Replay is gated on artifact
eligibility (Pebble, finished FULL, clean quality, byte-matching compat
record, materialization witness) and same-sync lookup provenance; anything
off degrades to a cold fetch.

**Not yet live in production:** subprocess connectors can't receive the
lookup, so capable connectors produce (stamp rows, publish validators) but
consume cold. Phase 6c adds cross-process delivery and the runner retry
ladder.

Verified per `docs/verification/sync-replay-6b/plan.md` (frozen before
code) — chaos suites over the real syncer and stores with differential
oracles against cold baselines, interruption/resume, generational chains,
all `-race`; plus three independent reviews whose findings are fixed and
instrumented (CO-6b-003). Evidence in `evidence.md`. Hot-path cost when the
capability is absent: ~100ns per page.