### PR TITLE
agent rules for diction

### DIFF
--- a/.cursor/rules/no-ai-slop.mdc
+++ b/.cursor/rules/no-ai-slop.mdc
@@ -1,0 +1,10 @@
+---
+description: Follow AGENTS.md diction in all writing and conversation
+alwaysApply: true
+---
+
+# Diction
+
+Follow `AGENTS.md` for all writing in this repo: comments, docs, commits,
+PRs, review notes, and conversation with humans. Name the function, type,
+hook, or check. State the fact with essential framing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,65 @@
+# Agent instructions
+
+This applies to every agent working in this repository: comments, docs,
+commits, PRs, review notes, and conversation with humans. It is not limited
+to code edits.
+
+Project overview, build commands, and architecture live in `CLAUDE.md`.
+Review and verification live in `docs/REVIEW_CHECKLIST.md` and
+`docs/BUG_CATCHING.md`.
+
+## Diction
+
+Name the function, type, hook, or check. State the fact with essential
+framing. Leave historical uses alone unless you are already editing that
+comment. Words not listed here are fine.
+
+### Hard ban
+
+spine, spines, seam, seams, specimen, specimens, load-bearing,
+fail-closed posture
+
+### Minimize, do not ban
+
+insight, insights, key insight, substrate, keystone, linchpin, bedrock,
+cornerstone, throughline, constellation, residue, remnant, vestige,
+affordance, taxonomy, fiber
+
+Fiber is fine as a language primitive, a named utility, or a math term.
+Drop it as a metaphor for a path, goroutine, edge, or piece of the system.
+
+Essay glue: the crux, mental model, the shape of, the upshot, punchline,
+takeaway, kicker, here's the catch, the wrinkle, crucially, importantly,
+notably, furthermore, moreover, it's worth noting, worth calling out,
+at its core, in other words, to be clear, delve, unpack, underscore
+(as a verb), highlight, showcase.
+
+Ad-copy: leverage, robust, holistic, nuance, nuanced, seamless,
+seamlessly, landscape, tapestry, first-class, baked in, wired up,
+battle-tested, golden path, north star, elegant, principled, surgical,
+the cleanest, purest form, facilitate, utilize, comprehensive,
+intricate, nestled, vibrant, pivotal, paradigm, interplay, ecosystem.
+
+Prefer none of these. One is better than a paragraph of them.
+
+### Instead of
+
+| Instead of | Write |
+| --- | --- |
+| spine | chain, path, `i → i+1` edges |
+| seam | hook, injection point, after X / before Y, `testSeams.Foo` |
+| specimen | example, case, this bug |
+| load-bearing | required; this test fails if X is wrong |
+| fail-closed posture | fail-closed |
+| fiber (metaphor) | goroutine, request, edge, path |
+| key insight | the fact, with no preamble |
+| substrate | the index / table this sits on |
+
+### Exceptions (existing names only)
+
+Cite these when they already exist. Do not mint new ones.
+
+- Identifiers: `testSeams`, `seamFailureCases`, `choke_point_meta_test.go`
+- Product / proto: `SecurityInsight`, sidecar files, payload bytes
+- Handbook terms when following `docs/BUG_CATCHING.md`: oracle, harness,
+  obligation, closure, instrument, ride-along

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,12 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Diction
+
+Follow `AGENTS.md` for all writing: comments, docs, commits, PRs, review
+notes, and conversation with humans. Name the function, type, hook, or
+check. State the fact with essential framing.
+
 ## Project Overview
 
 Baton is a CLI tool for exploring and analyzing identity governance data (users, permissions, roles, groups, resources) stored in `.c1z` files. It includes a web-based explorer UI built with React/TypeScript, embedded into the Go binary.

--- a/pkg/dotc1z/engine/pebble/grants.go
+++ b/pkg/dotc1z/engine/pebble/grants.go
@@ -46,8 +46,8 @@ func (e *Engine) PutGrantRecord(ctx context.Context, r *v3.GrantRecord) error {
 // the latest occurrence of each external_id and process only those —
 // earlier duplicates are dropped before any batch byte is written.
 // db.Get doesn't see in-batch writes either way, so this dedup pass is
-// the load-bearing safety net that neither the old read-before-write
-// path nor a pure skip-Get path provides.
+// required: neither the old read-before-write path nor a pure skip-Get
+// path drops earlier duplicates in the same batch.
 //
 // Read-before-write overwrite probe. On a NON-fresh sync the engine
 // must Get the prior primary key so StageGrantPutInline can stage the


### PR DESCRIPTION
Agents were filling comments with stacked metaphors (spine, seam, specimen, load-bearing). Put the rules in AGENTS.md so every agent in the repo follows them.