### PR TITLE
Stop reproducing file-upload field values in config decode errors

### DIFF
--- a/pkg/field/decode_hooks.go
+++ b/pkg/field/decode_hooks.go
@@ -94,12 +94,6 @@ func getFileContentFromPath(path string) ([]byte, error) {
 	return content, nil
 }
 
-// redactPathError strips the file path out of an *fs.PathError (as returned
-// by os.Stat/os.ReadFile) before it reaches an error message. The field value
-// passed into this decode hook may be a credential file's contents rather
-// than an actual path, and fs.PathError.Error() otherwise reproduces it
-// verbatim. The underlying OS error (e.g. "no such file or directory") is
-// preserved so the failure reason is still diagnosable.
 func redactPathError(err error) error {
 	var pathErr *fs.PathError
 	if errors.As(err, &pathErr) {
@@ -134,9 +128,6 @@ func parseFileContent(data string) ([]byte, error) {
 func parseJSONBase64DataURL(dataURL string) ([]byte, error) {
 	parsedURL, err := url.Parse(dataURL)
 	if err != nil {
-		// url.Error.Error() quotes the full input URL, which here is the
-		// field's raw value (e.g. a PEM or key) rather than an actual URL.
-		// Unwrap to the underlying parse failure so it isn't echoed back.
 		var urlErr *url.Error
 		if errors.As(err, &urlErr) {
 			return nil, fmt.Errorf("invalid data URL: %w", urlErr.Err)

--- a/pkg/field/decode_hooks.go
+++ b/pkg/field/decode_hooks.go
@@ -2,7 +2,9 @@ package field
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
+	"io/fs"
 	"net/url"
 	"os"
 	"reflect"
@@ -75,7 +77,7 @@ func getFileContentFromPath(path string) ([]byte, error) {
 	// Check if the file exists
 	fileInfo, err := os.Stat(path)
 	if err != nil {
-		return nil, fmt.Errorf("cannot access file: %w", err)
+		return nil, fmt.Errorf("cannot access file: %w", redactPathError(err))
 	}
 
 	// Check file size limit (2MB)
@@ -87,9 +89,23 @@ func getFileContentFromPath(path string) ([]byte, error) {
 	// Read the file
 	content, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("error reading file: %w", err)
+		return nil, fmt.Errorf("error reading file: %w", redactPathError(err))
 	}
 	return content, nil
+}
+
+// redactPathError strips the file path out of an *fs.PathError (as returned
+// by os.Stat/os.ReadFile) before it reaches an error message. The field value
+// passed into this decode hook may be a credential file's contents rather
+// than an actual path, and fs.PathError.Error() otherwise reproduces it
+// verbatim. The underlying OS error (e.g. "no such file or directory") is
+// preserved so the failure reason is still diagnosable.
+func redactPathError(err error) error {
+	var pathErr *fs.PathError
+	if errors.As(err, &pathErr) {
+		return pathErr.Err
+	}
+	return err
 }
 
 // parseFileContent returns the file upload content from a string field value.
@@ -118,6 +134,13 @@ func parseFileContent(data string) ([]byte, error) {
 func parseJSONBase64DataURL(dataURL string) ([]byte, error) {
 	parsedURL, err := url.Parse(dataURL)
 	if err != nil {
+		// url.Error.Error() quotes the full input URL, which here is the
+		// field's raw value (e.g. a PEM or key) rather than an actual URL.
+		// Unwrap to the underlying parse failure so it isn't echoed back.
+		var urlErr *url.Error
+		if errors.As(err, &urlErr) {
+			return nil, fmt.Errorf("invalid data URL: %w", urlErr.Err)
+		}
 		return nil, fmt.Errorf("invalid data URL: %w", err)
 	}
 

--- a/pkg/field/decode_hooks_test.go
+++ b/pkg/field/decode_hooks_test.go
@@ -11,6 +11,53 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestFileUploadDecodeHook_DoesNotLeakValueInErrors guards against
+// regressions of CE-1284: the field's value (which may be secret file
+// content, not an actual path) must never be reproduced in a decode error.
+func TestFileUploadDecodeHook_DoesNotLeakValueInErrors(t *testing.T) {
+	tempDir := t.TempDir()
+
+	t.Run("stat failure on a secret-like value does not echo it", func(t *testing.T) {
+		secret := "TOTALLY-SECRET-VALUE-THAT-MUST-NOT-LEAK"
+
+		_, err := mapstructure.DecodeHookExec(
+			FileUploadDecodeHook(true),
+			reflect.ValueOf(secret),
+			reflect.ValueOf([]byte{}),
+		)
+		require.Error(t, err)
+		require.NotContains(t, err.Error(), secret)
+	})
+
+	t.Run("read failure on a directory does not echo its name", func(t *testing.T) {
+		secretDirName := "TOTALLY-SECRET-DIR-NAME"
+		secretDir := filepath.Join(tempDir, secretDirName)
+		require.NoError(t, os.Mkdir(secretDir, 0700))
+
+		_, err := mapstructure.DecodeHookExec(
+			FileUploadDecodeHook(true),
+			reflect.ValueOf(secretDir),
+			reflect.ValueOf([]byte{}),
+		)
+		require.Error(t, err)
+		require.NotContains(t, err.Error(), secretDirName)
+	})
+
+	t.Run("invalid data URL does not echo the payload", func(t *testing.T) {
+		secret := "SECRET\x00PAYLOAD-THAT-MUST-NOT-LEAK"
+		dataURL := "data:application/json;base64," + secret
+
+		_, err := mapstructure.DecodeHookExec(
+			FileUploadDecodeHook(false),
+			reflect.ValueOf(dataURL),
+			reflect.ValueOf([]byte{}),
+		)
+		require.Error(t, err)
+		require.NotContains(t, err.Error(), secret)
+		require.NotContains(t, err.Error(), "PAYLOAD-THAT-MUST-NOT-LEAK")
+	})
+}
+
 func TestFileUploadDecodeHook(t *testing.T) {
 	// Create a temporary file for testing
 	tempDir := t.TempDir()


### PR DESCRIPTION
## Summary

`FileUploadDecodeHook`'s path-resolution branch (`readFromPath=true`, used by the CLI, gRPC server, and capabilities commands) wraps three stdlib errors directly:

- `os.Stat` failure -> `cannot access file: %w`
- `os.ReadFile` failure -> `error reading file: %w`
- `url.Parse` failure (in the `data:` URL branch, reachable from either mode) -> `invalid data URL: %w`

`*fs.PathError` and `*url.Error` both embed the raw input string in their `Error()` output. Since this field type carries credential files (service-account JSON, certs, private keys), a value supplied in the wrong shape — e.g. the file's raw content passed where a path was expected — gets written verbatim to stderr and whatever collects it. `WithIsSecret(true)` does not protect this: it only feeds GUI schema rendering (`schemaFieldToV1` in `pkg/field/marshal.go`) and is never visible to the decode hook, whose `mapstructure.DecodeHookFunc` signature only receives types and the raw value.

## Fix

- Added `redactPathError`, which unwraps an `*fs.PathError` to its `.Err` field via `errors.As`, dropping `.Path`. Applied at both `os.Stat`/`os.ReadFile` sites in `getFileContentFromPath`.
- Applied the same unwrap pattern to the `url.Parse` failure in `parseJSONBase64DataURL`, dropping the quoted URL and keeping only the underlying parse-failure reason.

The failure category (not found / permission denied / name too long / invalid control character) is preserved for diagnosability; the field value itself is not.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./pkg/field/...`
- [x] `golangci-lint run ./pkg/field/...` (0 issues)
- [x] Existing `pkg/field` test suite passes unmodified (no behavior change on valid input)
- [x] Added `TestFileUploadDecodeHook_DoesNotLeakValueInErrors`, covering all three sites, asserting a secret marker never appears in the resulting error string
- [x] Full repo `go test ./...` passes

Resolves CE-1284.