### PR TITLE
Syncer Refactor 

### DIFF
--- a/docs/REVIEW_CHECKLIST.md
+++ b/docs/REVIEW_CHECKLIST.md
@@ -84,6 +84,54 @@ Executable failure · failure re-converges derived state · success reaches the
 checkpoint · partial progress accounted and retryable · released exactly once
 · durability class justified by a named fence.
 
+## Syncer structure (`pkg/sync`)
+
+Structural rules for `syncer`. They exist because two feature branches grew it
+from 57 fields to 81, from 3 test hooks to 11, and from 13 capability type
+assertions to 54 — each feature got a file, but every function became a method
+on `*syncer` and every value a new field. Reject on these, not on taste.
+
+- A feature adds a runtime struct with its own file and its own receiver,
+  owned by `syncer` as exactly one field. It does not add fields to `syncer`.
+  "One field that is a bag of eleven" does not satisfy this.
+- Store capabilities — anything `pkg/sync` discovers on the store or its
+  sub-stores by optional interface, whether that interface is exported from
+  `c1zstore`/`dotc1z`/`connectorstore`, declared locally, or written inline as
+  an anonymous `interface{...}` in the assertion — are resolved once,
+  at attach, into `storeCaps` (`store_caps.go`). Attach means `setStore`, the
+  only writer of `syncer.store` — a store attached without its caps does not
+  fail, it silently runs the SQLite paths on a Pebble store. The check is
+  `rg -nU '\.store\s*=[^=]|syncer\{[^}]*\bstore:' pkg/sync`: one hit, in
+  `setStore`. It sees any receiver name and multi-line keyed literals; it
+  does not see positional literals, a `store:` key after a nested `{}` in the
+  same literal, or writes through `&s.store` — read those by eye. The syncer
+  builds its expansion adapter through `s.expanderStore()`, never a literal.
+  Package-level entry points that
+  receive a bare store (`GraphFromStore`, `runIngestInvariants`,
+  `NewExpanderStore`) resolve at entry through the same functions. No
+  `x.(Interface)` on a store at a use site in `pkg/sync`; the only resolution
+  sites are in `store_caps.go`. A use-site assertion hides how many
+  capabilities the syncer depends on and makes each new dependency a two-line
+  change nobody reviews as a dependency. Known exception: `pkg/sync/expand`
+  widens its own `ExpanderStore` parameter by assertion; that is the expander's
+  interface design, not store capability discovery, and is out of scope for
+  this rule.
+- Test seams live in `syncTestHooks` (`hooks.go`) and nowhere else, reached as
+  `s.testHooks.x`. A seam stays nil in production and no production path may
+  set one. The struct name carries the "test" marking, so its fields do not:
+  apart from the `syncer.testHooks` anchor itself, any `test`-prefixed field
+  in `pkg/sync` is by itself the finding.
+- `state` is the resumable action stack; nothing else goes on it. (It is
+  currently also a grab-bag of facts and run stats — CXE-1356 splits it. This
+  is the rule going forward: do not add to the grab-bag.)
+- Configuration is immutable after `NewSyncer`. Anything mutated during
+  `Sync` is not configuration and does not belong in `syncConfig` — for
+  something that resumes across process boundaries, the immutable/mutable
+  line is a correctness property, not bookkeeping. The check is
+  `rg -nU '\.cfg\.\w+\s*=[^=]|syncer\{[^}]*\bcfg:' pkg/sync --glob '!*_test.go'`:
+  every hit is inside a `With*` option or `NewSyncer`. Same blind spots as
+  the store check above.
+
 ## Principle index (§5)
 
 5.1 durable claims are ordered after the facts they claim · 5.2 every exit

--- a/pkg/sync/chaos_cancellation_test.go
+++ b/pkg/sync/chaos_cancellation_test.go
@@ -191,7 +191,7 @@ func TestChaosExternalCancelStopsQuietlyAndCheckpoints(t *testing.T) {
 	require.True(t, ok)
 	var cancelIssued atomic.Bool
 	var checkpointAfterCancel atomic.Bool
-	sc.testCheckpointHook = func(string) {
+	sc.testHooks.checkpointHook = func(string) {
 		if cancelIssued.Load() {
 			checkpointAfterCancel.Store(true)
 		}

--- a/pkg/sync/chaos_cancellation_test.go
+++ b/pkg/sync/chaos_cancellation_test.go
@@ -312,7 +312,7 @@ func TestParallelBatchSecondGenuineFailureStillLogs(t *testing.T) {
 	st := newEmptySchedulerState(t)
 	first := st.pushAction(ctx, Action{Op: SyncGrantsOp, ResourceID: "group-1"})
 	second := st.pushAction(ctx, Action{Op: SyncGrantsOp, ResourceID: "group-2"})
-	s := &syncer{state: st, workerCount: 2}
+	s := &syncer{state: st, cfg: syncConfig{workerCount: 2}}
 
 	// Bounded rendezvous, not a WaitGroup: if the pool ever stops dispatching
 	// these two actions concurrently, the premise is broken and this must fail
@@ -368,7 +368,7 @@ func TestParallelBatchFailureDuringStopStaysQuiet(t *testing.T) {
 
 	st := newEmptySchedulerState(t)
 	action := st.pushAction(ctx, Action{Op: SyncGrantsOp, ResourceID: "group-1"})
-	s := &syncer{state: st, workerCount: 1}
+	s := &syncer{state: st, cfg: syncConfig{workerCount: 1}}
 
 	f := func(ctx context.Context, action *Action) error {
 		stop(context.DeadlineExceeded)

--- a/pkg/sync/chaos_external_principal_test.go
+++ b/pkg/sync/chaos_external_principal_test.go
@@ -134,6 +134,10 @@ type recordingBatchDeleteStore struct {
 	batches [][]string
 }
 
+// SyncMeta answers the capability resolution setStore performs at attach; see
+// legacyPaginatedCheckpointStore.SyncMeta.
+func (s *recordingBatchDeleteStore) SyncMeta() c1zstore.SyncMeta { return nil }
+
 func (s *recordingBatchDeleteStore) DeleteGrantsByRefs(_ context.Context, grants ...*v2.Grant) error {
 	ids := make([]string, 0, len(grants))
 	for _, grant := range grants {
@@ -149,6 +153,10 @@ type recordingSingularDeleteStore struct {
 	c1zstore.Store
 	deleted []string
 }
+
+// SyncMeta answers the capability resolution setStore performs at attach; see
+// legacyPaginatedCheckpointStore.SyncMeta.
+func (s *recordingSingularDeleteStore) SyncMeta() c1zstore.SyncMeta { return nil }
 
 func (s *recordingSingularDeleteStore) DeleteGrantByRefs(_ context.Context, grant *v2.Grant) error {
 	s.deleted = append(s.deleted, grant.GetId())

--- a/pkg/sync/chaos_external_principal_test.go
+++ b/pkg/sync/chaos_external_principal_test.go
@@ -60,8 +60,8 @@ func (s *chaosExternalPrincipalCutStore) DeleteGrantByRefs(
 // With no delete cut armed there is nothing to interleave, so the batch is
 // handed to the store whole and actually exercises multi-grant chunking.
 //
-// The syncer asserts grantsByRefsBatchDeleter on THIS wrapper, so declaring
-// the method routes every engine here — including SQLite, which has no
+// The syncer resolves grantsByRefsBatchDeleter on THIS wrapper at attach, so
+// declaring the method routes every engine here — including SQLite, which has no
 // batched delete. Degrade to the wrapped store's singular delete in that case
 // instead of advertising batch support it does not have, so the SQLite
 // scenarios keep the one-commit-per-grant shape production would give them.
@@ -138,6 +138,10 @@ type recordingBatchDeleteStore struct {
 // legacyPaginatedCheckpointStore.SyncMeta.
 func (s *recordingBatchDeleteStore) SyncMeta() c1zstore.SyncMeta { return nil }
 
+// Grants answers the same attach-time capability resolution; see
+// legacyPaginatedCheckpointStore.Grants.
+func (s *recordingBatchDeleteStore) Grants() c1zstore.GrantStore { return nil }
+
 func (s *recordingBatchDeleteStore) DeleteGrantsByRefs(_ context.Context, grants ...*v2.Grant) error {
 	ids := make([]string, 0, len(grants))
 	for _, grant := range grants {
@@ -157,6 +161,10 @@ type recordingSingularDeleteStore struct {
 // SyncMeta answers the capability resolution setStore performs at attach; see
 // legacyPaginatedCheckpointStore.SyncMeta.
 func (s *recordingSingularDeleteStore) SyncMeta() c1zstore.SyncMeta { return nil }
+
+// Grants answers the same attach-time capability resolution; see
+// legacyPaginatedCheckpointStore.Grants.
+func (s *recordingSingularDeleteStore) Grants() c1zstore.GrantStore { return nil }
 
 func (s *recordingSingularDeleteStore) DeleteGrantByRefs(_ context.Context, grant *v2.Grant) error {
 	s.deleted = append(s.deleted, grant.GetId())

--- a/pkg/sync/checkpoint_cut_test.go
+++ b/pkg/sync/checkpoint_cut_test.go
@@ -380,7 +380,7 @@ func runCutAttempt(
 	sc.checkpointInterval = 0
 	checkpoints := 0
 	spawnedTokens := 0
-	sc.testCheckpointHook = func(token string) {
+	sc.testHooks.checkpointHook = func(token string) {
 		checkpoints++
 		if strings.Contains(token, `"spawned":true`) {
 			spawnedTokens++

--- a/pkg/sync/config.go
+++ b/pkg/sync/config.go
@@ -1,0 +1,73 @@
+package sync //nolint:revive,nolintlint // we can't change the package name for backwards compatibility
+
+import (
+	"time"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
+	"github.com/conductorone/baton-sdk/pkg/metrics"
+	"github.com/conductorone/baton-sdk/pkg/types/sessions"
+	"github.com/conductorone/baton-sdk/pkg/uotel"
+)
+
+// syncConfig is everything the caller decides before a sync starts: the
+// complete set of values written by the exported With* options (SyncOpt)
+// and by nothing else. NewSyncer applies the options and then never writes
+// to it again, so a syncConfig read during Sync — including after a resume,
+// on any worker goroutine — is the caller's original request.
+//
+// Fields that an option seeds but the sync then mutates are NOT config and
+// stay on syncer: store (WithConnectorStore, replaced by loadStore) and
+// syncID (WithSyncID, replaced by startOrResumeSync). Keeping them out
+// makes the immutable set trustworthy, which matters because a sync
+// resumes across process boundaries: mutable run state has to survive in
+// the store, config only has to be passed again.
+type syncConfig struct {
+	c1zPath                             string
+	externalResourceC1ZPath             string
+	externalResourceEntitlementIdFilter string
+	// externalResourceTraits are the resource type traits that this
+	// connector wants synced from the external resource source and made
+	// available to the External Identity Matcher (see externalMatchTraits,
+	// set via WithExternalResourceTraits). When left empty the matcher
+	// falls back to TRAIT_USER/TRAIT_GROUP, preserving pre-CE-975 behavior
+	// for callers that never opt in.
+	externalResourceTraits      []v2.ResourceType_Trait
+	previousSyncC1ZPath         string
+	previousSyncC1ZPathOptional bool
+	// failFastInvariants promotes every ingestion-invariant verdict
+	// (see ingest_invariants.go) to a hard, plainly-attributed sync
+	// failure — tolerated warns fail — and enables I4 (skipped
+	// entirely in default mode). Tests and equivalence harnesses set
+	// it; production default follows the per-invariant policy in the
+	// verdict table (ingestInvariants).
+	failFastInvariants bool
+	runDuration        time.Duration
+	transitionHandler  func(s Action)
+	progressHandler    func(p *Progress)
+	tmpDir             string
+	storageEngine      c1zstore.Engine
+	skipFullSync       bool
+	// compactionMergedStore marks the store as a pre-sealed artifact
+	// this process did not collect (WithCompactionMergedStore — the
+	// compactor's keep-newer merge and rollback-expansion's replay):
+	// invariant verdicts attribute merge-manufactured shapes to the
+	// merge and soften hard arms to aggregated warnings. Distinct from
+	// onlyExpandGrants, which changes WHAT syncs and carries no
+	// invariant policy on its own.
+	compactionMergedStore      bool
+	targetedSyncResources      []*v2.Resource
+	onlyExpandGrants           bool
+	preserveEntitlementGraph   bool
+	dontExpandGrants           bool
+	checkpointEntitlementGraph bool
+	skipEntitlementsAndGrants  bool
+	skipGrants                 bool
+	syncType                   connectorstore.SyncType
+	setSessionStore            sessions.SetSessionStore
+	syncResourceTypes          []string
+	workerCount                int // If 1, sync is sequential (default). If > 1, sync operations are done in parallel.
+	metricsHandler             metrics.Handler
+	syncIdentity               uotel.SyncIdentity
+}

--- a/pkg/sync/external_match_folding_test.go
+++ b/pkg/sync/external_match_folding_test.go
@@ -223,7 +223,8 @@ func observeExternalMatch(
 	state.SetHasExternalResourcesGrants()
 	state.PushAction(ctx, Action{Op: SyncExternalResourcesOp})
 
-	syncer := &syncer{store: store, state: state}
+	syncer := &syncer{state: state}
+	syncer.setStore(store)
 	require.NoError(t, syncer.processGrantsWithExternalPrincipals(ctx, principals))
 
 	return readExternalMatchGrants(t, ctx, store)

--- a/pkg/sync/external_principal_batch_delete_test.go
+++ b/pkg/sync/external_principal_batch_delete_test.go
@@ -28,6 +28,10 @@ type batchDeleteRouteStore struct {
 
 func (s *batchDeleteRouteStore) Grants() c1zstore.GrantStore { return &s.grants }
 
+// SyncMeta answers the capability resolution setStore performs at attach; see
+// legacyPaginatedCheckpointStore.SyncMeta.
+func (s *batchDeleteRouteStore) SyncMeta() c1zstore.SyncMeta { return nil }
+
 func (s *batchDeleteRouteStore) PutGrants(_ context.Context, grants ...*v2.Grant) error {
 	s.putGrantsSizes = append(s.putGrantsSizes, len(grants))
 	return nil
@@ -99,7 +103,9 @@ func newBatchDeleteRouteStore(size int) (*batchDeleteRouteStore, []string) {
 func newExternalMatchSyncer(store c1zstore.Store) *syncer {
 	st := newState()
 	st.SetHasExternalResourcesGrants()
-	return &syncer{store: store, state: st}
+	s := &syncer{state: st}
+	s.setStore(store)
+	return s
 }
 
 // TestProcessGrantsWithExternalPrincipalsDeleteRouting pins the three-way

--- a/pkg/sync/external_principal_cleanup_scale_test.go
+++ b/pkg/sync/external_principal_cleanup_scale_test.go
@@ -43,6 +43,10 @@ type cleanupScaleStore struct {
 	grantDeletes       int
 }
 
+// SyncMeta answers the capability resolution setStore performs at attach; see
+// legacyPaginatedCheckpointStore.SyncMeta.
+func (s *cleanupScaleStore) SyncMeta() c1zstore.SyncMeta { return nil }
+
 func (s *cleanupScaleStore) ListResources(
 	context.Context,
 	*v2.ResourcesServiceListResourcesRequest,
@@ -119,7 +123,8 @@ func TestChaosConnectorExternalPrincipalCleanupUsesOnePassPerKeyspace(t *testing
 				store.grants.rows = append(store.grants.rows, c1zstore.GrantAnnotation{Grant: grant})
 			}
 
-			syncer := &syncer{store: store}
+			syncer := &syncer{}
+			syncer.setStore(store)
 			require.NoError(t, syncer.deleteStaleExternalPrincipals(t.Context(), nil))
 			require.Equal(t, 1, store.resourceScans)
 			require.Equal(t, 1, store.entitlementScans)

--- a/pkg/sync/external_principal_index_verification_test.go
+++ b/pkg/sync/external_principal_index_verification_test.go
@@ -381,7 +381,8 @@ func TestVerificationExternalPrincipalMatchDeleteCutResumesToGolden(t *testing.T
 	goldenState := newState()
 	goldenState.SetHasExternalResourcesGrants()
 	goldenState.PushAction(ctx, Action{Op: SyncExternalResourcesOp})
-	goldenSyncer := &syncer{store: goldenStore, state: goldenState}
+	goldenSyncer := &syncer{state: goldenState}
+	goldenSyncer.setStore(goldenStore)
 	require.NoError(t, goldenSyncer.processGrantsWithExternalPrincipals(ctx, principals))
 	finishExternalMatchVerificationSync(t, goldenStore, goldenState)
 	goldenDigest := grantDigest(t, goldenPath, goldenSyncID)
@@ -396,7 +397,8 @@ func TestVerificationExternalPrincipalMatchDeleteCutResumesToGolden(t *testing.T
 	currentToken, err := cutStore.CurrentSyncStep(ctx)
 	require.NoError(t, err)
 	require.NoError(t, cutState.Unmarshal(currentToken))
-	cutSyncer := &syncer{store: cutWrapper, state: cutState}
+	cutSyncer := &syncer{state: cutState}
+	cutSyncer.setStore(cutWrapper)
 	err = cutSyncer.processGrantsWithExternalPrincipals(ctx, principals)
 	require.ErrorIs(t, err, errVerificationDeleteCut)
 	require.Equal(t, []int{9}, cutWrapper.putBatchSizes, "test premise: cut happened after the bulk put")
@@ -415,7 +417,8 @@ func TestVerificationExternalPrincipalMatchDeleteCutResumesToGolden(t *testing.T
 	require.NotNil(t, resumedState.Current(), "unfinished action must survive the cut")
 
 	resumedWrapper := &interruptingExternalMatchStore{Store: resumedStore}
-	resumedSyncer := &syncer{store: resumedWrapper, state: resumedState}
+	resumedSyncer := &syncer{state: resumedState}
+	resumedSyncer.setStore(resumedWrapper)
 	require.NoError(t, resumedSyncer.processGrantsWithExternalPrincipals(ctx, principals))
 	require.Equal(t, []int{33}, resumedWrapper.putBatchSizes,
 		"resume scans two remaining carriers plus nine expanded grants, each matching three principals")

--- a/pkg/sync/hooks.go
+++ b/pkg/sync/hooks.go
@@ -1,0 +1,30 @@
+package sync //nolint:revive,nolintlint // we can't change the package name for backwards compatibility
+
+// syncTestHooks is the syncer's set of test seams: observation and
+// fault-injection points the verification harnesses attach to in order to
+// make an ordering-sensitive boundary reachable from a test. Every field is
+// nil in production, so a seam costs one pointer comparison on the path it
+// guards — the same cost these had as individual syncer fields.
+//
+// They live together so a reader can find every place a test can perturb a
+// sync in one file, and so that adding a seam does not widen syncer. No
+// production code path may set one of these; the only writers are in
+// _test.go files, which is what the type name asserts. The fields therefore
+// carry no `test` prefix of their own — any `test`-prefixed field elsewhere
+// in the package is a seam that escaped this struct.
+type syncTestHooks struct {
+	// ingestHaltHook, when non-nil, fires at named seams of the
+	// ingestion-invariant pass (see ingestInvariantHaltStages);
+	// returning an error fails the sync at exactly that boundary. The
+	// halt sweep uses it to prove crash/resume equivalence at every
+	// ordering-sensitive point.
+	ingestHaltHook func(stage string) error
+	// checkpointHook, when non-nil, observes every durably written
+	// checkpoint token. The cut harness uses it to count checkpoints
+	// and to simulate a crash immediately after a chosen one.
+	checkpointHook func(token string)
+	// queueAudit, when non-nil, records every parallelActionQueue
+	// event (seed/dequeue/commit/abort/done) for post-hoc verification
+	// of the queue contract.
+	queueAudit *queueAudit
+}

--- a/pkg/sync/ingest_filter.go
+++ b/pkg/sync/ingest_filter.go
@@ -183,7 +183,7 @@ func (s *syncer) filterFreshEntitlements(
 	ctx context.Context,
 	entitlements []*v2.Entitlement,
 ) ([]*v2.Entitlement, error) {
-	if s.syncType != connectorstore.SyncTypeFull || len(entitlements) == 0 {
+	if s.cfg.syncType != connectorstore.SyncTypeFull || len(entitlements) == 0 {
 		return entitlements, nil
 	}
 	out := make([]*v2.Entitlement, 0, len(entitlements))
@@ -284,7 +284,7 @@ func (s *syncer) filterGrantExpansionTypes(
 }
 
 func (s *syncer) filterFreshGrants(ctx context.Context, grants []*v2.Grant) ([]*v2.Grant, error) {
-	if s.syncType != connectorstore.SyncTypeFull || len(grants) == 0 {
+	if s.cfg.syncType != connectorstore.SyncTypeFull || len(grants) == 0 {
 		return grants, nil
 	}
 	out := make([]*v2.Grant, 0, len(grants))
@@ -345,7 +345,7 @@ func (s *syncer) filterFreshGrants(ctx context.Context, grants []*v2.Grant) ([]*
 // resources whose type is absent from the sync's resource types, so storing
 // them is dead data even though the resource row itself could be written.
 func (s *syncer) filterFreshGrantResource(ctx context.Context, resource *v2.Resource) (bool, error) {
-	if s.syncType != connectorstore.SyncTypeFull || resource.GetId() == nil {
+	if s.cfg.syncType != connectorstore.SyncTypeFull || resource.GetId() == nil {
 		return true, nil
 	}
 	exists, err := s.scheduledResourceTypeExists(ctx, resource.GetId().GetResourceType())

--- a/pkg/sync/ingest_filter_test.go
+++ b/pkg/sync/ingest_filter_test.go
@@ -78,7 +78,7 @@ func TestFreshIngestFilterMirrorsMachineryExemptions(t *testing.T) {
 			disabled := ingestFilterResource("iam_policy", "p1")
 			goodEntitlement := ingestFilterEntitlement(group, "group:g1:member")
 			disabledEntitlement := ingestFilterEntitlement(disabled, "iam_policy:p1:assigned")
-			s := &syncer{store: store, syncType: connectorstore.SyncTypeFull}
+			s := &syncer{store: store, cfg: syncConfig{syncType: connectorstore.SyncTypeFull}}
 
 			entitlements, err := s.filterFreshEntitlements(ctx, []*v2.Entitlement{goodEntitlement, disabledEntitlement})
 			require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestFreshIngestFilterNarrowsExpansionWithoutWidening(t *testing.T) {
 		}.Build())...,
 	))
 
-	s := &syncer{store: store, syncType: connectorstore.SyncTypeFull}
+	s := &syncer{store: store, cfg: syncConfig{syncType: connectorstore.SyncTypeFull}}
 	filtered, err := s.filterFreshGrants(ctx, []*v2.Grant{mixed, disabledOnly, unfiltered, matchExpansion, matchAllExpansion, matchKeyExpansion})
 	require.NoError(t, err)
 	require.Len(t, filtered, 6, "filtering expansion metadata does not drop the base grant")
@@ -287,7 +287,7 @@ func grantIDs(grants []*v2.Grant) []string {
 }
 
 func TestFreshIngestFilterBypassesPartialSyncs(t *testing.T) {
-	s := &syncer{syncType: connectorstore.SyncTypePartial}
+	s := &syncer{cfg: syncConfig{syncType: connectorstore.SyncTypePartial}}
 	disabled := ingestFilterEntitlement(ingestFilterResource("iam_policy", "p1"), "iam_policy:p1:assigned")
 	entitlements, err := s.filterFreshEntitlements(t.Context(), []*v2.Entitlement{disabled})
 	require.NoError(t, err)
@@ -586,7 +586,7 @@ func TestFreshIngestFilterRoutesNilEntries(t *testing.T) {
 		v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build(),
 	))
 
-	s := &syncer{store: store, syncType: connectorstore.SyncTypeFull}
+	s := &syncer{store: store, cfg: syncConfig{syncType: connectorstore.SyncTypeFull}}
 
 	missingRefEnt := v2.Entitlement_builder{Id: "no-resource"}.Build()
 	goodEnt := ingestFilterEntitlement(ingestFilterResource("group", "g1"), "group:g1:member")
@@ -641,7 +641,7 @@ func TestFreshIngestFilterProbeFailureFailsSyncNotDrops(t *testing.T) {
 
 	t.Run("local store failure", func(t *testing.T) {
 		failing := &resourceTypeProbeStore{Store: store, err: status.Error(codes.Internal, "probe boom")}
-		s := &syncer{store: failing, syncType: connectorstore.SyncTypeFull}
+		s := &syncer{store: failing, cfg: syncConfig{syncType: connectorstore.SyncTypeFull}}
 
 		_, err := s.filterFreshEntitlements(ctx, []*v2.Entitlement{entitlement})
 		require.ErrorContains(t, err, "probe boom")
@@ -654,7 +654,7 @@ func TestFreshIngestFilterProbeFailureFailsSyncNotDrops(t *testing.T) {
 	t.Run("external reader failure", func(t *testing.T) {
 		external := newIngestFilterStore(ctx, t, c1zstore.EnginePebble)
 		failingExternal := &resourceTypeProbeStore{Store: external, err: status.Error(codes.Internal, "external boom")}
-		s := &syncer{store: store, externalResourceReader: failingExternal, syncType: connectorstore.SyncTypeFull}
+		s := &syncer{store: store, externalResourceReader: failingExternal, cfg: syncConfig{syncType: connectorstore.SyncTypeFull}}
 
 		_, err := s.filterFreshEntitlements(ctx, []*v2.Entitlement{entitlement})
 		require.ErrorContains(t, err, "external boom")
@@ -673,7 +673,7 @@ func TestFreshIngestFilterCachesProbeVerdicts(t *testing.T) {
 	))
 
 	counting := &resourceTypeProbeStore{Store: store, calls: map[string]int{}}
-	s := &syncer{store: counting, syncType: connectorstore.SyncTypeFull}
+	s := &syncer{store: counting, cfg: syncConfig{syncType: connectorstore.SyncTypeFull}}
 
 	group := ingestFilterResource("group", "g1")
 	disabled := ingestFilterResource("iam_policy", "p1")
@@ -712,7 +712,7 @@ func TestFreshIngestFilterKeepsExternalSuppliedTypes(t *testing.T) {
 		v2.ResourceType_builder{Id: "widget", DisplayName: "Widget"}.Build(),
 	))
 
-	s := &syncer{store: store, externalResourceReader: external, syncType: connectorstore.SyncTypeFull}
+	s := &syncer{store: store, externalResourceReader: external, cfg: syncConfig{syncType: connectorstore.SyncTypeFull}}
 
 	group := ingestFilterResource("group", "g1")
 	externalUser := ingestFilterResource("user", "u1")

--- a/pkg/sync/ingest_filter_test.go
+++ b/pkg/sync/ingest_filter_test.go
@@ -78,7 +78,8 @@ func TestFreshIngestFilterMirrorsMachineryExemptions(t *testing.T) {
 			disabled := ingestFilterResource("iam_policy", "p1")
 			goodEntitlement := ingestFilterEntitlement(group, "group:g1:member")
 			disabledEntitlement := ingestFilterEntitlement(disabled, "iam_policy:p1:assigned")
-			s := &syncer{store: store, cfg: syncConfig{syncType: connectorstore.SyncTypeFull}}
+			s := &syncer{cfg: syncConfig{syncType: connectorstore.SyncTypeFull}}
+			s.setStore(store)
 
 			entitlements, err := s.filterFreshEntitlements(ctx, []*v2.Entitlement{goodEntitlement, disabledEntitlement})
 			require.NoError(t, err)
@@ -181,7 +182,8 @@ func TestFreshIngestFilterNarrowsExpansionWithoutWidening(t *testing.T) {
 		}.Build())...,
 	))
 
-	s := &syncer{store: store, cfg: syncConfig{syncType: connectorstore.SyncTypeFull}}
+	s := &syncer{cfg: syncConfig{syncType: connectorstore.SyncTypeFull}}
+	s.setStore(store)
 	filtered, err := s.filterFreshGrants(ctx, []*v2.Grant{mixed, disabledOnly, unfiltered, matchExpansion, matchAllExpansion, matchKeyExpansion})
 	require.NoError(t, err)
 	require.Len(t, filtered, 6, "filtering expansion metadata does not drop the base grant")
@@ -586,7 +588,8 @@ func TestFreshIngestFilterRoutesNilEntries(t *testing.T) {
 		v2.ResourceType_builder{Id: "group", DisplayName: "Group"}.Build(),
 	))
 
-	s := &syncer{store: store, cfg: syncConfig{syncType: connectorstore.SyncTypeFull}}
+	s := &syncer{cfg: syncConfig{syncType: connectorstore.SyncTypeFull}}
+	s.setStore(store)
 
 	missingRefEnt := v2.Entitlement_builder{Id: "no-resource"}.Build()
 	goodEnt := ingestFilterEntitlement(ingestFilterResource("group", "g1"), "group:g1:member")
@@ -641,7 +644,8 @@ func TestFreshIngestFilterProbeFailureFailsSyncNotDrops(t *testing.T) {
 
 	t.Run("local store failure", func(t *testing.T) {
 		failing := &resourceTypeProbeStore{Store: store, err: status.Error(codes.Internal, "probe boom")}
-		s := &syncer{store: failing, cfg: syncConfig{syncType: connectorstore.SyncTypeFull}}
+		s := &syncer{cfg: syncConfig{syncType: connectorstore.SyncTypeFull}}
+		s.setStore(failing)
 
 		_, err := s.filterFreshEntitlements(ctx, []*v2.Entitlement{entitlement})
 		require.ErrorContains(t, err, "probe boom")
@@ -654,7 +658,8 @@ func TestFreshIngestFilterProbeFailureFailsSyncNotDrops(t *testing.T) {
 	t.Run("external reader failure", func(t *testing.T) {
 		external := newIngestFilterStore(ctx, t, c1zstore.EnginePebble)
 		failingExternal := &resourceTypeProbeStore{Store: external, err: status.Error(codes.Internal, "external boom")}
-		s := &syncer{store: store, externalResourceReader: failingExternal, cfg: syncConfig{syncType: connectorstore.SyncTypeFull}}
+		s := &syncer{externalResourceReader: failingExternal, cfg: syncConfig{syncType: connectorstore.SyncTypeFull}}
+		s.setStore(store)
 
 		_, err := s.filterFreshEntitlements(ctx, []*v2.Entitlement{entitlement})
 		require.ErrorContains(t, err, "external boom")
@@ -673,7 +678,8 @@ func TestFreshIngestFilterCachesProbeVerdicts(t *testing.T) {
 	))
 
 	counting := &resourceTypeProbeStore{Store: store, calls: map[string]int{}}
-	s := &syncer{store: counting, cfg: syncConfig{syncType: connectorstore.SyncTypeFull}}
+	s := &syncer{cfg: syncConfig{syncType: connectorstore.SyncTypeFull}}
+	s.setStore(counting)
 
 	group := ingestFilterResource("group", "g1")
 	disabled := ingestFilterResource("iam_policy", "p1")
@@ -712,7 +718,8 @@ func TestFreshIngestFilterKeepsExternalSuppliedTypes(t *testing.T) {
 		v2.ResourceType_builder{Id: "widget", DisplayName: "Widget"}.Build(),
 	))
 
-	s := &syncer{store: store, externalResourceReader: external, cfg: syncConfig{syncType: connectorstore.SyncTypeFull}}
+	s := &syncer{externalResourceReader: external, cfg: syncConfig{syncType: connectorstore.SyncTypeFull}}
+	s.setStore(store)
 
 	group := ingestFilterResource("group", "g1")
 	externalUser := ingestFilterResource("user", "u1")

--- a/pkg/sync/ingest_invariant_verification_test.go
+++ b/pkg/sync/ingest_invariant_verification_test.go
@@ -83,11 +83,13 @@ func TestIngestInvariantVerificationCoverageByEngine(t *testing.T) {
 			syncID, err := store.StartNewSync(ctx, tc.syncType, "")
 			require.NoError(t, err)
 			s := &syncer{
-				store:                 store,
-				syncID:                syncID,
-				syncType:              tc.syncType,
-				compactionMergedStore: tc.compaction,
-				failFastInvariants:    tc.failFast,
+				store:  store,
+				syncID: syncID,
+				cfg: syncConfig{
+					syncType:              tc.syncType,
+					compactionMergedStore: tc.compaction,
+					failFastInvariants:    tc.failFast,
+				},
 				resourcesPhaseRanHere: tc.resources,
 			}
 			require.NoError(t, s.runIngestionInvariants(ctx))
@@ -312,7 +314,7 @@ func TestFailedIngestInvariantPassDoesNotWriteVerification(t *testing.T) {
 	}))
 	require.NoError(t, store.SetCurrentSync(ctx, syncID))
 
-	s := &syncer{store: store, syncID: syncID, syncType: connectorstore.SyncTypeFull}
+	s := &syncer{store: store, syncID: syncID, cfg: syncConfig{syncType: connectorstore.SyncTypeFull}}
 	require.Error(t, s.runIngestionInvariants(ctx))
 
 	// The failed pass must have invalidated the inherited proof, and no

--- a/pkg/sync/ingest_invariant_verification_test.go
+++ b/pkg/sync/ingest_invariant_verification_test.go
@@ -150,7 +150,7 @@ func TestCrashBetweenInvariantPassAndSealLeavesNoMarker(t *testing.T) {
 				WithStorageEngine(engine),
 			)
 			require.NoError(t, err)
-			crashed.(*syncer).testIngestHaltHook = func(stage string) error {
+			crashed.(*syncer).testHooks.ingestHaltHook = func(stage string) error {
 				if stage == haltStageInvariantsComplete {
 					return errCrash
 				}

--- a/pkg/sync/ingest_invariant_verification_test.go
+++ b/pkg/sync/ingest_invariant_verification_test.go
@@ -83,7 +83,6 @@ func TestIngestInvariantVerificationCoverageByEngine(t *testing.T) {
 			syncID, err := store.StartNewSync(ctx, tc.syncType, "")
 			require.NoError(t, err)
 			s := &syncer{
-				store:  store,
 				syncID: syncID,
 				cfg: syncConfig{
 					syncType:              tc.syncType,
@@ -92,6 +91,7 @@ func TestIngestInvariantVerificationCoverageByEngine(t *testing.T) {
 				},
 				resourcesPhaseRanHere: tc.resources,
 			}
+			s.setStore(store)
 			require.NoError(t, s.runIngestionInvariants(ctx))
 			// The production seam checkpoints after validation. Pebble must
 			// preserve provenance while updating the sync token.
@@ -314,7 +314,8 @@ func TestFailedIngestInvariantPassDoesNotWriteVerification(t *testing.T) {
 	}))
 	require.NoError(t, store.SetCurrentSync(ctx, syncID))
 
-	s := &syncer{store: store, syncID: syncID, cfg: syncConfig{syncType: connectorstore.SyncTypeFull}}
+	s := &syncer{syncID: syncID, cfg: syncConfig{syncType: connectorstore.SyncTypeFull}}
+	s.setStore(store)
 	require.Error(t, s.runIngestionInvariants(ctx))
 
 	// The failed pass must have invalidated the inherited proof, and no

--- a/pkg/sync/ingest_invariants.go
+++ b/pkg/sync/ingest_invariants.go
@@ -504,9 +504,7 @@ func runIngestInvariants(
 		return nil, fmt.Errorf("ingest invariants: policy.SyncType is required (the zero value would silently skip the full-keyspace invariants; pass the sync's actual type)")
 	}
 	pass := &ingestInvariantsPass{store: store, p: &policy}
-	if facts, ok := store.(dotc1z.IngestInvariantStore); ok {
-		pass.facts = facts
-	}
+	pass.facts = resolveReaderCaps(store).ingestFacts
 	var skippedNoStore []string
 	coverage := make([]string, 0, len(ingestInvariants))
 	for i := range ingestInvariants {
@@ -615,7 +613,7 @@ func storeCarriesTypeScopedTypes(ctx context.Context, store connectorstore.Reade
 // unfinished artifact the resume machinery will rewrite.
 func (s *syncer) runIngestionInvariants(ctx context.Context) error {
 	s.pendingInvariantVerification = nil
-	if verificationWriter, ok := s.store.SyncMeta().(c1zstore.IngestInvariantVerificationWriter); ok {
+	if verificationWriter := s.caps.ingestVerification; verificationWriter != nil {
 		// Invalidate any proof inherited from an earlier pass before
 		// re-evaluating. A failed rerun must leave the sync unverified.
 		if err := verificationWriter.ClearIngestInvariantVerification(ctx, s.syncID); err != nil {
@@ -662,8 +660,8 @@ func (s *syncer) persistIngestInvariantVerification(ctx context.Context) error {
 	}
 	verification := *s.pendingInvariantVerification
 	s.pendingInvariantVerification = nil
-	verificationWriter, ok := s.store.SyncMeta().(c1zstore.IngestInvariantVerificationWriter)
-	if !ok {
+	verificationWriter := s.caps.ingestVerification
+	if verificationWriter == nil {
 		// SyncMeta predates verification metadata and is implemented outside
 		// this repository. Preserve its established behavior; the absent
 		// marker truthfully distinguishes it from built-in verified stores.

--- a/pkg/sync/ingest_invariants.go
+++ b/pkg/sync/ingest_invariants.go
@@ -624,12 +624,12 @@ func (s *syncer) runIngestionInvariants(ctx context.Context) error {
 	}
 	policy := IngestInvariantsPolicy{
 		ActiveSyncID:      s.getActiveSyncID(),
-		SyncType:          s.syncType,
-		FailFast:          s.failFastInvariants,
-		CompactionMerge:   s.compactionMergedStore,
+		SyncType:          s.cfg.syncType,
+		FailFast:          s.cfg.failFastInvariants,
+		CompactionMerge:   s.cfg.compactionMergedStore,
 		childSchedule:     &s.childSchedule,
 		resourcesPhaseRan: s.resourcesPhaseRanHere,
-		syncResourceTypes: s.syncResourceTypes,
+		syncResourceTypes: s.cfg.syncResourceTypes,
 		onRetainedInvalid: func() {
 			s.ingestFilterStats.blockReplay(ingestQualityReasonRetainedInvalid)
 		},

--- a/pkg/sync/ingest_invariants.go
+++ b/pkg/sync/ingest_invariants.go
@@ -637,8 +637,8 @@ func (s *syncer) runIngestionInvariants(ctx context.Context) error {
 	if st, ok := s.state.(*state); ok {
 		policy.undrainedSpawned = st.UndrainedSpawnedCursors
 	}
-	if s.testIngestHaltHook != nil {
-		policy.halt = s.testIngestHaltHook
+	if s.testHooks.ingestHaltHook != nil {
+		policy.halt = s.testHooks.ingestHaltHook
 	}
 	verification, err := RunIngestInvariantsWithVerification(ctx, s.store, policy)
 	if err != nil {

--- a/pkg/sync/ingest_invariants_crash_resume_test.go
+++ b/pkg/sync/ingest_invariants_crash_resume_test.go
@@ -60,7 +60,7 @@ func TestSyncerCrashResumeAtInvariantSeams(t *testing.T) {
 					WithStorageEngine(c1zstore.EnginePebble),
 				)
 				require.NoError(t, err)
-				s.(*syncer).testIngestHaltHook = hook
+				s.(*syncer).testHooks.ingestHaltHook = hook
 				return s
 			}
 

--- a/pkg/sync/ingest_invariants_test.go
+++ b/pkg/sync/ingest_invariants_test.go
@@ -642,7 +642,7 @@ func TestSyncerWiresSpawnDrainEvidenceIntoInvariants(t *testing.T) {
 	st := newEmptySchedulerState(t)
 	st.PushAction(ctx, Action{Op: SyncGrantsOp, ResourceTypeID: "group", PageToken: "wired", Spawned: true, TypeScoped: true})
 
-	s := &syncer{state: st, store: store, syncID: syncID, syncType: connectorstore.SyncTypeFull}
+	s := &syncer{state: st, store: store, syncID: syncID, cfg: syncConfig{syncType: connectorstore.SyncTypeFull}}
 	err := s.runIngestionInvariants(ctx)
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrIngestInvariantViolated)

--- a/pkg/sync/ingest_invariants_test.go
+++ b/pkg/sync/ingest_invariants_test.go
@@ -642,7 +642,8 @@ func TestSyncerWiresSpawnDrainEvidenceIntoInvariants(t *testing.T) {
 	st := newEmptySchedulerState(t)
 	st.PushAction(ctx, Action{Op: SyncGrantsOp, ResourceTypeID: "group", PageToken: "wired", Spawned: true, TypeScoped: true})
 
-	s := &syncer{state: st, store: store, syncID: syncID, cfg: syncConfig{syncType: connectorstore.SyncTypeFull}}
+	s := &syncer{state: st, syncID: syncID, cfg: syncConfig{syncType: connectorstore.SyncTypeFull}}
+	s.setStore(store)
 	err := s.runIngestionInvariants(ctx)
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrIngestInvariantViolated)

--- a/pkg/sync/parallel_audit_test.go
+++ b/pkg/sync/parallel_audit_test.go
@@ -25,7 +25,7 @@ package sync //nolint:revive,nolintlint // backwards-compatible package name
 //       they match (every taken action was returned).
 //
 // Any heavy test that runs the scheduler gets these checks for free by
-// attaching an audit (syncer.testQueueAudit) and calling verifyQueueAudit.
+// attaching an audit (syncer.testHooks.queueAudit) and calling verifyQueueAudit.
 
 import (
 	"fmt"
@@ -148,6 +148,6 @@ func attachQueueAudit(t *testing.T, s Syncer) *queueAudit {
 	sc, ok := s.(*syncer)
 	require.True(t, ok, "syncer under test is not *syncer")
 	audit := &queueAudit{}
-	sc.testQueueAudit = audit
+	sc.testHooks.queueAudit = audit
 	return audit
 }

--- a/pkg/sync/parallel_scheduler_test.go
+++ b/pkg/sync/parallel_scheduler_test.go
@@ -129,7 +129,7 @@ func TestSyncParallelDrainsMultipleSpawnedCursors(t *testing.T) {
 		ResourceTypeID: "group",
 		ResourceID:     "group-1",
 	})
-	s := &syncer{state: st, workerCount: 3}
+	s := &syncer{state: st, cfg: syncConfig{workerCount: 3}}
 
 	var mu sync.Mutex
 	processed := make(map[string]int)
@@ -173,7 +173,7 @@ func TestSyncParallelBreaksCyclicSpawnedCursorIdempotently(t *testing.T) {
 		ResourceID:     "group-1",
 		PageToken:      "loop",
 	})
-	s := &syncer{state: st, workerCount: 1}
+	s := &syncer{state: st, cfg: syncConfig{workerCount: 1}}
 
 	calls := 0
 	f := func(ctx context.Context, action *Action) error {
@@ -219,7 +219,7 @@ func TestFailedSiblingAdmissionDoesNotAdvanceParentCursor(t *testing.T) {
 		ResourceID:     "group-1",
 		PageToken:      "origin",
 	})
-	s := &syncer{state: st, workerCount: 1}
+	s := &syncer{state: st, cfg: syncConfig{workerCount: 1}}
 
 	calls := 0
 	f := func(ctx context.Context, action *Action) error {
@@ -285,7 +285,7 @@ func TestContinuationReconvergenceFinishesParent(t *testing.T) {
 		PageToken:      "held-token",
 		Spawned:        true,
 	})
-	s := &syncer{state: st, workerCount: 1}
+	s := &syncer{state: st, cfg: syncConfig{workerCount: 1}}
 
 	processed := map[string]int{}
 	f := func(ctx context.Context, action *Action) error {
@@ -317,7 +317,7 @@ func TestSpawnedCursorCannotCollideWithParentContinuation(t *testing.T) {
 		ResourceID:     "group-1",
 		PageToken:      "current",
 	})
-	s := &syncer{state: st, workerCount: 1}
+	s := &syncer{state: st, cfg: syncConfig{workerCount: 1}}
 
 	calls := 0
 	f := func(ctx context.Context, action *Action) error {
@@ -585,7 +585,7 @@ func TestSyncParallelErrorAbortsQueuedWorkAndCancelsPeer(t *testing.T) {
 	fail := st.pushAction(ctx, Action{Op: SyncGrantsOp, ResourceID: "fail"})
 	slow := st.pushAction(ctx, Action{Op: SyncGrantsOp, ResourceID: "slow"})
 	queued := st.pushAction(ctx, Action{Op: SyncGrantsOp, ResourceID: "queued"})
-	s := &syncer{state: st, workerCount: 2}
+	s := &syncer{state: st, cfg: syncConfig{workerCount: 2}}
 
 	slowStarted := make(chan struct{})
 	var queuedRan bool
@@ -627,7 +627,7 @@ func TestSyncParallelAggregatesWarningAndContinues(t *testing.T) {
 	st := newEmptySchedulerState(t)
 	warningAction := st.pushAction(ctx, Action{Op: SyncGrantsOp, ResourceID: "missing"})
 	successAction := st.pushAction(ctx, Action{Op: SyncGrantsOp, ResourceID: "present"})
-	s := &syncer{state: st, workerCount: 2}
+	s := &syncer{state: st, cfg: syncConfig{workerCount: 2}}
 
 	f := func(ctx context.Context, action *Action) error {
 		if action.ResourceID == "missing" {
@@ -648,7 +648,7 @@ func TestSyncParallelRetriesActionWithinWorker(t *testing.T) {
 	ctx := t.Context()
 	st := newEmptySchedulerState(t)
 	action := st.pushAction(ctx, Action{Op: SyncGrantsOp, ResourceID: "group-1"})
-	s := &syncer{state: st, workerCount: 1}
+	s := &syncer{state: st, cfg: syncConfig{workerCount: 1}}
 
 	calls := 0
 	f := func(ctx context.Context, action *Action) error {
@@ -671,7 +671,7 @@ func TestSyncParallelFiltersSpawnedActionsFromOtherOperations(t *testing.T) {
 	ctx := t.Context()
 	st := newEmptySchedulerState(t)
 	origin := st.pushAction(ctx, Action{Op: SyncGrantsOp, ResourceID: "group-1"})
-	s := &syncer{state: st, workerCount: 2}
+	s := &syncer{state: st, cfg: syncConfig{workerCount: 2}}
 
 	calls := 0
 	f := func(ctx context.Context, action *Action) error {
@@ -693,7 +693,7 @@ func TestSyncParallelFiltersSpawnedActionsFromOtherOperations(t *testing.T) {
 func TestSyncParallelEmptyBatchWithIdleWorkers(t *testing.T) {
 	ctx := t.Context()
 	st := newEmptySchedulerState(t)
-	s := &syncer{state: st, workerCount: 8}
+	s := &syncer{state: st, cfg: syncConfig{workerCount: 8}}
 
 	warnings, err := s.syncParallel(ctx, newTestRetryer(ctx), nil, func(context.Context, *Action) error {
 		panic("empty batch invoked worker function")
@@ -720,7 +720,7 @@ func TestSpawnedCursorsResumeAfterPartialCompletion(t *testing.T) {
 	require.NoError(t, err)
 	resumed := newState()
 	require.NoError(t, resumed.Unmarshal(token))
-	s := &syncer{state: resumed, workerCount: 2}
+	s := &syncer{state: resumed, cfg: syncConfig{workerCount: 2}}
 
 	var mu sync.Mutex
 	var processed []string
@@ -809,7 +809,7 @@ func TestOriginContinuationAndSiblingsResumeExactlyOnce(t *testing.T) {
 	require.NoError(t, err)
 	resumed := newState()
 	require.NoError(t, resumed.Unmarshal(token))
-	s := &syncer{state: resumed, workerCount: 2}
+	s := &syncer{state: resumed, cfg: syncConfig{workerCount: 2}}
 
 	var mu sync.Mutex
 	processed := make(map[string]int)

--- a/pkg/sync/parallel_scheduler_test.go
+++ b/pkg/sync/parallel_scheduler_test.go
@@ -32,6 +32,10 @@ type legacyPaginatedCheckpointStore struct {
 // which is what this double intends.
 func (s *legacyPaginatedCheckpointStore) SyncMeta() c1zstore.SyncMeta { return nil }
 
+// Grants reports "no grant sub-store", for the same reason as SyncMeta above:
+// capability resolution at attach asks for it.
+func (s *legacyPaginatedCheckpointStore) Grants() c1zstore.GrantStore { return nil }
+
 func (s *legacyPaginatedCheckpointStore) ListResourceTypes(
 	context.Context,
 	*v2.ResourceTypesServiceListResourceTypesRequest,

--- a/pkg/sync/parallel_scheduler_test.go
+++ b/pkg/sync/parallel_scheduler_test.go
@@ -25,6 +25,13 @@ type legacyPaginatedCheckpointStore struct {
 	listResourcesErr error
 }
 
+// SyncMeta reports "no sync-metadata sub-store". syncer.setStore resolves the
+// store's optional capabilities once at attach (store_caps.go), which asks
+// every store for its SyncMeta; a double with a nil embedded interface has to
+// answer rather than panic. nil means the verification capability is absent,
+// which is what this double intends.
+func (s *legacyPaginatedCheckpointStore) SyncMeta() c1zstore.SyncMeta { return nil }
+
 func (s *legacyPaginatedCheckpointStore) ListResourceTypes(
 	context.Context,
 	*v2.ResourceTypesServiceListResourceTypesRequest,
@@ -505,10 +512,8 @@ func TestLegacyPaginatedCheckpointPlansTypeScopedCollection(t *testing.T) {
 			ctx := t.Context()
 			st := newEmptySchedulerState(t)
 			root := st.pushAction(ctx, Action{Op: tt.op, PageToken: "legacy-page-2"})
-			s := &syncer{
-				state: st,
-				store: &legacyPaginatedCheckpointStore{resourceType: tt.annotation},
-			}
+			s := &syncer{state: st}
+			s.setStore(&legacyPaginatedCheckpointStore{resourceType: tt.annotation})
 
 			require.NoError(t, tt.sync(s, ctx, root))
 			planned := st.Current()
@@ -532,7 +537,8 @@ func TestTypeScopedPlanningFailureDoesNotCommitMarker(t *testing.T) {
 		}.Build(),
 		listResourcesErr: errors.New("injected list-resources failure"),
 	}
-	s := &syncer{state: st, store: store}
+	s := &syncer{state: st}
+	s.setStore(store)
 
 	require.ErrorContains(t, s.SyncGrants(ctx, root), "injected list-resources failure")
 	persisted := st.GetAction(root.ID)
@@ -559,7 +565,8 @@ func TestTypeScopedPlanningMarkerSurvivesCheckpoint(t *testing.T) {
 		}.Build(),
 		nextPageToken: "page-3",
 	}
-	s := &syncer{state: st, store: store}
+	s := &syncer{state: st}
+	s.setStore(store)
 
 	require.NoError(t, s.SyncGrants(ctx, root))
 	planned := st.Current()

--- a/pkg/sync/parallel_syncer.go
+++ b/pkg/sync/parallel_syncer.go
@@ -755,8 +755,8 @@ func (s *syncer) syncParallel(ctx context.Context, retryer *retry.Retryer, actio
 	defer cancel(nil)
 
 	queue := newParallelActionQueue(actions)
-	if s.testQueueAudit != nil {
-		queue.attachAudit(s.testQueueAudit, batchOp, s.testQueueAudit.newBatch())
+	if s.testHooks.queueAudit != nil {
+		queue.attachAudit(s.testHooks.queueAudit, batchOp, s.testHooks.queueAudit.newBatch())
 	}
 	s.setParallelActionTransitioner(func(
 		transitionCtx context.Context,
@@ -817,8 +817,8 @@ func (s *syncer) syncParallel(ctx context.Context, retryer *retry.Retryer, actio
 	wg.Wait()
 
 	batchErr = errors.Join(errs...)
-	if s.testQueueAudit != nil {
-		s.testQueueAudit.record(queueAuditEvent{kind: auditBatchEnd, batch: queue.auditBatch, clean: batchErr == nil})
+	if s.testHooks.queueAudit != nil {
+		s.testHooks.queueAudit.record(queueAuditEvent{kind: auditBatchEnd, batch: queue.auditBatch, clean: batchErr == nil})
 	}
 	return warnings, batchErr
 }

--- a/pkg/sync/parallel_syncer.go
+++ b/pkg/sync/parallel_syncer.go
@@ -211,10 +211,10 @@ func (s *syncer) parallelSync(
 		case InitOp:
 			s.state.FinishAction(ctx, stateAction)
 
-			if s.skipEntitlementsAndGrants {
+			if s.cfg.skipEntitlementsAndGrants {
 				s.state.SetShouldSkipEntitlementsAndGrants()
 			}
-			if s.skipGrants {
+			if s.cfg.skipGrants {
 				s.state.SetShouldSkipGrants()
 			}
 			if len(targetedResources) > 0 {
@@ -245,7 +245,7 @@ func (s *syncer) parallelSync(
 			if s.externalResourceReader != nil {
 				s.state.PushAction(ctx, Action{Op: SyncExternalResourcesOp})
 			}
-			if s.onlyExpandGrants {
+			if s.cfg.onlyExpandGrants {
 				s.state.SetNeedsExpansion()
 				err = s.Checkpoint(ctx, true)
 				if err != nil {
@@ -420,7 +420,7 @@ func (s *syncer) parallelSync(
 				}
 			}
 
-			if s.dontExpandGrants || !s.state.NeedsExpansion() {
+			if s.cfg.dontExpandGrants || !s.state.NeedsExpansion() {
 				l.Debug("skipping grant expansion, no grants to expand")
 				s.state.FinishAction(ctx, stateAction)
 				continue
@@ -725,7 +725,7 @@ func (s *syncer) setParallelActionTransitioner(
 
 func (s *syncer) syncParallel(ctx context.Context, retryer *retry.Retryer, actions []*Action, f func(ctx context.Context, action *Action) error) ([]error, error) {
 	l := ctxzap.Extract(ctx)
-	l.Info("syncing in parallel", zap.Int("actions", len(actions)), zap.Int("workers", s.workerCount))
+	l.Info("syncing in parallel", zap.Int("actions", len(actions)), zap.Int("workers", s.cfg.workerCount))
 
 	// One bounded summary span per fan-out batch. The per-action work (f) starts
 	// its own linked-root span, so this stays a handful of spans per sync rather
@@ -740,7 +740,7 @@ func (s *syncer) syncParallel(ctx context.Context, retryer *retry.Retryer, actio
 	span.SetAttributes(
 		attribute.String("sync.op", op),
 		attribute.Int("sync.action_count", len(actions)),
-		attribute.Int("sync.worker_count", s.workerCount),
+		attribute.Int("sync.worker_count", s.cfg.workerCount),
 	)
 	uotel.SetSyncIdentityAttrs(ctx, span)
 	var batchErr error
@@ -775,7 +775,7 @@ func (s *syncer) syncParallel(ctx context.Context, retryer *retry.Retryer, actio
 	var errs []error
 
 	var wg native_sync.WaitGroup
-	for i := 0; i < s.workerCount; i++ {
+	for i := 0; i < s.cfg.workerCount; i++ {
 		wg.Go(func() {
 			for {
 				action, ok := queue.next()

--- a/pkg/sync/pebble_expansion_fastpath_test.go
+++ b/pkg/sync/pebble_expansion_fastpath_test.go
@@ -55,7 +55,19 @@ func TestPebbleExpansionUsesSynthesizedFastPath(t *testing.T) {
 	graph.AddEntitlementID(dstID)
 	require.NoError(t, graph.AddEdge(ctx, srcID, dstID, false, []string{"user"}))
 
-	adapter := expanderStoreAdapter{store: store}
+	adapter := NewExpanderStore(store)
+
+	// Pin the layer seam before running the projection. The write-path
+	// assertions below cannot see it: the layered and unlayered synthesized
+	// paths feed the same counters, so an adapter built without `caps:`
+	// passes them while silently dropping expansion to the per-row path.
+	layered, ok := adapter.(expandedGrantLayerStorer)
+	require.True(t, ok)
+	opened, err := layered.BeginExpandedGrantLayer(ctx)
+	require.NoError(t, err)
+	require.True(t, opened, "Pebble must serve a layer session through NewExpanderStore")
+	require.NoError(t, layered.AbortExpandedGrantLayer(ctx))
+
 	require.NoError(t, expand.NewExpander(adapter, graph).RunTopologicalMergeProjection(ctx))
 
 	eng, ok := enginepebble.AsEngine(store)
@@ -99,7 +111,7 @@ func TestPebbleExpansionSplitsSynthesizedAndUpdatePaths(t *testing.T) {
 	graph.AddEntitlementID(dstID)
 	require.NoError(t, graph.AddEdge(ctx, srcID, dstID, false, []string{"user"}))
 
-	adapter := expanderStoreAdapter{store: store}
+	adapter := NewExpanderStore(store)
 	require.NoError(t, expand.NewExpander(adapter, graph).RunTopologicalMergeProjection(ctx))
 
 	eng, ok := enginepebble.AsEngine(store)
@@ -107,4 +119,82 @@ func TestPebbleExpansionSplitsSynthesizedAndUpdatePaths(t *testing.T) {
 	stats := eng.ExpandWritePathStats()
 	require.Greater(t, stats.SynthesizedRows, int64(0), "alice should synthesize")
 	require.Greater(t, stats.ExpandedRows, int64(0), "bob base grant should update")
+}
+
+// TestPebbleExpanderStoreResolvesLayerCapability pins the grant-layer seam at
+// both ends: the resolution site in store_caps.go must find the capability on
+// a Pebble store, and NewExpanderStore must carry it into the adapter.
+//
+// This is a hot-path performance property with no single-run oracle. Dropping
+// `caps:` from an expanderStoreAdapter literal compiles, keeps every
+// write-path assertion in this file green, and quietly moves Pebble expansion
+// from batched layer sessions to the per-row path. The planted violation below
+// is the control: it shows what a dropped `caps:` looks like, and therefore
+// that the assertions above it would catch one.
+func TestPebbleExpanderStoreResolvesLayerCapability(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "layer-seam.c1z")
+	store, err := dotc1z.NewStore(ctx, path, dotc1z.WithEngine(c1zstore.EnginePebble))
+	require.NoError(t, err)
+	defer store.Close(ctx)
+
+	_, err = store.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+
+	// The resolution site itself, independent of the adapter.
+	require.NotNil(t, resolveStoreCaps(store).expandedGrantLayer,
+		"resolveStoreCaps must find the grant-layer capability on a Pebble store")
+
+	// The wiring: NewExpanderStore resolves at entry, so the adapter it
+	// returns serves a real session.
+	wired, ok := NewExpanderStore(store).(expandedGrantLayerStorer)
+	require.True(t, ok)
+	opened, err := wired.BeginExpandedGrantLayer(ctx)
+	require.NoError(t, err)
+	require.True(t, opened, "Pebble must serve a layer session through NewExpanderStore")
+	require.NoError(t, wired.AbortExpandedGrantLayer(ctx))
+
+	// Planted violation: the same Pebble store, adapter built without caps.
+	unwired := expanderStoreAdapter{store: store}
+	openedUnwired, err := unwired.BeginExpandedGrantLayer(ctx)
+	require.NoError(t, err)
+	require.False(t, openedUnwired,
+		"an adapter built without caps: must report no layer support")
+	require.ErrorContains(t,
+		unwired.AddExpandedGrantLayerContributions(ctx, nil, nil, nil),
+		"does not support layer sessions")
+}
+
+// TestPebbleSyncerExpanderStoreCarriesLayerCapability pins the production
+// construction site. NewExpanderStore is covered above, but the sync itself
+// builds its adapter through (*syncer).expanderStore from the capabilities
+// setStore resolved, and that is the path a real sync's expansion runs on.
+// Without this test, an expanderStore that ignored s.caps would compile and
+// pass every other test in the package while dropping Pebble expansion to
+// the per-row path; the planted violation above shows exactly what that
+// looks like.
+func TestPebbleSyncerExpanderStoreCarriesLayerCapability(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "syncer-layer-seam.c1z")
+	store, err := dotc1z.NewStore(ctx, path, dotc1z.WithEngine(c1zstore.EnginePebble))
+	require.NoError(t, err)
+	defer store.Close(ctx)
+
+	_, err = store.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+	require.NoError(t, err)
+
+	s := &syncer{}
+	s.setStore(store)
+
+	layered, ok := s.expanderStore().(expandedGrantLayerStorer)
+	require.True(t, ok)
+	opened, err := layered.BeginExpandedGrantLayer(ctx)
+	require.NoError(t, err)
+	require.True(t, opened, "the syncer's own expansion adapter must serve a Pebble layer session")
+	require.NoError(t, layered.AbortExpandedGrantLayer(ctx))
+
+	// And the cheaper fast paths ride along on the same caps: the syncer's
+	// adapter must answer the principal-sort question the way Pebble does.
+	require.True(t, s.expanderStore().GrantsForEntitlementPrincipalSorted(),
+		"the syncer's expansion adapter must carry Pebble's principal-sort capability")
 }

--- a/pkg/sync/queue_audit.go
+++ b/pkg/sync/queue_audit.go
@@ -14,7 +14,7 @@ import (
 // the checker replays the log against the contract post-hoc.
 //
 // Production cost is one nil check per queue operation: the syncer only
-// attaches an audit when a test sets testQueueAudit.
+// attaches an audit when a test sets syncTestHooks.queueAudit.
 type queueAudit struct {
 	mu       native_sync.Mutex
 	events   []queueAuditEvent

--- a/pkg/sync/resource_ownership_test.go
+++ b/pkg/sync/resource_ownership_test.go
@@ -20,6 +20,10 @@ type ownershipGuardStore struct {
 // legacyPaginatedCheckpointStore.SyncMeta.
 func (s *ownershipGuardStore) SyncMeta() c1zstore.SyncMeta { return nil }
 
+// Grants answers the same attach-time capability resolution; see
+// legacyPaginatedCheckpointStore.Grants.
+func (s *ownershipGuardStore) Grants() c1zstore.GrantStore { return nil }
+
 func (s *ownershipGuardStore) PutResources(context.Context, ...*v2.Resource) error {
 	s.putCalls++
 	return nil

--- a/pkg/sync/resource_ownership_test.go
+++ b/pkg/sync/resource_ownership_test.go
@@ -16,6 +16,10 @@ type ownershipGuardStore struct {
 	putCalls int
 }
 
+// SyncMeta answers the capability resolution setStore performs at attach; see
+// legacyPaginatedCheckpointStore.SyncMeta.
+func (s *ownershipGuardStore) SyncMeta() c1zstore.SyncMeta { return nil }
+
 func (s *ownershipGuardStore) PutResources(context.Context, ...*v2.Resource) error {
 	s.putCalls++
 	return nil
@@ -23,7 +27,8 @@ func (s *ownershipGuardStore) PutResources(context.Context, ...*v2.Resource) err
 
 func TestPutConnectorResourcesRejectsReservedOwnership(t *testing.T) {
 	store := &ownershipGuardStore{}
-	syncer := &syncer{store: store}
+	syncer := &syncer{}
+	syncer.setStore(store)
 	reserved := v2.Resource_builder{
 		Id: v2.ResourceId_builder{
 			ResourceType: "user",

--- a/pkg/sync/state.go
+++ b/pkg/sync/state.go
@@ -134,11 +134,13 @@ type EntitlementGraphStore interface {
 // syncID. Returns nil (no error) when the store lacks the capability, no graph
 // was preserved, or the stored graph belongs to a different sync.
 func GraphFromStore(ctx context.Context, store c1zstore.Store, syncID string) (*expand.EntitlementGraph, error) {
-	gs, ok := store.(EntitlementGraphStore)
-	if !ok {
+	// Exported entry point: callers hand us a bare store, so this is one of
+	// the two places allowed to resolve capabilities (see store_caps.go).
+	caps := resolveReaderCaps(store)
+	if caps.entitlementGraph == nil {
 		return nil, nil
 	}
-	data, err := gs.GetEntitlementGraphBlob(ctx)
+	data, err := caps.entitlementGraph.GetEntitlementGraphBlob(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -152,11 +154,10 @@ func GraphFromStore(ctx context.Context, store c1zstore.Store, syncID string) (*
 	if boundDigest == nil {
 		return nil, nil
 	}
-	digestReader, ok := store.(c1zstore.GrantGenerationDigestReader)
-	if !ok {
+	if caps.grantDigest == nil {
 		return nil, nil
 	}
-	currentDigest, found, err := digestReader.GrantGenerationDigest(ctx)
+	currentDigest, found, err := caps.grantDigest.GrantGenerationDigest(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sync/state_test.go
+++ b/pkg/sync/state_test.go
@@ -568,12 +568,12 @@ func TestSyncerTokenVersionStampSurvivesGraphOmission(t *testing.T) {
 // this the knob is inert and the OOM escape hatch does not exist.
 func TestWithEntitlementGraphInCheckpointsReachesState(t *testing.T) {
 	s := &syncer{}
-	require.False(t, s.checkpointEntitlementGraph)
+	require.False(t, s.cfg.checkpointEntitlementGraph)
 
 	WithEntitlementGraphInCheckpoints(true)(s)
-	require.True(t, s.checkpointEntitlementGraph)
+	require.True(t, s.cfg.checkpointEntitlementGraph)
 
-	st := newState(withCheckpointEntitlementGraph(s.checkpointEntitlementGraph))
+	st := newState(withCheckpointEntitlementGraph(s.cfg.checkpointEntitlementGraph))
 	require.True(t, st.checkpointEntitlementGraph)
 }
 

--- a/pkg/sync/stop_checkpoint_test.go
+++ b/pkg/sync/stop_checkpoint_test.go
@@ -51,7 +51,7 @@ func TestPeriodicCheckpointStopExitTakesDetachedRescue(t *testing.T) {
 	st := newEmptySchedulerState(t)
 	st.pushAction(ctx, Action{Op: SyncGrantsOp, ResourceID: "group-1"})
 	store := &checkpointOutcomeStore{failWhenCallerDone: true}
-	s := &syncer{state: st, store: store, workerCount: 1}
+	s := &syncer{state: st, store: store, cfg: syncConfig{workerCount: 1}}
 
 	// The stop lands "between batches": the loop's first periodic checkpoint
 	// is the first code to observe it.
@@ -80,7 +80,7 @@ func TestPeriodicCheckpointFailureWithLiveCallerIsNotRetried(t *testing.T) {
 	st := newEmptySchedulerState(t)
 	st.pushAction(ctx, Action{Op: SyncGrantsOp, ResourceID: "group-1"})
 	store := &checkpointOutcomeStore{failAlways: true}
-	s := &syncer{state: st, store: store, workerCount: 1}
+	s := &syncer{state: st, store: store, cfg: syncConfig{workerCount: 1}}
 
 	_, err := s.parallelSync(ctx, ctx, nil)
 	require.ErrorIs(t, err, errInjectedCheckpointWrite,

--- a/pkg/sync/stop_checkpoint_test.go
+++ b/pkg/sync/stop_checkpoint_test.go
@@ -16,14 +16,20 @@ var errInjectedCheckpointWrite = errors.New("injected checkpoint write failure")
 
 // checkpointOutcomeStore stubs the single store call the loop-top periodic
 // checkpoint reaches (CheckpointSync) and records the outcome of each call.
-// Every other method panics through the embedded nil interface, which is
-// part of the assertion — this exit must touch nothing else in the store.
+// Every other method except SyncMeta panics through the embedded nil
+// interface, which is part of the assertion — this exit must touch nothing
+// else in the store.
 type checkpointOutcomeStore struct {
 	c1zstore.Store
 	failWhenCallerDone bool
 	failAlways         bool
 	outcomes           []error
 }
+
+// SyncMeta answers the capability resolution setStore performs at attach; see
+// legacyPaginatedCheckpointStore.SyncMeta. It returns nil rather than panicking
+// because attach happens before the exit under test, not on it.
+func (s *checkpointOutcomeStore) SyncMeta() c1zstore.SyncMeta { return nil }
 
 func (s *checkpointOutcomeStore) CheckpointSync(ctx context.Context, _ string) error {
 	var err error
@@ -51,7 +57,8 @@ func TestPeriodicCheckpointStopExitTakesDetachedRescue(t *testing.T) {
 	st := newEmptySchedulerState(t)
 	st.pushAction(ctx, Action{Op: SyncGrantsOp, ResourceID: "group-1"})
 	store := &checkpointOutcomeStore{failWhenCallerDone: true}
-	s := &syncer{state: st, store: store, cfg: syncConfig{workerCount: 1}}
+	s := &syncer{state: st, cfg: syncConfig{workerCount: 1}}
+	s.setStore(store)
 
 	// The stop lands "between batches": the loop's first periodic checkpoint
 	// is the first code to observe it.
@@ -80,7 +87,8 @@ func TestPeriodicCheckpointFailureWithLiveCallerIsNotRetried(t *testing.T) {
 	st := newEmptySchedulerState(t)
 	st.pushAction(ctx, Action{Op: SyncGrantsOp, ResourceID: "group-1"})
 	store := &checkpointOutcomeStore{failAlways: true}
-	s := &syncer{state: st, store: store, cfg: syncConfig{workerCount: 1}}
+	s := &syncer{state: st, cfg: syncConfig{workerCount: 1}}
+	s.setStore(store)
 
 	_, err := s.parallelSync(ctx, ctx, nil)
 	require.ErrorIs(t, err, errInjectedCheckpointWrite,

--- a/pkg/sync/stop_checkpoint_test.go
+++ b/pkg/sync/stop_checkpoint_test.go
@@ -16,9 +16,10 @@ var errInjectedCheckpointWrite = errors.New("injected checkpoint write failure")
 
 // checkpointOutcomeStore stubs the single store call the loop-top periodic
 // checkpoint reaches (CheckpointSync) and records the outcome of each call.
-// Every other method except SyncMeta panics through the embedded nil
-// interface, which is part of the assertion — this exit must touch nothing
-// else in the store.
+// Every other method except SyncMeta and Grants panics through the embedded
+// nil interface, which is part of the assertion — this exit must touch
+// nothing else in the store. Those two are asked at attach, before the exit
+// under test, so the assertion is intact.
 type checkpointOutcomeStore struct {
 	c1zstore.Store
 	failWhenCallerDone bool
@@ -30,6 +31,10 @@ type checkpointOutcomeStore struct {
 // legacyPaginatedCheckpointStore.SyncMeta. It returns nil rather than panicking
 // because attach happens before the exit under test, not on it.
 func (s *checkpointOutcomeStore) SyncMeta() c1zstore.SyncMeta { return nil }
+
+// Grants answers the same attach-time capability resolution; see
+// legacyPaginatedCheckpointStore.Grants.
+func (s *checkpointOutcomeStore) Grants() c1zstore.GrantStore { return nil }
 
 func (s *checkpointOutcomeStore) CheckpointSync(ctx context.Context, _ string) error {
 	var err error

--- a/pkg/sync/store_caps.go
+++ b/pkg/sync/store_caps.go
@@ -1,0 +1,72 @@
+package sync //nolint:revive,nolintlint // we can't change the package name for backwards compatibility
+
+import (
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
+)
+
+// storeCaps is the set of optional store capabilities pkg/sync uses,
+// resolved once when a store is attached (syncer.setStore) and read as
+// plain fields afterwards. A nil field means "this engine does not
+// implement it" — SQLite implements almost none of these; Pebble
+// implements all of them.
+//
+// The point of resolving up front is that the store's shape is decided
+// once, in one place a reader can enumerate, instead of being rediscovered
+// by an `x.(Interface)` at each use site. Duck-typing at the use site
+// hides how many capabilities the syncer actually depends on, and makes
+// every new dependency a two-line addition nobody reviews as a dependency.
+type storeCaps struct {
+	// entitlementGraph is the c1z graph sidecar used to persist a
+	// preserved entitlement graph for later incremental expansion.
+	entitlementGraph EntitlementGraphStore
+	// grantDigest reads the exact whole-file grant digest written at seal
+	// time. A preserved graph is only reusable when it can be bound to
+	// one, so the graph sidecar is useless without this.
+	grantDigest c1zstore.GrantGenerationDigestReader
+	// ingestFacts is the referential-inspection surface the ingestion
+	// invariants query (ingest_invariants.go). Absent on engines without
+	// it, which is why the referential invariants degrade rather than
+	// fail there.
+	ingestFacts dotc1z.IngestInvariantStore
+	// ingestVerification writes and clears the ingestion-invariant
+	// verification marker. It is a capability of the store's SyncMeta
+	// sub-store, not of the store itself.
+	ingestVerification c1zstore.IngestInvariantVerificationWriter
+	// dbSize reports the store's uncompressed working-set size, which the
+	// progress log folds into the periodic expansion line.
+	dbSize connectorstore.DBSizeProvider
+}
+
+// resolveStoreCaps resolves every capability in storeCaps from a full
+// store, including the one that lives on its SyncMeta sub-store.
+//
+// This and resolveReaderCaps are the only places in pkg/sync that may
+// type-assert a store against an optional capability interface.
+func resolveStoreCaps(store c1zstore.Store) storeCaps {
+	if store == nil {
+		return storeCaps{}
+	}
+	caps := resolveReaderCaps(store)
+	if meta := store.SyncMeta(); meta != nil {
+		caps.ingestVerification, _ = meta.(c1zstore.IngestInvariantVerificationWriter)
+	}
+	return caps
+}
+
+// resolveReaderCaps resolves the capabilities reachable on a bare reader,
+// for the exported entry points that take one (GraphFromStore,
+// runIngestInvariants). ingestVerification is always nil here: it hangs off
+// SyncMeta, which a reader does not expose.
+func resolveReaderCaps(store connectorstore.Reader) storeCaps {
+	if store == nil {
+		return storeCaps{}
+	}
+	var caps storeCaps
+	caps.entitlementGraph, _ = store.(EntitlementGraphStore)
+	caps.grantDigest, _ = store.(c1zstore.GrantGenerationDigestReader)
+	caps.ingestFacts, _ = store.(dotc1z.IngestInvariantStore)
+	caps.dbSize, _ = store.(connectorstore.DBSizeProvider)
+	return caps
+}

--- a/pkg/sync/store_caps.go
+++ b/pkg/sync/store_caps.go
@@ -17,7 +17,64 @@ import (
 // by an `x.(Interface)` at each use site. Duck-typing at the use site
 // hides how many capabilities the syncer actually depends on, and makes
 // every new dependency a two-line addition nobody reviews as a dependency.
+//
+// The read-side subset is its own type, readerCaps, embedded here. The
+// exported entry points that take a bare reader (GraphFromStore,
+// runIngestInvariants) resolve a readerCaps, and a readerCaps is not
+// assignable to a storeCaps, so a syncer cannot be handed a reader's
+// capabilities in place of its store's — which would compile, and would
+// silently switch every write-side path to its fallback.
 type storeCaps struct {
+	readerCaps
+	// ingestVerification writes and clears the ingestion-invariant
+	// verification marker. It is a capability of the store's SyncMeta
+	// sub-store, not of the store itself.
+	ingestVerification c1zstore.IngestInvariantVerificationWriter
+	// resourceDeleter, entitlementDeleter and grantRefsDeleter are the
+	// record-level deletes that stale-external-principal reconciliation
+	// needs. All three or none: when any is nil the reconciliation pass
+	// warns which arms are missing and returns without deleting, leaving
+	// principals from an earlier attempt in place (SQLite implements none
+	// of them).
+	resourceDeleter    resourceRecordDeleter
+	entitlementDeleter entitlementRecordDeleter
+	grantRefsDeleter   grantByRefsDeleter
+	// grantBatchDeleter is the bulk form of grantRefsDeleter. When nil the
+	// external-principal delete path falls through to the per-grant loop,
+	// which commits once per grant.
+	grantBatchDeleter grantsByRefsBatchDeleter
+	// grantPrincipalKeys and principalSortedGrants are the store-level
+	// expansion fast paths. When nil the expander adapter lists whole
+	// grants and extracts principal keys itself, and reports grants as
+	// unsorted so the topological merge buffers and sorts per entitlement.
+	grantPrincipalKeys    grantPrincipalKeyLister
+	principalSortedGrants principalSortedGrantLister
+	// newExpandedGrants and newExpandedContributions are the Grants
+	// sub-store's write fast paths for expansion output. When nil the
+	// adapter falls back to StoreExpandedGrants, materializing grants and
+	// paying read-before-write.
+	newExpandedGrants        newExpandedGrantStorer
+	newExpandedContributions newExpandedGrantContributionStorer
+	// expandedGrantLayer is the layer-session surface for synthesized
+	// grants, and is a capability of the store's Grants sub-store rather
+	// than the store itself. When nil, BeginExpandedGrantLayer reports
+	// "no layer support" and the expander uses its unlayered path.
+	//
+	// Caching it is sound for the same reason as ingestVerification: both
+	// Grants() implementations (pebbleStore.Grants, C1File.Grants) return a
+	// fresh stateless wrapper over a pointer assigned once at construction
+	// and never reassigned.
+	expandedGrantLayer expandedGrantLayerStorer
+}
+
+// readerCaps is the subset of storeCaps reachable on a bare
+// connectorstore.Reader: everything a read-only consumer of a c1z (the
+// graph loader, the ingest-invariant pass, the progress log) can use.
+// A reader may be either engine indefinitely — external-resource and
+// previous-sync artifacts stay legacy SQLite long after Pebble is the only
+// sync target — so these are honestly optional in a way the write side is
+// not.
+type readerCaps struct {
 	// entitlementGraph is the c1z graph sidecar used to persist a
 	// preserved entitlement graph for later incremental expansion.
 	entitlementGraph EntitlementGraphStore
@@ -30,40 +87,53 @@ type storeCaps struct {
 	// it, which is why the referential invariants degrade rather than
 	// fail there.
 	ingestFacts dotc1z.IngestInvariantStore
-	// ingestVerification writes and clears the ingestion-invariant
-	// verification marker. It is a capability of the store's SyncMeta
-	// sub-store, not of the store itself.
-	ingestVerification c1zstore.IngestInvariantVerificationWriter
 	// dbSize reports the store's uncompressed working-set size, which the
 	// progress log folds into the periodic expansion line.
 	dbSize connectorstore.DBSizeProvider
 }
 
 // resolveStoreCaps resolves every capability in storeCaps from a full
-// store, including the one that lives on its SyncMeta sub-store.
+// store, including the ones that live on its SyncMeta and Grants
+// sub-stores. The write-side capabilities are resolved only here: a bare
+// reader cannot delete or open a grant layer.
 //
 // This and resolveReaderCaps are the only places in pkg/sync that may
-// type-assert a store against an optional capability interface.
+// type-assert a store against an optional capability interface, whether
+// the interface is exported from c1zstore/dotc1z/connectorstore or
+// declared locally in this package.
 func resolveStoreCaps(store c1zstore.Store) storeCaps {
 	if store == nil {
 		return storeCaps{}
 	}
-	caps := resolveReaderCaps(store)
+	caps := storeCaps{readerCaps: resolveReaderCaps(store)}
+	caps.resourceDeleter, _ = store.(resourceRecordDeleter)
+	caps.entitlementDeleter, _ = store.(entitlementRecordDeleter)
+	caps.grantRefsDeleter, _ = store.(grantByRefsDeleter)
+	caps.grantBatchDeleter, _ = store.(grantsByRefsBatchDeleter)
+	caps.grantPrincipalKeys, _ = store.(grantPrincipalKeyLister)
+	caps.principalSortedGrants, _ = store.(principalSortedGrantLister)
 	if meta := store.SyncMeta(); meta != nil {
 		caps.ingestVerification, _ = meta.(c1zstore.IngestInvariantVerificationWriter)
+	}
+	if grants := store.Grants(); grants != nil {
+		caps.expandedGrantLayer, _ = grants.(expandedGrantLayerStorer)
+		caps.newExpandedGrants, _ = grants.(newExpandedGrantStorer)
+		caps.newExpandedContributions, _ = grants.(newExpandedGrantContributionStorer)
 	}
 	return caps
 }
 
 // resolveReaderCaps resolves the capabilities reachable on a bare reader,
 // for the exported entry points that take one (GraphFromStore,
-// runIngestInvariants). ingestVerification is always nil here: it hangs off
-// SyncMeta, which a reader does not expose.
-func resolveReaderCaps(store connectorstore.Reader) storeCaps {
+// runIngestInvariants). The write-side capabilities are not part of the
+// result type: a reader cannot delete, open a grant layer, or write the
+// verification marker, and returning the narrower type is what keeps a
+// reader's capabilities from ever being assigned where a store's belong.
+func resolveReaderCaps(store connectorstore.Reader) readerCaps {
 	if store == nil {
-		return storeCaps{}
+		return readerCaps{}
 	}
-	var caps storeCaps
+	var caps readerCaps
 	caps.entitlementGraph, _ = store.(EntitlementGraphStore)
 	caps.grantDigest, _ = store.(c1zstore.GrantGenerationDigestReader)
 	caps.ingestFacts, _ = store.(dotc1z.IngestInvariantStore)

--- a/pkg/sync/store_caps_test.go
+++ b/pkg/sync/store_caps_test.go
@@ -1,0 +1,134 @@
+package sync //nolint:revive,nolintlint // we can't change the package name for backwards compatibility
+
+import (
+	"context"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/conductorone/baton-sdk/pkg/connectorstore"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z"
+	"github.com/conductorone/baton-sdk/pkg/dotc1z/c1zstore"
+)
+
+// storeCapsMatrix is the engine capability matrix: for each engine, whether
+// resolveStoreCaps finds each optional capability on a real store.
+//
+// Every failure mode of this resolution is silent. A capability that resolves
+// nil when the engine does implement it does not error — it downgrades:
+// unlayered grant expansion, the per-grant delete loop instead of
+// DeleteGrantsByRefs, no preserved entitlement graph, no ingest-invariant
+// verification marker. Nothing else in the suite would notice, so the matrix
+// is asserted here rather than described in field comments.
+//
+// Adding a field to storeCaps without adding it here fails the test.
+var storeCapsMatrix = map[c1zstore.Engine]map[string]bool{
+	c1zstore.EnginePebble: {
+		"entitlementGraph":         true,
+		"grantDigest":              true,
+		"ingestFacts":              true,
+		"ingestVerification":       true,
+		"dbSize":                   true,
+		"resourceDeleter":          true,
+		"entitlementDeleter":       true,
+		"grantRefsDeleter":         true,
+		"grantBatchDeleter":        true,
+		"grantPrincipalKeys":       true,
+		"principalSortedGrants":    true,
+		"newExpandedGrants":        true,
+		"newExpandedContributions": true,
+		"expandedGrantLayer":       true,
+	},
+	c1zstore.EngineSQLite: {
+		"entitlementGraph":   false,
+		"grantDigest":        false,
+		"ingestFacts":        false,
+		"ingestVerification": true,
+		"dbSize":             true,
+		// SQLite deletes by public grant id and implements none of the
+		// record-level or refs-based deletes.
+		"resourceDeleter":    false,
+		"entitlementDeleter": false,
+		"grantRefsDeleter":   false,
+		"grantBatchDeleter":  false,
+		"grantPrincipalKeys": false,
+		// Present but answers false — see the effective-answer assertion
+		// below. Satisfying the interface is not the same as the capability.
+		"principalSortedGrants":    true,
+		"newExpandedGrants":        false,
+		"newExpandedContributions": false,
+		"expandedGrantLayer":       false,
+	},
+}
+
+func TestStoreCapsEngineMatrix(t *testing.T) {
+	for engine, expected := range storeCapsMatrix {
+		t.Run(string(engine), func(t *testing.T) {
+			ctx := context.Background()
+			store, err := dotc1z.NewStore(ctx,
+				filepath.Join(t.TempDir(), "caps.c1z"),
+				dotc1z.WithEngine(engine))
+			require.NoError(t, err)
+			defer store.Close(ctx)
+			_, err = store.StartNewSync(ctx, connectorstore.SyncTypeFull, "")
+			require.NoError(t, err)
+
+			// VisibleFields flattens the embedded readerCaps so the matrix
+			// is one flat map over every capability; the embedded struct
+			// itself is skipped as a non-capability.
+			caps := reflect.ValueOf(resolveStoreCaps(store))
+			var seen int
+			for _, sf := range reflect.VisibleFields(caps.Type()) {
+				if sf.Anonymous {
+					continue
+				}
+				seen++
+				field := caps.FieldByIndex(sf.Index)
+				require.Equal(t, reflect.Interface, field.Kind(),
+					"storeCaps.%s is not an interface; this test assumes capabilities are nil-able interfaces", sf.Name)
+				want, listed := expected[sf.Name]
+				require.True(t, listed, "storeCaps.%s is missing from the engine matrix; add it", sf.Name)
+				require.Equal(t, want, !field.IsNil(), "storeCaps.%s on %s", sf.Name, engine)
+			}
+			require.Equal(t, len(expected), seen,
+				"the matrix must list every storeCaps field exactly once")
+
+			// Interface satisfaction is not the answer. SQLite implements
+			// GrantsForEntitlementPrincipalSorted and returns false, so the
+			// non-nil capability above must not be read as "grants are
+			// sorted" — the expander's buffering fallback depends on this.
+			require.Equal(t, engine == c1zstore.EnginePebble,
+				NewExpanderStore(store).GrantsForEntitlementPrincipalSorted(),
+				"effective principal-sort answer on %s", engine)
+
+			// The reader-side resolver sees the same store through a
+			// narrower type and must agree with the embedded subset.
+			require.Equal(t, resolveStoreCaps(store).readerCaps, resolveReaderCaps(store),
+				"resolveReaderCaps must match the readerCaps embedded by resolveStoreCaps on %s", engine)
+		})
+	}
+}
+
+// TestResolveStoreCapsNilStore pins the guards: a nil store, and a store
+// whose sub-stores are nil, resolve to an all-nil capability set rather than
+// panicking. Partial test doubles depend on this.
+func TestResolveStoreCapsNilStore(t *testing.T) {
+	require.Equal(t, storeCaps{}, resolveStoreCaps(nil))
+
+	caps := resolveStoreCaps(nilSubStoreStore{})
+	require.Nil(t, caps.ingestVerification)
+	require.Nil(t, caps.expandedGrantLayer)
+	require.Nil(t, caps.newExpandedGrants)
+	require.Nil(t, caps.newExpandedContributions)
+}
+
+// nilSubStoreStore is a store whose SyncMeta and Grants sub-stores are nil,
+// the shape partial doubles take.
+type nilSubStoreStore struct {
+	c1zstore.Store
+}
+
+func (nilSubStoreStore) SyncMeta() c1zstore.SyncMeta { return nil }
+func (nilSubStoreStore) Grants() c1zstore.GrantStore { return nil }

--- a/pkg/sync/sync_summary_test.go
+++ b/pkg/sync/sync_summary_test.go
@@ -116,9 +116,11 @@ func TestSyncSummaryFieldsShape(t *testing.T) {
 	s := &syncer{
 		recordStats: true,
 		syncID:      "sync-1",
-		syncType:    connectorstore.SyncTypeFull,
-		workerCount: 20,
-		state:       newState(),
+		cfg: syncConfig{
+			syncType:    connectorstore.SyncTypeFull,
+			workerCount: 20,
+		},
+		state: newState(),
 	}
 	s.state.AddStepDuration("list-grants", time.Second)
 	s.state.AddStepDuration("checkpoint", 29*time.Millisecond)

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -166,12 +166,8 @@ type syncer struct {
 	// entitlements across the whole sync (see expand.DroppedEdgeStats);
 	// summarized once when expansion completes.
 	expandDropStats *expand.DroppedEdgeStats
-	// testIngestHaltHook, when non-nil, fires at named seams of the
-	// ingestion-invariant pass (see ingestInvariantHaltStages);
-	// returning an error fails the sync at exactly that boundary. The
-	// halt sweep uses it to prove crash/resume equivalence at every
-	// ordering-sensitive point. Nil in production: one pointer check.
-	testIngestHaltHook func(stage string) error
+	// testHooks are the test seams (see hooks.go). All nil in production.
+	testHooks syncTestHooks
 	// pendingInvariantVerification is the verification a successful
 	// runIngestionInvariants staged, awaiting persistence by
 	// persistIngestInvariantVerification AFTER EndSync. Deferring the
@@ -183,17 +179,7 @@ type syncer struct {
 	// minCheckpointInterval). The checkpoint-cut verification harness
 	// sets it to zero so every loop-top checkpoint durably commits,
 	// making each one an enumerable crash-cut point.
-	checkpointInterval time.Duration
-	// testCheckpointHook, when non-nil, observes every durably written
-	// checkpoint token. The cut harness uses it to count checkpoints
-	// and to simulate a crash immediately after a chosen one. Nil in
-	// production: one pointer check.
-	testCheckpointHook func(token string)
-	// testQueueAudit, when non-nil, records every parallelActionQueue
-	// event (seed/dequeue/commit/abort/done) for post-hoc verification
-	// of the queue contract. Nil in production: one pointer check per
-	// queue operation.
-	testQueueAudit                        *queueAudit
+	checkpointInterval                    time.Duration
 	connector                             types.ConnectorClient
 	state                                 State
 	lastCheckPointTime                    time.Time
@@ -465,8 +451,8 @@ func (s *syncer) Checkpoint(ctx context.Context, force bool) error {
 	if err != nil {
 		return err
 	}
-	if s.testCheckpointHook != nil {
-		s.testCheckpointHook(checkpoint)
+	if s.testHooks.checkpointHook != nil {
+		s.testHooks.checkpointHook(checkpoint)
 	}
 
 	return nil
@@ -1047,12 +1033,12 @@ func (s *syncer) Sync(ctx context.Context) error {
 	if err := s.runIngestionInvariants(ctx); err != nil {
 		return s.returnSyncError(l, span, err)
 	}
-	if s.testIngestHaltHook != nil {
+	if s.testHooks.ingestHaltHook != nil {
 		// The seam AFTER the invariant pass and BEFORE the
 		// checkpoint/EndSync below: a resumed sync re-runs the whole
 		// invariant pass over the same state, so every check must be
 		// idempotent.
-		if err := s.testIngestHaltHook(haltStageInvariantsComplete); err != nil {
+		if err := s.testHooks.ingestHaltHook(haltStageInvariantsComplete); err != nil {
 			return s.returnSyncError(l, span, err)
 		}
 	}

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -151,8 +151,11 @@ func (sm *syncMap[K, V]) Store(key K, val V) {
 type syncer struct {
 	// cfg is the caller's request: every value set by a With* option and
 	// nothing else, immutable once NewSyncer returns (see config.go).
-	cfg                    syncConfig
-	store                  c1zstore.Store
+	cfg   syncConfig
+	store c1zstore.Store
+	// caps are store's optional capabilities, resolved once by setStore
+	// (see store_caps.go). Always in step with store.
+	caps                   storeCaps
 	externalResourceReader connectorstore.Reader
 	previousSyncReader     connectorstore.Reader
 	// Ingestion-invariant state (see ingest_invariants.go):
@@ -232,15 +235,14 @@ func (s *syncer) persistEntitlementGraphToStore(ctx context.Context, syncID stri
 	if g == nil {
 		return
 	}
-	gs, ok := s.store.(EntitlementGraphStore)
-	if !ok {
+	gs := s.caps.entitlementGraph
+	if gs == nil {
 		return
 	}
-	digestReader, ok := s.store.(c1zstore.GrantGenerationDigestReader)
-	if !ok {
+	if s.caps.grantDigest == nil {
 		return
 	}
-	digest, found, err := digestReader.GrantGenerationDigest(ctx)
+	digest, found, err := s.caps.grantDigest.GrantGenerationDigest(ctx)
 	if err != nil || !found {
 		ctxzap.Extract(ctx).Warn("preserve entitlement graph: sealed grant digest unavailable; graph will not be reusable", zap.Error(err))
 		return
@@ -945,7 +947,7 @@ func (s *syncer) Sync(ctx context.Context) error {
 	// stale marker would read as verified while collection rewrites the
 	// data underneath it. The invariant pass re-stages and the marker is
 	// re-persisted after EndSync.
-	if w, ok := s.store.SyncMeta().(c1zstore.IngestInvariantVerificationWriter); ok {
+	if w := s.caps.ingestVerification; w != nil {
 		if err := w.ClearIngestInvariantVerification(ctx, syncID); err != nil {
 			return s.returnSyncError(l, span, fmt.Errorf("clear prior ingest invariant verification: %w", err))
 		}
@@ -1051,9 +1053,7 @@ func (s *syncer) Sync(ctx context.Context) error {
 	var graphToPersist *expand.EntitlementGraph
 	if s.cfg.preserveEntitlementGraph {
 		s.state.ClearEntitlementGraphTransientState(ctx)
-		_, hasGraphSidecar := s.store.(EntitlementGraphStore)
-		_, hasGrantDigest := s.store.(c1zstore.GrantGenerationDigestReader)
-		if hasGraphSidecar && hasGrantDigest {
+		if s.caps.entitlementGraph != nil && s.caps.grantDigest != nil {
 			graphToPersist = s.state.PeekEntitlementGraph()
 			s.state.ClearEntitlementGraph(ctx)
 		}
@@ -3816,7 +3816,7 @@ func (s *syncer) loadStore(ctx context.Context) error {
 		kind := "c1z_" + store.Metadata().Engine
 		s.cfg.setSessionStore.SetSessionStore(ctx, session.NewInstrumentedSessionStore(store.SessionStore(), kind, "", s.recordSessionOp))
 	}
-	s.store = store
+	s.setStore(store)
 
 	// Now that s.store is populated, wire the expand progress log's size
 	// provider. NewSyncer could not do this when the caller used
@@ -3826,17 +3826,25 @@ func (s *syncer) loadStore(ctx context.Context) error {
 	return nil
 }
 
+// setStore is the only way a store is attached to a syncer: it resolves the
+// store's optional capabilities in the same statement, so s.caps can never
+// describe a different store than s.store. Both attach points (NewSyncer for
+// WithConnectorStore, loadStore for WithC1ZPath) go through here, as do the
+// tests that drive a syncer without NewSyncer.
+func (s *syncer) setStore(store c1zstore.Store) {
+	s.store = store
+	s.caps = resolveStoreCaps(store)
+}
+
 // wireCountsDBSizeProvider attaches the store's DBSizeProvider capability
 // (if implemented) to s.counts so LogExpandProgress emits decompressed_bytes
 // and growth delta during long expansions. Idempotent: may be called from
 // both NewSyncer (WithConnectorStore case) and loadStore (WithC1ZPath case).
 func (s *syncer) wireCountsDBSizeProvider() {
-	if s.counts == nil || s.store == nil {
+	if s.counts == nil || s.caps.dbSize == nil {
 		return
 	}
-	if sp, ok := s.store.(connectorstore.DBSizeProvider); ok {
-		s.counts.SetDBSizeProvider(sp)
-	}
+	s.counts.SetDBSizeProvider(s.caps.dbSize)
 }
 
 // Close closes the store so the c1z is flushed to disk.
@@ -3940,7 +3948,7 @@ func WithProgressHandler(f func(s *Progress)) SyncOpt {
 // Either this or WithC1ZPath must be provided to create a new syncer.
 func WithConnectorStore(store c1zstore.Store) SyncOpt {
 	return func(s *syncer) {
-		s.store = store
+		s.setStore(store)
 	}
 }
 

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -149,33 +149,19 @@ func (sm *syncMap[K, V]) Store(key K, val V) {
 
 // syncer orchestrates a connector sync and stores the results using the provided datasource.Writer.
 type syncer struct {
-	c1zPath                             string
-	externalResourceC1ZPath             string
-	externalResourceEntitlementIdFilter string
-	// externalResourceTraits are the resource type traits that this
-	// connector wants synced from the external resource source and made
-	// available to the External Identity Matcher (see externalMatchTraits,
-	// set via WithExternalResourceTraits). When left empty the matcher
-	// falls back to TRAIT_USER/TRAIT_GROUP, preserving pre-CE-975 behavior
-	// for callers that never opt in.
-	externalResourceTraits      []v2.ResourceType_Trait
-	previousSyncC1ZPath         string
-	previousSyncC1ZPathOptional bool
-	store                       c1zstore.Store
-	externalResourceReader      connectorstore.Reader
-	previousSyncReader          connectorstore.Reader
+	// cfg is the caller's request: every value set by a With* option and
+	// nothing else, immutable once NewSyncer returns (see config.go).
+	cfg                    syncConfig
+	store                  c1zstore.Store
+	externalResourceReader connectorstore.Reader
+	previousSyncReader     connectorstore.Reader
 	// Ingestion-invariant state (see ingest_invariants.go):
 	// childSchedule is the monotone record backing invariant I4;
 	// resourcesPhaseRanHere gates I4 to processes that actually ran the
-	// resources phase; failFastInvariants promotes every invariant
-	// verdict to a hard, plainly-attributed sync failure — tolerated
-	// warns fail — and enables I4 (skipped entirely in default mode).
-	// Tests and equivalence harnesses set it; production default
-	// follows the per-invariant policy in the verdict table
-	// (ingestInvariants).
+	// resources phase. The fail-fast policy that promotes every verdict
+	// to a hard failure is cfg.failFastInvariants.
 	childSchedule         childScheduleSet
 	resourcesPhaseRanHere bool
-	failFastInvariants    bool
 	// expandDropStats aggregates expansion edges dropped over missing
 	// entitlements across the whole sync (see expand.DroppedEdgeStats);
 	// summarized once when expansion completes.
@@ -207,30 +193,11 @@ type syncer struct {
 	// event (seed/dequeue/commit/abort/done) for post-hoc verification
 	// of the queue contract. Nil in production: one pointer check per
 	// queue operation.
-	testQueueAudit           *queueAudit
-	connector                types.ConnectorClient
-	state                    State
-	runDuration              time.Duration
-	transitionHandler        func(s Action)
-	progressHandler          func(p *Progress)
-	tmpDir                   string
-	storageEngine            c1zstore.Engine
-	skipFullSync             bool
-	lastCheckPointTime       time.Time
-	counts                   *progresslog.ProgressLog
-	targetedSyncResources    []*v2.Resource
-	onlyExpandGrants         bool
-	preserveEntitlementGraph bool
-	// compactionMergedStore marks the store as a pre-sealed artifact
-	// this process did not collect (WithCompactionMergedStore — the
-	// compactor's keep-newer merge and rollback-expansion's replay):
-	// invariant verdicts attribute merge-manufactured shapes to the
-	// merge and soften hard arms to aggregated warnings. Distinct from
-	// onlyExpandGrants, which changes WHAT syncs and carries no
-	// invariant policy on its own.
-	compactionMergedStore                 bool
-	dontExpandGrants                      bool
-	checkpointEntitlementGraph            bool
+	testQueueAudit                        *queueAudit
+	connector                             types.ConnectorClient
+	state                                 State
+	lastCheckPointTime                    time.Time
+	counts                                *progresslog.ProgressLog
 	syncID                                string
 	skipEGForResourceType                 syncMap[string, bool]
 	skipEntitlementsForResourceType       syncMap[string, bool]
@@ -239,16 +206,8 @@ type syncer struct {
 	typeScopedEntitlementsForResourceType syncMap[string, bool]
 	scheduledResourceTypes                syncMap[string, bool]
 	ingestFilterStats                     ingestFilterStats
-	skipEntitlementsAndGrants             bool
-	skipGrants                            bool
 	resourceTypeTraits                    syncMap[string, []v2.ResourceType_Trait]
-	syncType                              connectorstore.SyncType
 	injectSyncIDAnnotation                bool
-	setSessionStore                       sessions.SetSessionStore
-	syncResourceTypes                     []string
-	workerCount                           int // If 1, sync is sequential (default). If > 1, sync operations are done in parallel.
-	metricsHandler                        metrics.Handler
-	syncIdentity                          uotel.SyncIdentity
 	recordStats                           bool
 	// parallelActionTransitioner atomically commits parent pagination and
 	// spawned work to state and the active worker pool.
@@ -572,10 +531,10 @@ func (s *syncer) syncSummaryFields(span trace.Span) []zap.Field {
 	}
 
 	attrs := []attribute.KeyValue{
-		attribute.String("sync.type", string(s.syncType)),
+		attribute.String("sync.type", string(s.cfg.syncType)),
 		attribute.Int64("sync.steps.total_ms", stepsTotalMs),
 		attribute.Int64("sync.completed_actions", int64(s.state.GetCompletedActionsCount())), //nolint:gosec // action counts fit int64
-		attribute.Int("sync.worker_count", s.workerCount),
+		attribute.Int("sync.worker_count", s.cfg.workerCount),
 	}
 	for _, op := range timedSyncOps {
 		bucket := op.String()
@@ -609,17 +568,17 @@ func (s *syncer) syncSummaryFields(span trace.Span) []zap.Field {
 
 	fields := []zap.Field{
 		zap.String("sync_id", s.syncID),
-		zap.String("sync_type", string(s.syncType)),
+		zap.String("sync_type", string(s.cfg.syncType)),
 		zap.Any("sync_step_durations_ms", ops),
 		zap.Int64("sync_steps_total_ms", stepsTotalMs),
 		zap.Any("connector_call_stats", flatCalls),
 		zap.Uint64("completed_actions", s.state.GetCompletedActionsCount()),
-		zap.Int("worker_count", s.workerCount),
+		zap.Int("worker_count", s.cfg.workerCount),
 	}
 	// Prefer identity from WithSyncIdentity so dashboards can group by
 	// catalog_name (platform context often has catalog_id but not the name).
-	if s.syncIdentity.CatalogName != "" {
-		fields = append(fields, zap.String("catalog_name", s.syncIdentity.CatalogName))
+	if s.cfg.syncIdentity.CatalogName != "" {
+		fields = append(fields, zap.String("catalog_name", s.cfg.syncIdentity.CatalogName))
 	}
 	if len(waits) > 0 {
 		fields = append(fields, zap.Any("sync_step_wait_ms", waits))
@@ -732,16 +691,16 @@ func (s *syncer) returnSyncError(l *zap.Logger, span trace.Span, err error) erro
 }
 
 func (s *syncer) handleInitialActionForStep(ctx context.Context, a Action) {
-	if s.transitionHandler != nil {
-		s.transitionHandler(a)
+	if s.cfg.transitionHandler != nil {
+		s.cfg.transitionHandler(a)
 	}
 }
 
 func (s *syncer) handleProgress(ctx context.Context, a *Action, c int) {
-	if s.progressHandler != nil {
+	if s.cfg.progressHandler != nil {
 		//nolint:gosec // No risk of overflow because `c` is a slice length.
 		count := uint32(c)
-		s.progressHandler(NewProgress(a, count))
+		s.cfg.progressHandler(NewProgress(a, count))
 	}
 }
 
@@ -837,8 +796,8 @@ func (s *syncer) startOrResumeSync(ctx context.Context) (string, bool, error) {
 	var syncID string
 	var newSync bool
 	var err error
-	if len(s.targetedSyncResources) == 0 {
-		syncID, newSync, err = s.store.StartOrResumeSync(ctx, s.syncType, "")
+	if len(s.cfg.targetedSyncResources) == 0 {
+		syncID, newSync, err = s.store.StartOrResumeSync(ctx, s.cfg.syncType, "")
 		if err != nil {
 			return "", false, err
 		}
@@ -882,8 +841,8 @@ func (s *syncer) Sync(ctx context.Context) error {
 	// Propagate connector identity to every descendant span (sync + dotc1z).
 	// An explicit WithSyncIdentity option wins; otherwise inherit whatever the
 	// caller already set on ctx.
-	if !s.syncIdentity.IsZero() {
-		ctx = uotel.WithSyncIdentity(ctx, s.syncIdentity)
+	if !s.cfg.syncIdentity.IsZero() {
+		ctx = uotel.WithSyncIdentity(ctx, s.cfg.syncIdentity)
 	}
 	uotel.SetSyncIdentityAttrs(ctx, span)
 	var err error
@@ -895,7 +854,7 @@ func (s *syncer) Sync(ctx context.Context) error {
 	// rate_limit_wait bucket alongside retry backoff.
 	ctx = s.withRateLimitWaitObserver(ctx)
 
-	if s.skipFullSync {
+	if s.cfg.skipFullSync {
 		return s.SkipSync(ctx)
 	}
 
@@ -904,8 +863,8 @@ func (s *syncer) Sync(ctx context.Context) error {
 
 	runCtx := ctx
 	var runCanc context.CancelFunc
-	if s.runDuration > 0 {
-		runCtx, runCanc = context.WithTimeout(ctx, s.runDuration)
+	if s.cfg.runDuration > 0 {
+		runCtx, runCanc = context.WithTimeout(ctx, s.cfg.runDuration)
 	}
 	if runCanc != nil {
 		defer runCanc()
@@ -936,8 +895,8 @@ func (s *syncer) Sync(ctx context.Context) error {
 	}
 
 	syncResourceTypeMap := make(map[string]bool)
-	if len(s.syncResourceTypes) > 0 {
-		for _, rt := range s.syncResourceTypes {
+	if len(s.cfg.syncResourceTypes) > 0 {
+		for _, rt := range s.cfg.syncResourceTypes {
 			syncResourceTypeMap[rt] = true
 		}
 	}
@@ -950,9 +909,9 @@ func (s *syncer) Sync(ctx context.Context) error {
 		parentResourceTypeID string
 		parentResourceID     string
 	}
-	seenTargetedResources := make(map[targetedResourceKey]struct{}, len(s.targetedSyncResources))
-	for _, r := range s.targetedSyncResources {
-		if len(s.syncResourceTypes) > 0 {
+	seenTargetedResources := make(map[targetedResourceKey]struct{}, len(s.cfg.targetedSyncResources))
+	for _, r := range s.cfg.targetedSyncResources {
+		if len(s.cfg.syncResourceTypes) > 0 {
 			if _, ok := syncResourceTypeMap[r.GetId().GetResourceType()]; !ok {
 				continue
 			}
@@ -1011,7 +970,7 @@ func (s *syncer) Sync(ctx context.Context) error {
 		return err
 	}
 
-	state := newState(withCheckpointEntitlementGraph(s.checkpointEntitlementGraph))
+	state := newState(withCheckpointEntitlementGraph(s.cfg.checkpointEntitlementGraph))
 	err = state.Unmarshal(currentStep)
 	if err != nil {
 		return err
@@ -1044,7 +1003,7 @@ func (s *syncer) Sync(ctx context.Context) error {
 		entitlementGraph := s.state.EntitlementGraph(ctx)
 		l.Info("resumed previous sync",
 			zap.String("sync_id", syncID),
-			zap.String("sync_type", string(s.syncType)),
+			zap.String("sync_type", string(s.cfg.syncType)),
 			zap.String("current_action_op", currentActionOp),
 			zap.String("current_action_resource_id", currentActionResourceID),
 			zap.String("current_action_resource_type_id", currentActionResourceTypeID),
@@ -1104,7 +1063,7 @@ func (s *syncer) Sync(ctx context.Context) error {
 	// stays skinny — a whale graph is megabytes), else kept in the final token.
 	// Transient working state is stripped either way; a reload rebuilds it.
 	var graphToPersist *expand.EntitlementGraph
-	if s.preserveEntitlementGraph {
+	if s.cfg.preserveEntitlementGraph {
 		s.state.ClearEntitlementGraphTransientState(ctx)
 		_, hasGraphSidecar := s.store.(EntitlementGraphStore)
 		_, hasGrantDigest := s.store.(c1zstore.GrantGenerationDigestReader)
@@ -1195,8 +1154,8 @@ func (s *syncer) SkipSync(ctx context.Context) (err error) {
 
 	runCtx := ctx
 	var runCanc context.CancelFunc
-	if s.runDuration > 0 {
-		runCtx, runCanc = context.WithTimeout(ctx, s.runDuration)
+	if s.cfg.runDuration > 0 {
+		runCtx, runCanc = context.WithTimeout(ctx, s.cfg.runDuration)
 	}
 	if runCanc != nil {
 		defer runCanc()
@@ -1297,9 +1256,9 @@ func (s *syncer) SyncResourceTypes(ctx context.Context, action *Action) error {
 	}
 
 	var resourceTypes []*v2.ResourceType
-	if len(s.syncResourceTypes) > 0 {
+	if len(s.cfg.syncResourceTypes) > 0 {
 		syncResourceTypeMap := make(map[string]bool)
-		for _, rt := range s.syncResourceTypes {
+		for _, rt := range s.cfg.syncResourceTypes {
 			syncResourceTypeMap[rt] = true
 		}
 		for _, rt := range connectorResourceTypes {
@@ -1322,7 +1281,7 @@ func (s *syncer) SyncResourceTypes(ctx context.Context, action *Action) error {
 	if resp.GetNextPageToken() == "" {
 		s.counts.LogResourceTypesProgress(ctx)
 
-		if len(s.syncResourceTypes) > 0 {
+		if len(s.cfg.syncResourceTypes) > 0 {
 			validResourceTypesResp, err := s.store.ListResourceTypes(ctx, v2.ResourceTypesServiceListResourceTypesRequest_builder{
 				PageToken:    action.PageToken,
 				ActiveSyncId: s.getActiveSyncID(),
@@ -1330,7 +1289,7 @@ func (s *syncer) SyncResourceTypes(ctx context.Context, action *Action) error {
 			if err != nil {
 				return err
 			}
-			err = validateSyncResourceTypesFilter(s.syncResourceTypes, validResourceTypesResp.GetList())
+			err = validateSyncResourceTypesFilter(s.cfg.syncResourceTypes, validResourceTypesResp.GetList())
 			if err != nil {
 				return err
 			}
@@ -1411,7 +1370,7 @@ func (s *syncer) pushChildResourceActions(ctx context.Context, childTypeIDs []st
 func (s *syncer) childResourceActions(childTypeIDs []string, parentTypeID, parentID string) []Action {
 	var actions []Action
 	for _, childTypeID := range childTypeIDs {
-		if len(s.syncResourceTypes) > 0 && !slices.Contains(s.syncResourceTypes, childTypeID) {
+		if len(s.cfg.syncResourceTypes) > 0 && !slices.Contains(s.cfg.syncResourceTypes, childTypeID) {
 			continue
 		}
 		// Monotone evidence for ingestion invariant I4 (see
@@ -1436,7 +1395,7 @@ func (s *syncer) childResourceActions(childTypeIDs []string, parentTypeID, paren
 func (s *syncer) pendingChildResourceActions(childTypeIDs []string, parentTypeID, parentID string) []Action {
 	var actions []Action
 	for _, childTypeID := range childTypeIDs {
-		if len(s.syncResourceTypes) > 0 && !slices.Contains(s.syncResourceTypes, childTypeID) {
+		if len(s.cfg.syncResourceTypes) > 0 && !slices.Contains(s.cfg.syncResourceTypes, childTypeID) {
 			continue
 		}
 		if s.childSchedule.has(childTypeID, parentTypeID, parentID) {
@@ -2785,7 +2744,7 @@ func (s *syncer) syncGrantsForResource(ctx context.Context, action *Action) erro
 
 	for _, grant := range grants {
 		grantAnnos := annotations.Annotations(grant.GetAnnotations())
-		if !s.dontExpandGrants && grantAnnos.Contains(&v2.GrantExpandable{}) {
+		if !s.cfg.dontExpandGrants && grantAnnos.Contains(&v2.GrantExpandable{}) {
 			s.state.SetNeedsExpansion()
 		}
 		if grantAnnos.ContainsAny(&v2.ExternalResourceMatchAll{}, &v2.ExternalResourceMatch{}, &v2.ExternalResourceMatchID{}) {
@@ -2864,8 +2823,8 @@ func (s *syncer) SyncExternalResources(ctx context.Context, action *Action) erro
 	l := ctxzap.Extract(ctx)
 	l.Info("Syncing external resources")
 
-	if s.externalResourceEntitlementIdFilter != "" {
-		err := s.SyncExternalResourcesWithGrantToEntitlement(ctx, s.externalResourceEntitlementIdFilter)
+	if s.cfg.externalResourceEntitlementIdFilter != "" {
+		err := s.SyncExternalResourcesWithGrantToEntitlement(ctx, s.cfg.externalResourceEntitlementIdFilter)
 		if err != nil {
 			return err
 		}
@@ -2887,14 +2846,14 @@ func (s *syncer) SyncExternalResources(ctx context.Context, action *Action) erro
 // caller that still wants user/group matching alongside a new trait must
 // list all three.
 func (s *syncer) externalMatchTraits() map[v2.ResourceType_Trait]bool {
-	if len(s.externalResourceTraits) == 0 {
+	if len(s.cfg.externalResourceTraits) == 0 {
 		return map[v2.ResourceType_Trait]bool{
 			v2.ResourceType_TRAIT_USER:  true,
 			v2.ResourceType_TRAIT_GROUP: true,
 		}
 	}
-	traits := make(map[v2.ResourceType_Trait]bool, len(s.externalResourceTraits))
-	for _, t := range s.externalResourceTraits {
+	traits := make(map[v2.ResourceType_Trait]bool, len(s.cfg.externalResourceTraits))
+	for _, t := range s.cfg.externalResourceTraits {
 		traits[t] = true
 	}
 	return traits
@@ -3854,22 +3813,22 @@ func (s *syncer) loadStore(ctx context.Context) error {
 		return nil
 	}
 
-	storeOpts := []dotc1z.C1ZOption{dotc1z.WithTmpDir(s.tmpDir)}
-	if s.storageEngine != "" {
-		storeOpts = append(storeOpts, dotc1z.WithEngine(s.storageEngine))
+	storeOpts := []dotc1z.C1ZOption{dotc1z.WithTmpDir(s.cfg.tmpDir)}
+	if s.cfg.storageEngine != "" {
+		storeOpts = append(storeOpts, dotc1z.WithEngine(s.cfg.storageEngine))
 	}
-	store, err := dotc1z.NewStore(ctx, s.c1zPath, storeOpts...)
+	store, err := dotc1z.NewStore(ctx, s.cfg.c1zPath, storeOpts...)
 	if err != nil {
 		return err
 	}
 
-	if s.setSessionStore != nil {
+	if s.cfg.setSessionStore != nil {
 		// Instrumented so session-store cost is attributable in the sync
 		// stats instead of vanishing into inflated connector-call latency
 		// (e.g. a broken backend whose every request times out before the
 		// connector falls back to real work).
 		kind := "c1z_" + store.Metadata().Engine
-		s.setSessionStore.SetSessionStore(ctx, session.NewInstrumentedSessionStore(store.SessionStore(), kind, "", s.recordSessionOp))
+		s.cfg.setSessionStore.SetSessionStore(ctx, session.NewInstrumentedSessionStore(store.SessionStore(), kind, "", s.recordSessionOp))
 	}
 	s.store = store
 
@@ -3966,7 +3925,7 @@ type SyncOpt func(s *syncer)
 func WithRunDuration(d time.Duration) SyncOpt {
 	return func(s *syncer) {
 		if d > 0 {
-			s.runDuration = d
+			s.cfg.runDuration = d
 		}
 	}
 }
@@ -3975,7 +3934,7 @@ func WithRunDuration(d time.Duration) SyncOpt {
 func WithTransitionHandler(f func(s Action)) SyncOpt {
 	return func(s *syncer) {
 		if f != nil {
-			s.transitionHandler = f
+			s.cfg.transitionHandler = f
 		}
 	}
 }
@@ -3986,7 +3945,7 @@ func WithTransitionHandler(f func(s Action)) SyncOpt {
 func WithProgressHandler(f func(s *Progress)) SyncOpt {
 	return func(s *syncer) {
 		if f != nil {
-			s.progressHandler = f
+			s.cfg.progressHandler = f
 		}
 	}
 }
@@ -4003,13 +3962,13 @@ func WithConnectorStore(store c1zstore.Store) SyncOpt {
 // Either this or WithConnectorStore must be provided to create a new syncer.
 func WithC1ZPath(path string) SyncOpt {
 	return func(s *syncer) {
-		s.c1zPath = path
+		s.cfg.c1zPath = path
 	}
 }
 
 func WithTmpDir(path string) SyncOpt {
 	return func(s *syncer) {
-		s.tmpDir = path
+		s.cfg.tmpDir = path
 	}
 }
 
@@ -4017,7 +3976,7 @@ func WithTmpDir(path string) SyncOpt {
 // file via WithC1ZPath. Empty uses the baton-sdk default.
 func WithStorageEngine(engine c1zstore.Engine) SyncOpt {
 	return func(s *syncer) {
-		s.storageEngine = engine
+		s.cfg.storageEngine = engine
 	}
 }
 
@@ -4031,20 +3990,20 @@ func WithStorageEngine(engine c1zstore.Engine) SyncOpt {
 // InsertResourceGrants arm.
 func WithFailFastInvariants() SyncOpt {
 	return func(s *syncer) {
-		s.failFastInvariants = true
+		s.cfg.failFastInvariants = true
 	}
 }
 
 // WithSkipFullSync skips syncing entirely.
 func WithSkipFullSync() SyncOpt {
 	return func(s *syncer) {
-		s.skipFullSync = true
+		s.cfg.skipFullSync = true
 	}
 }
 
 func WithExternalResourceC1ZPath(path string) SyncOpt {
 	return func(s *syncer) {
-		s.externalResourceC1ZPath = path
+		s.cfg.externalResourceC1ZPath = path
 	}
 }
 
@@ -4071,8 +4030,8 @@ func WithExternalResourceC1ZPath(path string) SyncOpt {
 // do not carry the replay indexes and compaction provenance this gate requires.
 func WithPreviousSyncC1ZPath(path string) SyncOpt {
 	return func(s *syncer) {
-		s.previousSyncC1ZPath = path
-		s.previousSyncC1ZPathOptional = false
+		s.cfg.previousSyncC1ZPath = path
+		s.cfg.previousSyncC1ZPathOptional = false
 	}
 }
 
@@ -4087,14 +4046,14 @@ func WithPreviousSyncC1ZPath(path string) SyncOpt {
 // surfaces open, metadata-read, and close failures.
 func WithOptionalPreviousSyncC1ZPath(path string) SyncOpt {
 	return func(s *syncer) {
-		s.previousSyncC1ZPath = path
-		s.previousSyncC1ZPathOptional = true
+		s.cfg.previousSyncC1ZPath = path
+		s.cfg.previousSyncC1ZPathOptional = true
 	}
 }
 
 func WithExternalResourceEntitlementIdFilter(entitlementId string) SyncOpt {
 	return func(s *syncer) {
-		s.externalResourceEntitlementIdFilter = entitlementId
+		s.cfg.externalResourceEntitlementIdFilter = entitlementId
 	}
 }
 
@@ -4110,25 +4069,25 @@ func WithExternalResourceEntitlementIdFilter(entitlementId string) SyncOpt {
 // would pass TRAIT_USER, TRAIT_GROUP, TRAIT_APP.
 func WithExternalResourceTraits(traits ...v2.ResourceType_Trait) SyncOpt {
 	return func(s *syncer) {
-		s.externalResourceTraits = append(s.externalResourceTraits, traits...)
+		s.cfg.externalResourceTraits = append(s.cfg.externalResourceTraits, traits...)
 	}
 }
 
 func WithTargetedSyncResources(resources []*v2.Resource) SyncOpt {
 	return func(s *syncer) {
-		s.targetedSyncResources = resources
+		s.cfg.targetedSyncResources = resources
 		if len(resources) > 0 {
-			s.syncType = connectorstore.SyncTypePartial
+			s.cfg.syncType = connectorstore.SyncTypePartial
 			return
 		}
 		// No targeted resource IDs, so we need to update the sync type to either full or resources only.
-		WithSkipEntitlementsAndGrants(s.skipEntitlementsAndGrants)(s)
+		WithSkipEntitlementsAndGrants(s.cfg.skipEntitlementsAndGrants)(s)
 	}
 }
 
 func WithSessionStore(sessionStore sessions.SetSessionStore) SyncOpt {
 	return func(s *syncer) {
-		s.setSessionStore = sessionStore
+		s.cfg.setSessionStore = sessionStore
 	}
 }
 
@@ -4136,14 +4095,14 @@ func WithSessionStore(sessionStore sessions.SetSessionStore) SyncOpt {
 // If empty (the default), all resource types will be synced.
 func WithSyncResourceTypes(resourceTypeIDs []string) SyncOpt {
 	return func(s *syncer) {
-		s.syncResourceTypes = resourceTypeIDs
+		s.cfg.syncResourceTypes = resourceTypeIDs
 	}
 }
 
 // WithOnlyExpandGrants sets whether to skip syncing resources and only expand grants.
 func WithOnlyExpandGrants() SyncOpt {
 	return func(s *syncer) {
-		s.onlyExpandGrants = true
+		s.cfg.onlyExpandGrants = true
 	}
 }
 
@@ -4161,7 +4120,7 @@ func WithOnlyExpandGrants() SyncOpt {
 // A normal connector sync must never set this.
 func WithCompactionMergedStore() SyncOpt {
 	return func(s *syncer) {
-		s.compactionMergedStore = true
+		s.cfg.compactionMergedStore = true
 	}
 }
 
@@ -4170,7 +4129,7 @@ func WithCompactionMergedStore() SyncOpt {
 // that capability retain it in the final sync token as a legacy fallback.
 func WithPreserveEntitlementGraph() SyncOpt {
 	return func(s *syncer) {
-		s.preserveEntitlementGraph = true
+		s.cfg.preserveEntitlementGraph = true
 	}
 }
 
@@ -4179,7 +4138,7 @@ func WithPreserveEntitlementGraph() SyncOpt {
 // C1 will process the uploaded c1z and expand grants itself.
 func WithDontExpandGrants() SyncOpt {
 	return func(s *syncer) {
-		s.dontExpandGrants = true
+		s.cfg.dontExpandGrants = true
 	}
 }
 func WithSyncID(syncID string) SyncOpt {
@@ -4192,15 +4151,15 @@ func WithSyncID(syncID string) SyncOpt {
 // If true, only resources will be synced.
 func WithSkipEntitlementsAndGrants(skip bool) SyncOpt {
 	return func(s *syncer) {
-		s.skipEntitlementsAndGrants = skip
+		s.cfg.skipEntitlementsAndGrants = skip
 		// Partial syncs can skip entitlements and grants, so don't update the sync type in that case.
-		if s.syncType == connectorstore.SyncTypePartial {
+		if s.cfg.syncType == connectorstore.SyncTypePartial {
 			return
 		}
 		if skip {
-			s.syncType = connectorstore.SyncTypeResourcesOnly
+			s.cfg.syncType = connectorstore.SyncTypeResourcesOnly
 		} else {
-			s.syncType = connectorstore.SyncTypeFull
+			s.cfg.syncType = connectorstore.SyncTypeFull
 		}
 	}
 }
@@ -4209,7 +4168,7 @@ func WithSkipEntitlementsAndGrants(skip bool) SyncOpt {
 // Entitlements will still be synced.
 func WithSkipGrants(skip bool) SyncOpt {
 	return func(s *syncer) {
-		s.skipGrants = skip
+		s.cfg.skipGrants = skip
 	}
 }
 
@@ -4226,7 +4185,7 @@ func WithSkipGrants(skip bool) SyncOpt {
 // is expensive enough to encode that checkpointing may OOM.
 func WithEntitlementGraphInCheckpoints(enabled bool) SyncOpt {
 	return func(s *syncer) {
-		s.checkpointEntitlementGraph = enabled
+		s.cfg.checkpointEntitlementGraph = enabled
 	}
 }
 
@@ -4253,7 +4212,7 @@ func WithMetricsHandler(h metrics.Handler) SyncOpt {
 		if h == nil {
 			return
 		}
-		s.metricsHandler = h
+		s.cfg.metricsHandler = h
 	}
 }
 
@@ -4263,7 +4222,7 @@ func WithMetricsHandler(h metrics.Handler) SyncOpt {
 // If < -1, 1 worker is used. (Nothing should do this, but there's no way to return an error in this option.)
 func WithWorkerCount(count int) SyncOpt {
 	return func(s *syncer) {
-		s.workerCount = NormalizeWorkerCount(count)
+		s.cfg.workerCount = NormalizeWorkerCount(count)
 	}
 }
 
@@ -4274,16 +4233,18 @@ func WithWorkerCount(count int) SyncOpt {
 // via uotel.WithSyncIdentity, which is how it reaches dotc1z spans too.
 func WithSyncIdentity(id uotel.SyncIdentity) SyncOpt {
 	return func(s *syncer) {
-		s.syncIdentity = id
+		s.cfg.syncIdentity = id
 	}
 }
 
 // NewSyncer returns a new syncer object.
 func NewSyncer(ctx context.Context, c types.ConnectorClient, opts ...SyncOpt) (Syncer, error) {
 	s := &syncer{
-		connector:          c,
-		syncType:           connectorstore.SyncTypeFull,
-		workerCount:        1,
+		connector: c,
+		cfg: syncConfig{
+			syncType:    connectorstore.SyncTypeFull,
+			workerCount: 1,
+		},
 		checkpointInterval: minCheckpointInterval,
 	}
 
@@ -4291,13 +4252,13 @@ func NewSyncer(ctx context.Context, c types.ConnectorClient, opts ...SyncOpt) (S
 		o(s)
 	}
 
-	if s.store == nil && s.c1zPath == "" {
+	if s.store == nil && s.cfg.c1zPath == "" {
 		return nil, errors.New("a connector store writer or a db path must be provided")
 	}
 
 	progressLogOpts := []progresslog.Option{}
-	if s.metricsHandler != nil {
-		progressLogOpts = append(progressLogOpts, progresslog.WithMetricsHandler(s.metricsHandler))
+	if s.cfg.metricsHandler != nil {
+		progressLogOpts = append(progressLogOpts, progresslog.WithMetricsHandler(s.cfg.metricsHandler))
 	}
 	s.counts = progresslog.NewProgressCounts(ctx, progressLogOpts...)
 	// Wire the DBSizeProvider now if the store is already set (WithConnectorStore
@@ -4306,86 +4267,86 @@ func NewSyncer(ctx context.Context, c types.ConnectorClient, opts ...SyncOpt) (S
 	// would ship dead for every c1z-path caller — see syncer.loadStore.
 	s.wireCountsDBSizeProvider()
 
-	if s.externalResourceC1ZPath != "" {
-		externalC1ZReader, err := dotc1z.NewStore(ctx, s.externalResourceC1ZPath, dotc1z.WithTmpDir(s.tmpDir), dotc1z.WithReadOnly(true))
+	if s.cfg.externalResourceC1ZPath != "" {
+		externalC1ZReader, err := dotc1z.NewStore(ctx, s.cfg.externalResourceC1ZPath, dotc1z.WithTmpDir(s.cfg.tmpDir), dotc1z.WithReadOnly(true))
 		if err != nil {
 			return nil, err
 		}
 		s.externalResourceReader = externalC1ZReader
 	}
 
-	if s.previousSyncC1ZPath != "" {
+	if s.cfg.previousSyncC1ZPath != "" {
 		// Open the previous-sync c1z read-only and engine-agnostically
 		// (NewStore selects the engine from the file's magic byte), then
 		// require Pebble: source-cache manifests and replay indexes are a
 		// Pebble capability, so SQLite artifacts are cold inputs.
-		previousSyncStore, err := dotc1z.NewStore(ctx, s.previousSyncC1ZPath,
+		previousSyncStore, err := dotc1z.NewStore(ctx, s.cfg.previousSyncC1ZPath,
 			dotc1z.WithReadOnly(true),
-			dotc1z.WithTmpDir(s.tmpDir),
+			dotc1z.WithTmpDir(s.cfg.tmpDir),
 		)
 		switch {
 		case err == nil:
 			if _, ok := enginepkg.AsEngine(previousSyncStore); !ok {
 				if closeErr := previousSyncStore.Close(ctx); closeErr != nil {
-					if s.previousSyncC1ZPathOptional {
+					if s.cfg.previousSyncC1ZPathOptional {
 						ctxzap.Extract(ctx).Warn("non-Pebble previous-sync c1z could not close cleanly; syncing without source-cache replay",
-							zap.String("previous_sync_c1z_path", s.previousSyncC1ZPath),
+							zap.String("previous_sync_c1z_path", s.cfg.previousSyncC1ZPath),
 							zap.Error(closeErr),
 						)
 						break
 					}
-					return nil, fmt.Errorf("error closing non-Pebble previous-sync c1z %q: %w", s.previousSyncC1ZPath, closeErr)
+					return nil, fmt.Errorf("error closing non-Pebble previous-sync c1z %q: %w", s.cfg.previousSyncC1ZPath, closeErr)
 				}
 				ctxzap.Extract(ctx).Warn("previous-sync c1z uses an engine that is not replay-eligible; syncing without source-cache replay",
-					zap.String("previous_sync_c1z_path", s.previousSyncC1ZPath),
+					zap.String("previous_sync_c1z_path", s.cfg.previousSyncC1ZPath),
 				)
 				break
 			}
 			run, metaErr := previousSyncStore.SyncMeta().LatestFinishedSyncOfAnyType(ctx)
 			if metaErr != nil {
 				closeErr := previousSyncStore.Close(ctx)
-				if s.previousSyncC1ZPathOptional {
+				if s.cfg.previousSyncC1ZPathOptional {
 					ctxzap.Extract(ctx).Warn("previous-sync c1z metadata unusable; syncing without source-cache replay",
-						zap.String("previous_sync_c1z_path", s.previousSyncC1ZPath),
+						zap.String("previous_sync_c1z_path", s.cfg.previousSyncC1ZPath),
 						zap.Error(errors.Join(metaErr, closeErr)),
 					)
 					break
 				}
 				return nil, fmt.Errorf(
 					"error reading previous-sync c1z %q metadata: %w",
-					s.previousSyncC1ZPath,
+					s.cfg.previousSyncC1ZPath,
 					errors.Join(metaErr, closeErr),
 				)
 			}
 			if run == nil || !run.UsableAsReplaySource() {
 				if closeErr := previousSyncStore.Close(ctx); closeErr != nil {
-					if s.previousSyncC1ZPathOptional {
+					if s.cfg.previousSyncC1ZPathOptional {
 						ctxzap.Extract(ctx).Warn("ineligible previous-sync c1z could not close cleanly; syncing without source-cache replay",
-							zap.String("previous_sync_c1z_path", s.previousSyncC1ZPath),
+							zap.String("previous_sync_c1z_path", s.cfg.previousSyncC1ZPath),
 							zap.Error(closeErr),
 						)
 						break
 					}
-					return nil, fmt.Errorf("error closing ineligible previous-sync c1z %q: %w", s.previousSyncC1ZPath, closeErr)
+					return nil, fmt.Errorf("error closing ineligible previous-sync c1z %q: %w", s.cfg.previousSyncC1ZPath, closeErr)
 				}
 				ctxzap.Extract(ctx).Warn("previous-sync c1z is not replay-eligible; syncing without source-cache replay",
-					zap.String("previous_sync_c1z_path", s.previousSyncC1ZPath),
+					zap.String("previous_sync_c1z_path", s.cfg.previousSyncC1ZPath),
 				)
 				break
 			}
 			s.previousSyncReader = previousSyncStore
-		case s.previousSyncC1ZPathOptional:
+		case s.cfg.previousSyncC1ZPathOptional:
 			// Best-effort replay source (see WithOptionalPreviousSyncC1ZPath):
 			// a missing/corrupt/incompatible cache file degrades to a sync
 			// without ETag replay, never a failed sync. The caller that
 			// maintains the cache replaces it after its next successful
 			// upload, so a bad file self-heals.
 			ctxzap.Extract(ctx).Warn("previous-sync c1z unusable; syncing without etag replay",
-				zap.String("previous_sync_c1z_path", s.previousSyncC1ZPath),
+				zap.String("previous_sync_c1z_path", s.cfg.previousSyncC1ZPath),
 				zap.Error(err),
 			)
 		default:
-			return nil, fmt.Errorf("error opening previous-sync c1z %q: %w", s.previousSyncC1ZPath, err)
+			return nil, fmt.Errorf("error opening previous-sync c1z %q: %w", s.cfg.previousSyncC1ZPath, err)
 		}
 	}
 

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -219,14 +219,34 @@ var _ Syncer = (*syncer)(nil)
 // a single narrow interface without knowing about C1ZStore.
 type expanderStoreAdapter struct {
 	store c1zstore.Store
+	// caps are the store's optional fast paths, resolved once when the
+	// adapter is built (see storeCaps). A nil capability means the engine
+	// does not offer it, and each method below reports that exactly as the
+	// use-site assertion it replaced did. Holding the whole set rather than
+	// one field per capability keeps both construction sites from having to
+	// grow every time the expander learns about another fast path.
+	caps storeCaps
 }
 
 // NewExpanderStore adapts a c1zstore.Store into an expand.ExpanderStore,
 // bridging engine differences (Pebble exposes StoreExpandedGrants on its
 // Grants() sub-store, SQLite at top level). Use this instead of type-asserting
-// the store, which is unsafe for Pebble.
+// the store, which is unsafe for Pebble — and because this is where the
+// store's optional expansion capabilities are resolved for callers who hand
+// us a bare store. The syncer itself uses (*syncer).expanderStore, which
+// reuses the capabilities it already resolved at attach time.
 func NewExpanderStore(store c1zstore.Store) expand.ExpanderStore {
-	return expanderStoreAdapter{store: store}
+	return &expanderStoreAdapter{store: store, caps: resolveStoreCaps(store)}
+}
+
+// expanderStore is the syncer's one construction site for the expansion
+// adapter. It exists so the production expansion path cannot be built with a
+// zero storeCaps by accident: there is no argument to forget, the adapter
+// takes whatever setStore resolved. The adapter is returned by pointer so
+// calls through the expand.ExpanderStore interface do not copy the
+// capability set on every page.
+func (s *syncer) expanderStore() expand.ExpanderStore {
+	return &expanderStoreAdapter{store: s.store, caps: s.caps}
 }
 
 // persistEntitlementGraphToStore binds the preserved graph to the exact sealed
@@ -258,7 +278,7 @@ func (s *syncer) persistEntitlementGraphToStore(ctx context.Context, syncID stri
 	}
 }
 
-func (a expanderStoreAdapter) GetEntitlement(ctx context.Context, req *reader_v2.EntitlementsReaderServiceGetEntitlementRequest) (*reader_v2.EntitlementsReaderServiceGetEntitlementResponse, error) {
+func (a *expanderStoreAdapter) GetEntitlement(ctx context.Context, req *reader_v2.EntitlementsReaderServiceGetEntitlementRequest) (*reader_v2.EntitlementsReaderServiceGetEntitlementResponse, error) {
 	return a.store.GetEntitlement(ctx, req)
 }
 
@@ -279,7 +299,7 @@ func requireEntitlementRefs(ent *v2.Entitlement) error {
 	return nil
 }
 
-func (a expanderStoreAdapter) ListGrantsForEntitlement(
+func (a *expanderStoreAdapter) ListGrantsForEntitlement(
 	ctx context.Context,
 	req *reader_v2.GrantsReaderServiceListGrantsForEntitlementRequest,
 ) (*reader_v2.GrantsReaderServiceListGrantsForEntitlementResponse, error) {
@@ -289,7 +309,7 @@ func (a expanderStoreAdapter) ListGrantsForEntitlement(
 	return a.store.ListGrantsForEntitlement(ctx, req)
 }
 
-func (a expanderStoreAdapter) ListGrantPrincipalKeysForEntitlement(
+func (a *expanderStoreAdapter) ListGrantPrincipalKeysForEntitlement(
 	ctx context.Context,
 	entitlement *v2.Entitlement,
 	pageToken string,
@@ -300,9 +320,7 @@ func (a expanderStoreAdapter) ListGrantPrincipalKeysForEntitlement(
 	}
 	// Preserve Pebble's compact prefetch path through this wrapper. Non-Pebble
 	// stores fall back to regular grant listing and local key extraction.
-	if store, ok := a.store.(interface {
-		ListGrantPrincipalKeysForEntitlement(context.Context, *v2.Entitlement, string, uint32) ([]string, string, error)
-	}); ok {
+	if store := a.caps.grantPrincipalKeys; store != nil {
 		return store.ListGrantPrincipalKeysForEntitlement(ctx, entitlement, pageToken, pageSize)
 	}
 	resp, err := a.store.ListGrantsForEntitlement(ctx, reader_v2.GrantsReaderServiceListGrantsForEntitlementRequest_builder{
@@ -324,23 +342,19 @@ func (a expanderStoreAdapter) ListGrantPrincipalKeysForEntitlement(
 	return keys, resp.GetNextPageToken(), nil
 }
 
-func (a expanderStoreAdapter) StoreExpandedGrants(ctx context.Context, grants ...*v2.Grant) error {
+func (a *expanderStoreAdapter) StoreExpandedGrants(ctx context.Context, grants ...*v2.Grant) error {
 	return a.store.Grants().StoreExpandedGrants(ctx, grants...)
 }
 
-func (a expanderStoreAdapter) StoreNewExpandedGrants(ctx context.Context, grants ...*v2.Grant) error {
-	if fast, ok := a.store.Grants().(interface {
-		StoreNewExpandedGrants(context.Context, ...*v2.Grant) error
-	}); ok {
+func (a *expanderStoreAdapter) StoreNewExpandedGrants(ctx context.Context, grants ...*v2.Grant) error {
+	if fast := a.caps.newExpandedGrants; fast != nil {
 		return fast.StoreNewExpandedGrants(ctx, grants...)
 	}
 	return a.store.Grants().StoreExpandedGrants(ctx, grants...)
 }
 
-func (a expanderStoreAdapter) StoreNewExpandedGrantContributions(ctx context.Context, dest *v2.Entitlement, principals []*storage_v3.PrincipalRef, sources []batonGrant.Sources) error {
-	if fast, ok := a.store.Grants().(interface {
-		StoreNewExpandedGrantContributions(context.Context, *v2.Entitlement, []*storage_v3.PrincipalRef, []batonGrant.Sources) error
-	}); ok {
+func (a *expanderStoreAdapter) StoreNewExpandedGrantContributions(ctx context.Context, dest *v2.Entitlement, principals []*storage_v3.PrincipalRef, sources []batonGrant.Sources) error {
+	if fast := a.caps.newExpandedContributions; fast != nil {
 		return fast.StoreNewExpandedGrantContributions(ctx, dest, principals, sources)
 	}
 	grants := make([]*v2.Grant, 0, len(principals))
@@ -355,6 +369,34 @@ func (a expanderStoreAdapter) StoreNewExpandedGrantContributions(ctx context.Con
 	return a.store.Grants().StoreExpandedGrants(ctx, grants...)
 }
 
+// grantPrincipalKeyLister is the store's compact principal-key prefetch for an
+// entitlement (Pebble). Without it the adapter lists whole grants and extracts
+// the keys locally.
+type grantPrincipalKeyLister interface {
+	ListGrantPrincipalKeysForEntitlement(context.Context, *v2.Entitlement, string, uint32) ([]string, string, error)
+}
+
+// principalSortedGrantLister reports whether the engine yields an
+// entitlement's grants in principal order (Pebble's entitlement-first key
+// does). Without it the topological merge buffers and sorts per entitlement.
+type principalSortedGrantLister interface {
+	GrantsForEntitlementPrincipalSorted() bool
+}
+
+// newExpandedGrantStorer persists caller-proven-new expanded grants without
+// read-before-write, on the store's GrantStore (Pebble). Without it the
+// adapter falls back to StoreExpandedGrants.
+type newExpandedGrantStorer interface {
+	StoreNewExpandedGrants(context.Context, ...*v2.Grant) error
+}
+
+// newExpandedGrantContributionStorer is the contribution-shaped form of
+// newExpandedGrantStorer: it takes destination plus principal refs and skips
+// materializing v2.Grants. Without it the adapter builds the grants itself.
+type newExpandedGrantContributionStorer interface {
+	StoreNewExpandedGrantContributions(context.Context, *v2.Entitlement, []*storage_v3.PrincipalRef, []batonGrant.Sources) error
+}
+
 // expandedGrantLayerStorer is the layer-scoped synthesized-grant layer session
 // surface the store's GrantStore may implement (Pebble). Local interface so
 // the adapter can pass sessions through without importing engine internals.
@@ -365,32 +407,30 @@ type expandedGrantLayerStorer interface {
 	AbortExpandedGrantLayer(ctx context.Context) error
 }
 
-func (a expanderStoreAdapter) BeginExpandedGrantLayer(ctx context.Context) (bool, error) {
-	if fast, ok := a.store.Grants().(expandedGrantLayerStorer); ok {
-		return fast.BeginExpandedGrantLayer(ctx)
+func (a *expanderStoreAdapter) BeginExpandedGrantLayer(ctx context.Context) (bool, error) {
+	if a.caps.expandedGrantLayer != nil {
+		return a.caps.expandedGrantLayer.BeginExpandedGrantLayer(ctx)
 	}
 	return false, nil
 }
 
-func (a expanderStoreAdapter) AddExpandedGrantLayerContributions(ctx context.Context, dest *v2.Entitlement, principals []*storage_v3.PrincipalRef, sources []batonGrant.Sources) error {
-	fast, ok := a.store.Grants().(expandedGrantLayerStorer)
-	if !ok {
+func (a *expanderStoreAdapter) AddExpandedGrantLayerContributions(ctx context.Context, dest *v2.Entitlement, principals []*storage_v3.PrincipalRef, sources []batonGrant.Sources) error {
+	if a.caps.expandedGrantLayer == nil {
 		return errors.New("expanded grant layer: store does not support layer sessions")
 	}
-	return fast.AddExpandedGrantLayerContributions(ctx, dest, principals, sources)
+	return a.caps.expandedGrantLayer.AddExpandedGrantLayerContributions(ctx, dest, principals, sources)
 }
 
-func (a expanderStoreAdapter) FinishExpandedGrantLayer(ctx context.Context) error {
-	fast, ok := a.store.Grants().(expandedGrantLayerStorer)
-	if !ok {
+func (a *expanderStoreAdapter) FinishExpandedGrantLayer(ctx context.Context) error {
+	if a.caps.expandedGrantLayer == nil {
 		return errors.New("expanded grant layer: store does not support layer sessions")
 	}
-	return fast.FinishExpandedGrantLayer(ctx)
+	return a.caps.expandedGrantLayer.FinishExpandedGrantLayer(ctx)
 }
 
-func (a expanderStoreAdapter) AbortExpandedGrantLayer(ctx context.Context) error {
-	if fast, ok := a.store.Grants().(expandedGrantLayerStorer); ok {
-		return fast.AbortExpandedGrantLayer(ctx)
+func (a *expanderStoreAdapter) AbortExpandedGrantLayer(ctx context.Context) error {
+	if a.caps.expandedGrantLayer != nil {
+		return a.caps.expandedGrantLayer.AbortExpandedGrantLayer(ctx)
 	}
 	return nil
 }
@@ -419,11 +459,9 @@ func resourceFromPrincipalRef(ref *storage_v3.PrincipalRef) *v2.Resource {
 // principal-sort guarantee (Pebble) so the topological merge can stream grant
 // groups instead of buffering and sorting each entitlement. Engines that do not
 // implement it (SQLite) report false and get the buffering fallback.
-func (a expanderStoreAdapter) GrantsForEntitlementPrincipalSorted() bool {
-	store, ok := a.store.(interface {
-		GrantsForEntitlementPrincipalSorted() bool
-	})
-	return ok && store.GrantsForEntitlementPrincipalSorted()
+func (a *expanderStoreAdapter) GrantsForEntitlementPrincipalSorted() bool {
+	store := a.caps.principalSortedGrants
+	return store != nil && store.GrantsForEntitlementPrincipalSorted()
 }
 
 const minCheckpointInterval = 10 * time.Second
@@ -3149,9 +3187,12 @@ func (s *syncer) deleteStaleExternalPrincipals(
 		currentIDs[id.GetResourceType()+"\x00"+id.GetResource()] = struct{}{}
 	}
 
-	resourceDeleter, canDeleteResources := s.store.(resourceRecordDeleter)
-	entitlementDeleter, canDeleteEntitlements := s.store.(entitlementRecordDeleter)
-	grantDeleter, canDeleteGrants := s.store.(grantByRefsDeleter)
+	resourceDeleter := s.caps.resourceDeleter
+	entitlementDeleter := s.caps.entitlementDeleter
+	grantDeleter := s.caps.grantRefsDeleter
+	canDeleteResources := resourceDeleter != nil
+	canDeleteEntitlements := entitlementDeleter != nil
+	canDeleteGrants := grantDeleter != nil
 	var staleIDs []*v2.ResourceId
 	pageToken := ""
 	for {
@@ -3662,7 +3703,7 @@ func (s *syncer) processGrantsWithExternalPrincipals(ctx context.Context, princi
 	// network-attached storage this loop cost ~956s for ~90k grants. The
 	// batch form amortizes the fsync without weakening durability.
 	// err is the named value the deferred span reports, so assign it.
-	if batchDeleter, ok := s.store.(grantsByRefsBatchDeleter); ok {
+	if batchDeleter := s.caps.grantBatchDeleter; batchDeleter != nil {
 		err = batchDeleter.DeleteGrantsByRefs(ctx, pendingDeletes...)
 		return err
 	}
@@ -3670,7 +3711,7 @@ func (s *syncer) processGrantsWithExternalPrincipals(ctx context.Context, princi
 	// Prefer the refs-based delete (exact structural identity) when the
 	// store supports it; external ids are a lossy external contract and
 	// stores keyed by structural identity cannot always resolve them.
-	refsDeleter, _ := s.store.(grantByRefsDeleter)
+	refsDeleter := s.caps.grantRefsDeleter
 	for _, grantToDelete := range pendingDeletes {
 		if refsDeleter != nil {
 			err = refsDeleter.DeleteGrantByRefs(ctx, grantToDelete)
@@ -3761,12 +3802,13 @@ func (s *syncer) expandGrantsForEntitlements(ctx context.Context, action *Action
 
 	// Create an expander and run a single step.
 	// The expander needs Reader methods (on s.store) plus StoreExpandedGrants
-	// (on s.store.Grants()). An inline adapter composes them so expand
-	// stays decoupled from C1ZStore.
+	// (on s.store.Grants()). s.expanderStore composes them so expand stays
+	// decoupled from C1ZStore and so the adapter carries the capabilities
+	// setStore resolved.
 	if s.expandDropStats == nil {
 		s.expandDropStats = &expand.DroppedEdgeStats{}
 	}
-	expander := expand.NewExpander(expanderStoreAdapter{s.store}, graph)
+	expander := expand.NewExpander(s.expanderStore(), graph)
 	expander.SetDropStats(s.expandDropStats)
 	err = expander.RunSingleStep(ctx)
 	if err != nil {

--- a/pkg/sync/type_scoped_test.go
+++ b/pkg/sync/type_scoped_test.go
@@ -439,7 +439,7 @@ func TestSpawnedCursorJoinsActiveParallelBatch(t *testing.T) {
 		ResourceTypeID: "group",
 		ResourceID:     "group-1",
 	})
-	s := &syncer{state: st, workerCount: 2}
+	s := &syncer{state: st, cfg: syncConfig{workerCount: 2}}
 	childStarted := make(chan struct{})
 
 	f := func(ctx context.Context, action *Action) error {


### PR DESCRIPTION
# Give `pkg/sync` typed seams, and a rule that keeps them

## Why

`syncer` had grown to 57 fields with no organizing principle: option-set
configuration, test hooks, per-run mutable state, and cached store capabilities
all sat flat on the same struct. The cost is not aesthetic. Two in-flight
feature branches independently grew it to 81 fields, 11 test hooks, and 54
capability type assertions — each feature got its own file, but every function
became a method on `*syncer` and every value became a new field. At that size
nobody can answer basic questions from the type: which values are frozen after
construction, which exist only for tests, and what the syncer actually requires
of its store.

This PR makes those three questions answerable from the type, then writes down
the rule so the next feature does not undo it.

## What changes

**Configuration is now immutable and visibly so.** Every field written by a
`With*` option moved into `syncConfig` (`config.go`). Options write to it,
nothing writes to it after `NewSyncer` returns. A field mutated during `Sync`
is by definition not configuration and stayed on `syncer`. For a syncer that
resumes across process boundaries, the immutable/mutable line is a correctness
property, not bookkeeping — a "config" field that some path quietly rewrites
mid-sync is a resume bug waiting to happen.

**Test seams are isolated and named as such.** The three seams moved into
`syncTestHooks` (`hooks.go`), held as `syncer.testHooks`, and dropped their
individual `test` prefixes since the type name now carries the marking. Apart
from the `testHooks` anchor, a `test`-prefixed field anywhere in `pkg/sync` is
now by itself a review finding.

**Store capabilities are discovered once, in one place.** `pkg/sync` leans on
optional store interfaces — batch and record-level deletes, grant digests,
ingest invariants, DB size, entitlement graph, and five expansion fast paths —
and previously rediscovered them by type assertion at the point of use. There
were **24 such assertions** across `syncer.go`, `ingest_invariants.go` and
`state.go`, resolving **14 distinct capabilities**, several re-asserted on
every call. They are now resolved once when the store is attached
(`setStore`), into `storeCaps` (`store_caps.go`), and every use site is a
plain field read.

The read-side subset is its own type, `readerCaps`, embedded in `storeCaps`.
The exported entry points that take a bare reader (`GraphFromStore`,
`runIngestInvariants`) resolve a `readerCaps`; because it is not assignable to
`storeCaps`, a syncer cannot be handed a reader's four capabilities in place
of its store's fourteen — that mistake is a compile error rather than a
silent downgrade.

What `storeCaps` actually describes is the SQLite/Pebble split: 11 of the 14
capabilities are Pebble-only, and every fallback branch is the SQLite path.
Once Pebble is the only sync target (CXE-1358 / CXE-1311), the write side
collapses into required store methods and `readerCaps` is what remains —
honestly optional, because external-resource and previous-sync readers may be
legacy SQLite indefinitely. This PR gives that collapse a clean seam to cut on.

**The syncer builds its expansion adapter through one constructor.**
`(*syncer).expanderStore()` takes no arguments and reads `s.caps`, so the
production expansion path cannot be built with a zero capability set by
forgetting an argument. `expanderStoreAdapter` methods take pointer receivers;
the adapter is 240 bytes with `storeCaps` held by value, and a value receiver
through `expand.ExpanderStore` copied it on every call. Cost-curve delta for
expansion: none — O(1) per adapter call, unchanged in grants/entitlements/graph
size; the constant goes from one 240-byte copy per call to a pointer.

**A rule in the checklist.** `docs/REVIEW_CHECKLIST.md` gains a "Syncer
structure" section: features add a runtime struct with their own file and
receiver rather than fields to `syncer`; store capabilities resolve once at
attach; test seams live only in `syncTestHooks`; `state` is the resumable
action stack and nothing else; configuration is immutable after `NewSyncer`.
The capability rule explicitly covers interfaces that are exported, declared
locally, *or written inline as an anonymous `interface{...}`* — the last form
is how four assertions escaped two earlier passes — and names its one
exception (`pkg/sync/expand` widening its own `ExpanderStore` parameter). The
store-attach and config-immutability rules each carry the one-line `rg` a
reviewer runs to check them, with their blind spots listed.

## Effect

| | Before | After |
|---|---|---|
| `syncer` fields | 57 | 30 from this PR's commits; 31 on the rebased tree (#1124 added `skipGrantsForResourceType` to `main` in the meantime) |
| Capability assertions at use sites | 24 | 0 |
| Distinct capabilities, resolved once | — | 14 (10 write-side + 4 in `readerCaps`) |
| `test`-prefixed fields on `syncer` | 3 | 0 (+1 `testHooks` anchor) |
| `With*` options | 28 | 28 (unchanged) |

No production behavior change and no API change: the `With*` functions and
`SyncOpt` are untouched, so no connector needs to do anything. `pkg/dotc1z`
and `pkg/synccompactor` are untouched.

## Properties that are now tested, because nothing else would catch them

These fail silently — they degrade a hot path rather than erroring, and every
pre-existing assertion stays green.

**The engine capability matrix.** A capability that resolves nil when the
engine does implement it downgrades to the slow path. `TestStoreCapsEngineMatrix`
opens a real Pebble store and a real SQLite store and asserts the expected
nil/non-nil value of every `storeCaps` field for each engine, reflecting over
the struct (flattening the embedded `readerCaps`) so that **adding a field
without adding it to the matrix fails the test**, and asserts
`resolveReaderCaps` agrees with the embedded subset. Dropping any single
resolution line fails it, which was verified.

Worth knowing when reading that matrix: satisfying an interface is not the
same as having the capability. `C1File.GrantsForEntitlementPrincipalSorted()`
exists and returns `false`, so that capability resolves non-nil on both
engines and the real answer still comes from calling it. The test asserts
both facts.

**The expansion layer seam, at both construction sites.** The layered and
unlayered synthesized-write paths increment the same engine counters, so an
adapter built without its caps passes every write-path assertion while
quietly dropping Pebble expansion to the per-row path.
`TestPebbleExpanderStoreResolvesLayerCapability` pins the resolution site and
`NewExpanderStore`, with a planted violation showing what the omission looks
like; `TestPebbleSyncerExpanderStoreCarriesLayerCapability` pins the syncer's
own `expanderStore()` by attaching a Pebble store through `setStore`. Each
fails if its wiring is removed, which was verified by removing it.

## Notes for review

**One behavior change at construction time.** Capability resolution calls
`store.SyncMeta()` and `store.Grants()` inside `NewSyncer`, whereas previously
nothing invoked a method on the caller's store until `Sync`. Checked against
the consumers: the Lambda/`c1api` path uses `WithC1ZPath`, not
`WithConnectorStore`, so it opens the store inside `Sync` exactly as before,
and both `WithConnectorStore` call sites in the platform repo pass a real
`dotc1z.NewStore`. Only two production `c1zstore.Store` implementations exist
(`C1File`, `pebbleStore`); their sub-store accessors return stateless wrappers
over a pointer assigned once at construction, which is also why caching
sub-store capabilities is sound. No out-of-repo implementation exists today;
one would see these calls earlier than before.

**"Resolved once" means once per attach, not once per sync,** and is not a
performance claim. Package-level entry points that receive a bare store
re-resolve at entry through the same functions rather than carrying a syncer.

**The attach and config invariants are checked by grep, not by test.** Two
rounds of go/types source fences were built and then removed: ~300 lines of
reflection to guard a low-probability, diff-visible, perf-only bypass of an
invariant that CXE-1358 deletes. The checklist carries the `rg` for each rule
and states what it does not see.

**Test doubles.** Partial doubles that reach attach gained one-line
`SyncMeta() nil` and `Grants() nil` stubs. `checkpointOutcomeStore`'s "every
other method panics" assertion is narrowed to exclude those two; attach
happens before the exit under test, so the assertion is intact.

**`checkpointInterval` stays on `syncer`** — no exported option sets it, only
verification harnesses write it. Excluding it from `syncConfig` is deliberate;
it is deleted along with the token write path in CXE-1358.