### PR TITLE
Syncer: Reduce warning threshold for list resources.

### DIFF
--- a/pkg/sync/parallel_scheduler_test.go
+++ b/pkg/sync/parallel_scheduler_test.go
@@ -74,10 +74,41 @@ func newTestRetryer(ctx context.Context) *retry.Retryer {
 }
 
 func TestTooManyWarningsThreshold(t *testing.T) {
-	require.False(t, tooManyWarnings(10, 1), "requires more than ten warnings")
-	require.False(t, tooManyWarnings(11, 0), "requires completed actions")
-	require.False(t, tooManyWarnings(11, 110), "exactly ten percent is allowed")
-	require.True(t, tooManyWarnings(11, 109), "more than ten percent must stop the sync")
+	require.False(t, tooManyWarnings(10, 1, 0.1), "requires more than ten warnings")
+	require.False(t, tooManyWarnings(11, 0, 0.1), "requires completed actions")
+	require.False(t, tooManyWarnings(11, 110, 0.1), "exactly ten percent is allowed")
+	require.True(t, tooManyWarnings(11, 109, 0.1), "more than ten percent must stop the sync")
+
+	require.False(t, tooManyWarnings(11, 220, 0.05), "exactly five percent is allowed")
+	require.True(t, tooManyWarnings(11, 219, 0.05), "more than five percent must stop the sync")
+	require.False(t, tooManyWarnings(11, 0, 0.05), "empty list-resource counts must not trip the five percent check")
+}
+
+func TestTooManyListResourceWarnings(t *testing.T) {
+	bad := ActionCount{CompletedCount: 20, WarningCount: 11}
+
+	require.False(t, tooManyListResourceWarnings(bad, 0),
+		"resumed counts must not stop a run that has not completed a list-resource action")
+	require.False(t, tooManyListResourceWarnings(bad, 10),
+		"ten completions this run are not enough to re-arm the durable ratio")
+	require.True(t, tooManyListResourceWarnings(bad, 11),
+		"more than ten completions this run re-arm the durable ratio")
+	require.False(t, tooManyListResourceWarnings(ActionCount{CompletedCount: 220, WarningCount: 11}, 11),
+		"exactly five percent is allowed")
+	require.False(t, tooManyListResourceWarnings(ActionCount{CompletedCount: 20, WarningCount: 10}, 11),
+		"requires more than ten warnings")
+	require.False(t, tooManyListResourceWarnings(ActionCount{}, 11),
+		"a run with no list-resource warnings never trips")
+}
+
+func TestRecordListResourceCompletedThisRun(t *testing.T) {
+	s := &syncer{}
+	s.recordListResourceCompletedThisRun(&Action{Op: SyncGrantsOp})
+	require.Equal(t, uint64(0), s.listResourceActionsCompletedThisRun.Load())
+	s.recordListResourceCompletedThisRun(&Action{Op: SyncResourcesOp})
+	require.Equal(t, uint64(1), s.listResourceActionsCompletedThisRun.Load())
+	s.recordListResourceCompletedThisRun(nil)
+	require.Equal(t, uint64(1), s.listResourceActionsCompletedThisRun.Load())
 }
 
 func TestCollectionProgressAccounting(t *testing.T) {

--- a/pkg/sync/parallel_syncer.go
+++ b/pkg/sync/parallel_syncer.go
@@ -174,12 +174,24 @@ func (s *syncer) parallelSync(
 			return warnings, err
 		}
 
-		// If we have more than 10 warnings and more than 10% of actions ended in a warning, exit the sync.
-		if len(warnings) > 10 {
-			completedActionsCount := s.state.GetCompletedActionsCount()
-			if tooManyWarnings(len(warnings), completedActionsCount) {
-				return warnings, fmt.Errorf("%w: warnings: %v completed actions: %d", ErrTooManyWarnings, warnings, completedActionsCount)
-			}
+		// If > 10% of actions ended in a warning, exit the sync.
+		completedActionsCount := s.state.GetCompletedActionsCount()
+		if tooManyWarnings(uint64(len(warnings)), completedActionsCount, 0.1) {
+			return warnings, fmt.Errorf("%w: warnings: %v completed actions: %d", ErrTooManyWarnings, warnings, completedActionsCount)
+		}
+		// If > 5% of list resource actions ended in a warning, exit the sync.
+		// Wait until this run has finished more than ten list-resource actions
+		// so a resumed token cannot abort before new listing work has a chance
+		// to move the ratio.
+		listResourceActionsCount := s.state.GetActionCount(SyncResourcesOp)
+		if tooManyListResourceWarnings(listResourceActionsCount, s.listResourceActionsCompletedThisRun.Load()) {
+			return warnings, fmt.Errorf(
+				"%w: warnings: %v list resource warning count: %d completed list resource actions: %d",
+				ErrTooManyWarnings,
+				warnings,
+				listResourceActionsCount.WarningCount,
+				listResourceActionsCount.CompletedCount,
+			)
 		}
 		select {
 		case <-runCtx.Done():
@@ -209,7 +221,7 @@ func (s *syncer) parallelSync(
 
 		switch stateAction.Op {
 		case InitOp:
-			s.state.FinishAction(ctx, stateAction)
+			s.finishAction(ctx, stateAction)
 
 			if s.cfg.skipEntitlementsAndGrants {
 				s.state.SetShouldSkipEntitlementsAndGrants()
@@ -320,7 +332,7 @@ func (s *syncer) parallelSync(
 			if isWarning(ctx, err) {
 				l.Warn("skipping sync static entitlements action", zap.Any("stateAction", stateAction), zap.Error(err))
 				warnings = append(warnings, err)
-				s.state.FinishAction(ctx, stateAction)
+				s.finishActionWithWarning(ctx, stateAction)
 				continue
 			}
 			if !s.timedShouldWaitAndRetry(workerCtx, SyncStaticEntitlementsOp, stateAction.ResourceTypeID, retryer, err) {
@@ -335,7 +347,7 @@ func (s *syncer) parallelSync(
 				if isWarning(ctx, err) {
 					l.Warn("skipping sync entitlement action", zap.Any("stateAction", stateAction), zap.Error(err))
 					warnings = append(warnings, err)
-					s.state.FinishAction(ctx, stateAction)
+					s.finishActionWithWarning(ctx, stateAction)
 					continue
 				}
 				if !s.timedShouldWaitAndRetry(workerCtx, SyncEntitlementsOp, stateAction.ResourceTypeID, retryer, err) {
@@ -362,7 +374,7 @@ func (s *syncer) parallelSync(
 				if isWarning(ctx, err) {
 					l.Warn("skipping sync grant action", zap.Any("stateAction", stateAction), zap.Error(err))
 					warnings = append(warnings, err)
-					s.state.FinishAction(ctx, stateAction)
+					s.finishActionWithWarning(ctx, stateAction)
 					continue
 				}
 				if !s.timedShouldWaitAndRetry(workerCtx, SyncGrantsOp, stateAction.ResourceTypeID, retryer, err) {
@@ -422,7 +434,7 @@ func (s *syncer) parallelSync(
 
 			if s.cfg.dontExpandGrants || !s.state.NeedsExpansion() {
 				l.Debug("skipping grant expansion, no grants to expand")
-				s.state.FinishAction(ctx, stateAction)
+				s.finishAction(ctx, stateAction)
 				continue
 			}
 
@@ -492,10 +504,23 @@ func (s *syncer) checkpointOnStop(ctx context.Context) {
 	}
 }
 
-func tooManyWarnings(warningCount int, completedActionsCount uint64) bool {
+func tooManyWarnings(warningCount uint64, completedActionsCount uint64, threshold float64) bool {
 	return warningCount > 10 &&
 		completedActionsCount > 0 &&
-		float64(warningCount)/float64(completedActionsCount) > 0.1
+		float64(warningCount)/float64(completedActionsCount) > threshold
+}
+
+// tooManyListResourceWarnings judges the checkpointed list-resource warning
+// ratio, but only after this run has finished more than ten list-resource
+// actions. ErrTooManyWarnings is preservable (IsSyncPreservable), so the next
+// run resumes the token that tripped it. Judging the resumed counts before any
+// new list-resource work completes would abort on the first loop iteration
+// with zero progress, and no new completion could ever move the ratio. The
+// this-run floor means each resume drains at least eleven list-resource
+// actions, and once none remain the ratio stops gating the rest of the sync.
+func tooManyListResourceWarnings(counts ActionCount, completedThisRun uint64) bool {
+	return completedThisRun > 10 &&
+		tooManyWarnings(counts.WarningCount, counts.CompletedCount, 0.05)
 }
 
 type workerResult struct {
@@ -830,7 +855,7 @@ func (s *syncer) syncOneAction(ctx context.Context, l *zap.Logger, retryer *retr
 		err := f(ctx, action)
 		if isWarning(ctx, err) {
 			l.Warn("skipping sync action", zap.Any("action", action), zap.Error(err))
-			s.state.FinishAction(ctx, action)
+			s.finishActionWithWarning(ctx, action)
 			return workerResult{warning: err}
 		}
 		if err != nil {

--- a/pkg/sync/state.go
+++ b/pkg/sync/state.go
@@ -34,6 +34,7 @@ const StateTokenVersionTypeScoped = 2
 type State interface {
 	PushAction(ctx context.Context, action Action)
 	FinishAction(ctx context.Context, action *Action)
+	FinishActionWithWarning(ctx context.Context, action *Action)
 	NextPage(ctx context.Context, actionID string, pageToken string) error
 	EntitlementGraph(ctx context.Context) *expand.EntitlementGraph
 	PeekEntitlementGraph() *expand.EntitlementGraph
@@ -55,6 +56,7 @@ type State interface {
 	ShouldSkipGrants() bool
 	SetShouldSkipGrants()
 	GetCompletedActionsCount() uint64
+	GetActionCount(op ActionOp) ActionCount
 	AddStepDuration(bucket string, duration time.Duration)
 	StepDurations() map[string]int64
 	RecordConnectorCall(method string, duration time.Duration)
@@ -295,6 +297,11 @@ type Action struct {
 
 var _ State = &state{}
 
+type ActionCount struct {
+	CompletedCount uint64 `json:"completed_count,omitempty"`
+	WarningCount   uint64 `json:"warning_count,omitempty"`
+}
+
 // state is an object used for tracking the current status of a connector sync. It operates like a stack.
 type state struct {
 	mtx                             sync.RWMutex
@@ -308,6 +315,7 @@ type state struct {
 	shouldSkipEntitlementsAndGrants bool
 	shouldSkipGrants                bool
 	completedActionsCount           uint64
+	actionCountsMap                 map[string]ActionCount
 	stepDurationsMs                 map[string]int64
 	connectorCallStats              map[string]*ConnectorCallStat
 	sessionStoreStats               map[string]*SessionStoreStat
@@ -410,6 +418,7 @@ type serializedTokenV1 struct {
 	ShouldSkipEntitlementsAndGrants bool                     `json:"should_skip_entitlements_and_grants,omitempty"`
 	ShouldSkipGrants                bool                     `json:"should_skip_grants,omitempty"`
 	CompletedActionsCount           uint64                   `json:"completed_actions_count,omitempty"`
+	ActionCountsMap                 map[string]ActionCount   `json:"action_counts,omitempty"`
 	// Exclusion-group tracking maps (exclusion_group_resource_types,
 	// exclusion_group_defaults, exclusion_group_counts) were removed
 	// when the streaming exclusion-group validation was replaced by
@@ -435,6 +444,7 @@ func newState() *state {
 		sessionStoreStats:  make(map[string]*SessionStoreStat),
 		spawnedInFlight:    make(map[string]Action),
 		spawnedAdmitted:    make(map[parallelActionKey]string),
+		actionCountsMap:    make(map[string]ActionCount),
 	}
 }
 
@@ -521,6 +531,7 @@ func unmarshalTokenV0(input string) (serializedTokenV1, error) {
 		ShouldSkipEntitlementsAndGrants: tokenV0.ShouldSkipEntitlementsAndGrants,
 		ShouldSkipGrants:                tokenV0.ShouldSkipGrants,
 		CompletedActionsCount:           tokenV0.CompletedActionsCount,
+		ActionCountsMap:                 make(map[string]ActionCount),
 		Version:                         1,
 	}, nil
 }
@@ -574,6 +585,10 @@ func (st *state) Unmarshal(input string) error {
 		st.shouldSkipGrants = token.ShouldSkipGrants
 		st.shouldFetchRelatedResources = token.ShouldFetchRelatedResources
 		st.completedActionsCount = token.CompletedActionsCount
+		st.actionCountsMap = token.ActionCountsMap
+		if st.actionCountsMap == nil {
+			st.actionCountsMap = make(map[string]ActionCount)
+		}
 		st.stepDurationsMs = token.StepDurationsMs
 		if st.stepDurationsMs == nil {
 			st.stepDurationsMs = make(map[string]int64)
@@ -613,6 +628,7 @@ func (st *state) Unmarshal(input string) error {
 		st.actions[actionID] = Action{Op: InitOp, ID: actionID}
 		st.actionOrder = append(st.actionOrder, actionID)
 		st.completedActionsCount = 0
+		st.actionCountsMap = make(map[string]ActionCount)
 		st.stepDurationsMs = make(map[string]int64)
 		st.connectorCallStats = make(map[string]*ConnectorCallStat)
 		st.sessionStoreStats = make(map[string]*SessionStoreStat)
@@ -720,6 +736,7 @@ func (st *state) Marshal() (string, error) {
 		ShouldSkipEntitlementsAndGrants: st.shouldSkipEntitlementsAndGrants,
 		ShouldSkipGrants:                st.shouldSkipGrants,
 		CompletedActionsCount:           st.completedActionsCount,
+		ActionCountsMap:                 st.actionCountsMap,
 		StepDurationsMs:                 st.stepDurationsMs,
 		ConnectorCallStats:              st.connectorCallStats,
 		SessionStoreStats:               st.sessionStoreStats,
@@ -1011,15 +1028,7 @@ func (st *state) transitionAction(
 		return pushed, nil
 	}
 
-	index, ok := slices.BinarySearch(st.actionOrder, parent.ID)
-	if !ok {
-		panic(fmt.Sprintf("action ID %s does not exist in action order", parent.ID))
-	}
-	st.actionOrder = slices.Delete(st.actionOrder, index, index+1)
-	delete(st.actions, parent.ID)
-	delete(st.spawnedInFlight, parent.ID)
-	st.completedActionsCount++
-	ctxzap.Extract(ctx).Debug("finishing action", zap.Any("action", parent))
+	st.finishAction(ctx, parent, false)
 	return pushed, nil
 }
 
@@ -1027,7 +1036,17 @@ func (st *state) transitionAction(
 func (st *state) FinishAction(ctx context.Context, action *Action) {
 	st.mtx.Lock()
 	defer st.mtx.Unlock()
+	st.finishAction(ctx, action, false)
+}
 
+func (st *state) FinishActionWithWarning(ctx context.Context, action *Action) {
+	st.mtx.Lock()
+	defer st.mtx.Unlock()
+	st.finishAction(ctx, action, true)
+}
+
+// finishAction requires st.mtx to be locked before calling it.
+func (st *state) finishAction(ctx context.Context, action *Action, isWarning bool) {
 	if action == nil {
 		panic("action cannot be nil")
 	}
@@ -1044,6 +1063,12 @@ func (st *state) FinishAction(ctx context.Context, action *Action) {
 	delete(st.actions, action.ID)
 	delete(st.spawnedInFlight, action.ID)
 	st.completedActionsCount++
+	actionCount := st.actionCountsMap[action.Op.String()]
+	actionCount.CompletedCount++
+	if isWarning {
+		actionCount.WarningCount++
+	}
+	st.actionCountsMap[action.Op.String()] = actionCount
 	ctxzap.Extract(ctx).Debug("finishing action", zap.Any("action", action))
 }
 
@@ -1162,4 +1187,10 @@ func (st *state) GetCompletedActionsCount() uint64 {
 	st.mtx.RLock()
 	defer st.mtx.RUnlock()
 	return st.completedActionsCount
+}
+
+func (st *state) GetActionCount(op ActionOp) ActionCount {
+	st.mtx.RLock()
+	defer st.mtx.RUnlock()
+	return st.actionCountsMap[op.String()]
 }

--- a/pkg/sync/state_test.go
+++ b/pkg/sync/state_test.go
@@ -121,6 +121,111 @@ func TestSyncerTokenMarshalUnmarshal(t *testing.T) {
 	require.Equal(t, i, -1)
 }
 
+func TestActionCountsIncrementAndCheckpoint(t *testing.T) {
+	ctx := t.Context()
+	st := newState()
+	st.PushAction(ctx, Action{Op: SyncResourcesOp, ResourceTypeID: "user"})
+	parent := st.Current()
+	require.Equal(t, uint64(0), st.GetActionCount(SyncResourcesOp).CompletedCount)
+	require.Equal(t, uint64(0), st.GetCompletedActionsCount())
+
+	_, err := st.transitionAction(ctx, parent, "page-2", nil)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), st.GetActionCount(SyncResourcesOp).CompletedCount, "pagination must not count as completion")
+	require.Equal(t, uint64(0), st.GetCompletedActionsCount())
+
+	parent = st.Current()
+	_, err = st.transitionAction(ctx, parent, "", nil)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), st.GetActionCount(SyncResourcesOp).CompletedCount)
+	require.Equal(t, uint64(1), st.GetCompletedActionsCount())
+
+	st.PushAction(ctx, Action{Op: SyncResourcesOp, ResourceTypeID: "group"})
+	st.FinishAction(ctx, st.Current())
+	require.Equal(t, uint64(2), st.GetActionCount(SyncResourcesOp).CompletedCount)
+	require.Equal(t, uint64(0), st.GetActionCount(SyncResourcesOp).WarningCount)
+	require.Equal(t, uint64(2), st.GetCompletedActionsCount())
+
+	st.PushAction(ctx, Action{Op: SyncGrantsOp, ResourceTypeID: "user"})
+	st.FinishActionWithWarning(ctx, st.Current())
+	require.Equal(t, uint64(2), st.GetActionCount(SyncResourcesOp).CompletedCount)
+	require.Equal(t, uint64(1), st.GetActionCount(SyncGrantsOp).CompletedCount)
+	require.Equal(t, uint64(1), st.GetActionCount(SyncGrantsOp).WarningCount)
+	require.Equal(t, uint64(0), st.GetActionCount(SyncResourcesOp).WarningCount)
+	require.Equal(t, uint64(3), st.GetCompletedActionsCount())
+
+	st.PushAction(ctx, Action{Op: SyncResourcesOp, ResourceTypeID: "role"})
+	st.FinishActionWithWarning(ctx, st.Current())
+	require.Equal(t, uint64(3), st.GetActionCount(SyncResourcesOp).CompletedCount)
+	require.Equal(t, uint64(1), st.GetActionCount(SyncResourcesOp).WarningCount)
+
+	tokenString, err := st.Marshal()
+	require.NoError(t, err)
+	got := newState()
+	require.NoError(t, got.Unmarshal(tokenString))
+	require.Equal(t, uint64(3), got.GetActionCount(SyncResourcesOp).CompletedCount)
+	require.Equal(t, uint64(1), got.GetActionCount(SyncResourcesOp).WarningCount)
+	require.Equal(t, uint64(1), got.GetActionCount(SyncGrantsOp).CompletedCount)
+	require.Equal(t, uint64(1), got.GetActionCount(SyncGrantsOp).WarningCount)
+	require.Equal(t, uint64(4), got.GetCompletedActionsCount())
+
+	tokenV0Bytes, err := json.Marshal(serializedTokenV0{
+		Actions:               []Action{{Op: InitOp}},
+		CompletedActionsCount: 45,
+	})
+	require.NoError(t, err)
+	v0 := newState()
+	require.NoError(t, v0.Unmarshal(string(tokenV0Bytes)))
+	require.Equal(t, uint64(0), v0.GetActionCount(SyncResourcesOp).CompletedCount)
+	require.Equal(t, uint64(0), v0.GetActionCount(SyncResourcesOp).WarningCount)
+	require.Equal(t, uint64(45), v0.GetCompletedActionsCount())
+
+	legacy, err := json.Marshal(serializedTokenV1{Version: StateTokenVersion, CompletedActionsCount: 5})
+	require.NoError(t, err)
+	fresh := newState()
+	require.NoError(t, fresh.Unmarshal(string(legacy)))
+	require.Equal(t, uint64(0), fresh.GetActionCount(SyncResourcesOp).CompletedCount)
+	require.Equal(t, uint64(0), fresh.GetActionCount(SyncResourcesOp).WarningCount)
+	fresh.PushAction(ctx, Action{Op: SyncResourcesOp, ResourceTypeID: "user"})
+	fresh.FinishAction(ctx, fresh.Current())
+	require.Equal(t, uint64(1), fresh.GetActionCount(SyncResourcesOp).CompletedCount)
+	require.Equal(t, uint64(0), fresh.GetActionCount(SyncResourcesOp).WarningCount)
+}
+
+func TestResumedActionWarningCountsTripThreshold(t *testing.T) {
+	tokenBytes, err := json.Marshal(serializedTokenV1{
+		Version:               StateTokenVersion,
+		CompletedActionsCount: 220,
+		ActionCountsMap: map[string]ActionCount{
+			SyncResourcesOp.String(): {CompletedCount: 20, WarningCount: 11},
+			SyncGrantsOp.String():    {CompletedCount: 200, WarningCount: 2},
+		},
+	})
+	require.NoError(t, err)
+
+	st := newState()
+	require.NoError(t, st.Unmarshal(string(tokenBytes)))
+	require.Equal(t, uint64(220), st.GetCompletedActionsCount())
+	require.Equal(t, uint64(2), st.GetActionCount(SyncGrantsOp).WarningCount)
+
+	listResources := st.GetActionCount(SyncResourcesOp)
+	require.True(t, tooManyWarnings(listResources.WarningCount, listResources.CompletedCount, 0.05),
+		"resume must use checkpointed list-resource warnings, not an empty in-memory slice")
+	require.False(t, tooManyWarnings(st.GetActionCount(SyncGrantsOp).WarningCount, st.GetActionCount(SyncGrantsOp).CompletedCount, 0.1),
+		"grant warnings stay on the grant bucket and do not trip the list-resource threshold")
+
+	// ErrTooManyWarnings is preservable, so this token is what the next run
+	// resumes. The ratio alone must not stop that run before this process
+	// finishes more than ten list-resource actions, or every resume exits
+	// with zero progress.
+	require.False(t, tooManyListResourceWarnings(listResources, 0),
+		"a resumed run must not abort before completing a list-resource action")
+	require.False(t, tooManyListResourceWarnings(listResources, 10),
+		"ten completions this run are not enough to re-arm the durable ratio")
+	require.True(t, tooManyListResourceWarnings(listResources, 11),
+		"more than ten completions this run re-arm the durable ratio")
+}
+
 func TestSyncerTokenTimingStatsMarshalUnmarshal(t *testing.T) {
 	st := newState()
 	st.AddStepDuration("list-resources", 1500*time.Millisecond)

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	native_sync "sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
@@ -198,6 +199,11 @@ type syncer struct {
 	resourceTypeTraits                    syncMap[string, []v2.ResourceType_Trait]
 	injectSyncIDAnnotation                bool
 	recordStats                           bool
+	// listResourceActionsCompletedThisRun is process-local: it is not in the
+	// sync token. tooManyListResourceWarnings uses it so a resumed token
+	// whose durable list-resource ratio already trips cannot abort before
+	// this run finishes more than ten list-resource actions.
+	listResourceActionsCompletedThisRun atomic.Uint64
 	// parallelActionTransitioner atomically commits parent pagination and
 	// spawned work to state and the active worker pool.
 	parallelTransitionMu       native_sync.RWMutex
@@ -776,7 +782,11 @@ func (s *syncer) transitionActionState(
 	childActions []Action,
 ) ([]*Action, error) {
 	if st, ok := s.state.(*state); ok {
-		return st.transitionAction(ctx, action, nextPageToken, childActions)
+		pushed, err := st.transitionAction(ctx, action, nextPageToken, childActions)
+		if err == nil && nextPageToken == "" {
+			s.recordListResourceCompletedThisRun(action)
+		}
+		return pushed, err
 	}
 	if nextPageToken != "" {
 		if err := s.state.NextPage(ctx, action.ID, nextPageToken); err != nil {
@@ -788,8 +798,25 @@ func (s *syncer) transitionActionState(
 	}
 	if nextPageToken == "" {
 		s.state.FinishAction(ctx, action)
+		s.recordListResourceCompletedThisRun(action)
 	}
 	return nil, nil
+}
+
+func (s *syncer) finishAction(ctx context.Context, action *Action) {
+	s.state.FinishAction(ctx, action)
+	s.recordListResourceCompletedThisRun(action)
+}
+
+func (s *syncer) finishActionWithWarning(ctx context.Context, action *Action) {
+	s.state.FinishActionWithWarning(ctx, action)
+	s.recordListResourceCompletedThisRun(action)
+}
+
+func (s *syncer) recordListResourceCompletedThisRun(action *Action) {
+	if action != nil && action.Op == SyncResourcesOp {
+		s.listResourceActionsCompletedThisRun.Add(1)
+	}
 }
 
 func isWarning(ctx context.Context, err error) bool {


### PR DESCRIPTION
If > 5% of list resource actions result in a warning (such as 404 not found), exit the sync with an error.