### PR TITLE
Allow custom actions to return encrypted secret values

### DIFF
--- a/docs/verification/encrypted-action-results/evidence.md
+++ b/docs/verification/encrypted-action-results/evidence.md
@@ -1,0 +1,88 @@
+# Encrypted Action Results Evidence
+
+Revision: working tree.
+
+## Current-stage criteria
+
+- C1: verified to stated coverage by generation, Buf lint, Buf breaking, and
+  `TestActionInvokeTaskThreadsEncryptionConfigs`.
+- C2: verified to stated coverage by the existing action and connectorbuilder
+  suites plus secret-registration rejection tests.
+- C3: verified to stated coverage for missing, nil, and unknown-provider
+  recipients; each case asserts the handler was not invoked.
+- C4: verified to stated coverage for public secret fields, undeclared and
+  non-secret names, duplicate names, nil values, empty names, empty bytes, handler
+  errors, and injected encryption failure.
+- C5: verified to stated coverage for two plaintext values with two age recipients,
+  including name, description, schema, decrypted bytes, and the full P × R fan-out.
+- C6: verified to stated coverage by inline and pending-then-status cases. The
+  status test also mutates the caller-owned recipient after invoke and proves
+  settlement uses the captured recipient.
+- C7: verified to stated coverage by focused race tests and secret-handler
+  cancellation followed by late encrypted completion. This is measured execution,
+  not exhaustive schedule coverage.
+- C8: verified to stated coverage by assertions that public responses and RPC
+  messages omit plaintext, including handler-error, encryption-error, and panic
+  paths. Recovered panic values are not logged or returned. Connector-supplied
+  ordinary error strings remain outside this guarantee.
+- C9: verified by inspection. Existing handlers add constant adapter work and no
+  encryption. Secret handlers perform O(P × R) encryption and retain O(P × R)
+  ciphertext.
+
+## Implementation-obligation addendum
+
+- Registration stores an immutable set of secret return names derived from the
+  schema. `Register` rejects schemas with secret return types; only
+  `RegisterWithSecrets` can install their handlers.
+- `InvokeActionWithWaitAndEncryption` clones and validates every recipient before
+  creating an `OutstandingAction` or invoking the handler. The clone prevents
+  caller mutation from changing recipients while detached work runs.
+- The detached handler holds plaintext only in its local `actionHandlerResult`.
+  `prepareActionResult` validates names and public-field exclusion, encrypts the
+  values, and passes only ciphertext to `setOutcomeWithEncryptedData`.
+- The `OutstandingAction` mutex owns status, public response, encrypted data,
+  annotations, errors, and provisional-cancellation replacement. Invoke and status
+  read all five result components under that mutex.
+- `setOutcomeWithEncryptedData` clones the public response, ciphertext messages,
+  and annotations before publication. Error, panic, and encryption-failure paths
+  retain no encrypted or plaintext result.
+- `ActionManager.encryptPlaintext` is initialized to
+  `EncryptionManager.Encrypt`; the package test replaces it before invocation to
+  prove an encryption failure settles as FAILED without publishing plaintext.
+- Existing `InvokeAction`, `InvokeActionWithWait`, `GetActionStatus`, and
+  `ActionHandler` signatures remain. Their adapters use the same registration,
+  lifecycle, and settlement functions as secret handlers.
+- The exported `connectorbuilder.ActionManager` method set remains unchanged.
+  Connector dispatch asserts a private encrypted-result extension implemented by
+  the SDK manager.
+- Global and resource registries install the same `registeredActionHandler` and
+  converge in `invokeRegisteredAction`.
+- Local invocation has additive constructors/options that carry recipients into
+  `ActionInvokeTask`; existing constructors delegate with no recipients.
+
+## Commands
+
+- `make protofmt && make protogen`: passed.
+- `buf lint`: passed.
+- `buf breaking --against '.git#branch=main'`: passed.
+- `go test -count=1 ./pkg/actions ./pkg/connectorbuilder ./pkg/tasks/c1api ./pkg/tasks/local`:
+  passed as focused package runs; the c1api assertion was run as
+  `TestActionInvokeTaskThreadsEncryptionConfigs`.
+- `go test -race -count=1 ./pkg/actions ./pkg/connectorbuilder`: passed.
+- `golangci-lint run --timeout=3m ./pkg/actions/... ./pkg/connectorbuilder/...
+  ./pkg/connectorrunner/... ./pkg/tasks/local/...`: passed with zero issues.
+- `make lint`: the implementation's `nilerr` finding was fixed. The repository-wide
+  run remains red on six pre-existing findings in `pkg/dotc1z`, `pkg/crypto`,
+  `pkg/sync`, and the deprecated action-status name assignment.
+- `go test -tags=baton_lambda_support ./...`: all affected packages passed. The
+  repository-wide run remains red because
+  `pkg/tasks/c1api.TestBootstrapSucceedsOnFirstAttempt` timed out and two
+  `pkg/uhttp` tests could not write their SQLite database in this environment.
+
+## Final audit
+
+The post-CO-001 independent implementation read found no remaining HIGH or MEDIUM
+defects. Its LOW gaps were reduced by adding the compile-time
+`encryptedActionManager` assertion and a ciphertext ownership-clone test. Panic-log
+redaction remains verified by direct code inspection plus an RPC payload test, not
+by a captured-log oracle.

--- a/docs/verification/encrypted-action-results/plan.md
+++ b/docs/verification/encrypted-action-results/plan.md
@@ -1,0 +1,99 @@
+# Encrypted Action Results Verification Plan
+
+Status: frozen implementation-blind baseline.
+
+## Risk
+
+This change is HIGH risk. A plaintext action result can cross an RPC boundary,
+enter task storage, and be logged. Remediation cannot retract a disclosed secret,
+and the public protobuf and Go APIs have consumers outside this repository.
+
+The feature is opt-in. Existing `ActionHandler` registrations and actions without
+secret return values retain their current behavior.
+
+## Contract
+
+- C1 supplies encryption recipients on `ActionInvokeTask`; the task handler copies
+  them to `InvokeActionRequest`.
+- A new handler type returns public result fields separately from
+  `PlaintextData`.
+- A secret handler cannot run unless at least one valid encryption recipient was
+  supplied.
+- Every plaintext result name identifies exactly one `return_types` field marked
+  `is_secret`; duplicate, empty, undeclared, and non-secret names are rejected.
+- A public result struct must not contain a field declared secret.
+- Encryption runs once when the handler settles. `OutstandingAction` retains only
+  ciphertext, never plaintext.
+- A completed inline response and every later status response return the same
+  encrypted values. Pending and running responses contain no encrypted values.
+- One plaintext value and N recipients produce N `EncryptedData` values. Encryption
+  failure settles the action as failed without exposing plaintext.
+- Existing handlers, deprecated action managers, and actions with only public
+  return fields require no encryption configuration and preserve their API behavior.
+- `EncryptedData.name` equals the matching return field name.
+
+## Coverage model
+
+The executable dimensions are:
+
+- handler: existing / secret;
+- scope: global / resource;
+- observation: completed inline / pending then status;
+- recipients: missing / invalid / one / multiple;
+- output: no plaintext / one plaintext / duplicate names / empty name or bytes /
+  undeclared name / name declared non-secret / secret name also present publicly;
+- handler result: success / error / panic / cancellation.
+
+Global and resource registration share the same result adapter and settlement
+function; representative tests may reduce output-validation and encryption-failure
+cells across scope after implementation inspection confirms that path.
+
+## Criteria
+
+- C1: Generated protobufs expose encryption configs on action invocation tasks and
+  requests, and encrypted data on invoke and status responses.
+- C2: Existing handler behavior and source compatibility remain intact.
+- C3: Secret handlers reject missing or invalid recipients before provider work.
+- C4: Secret output validation rejects every invalid output class without returning
+  plaintext.
+- C5: Encryption fan-out preserves metadata and creates one ciphertext per
+  plaintext-recipient pair.
+- C6: Inline completion and status polling expose identical ciphertext.
+- C7: Concurrent status reads cannot race with settlement or observe a partial
+  outcome.
+- C8: Logs and RPC messages contain no plaintext result.
+- C9: Existing actions incur no asymptotic cost change; secret actions add
+  O(P × R) encryption work for P plaintext values and R recipients.
+
+## Instruments
+
+- Proto generation and Buf lint/breaking checks cover C1.
+- Table-driven package tests cover C2-C6 and the output-validation rows.
+- Race detection on `pkg/actions` and `pkg/connectorbuilder` covers C7.
+- Tests assert plaintext absence from public structs and protobuf responses for C8.
+- Code inspection confirms the cost expression and that existing handlers bypass
+  encryption work for C9.
+
+Evidence and criterion status are recorded in `evidence.md`.
+
+## Change orders
+
+### CO-001 — compatibility and local invocation
+
+Source: independent implementation audits.
+
+Classification:
+
+- Correction: keep the exported `connectorbuilder.ActionManager` method set
+  unchanged. Encrypted dispatch is an internal optional interface implemented by
+  the SDK action manager.
+- Correction: redact recovered panic values from logs and action errors because a
+  connector can panic with secret-bearing data.
+- Extension: add local action-invocation constructors and runner options that
+  accept encryption recipients and retain the existing constructors as nil-recipient
+  delegates.
+
+Affected criteria: C2, C7, C8. Verification adds compilation of existing action
+consumers, a panic-redaction test, local task recipient plumbing, and another focused
+race run. The extension does not change the protobuf contract or secret settlement
+path.

--- a/pb/c1/config/v1/config.pb.go
+++ b/pb/c1/config/v1/config.pb.go
@@ -554,7 +554,11 @@ type Field struct {
 	Placeholder string                 `protobuf:"bytes,4,opt,name=placeholder,proto3" json:"placeholder,omitempty"`
 	IsRequired  bool                   `protobuf:"varint,5,opt,name=is_required,json=isRequired,proto3" json:"is_required,omitempty"`
 	IsOps       bool                   `protobuf:"varint,6,opt,name=is_ops,json=isOps,proto3" json:"is_ops,omitempty"`
-	IsSecret    bool                   `protobuf:"varint,7,opt,name=is_secret,json=isSecret,proto3" json:"is_secret,omitempty"`
+	// For configuration and action arguments, the UI obscures this field. For
+	// action return types, the connector must return the value as PlaintextData
+	// through ActionHandlerWithSecrets; it is omitted from the public response
+	// and returned as EncryptedData.
+	IsSecret bool `protobuf:"varint,7,opt,name=is_secret,json=isSecret,proto3" json:"is_secret,omitempty"`
 	// Types that are valid to be assigned to Field:
 	//
 	//	*Field_StringField
@@ -1088,7 +1092,11 @@ type Field_builder struct {
 	Placeholder string
 	IsRequired  bool
 	IsOps       bool
-	IsSecret    bool
+	// For configuration and action arguments, the UI obscures this field. For
+	// action return types, the connector must return the value as PlaintextData
+	// through ActionHandlerWithSecrets; it is omitted from the public response
+	// and returned as EncryptedData.
+	IsSecret bool
 	// Fields of oneof Field:
 	StringField          *StringField
 	IntField             *IntField

--- a/pb/c1/config/v1/config_protoopaque.pb.go
+++ b/pb/c1/config/v1/config_protoopaque.pb.go
@@ -1074,7 +1074,11 @@ type Field_builder struct {
 	Placeholder string
 	IsRequired  bool
 	IsOps       bool
-	IsSecret    bool
+	// For configuration and action arguments, the UI obscures this field. For
+	// action return types, the connector must return the value as PlaintextData
+	// through ActionHandlerWithSecrets; it is omitted from the public response
+	// and returned as EncryptedData.
+	IsSecret bool
 	// Fields of oneof xxx_hidden_Field:
 	StringField          *StringField
 	IntField             *IntField

--- a/pb/c1/connector/v2/action.pb.go
+++ b/pb/c1/connector/v2/action.pb.go
@@ -323,9 +323,11 @@ type InvokeActionRequest struct {
 	// waits and waits beyond the validated ceiling are rejected as caller
 	// bugs where the transport enforces validation rules; the server-side
 	// cap is the backstop everywhere.
-	InlineWait    *durationpb.Duration `protobuf:"bytes,5,opt,name=inline_wait,json=inlineWait,proto3" json:"inline_wait,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	InlineWait *durationpb.Duration `protobuf:"bytes,5,opt,name=inline_wait,json=inlineWait,proto3" json:"inline_wait,omitempty"`
+	// Public keys the connector uses to encrypt secret return values.
+	EncryptionConfigs []*EncryptionConfig `protobuf:"bytes,6,rep,name=encryption_configs,json=encryptionConfigs,proto3" json:"encryption_configs,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *InvokeActionRequest) Reset() {
@@ -388,6 +390,13 @@ func (x *InvokeActionRequest) GetInlineWait() *durationpb.Duration {
 	return nil
 }
 
+func (x *InvokeActionRequest) GetEncryptionConfigs() []*EncryptionConfig {
+	if x != nil {
+		return x.EncryptionConfigs
+	}
+	return nil
+}
+
 func (x *InvokeActionRequest) SetName(v string) {
 	x.Name = v
 }
@@ -406,6 +415,10 @@ func (x *InvokeActionRequest) SetResourceTypeId(v string) {
 
 func (x *InvokeActionRequest) SetInlineWait(v *durationpb.Duration) {
 	x.InlineWait = v
+}
+
+func (x *InvokeActionRequest) SetEncryptionConfigs(v []*EncryptionConfig) {
+	x.EncryptionConfigs = v
 }
 
 func (x *InvokeActionRequest) HasArgs() bool {
@@ -451,6 +464,8 @@ type InvokeActionRequest_builder struct {
 	// bugs where the transport enforces validation rules; the server-side
 	// cap is the backstop everywhere.
 	InlineWait *durationpb.Duration
+	// Public keys the connector uses to encrypt secret return values.
+	EncryptionConfigs []*EncryptionConfig
 }
 
 func (b0 InvokeActionRequest_builder) Build() *InvokeActionRequest {
@@ -462,16 +477,19 @@ func (b0 InvokeActionRequest_builder) Build() *InvokeActionRequest {
 	x.Annotations = b.Annotations
 	x.ResourceTypeId = b.ResourceTypeId
 	x.InlineWait = b.InlineWait
+	x.EncryptionConfigs = b.EncryptionConfigs
 	return m0
 }
 
 type InvokeActionResponse struct {
-	state         protoimpl.MessageState `protogen:"hybrid.v1"`
-	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
-	Status        BatonActionStatus      `protobuf:"varint,2,opt,name=status,proto3,enum=c1.connector.v2.BatonActionStatus" json:"status,omitempty"`
-	Annotations   []*anypb.Any           `protobuf:"bytes,3,rep,name=annotations,proto3" json:"annotations,omitempty"`
-	Response      *structpb.Struct       `protobuf:"bytes,4,opt,name=response,proto3" json:"response,omitempty"`
-	Name          string                 `protobuf:"bytes,5,opt,name=name,proto3" json:"name,omitempty"`
+	state       protoimpl.MessageState `protogen:"hybrid.v1"`
+	Id          string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Status      BatonActionStatus      `protobuf:"varint,2,opt,name=status,proto3,enum=c1.connector.v2.BatonActionStatus" json:"status,omitempty"`
+	Annotations []*anypb.Any           `protobuf:"bytes,3,rep,name=annotations,proto3" json:"annotations,omitempty"`
+	Response    *structpb.Struct       `protobuf:"bytes,4,opt,name=response,proto3" json:"response,omitempty"`
+	Name        string                 `protobuf:"bytes,5,opt,name=name,proto3" json:"name,omitempty"`
+	// Secret return values encrypted for every requested recipient.
+	EncryptedData []*EncryptedData `protobuf:"bytes,6,rep,name=encrypted_data,json=encryptedData,proto3" json:"encrypted_data,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -536,6 +554,13 @@ func (x *InvokeActionResponse) GetName() string {
 	return ""
 }
 
+func (x *InvokeActionResponse) GetEncryptedData() []*EncryptedData {
+	if x != nil {
+		return x.EncryptedData
+	}
+	return nil
+}
+
 func (x *InvokeActionResponse) SetId(v string) {
 	x.Id = v
 }
@@ -554,6 +579,10 @@ func (x *InvokeActionResponse) SetResponse(v *structpb.Struct) {
 
 func (x *InvokeActionResponse) SetName(v string) {
 	x.Name = v
+}
+
+func (x *InvokeActionResponse) SetEncryptedData(v []*EncryptedData) {
+	x.EncryptedData = v
 }
 
 func (x *InvokeActionResponse) HasResponse() bool {
@@ -575,6 +604,8 @@ type InvokeActionResponse_builder struct {
 	Annotations []*anypb.Any
 	Response    *structpb.Struct
 	Name        string
+	// Secret return values encrypted for every requested recipient.
+	EncryptedData []*EncryptedData
 }
 
 func (b0 InvokeActionResponse_builder) Build() *InvokeActionResponse {
@@ -586,6 +617,7 @@ func (b0 InvokeActionResponse_builder) Build() *InvokeActionResponse {
 	x.Annotations = b.Annotations
 	x.Response = b.Response
 	x.Name = b.Name
+	x.EncryptedData = b.EncryptedData
 	return m0
 }
 
@@ -679,12 +711,14 @@ func (b0 GetActionStatusRequest_builder) Build() *GetActionStatusRequest {
 }
 
 type GetActionStatusResponse struct {
-	state         protoimpl.MessageState `protogen:"hybrid.v1"`
-	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	Id            string                 `protobuf:"bytes,2,opt,name=id,proto3" json:"id,omitempty"`
-	Status        BatonActionStatus      `protobuf:"varint,3,opt,name=status,proto3,enum=c1.connector.v2.BatonActionStatus" json:"status,omitempty"`
-	Annotations   []*anypb.Any           `protobuf:"bytes,4,rep,name=annotations,proto3" json:"annotations,omitempty"`
-	Response      *structpb.Struct       `protobuf:"bytes,5,opt,name=response,proto3" json:"response,omitempty"`
+	state       protoimpl.MessageState `protogen:"hybrid.v1"`
+	Name        string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Id          string                 `protobuf:"bytes,2,opt,name=id,proto3" json:"id,omitempty"`
+	Status      BatonActionStatus      `protobuf:"varint,3,opt,name=status,proto3,enum=c1.connector.v2.BatonActionStatus" json:"status,omitempty"`
+	Annotations []*anypb.Any           `protobuf:"bytes,4,rep,name=annotations,proto3" json:"annotations,omitempty"`
+	Response    *structpb.Struct       `protobuf:"bytes,5,opt,name=response,proto3" json:"response,omitempty"`
+	// Secret return values encrypted when the action settled.
+	EncryptedData []*EncryptedData `protobuf:"bytes,6,rep,name=encrypted_data,json=encryptedData,proto3" json:"encrypted_data,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -749,6 +783,13 @@ func (x *GetActionStatusResponse) GetResponse() *structpb.Struct {
 	return nil
 }
 
+func (x *GetActionStatusResponse) GetEncryptedData() []*EncryptedData {
+	if x != nil {
+		return x.EncryptedData
+	}
+	return nil
+}
+
 func (x *GetActionStatusResponse) SetName(v string) {
 	x.Name = v
 }
@@ -767,6 +808,10 @@ func (x *GetActionStatusResponse) SetAnnotations(v []*anypb.Any) {
 
 func (x *GetActionStatusResponse) SetResponse(v *structpb.Struct) {
 	x.Response = v
+}
+
+func (x *GetActionStatusResponse) SetEncryptedData(v []*EncryptedData) {
+	x.EncryptedData = v
 }
 
 func (x *GetActionStatusResponse) HasResponse() bool {
@@ -788,6 +833,8 @@ type GetActionStatusResponse_builder struct {
 	Status      BatonActionStatus
 	Annotations []*anypb.Any
 	Response    *structpb.Struct
+	// Secret return values encrypted when the action settled.
+	EncryptedData []*EncryptedData
 }
 
 func (b0 GetActionStatusResponse_builder) Build() *GetActionStatusResponse {
@@ -799,6 +846,7 @@ func (b0 GetActionStatusResponse_builder) Build() *GetActionStatusResponse {
 	x.Status = b.Status
 	x.Annotations = b.Annotations
 	x.Response = b.Response
+	x.EncryptedData = b.EncryptedData
 	return m0
 }
 
@@ -1103,7 +1151,7 @@ var File_c1_connector_v2_action_proto protoreflect.FileDescriptor
 
 const file_c1_connector_v2_action_proto_rawDesc = "" +
 	"\n" +
-	"\x1cc1/connector/v2/action.proto\x12\x0fc1.connector.v2\x1a\x19c1/config/v1/config.proto\x1a\x19google/protobuf/any.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x17validate/validate.proto\"\xfb\x02\n" +
+	"\x1cc1/connector/v2/action.proto\x12\x0fc1.connector.v2\x1a\x19c1/config/v1/config.proto\x1a\x1ec1/connector/v2/resource.proto\x1a\x19google/protobuf/any.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x17validate/validate.proto\"\xfb\x02\n" +
 	"\x11BatonActionSchema\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x121\n" +
 	"\targuments\x18\x02 \x03(\v2\x13.c1.config.v1.FieldR\targuments\x12:\n" +
@@ -1113,30 +1161,33 @@ const file_c1_connector_v2_action_proto_rawDesc = "" +
 	"\vdescription\x18\x06 \x01(\tR\vdescription\x12<\n" +
 	"\vaction_type\x18\a \x03(\x0e2\x1b.c1.connector.v2.ActionTypeR\n" +
 	"actionType\x12(\n" +
-	"\x10resource_type_id\x18\b \x01(\tR\x0eresourceTypeId\"\x84\x02\n" +
+	"\x10resource_type_id\x18\b \x01(\tR\x0eresourceTypeId\"\xd6\x02\n" +
 	"\x13InvokeActionRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12+\n" +
 	"\x04args\x18\x02 \x01(\v2\x17.google.protobuf.StructR\x04args\x126\n" +
 	"\vannotations\x18\x03 \x03(\v2\x14.google.protobuf.AnyR\vannotations\x12(\n" +
 	"\x10resource_type_id\x18\x04 \x01(\tR\x0eresourceTypeId\x12J\n" +
 	"\vinline_wait\x18\x05 \x01(\v2\x19.google.protobuf.DurationB\x0e\xfaB\v\xaa\x01\b\"\x04\b\x80\xa3\x052\x00R\n" +
-	"inlineWait\"\xe3\x01\n" +
+	"inlineWait\x12P\n" +
+	"\x12encryption_configs\x18\x06 \x03(\v2!.c1.connector.v2.EncryptionConfigR\x11encryptionConfigs\"\xaa\x02\n" +
 	"\x14InvokeActionResponse\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12:\n" +
 	"\x06status\x18\x02 \x01(\x0e2\".c1.connector.v2.BatonActionStatusR\x06status\x126\n" +
 	"\vannotations\x18\x03 \x03(\v2\x14.google.protobuf.AnyR\vannotations\x123\n" +
 	"\bresponse\x18\x04 \x01(\v2\x17.google.protobuf.StructR\bresponse\x12\x12\n" +
-	"\x04name\x18\x05 \x01(\tR\x04name\"x\n" +
+	"\x04name\x18\x05 \x01(\tR\x04name\x12E\n" +
+	"\x0eencrypted_data\x18\x06 \x03(\v2\x1e.c1.connector.v2.EncryptedDataR\rencryptedData\"x\n" +
 	"\x16GetActionStatusRequest\x12\x16\n" +
 	"\x04name\x18\x01 \x01(\tB\x02\x18\x01R\x04name\x12\x0e\n" +
 	"\x02id\x18\x02 \x01(\tR\x02id\x126\n" +
-	"\vannotations\x18\x03 \x03(\v2\x14.google.protobuf.AnyR\vannotations\"\xe6\x01\n" +
+	"\vannotations\x18\x03 \x03(\v2\x14.google.protobuf.AnyR\vannotations\"\xad\x02\n" +
 	"\x17GetActionStatusResponse\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x0e\n" +
 	"\x02id\x18\x02 \x01(\tR\x02id\x12:\n" +
 	"\x06status\x18\x03 \x01(\x0e2\".c1.connector.v2.BatonActionStatusR\x06status\x126\n" +
 	"\vannotations\x18\x04 \x03(\v2\x14.google.protobuf.AnyR\vannotations\x123\n" +
-	"\bresponse\x18\x05 \x01(\v2\x17.google.protobuf.StructR\bresponse\"d\n" +
+	"\bresponse\x18\x05 \x01(\v2\x17.google.protobuf.StructR\bresponse\x12E\n" +
+	"\x0eencrypted_data\x18\x06 \x03(\v2\x1e.c1.connector.v2.EncryptedDataR\rencryptedData\"d\n" +
 	"\x16GetActionSchemaRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x126\n" +
 	"\vannotations\x18\x02 \x03(\v2\x14.google.protobuf.AnyR\vannotations\"\x8d\x01\n" +
@@ -1193,6 +1244,8 @@ var file_c1_connector_v2_action_proto_goTypes = []any{
 	(*structpb.Struct)(nil),           // 13: google.protobuf.Struct
 	(*anypb.Any)(nil),                 // 14: google.protobuf.Any
 	(*durationpb.Duration)(nil),       // 15: google.protobuf.Duration
+	(*EncryptionConfig)(nil),          // 16: c1.connector.v2.EncryptionConfig
+	(*EncryptedData)(nil),             // 17: c1.connector.v2.EncryptedData
 }
 var file_c1_connector_v2_action_proto_depIdxs = []int32{
 	11, // 0: c1.connector.v2.BatonActionSchema.arguments:type_name -> c1.config.v1.Field
@@ -1202,32 +1255,35 @@ var file_c1_connector_v2_action_proto_depIdxs = []int32{
 	13, // 4: c1.connector.v2.InvokeActionRequest.args:type_name -> google.protobuf.Struct
 	14, // 5: c1.connector.v2.InvokeActionRequest.annotations:type_name -> google.protobuf.Any
 	15, // 6: c1.connector.v2.InvokeActionRequest.inline_wait:type_name -> google.protobuf.Duration
-	0,  // 7: c1.connector.v2.InvokeActionResponse.status:type_name -> c1.connector.v2.BatonActionStatus
-	14, // 8: c1.connector.v2.InvokeActionResponse.annotations:type_name -> google.protobuf.Any
-	13, // 9: c1.connector.v2.InvokeActionResponse.response:type_name -> google.protobuf.Struct
-	14, // 10: c1.connector.v2.GetActionStatusRequest.annotations:type_name -> google.protobuf.Any
-	0,  // 11: c1.connector.v2.GetActionStatusResponse.status:type_name -> c1.connector.v2.BatonActionStatus
-	14, // 12: c1.connector.v2.GetActionStatusResponse.annotations:type_name -> google.protobuf.Any
-	13, // 13: c1.connector.v2.GetActionStatusResponse.response:type_name -> google.protobuf.Struct
-	14, // 14: c1.connector.v2.GetActionSchemaRequest.annotations:type_name -> google.protobuf.Any
-	2,  // 15: c1.connector.v2.GetActionSchemaResponse.schema:type_name -> c1.connector.v2.BatonActionSchema
-	14, // 16: c1.connector.v2.GetActionSchemaResponse.annotations:type_name -> google.protobuf.Any
-	14, // 17: c1.connector.v2.ListActionSchemasRequest.annotations:type_name -> google.protobuf.Any
-	2,  // 18: c1.connector.v2.ListActionSchemasResponse.schemas:type_name -> c1.connector.v2.BatonActionSchema
-	14, // 19: c1.connector.v2.ListActionSchemasResponse.annotations:type_name -> google.protobuf.Any
-	3,  // 20: c1.connector.v2.ActionService.InvokeAction:input_type -> c1.connector.v2.InvokeActionRequest
-	5,  // 21: c1.connector.v2.ActionService.GetActionStatus:input_type -> c1.connector.v2.GetActionStatusRequest
-	7,  // 22: c1.connector.v2.ActionService.GetActionSchema:input_type -> c1.connector.v2.GetActionSchemaRequest
-	9,  // 23: c1.connector.v2.ActionService.ListActionSchemas:input_type -> c1.connector.v2.ListActionSchemasRequest
-	4,  // 24: c1.connector.v2.ActionService.InvokeAction:output_type -> c1.connector.v2.InvokeActionResponse
-	6,  // 25: c1.connector.v2.ActionService.GetActionStatus:output_type -> c1.connector.v2.GetActionStatusResponse
-	8,  // 26: c1.connector.v2.ActionService.GetActionSchema:output_type -> c1.connector.v2.GetActionSchemaResponse
-	10, // 27: c1.connector.v2.ActionService.ListActionSchemas:output_type -> c1.connector.v2.ListActionSchemasResponse
-	24, // [24:28] is the sub-list for method output_type
-	20, // [20:24] is the sub-list for method input_type
-	20, // [20:20] is the sub-list for extension type_name
-	20, // [20:20] is the sub-list for extension extendee
-	0,  // [0:20] is the sub-list for field type_name
+	16, // 7: c1.connector.v2.InvokeActionRequest.encryption_configs:type_name -> c1.connector.v2.EncryptionConfig
+	0,  // 8: c1.connector.v2.InvokeActionResponse.status:type_name -> c1.connector.v2.BatonActionStatus
+	14, // 9: c1.connector.v2.InvokeActionResponse.annotations:type_name -> google.protobuf.Any
+	13, // 10: c1.connector.v2.InvokeActionResponse.response:type_name -> google.protobuf.Struct
+	17, // 11: c1.connector.v2.InvokeActionResponse.encrypted_data:type_name -> c1.connector.v2.EncryptedData
+	14, // 12: c1.connector.v2.GetActionStatusRequest.annotations:type_name -> google.protobuf.Any
+	0,  // 13: c1.connector.v2.GetActionStatusResponse.status:type_name -> c1.connector.v2.BatonActionStatus
+	14, // 14: c1.connector.v2.GetActionStatusResponse.annotations:type_name -> google.protobuf.Any
+	13, // 15: c1.connector.v2.GetActionStatusResponse.response:type_name -> google.protobuf.Struct
+	17, // 16: c1.connector.v2.GetActionStatusResponse.encrypted_data:type_name -> c1.connector.v2.EncryptedData
+	14, // 17: c1.connector.v2.GetActionSchemaRequest.annotations:type_name -> google.protobuf.Any
+	2,  // 18: c1.connector.v2.GetActionSchemaResponse.schema:type_name -> c1.connector.v2.BatonActionSchema
+	14, // 19: c1.connector.v2.GetActionSchemaResponse.annotations:type_name -> google.protobuf.Any
+	14, // 20: c1.connector.v2.ListActionSchemasRequest.annotations:type_name -> google.protobuf.Any
+	2,  // 21: c1.connector.v2.ListActionSchemasResponse.schemas:type_name -> c1.connector.v2.BatonActionSchema
+	14, // 22: c1.connector.v2.ListActionSchemasResponse.annotations:type_name -> google.protobuf.Any
+	3,  // 23: c1.connector.v2.ActionService.InvokeAction:input_type -> c1.connector.v2.InvokeActionRequest
+	5,  // 24: c1.connector.v2.ActionService.GetActionStatus:input_type -> c1.connector.v2.GetActionStatusRequest
+	7,  // 25: c1.connector.v2.ActionService.GetActionSchema:input_type -> c1.connector.v2.GetActionSchemaRequest
+	9,  // 26: c1.connector.v2.ActionService.ListActionSchemas:input_type -> c1.connector.v2.ListActionSchemasRequest
+	4,  // 27: c1.connector.v2.ActionService.InvokeAction:output_type -> c1.connector.v2.InvokeActionResponse
+	6,  // 28: c1.connector.v2.ActionService.GetActionStatus:output_type -> c1.connector.v2.GetActionStatusResponse
+	8,  // 29: c1.connector.v2.ActionService.GetActionSchema:output_type -> c1.connector.v2.GetActionSchemaResponse
+	10, // 30: c1.connector.v2.ActionService.ListActionSchemas:output_type -> c1.connector.v2.ListActionSchemasResponse
+	27, // [27:31] is the sub-list for method output_type
+	23, // [23:27] is the sub-list for method input_type
+	23, // [23:23] is the sub-list for extension type_name
+	23, // [23:23] is the sub-list for extension extendee
+	0,  // [0:23] is the sub-list for field type_name
 }
 
 func init() { file_c1_connector_v2_action_proto_init() }
@@ -1235,6 +1291,7 @@ func file_c1_connector_v2_action_proto_init() {
 	if File_c1_connector_v2_action_proto != nil {
 		return
 	}
+	file_c1_connector_v2_resource_proto_init()
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{

--- a/pb/c1/connector/v2/action.pb.validate.go
+++ b/pb/c1/connector/v2/action.pb.validate.go
@@ -367,6 +367,40 @@ func (m *InvokeActionRequest) validate(all bool) error {
 		}
 	}
 
+	for idx, item := range m.GetEncryptionConfigs() {
+		_, _ = idx, item
+
+		if all {
+			switch v := interface{}(item).(type) {
+			case interface{ ValidateAll() error }:
+				if err := v.ValidateAll(); err != nil {
+					errors = append(errors, InvokeActionRequestValidationError{
+						field:  fmt.Sprintf("EncryptionConfigs[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			case interface{ Validate() error }:
+				if err := v.Validate(); err != nil {
+					errors = append(errors, InvokeActionRequestValidationError{
+						field:  fmt.Sprintf("EncryptionConfigs[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			}
+		} else if v, ok := interface{}(item).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return InvokeActionRequestValidationError{
+					field:  fmt.Sprintf("EncryptionConfigs[%v]", idx),
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
+	}
+
 	if len(errors) > 0 {
 		return InvokeActionRequestMultiError(errors)
 	}
@@ -537,6 +571,40 @@ func (m *InvokeActionResponse) validate(all bool) error {
 	}
 
 	// no validation rules for Name
+
+	for idx, item := range m.GetEncryptedData() {
+		_, _ = idx, item
+
+		if all {
+			switch v := interface{}(item).(type) {
+			case interface{ ValidateAll() error }:
+				if err := v.ValidateAll(); err != nil {
+					errors = append(errors, InvokeActionResponseValidationError{
+						field:  fmt.Sprintf("EncryptedData[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			case interface{ Validate() error }:
+				if err := v.Validate(); err != nil {
+					errors = append(errors, InvokeActionResponseValidationError{
+						field:  fmt.Sprintf("EncryptedData[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			}
+		} else if v, ok := interface{}(item).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return InvokeActionResponseValidationError{
+					field:  fmt.Sprintf("EncryptedData[%v]", idx),
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
+	}
 
 	if len(errors) > 0 {
 		return InvokeActionResponseMultiError(errors)
@@ -847,6 +915,40 @@ func (m *GetActionStatusResponse) validate(all bool) error {
 				cause:  err,
 			}
 		}
+	}
+
+	for idx, item := range m.GetEncryptedData() {
+		_, _ = idx, item
+
+		if all {
+			switch v := interface{}(item).(type) {
+			case interface{ ValidateAll() error }:
+				if err := v.ValidateAll(); err != nil {
+					errors = append(errors, GetActionStatusResponseValidationError{
+						field:  fmt.Sprintf("EncryptedData[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			case interface{ Validate() error }:
+				if err := v.Validate(); err != nil {
+					errors = append(errors, GetActionStatusResponseValidationError{
+						field:  fmt.Sprintf("EncryptedData[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			}
+		} else if v, ok := interface{}(item).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return GetActionStatusResponseValidationError{
+					field:  fmt.Sprintf("EncryptedData[%v]", idx),
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
 	}
 
 	if len(errors) > 0 {

--- a/pb/c1/connector/v2/action_protoopaque.pb.go
+++ b/pb/c1/connector/v2/action_protoopaque.pb.go
@@ -310,14 +310,15 @@ func (b0 BatonActionSchema_builder) Build() *BatonActionSchema {
 }
 
 type InvokeActionRequest struct {
-	state                     protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_Name           string                 `protobuf:"bytes,1,opt,name=name,proto3"`
-	xxx_hidden_Args           *structpb.Struct       `protobuf:"bytes,2,opt,name=args,proto3"`
-	xxx_hidden_Annotations    *[]*anypb.Any          `protobuf:"bytes,3,rep,name=annotations,proto3"`
-	xxx_hidden_ResourceTypeId string                 `protobuf:"bytes,4,opt,name=resource_type_id,json=resourceTypeId,proto3"`
-	xxx_hidden_InlineWait     *durationpb.Duration   `protobuf:"bytes,5,opt,name=inline_wait,json=inlineWait,proto3"`
-	unknownFields             protoimpl.UnknownFields
-	sizeCache                 protoimpl.SizeCache
+	state                        protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Name              string                 `protobuf:"bytes,1,opt,name=name,proto3"`
+	xxx_hidden_Args              *structpb.Struct       `protobuf:"bytes,2,opt,name=args,proto3"`
+	xxx_hidden_Annotations       *[]*anypb.Any          `protobuf:"bytes,3,rep,name=annotations,proto3"`
+	xxx_hidden_ResourceTypeId    string                 `protobuf:"bytes,4,opt,name=resource_type_id,json=resourceTypeId,proto3"`
+	xxx_hidden_InlineWait        *durationpb.Duration   `protobuf:"bytes,5,opt,name=inline_wait,json=inlineWait,proto3"`
+	xxx_hidden_EncryptionConfigs *[]*EncryptionConfig   `protobuf:"bytes,6,rep,name=encryption_configs,json=encryptionConfigs,proto3"`
+	unknownFields                protoimpl.UnknownFields
+	sizeCache                    protoimpl.SizeCache
 }
 
 func (x *InvokeActionRequest) Reset() {
@@ -382,6 +383,15 @@ func (x *InvokeActionRequest) GetInlineWait() *durationpb.Duration {
 	return nil
 }
 
+func (x *InvokeActionRequest) GetEncryptionConfigs() []*EncryptionConfig {
+	if x != nil {
+		if x.xxx_hidden_EncryptionConfigs != nil {
+			return *x.xxx_hidden_EncryptionConfigs
+		}
+	}
+	return nil
+}
+
 func (x *InvokeActionRequest) SetName(v string) {
 	x.xxx_hidden_Name = v
 }
@@ -400,6 +410,10 @@ func (x *InvokeActionRequest) SetResourceTypeId(v string) {
 
 func (x *InvokeActionRequest) SetInlineWait(v *durationpb.Duration) {
 	x.xxx_hidden_InlineWait = v
+}
+
+func (x *InvokeActionRequest) SetEncryptionConfigs(v []*EncryptionConfig) {
+	x.xxx_hidden_EncryptionConfigs = &v
 }
 
 func (x *InvokeActionRequest) HasArgs() bool {
@@ -445,6 +459,8 @@ type InvokeActionRequest_builder struct {
 	// bugs where the transport enforces validation rules; the server-side
 	// cap is the backstop everywhere.
 	InlineWait *durationpb.Duration
+	// Public keys the connector uses to encrypt secret return values.
+	EncryptionConfigs []*EncryptionConfig
 }
 
 func (b0 InvokeActionRequest_builder) Build() *InvokeActionRequest {
@@ -456,18 +472,20 @@ func (b0 InvokeActionRequest_builder) Build() *InvokeActionRequest {
 	x.xxx_hidden_Annotations = &b.Annotations
 	x.xxx_hidden_ResourceTypeId = b.ResourceTypeId
 	x.xxx_hidden_InlineWait = b.InlineWait
+	x.xxx_hidden_EncryptionConfigs = &b.EncryptionConfigs
 	return m0
 }
 
 type InvokeActionResponse struct {
-	state                  protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_Id          string                 `protobuf:"bytes,1,opt,name=id,proto3"`
-	xxx_hidden_Status      BatonActionStatus      `protobuf:"varint,2,opt,name=status,proto3,enum=c1.connector.v2.BatonActionStatus"`
-	xxx_hidden_Annotations *[]*anypb.Any          `protobuf:"bytes,3,rep,name=annotations,proto3"`
-	xxx_hidden_Response    *structpb.Struct       `protobuf:"bytes,4,opt,name=response,proto3"`
-	xxx_hidden_Name        string                 `protobuf:"bytes,5,opt,name=name,proto3"`
-	unknownFields          protoimpl.UnknownFields
-	sizeCache              protoimpl.SizeCache
+	state                    protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Id            string                 `protobuf:"bytes,1,opt,name=id,proto3"`
+	xxx_hidden_Status        BatonActionStatus      `protobuf:"varint,2,opt,name=status,proto3,enum=c1.connector.v2.BatonActionStatus"`
+	xxx_hidden_Annotations   *[]*anypb.Any          `protobuf:"bytes,3,rep,name=annotations,proto3"`
+	xxx_hidden_Response      *structpb.Struct       `protobuf:"bytes,4,opt,name=response,proto3"`
+	xxx_hidden_Name          string                 `protobuf:"bytes,5,opt,name=name,proto3"`
+	xxx_hidden_EncryptedData *[]*EncryptedData      `protobuf:"bytes,6,rep,name=encrypted_data,json=encryptedData,proto3"`
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
 }
 
 func (x *InvokeActionResponse) Reset() {
@@ -532,6 +550,15 @@ func (x *InvokeActionResponse) GetName() string {
 	return ""
 }
 
+func (x *InvokeActionResponse) GetEncryptedData() []*EncryptedData {
+	if x != nil {
+		if x.xxx_hidden_EncryptedData != nil {
+			return *x.xxx_hidden_EncryptedData
+		}
+	}
+	return nil
+}
+
 func (x *InvokeActionResponse) SetId(v string) {
 	x.xxx_hidden_Id = v
 }
@@ -550,6 +577,10 @@ func (x *InvokeActionResponse) SetResponse(v *structpb.Struct) {
 
 func (x *InvokeActionResponse) SetName(v string) {
 	x.xxx_hidden_Name = v
+}
+
+func (x *InvokeActionResponse) SetEncryptedData(v []*EncryptedData) {
+	x.xxx_hidden_EncryptedData = &v
 }
 
 func (x *InvokeActionResponse) HasResponse() bool {
@@ -571,6 +602,8 @@ type InvokeActionResponse_builder struct {
 	Annotations []*anypb.Any
 	Response    *structpb.Struct
 	Name        string
+	// Secret return values encrypted for every requested recipient.
+	EncryptedData []*EncryptedData
 }
 
 func (b0 InvokeActionResponse_builder) Build() *InvokeActionResponse {
@@ -582,6 +615,7 @@ func (b0 InvokeActionResponse_builder) Build() *InvokeActionResponse {
 	x.xxx_hidden_Annotations = &b.Annotations
 	x.xxx_hidden_Response = b.Response
 	x.xxx_hidden_Name = b.Name
+	x.xxx_hidden_EncryptedData = &b.EncryptedData
 	return m0
 }
 
@@ -676,14 +710,15 @@ func (b0 GetActionStatusRequest_builder) Build() *GetActionStatusRequest {
 }
 
 type GetActionStatusResponse struct {
-	state                  protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_Name        string                 `protobuf:"bytes,1,opt,name=name,proto3"`
-	xxx_hidden_Id          string                 `protobuf:"bytes,2,opt,name=id,proto3"`
-	xxx_hidden_Status      BatonActionStatus      `protobuf:"varint,3,opt,name=status,proto3,enum=c1.connector.v2.BatonActionStatus"`
-	xxx_hidden_Annotations *[]*anypb.Any          `protobuf:"bytes,4,rep,name=annotations,proto3"`
-	xxx_hidden_Response    *structpb.Struct       `protobuf:"bytes,5,opt,name=response,proto3"`
-	unknownFields          protoimpl.UnknownFields
-	sizeCache              protoimpl.SizeCache
+	state                    protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Name          string                 `protobuf:"bytes,1,opt,name=name,proto3"`
+	xxx_hidden_Id            string                 `protobuf:"bytes,2,opt,name=id,proto3"`
+	xxx_hidden_Status        BatonActionStatus      `protobuf:"varint,3,opt,name=status,proto3,enum=c1.connector.v2.BatonActionStatus"`
+	xxx_hidden_Annotations   *[]*anypb.Any          `protobuf:"bytes,4,rep,name=annotations,proto3"`
+	xxx_hidden_Response      *structpb.Struct       `protobuf:"bytes,5,opt,name=response,proto3"`
+	xxx_hidden_EncryptedData *[]*EncryptedData      `protobuf:"bytes,6,rep,name=encrypted_data,json=encryptedData,proto3"`
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
 }
 
 func (x *GetActionStatusResponse) Reset() {
@@ -748,6 +783,15 @@ func (x *GetActionStatusResponse) GetResponse() *structpb.Struct {
 	return nil
 }
 
+func (x *GetActionStatusResponse) GetEncryptedData() []*EncryptedData {
+	if x != nil {
+		if x.xxx_hidden_EncryptedData != nil {
+			return *x.xxx_hidden_EncryptedData
+		}
+	}
+	return nil
+}
+
 func (x *GetActionStatusResponse) SetName(v string) {
 	x.xxx_hidden_Name = v
 }
@@ -766,6 +810,10 @@ func (x *GetActionStatusResponse) SetAnnotations(v []*anypb.Any) {
 
 func (x *GetActionStatusResponse) SetResponse(v *structpb.Struct) {
 	x.xxx_hidden_Response = v
+}
+
+func (x *GetActionStatusResponse) SetEncryptedData(v []*EncryptedData) {
+	x.xxx_hidden_EncryptedData = &v
 }
 
 func (x *GetActionStatusResponse) HasResponse() bool {
@@ -787,6 +835,8 @@ type GetActionStatusResponse_builder struct {
 	Status      BatonActionStatus
 	Annotations []*anypb.Any
 	Response    *structpb.Struct
+	// Secret return values encrypted when the action settled.
+	EncryptedData []*EncryptedData
 }
 
 func (b0 GetActionStatusResponse_builder) Build() *GetActionStatusResponse {
@@ -798,6 +848,7 @@ func (b0 GetActionStatusResponse_builder) Build() *GetActionStatusResponse {
 	x.xxx_hidden_Status = b.Status
 	x.xxx_hidden_Annotations = &b.Annotations
 	x.xxx_hidden_Response = b.Response
+	x.xxx_hidden_EncryptedData = &b.EncryptedData
 	return m0
 }
 
@@ -1111,7 +1162,7 @@ var File_c1_connector_v2_action_proto protoreflect.FileDescriptor
 
 const file_c1_connector_v2_action_proto_rawDesc = "" +
 	"\n" +
-	"\x1cc1/connector/v2/action.proto\x12\x0fc1.connector.v2\x1a\x19c1/config/v1/config.proto\x1a\x19google/protobuf/any.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x17validate/validate.proto\"\xfb\x02\n" +
+	"\x1cc1/connector/v2/action.proto\x12\x0fc1.connector.v2\x1a\x19c1/config/v1/config.proto\x1a\x1ec1/connector/v2/resource.proto\x1a\x19google/protobuf/any.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x17validate/validate.proto\"\xfb\x02\n" +
 	"\x11BatonActionSchema\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x121\n" +
 	"\targuments\x18\x02 \x03(\v2\x13.c1.config.v1.FieldR\targuments\x12:\n" +
@@ -1121,30 +1172,33 @@ const file_c1_connector_v2_action_proto_rawDesc = "" +
 	"\vdescription\x18\x06 \x01(\tR\vdescription\x12<\n" +
 	"\vaction_type\x18\a \x03(\x0e2\x1b.c1.connector.v2.ActionTypeR\n" +
 	"actionType\x12(\n" +
-	"\x10resource_type_id\x18\b \x01(\tR\x0eresourceTypeId\"\x84\x02\n" +
+	"\x10resource_type_id\x18\b \x01(\tR\x0eresourceTypeId\"\xd6\x02\n" +
 	"\x13InvokeActionRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12+\n" +
 	"\x04args\x18\x02 \x01(\v2\x17.google.protobuf.StructR\x04args\x126\n" +
 	"\vannotations\x18\x03 \x03(\v2\x14.google.protobuf.AnyR\vannotations\x12(\n" +
 	"\x10resource_type_id\x18\x04 \x01(\tR\x0eresourceTypeId\x12J\n" +
 	"\vinline_wait\x18\x05 \x01(\v2\x19.google.protobuf.DurationB\x0e\xfaB\v\xaa\x01\b\"\x04\b\x80\xa3\x052\x00R\n" +
-	"inlineWait\"\xe3\x01\n" +
+	"inlineWait\x12P\n" +
+	"\x12encryption_configs\x18\x06 \x03(\v2!.c1.connector.v2.EncryptionConfigR\x11encryptionConfigs\"\xaa\x02\n" +
 	"\x14InvokeActionResponse\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12:\n" +
 	"\x06status\x18\x02 \x01(\x0e2\".c1.connector.v2.BatonActionStatusR\x06status\x126\n" +
 	"\vannotations\x18\x03 \x03(\v2\x14.google.protobuf.AnyR\vannotations\x123\n" +
 	"\bresponse\x18\x04 \x01(\v2\x17.google.protobuf.StructR\bresponse\x12\x12\n" +
-	"\x04name\x18\x05 \x01(\tR\x04name\"x\n" +
+	"\x04name\x18\x05 \x01(\tR\x04name\x12E\n" +
+	"\x0eencrypted_data\x18\x06 \x03(\v2\x1e.c1.connector.v2.EncryptedDataR\rencryptedData\"x\n" +
 	"\x16GetActionStatusRequest\x12\x16\n" +
 	"\x04name\x18\x01 \x01(\tB\x02\x18\x01R\x04name\x12\x0e\n" +
 	"\x02id\x18\x02 \x01(\tR\x02id\x126\n" +
-	"\vannotations\x18\x03 \x03(\v2\x14.google.protobuf.AnyR\vannotations\"\xe6\x01\n" +
+	"\vannotations\x18\x03 \x03(\v2\x14.google.protobuf.AnyR\vannotations\"\xad\x02\n" +
 	"\x17GetActionStatusResponse\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x0e\n" +
 	"\x02id\x18\x02 \x01(\tR\x02id\x12:\n" +
 	"\x06status\x18\x03 \x01(\x0e2\".c1.connector.v2.BatonActionStatusR\x06status\x126\n" +
 	"\vannotations\x18\x04 \x03(\v2\x14.google.protobuf.AnyR\vannotations\x123\n" +
-	"\bresponse\x18\x05 \x01(\v2\x17.google.protobuf.StructR\bresponse\"d\n" +
+	"\bresponse\x18\x05 \x01(\v2\x17.google.protobuf.StructR\bresponse\x12E\n" +
+	"\x0eencrypted_data\x18\x06 \x03(\v2\x1e.c1.connector.v2.EncryptedDataR\rencryptedData\"d\n" +
 	"\x16GetActionSchemaRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x126\n" +
 	"\vannotations\x18\x02 \x03(\v2\x14.google.protobuf.AnyR\vannotations\"\x8d\x01\n" +
@@ -1201,6 +1255,8 @@ var file_c1_connector_v2_action_proto_goTypes = []any{
 	(*structpb.Struct)(nil),           // 13: google.protobuf.Struct
 	(*anypb.Any)(nil),                 // 14: google.protobuf.Any
 	(*durationpb.Duration)(nil),       // 15: google.protobuf.Duration
+	(*EncryptionConfig)(nil),          // 16: c1.connector.v2.EncryptionConfig
+	(*EncryptedData)(nil),             // 17: c1.connector.v2.EncryptedData
 }
 var file_c1_connector_v2_action_proto_depIdxs = []int32{
 	11, // 0: c1.connector.v2.BatonActionSchema.arguments:type_name -> c1.config.v1.Field
@@ -1210,32 +1266,35 @@ var file_c1_connector_v2_action_proto_depIdxs = []int32{
 	13, // 4: c1.connector.v2.InvokeActionRequest.args:type_name -> google.protobuf.Struct
 	14, // 5: c1.connector.v2.InvokeActionRequest.annotations:type_name -> google.protobuf.Any
 	15, // 6: c1.connector.v2.InvokeActionRequest.inline_wait:type_name -> google.protobuf.Duration
-	0,  // 7: c1.connector.v2.InvokeActionResponse.status:type_name -> c1.connector.v2.BatonActionStatus
-	14, // 8: c1.connector.v2.InvokeActionResponse.annotations:type_name -> google.protobuf.Any
-	13, // 9: c1.connector.v2.InvokeActionResponse.response:type_name -> google.protobuf.Struct
-	14, // 10: c1.connector.v2.GetActionStatusRequest.annotations:type_name -> google.protobuf.Any
-	0,  // 11: c1.connector.v2.GetActionStatusResponse.status:type_name -> c1.connector.v2.BatonActionStatus
-	14, // 12: c1.connector.v2.GetActionStatusResponse.annotations:type_name -> google.protobuf.Any
-	13, // 13: c1.connector.v2.GetActionStatusResponse.response:type_name -> google.protobuf.Struct
-	14, // 14: c1.connector.v2.GetActionSchemaRequest.annotations:type_name -> google.protobuf.Any
-	2,  // 15: c1.connector.v2.GetActionSchemaResponse.schema:type_name -> c1.connector.v2.BatonActionSchema
-	14, // 16: c1.connector.v2.GetActionSchemaResponse.annotations:type_name -> google.protobuf.Any
-	14, // 17: c1.connector.v2.ListActionSchemasRequest.annotations:type_name -> google.protobuf.Any
-	2,  // 18: c1.connector.v2.ListActionSchemasResponse.schemas:type_name -> c1.connector.v2.BatonActionSchema
-	14, // 19: c1.connector.v2.ListActionSchemasResponse.annotations:type_name -> google.protobuf.Any
-	3,  // 20: c1.connector.v2.ActionService.InvokeAction:input_type -> c1.connector.v2.InvokeActionRequest
-	5,  // 21: c1.connector.v2.ActionService.GetActionStatus:input_type -> c1.connector.v2.GetActionStatusRequest
-	7,  // 22: c1.connector.v2.ActionService.GetActionSchema:input_type -> c1.connector.v2.GetActionSchemaRequest
-	9,  // 23: c1.connector.v2.ActionService.ListActionSchemas:input_type -> c1.connector.v2.ListActionSchemasRequest
-	4,  // 24: c1.connector.v2.ActionService.InvokeAction:output_type -> c1.connector.v2.InvokeActionResponse
-	6,  // 25: c1.connector.v2.ActionService.GetActionStatus:output_type -> c1.connector.v2.GetActionStatusResponse
-	8,  // 26: c1.connector.v2.ActionService.GetActionSchema:output_type -> c1.connector.v2.GetActionSchemaResponse
-	10, // 27: c1.connector.v2.ActionService.ListActionSchemas:output_type -> c1.connector.v2.ListActionSchemasResponse
-	24, // [24:28] is the sub-list for method output_type
-	20, // [20:24] is the sub-list for method input_type
-	20, // [20:20] is the sub-list for extension type_name
-	20, // [20:20] is the sub-list for extension extendee
-	0,  // [0:20] is the sub-list for field type_name
+	16, // 7: c1.connector.v2.InvokeActionRequest.encryption_configs:type_name -> c1.connector.v2.EncryptionConfig
+	0,  // 8: c1.connector.v2.InvokeActionResponse.status:type_name -> c1.connector.v2.BatonActionStatus
+	14, // 9: c1.connector.v2.InvokeActionResponse.annotations:type_name -> google.protobuf.Any
+	13, // 10: c1.connector.v2.InvokeActionResponse.response:type_name -> google.protobuf.Struct
+	17, // 11: c1.connector.v2.InvokeActionResponse.encrypted_data:type_name -> c1.connector.v2.EncryptedData
+	14, // 12: c1.connector.v2.GetActionStatusRequest.annotations:type_name -> google.protobuf.Any
+	0,  // 13: c1.connector.v2.GetActionStatusResponse.status:type_name -> c1.connector.v2.BatonActionStatus
+	14, // 14: c1.connector.v2.GetActionStatusResponse.annotations:type_name -> google.protobuf.Any
+	13, // 15: c1.connector.v2.GetActionStatusResponse.response:type_name -> google.protobuf.Struct
+	17, // 16: c1.connector.v2.GetActionStatusResponse.encrypted_data:type_name -> c1.connector.v2.EncryptedData
+	14, // 17: c1.connector.v2.GetActionSchemaRequest.annotations:type_name -> google.protobuf.Any
+	2,  // 18: c1.connector.v2.GetActionSchemaResponse.schema:type_name -> c1.connector.v2.BatonActionSchema
+	14, // 19: c1.connector.v2.GetActionSchemaResponse.annotations:type_name -> google.protobuf.Any
+	14, // 20: c1.connector.v2.ListActionSchemasRequest.annotations:type_name -> google.protobuf.Any
+	2,  // 21: c1.connector.v2.ListActionSchemasResponse.schemas:type_name -> c1.connector.v2.BatonActionSchema
+	14, // 22: c1.connector.v2.ListActionSchemasResponse.annotations:type_name -> google.protobuf.Any
+	3,  // 23: c1.connector.v2.ActionService.InvokeAction:input_type -> c1.connector.v2.InvokeActionRequest
+	5,  // 24: c1.connector.v2.ActionService.GetActionStatus:input_type -> c1.connector.v2.GetActionStatusRequest
+	7,  // 25: c1.connector.v2.ActionService.GetActionSchema:input_type -> c1.connector.v2.GetActionSchemaRequest
+	9,  // 26: c1.connector.v2.ActionService.ListActionSchemas:input_type -> c1.connector.v2.ListActionSchemasRequest
+	4,  // 27: c1.connector.v2.ActionService.InvokeAction:output_type -> c1.connector.v2.InvokeActionResponse
+	6,  // 28: c1.connector.v2.ActionService.GetActionStatus:output_type -> c1.connector.v2.GetActionStatusResponse
+	8,  // 29: c1.connector.v2.ActionService.GetActionSchema:output_type -> c1.connector.v2.GetActionSchemaResponse
+	10, // 30: c1.connector.v2.ActionService.ListActionSchemas:output_type -> c1.connector.v2.ListActionSchemasResponse
+	27, // [27:31] is the sub-list for method output_type
+	23, // [23:27] is the sub-list for method input_type
+	23, // [23:23] is the sub-list for extension type_name
+	23, // [23:23] is the sub-list for extension extendee
+	0,  // [0:23] is the sub-list for field type_name
 }
 
 func init() { file_c1_connector_v2_action_proto_init() }
@@ -1243,6 +1302,7 @@ func file_c1_connector_v2_action_proto_init() {
 	if File_c1_connector_v2_action_proto != nil {
 		return
 	}
+	file_c1_connector_v2_resource_proto_init()
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{

--- a/pb/c1/connectorapi/baton/v1/baton.pb.go
+++ b/pb/c1/connectorapi/baton/v1/baton.pb.go
@@ -4528,8 +4528,10 @@ type Task_ActionInvokeTask struct {
 	Annotations []*anypb.Any           `protobuf:"bytes,3,rep,name=annotations,proto3" json:"annotations,omitempty"`
 	// Optional: if set, invokes a resource-scoped action
 	ResourceTypeId string `protobuf:"bytes,4,opt,name=resource_type_id,json=resourceTypeId,proto3" json:"resource_type_id,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// Public keys the connector uses to encrypt secret return values.
+	EncryptionConfigs []*v2.EncryptionConfig `protobuf:"bytes,5,rep,name=encryption_configs,json=encryptionConfigs,proto3" json:"encryption_configs,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *Task_ActionInvokeTask) Reset() {
@@ -4585,6 +4587,13 @@ func (x *Task_ActionInvokeTask) GetResourceTypeId() string {
 	return ""
 }
 
+func (x *Task_ActionInvokeTask) GetEncryptionConfigs() []*v2.EncryptionConfig {
+	if x != nil {
+		return x.EncryptionConfigs
+	}
+	return nil
+}
+
 func (x *Task_ActionInvokeTask) SetName(v string) {
 	x.Name = v
 }
@@ -4599,6 +4608,10 @@ func (x *Task_ActionInvokeTask) SetAnnotations(v []*anypb.Any) {
 
 func (x *Task_ActionInvokeTask) SetResourceTypeId(v string) {
 	x.ResourceTypeId = v
+}
+
+func (x *Task_ActionInvokeTask) SetEncryptionConfigs(v []*v2.EncryptionConfig) {
+	x.EncryptionConfigs = v
 }
 
 func (x *Task_ActionInvokeTask) HasArgs() bool {
@@ -4620,6 +4633,8 @@ type Task_ActionInvokeTask_builder struct {
 	Annotations []*anypb.Any
 	// Optional: if set, invokes a resource-scoped action
 	ResourceTypeId string
+	// Public keys the connector uses to encrypt secret return values.
+	EncryptionConfigs []*v2.EncryptionConfig
 }
 
 func (b0 Task_ActionInvokeTask_builder) Build() *Task_ActionInvokeTask {
@@ -4630,6 +4645,7 @@ func (b0 Task_ActionInvokeTask_builder) Build() *Task_ActionInvokeTask {
 	x.Args = b.Args
 	x.Annotations = b.Annotations
 	x.ResourceTypeId = b.ResourceTypeId
+	x.EncryptionConfigs = b.EncryptionConfigs
 	return m0
 }
 
@@ -5598,7 +5614,7 @@ var File_c1_connectorapi_baton_v1_baton_proto protoreflect.FileDescriptor
 
 const file_c1_connectorapi_baton_v1_baton_proto_rawDesc = "" +
 	"\n" +
-	"$c1/connectorapi/baton/v1/baton.proto\x12\x18c1.connectorapi.baton.v1\x1a\x1fc1/connector/v2/connector.proto\x1a!c1/connector/v2/entitlement.proto\x1a\x1bc1/connector/v2/grant.proto\x1a\x1ec1/connector/v2/resource.proto\x1a\x1cc1/connector/v2/ticket.proto\x1a\x19google/protobuf/any.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x17google/rpc/status.proto\x1a\x17validate/validate.proto\"\x921\n" +
+	"$c1/connectorapi/baton/v1/baton.proto\x12\x18c1.connectorapi.baton.v1\x1a\x1fc1/connector/v2/connector.proto\x1a!c1/connector/v2/entitlement.proto\x1a\x1bc1/connector/v2/grant.proto\x1a\x1ec1/connector/v2/resource.proto\x1a\x1cc1/connector/v2/ticket.proto\x1a\x19google/protobuf/any.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x17google/rpc/status.proto\x1a\x17validate/validate.proto\"\xe41\n" +
 	"\x04Task\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12=\n" +
 	"\x06status\x18\x02 \x01(\x0e2%.c1.connectorapi.baton.v1.Task.StatusR\x06status\x12=\n" +
@@ -5705,12 +5721,13 @@ const file_c1_connectorapi_baton_v1_baton_proto_rawDesc = "" +
 	"\x10resource_type_id\x18\x02 \x01(\tR\x0eresourceTypeId\x1aa\n" +
 	"\x13ActionGetSchemaTask\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x126\n" +
-	"\vannotations\x18\x02 \x03(\v2\x14.google.protobuf.AnyR\vannotations\x1a\xb5\x01\n" +
+	"\vannotations\x18\x02 \x03(\v2\x14.google.protobuf.AnyR\vannotations\x1a\x87\x02\n" +
 	"\x10ActionInvokeTask\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12+\n" +
 	"\x04args\x18\x02 \x01(\v2\x17.google.protobuf.StructR\x04args\x126\n" +
 	"\vannotations\x18\x03 \x03(\v2\x14.google.protobuf.AnyR\vannotations\x12(\n" +
-	"\x10resource_type_id\x18\x04 \x01(\tR\x0eresourceTypeId\x1an\n" +
+	"\x10resource_type_id\x18\x04 \x01(\tR\x0eresourceTypeId\x12P\n" +
+	"\x12encryption_configs\x18\x05 \x03(\v2!.c1.connector.v2.EncryptionConfigR\x11encryptionConfigs\x1an\n" +
 	"\x10ActionStatusTask\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x0e\n" +
 	"\x02id\x18\x02 \x01(\tR\x02id\x126\n" +
@@ -5994,35 +6011,36 @@ var file_c1_connectorapi_baton_v1_baton_proto_depIdxs = []int32{
 	49,  // 85: c1.connectorapi.baton.v1.Task.ActionGetSchemaTask.annotations:type_name -> google.protobuf.Any
 	63,  // 86: c1.connectorapi.baton.v1.Task.ActionInvokeTask.args:type_name -> google.protobuf.Struct
 	49,  // 87: c1.connectorapi.baton.v1.Task.ActionInvokeTask.annotations:type_name -> google.protobuf.Any
-	49,  // 88: c1.connectorapi.baton.v1.Task.ActionStatusTask.annotations:type_name -> google.protobuf.Any
-	49,  // 89: c1.connectorapi.baton.v1.Task.CreateSyncDiffTask.annotations:type_name -> google.protobuf.Any
-	40,  // 90: c1.connectorapi.baton.v1.Task.CompactSyncs.compactable_syncs:type_name -> c1.connectorapi.baton.v1.Task.CompactSyncs.CompactableSync
-	49,  // 91: c1.connectorapi.baton.v1.Task.CompactSyncs.annotations:type_name -> google.protobuf.Any
-	49,  // 92: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadMetadata.annotations:type_name -> google.protobuf.Any
-	49,  // 93: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadEOF.annotations:type_name -> google.protobuf.Any
-	49,  // 94: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Error.annotations:type_name -> google.protobuf.Any
-	49,  // 95: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Error.response:type_name -> google.protobuf.Any
-	49,  // 96: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Success.annotations:type_name -> google.protobuf.Any
-	49,  // 97: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Success.response:type_name -> google.protobuf.Any
-	2,   // 98: c1.connectorapi.baton.v1.BatonService.Hello:input_type -> c1.connectorapi.baton.v1.BatonServiceHelloRequest
-	4,   // 99: c1.connectorapi.baton.v1.BatonService.GetTask:input_type -> c1.connectorapi.baton.v1.BatonServiceGetTaskRequest
-	5,   // 100: c1.connectorapi.baton.v1.BatonService.GetTasks:input_type -> c1.connectorapi.baton.v1.BatonServiceGetTasksRequest
-	8,   // 101: c1.connectorapi.baton.v1.BatonService.Heartbeat:input_type -> c1.connectorapi.baton.v1.BatonServiceHeartbeatRequest
-	12,  // 102: c1.connectorapi.baton.v1.BatonService.FinishTask:input_type -> c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest
-	10,  // 103: c1.connectorapi.baton.v1.BatonService.UploadAsset:input_type -> c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest
-	14,  // 104: c1.connectorapi.baton.v1.BatonService.StartDebugging:input_type -> c1.connectorapi.baton.v1.StartDebuggingRequest
-	3,   // 105: c1.connectorapi.baton.v1.BatonService.Hello:output_type -> c1.connectorapi.baton.v1.BatonServiceHelloResponse
-	7,   // 106: c1.connectorapi.baton.v1.BatonService.GetTask:output_type -> c1.connectorapi.baton.v1.BatonServiceGetTaskResponse
-	6,   // 107: c1.connectorapi.baton.v1.BatonService.GetTasks:output_type -> c1.connectorapi.baton.v1.BatonServiceGetTasksResponse
-	9,   // 108: c1.connectorapi.baton.v1.BatonService.Heartbeat:output_type -> c1.connectorapi.baton.v1.BatonServiceHeartbeatResponse
-	13,  // 109: c1.connectorapi.baton.v1.BatonService.FinishTask:output_type -> c1.connectorapi.baton.v1.BatonServiceFinishTaskResponse
-	11,  // 110: c1.connectorapi.baton.v1.BatonService.UploadAsset:output_type -> c1.connectorapi.baton.v1.BatonServiceUploadAssetResponse
-	15,  // 111: c1.connectorapi.baton.v1.BatonService.StartDebugging:output_type -> c1.connectorapi.baton.v1.StartDebuggingResponse
-	105, // [105:112] is the sub-list for method output_type
-	98,  // [98:105] is the sub-list for method input_type
-	98,  // [98:98] is the sub-list for extension type_name
-	98,  // [98:98] is the sub-list for extension extendee
-	0,   // [0:98] is the sub-list for field type_name
+	58,  // 88: c1.connectorapi.baton.v1.Task.ActionInvokeTask.encryption_configs:type_name -> c1.connector.v2.EncryptionConfig
+	49,  // 89: c1.connectorapi.baton.v1.Task.ActionStatusTask.annotations:type_name -> google.protobuf.Any
+	49,  // 90: c1.connectorapi.baton.v1.Task.CreateSyncDiffTask.annotations:type_name -> google.protobuf.Any
+	40,  // 91: c1.connectorapi.baton.v1.Task.CompactSyncs.compactable_syncs:type_name -> c1.connectorapi.baton.v1.Task.CompactSyncs.CompactableSync
+	49,  // 92: c1.connectorapi.baton.v1.Task.CompactSyncs.annotations:type_name -> google.protobuf.Any
+	49,  // 93: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadMetadata.annotations:type_name -> google.protobuf.Any
+	49,  // 94: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadEOF.annotations:type_name -> google.protobuf.Any
+	49,  // 95: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Error.annotations:type_name -> google.protobuf.Any
+	49,  // 96: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Error.response:type_name -> google.protobuf.Any
+	49,  // 97: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Success.annotations:type_name -> google.protobuf.Any
+	49,  // 98: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Success.response:type_name -> google.protobuf.Any
+	2,   // 99: c1.connectorapi.baton.v1.BatonService.Hello:input_type -> c1.connectorapi.baton.v1.BatonServiceHelloRequest
+	4,   // 100: c1.connectorapi.baton.v1.BatonService.GetTask:input_type -> c1.connectorapi.baton.v1.BatonServiceGetTaskRequest
+	5,   // 101: c1.connectorapi.baton.v1.BatonService.GetTasks:input_type -> c1.connectorapi.baton.v1.BatonServiceGetTasksRequest
+	8,   // 102: c1.connectorapi.baton.v1.BatonService.Heartbeat:input_type -> c1.connectorapi.baton.v1.BatonServiceHeartbeatRequest
+	12,  // 103: c1.connectorapi.baton.v1.BatonService.FinishTask:input_type -> c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest
+	10,  // 104: c1.connectorapi.baton.v1.BatonService.UploadAsset:input_type -> c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest
+	14,  // 105: c1.connectorapi.baton.v1.BatonService.StartDebugging:input_type -> c1.connectorapi.baton.v1.StartDebuggingRequest
+	3,   // 106: c1.connectorapi.baton.v1.BatonService.Hello:output_type -> c1.connectorapi.baton.v1.BatonServiceHelloResponse
+	7,   // 107: c1.connectorapi.baton.v1.BatonService.GetTask:output_type -> c1.connectorapi.baton.v1.BatonServiceGetTaskResponse
+	6,   // 108: c1.connectorapi.baton.v1.BatonService.GetTasks:output_type -> c1.connectorapi.baton.v1.BatonServiceGetTasksResponse
+	9,   // 109: c1.connectorapi.baton.v1.BatonService.Heartbeat:output_type -> c1.connectorapi.baton.v1.BatonServiceHeartbeatResponse
+	13,  // 110: c1.connectorapi.baton.v1.BatonService.FinishTask:output_type -> c1.connectorapi.baton.v1.BatonServiceFinishTaskResponse
+	11,  // 111: c1.connectorapi.baton.v1.BatonService.UploadAsset:output_type -> c1.connectorapi.baton.v1.BatonServiceUploadAssetResponse
+	15,  // 112: c1.connectorapi.baton.v1.BatonService.StartDebugging:output_type -> c1.connectorapi.baton.v1.StartDebuggingResponse
+	106, // [106:113] is the sub-list for method output_type
+	99,  // [99:106] is the sub-list for method input_type
+	99,  // [99:99] is the sub-list for extension type_name
+	99,  // [99:99] is the sub-list for extension extendee
+	0,   // [0:99] is the sub-list for field type_name
 }
 
 func init() { file_c1_connectorapi_baton_v1_baton_proto_init() }

--- a/pb/c1/connectorapi/baton/v1/baton.pb.validate.go
+++ b/pb/c1/connectorapi/baton/v1/baton.pb.validate.go
@@ -6962,6 +6962,40 @@ func (m *Task_ActionInvokeTask) validate(all bool) error {
 
 	// no validation rules for ResourceTypeId
 
+	for idx, item := range m.GetEncryptionConfigs() {
+		_, _ = idx, item
+
+		if all {
+			switch v := interface{}(item).(type) {
+			case interface{ ValidateAll() error }:
+				if err := v.ValidateAll(); err != nil {
+					errors = append(errors, Task_ActionInvokeTaskValidationError{
+						field:  fmt.Sprintf("EncryptionConfigs[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			case interface{ Validate() error }:
+				if err := v.Validate(); err != nil {
+					errors = append(errors, Task_ActionInvokeTaskValidationError{
+						field:  fmt.Sprintf("EncryptionConfigs[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			}
+		} else if v, ok := interface{}(item).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return Task_ActionInvokeTaskValidationError{
+					field:  fmt.Sprintf("EncryptionConfigs[%v]", idx),
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
+	}
+
 	if len(errors) > 0 {
 		return Task_ActionInvokeTaskMultiError(errors)
 	}

--- a/pb/c1/connectorapi/baton/v1/baton_protoopaque.pb.go
+++ b/pb/c1/connectorapi/baton/v1/baton_protoopaque.pb.go
@@ -4517,13 +4517,14 @@ func (b0 Task_ActionGetSchemaTask_builder) Build() *Task_ActionGetSchemaTask {
 }
 
 type Task_ActionInvokeTask struct {
-	state                     protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_Name           string                 `protobuf:"bytes,1,opt,name=name,proto3"`
-	xxx_hidden_Args           *structpb.Struct       `protobuf:"bytes,2,opt,name=args,proto3"`
-	xxx_hidden_Annotations    *[]*anypb.Any          `protobuf:"bytes,3,rep,name=annotations,proto3"`
-	xxx_hidden_ResourceTypeId string                 `protobuf:"bytes,4,opt,name=resource_type_id,json=resourceTypeId,proto3"`
-	unknownFields             protoimpl.UnknownFields
-	sizeCache                 protoimpl.SizeCache
+	state                        protoimpl.MessageState  `protogen:"opaque.v1"`
+	xxx_hidden_Name              string                  `protobuf:"bytes,1,opt,name=name,proto3"`
+	xxx_hidden_Args              *structpb.Struct        `protobuf:"bytes,2,opt,name=args,proto3"`
+	xxx_hidden_Annotations       *[]*anypb.Any           `protobuf:"bytes,3,rep,name=annotations,proto3"`
+	xxx_hidden_ResourceTypeId    string                  `protobuf:"bytes,4,opt,name=resource_type_id,json=resourceTypeId,proto3"`
+	xxx_hidden_EncryptionConfigs *[]*v2.EncryptionConfig `protobuf:"bytes,5,rep,name=encryption_configs,json=encryptionConfigs,proto3"`
+	unknownFields                protoimpl.UnknownFields
+	sizeCache                    protoimpl.SizeCache
 }
 
 func (x *Task_ActionInvokeTask) Reset() {
@@ -4581,6 +4582,15 @@ func (x *Task_ActionInvokeTask) GetResourceTypeId() string {
 	return ""
 }
 
+func (x *Task_ActionInvokeTask) GetEncryptionConfigs() []*v2.EncryptionConfig {
+	if x != nil {
+		if x.xxx_hidden_EncryptionConfigs != nil {
+			return *x.xxx_hidden_EncryptionConfigs
+		}
+	}
+	return nil
+}
+
 func (x *Task_ActionInvokeTask) SetName(v string) {
 	x.xxx_hidden_Name = v
 }
@@ -4595,6 +4605,10 @@ func (x *Task_ActionInvokeTask) SetAnnotations(v []*anypb.Any) {
 
 func (x *Task_ActionInvokeTask) SetResourceTypeId(v string) {
 	x.xxx_hidden_ResourceTypeId = v
+}
+
+func (x *Task_ActionInvokeTask) SetEncryptionConfigs(v []*v2.EncryptionConfig) {
+	x.xxx_hidden_EncryptionConfigs = &v
 }
 
 func (x *Task_ActionInvokeTask) HasArgs() bool {
@@ -4616,6 +4630,8 @@ type Task_ActionInvokeTask_builder struct {
 	Annotations []*anypb.Any
 	// Optional: if set, invokes a resource-scoped action
 	ResourceTypeId string
+	// Public keys the connector uses to encrypt secret return values.
+	EncryptionConfigs []*v2.EncryptionConfig
 }
 
 func (b0 Task_ActionInvokeTask_builder) Build() *Task_ActionInvokeTask {
@@ -4626,6 +4642,7 @@ func (b0 Task_ActionInvokeTask_builder) Build() *Task_ActionInvokeTask {
 	x.xxx_hidden_Args = b.Args
 	x.xxx_hidden_Annotations = &b.Annotations
 	x.xxx_hidden_ResourceTypeId = b.ResourceTypeId
+	x.xxx_hidden_EncryptionConfigs = &b.EncryptionConfigs
 	return m0
 }
 
@@ -5607,7 +5624,7 @@ var File_c1_connectorapi_baton_v1_baton_proto protoreflect.FileDescriptor
 
 const file_c1_connectorapi_baton_v1_baton_proto_rawDesc = "" +
 	"\n" +
-	"$c1/connectorapi/baton/v1/baton.proto\x12\x18c1.connectorapi.baton.v1\x1a\x1fc1/connector/v2/connector.proto\x1a!c1/connector/v2/entitlement.proto\x1a\x1bc1/connector/v2/grant.proto\x1a\x1ec1/connector/v2/resource.proto\x1a\x1cc1/connector/v2/ticket.proto\x1a\x19google/protobuf/any.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x17google/rpc/status.proto\x1a\x17validate/validate.proto\"\x921\n" +
+	"$c1/connectorapi/baton/v1/baton.proto\x12\x18c1.connectorapi.baton.v1\x1a\x1fc1/connector/v2/connector.proto\x1a!c1/connector/v2/entitlement.proto\x1a\x1bc1/connector/v2/grant.proto\x1a\x1ec1/connector/v2/resource.proto\x1a\x1cc1/connector/v2/ticket.proto\x1a\x19google/protobuf/any.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x17google/rpc/status.proto\x1a\x17validate/validate.proto\"\xe41\n" +
 	"\x04Task\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12=\n" +
 	"\x06status\x18\x02 \x01(\x0e2%.c1.connectorapi.baton.v1.Task.StatusR\x06status\x12=\n" +
@@ -5714,12 +5731,13 @@ const file_c1_connectorapi_baton_v1_baton_proto_rawDesc = "" +
 	"\x10resource_type_id\x18\x02 \x01(\tR\x0eresourceTypeId\x1aa\n" +
 	"\x13ActionGetSchemaTask\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x126\n" +
-	"\vannotations\x18\x02 \x03(\v2\x14.google.protobuf.AnyR\vannotations\x1a\xb5\x01\n" +
+	"\vannotations\x18\x02 \x03(\v2\x14.google.protobuf.AnyR\vannotations\x1a\x87\x02\n" +
 	"\x10ActionInvokeTask\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12+\n" +
 	"\x04args\x18\x02 \x01(\v2\x17.google.protobuf.StructR\x04args\x126\n" +
 	"\vannotations\x18\x03 \x03(\v2\x14.google.protobuf.AnyR\vannotations\x12(\n" +
-	"\x10resource_type_id\x18\x04 \x01(\tR\x0eresourceTypeId\x1an\n" +
+	"\x10resource_type_id\x18\x04 \x01(\tR\x0eresourceTypeId\x12P\n" +
+	"\x12encryption_configs\x18\x05 \x03(\v2!.c1.connector.v2.EncryptionConfigR\x11encryptionConfigs\x1an\n" +
 	"\x10ActionStatusTask\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x0e\n" +
 	"\x02id\x18\x02 \x01(\tR\x02id\x126\n" +
@@ -6003,35 +6021,36 @@ var file_c1_connectorapi_baton_v1_baton_proto_depIdxs = []int32{
 	49,  // 85: c1.connectorapi.baton.v1.Task.ActionGetSchemaTask.annotations:type_name -> google.protobuf.Any
 	63,  // 86: c1.connectorapi.baton.v1.Task.ActionInvokeTask.args:type_name -> google.protobuf.Struct
 	49,  // 87: c1.connectorapi.baton.v1.Task.ActionInvokeTask.annotations:type_name -> google.protobuf.Any
-	49,  // 88: c1.connectorapi.baton.v1.Task.ActionStatusTask.annotations:type_name -> google.protobuf.Any
-	49,  // 89: c1.connectorapi.baton.v1.Task.CreateSyncDiffTask.annotations:type_name -> google.protobuf.Any
-	40,  // 90: c1.connectorapi.baton.v1.Task.CompactSyncs.compactable_syncs:type_name -> c1.connectorapi.baton.v1.Task.CompactSyncs.CompactableSync
-	49,  // 91: c1.connectorapi.baton.v1.Task.CompactSyncs.annotations:type_name -> google.protobuf.Any
-	49,  // 92: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadMetadata.annotations:type_name -> google.protobuf.Any
-	49,  // 93: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadEOF.annotations:type_name -> google.protobuf.Any
-	49,  // 94: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Error.annotations:type_name -> google.protobuf.Any
-	49,  // 95: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Error.response:type_name -> google.protobuf.Any
-	49,  // 96: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Success.annotations:type_name -> google.protobuf.Any
-	49,  // 97: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Success.response:type_name -> google.protobuf.Any
-	2,   // 98: c1.connectorapi.baton.v1.BatonService.Hello:input_type -> c1.connectorapi.baton.v1.BatonServiceHelloRequest
-	4,   // 99: c1.connectorapi.baton.v1.BatonService.GetTask:input_type -> c1.connectorapi.baton.v1.BatonServiceGetTaskRequest
-	5,   // 100: c1.connectorapi.baton.v1.BatonService.GetTasks:input_type -> c1.connectorapi.baton.v1.BatonServiceGetTasksRequest
-	8,   // 101: c1.connectorapi.baton.v1.BatonService.Heartbeat:input_type -> c1.connectorapi.baton.v1.BatonServiceHeartbeatRequest
-	12,  // 102: c1.connectorapi.baton.v1.BatonService.FinishTask:input_type -> c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest
-	10,  // 103: c1.connectorapi.baton.v1.BatonService.UploadAsset:input_type -> c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest
-	14,  // 104: c1.connectorapi.baton.v1.BatonService.StartDebugging:input_type -> c1.connectorapi.baton.v1.StartDebuggingRequest
-	3,   // 105: c1.connectorapi.baton.v1.BatonService.Hello:output_type -> c1.connectorapi.baton.v1.BatonServiceHelloResponse
-	7,   // 106: c1.connectorapi.baton.v1.BatonService.GetTask:output_type -> c1.connectorapi.baton.v1.BatonServiceGetTaskResponse
-	6,   // 107: c1.connectorapi.baton.v1.BatonService.GetTasks:output_type -> c1.connectorapi.baton.v1.BatonServiceGetTasksResponse
-	9,   // 108: c1.connectorapi.baton.v1.BatonService.Heartbeat:output_type -> c1.connectorapi.baton.v1.BatonServiceHeartbeatResponse
-	13,  // 109: c1.connectorapi.baton.v1.BatonService.FinishTask:output_type -> c1.connectorapi.baton.v1.BatonServiceFinishTaskResponse
-	11,  // 110: c1.connectorapi.baton.v1.BatonService.UploadAsset:output_type -> c1.connectorapi.baton.v1.BatonServiceUploadAssetResponse
-	15,  // 111: c1.connectorapi.baton.v1.BatonService.StartDebugging:output_type -> c1.connectorapi.baton.v1.StartDebuggingResponse
-	105, // [105:112] is the sub-list for method output_type
-	98,  // [98:105] is the sub-list for method input_type
-	98,  // [98:98] is the sub-list for extension type_name
-	98,  // [98:98] is the sub-list for extension extendee
-	0,   // [0:98] is the sub-list for field type_name
+	58,  // 88: c1.connectorapi.baton.v1.Task.ActionInvokeTask.encryption_configs:type_name -> c1.connector.v2.EncryptionConfig
+	49,  // 89: c1.connectorapi.baton.v1.Task.ActionStatusTask.annotations:type_name -> google.protobuf.Any
+	49,  // 90: c1.connectorapi.baton.v1.Task.CreateSyncDiffTask.annotations:type_name -> google.protobuf.Any
+	40,  // 91: c1.connectorapi.baton.v1.Task.CompactSyncs.compactable_syncs:type_name -> c1.connectorapi.baton.v1.Task.CompactSyncs.CompactableSync
+	49,  // 92: c1.connectorapi.baton.v1.Task.CompactSyncs.annotations:type_name -> google.protobuf.Any
+	49,  // 93: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadMetadata.annotations:type_name -> google.protobuf.Any
+	49,  // 94: c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest.UploadEOF.annotations:type_name -> google.protobuf.Any
+	49,  // 95: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Error.annotations:type_name -> google.protobuf.Any
+	49,  // 96: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Error.response:type_name -> google.protobuf.Any
+	49,  // 97: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Success.annotations:type_name -> google.protobuf.Any
+	49,  // 98: c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest.Success.response:type_name -> google.protobuf.Any
+	2,   // 99: c1.connectorapi.baton.v1.BatonService.Hello:input_type -> c1.connectorapi.baton.v1.BatonServiceHelloRequest
+	4,   // 100: c1.connectorapi.baton.v1.BatonService.GetTask:input_type -> c1.connectorapi.baton.v1.BatonServiceGetTaskRequest
+	5,   // 101: c1.connectorapi.baton.v1.BatonService.GetTasks:input_type -> c1.connectorapi.baton.v1.BatonServiceGetTasksRequest
+	8,   // 102: c1.connectorapi.baton.v1.BatonService.Heartbeat:input_type -> c1.connectorapi.baton.v1.BatonServiceHeartbeatRequest
+	12,  // 103: c1.connectorapi.baton.v1.BatonService.FinishTask:input_type -> c1.connectorapi.baton.v1.BatonServiceFinishTaskRequest
+	10,  // 104: c1.connectorapi.baton.v1.BatonService.UploadAsset:input_type -> c1.connectorapi.baton.v1.BatonServiceUploadAssetRequest
+	14,  // 105: c1.connectorapi.baton.v1.BatonService.StartDebugging:input_type -> c1.connectorapi.baton.v1.StartDebuggingRequest
+	3,   // 106: c1.connectorapi.baton.v1.BatonService.Hello:output_type -> c1.connectorapi.baton.v1.BatonServiceHelloResponse
+	7,   // 107: c1.connectorapi.baton.v1.BatonService.GetTask:output_type -> c1.connectorapi.baton.v1.BatonServiceGetTaskResponse
+	6,   // 108: c1.connectorapi.baton.v1.BatonService.GetTasks:output_type -> c1.connectorapi.baton.v1.BatonServiceGetTasksResponse
+	9,   // 109: c1.connectorapi.baton.v1.BatonService.Heartbeat:output_type -> c1.connectorapi.baton.v1.BatonServiceHeartbeatResponse
+	13,  // 110: c1.connectorapi.baton.v1.BatonService.FinishTask:output_type -> c1.connectorapi.baton.v1.BatonServiceFinishTaskResponse
+	11,  // 111: c1.connectorapi.baton.v1.BatonService.UploadAsset:output_type -> c1.connectorapi.baton.v1.BatonServiceUploadAssetResponse
+	15,  // 112: c1.connectorapi.baton.v1.BatonService.StartDebugging:output_type -> c1.connectorapi.baton.v1.StartDebuggingResponse
+	106, // [106:113] is the sub-list for method output_type
+	99,  // [99:106] is the sub-list for method input_type
+	99,  // [99:99] is the sub-list for extension type_name
+	99,  // [99:99] is the sub-list for extension extendee
+	0,   // [0:99] is the sub-list for field type_name
 }
 
 func init() { file_c1_connectorapi_baton_v1_baton_proto_init() }

--- a/pkg/actions/actions.go
+++ b/pkg/actions/actions.go
@@ -11,6 +11,7 @@ import (
 	config "github.com/conductorone/baton-sdk/pb/c1/config/v1"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/crypto"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"github.com/segmentio/ksuid"
 	"go.opentelemetry.io/otel/trace"
@@ -23,6 +24,29 @@ import (
 )
 
 type ActionHandler func(ctx context.Context, args *structpb.Struct) (*structpb.Struct, annotations.Annotations, error)
+
+// ActionHandlerWithSecrets returns public values separately from plaintext
+// secret values. The action manager encrypts PlaintextData before publishing
+// the result or retaining it for a later status request.
+type ActionHandlerWithSecrets func(
+	ctx context.Context,
+	args *structpb.Struct,
+) (*structpb.Struct, []*v2.PlaintextData, annotations.Annotations, error)
+
+type actionHandlerResult struct {
+	response      *structpb.Struct
+	plaintextData []*v2.PlaintextData
+	annotations   annotations.Annotations
+	err           error
+}
+
+type registeredActionHandler struct {
+	invoke                    func(context.Context, *structpb.Struct) actionHandlerResult
+	secretReturnNames         map[string]struct{}
+	requiredSecretReturnNames []string
+}
+
+type actionEncryptFunc func(context.Context, *crypto.EncryptionManager, *v2.PlaintextData) ([]*v2.EncryptedData, error)
 
 // IsInFlight reports whether the status describes an action
 // still executing: PENDING or RUNNING.
@@ -38,13 +62,14 @@ func IsSettled(s v2.BatonActionStatus) bool {
 }
 
 type OutstandingAction struct {
-	Id        string
-	Name      string
-	Status    v2.BatonActionStatus
-	Rv        *structpb.Struct
-	Annos     annotations.Annotations
-	Err       error
-	StartedAt time.Time
+	Id            string
+	Name          string
+	Status        v2.BatonActionStatus
+	Rv            *structpb.Struct
+	EncryptedData []*v2.EncryptedData
+	Annos         annotations.Annotations
+	Err           error
+	StartedAt     time.Time
 	sync.Mutex
 
 	// cancelled marks a FAILED status that came from request cancellation
@@ -119,11 +144,13 @@ func (oa *OutstandingAction) SetError(ctx context.Context, err error) {
 	oa.Lock()
 	defer oa.Unlock()
 	if oa.Status == v2.BatonActionStatus_BATON_ACTION_STATUS_FAILED {
+		oa.EncryptedData = nil
 		oa.setErrorLocked(err)
 		oa.cancelled = false
 		return
 	}
 	if oa.setStatusLocked(ctx, v2.BatonActionStatus_BATON_ACTION_STATUS_FAILED) {
+		oa.EncryptedData = nil
 		oa.setErrorLocked(err)
 	}
 }
@@ -169,9 +196,20 @@ func (oa *OutstandingAction) Result() (string, v2.BatonActionStatus, *structpb.S
 
 // result is the unexported form of Result.
 func (oa *OutstandingAction) result() (string, v2.BatonActionStatus, *structpb.Struct, annotations.Annotations) {
+	id, status, response, _, annos := oa.resultWithEncryptedData()
+	return id, status, response, annos
+}
+
+// ResultWithEncryptedData returns the action's public and encrypted outcomes.
+// The returned messages are owned by the action and must not be modified.
+func (oa *OutstandingAction) ResultWithEncryptedData() (string, v2.BatonActionStatus, *structpb.Struct, []*v2.EncryptedData, annotations.Annotations) {
+	return oa.resultWithEncryptedData()
+}
+
+func (oa *OutstandingAction) resultWithEncryptedData() (string, v2.BatonActionStatus, *structpb.Struct, []*v2.EncryptedData, annotations.Annotations) {
 	oa.Lock()
 	defer oa.Unlock()
-	return oa.Id, oa.Status, oa.Rv, oa.Annos
+	return oa.Id, oa.Status, oa.Rv, oa.EncryptedData, oa.Annos
 }
 
 // setOutcome publishes the handler's result and terminal status in one
@@ -181,8 +219,27 @@ func (oa *OutstandingAction) result() (string, v2.BatonActionStatus, *structpb.S
 // exception: a cancellation-FAILED status is provisional, and the handler's
 // own outcome — success or failure — replaces it.
 func (oa *OutstandingAction) setOutcome(ctx context.Context, rv *structpb.Struct, annos annotations.Annotations, err error) {
+	oa.setOutcomeWithEncryptedData(ctx, rv, nil, annos, err)
+}
+
+func (oa *OutstandingAction) setOutcomeWithEncryptedData(
+	ctx context.Context,
+	rv *structpb.Struct,
+	encryptedData []*v2.EncryptedData,
+	annos annotations.Annotations,
+	err error,
+) {
 	if rv != nil {
 		rv = proto.Clone(rv).(*structpb.Struct)
+	}
+	if encryptedData != nil {
+		encryptedDataCopy := make([]*v2.EncryptedData, len(encryptedData))
+		for i, encrypted := range encryptedData {
+			if encrypted != nil {
+				encryptedDataCopy[i] = proto.Clone(encrypted).(*v2.EncryptedData)
+			}
+		}
+		encryptedData = encryptedDataCopy
 	}
 	if annos != nil {
 		annosCopy := make(annotations.Annotations, len(annos))
@@ -200,6 +257,7 @@ func (oa *OutstandingAction) setOutcome(ctx context.Context, rv *structpb.Struct
 	if err != nil {
 		if oa.Status == v2.BatonActionStatus_BATON_ACTION_STATUS_FAILED || oa.setStatusLocked(ctx, v2.BatonActionStatus_BATON_ACTION_STATUS_FAILED) {
 			oa.Rv = rv
+			oa.EncryptedData = nil
 			oa.Annos = annos
 			oa.setErrorLocked(err)
 			oa.cancelled = false
@@ -216,6 +274,7 @@ func (oa *OutstandingAction) setOutcome(ctx context.Context, rv *structpb.Struct
 		oa.cancelled = false
 		oa.Status = v2.BatonActionStatus_BATON_ACTION_STATUS_COMPLETE
 		oa.Rv = rv
+		oa.EncryptedData = encryptedData
 		oa.Annos = annos
 		oa.Err = nil
 		return
@@ -223,6 +282,7 @@ func (oa *OutstandingAction) setOutcome(ctx context.Context, rv *structpb.Struct
 
 	if oa.setStatusLocked(ctx, v2.BatonActionStatus_BATON_ACTION_STATUS_COMPLETE) {
 		oa.Rv = rv
+		oa.EncryptedData = encryptedData
 		oa.Annos = annos
 	}
 }
@@ -266,6 +326,26 @@ type ActionRegistry interface {
 	RegisterAction(ctx context.Context, name string, schema *v2.BatonActionSchema, handler ActionHandler) error
 }
 
+type actionRegistryWithSecrets interface {
+	RegisterWithSecrets(ctx context.Context, schema *v2.BatonActionSchema, handler ActionHandlerWithSecrets) error
+}
+
+// RegisterWithSecrets registers an action whose handler can return plaintext
+// secret values. The registry validates and encrypts those values before they
+// are observable through InvokeAction or GetActionStatus.
+func RegisterWithSecrets(
+	ctx context.Context,
+	registry ActionRegistry,
+	schema *v2.BatonActionSchema,
+	handler ActionHandlerWithSecrets,
+) error {
+	secretRegistry, ok := registry.(actionRegistryWithSecrets)
+	if !ok {
+		return errors.New("action registry does not support secret results")
+	}
+	return secretRegistry.RegisterWithSecrets(ctx, schema, handler)
+}
+
 // Deprecated: Use ActionRegistry instead.
 // ResourceTypeActionRegistry is an alias for ActionRegistry for backwards compatibility.
 type ResourceTypeActionRegistry = ActionRegistry
@@ -274,25 +354,29 @@ type ResourceTypeActionRegistry = ActionRegistry
 type ActionManager struct {
 	// Global actions (no resource type)
 	schemas  map[string]*v2.BatonActionSchema // actionName -> schema
-	handlers map[string]ActionHandler         // actionName -> handler
+	handlers map[string]registeredActionHandler
 
 	// Resource-scoped actions (keyed by resource type)
 	resourceSchemas  map[string]map[string]*v2.BatonActionSchema // resourceTypeID -> actionName -> schema
-	resourceHandlers map[string]map[string]ActionHandler         // resourceTypeID -> actionName -> handler
+	resourceHandlers map[string]map[string]registeredActionHandler
 
 	// Outstanding actions (shared across global and resource-scoped)
 	actions map[string]*OutstandingAction // actionID -> outstanding action
 
-	mu sync.RWMutex
+	encryptPlaintext actionEncryptFunc
+	mu               sync.RWMutex
 }
 
 func NewActionManager(_ context.Context) *ActionManager {
 	return &ActionManager{
 		schemas:          make(map[string]*v2.BatonActionSchema),
-		handlers:         make(map[string]ActionHandler),
+		handlers:         make(map[string]registeredActionHandler),
 		resourceSchemas:  make(map[string]map[string]*v2.BatonActionSchema),
-		resourceHandlers: make(map[string]map[string]ActionHandler),
+		resourceHandlers: make(map[string]map[string]registeredActionHandler),
 		actions:          make(map[string]*OutstandingAction),
+		encryptPlaintext: func(ctx context.Context, manager *crypto.EncryptionManager, plaintext *v2.PlaintextData) ([]*v2.EncryptedData, error) {
+			return manager.Encrypt(ctx, plaintext)
+		},
 	}
 }
 
@@ -367,10 +451,51 @@ func (a *ActionManager) Register(ctx context.Context, schema *v2.BatonActionSche
 // Deprecated: Use Register instead.
 // RegisterAction registers a global action (not scoped to a resource type).
 func (a *ActionManager) RegisterAction(ctx context.Context, name string, schema *v2.BatonActionSchema, handler ActionHandler) error {
+	if handler == nil {
+		return errors.New("action handler cannot be nil")
+	}
+	if hasSecretReturnTypes(schema) {
+		return errors.New("action schemas with secret return types must use RegisterWithSecrets")
+	}
+	return a.registerGlobalAction(ctx, name, schema, registeredActionHandler{
+		invoke: func(ctx context.Context, args *structpb.Struct) actionHandlerResult {
+			response, annos, err := handler(ctx, args)
+			return actionHandlerResult{response: response, annotations: annos, err: err}
+		},
+	})
+}
+
+// RegisterWithSecrets registers a global action that returns plaintext secret
+// values separately from its public response.
+func (a *ActionManager) RegisterWithSecrets(ctx context.Context, schema *v2.BatonActionSchema, handler ActionHandlerWithSecrets) error {
+	if schema == nil {
+		return errors.New("action schema cannot be nil")
+	}
+	if handler == nil {
+		return errors.New("action handler cannot be nil")
+	}
+	if !hasSecretReturnTypes(schema) {
+		return errors.New("secret action handler requires at least one secret return type")
+	}
+	secretReturnNames, requiredSecretReturnNames, err := validateSecretReturnTypes(schema.GetReturnTypes())
+	if err != nil {
+		return err
+	}
+	return a.registerGlobalAction(ctx, schema.GetName(), schema, registeredActionHandler{
+		invoke: func(ctx context.Context, args *structpb.Struct) actionHandlerResult {
+			response, plaintextData, annos, err := handler(ctx, args)
+			return actionHandlerResult{response: response, plaintextData: plaintextData, annotations: annos, err: err}
+		},
+		secretReturnNames:         secretReturnNames,
+		requiredSecretReturnNames: requiredSecretReturnNames,
+	})
+}
+
+func (a *ActionManager) registerGlobalAction(ctx context.Context, name string, schema *v2.BatonActionSchema, handler registeredActionHandler) error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	if handler == nil {
+	if handler.invoke == nil {
 		return errors.New("action handler cannot be nil")
 	}
 	err := a.registerActionSchema(ctx, name, schema)
@@ -402,6 +527,57 @@ func (a *ActionManager) RegisterResourceAction(
 	schema *v2.BatonActionSchema,
 	handler ActionHandler,
 ) error {
+	if handler == nil {
+		return errors.New("action handler cannot be nil")
+	}
+	if hasSecretReturnTypes(schema) {
+		return errors.New("action schemas with secret return types must use RegisterResourceActionWithSecrets")
+	}
+	return a.registerResourceAction(ctx, resourceTypeID, schema, registeredActionHandler{
+		invoke: func(ctx context.Context, args *structpb.Struct) actionHandlerResult {
+			response, annos, err := handler(ctx, args)
+			return actionHandlerResult{response: response, annotations: annos, err: err}
+		},
+	})
+}
+
+// RegisterResourceActionWithSecrets registers a resource-scoped action that
+// returns plaintext secret values separately from its public response.
+func (a *ActionManager) RegisterResourceActionWithSecrets(
+	ctx context.Context,
+	resourceTypeID string,
+	schema *v2.BatonActionSchema,
+	handler ActionHandlerWithSecrets,
+) error {
+	if schema == nil {
+		return errors.New("action schema cannot be nil")
+	}
+	if handler == nil {
+		return errors.New("action handler cannot be nil")
+	}
+	if !hasSecretReturnTypes(schema) {
+		return errors.New("secret action handler requires at least one secret return type")
+	}
+	secretReturnNames, requiredSecretReturnNames, err := validateSecretReturnTypes(schema.GetReturnTypes())
+	if err != nil {
+		return err
+	}
+	return a.registerResourceAction(ctx, resourceTypeID, schema, registeredActionHandler{
+		invoke: func(ctx context.Context, args *structpb.Struct) actionHandlerResult {
+			response, plaintextData, annos, err := handler(ctx, args)
+			return actionHandlerResult{response: response, plaintextData: plaintextData, annotations: annos, err: err}
+		},
+		secretReturnNames:         secretReturnNames,
+		requiredSecretReturnNames: requiredSecretReturnNames,
+	})
+}
+
+func (a *ActionManager) registerResourceAction(
+	ctx context.Context,
+	resourceTypeID string,
+	schema *v2.BatonActionSchema,
+	handler registeredActionHandler,
+) error {
 	if resourceTypeID == "" {
 		return errors.New("resource type ID cannot be empty")
 	}
@@ -411,7 +587,7 @@ func (a *ActionManager) RegisterResourceAction(
 	if schema.GetName() == "" {
 		return errors.New("action schema name cannot be empty")
 	}
-	if handler == nil {
+	if handler.invoke == nil {
 		return fmt.Errorf("handler cannot be nil for action %s", schema.GetName())
 	}
 
@@ -425,7 +601,7 @@ func (a *ActionManager) RegisterResourceAction(
 		a.resourceSchemas[resourceTypeID] = make(map[string]*v2.BatonActionSchema)
 	}
 	if a.resourceHandlers[resourceTypeID] == nil {
-		a.resourceHandlers[resourceTypeID] = make(map[string]ActionHandler)
+		a.resourceHandlers[resourceTypeID] = make(map[string]registeredActionHandler)
 	}
 
 	actionName := schema.GetName()
@@ -471,6 +647,10 @@ type resourceTypeActionRegistry struct {
 
 func (r *resourceTypeActionRegistry) Register(ctx context.Context, schema *v2.BatonActionSchema, handler ActionHandler) error {
 	return r.actionManager.RegisterResourceAction(ctx, r.resourceTypeID, schema, handler)
+}
+
+func (r *resourceTypeActionRegistry) RegisterWithSecrets(ctx context.Context, schema *v2.BatonActionSchema, handler ActionHandlerWithSecrets) error {
+	return r.actionManager.RegisterResourceActionWithSecrets(ctx, r.resourceTypeID, schema, handler)
 }
 
 // Deprecated: Use Register instead.
@@ -557,19 +737,29 @@ func (a *ActionManager) GetActionSchema(_ context.Context, name string) (*v2.Bat
 	return schema, nil, nil
 }
 
-func (a *ActionManager) GetActionStatus(_ context.Context, actionId string) (v2.BatonActionStatus, string, *structpb.Struct, annotations.Annotations, error) {
+func (a *ActionManager) GetActionStatus(ctx context.Context, actionId string) (v2.BatonActionStatus, string, *structpb.Struct, annotations.Annotations, error) {
+	status, name, response, _, annos, err := a.GetActionStatusWithEncryptedData(ctx, actionId)
+	return status, name, response, annos, err
+}
+
+// GetActionStatusWithEncryptedData returns an outstanding action's public and
+// encrypted results in one consistent snapshot.
+func (a *ActionManager) GetActionStatusWithEncryptedData(
+	_ context.Context,
+	actionId string,
+) (v2.BatonActionStatus, string, *structpb.Struct, []*v2.EncryptedData, annotations.Annotations, error) {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 
 	oa := a.actions[actionId]
 	if oa == nil {
-		return v2.BatonActionStatus_BATON_ACTION_STATUS_UNKNOWN, "", nil, nil, status.Error(codes.NotFound, fmt.Sprintf("action id %s not found", actionId))
+		return v2.BatonActionStatus_BATON_ACTION_STATUS_UNKNOWN, "", nil, nil, nil, status.Error(codes.NotFound, fmt.Sprintf("action id %s not found", actionId))
 	}
 
 	// Don't return oa.Err here because error is for GetActionStatus, not the action itself.
 	// oa.Rv contains any error.
-	_, st, rv, annos := oa.result()
-	return st, oa.Name, rv, annos, nil
+	_, st, rv, encryptedData, annos := oa.resultWithEncryptedData()
+	return st, oa.Name, rv, encryptedData, annos, nil
 }
 
 // InvokeAction invokes an action. If resourceTypeID is set, it invokes a resource-scoped action.
@@ -593,6 +783,27 @@ func (a *ActionManager) InvokeActionWithWait(
 	args *structpb.Struct,
 	inlineWait time.Duration,
 ) (string, v2.BatonActionStatus, *structpb.Struct, annotations.Annotations, error) {
+	id, actionStatus, response, _, annos, err := a.InvokeActionWithWaitAndEncryption(
+		ctx,
+		name,
+		resourceTypeID,
+		args,
+		inlineWait,
+		nil,
+	)
+	return id, actionStatus, response, annos, err
+}
+
+// InvokeActionWithWaitAndEncryption invokes an action with recipients for any
+// secret return values.
+func (a *ActionManager) InvokeActionWithWaitAndEncryption(
+	ctx context.Context,
+	name string,
+	resourceTypeID string,
+	args *structpb.Struct,
+	inlineWait time.Duration,
+	encryptionConfigs []*v2.EncryptionConfig,
+) (string, v2.BatonActionStatus, *structpb.Struct, []*v2.EncryptedData, annotations.Annotations, error) {
 	clamped := clampInlineWait(inlineWait)
 	if clamped < inlineWait {
 		ctxzap.Extract(ctx).Warn("capping requested inline wait",
@@ -602,10 +813,10 @@ func (a *ActionManager) InvokeActionWithWait(
 	inlineWait = clamped
 
 	if resourceTypeID != "" {
-		return a.invokeResourceAction(ctx, resourceTypeID, name, args, inlineWait)
+		return a.invokeResourceAction(ctx, resourceTypeID, name, args, inlineWait, encryptionConfigs)
 	}
 
-	return a.invokeGlobalAction(ctx, name, args, inlineWait)
+	return a.invokeGlobalAction(ctx, name, args, inlineWait, encryptionConfigs)
 }
 
 // invokeGlobalAction invokes a global (non-resource-scoped) action.
@@ -614,80 +825,21 @@ func (a *ActionManager) invokeGlobalAction(
 	name string,
 	args *structpb.Struct,
 	inlineWait time.Duration,
-) (string, v2.BatonActionStatus, *structpb.Struct, annotations.Annotations, error) {
+	encryptionConfigs []*v2.EncryptionConfig,
+) (string, v2.BatonActionStatus, *structpb.Struct, []*v2.EncryptedData, annotations.Annotations, error) {
 	a.mu.RLock()
 	handler, ok := a.handlers[name]
 	schema, schemaOk := a.schemas[name]
 	a.mu.RUnlock()
 
 	if !ok {
-		return "", v2.BatonActionStatus_BATON_ACTION_STATUS_FAILED, nil, nil, status.Error(codes.NotFound, fmt.Sprintf("handler for action %s not found", name))
+		return "", v2.BatonActionStatus_BATON_ACTION_STATUS_FAILED, nil, nil, nil, status.Error(codes.NotFound, fmt.Sprintf("handler for action %s not found", name))
 	}
 	if !schemaOk || schema == nil {
-		return "", v2.BatonActionStatus_BATON_ACTION_STATUS_FAILED, nil, nil, status.Error(codes.Internal, fmt.Sprintf("schema for action %s not found", name))
+		return "", v2.BatonActionStatus_BATON_ACTION_STATUS_FAILED, nil, nil, nil, status.Error(codes.Internal, fmt.Sprintf("schema for action %s not found", name))
 	}
 
-	// Validate constraints
-	if err := validateActionConstraints(schema.GetConstraints(), args); err != nil {
-		return "", v2.BatonActionStatus_BATON_ACTION_STATUS_FAILED, nil, nil, status.Error(codes.InvalidArgument, err.Error())
-	}
-
-	oa := a.GetNewAction(name)
-
-	done := make(chan struct{})
-
-	// The handler runs detached. Return its final result if it finishes
-	// within the inline wait; otherwise return the in-flight status.
-	go func() { // #nosec G118 -- action handlers intentionally outlive the request context and keep only trace/log metadata.
-		defer close(done)
-		defer func() {
-			if r := recover(); r != nil {
-				ctxzap.Extract(ctx).Error("panic in global action handler",
-					zap.String("action", name),
-					zap.Any("panic", r),
-					zap.Stack("stack"))
-				oa.SetError(ctx, fmt.Errorf("panic in action handler: %v", r))
-			}
-		}()
-		oa.SetStatus(ctx, v2.BatonActionStatus_BATON_ACTION_STATUS_RUNNING)
-		bgCtx := trace.ContextWithSpanContext(context.Background(), trace.SpanContextFromContext(ctx))
-		bgCtx = ctxzap.ToContext(bgCtx, ctxzap.Extract(ctx))
-		handlerCtx, cancel := context.WithTimeoutCause(bgCtx, 1*time.Hour, errors.New("action handler timed out"))
-		defer cancel()
-		rv, annos, oaErr := handler(handlerCtx, args)
-		oa.setOutcome(ctx, rv, annos, oaErr)
-	}()
-
-	// Stop releases the timer deterministically when the handler wins the
-	// select; an abandoned time.After timer would only be GC-eligible.
-	waitTimer := time.NewTimer(inlineWait)
-	defer waitTimer.Stop()
-
-	select {
-	case <-done:
-		id, st, rv, annos := oa.result()
-		return id, st, rv, annos, nil
-	case <-waitTimer.C:
-		id, st, rv, annos := oa.result()
-		return id, st, rv, annos, nil
-	case <-ctx.Done():
-		// The handler may have finished in the same instant; prefer its
-		// completed result over a spurious cancellation return.
-		select {
-		case <-done:
-			id, st, rv, annos := oa.result()
-			return id, st, rv, annos, nil
-		default:
-		}
-		oa.setCancelled(ctx, ctx.Err())
-		id, st, rv, annos := oa.result()
-		if st == v2.BatonActionStatus_BATON_ACTION_STATUS_COMPLETE {
-			// The handler won the race to the lock; its completed result is
-			// the authoritative pairing, not the cancellation.
-			return id, st, rv, annos, nil
-		}
-		return id, st, rv, annos, ctx.Err()
-	}
+	return a.invokeRegisteredAction(ctx, name, "", args, inlineWait, encryptionConfigs, schema, handler)
 }
 
 // invokeResourceAction invokes a resource-scoped action.
@@ -697,19 +849,20 @@ func (a *ActionManager) invokeResourceAction(
 	actionName string,
 	args *structpb.Struct,
 	inlineWait time.Duration,
-) (string, v2.BatonActionStatus, *structpb.Struct, annotations.Annotations, error) {
+	encryptionConfigs []*v2.EncryptionConfig,
+) (string, v2.BatonActionStatus, *structpb.Struct, []*v2.EncryptedData, annotations.Annotations, error) {
 	if resourceTypeID == "" {
-		return "", v2.BatonActionStatus_BATON_ACTION_STATUS_FAILED, nil, nil, status.Error(codes.InvalidArgument, "resource type ID is required")
+		return "", v2.BatonActionStatus_BATON_ACTION_STATUS_FAILED, nil, nil, nil, status.Error(codes.InvalidArgument, "resource type ID is required")
 	}
 	if actionName == "" {
-		return "", v2.BatonActionStatus_BATON_ACTION_STATUS_FAILED, nil, nil, status.Error(codes.InvalidArgument, "action name is required")
+		return "", v2.BatonActionStatus_BATON_ACTION_STATUS_FAILED, nil, nil, nil, status.Error(codes.InvalidArgument, "action name is required")
 	}
 
 	a.mu.RLock()
 	handlers, ok := a.resourceHandlers[resourceTypeID]
 	if !ok {
 		a.mu.RUnlock()
-		return "", v2.BatonActionStatus_BATON_ACTION_STATUS_FAILED, nil, nil, status.Error(codes.NotFound, fmt.Sprintf("no actions found for resource type %s", resourceTypeID))
+		return "", v2.BatonActionStatus_BATON_ACTION_STATUS_FAILED, nil, nil, nil, status.Error(codes.NotFound, fmt.Sprintf("no actions found for resource type %s", resourceTypeID))
 	}
 
 	handler, ok := handlers[actionName]
@@ -719,41 +872,79 @@ func (a *ActionManager) invokeResourceAction(
 			v2.BatonActionStatus_BATON_ACTION_STATUS_FAILED,
 			nil,
 			nil,
+			nil,
 			status.Error(codes.NotFound, fmt.Sprintf("handler for action %s not found for resource type %s", actionName, resourceTypeID))
 	}
 
 	schemas, ok := a.resourceSchemas[resourceTypeID]
 	if !ok {
 		a.mu.RUnlock()
-		return "", v2.BatonActionStatus_BATON_ACTION_STATUS_FAILED, nil, nil, status.Error(codes.Internal, fmt.Sprintf("schemas not found for resource type %s", resourceTypeID))
+		return "", v2.BatonActionStatus_BATON_ACTION_STATUS_FAILED, nil, nil, nil, status.Error(codes.Internal, fmt.Sprintf("schemas not found for resource type %s", resourceTypeID))
 	}
 
 	schema, ok := schemas[actionName]
 	if !ok {
 		a.mu.RUnlock()
-		return "", v2.BatonActionStatus_BATON_ACTION_STATUS_FAILED, nil, nil, status.Error(codes.Internal, fmt.Sprintf("schema not found for action %s", actionName))
+		return "", v2.BatonActionStatus_BATON_ACTION_STATUS_FAILED, nil, nil, nil, status.Error(codes.Internal, fmt.Sprintf("schema not found for action %s", actionName))
 	}
 	a.mu.RUnlock()
 
-	// Validate constraints
+	return a.invokeRegisteredAction(ctx, actionName, resourceTypeID, args, inlineWait, encryptionConfigs, schema, handler)
+}
+
+func (a *ActionManager) invokeRegisteredAction(
+	ctx context.Context,
+	actionName string,
+	resourceTypeID string,
+	args *structpb.Struct,
+	inlineWait time.Duration,
+	encryptionConfigs []*v2.EncryptionConfig,
+	schema *v2.BatonActionSchema,
+	handler registeredActionHandler,
+) (string, v2.BatonActionStatus, *structpb.Struct, []*v2.EncryptedData, annotations.Annotations, error) {
 	if err := validateActionConstraints(schema.GetConstraints(), args); err != nil {
-		return "", v2.BatonActionStatus_BATON_ACTION_STATUS_FAILED, nil, nil, status.Error(codes.InvalidArgument, err.Error())
+		return "", v2.BatonActionStatus_BATON_ACTION_STATUS_FAILED, nil, nil, nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	var encryptionManager *crypto.EncryptionManager
+	if len(handler.secretReturnNames) > 0 {
+		if len(encryptionConfigs) == 0 {
+			return "", v2.BatonActionStatus_BATON_ACTION_STATUS_FAILED, nil, nil, nil, status.Error(codes.InvalidArgument, "at least one encryption config is required for secret action results")
+		}
+		encryptionConfigs = cloneEncryptionConfigs(encryptionConfigs)
+		if err := crypto.ValidateEncryptionConfigs(encryptionConfigs); err != nil {
+			return "", v2.BatonActionStatus_BATON_ACTION_STATUS_FAILED, nil, nil, nil, err
+		}
+		var err error
+		encryptionManager, err = crypto.NewEncryptionManager(nil, encryptionConfigs)
+		if err != nil {
+			return "", v2.BatonActionStatus_BATON_ACTION_STATUS_FAILED, nil, nil, nil, status.Errorf(codes.InvalidArgument, "create encryption manager: %v", err)
+		}
 	}
 
 	oa := a.GetNewAction(actionName)
 	done := make(chan struct{})
 
-	// Invoke handler in goroutine
+	// The handler runs detached. Return its final result if it finishes
+	// within the inline wait; otherwise return the in-flight status.
 	go func() { // #nosec G118 -- action handlers intentionally outlive the request context and keep only trace/log metadata.
 		defer close(done)
 		defer func() {
 			if r := recover(); r != nil {
-				ctxzap.Extract(ctx).Error("panic in resource action handler",
-					zap.String("resource_type", resourceTypeID),
-					zap.String("action", actionName),
-					zap.Any("panic", r),
-					zap.Stack("stack"))
-				oa.SetError(ctx, fmt.Errorf("panic in action handler: %v", r))
+				if len(handler.secretReturnNames) > 0 {
+					ctxzap.Extract(ctx).Error("panic in action handler",
+						zap.String("resource_type", resourceTypeID),
+						zap.String("action", actionName),
+						zap.Stack("stack"))
+					oa.SetError(ctx, errors.New("panic in action handler"))
+				} else {
+					ctxzap.Extract(ctx).Error("panic in action handler",
+						zap.String("resource_type", resourceTypeID),
+						zap.String("action", actionName),
+						zap.Any("panic", r),
+						zap.Stack("stack"))
+					oa.SetError(ctx, fmt.Errorf("panic in action handler: %v", r))
+				}
 			}
 		}()
 		oa.SetStatus(ctx, v2.BatonActionStatus_BATON_ACTION_STATUS_RUNNING)
@@ -761,8 +952,21 @@ func (a *ActionManager) invokeResourceAction(
 		bgCtx = ctxzap.ToContext(bgCtx, ctxzap.Extract(ctx))
 		handlerCtx, cancel := context.WithTimeoutCause(bgCtx, 1*time.Hour, errors.New("action handler timed out"))
 		defer cancel()
-		rv, annos, oaErr := handler(handlerCtx, args)
-		oa.setOutcome(ctx, rv, annos, oaErr)
+		result := handler.invoke(handlerCtx, args)
+		encryptedData, resultErr := prepareActionResult(
+			handlerCtx,
+			handler,
+			encryptionManager,
+			a.encryptPlaintext,
+			result.response,
+			result.plaintextData,
+			result.err == nil,
+		)
+		if resultErr != nil {
+			result.response = nil
+			result.err = errors.Join(result.err, resultErr)
+		}
+		oa.setOutcomeWithEncryptedData(ctx, result.response, encryptedData, result.annotations, result.err)
 	}()
 
 	// Stop releases the timer deterministically when the handler wins the
@@ -772,29 +976,127 @@ func (a *ActionManager) invokeResourceAction(
 
 	select {
 	case <-done:
-		id, st, rv, annos := oa.result()
-		return id, st, rv, annos, nil
+		id, st, rv, encryptedData, annos := oa.resultWithEncryptedData()
+		return id, st, rv, encryptedData, annos, nil
 	case <-waitTimer.C:
-		id, st, rv, annos := oa.result()
-		return id, st, rv, annos, nil
+		id, st, rv, encryptedData, annos := oa.resultWithEncryptedData()
+		return id, st, rv, encryptedData, annos, nil
 	case <-ctx.Done():
 		// The handler may have finished in the same instant; prefer its
 		// completed result over a spurious cancellation return.
 		select {
 		case <-done:
-			id, st, rv, annos := oa.result()
-			return id, st, rv, annos, nil
+			id, st, rv, encryptedData, annos := oa.resultWithEncryptedData()
+			return id, st, rv, encryptedData, annos, nil
 		default:
 		}
 		oa.setCancelled(ctx, ctx.Err())
-		id, st, rv, annos := oa.result()
+		id, st, rv, encryptedData, annos := oa.resultWithEncryptedData()
 		if st == v2.BatonActionStatus_BATON_ACTION_STATUS_COMPLETE {
 			// The handler won the race to the lock; its completed result is
 			// the authoritative pairing, not the cancellation.
-			return id, st, rv, annos, nil
+			return id, st, rv, encryptedData, annos, nil
 		}
-		return id, st, rv, annos, ctx.Err()
+		return id, st, rv, encryptedData, annos, ctx.Err()
 	}
+}
+
+func hasSecretReturnTypes(schema *v2.BatonActionSchema) bool {
+	if schema == nil {
+		return false
+	}
+	for _, field := range schema.GetReturnTypes() {
+		if field.GetIsSecret() {
+			return true
+		}
+	}
+	return false
+}
+
+func validateSecretReturnTypes(returnTypes []*config.Field) (map[string]struct{}, []string, error) {
+	seen := make(map[string]struct{}, len(returnTypes))
+	requiredNames := make([]string, 0)
+	for _, field := range returnTypes {
+		if field == nil || !field.GetIsSecret() {
+			continue
+		}
+		name := field.GetName()
+		if name == "" {
+			return nil, nil, errors.New("secret return type name cannot be empty")
+		}
+		if _, ok := seen[name]; ok {
+			return nil, nil, fmt.Errorf("duplicate secret return type %q", name)
+		}
+		seen[name] = struct{}{}
+		if field.GetIsRequired() {
+			requiredNames = append(requiredNames, name)
+		}
+	}
+	return seen, requiredNames, nil
+}
+
+func cloneEncryptionConfigs(configs []*v2.EncryptionConfig) []*v2.EncryptionConfig {
+	cloned := make([]*v2.EncryptionConfig, len(configs))
+	for i, config := range configs {
+		if config != nil {
+			cloned[i] = proto.Clone(config).(*v2.EncryptionConfig)
+		}
+	}
+	return cloned
+}
+
+func prepareActionResult(
+	ctx context.Context,
+	handler registeredActionHandler,
+	encryptionManager *crypto.EncryptionManager,
+	encryptPlaintext actionEncryptFunc,
+	response *structpb.Struct,
+	plaintextData []*v2.PlaintextData,
+	encrypt bool,
+) ([]*v2.EncryptedData, error) {
+	if len(handler.secretReturnNames) == 0 {
+		return nil, nil
+	}
+
+	for name := range response.GetFields() {
+		if _, ok := handler.secretReturnNames[name]; ok {
+			return nil, fmt.Errorf("secret return value %q must not be included in the public response", name)
+		}
+	}
+
+	seen := make(map[string]struct{}, len(plaintextData))
+	for i, plaintext := range plaintextData {
+		if plaintext == nil || plaintext.GetName() == "" || len(plaintext.GetBytes()) == 0 {
+			return nil, fmt.Errorf("plaintext return value %d must have a name and non-empty bytes", i)
+		}
+		if _, ok := handler.secretReturnNames[plaintext.GetName()]; !ok {
+			return nil, fmt.Errorf("plaintext return value %q is not declared as a secret return type", plaintext.GetName())
+		}
+		if _, ok := seen[plaintext.GetName()]; ok {
+			return nil, fmt.Errorf("duplicate plaintext return value %q", plaintext.GetName())
+		}
+		seen[plaintext.GetName()] = struct{}{}
+	}
+
+	if !encrypt {
+		return nil, nil
+	}
+
+	for _, name := range handler.requiredSecretReturnNames {
+		if _, ok := seen[name]; !ok {
+			return nil, fmt.Errorf("required secret return type %q is missing", name)
+		}
+	}
+
+	var encryptedData []*v2.EncryptedData
+	for _, plaintext := range plaintextData {
+		encrypted, err := encryptPlaintext(ctx, encryptionManager, plaintext)
+		if err != nil {
+			return nil, fmt.Errorf("encrypt action return value %q: %w", plaintext.GetName(), err)
+		}
+		encryptedData = append(encryptedData, encrypted...)
+	}
+	return encryptedData, nil
 }
 
 // validateActionConstraints validates that the provided args satisfy the schema constraints.

--- a/pkg/actions/actions_test.go
+++ b/pkg/actions/actions_test.go
@@ -1,16 +1,20 @@
 package actions
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"runtime"
 	"testing"
 	"time"
 
+	filippoage "filippo.io/age"
 	config "github.com/conductorone/baton-sdk/pb/c1/config/v1"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/crypto"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -967,4 +971,570 @@ func TestActionStatusPredicates(t *testing.T) {
 			require.Equal(t, tc.settled, IsSettled(tc.status))
 		})
 	}
+}
+
+func secretActionSchema(name string) *v2.BatonActionSchema {
+	return v2.BatonActionSchema_builder{
+		Name: name,
+		ReturnTypes: []*config.Field{
+			config.Field_builder{
+				Name:       "success",
+				BoolField:  &config.BoolField{},
+				IsRequired: true,
+			}.Build(),
+			config.Field_builder{
+				Name:        "token",
+				StringField: &config.StringField{},
+				IsSecret:    true,
+			}.Build(),
+		},
+	}.Build()
+}
+
+func ageEncryptionConfig(t *testing.T) (*v2.EncryptionConfig, filippoage.Identity) {
+	t.Helper()
+	identity, err := filippoage.GenerateHybridIdentity()
+	require.NoError(t, err)
+	return v2.EncryptionConfig_builder{
+		AgeRecipientConfig: v2.EncryptionConfig_AgeRecipientConfig_builder{
+			Recipient: identity.Recipient().String(),
+		}.Build(),
+	}.Build(), identity
+}
+
+func decryptAgeActionResult(t *testing.T, encrypted *v2.EncryptedData, identity filippoage.Identity) []byte {
+	t.Helper()
+	reader, err := filippoage.Decrypt(bytes.NewReader(encrypted.GetEncryptedBytes()), identity)
+	require.NoError(t, err)
+	var plaintext bytes.Buffer
+	_, err = plaintext.ReadFrom(reader)
+	require.NoError(t, err)
+	return plaintext.Bytes()
+}
+
+func TestActionHandlerWithSecretsEncryptsInlineResultForEveryRecipient(t *testing.T) {
+	ctx := t.Context()
+	manager := NewActionManager(ctx)
+	schema := secretActionSchema("issue_token")
+	schema.SetReturnTypes(append(schema.GetReturnTypes(),
+		config.Field_builder{Name: "refresh_token", StringField: &config.StringField{}, IsSecret: true}.Build()))
+	handler := func(context.Context, *structpb.Struct) (*structpb.Struct, []*v2.PlaintextData, annotations.Annotations, error) {
+		response, err := structpb.NewStruct(map[string]interface{}{"success": true})
+		require.NoError(t, err)
+		return response, []*v2.PlaintextData{
+			v2.PlaintextData_builder{
+				Name:        "token",
+				Description: "issued token",
+				Schema:      "text/plain",
+				Bytes:       []byte("action-secret"),
+			}.Build(),
+			v2.PlaintextData_builder{
+				Name:  "refresh_token",
+				Bytes: []byte("refresh-secret"),
+			}.Build(),
+		}, nil, nil
+	}
+	require.NoError(t, RegisterWithSecrets(ctx, manager, schema, handler))
+
+	configA, identityA := ageEncryptionConfig(t)
+	configB, identityB := ageEncryptionConfig(t)
+	_, actionStatus, response, encryptedData, _, err := manager.InvokeActionWithWaitAndEncryption(
+		ctx,
+		"issue_token",
+		"",
+		nil,
+		time.Second,
+		[]*v2.EncryptionConfig{configA, configB},
+	)
+	require.NoError(t, err)
+	require.Equal(t, v2.BatonActionStatus_BATON_ACTION_STATUS_COMPLETE, actionStatus)
+	require.Equal(t, true, response.GetFields()["success"].GetBoolValue())
+	require.NotContains(t, response.GetFields(), "token")
+	require.Len(t, encryptedData, 4)
+	require.Equal(t, "token", encryptedData[0].GetName())
+	require.Equal(t, "issued token", encryptedData[0].GetDescription())
+	require.Equal(t, "text/plain", encryptedData[0].GetSchema())
+	require.Equal(t, []byte("action-secret"), decryptAgeActionResult(t, encryptedData[0], identityA))
+	require.Equal(t, []byte("action-secret"), decryptAgeActionResult(t, encryptedData[1], identityB))
+	require.Equal(t, "refresh_token", encryptedData[2].GetName())
+	require.Equal(t, []byte("refresh-secret"), decryptAgeActionResult(t, encryptedData[2], identityA))
+	require.Equal(t, []byte("refresh-secret"), decryptAgeActionResult(t, encryptedData[3], identityB))
+}
+
+func TestActionHandlerWithSecretsEncryptsBeforeStatusPublication(t *testing.T) {
+	ctx := t.Context()
+	manager := NewActionManager(ctx)
+	release := make(chan struct{})
+	handler := func(ctx context.Context, _ *structpb.Struct) (*structpb.Struct, []*v2.PlaintextData, annotations.Annotations, error) {
+		select {
+		case <-release:
+		case <-ctx.Done():
+			return nil, nil, nil, ctx.Err()
+		}
+		return &structpb.Struct{}, []*v2.PlaintextData{
+			v2.PlaintextData_builder{Name: "token", Bytes: []byte("polled-secret")}.Build(),
+		}, nil, nil
+	}
+	require.NoError(t, RegisterWithSecrets(ctx, manager, secretActionSchema("issue_token_async"), handler))
+	config, identity := ageEncryptionConfig(t)
+
+	id, actionStatus, _, encryptedData, _, err := manager.InvokeActionWithWaitAndEncryption(
+		ctx,
+		"issue_token_async",
+		"",
+		nil,
+		time.Millisecond,
+		[]*v2.EncryptionConfig{config},
+	)
+	require.NoError(t, err)
+	require.True(t, IsInFlight(actionStatus))
+	require.Empty(t, encryptedData)
+	// Detached settlement must use the recipient snapshot captured at invoke.
+	config.GetAgeRecipientConfig().SetRecipient("mutated-after-invoke")
+	close(release)
+
+	var settledEncrypted []*v2.EncryptedData
+	require.Eventually(t, func() bool {
+		status, _, response, gotEncrypted, _, statusErr := manager.GetActionStatusWithEncryptedData(ctx, id)
+		if statusErr != nil || status != v2.BatonActionStatus_BATON_ACTION_STATUS_COMPLETE {
+			return false
+		}
+		require.NotContains(t, response.GetFields(), "token")
+		settledEncrypted = gotEncrypted
+		return true
+	}, time.Second, time.Millisecond)
+	require.Len(t, settledEncrypted, 1)
+	require.Equal(t, []byte("polled-secret"), decryptAgeActionResult(t, settledEncrypted[0], identity))
+
+	_, _, _, repeatedEncrypted, _, err := manager.GetActionStatusWithEncryptedData(ctx, id)
+	require.NoError(t, err)
+	require.True(t, proto.Equal(settledEncrypted[0], repeatedEncrypted[0]))
+	_, resultStatus, _, resultEncrypted, _ := manager.actions[id].ResultWithEncryptedData()
+	require.Equal(t, v2.BatonActionStatus_BATON_ACTION_STATUS_COMPLETE, resultStatus)
+	require.True(t, proto.Equal(settledEncrypted[0], resultEncrypted[0]))
+}
+
+func TestActionHandlerWithSecretsRejectsInvalidRecipientsBeforeInvocation(t *testing.T) {
+	tests := []struct {
+		name    string
+		configs []*v2.EncryptionConfig
+	}{
+		{name: "missing"},
+		{name: "nil config", configs: []*v2.EncryptionConfig{nil}},
+		{name: "unknown provider", configs: []*v2.EncryptionConfig{v2.EncryptionConfig_builder{Provider: "unknown"}.Build()}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := t.Context()
+			manager := NewActionManager(ctx)
+			invoked := false
+			handler := func(context.Context, *structpb.Struct) (*structpb.Struct, []*v2.PlaintextData, annotations.Annotations, error) {
+				invoked = true
+				return nil, nil, nil, nil
+			}
+			require.NoError(t, RegisterWithSecrets(ctx, manager, secretActionSchema("issue_token"), handler))
+
+			_, _, _, _, _, err := manager.InvokeActionWithWaitAndEncryption(ctx, "issue_token", "", nil, time.Second, test.configs)
+			require.Error(t, err)
+			require.Equal(t, codes.InvalidArgument, status.Code(err))
+			require.False(t, invoked)
+		})
+	}
+}
+
+func TestResourceActionHandlerWithSecretsEncryptsResult(t *testing.T) {
+	ctx := t.Context()
+	manager := NewActionManager(ctx)
+	registry, err := manager.GetTypeRegistry(ctx, "service-account")
+	require.NoError(t, err)
+	handler := func(context.Context, *structpb.Struct) (*structpb.Struct, []*v2.PlaintextData, annotations.Annotations, error) {
+		return &structpb.Struct{}, []*v2.PlaintextData{
+			v2.PlaintextData_builder{Name: "token", Bytes: []byte("resource-secret")}.Build(),
+		}, nil, nil
+	}
+	require.NoError(t, RegisterWithSecrets(ctx, registry, secretActionSchema("issue_resource_token"), handler))
+	config, identity := ageEncryptionConfig(t)
+
+	_, actionStatus, response, encryptedData, _, err := manager.InvokeActionWithWaitAndEncryption(
+		ctx,
+		"issue_resource_token",
+		"service-account",
+		nil,
+		time.Second,
+		[]*v2.EncryptionConfig{config},
+	)
+	require.NoError(t, err)
+	require.Equal(t, v2.BatonActionStatus_BATON_ACTION_STATUS_COMPLETE, actionStatus)
+	require.NotContains(t, response.GetFields(), "token")
+	require.Len(t, encryptedData, 1)
+	require.Equal(t, []byte("resource-secret"), decryptAgeActionResult(t, encryptedData[0], identity))
+}
+
+func TestActionHandlerWithSecretsFailsWhenRequiredSecretIsMissingOnSuccess(t *testing.T) {
+	ctx := t.Context()
+	manager := NewActionManager(ctx)
+	schema := secretActionSchema("missing_required_token")
+	schema.GetReturnTypes()[1].SetIsRequired(true)
+	handler := func(context.Context, *structpb.Struct) (*structpb.Struct, []*v2.PlaintextData, annotations.Annotations, error) {
+		response, err := structpb.NewStruct(map[string]interface{}{"success": true})
+		require.NoError(t, err)
+		return response, nil, nil, nil
+	}
+	require.NoError(t, RegisterWithSecrets(ctx, manager, schema, handler))
+	config, _ := ageEncryptionConfig(t)
+
+	_, actionStatus, response, encryptedData, _, err := manager.InvokeActionWithWaitAndEncryption(
+		ctx,
+		"missing_required_token",
+		"",
+		nil,
+		time.Second,
+		[]*v2.EncryptionConfig{config},
+	)
+	require.NoError(t, err)
+	require.Equal(t, v2.BatonActionStatus_BATON_ACTION_STATUS_FAILED, actionStatus)
+	require.Empty(t, encryptedData)
+	require.Contains(t, response.GetFields()["error"].GetStringValue(), `required secret return type "token" is missing`)
+}
+
+func TestActionHandlerWithSecretsDoesNotRequireSecretWhenHandlerFails(t *testing.T) {
+	ctx := t.Context()
+	manager := NewActionManager(ctx)
+	schema := secretActionSchema("failing_required_token")
+	schema.GetReturnTypes()[1].SetIsRequired(true)
+	handler := func(context.Context, *structpb.Struct) (*structpb.Struct, []*v2.PlaintextData, annotations.Annotations, error) {
+		return nil, nil, nil, errors.New("provider rejected action")
+	}
+	require.NoError(t, RegisterWithSecrets(ctx, manager, schema, handler))
+	config, _ := ageEncryptionConfig(t)
+
+	_, actionStatus, response, encryptedData, _, err := manager.InvokeActionWithWaitAndEncryption(
+		ctx,
+		"failing_required_token",
+		"",
+		nil,
+		time.Second,
+		[]*v2.EncryptionConfig{config},
+	)
+	require.NoError(t, err)
+	require.Equal(t, v2.BatonActionStatus_BATON_ACTION_STATUS_FAILED, actionStatus)
+	require.Empty(t, encryptedData)
+	require.Equal(t, "provider rejected action", response.GetFields()["error"].GetStringValue())
+}
+
+func TestActionHandlerWithSecretsDropsPlaintextWhenHandlerFails(t *testing.T) {
+	ctx := t.Context()
+	manager := NewActionManager(ctx)
+	handler := func(context.Context, *structpb.Struct) (*structpb.Struct, []*v2.PlaintextData, annotations.Annotations, error) {
+		response, err := structpb.NewStruct(map[string]interface{}{"partial": "safe"})
+		require.NoError(t, err)
+		return response, []*v2.PlaintextData{
+			v2.PlaintextData_builder{Name: "token", Bytes: []byte("failed-action-secret")}.Build(),
+		}, nil, errors.New("provider rejected action")
+	}
+	require.NoError(t, RegisterWithSecrets(ctx, manager, secretActionSchema("failing_issue"), handler))
+	config, _ := ageEncryptionConfig(t)
+
+	_, actionStatus, response, encryptedData, _, err := manager.InvokeActionWithWaitAndEncryption(
+		ctx,
+		"failing_issue",
+		"",
+		nil,
+		time.Second,
+		[]*v2.EncryptionConfig{config},
+	)
+	require.NoError(t, err)
+	require.Equal(t, v2.BatonActionStatus_BATON_ACTION_STATUS_FAILED, actionStatus)
+	require.Empty(t, encryptedData)
+	require.Equal(t, "safe", response.GetFields()["partial"].GetStringValue())
+	require.Equal(t, "provider rejected action", response.GetFields()["error"].GetStringValue())
+	require.NotContains(t, response.String(), "failed-action-secret")
+}
+
+func TestActionHandlerWithSecretsDropsPlaintextWhenEncryptionFails(t *testing.T) {
+	ctx := t.Context()
+	manager := NewActionManager(ctx)
+	manager.encryptPlaintext = func(context.Context, *crypto.EncryptionManager, *v2.PlaintextData) ([]*v2.EncryptedData, error) {
+		return nil, errors.New("injected encryption failure")
+	}
+	plaintext := []byte("encryption-failure-secret")
+	handler := func(context.Context, *structpb.Struct) (*structpb.Struct, []*v2.PlaintextData, annotations.Annotations, error) {
+		return &structpb.Struct{}, []*v2.PlaintextData{
+			v2.PlaintextData_builder{Name: "token", Bytes: plaintext}.Build(),
+		}, nil, nil
+	}
+	require.NoError(t, RegisterWithSecrets(ctx, manager, secretActionSchema("oversized_token"), handler))
+	encryptionConfig, _ := ageEncryptionConfig(t)
+
+	_, actionStatus, response, encryptedData, _, err := manager.InvokeActionWithWaitAndEncryption(
+		ctx,
+		"oversized_token",
+		"",
+		nil,
+		time.Second,
+		[]*v2.EncryptionConfig{encryptionConfig},
+	)
+	require.NoError(t, err)
+	require.Equal(t, v2.BatonActionStatus_BATON_ACTION_STATUS_FAILED, actionStatus)
+	require.Empty(t, encryptedData)
+	require.Contains(t, response.GetFields()["error"].GetStringValue(), "encrypt action return value")
+	require.NotContains(t, response.String(), string(plaintext))
+}
+
+func TestActionHandlerWithSecretsClonesEncryptedResultBeforePublication(t *testing.T) {
+	ctx := t.Context()
+	manager := NewActionManager(ctx)
+	handlerOwned := v2.EncryptedData_builder{
+		Name:           "token",
+		EncryptedBytes: []byte("original-ciphertext"),
+	}.Build()
+	manager.encryptPlaintext = func(context.Context, *crypto.EncryptionManager, *v2.PlaintextData) ([]*v2.EncryptedData, error) {
+		return []*v2.EncryptedData{handlerOwned}, nil
+	}
+	handler := func(context.Context, *structpb.Struct) (*structpb.Struct, []*v2.PlaintextData, annotations.Annotations, error) {
+		return &structpb.Struct{}, []*v2.PlaintextData{
+			v2.PlaintextData_builder{Name: "token", Bytes: []byte("plaintext")}.Build(),
+		}, nil, nil
+	}
+	require.NoError(t, RegisterWithSecrets(ctx, manager, secretActionSchema("clone_ciphertext"), handler))
+	config, _ := ageEncryptionConfig(t)
+
+	id, actionStatus, _, encryptedData, _, err := manager.InvokeActionWithWaitAndEncryption(
+		ctx,
+		"clone_ciphertext",
+		"",
+		nil,
+		time.Second,
+		[]*v2.EncryptionConfig{config},
+	)
+	require.NoError(t, err)
+	require.Equal(t, v2.BatonActionStatus_BATON_ACTION_STATUS_COMPLETE, actionStatus)
+	handlerOwned.SetEncryptedBytes([]byte("mutated-ciphertext"))
+	require.Equal(t, []byte("original-ciphertext"), encryptedData[0].GetEncryptedBytes())
+
+	_, _, _, statusEncrypted, _, err := manager.GetActionStatusWithEncryptedData(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, []byte("original-ciphertext"), statusEncrypted[0].GetEncryptedBytes())
+}
+
+func TestActionHandlerWithSecretsRedactsPanicValue(t *testing.T) {
+	ctx := t.Context()
+	manager := NewActionManager(ctx)
+	handler := func(context.Context, *structpb.Struct) (*structpb.Struct, []*v2.PlaintextData, annotations.Annotations, error) {
+		panic("panic-secret")
+	}
+	require.NoError(t, RegisterWithSecrets(ctx, manager, secretActionSchema("panicking_issue"), handler))
+	config, _ := ageEncryptionConfig(t)
+
+	_, actionStatus, response, encryptedData, _, err := manager.InvokeActionWithWaitAndEncryption(
+		ctx,
+		"panicking_issue",
+		"",
+		nil,
+		time.Second,
+		[]*v2.EncryptionConfig{config},
+	)
+	require.NoError(t, err)
+	require.Equal(t, v2.BatonActionStatus_BATON_ACTION_STATUS_FAILED, actionStatus)
+	require.Empty(t, encryptedData)
+	require.Equal(t, "panic in action handler", response.GetFields()["error"].GetStringValue())
+	require.NotContains(t, response.String(), "panic-secret")
+}
+
+func TestActionHandlerIncludesPanicValueWhenHandlerDoesNotReturnSecrets(t *testing.T) {
+	ctx := t.Context()
+	manager := NewActionManager(ctx)
+	handler := func(context.Context, *structpb.Struct) (*structpb.Struct, annotations.Annotations, error) {
+		panic("lock failed")
+	}
+	require.NoError(t, manager.Register(ctx, testActionSchema, handler))
+
+	_, actionStatus, response, _, err := manager.InvokeActionWithWait(ctx, "lock_account", "", testInput, time.Second)
+	require.NoError(t, err)
+	require.Equal(t, v2.BatonActionStatus_BATON_ACTION_STATUS_FAILED, actionStatus)
+	require.Equal(t, "panic in action handler: lock failed", response.GetFields()["error"].GetStringValue())
+}
+
+func TestActionHandlerWithSecretsPublishesCiphertextAfterInvokeCancellation(t *testing.T) {
+	invokeCtx, cancel := context.WithCancel(t.Context())
+	manager := NewActionManager(invokeCtx)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	handler := func(context.Context, *structpb.Struct) (*structpb.Struct, []*v2.PlaintextData, annotations.Annotations, error) {
+		close(started)
+		<-release
+		return &structpb.Struct{}, []*v2.PlaintextData{
+			v2.PlaintextData_builder{Name: "token", Bytes: []byte("late-secret")}.Build(),
+		}, nil, nil
+	}
+	require.NoError(t, RegisterWithSecrets(invokeCtx, manager, secretActionSchema("cancelled_issue"), handler))
+	config, identity := ageEncryptionConfig(t)
+
+	type invokeResult struct {
+		id            string
+		status        v2.BatonActionStatus
+		encryptedData []*v2.EncryptedData
+		err           error
+	}
+	resultCh := make(chan invokeResult, 1)
+	go func() {
+		id, actionStatus, _, encryptedData, _, err := manager.InvokeActionWithWaitAndEncryption(
+			invokeCtx,
+			"cancelled_issue",
+			"",
+			nil,
+			time.Second,
+			[]*v2.EncryptionConfig{config},
+		)
+		resultCh <- invokeResult{id: id, status: actionStatus, encryptedData: encryptedData, err: err}
+	}()
+
+	<-started
+	cancel()
+	cancelledResult := <-resultCh
+	require.ErrorIs(t, cancelledResult.err, context.Canceled)
+	require.Equal(t, v2.BatonActionStatus_BATON_ACTION_STATUS_FAILED, cancelledResult.status)
+	require.Empty(t, cancelledResult.encryptedData)
+	close(release)
+
+	var settledEncrypted []*v2.EncryptedData
+	require.Eventually(t, func() bool {
+		status, _, _, encryptedData, _, err := manager.GetActionStatusWithEncryptedData(t.Context(), cancelledResult.id)
+		settledEncrypted = encryptedData
+		return err == nil && status == v2.BatonActionStatus_BATON_ACTION_STATUS_COMPLETE
+	}, time.Second, time.Millisecond)
+	require.Len(t, settledEncrypted, 1)
+	require.Equal(t, []byte("late-secret"), decryptAgeActionResult(t, settledEncrypted[0], identity))
+}
+
+func TestActionHandlerWithSecretsRejectsInvalidOutputs(t *testing.T) {
+	tests := []struct {
+		name      string
+		response  map[string]interface{}
+		plaintext []*v2.PlaintextData
+		errText   string
+	}{
+		{
+			name:     "secret in public response",
+			response: map[string]interface{}{"token": "plaintext-secret"},
+			errText:  "must not be included in the public response",
+		},
+		{
+			name: "undeclared plaintext",
+			plaintext: []*v2.PlaintextData{
+				v2.PlaintextData_builder{Name: "password", Bytes: []byte("undeclared-sensitive-value")}.Build(),
+			},
+			errText: "is not declared as a secret return type",
+		},
+		{
+			name: "duplicate plaintext name",
+			plaintext: []*v2.PlaintextData{
+				v2.PlaintextData_builder{Name: "token", Bytes: []byte("duplicate-value-one")}.Build(),
+				v2.PlaintextData_builder{Name: "token", Bytes: []byte("duplicate-value-two")}.Build(),
+			},
+			errText: "duplicate plaintext return value",
+		},
+		{
+			name: "empty plaintext bytes",
+			plaintext: []*v2.PlaintextData{
+				v2.PlaintextData_builder{Name: "token"}.Build(),
+			},
+			errText: "must have a name and non-empty bytes",
+		},
+		{
+			name:      "nil plaintext",
+			plaintext: []*v2.PlaintextData{nil},
+			errText:   "must have a name and non-empty bytes",
+		},
+		{
+			name: "empty plaintext name",
+			plaintext: []*v2.PlaintextData{
+				v2.PlaintextData_builder{Bytes: []byte("empty-name-sensitive-value")}.Build(),
+			},
+			errText: "must have a name and non-empty bytes",
+		},
+		{
+			name: "name declared non-secret",
+			plaintext: []*v2.PlaintextData{
+				v2.PlaintextData_builder{Name: "success", Bytes: []byte("non-secret-field-sensitive-value")}.Build(),
+			},
+			errText: "is not declared as a secret return type",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := t.Context()
+			manager := NewActionManager(ctx)
+			handler := func(context.Context, *structpb.Struct) (*structpb.Struct, []*v2.PlaintextData, annotations.Annotations, error) {
+				response, err := structpb.NewStruct(test.response)
+				require.NoError(t, err)
+				return response, test.plaintext, nil, nil
+			}
+			require.NoError(t, RegisterWithSecrets(ctx, manager, secretActionSchema("issue_token"), handler))
+			config, _ := ageEncryptionConfig(t)
+
+			id, actionStatus, response, encryptedData, _, err := manager.InvokeActionWithWaitAndEncryption(
+				ctx,
+				"issue_token",
+				"",
+				nil,
+				time.Second,
+				[]*v2.EncryptionConfig{config},
+			)
+			require.NoError(t, err)
+			require.Equal(t, v2.BatonActionStatus_BATON_ACTION_STATUS_FAILED, actionStatus)
+			require.Empty(t, encryptedData)
+			require.NotContains(t, response.String(), "plaintext-secret")
+			for _, plaintext := range test.plaintext {
+				if len(plaintext.GetBytes()) > 0 {
+					require.NotContains(t, response.String(), string(plaintext.GetBytes()))
+				}
+			}
+			require.Contains(t, response.GetFields()["error"].GetStringValue(), test.errText)
+
+			_, _, statusResponse, statusEncrypted, _, statusErr := manager.GetActionStatusWithEncryptedData(ctx, id)
+			require.NoError(t, statusErr)
+			require.Empty(t, statusEncrypted)
+			require.Contains(t, statusResponse.GetFields()["error"].GetStringValue(), test.errText)
+		})
+	}
+}
+
+type actionRegistryWithoutSecretSupport struct{}
+
+func (actionRegistryWithoutSecretSupport) Register(context.Context, *v2.BatonActionSchema, ActionHandler) error {
+	return nil
+}
+
+func (actionRegistryWithoutSecretSupport) RegisterAction(context.Context, string, *v2.BatonActionSchema, ActionHandler) error {
+	return nil
+}
+
+func TestSecretActionRegistrationValidatesSchemaAndRegistry(t *testing.T) {
+	ctx := t.Context()
+	handler := func(context.Context, *structpb.Struct) (*structpb.Struct, []*v2.PlaintextData, annotations.Annotations, error) {
+		return nil, nil, nil, nil
+	}
+
+	err := RegisterWithSecrets(ctx, actionRegistryWithoutSecretSupport{}, secretActionSchema("issue_token"), handler)
+	require.ErrorContains(t, err, "does not support secret results")
+
+	manager := NewActionManager(ctx)
+	err = manager.Register(ctx, secretActionSchema("issue_token"), testActionHandler)
+	require.ErrorContains(t, err, "must use RegisterWithSecrets")
+
+	err = manager.RegisterWithSecrets(ctx, v2.BatonActionSchema_builder{Name: "no_secret"}.Build(), handler)
+	require.ErrorContains(t, err, "requires at least one secret return type")
+
+	emptyNameSchema := secretActionSchema("empty_name")
+	emptyNameSchema.GetReturnTypes()[1].SetName("")
+	err = manager.RegisterWithSecrets(ctx, emptyNameSchema, handler)
+	require.ErrorContains(t, err, "name cannot be empty")
+
+	duplicateNameSchema := secretActionSchema("duplicate_name")
+	duplicateNameSchema.SetReturnTypes(append(duplicateNameSchema.GetReturnTypes(),
+		config.Field_builder{Name: "token", StringField: &config.StringField{}, IsSecret: true}.Build()))
+	err = manager.RegisterWithSecrets(ctx, duplicateNameSchema, handler)
+	require.ErrorContains(t, err, "duplicate secret return type")
 }

--- a/pkg/connectorbuilder/actions.go
+++ b/pkg/connectorbuilder/actions.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
@@ -78,6 +80,20 @@ type ActionManager interface {
 	// HasActions returns true if there are any registered actions.
 	HasActions() bool
 }
+
+type encryptedActionManager interface {
+	InvokeActionWithWaitAndEncryption(
+		ctx context.Context,
+		name string,
+		resourceTypeID string,
+		args *structpb.Struct,
+		inlineWait time.Duration,
+		encryptionConfigs []*v2.EncryptionConfig,
+	) (string, v2.BatonActionStatus, *structpb.Struct, []*v2.EncryptedData, annotations.Annotations, error)
+	GetActionStatusWithEncryptedData(ctx context.Context, id string) (v2.BatonActionStatus, string, *structpb.Struct, []*v2.EncryptedData, annotations.Annotations, error)
+}
+
+var _ encryptedActionManager = (*actions.ActionManager)(nil)
 
 // GlobalActionProvider allows connectors to register global (non-resource-scoped) actions.
 // This is the preferred method for registering global actions in new connectors.
@@ -191,18 +207,32 @@ func (b *builder) InvokeAction(ctx context.Context, request *v2.InvokeActionRequ
 
 	resourceTypeID := request.GetResourceTypeId()
 
-	id, actionStatus, resp, annos, err := b.actionManager.InvokeActionWithWait(ctx, request.GetName(), resourceTypeID, request.GetArgs(), request.GetInlineWait().AsDuration())
+	encryptedManager, ok := b.actionManager.(encryptedActionManager)
+	if !ok {
+		err = status.Error(codes.Internal, "action manager does not support encrypted action results")
+		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
+		return nil, err
+	}
+	id, actionStatus, resp, encryptedData, annos, err := encryptedManager.InvokeActionWithWaitAndEncryption(
+		ctx,
+		request.GetName(),
+		resourceTypeID,
+		request.GetArgs(),
+		request.GetInlineWait().AsDuration(),
+		request.GetEncryptionConfigs(),
+	)
 	if err != nil {
 		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
 		return nil, fmt.Errorf("error: invoking action failed: %w", err)
 	}
 
 	rv := v2.InvokeActionResponse_builder{
-		Id:          id,
-		Name:        request.GetName(),
-		Status:      actionStatus,
-		Annotations: annos,
-		Response:    resp,
+		Id:            id,
+		Name:          request.GetName(),
+		Status:        actionStatus,
+		Annotations:   annos,
+		Response:      resp,
+		EncryptedData: encryptedData,
 	}.Build()
 
 	b.m.RecordTaskSuccess(ctx, tt, b.nowFunc().Sub(start))
@@ -217,18 +247,25 @@ func (b *builder) GetActionStatus(ctx context.Context, request *v2.GetActionStat
 	start := b.nowFunc()
 	tt := tasks.ActionStatusType
 
-	actionStatus, name, rv, annos, err := b.actionManager.GetActionStatus(ctx, request.GetId())
+	encryptedManager, ok := b.actionManager.(encryptedActionManager)
+	if !ok {
+		err = status.Error(codes.Internal, "action manager does not support encrypted action results")
+		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
+		return nil, err
+	}
+	actionStatus, name, rv, encryptedData, annos, err := encryptedManager.GetActionStatusWithEncryptedData(ctx, request.GetId())
 	if err != nil {
 		b.m.RecordTaskFailure(ctx, tt, b.nowFunc().Sub(start), err)
 		return nil, fmt.Errorf("error: action status for id %s not found: %w", request.GetId(), err)
 	}
 
 	resp := v2.GetActionStatusResponse_builder{
-		Id:          request.GetId(),
-		Name:        name,
-		Status:      actionStatus,
-		Annotations: annos,
-		Response:    rv,
+		Id:            request.GetId(),
+		Name:          name,
+		Status:        actionStatus,
+		Annotations:   annos,
+		Response:      rv,
+		EncryptedData: encryptedData,
 	}.Build()
 	b.m.RecordTaskSuccess(ctx, tt, b.nowFunc().Sub(start))
 	return resp, nil

--- a/pkg/connectorbuilder/actions_inline_wait_test.go
+++ b/pkg/connectorbuilder/actions_inline_wait_test.go
@@ -1,10 +1,13 @@
 package connectorbuilder
 
 import (
+	"bytes"
 	"context"
 	"testing"
 	"time"
 
+	filippoage "filippo.io/age"
+	config "github.com/conductorone/baton-sdk/pb/c1/config/v1"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/actions"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
@@ -114,4 +117,65 @@ func TestInlineWaitValidationCeiling(t *testing.T) {
 			}
 		})
 	}
+}
+
+type testSecretGlobalActionProvider struct {
+	ConnectorBuilder
+}
+
+func (t *testSecretGlobalActionProvider) GlobalActions(ctx context.Context, registry actions.ActionRegistry) error {
+	schema := v2.BatonActionSchema_builder{
+		Name: "issue-token",
+		ReturnTypes: []*config.Field{
+			config.Field_builder{
+				Name:        "token",
+				StringField: &config.StringField{},
+				IsSecret:    true,
+			}.Build(),
+		},
+	}.Build()
+	handler := func(context.Context, *structpb.Struct) (*structpb.Struct, []*v2.PlaintextData, annotations.Annotations, error) {
+		return &structpb.Struct{}, []*v2.PlaintextData{
+			v2.PlaintextData_builder{Name: "token", Bytes: []byte("connector-secret")}.Build(),
+		}, nil, nil
+	}
+	return actions.RegisterWithSecrets(ctx, registry, schema, handler)
+}
+
+func TestInvokeActionReturnsEncryptedDataOnInvokeAndStatus(t *testing.T) {
+	ctx := t.Context()
+	identity, err := filippoage.GenerateHybridIdentity()
+	require.NoError(t, err)
+	encryptionConfig := v2.EncryptionConfig_builder{
+		AgeRecipientConfig: v2.EncryptionConfig_AgeRecipientConfig_builder{
+			Recipient: identity.Recipient().String(),
+		}.Build(),
+	}.Build()
+
+	connector, err := NewConnector(ctx, &testSecretGlobalActionProvider{
+		ConnectorBuilder: newTestConnector([]ResourceSyncer{}),
+	})
+	require.NoError(t, err)
+
+	invokeResponse, err := connector.InvokeAction(ctx, v2.InvokeActionRequest_builder{
+		Name:              "issue-token",
+		EncryptionConfigs: []*v2.EncryptionConfig{encryptionConfig},
+	}.Build())
+	require.NoError(t, err)
+	require.Equal(t, v2.BatonActionStatus_BATON_ACTION_STATUS_COMPLETE, invokeResponse.GetStatus())
+	require.Len(t, invokeResponse.GetEncryptedData(), 1)
+	require.NotContains(t, invokeResponse.GetResponse().GetFields(), "token")
+
+	statusResponse, err := connector.GetActionStatus(ctx, v2.GetActionStatusRequest_builder{Id: invokeResponse.GetId()}.Build())
+	require.NoError(t, err)
+	require.Equal(t, v2.BatonActionStatus_BATON_ACTION_STATUS_COMPLETE, statusResponse.GetStatus())
+	require.Len(t, statusResponse.GetEncryptedData(), 1)
+	require.Equal(t, invokeResponse.GetEncryptedData()[0].GetEncryptedBytes(), statusResponse.GetEncryptedData()[0].GetEncryptedBytes())
+
+	reader, err := filippoage.Decrypt(bytes.NewReader(statusResponse.GetEncryptedData()[0].GetEncryptedBytes()), identity)
+	require.NoError(t, err)
+	var plaintext bytes.Buffer
+	_, err = plaintext.ReadFrom(reader)
+	require.NoError(t, err)
+	require.Equal(t, "connector-secret", plaintext.String())
 }

--- a/pkg/connectorrunner/runner.go
+++ b/pkg/connectorrunner/runner.go
@@ -359,9 +359,10 @@ type createAccountConfig struct {
 }
 
 type invokeActionConfig struct {
-	action         string
-	resourceTypeID string // Optional: if set, invokes a resource-scoped action
-	args           *structpb.Struct
+	action            string
+	resourceTypeID    string // Optional: if set, invokes a resource-scoped action
+	args              *structpb.Struct
+	encryptionConfigs []*v2.EncryptionConfig
 }
 
 type listActionSchemasConfig struct {
@@ -567,13 +568,26 @@ func WithOnDemandCreateAccount(c1zPath string, login string, email string, profi
 // WithOnDemandInvokeAction creates an option for invoking an action.
 // If resourceTypeID is provided, it invokes a resource-scoped action.
 func WithOnDemandInvokeAction(c1zPath string, action string, resourceTypeID string, args *structpb.Struct) Option {
+	return WithOnDemandInvokeActionWithEncryption(c1zPath, action, resourceTypeID, args, nil)
+}
+
+// WithOnDemandInvokeActionWithEncryption creates an option for invoking an
+// action with recipients for encrypted results.
+func WithOnDemandInvokeActionWithEncryption(
+	c1zPath string,
+	action string,
+	resourceTypeID string,
+	args *structpb.Struct,
+	encryptionConfigs []*v2.EncryptionConfig,
+) Option {
 	return func(ctx context.Context, cfg *runnerConfig) error {
 		cfg.onDemand = true
 		cfg.c1zPath = c1zPath
 		cfg.invokeActionConfig = &invokeActionConfig{
-			action:         action,
-			resourceTypeID: resourceTypeID,
-			args:           args,
+			action:            action,
+			resourceTypeID:    resourceTypeID,
+			args:              args,
+			encryptionConfigs: encryptionConfigs,
 		}
 		return nil
 	}
@@ -1040,7 +1054,14 @@ func NewConnectorRunner(ctx context.Context, c types.ConnectorServer, opts ...Op
 			tm = local.NewCreateAccountManager(ctx, cfg.c1zPath, cfg.createAccountConfig.login, cfg.createAccountConfig.email, cfg.createAccountConfig.profile, cfg.createAccountConfig.resourceTypeID)
 
 		case cfg.invokeActionConfig != nil:
-			tm = local.NewActionInvoker(ctx, cfg.c1zPath, cfg.invokeActionConfig.action, cfg.invokeActionConfig.resourceTypeID, cfg.invokeActionConfig.args)
+			tm = local.NewActionInvokerWithEncryption(
+				ctx,
+				cfg.c1zPath,
+				cfg.invokeActionConfig.action,
+				cfg.invokeActionConfig.resourceTypeID,
+				cfg.invokeActionConfig.args,
+				cfg.invokeActionConfig.encryptionConfigs,
+			)
 
 		case cfg.listActionSchemasConfig != nil:
 			tm = local.NewListActionSchemas(ctx, cfg.listActionSchemasConfig.resourceTypeID)

--- a/pkg/tasks/c1api/actions.go
+++ b/pkg/tasks/c1api/actions.go
@@ -128,9 +128,10 @@ func (c *actionInvokeTaskHandler) HandleTask(ctx context.Context) error {
 	}
 
 	reqBuilder := v2.InvokeActionRequest_builder{
-		Name:        t.GetName(),
-		Args:        t.GetArgs(),
-		Annotations: t.GetAnnotations(),
+		Name:              t.GetName(),
+		Args:              t.GetArgs(),
+		Annotations:       t.GetAnnotations(),
+		EncryptionConfigs: t.GetEncryptionConfigs(),
 	}
 	if resourceTypeID := t.GetResourceTypeId(); resourceTypeID != "" {
 		reqBuilder.ResourceTypeId = resourceTypeID

--- a/pkg/tasks/c1api/actions_test.go
+++ b/pkg/tasks/c1api/actions_test.go
@@ -1,0 +1,72 @@
+package c1api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	v1 "github.com/conductorone/baton-sdk/pb/c1/connectorapi/baton/v1"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/types"
+)
+
+type actionInvokeClient struct {
+	types.ConnectorClient
+	request  *v2.InvokeActionRequest
+	response *v2.InvokeActionResponse
+}
+
+func (c *actionInvokeClient) InvokeAction(
+	_ context.Context,
+	request *v2.InvokeActionRequest,
+	_ ...grpc.CallOption,
+) (*v2.InvokeActionResponse, error) {
+	c.request = request
+	return c.response, nil
+}
+
+type actionInvokeTestHelpers struct {
+	client   types.ConnectorClient
+	response proto.Message
+}
+
+func (h *actionInvokeTestHelpers) ConnectorClient() types.ConnectorClient {
+	return h.client
+}
+
+func (h *actionInvokeTestHelpers) FinishTask(
+	_ context.Context,
+	response proto.Message,
+	_ annotations.Annotations,
+	err error,
+) error {
+	h.response = response
+	return err
+}
+
+func TestActionInvokeTaskThreadsEncryptionConfigs(t *testing.T) {
+	encryptionConfig := v2.EncryptionConfig_builder{Provider: "test-provider"}.Build()
+	response := v2.InvokeActionResponse_builder{
+		Status: v2.BatonActionStatus_BATON_ACTION_STATUS_COMPLETE,
+		EncryptedData: []*v2.EncryptedData{
+			v2.EncryptedData_builder{Name: "token", EncryptedBytes: []byte("ciphertext")}.Build(),
+		},
+	}.Build()
+	client := &actionInvokeClient{response: response}
+	helpers := &actionInvokeTestHelpers{client: client}
+	task := v1.Task_builder{
+		ActionInvoke: v1.Task_ActionInvokeTask_builder{
+			Name:              "issue-token",
+			EncryptionConfigs: []*v2.EncryptionConfig{encryptionConfig},
+		}.Build(),
+	}.Build()
+
+	require.NoError(t, newActionInvokeTaskHandler(task, helpers).HandleTask(t.Context()))
+	require.Len(t, client.request.GetEncryptionConfigs(), 1)
+	require.True(t, proto.Equal(encryptionConfig, client.request.GetEncryptionConfigs()[0]))
+	require.Same(t, response, helpers.response)
+}

--- a/pkg/tasks/local/action_invoker.go
+++ b/pkg/tasks/local/action_invoker.go
@@ -24,9 +24,10 @@ type localActionInvoker struct {
 	dbPath string
 	o      sync.Once
 
-	action         string
-	resourceTypeID string // Optional: if set, invokes a resource-scoped action
-	args           *structpb.Struct
+	action            string
+	resourceTypeID    string // Optional: if set, invokes a resource-scoped action
+	args              *structpb.Struct
+	encryptionConfigs []*v2.EncryptionConfig
 }
 
 func (m *localActionInvoker) GetTempDir() string {
@@ -42,9 +43,10 @@ func (m *localActionInvoker) Next(ctx context.Context) (*v1.Task, time.Duration,
 	m.o.Do(func() {
 		task = v1.Task_builder{
 			ActionInvoke: v1.Task_ActionInvokeTask_builder{
-				Name:           m.action,
-				Args:           m.args,
-				ResourceTypeId: m.resourceTypeID,
+				Name:              m.action,
+				Args:              m.args,
+				ResourceTypeId:    m.resourceTypeID,
+				EncryptionConfigs: m.encryptionConfigs,
 			}.Build(),
 		}.Build()
 	})
@@ -60,9 +62,10 @@ func (m *localActionInvoker) Process(ctx context.Context, task *v1.Task, cc type
 
 	t := task.GetActionInvoke()
 	reqBuilder := v2.InvokeActionRequest_builder{
-		Name:        t.GetName(),
-		Args:        t.GetArgs(),
-		Annotations: t.GetAnnotations(),
+		Name:              t.GetName(),
+		Args:              t.GetArgs(),
+		Annotations:       t.GetAnnotations(),
+		EncryptionConfigs: t.GetEncryptionConfigs(),
 	}
 	if resourceTypeID := t.GetResourceTypeId(); resourceTypeID != "" {
 		reqBuilder.ResourceTypeId = resourceTypeID
@@ -74,6 +77,7 @@ func (m *localActionInvoker) Process(ctx context.Context, task *v1.Task, cc type
 
 	status := resp.GetStatus()
 	finalResp := resp.GetResponse()
+	finalEncryptedData := resp.GetEncryptedData()
 	l.Info("ActionInvoke response",
 		zap.String("action_id", resp.GetId()),
 		zap.String("name", resp.GetName()),
@@ -97,10 +101,11 @@ func (m *localActionInvoker) Process(ctx context.Context, task *v1.Task, cc type
 			}
 			status = r.GetStatus()
 			finalResp = r.GetResponse()
+			finalEncryptedData = r.GetEncryptedData()
 		}
 	}
 
-	l.Info("ActionInvoke response", zap.Any("resp", finalResp))
+	l.Info("ActionInvoke response", zap.Any("resp", finalResp), zap.Any("encrypted_data", finalEncryptedData))
 
 	if status == v2.BatonActionStatus_BATON_ACTION_STATUS_FAILED {
 		return fmt.Errorf("action invoke failed: %v", finalResp)
@@ -112,10 +117,24 @@ func (m *localActionInvoker) Process(ctx context.Context, task *v1.Task, cc type
 // NewActionInvoker returns a task manager that queues an action invoke task.
 // If resourceTypeID is provided, it invokes a resource-scoped action.
 func NewActionInvoker(ctx context.Context, dbPath string, action string, resourceTypeID string, args *structpb.Struct) tasks.Manager {
+	return NewActionInvokerWithEncryption(ctx, dbPath, action, resourceTypeID, args, nil)
+}
+
+// NewActionInvokerWithEncryption returns a task manager that supplies
+// recipients for encrypted action results.
+func NewActionInvokerWithEncryption(
+	_ context.Context,
+	dbPath string,
+	action string,
+	resourceTypeID string,
+	args *structpb.Struct,
+	encryptionConfigs []*v2.EncryptionConfig,
+) tasks.Manager {
 	return &localActionInvoker{
-		dbPath:         dbPath,
-		action:         action,
-		resourceTypeID: resourceTypeID,
-		args:           args,
+		dbPath:            dbPath,
+		action:            action,
+		resourceTypeID:    resourceTypeID,
+		args:              args,
+		encryptionConfigs: encryptionConfigs,
 	}
 }

--- a/pkg/tasks/local/action_invoker_test.go
+++ b/pkg/tasks/local/action_invoker_test.go
@@ -1,0 +1,27 @@
+package local
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+)
+
+func TestActionInvokerThreadsEncryptionConfigs(t *testing.T) {
+	encryptionConfig := v2.EncryptionConfig_builder{Provider: "test-provider"}.Build()
+	manager := NewActionInvokerWithEncryption(
+		t.Context(),
+		"sync.c1z",
+		"issue-token",
+		"",
+		nil,
+		[]*v2.EncryptionConfig{encryptionConfig},
+	)
+
+	task, _, err := manager.Next(t.Context())
+	require.NoError(t, err)
+	require.Len(t, task.GetActionInvoke().GetEncryptionConfigs(), 1)
+	require.True(t, proto.Equal(encryptionConfig, task.GetActionInvoke().GetEncryptionConfigs()[0]))
+}

--- a/proto/c1/config/v1/config.proto
+++ b/proto/c1/config/v1/config.proto
@@ -53,6 +53,10 @@ message Field {
   string placeholder = 4;
   bool is_required = 5;
   bool is_ops = 6;
+  // For configuration and action arguments, the UI obscures this field. For
+  // action return types, the connector must return the value as PlaintextData
+  // through ActionHandlerWithSecrets; it is omitted from the public response
+  // and returned as EncryptedData.
   bool is_secret = 7;
 
   oneof field {

--- a/proto/c1/connector/v2/action.proto
+++ b/proto/c1/connector/v2/action.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package c1.connector.v2;
 
 import "c1/config/v1/config.proto";
+import "c1/connector/v2/resource.proto";
 import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
@@ -80,6 +81,8 @@ message InvokeActionRequest {
     gte: {}
     lte: {seconds: 86400}
   }];
+  // Public keys the connector uses to encrypt secret return values.
+  repeated EncryptionConfig encryption_configs = 6;
 }
 
 message InvokeActionResponse {
@@ -88,6 +91,8 @@ message InvokeActionResponse {
   repeated google.protobuf.Any annotations = 3;
   google.protobuf.Struct response = 4;
   string name = 5;
+  // Secret return values encrypted for every requested recipient.
+  repeated EncryptedData encrypted_data = 6;
 }
 
 message GetActionStatusRequest {
@@ -102,6 +107,8 @@ message GetActionStatusResponse {
   BatonActionStatus status = 3;
   repeated google.protobuf.Any annotations = 4;
   google.protobuf.Struct response = 5;
+  // Secret return values encrypted when the action settled.
+  repeated EncryptedData encrypted_data = 6;
 }
 
 message GetActionSchemaRequest {

--- a/proto/c1/connectorapi/baton/v1/baton.proto
+++ b/proto/c1/connectorapi/baton/v1/baton.proto
@@ -175,6 +175,8 @@ message Task {
     repeated google.protobuf.Any annotations = 3;
     // Optional: if set, invokes a resource-scoped action
     string resource_type_id = 4;
+    // Public keys the connector uses to encrypt secret return values.
+    repeated connector.v2.EncryptionConfig encryption_configs = 5;
   }
 
   message ActionStatusTask {


### PR DESCRIPTION
## Summary
- Add `ActionHandlerWithSecrets` so connectors can return `PlaintextData` separately from the public action `Struct`. The SDK encrypts those values for the request's `encryption_configs` before they appear on invoke or status responses.
- Existing `ActionHandler` registrations are unchanged. Secret-marked `return_types` (`is_secret`) must use the new registration path; plaintext never sits in `OutstandingAction` or on the wire.
- C1 and local invoke tasks now carry encryption configs. Local invoke keeps the old constructor and adds `NewActionInvokerWithEncryption`.

Verification plan and evidence: `docs/verification/encrypted-action-results/`.

## Test plan
- [x] `go test -count=1 ./pkg/actions ./pkg/connectorbuilder ./pkg/connectorrunner ./pkg/tasks/local`
- [x] `go test -count=1 -run '^TestActionInvokeTaskThreadsEncryptionConfigs$' ./pkg/tasks/c1api`
- [x] `go test -race -count=1 ./pkg/actions ./pkg/connectorbuilder`
- [x] `buf lint` and `buf breaking --against '.git#branch=main'`
- [ ] Confirm a connector that registers `ActionHandlerWithSecrets` can decrypt invoke and status `encrypted_data` with the matching private key
- [ ] Confirm an existing non-secret custom action still completes without encryption configs


Made with [Cursor](https://cursor.com)