### PR TITLE
drop inline graph writer

### DIFF
--- a/pkg/sync/config.go
+++ b/pkg/sync/config.go
@@ -56,18 +56,17 @@ type syncConfig struct {
 	// merge and soften hard arms to aggregated warnings. Distinct from
 	// onlyExpandGrants, which changes WHAT syncs and carries no
 	// invariant policy on its own.
-	compactionMergedStore      bool
-	targetedSyncResources      []*v2.Resource
-	onlyExpandGrants           bool
-	preserveEntitlementGraph   bool
-	dontExpandGrants           bool
-	checkpointEntitlementGraph bool
-	skipEntitlementsAndGrants  bool
-	skipGrants                 bool
-	syncType                   connectorstore.SyncType
-	setSessionStore            sessions.SetSessionStore
-	syncResourceTypes          []string
-	workerCount                int // If 1, sync is sequential (default). If > 1, sync operations are done in parallel.
-	metricsHandler             metrics.Handler
-	syncIdentity               uotel.SyncIdentity
+	compactionMergedStore     bool
+	targetedSyncResources     []*v2.Resource
+	onlyExpandGrants          bool
+	preserveEntitlementGraph  bool
+	dontExpandGrants          bool
+	skipEntitlementsAndGrants bool
+	skipGrants                bool
+	syncType                  connectorstore.SyncType
+	setSessionStore           sessions.SetSessionStore
+	syncResourceTypes         []string
+	workerCount               int // If 1, sync is sequential (default). If > 1, sync operations are done in parallel.
+	metricsHandler            metrics.Handler
+	syncIdentity              uotel.SyncIdentity
 }

--- a/pkg/sync/graph_compatibility_matrix_test.go
+++ b/pkg/sync/graph_compatibility_matrix_test.go
@@ -12,15 +12,14 @@ import (
 // TestGraphFromStore and synccompactor's TestCompactorGraphCompatibilityHealing.
 func TestEntitlementGraphTokenCompatibilityMatrix(t *testing.T) {
 	ctx := context.Background()
-	// Opt in to the legacy inline-graph token shape. Current checkpoints omit
-	// graphs by default, while readers remain compatible with older tokens.
-	stateWithGraph := newState(withCheckpointEntitlementGraph(true))
+	// Hand-build the legacy inline-graph token shape. Checkpoints no longer
+	// carry a graph, while readers remain compatible with older tokens.
+	stateWithGraph := newState()
 	graph := stateWithGraph.EntitlementGraph(ctx)
 	graph.AddEntitlementID("a")
 	graph.Loaded = true
 	graph.MarkExpansionComplete()
-	legacyToken, err := stateWithGraph.Marshal()
-	require.NoError(t, err)
+	legacyToken := marshalLegacyInlineGraphToken(t, stateWithGraph)
 
 	emptyState := newState()
 	emptyToken, err := emptyState.Marshal()

--- a/pkg/sync/graph_from_token_test.go
+++ b/pkg/sync/graph_from_token_test.go
@@ -43,11 +43,13 @@ func TestGraphFromToken_Empty(t *testing.T) {
 	require.Nil(t, loaded)
 }
 
-// TestPrepareExpansionReplayToken_ClearsPreservedGraph (U2): a token that
-// preserved its entitlement graph (WithPreserveEntitlementGraph) must have that
-// graph cleared when rewritten for replay — otherwise the replay skips graph
-// loading (graph already "expanded") and silently no-ops.
-func TestPrepareExpansionReplayToken_ClearsPreservedGraph(t *testing.T) {
+// TestPrepareExpansionReplayToken_DropsInlineGraph (U2): a token carrying an
+// inline entitlement graph — which only a pre-omission SDK writes — must not
+// carry one after being rewritten for replay, otherwise the replay skips graph
+// loading (graph already "expanded") and silently no-ops. Marshal's
+// unconditional drop is what enforces this; the clear in
+// PrepareExpansionReplayToken is redundant, so no assertion below pins it.
+func TestPrepareExpansionReplayToken_DropsInlineGraph(t *testing.T) {
 	ctx := context.Background()
 
 	// A finished sync that preserved its (fully-expanded) graph.

--- a/pkg/sync/graph_from_token_test.go
+++ b/pkg/sync/graph_from_token_test.go
@@ -18,12 +18,11 @@ func TestGraphFromToken(t *testing.T) {
 	g.AddEntitlementID("eng:member")
 	require.NoError(t, g.AddEdge(ctx, "eng:manager", "eng:member", false, nil))
 
-	// Opt in to the legacy inline-graph token shape. New checkpoints omit the
-	// graph by default, but readers must remain compatible with older tokens.
-	st := newState(withCheckpointEntitlementGraph(true))
+	// Hand-build the legacy inline-graph token shape. Checkpoints no longer
+	// carry the graph, but readers must remain compatible with older tokens.
+	st := newState()
 	st.entitlementGraph = g
-	token, err := st.Marshal()
-	require.NoError(t, err)
+	token := marshalLegacyInlineGraphToken(t, st)
 
 	loaded, err := GraphFromToken(token)
 	require.NoError(t, err)
@@ -59,12 +58,11 @@ func TestPrepareExpansionReplayToken_ClearsPreservedGraph(t *testing.T) {
 	g.MarkEdgeExpanded("eng:manager", "eng:member")
 	g.Loaded = true
 
-	// Build the legacy inline-graph token shape so replay compatibility is
-	// exercised even though new checkpoints omit graphs by default.
-	st := newState(withCheckpointEntitlementGraph(true))
+	// Hand-build the legacy inline-graph token shape so replay compatibility
+	// is exercised even though checkpoints no longer carry graphs.
+	st := newState()
 	st.entitlementGraph = g
-	token, err := st.Marshal()
-	require.NoError(t, err)
+	token := marshalLegacyInlineGraphToken(t, st)
 	// Sanity: the token really does carry a graph.
 	pre, err := GraphFromToken(token)
 	require.NoError(t, err)

--- a/pkg/sync/state.go
+++ b/pkg/sync/state.go
@@ -315,11 +315,6 @@ type state struct {
 	// state so Unmarshal→Marshal round trips (e.g. expansion replay
 	// tokens) preserve it.
 	compaction *CompactionTokenStats
-	// checkpointEntitlementGraph opts back in to serializing the graph
-	// inline. Off by default because the encoding is what OOM-kills workers
-	// on large tenants; on, it trades that risk for cross-restart expansion
-	// progress. See Marshal.
-	checkpointEntitlementGraph bool
 	// spawnedInFlight is the evidence set behind ingest invariant I10:
 	// every spawned sibling cursor (EnqueuePageTokens) admitted to the
 	// stack, keyed by action ID, removed only by the two legitimate
@@ -351,21 +346,6 @@ type state struct {
 	// cycles still terminate. Guarded by st.mtx; bounded by total
 	// spawned admissions in the process (32-byte keys).
 	spawnedAdmitted map[parallelActionKey]string
-}
-
-// stateOpt configures a state at construction. Not part of the State
-// interface: these are process-level knobs from SyncOpt, not token contents,
-// so they must not survive an Unmarshal from a token written elsewhere.
-type stateOpt func(*state)
-
-// withCheckpointEntitlementGraph serializes the entitlement graph into every
-// checkpoint, restoring the behavior from before it was dropped. Escape hatch
-// for a tenant whose expansion cannot finish within one worker lifetime; costs
-// O(graph) memory per checkpoint, which is what the default avoids.
-func withCheckpointEntitlementGraph(enabled bool) stateOpt {
-	return func(st *state) {
-		st.checkpointEntitlementGraph = enabled
-	}
 }
 
 // ConnectorCallStat contains cumulative latency statistics for one connector method.
@@ -441,8 +421,8 @@ type serializedTokenV1 struct {
 	Version            uint64                        `json:"version"`
 }
 
-func newState(opts ...stateOpt) *state {
-	st := &state{
+func newState() *state {
+	return &state{
 		actions:            make(map[string]Action),
 		actionOrder:        []string{},
 		currentActionID:    0,
@@ -454,10 +434,6 @@ func newState(opts ...stateOpt) *state {
 		spawnedInFlight:    make(map[string]Action),
 		spawnedAdmitted:    make(map[parallelActionKey]string),
 	}
-	for _, opt := range opts {
-		opt(st)
-	}
-	return st
 }
 
 // Current returns nil if there is no current action. Otherwise it returns a pointer to a copy of the current state.
@@ -681,7 +657,7 @@ func (st *state) UndrainedSpawnedCursors() []string {
 
 // Marshal returns a string encoding of the state object. This is useful for datastores to checkpoint the current state.
 //
-// By default the entitlement graph is NOT serialized. It is a projection of
+// The entitlement graph is never serialized. It is a projection of
 // data already in the store (loadEntitlementGraph rebuilds it from
 // PendingExpansionPage, with no connector calls), and for large tenants its
 // JSON encoding multiplied the checkpoint's memory footprint several times
@@ -700,30 +676,22 @@ func (st *state) UndrainedSpawnedCursors() []string {
 // safe for OLDER readers too — an old SDK resuming a graph-less token starts
 // a fresh graph and must restart the load from the first page. Only the
 // serialized copy is normalized; the live state keeps its page token.
-//
-// WithEntitlementGraphInCheckpoints restores the old inline-graph behavior. The
-// graph and the expansion page token then travel together, as they must: the
-// token is only resumable by a reader that also got the graph it indexes.
 func (st *state) Marshal() (string, error) {
 	st.mtx.RLock()
 	defer st.mtx.RUnlock()
 
 	actions := st.actions
-	graph := st.entitlementGraph
 
-	if !st.checkpointEntitlementGraph {
-		graph = nil
-		for _, action := range st.actions {
-			if action.Op == SyncGrantExpansionOp && action.PageToken != "" {
-				actions = make(map[string]Action, len(st.actions))
-				for id, a := range st.actions {
-					if a.Op == SyncGrantExpansionOp {
-						a.PageToken = ""
-					}
-					actions[id] = a
+	for _, action := range st.actions {
+		if action.Op == SyncGrantExpansionOp && action.PageToken != "" {
+			actions = make(map[string]Action, len(st.actions))
+			for id, a := range st.actions {
+				if a.Op == SyncGrantExpansionOp {
+					a.PageToken = ""
 				}
-				break
+				actions[id] = a
 			}
+			break
 		}
 	}
 
@@ -744,7 +712,7 @@ func (st *state) Marshal() (string, error) {
 		ActionOrder:                     st.actionOrder,
 		CurrentActionID:                 st.currentActionID,
 		NeedsExpansion:                  st.needsExpansion,
-		EntitlementGraph:                graph,
+		EntitlementGraph:                nil,
 		HasExternalResourceGrants:       st.hasExternalResourceGrants,
 		ShouldFetchRelatedResources:     st.shouldFetchRelatedResources,
 		ShouldSkipEntitlementsAndGrants: st.shouldSkipEntitlementsAndGrants,

--- a/pkg/sync/state.go
+++ b/pkg/sync/state.go
@@ -90,11 +90,13 @@ func PrepareExpansionReplayToken(stateStr string) (string, error) {
 		return "", err
 	}
 	st.SetNeedsExpansion()
-	// Clear any preserved entitlement graph. A graph preserved by
-	// WithPreserveEntitlementGraph has Loaded=true with every edge already
-	// marked expanded, so a replayed sync would skip graph loading and the
-	// expander would report done immediately — the replay would silently
-	// no-op. Clearing it makes the replay rebuild the graph from scratch.
+	// Clear any inline entitlement graph the token carried. Only a
+	// pre-omission SDK writes one — WithPreserveEntitlementGraph writes to the
+	// c1z sidecar. Such a graph has Loaded=true with every edge marked
+	// expanded, so a replayed sync would skip graph loading and the expander
+	// would report done immediately, making the replay a silent no-op. Marshal
+	// drops the graph from every token it writes, so this clear does not change
+	// the emitted bytes; it states the contract here instead of resting on that.
 	st.ClearEntitlementGraph(context.Background())
 	if st.Current() == nil {
 		// A finished sync deserializes with no action map, so seed one before

--- a/pkg/sync/state_test.go
+++ b/pkg/sync/state_test.go
@@ -418,9 +418,9 @@ func TestSyncTokenV0FromC1Z(t *testing.T) {
 // entitlement graph and a SyncGrantExpansionOp action paginating the load,
 // stacked on a non-expansion action whose own pagination must survive the
 // checkpoint normalization untouched.
-func buildLoadedGraphState(t *testing.T, ctx context.Context, pageToken string, opts ...stateOpt) *state {
+func buildLoadedGraphState(t *testing.T, ctx context.Context, pageToken string) *state {
 	t.Helper()
-	st := newState(opts...)
+	st := newState()
 
 	st.PushAction(ctx, Action{Op: SyncGrantsOp})
 	require.NoError(t, st.NextPage(ctx, st.Current().ID, "grants-p9"))
@@ -495,43 +495,6 @@ func TestSyncerTokenOmitsEntitlementGraph(t *testing.T) {
 	}
 }
 
-// WithEntitlementGraphInCheckpoints is the escape hatch for a tenant whose
-// expansion cannot finish within one worker lifetime. With it on, the graph and
-// the expansion pagination both stay in the token, so a resume continues the
-// load where it left off instead of restarting it.
-func TestSyncerTokenIncludesEntitlementGraphWhenEnabled(t *testing.T) {
-	ctx := t.Context()
-	st := buildLoadedGraphState(t, ctx, "page37", withCheckpointEntitlementGraph(true))
-
-	tokenString, err := st.Marshal()
-	require.NoError(t, err)
-	require.Contains(t, tokenString, `"entitlement_graph"`)
-
-	var raw serializedTokenV1
-	require.NoError(t, json.Unmarshal([]byte(tokenString), &raw))
-	require.NotNil(t, raw.EntitlementGraph)
-	// The graph and the page token that indexes it must travel together — a
-	// preserved page token against a dropped graph silently loses edges.
-	for _, a := range raw.ActionsMap {
-		if a.Op == SyncGrantExpansionOp {
-			require.Equal(t, "page37", a.PageToken, "expansion pagination must survive when the graph does")
-		}
-	}
-
-	// A resumed reader continues the load rather than restarting it, with the
-	// graph's contents intact.
-	resumed := newState()
-	require.NoError(t, resumed.Unmarshal(tokenString))
-	require.NotNil(t, resumed.entitlementGraph)
-	require.Equal(t, SyncGrantExpansionOp, resumed.Current().Op)
-	require.Equal(t, "page37", resumed.Current().PageToken)
-	require.Equal(t, 5, resumed.entitlementGraph.Depth)
-	require.Len(t, resumed.entitlementGraph.Nodes, len(st.entitlementGraph.Nodes))
-
-	// Default stays off, so one syncer's opt-in cannot leak into another's state.
-	require.False(t, newState().checkpointEntitlementGraph)
-}
-
 // Graph omission rewrites the serialized actions map, and the type-scoped
 // version stamp is computed from it. The rewrite must not drop the markers that
 // drive the stamp: a token that lands on version 1 while carrying them is
@@ -564,17 +527,21 @@ func TestSyncerTokenVersionStampSurvivesGraphOmission(t *testing.T) {
 	}
 }
 
-// The SyncOpt must actually reach the state that writes checkpoints; without
-// this the knob is inert and the OOM escape hatch does not exist.
-func TestWithEntitlementGraphInCheckpointsReachesState(t *testing.T) {
-	s := &syncer{}
-	require.False(t, s.cfg.checkpointEntitlementGraph)
-
-	WithEntitlementGraphInCheckpoints(true)(s)
-	require.True(t, s.cfg.checkpointEntitlementGraph)
-
-	st := newState(withCheckpointEntitlementGraph(s.cfg.checkpointEntitlementGraph))
-	require.True(t, st.checkpointEntitlementGraph)
+// marshalLegacyInlineGraphToken encodes st the way pre-omission SDKs did:
+// entitlement graph inline, expansion page token kept. No writer produces
+// this shape any more, so the reader tests build the bytes directly.
+func marshalLegacyInlineGraphToken(t *testing.T, st *state) string {
+	t.Helper()
+	legacy, err := json.Marshal(serializedTokenV1{
+		ActionsMap:       st.actions,
+		ActionOrder:      st.actionOrder,
+		CurrentActionID:  st.currentActionID,
+		NeedsExpansion:   st.needsExpansion,
+		EntitlementGraph: st.entitlementGraph,
+		Version:          StateTokenVersion,
+	})
+	require.NoError(t, err)
+	return string(legacy)
 }
 
 // Tokens written by older SDKs carry the graph inline. They must decode and
@@ -585,18 +552,10 @@ func TestSyncerTokenLegacyInlineGraphStillDecodes(t *testing.T) {
 	st.entitlementGraph.Loaded = true
 	st.entitlementGraph.HasNoCycles = true
 
-	// Serialize the way pre-omission SDKs did: graph inline, page token kept.
-	legacy, err := json.Marshal(serializedTokenV1{
-		ActionsMap:       st.actions,
-		ActionOrder:      st.actionOrder,
-		CurrentActionID:  st.currentActionID,
-		EntitlementGraph: st.entitlementGraph,
-		Version:          1,
-	})
-	require.NoError(t, err)
+	legacy := marshalLegacyInlineGraphToken(t, st)
 
 	resumed := newState()
-	require.NoError(t, resumed.Unmarshal(string(legacy)))
+	require.NoError(t, resumed.Unmarshal(legacy))
 
 	restored := resumed.entitlementGraph
 	require.NotNil(t, restored, "inline graph must be restored")

--- a/pkg/sync/syncer.go
+++ b/pkg/sync/syncer.go
@@ -996,7 +996,7 @@ func (s *syncer) Sync(ctx context.Context) error {
 		return err
 	}
 
-	state := newState(withCheckpointEntitlementGraph(s.cfg.checkpointEntitlementGraph))
+	state := newState()
 	err = state.Unmarshal(currentStep)
 	if err != nil {
 		return err
@@ -1085,8 +1085,10 @@ func (s *syncer) Sync(ctx context.Context) error {
 
 	// Force a checkpoint to clear completed actions & entitlement graph in sync_token.
 	// preserveEntitlementGraph keeps the graph for a later incremental
-	// expansion: written to the c1z sidecar when the store supports it (token
-	// stays skinny — a whale graph is megabytes), else kept in the final token.
+	// expansion by writing it to the c1z sidecar; the token never carries a
+	// graph. The only caller (synccompactor) sets the option solely for
+	// Pebble stores, which are the only implementers of both capabilities
+	// tested below, so a preserved graph always has a sidecar to go to.
 	// Transient working state is stripped either way; a reload rebuilds it.
 	var graphToPersist *expand.EntitlementGraph
 	if s.cfg.preserveEntitlementGraph {
@@ -4161,8 +4163,9 @@ func WithCompactionMergedStore() SyncOpt {
 }
 
 // WithPreserveEntitlementGraph preserves the entitlement graph for later
-// incremental expansion. Pebble stores it in the c1z sidecar; stores without
-// that capability retain it in the final sync token as a legacy fallback.
+// incremental expansion by writing it to the c1z sidecar, which only Pebble
+// stores implement. Set it only for a Pebble store: on any other engine the
+// graph has nowhere to go, and checkpoints never carry one.
 func WithPreserveEntitlementGraph() SyncOpt {
 	return func(s *syncer) {
 		s.cfg.preserveEntitlementGraph = true
@@ -4205,23 +4208,6 @@ func WithSkipEntitlementsAndGrants(skip bool) SyncOpt {
 func WithSkipGrants(skip bool) SyncOpt {
 	return func(s *syncer) {
 		s.cfg.skipGrants = skip
-	}
-}
-
-// WithEntitlementGraphInCheckpoints serializes the entitlement graph into every
-// checkpoint token. Off by default: the graph is a projection of data already in
-// the store, and encoding it costs O(graph) memory several times over per
-// checkpoint, which OOM-kills workers on large tenants.
-//
-// Enable it to keep expansion progress across restarts. That matters only for a
-// tenant whose expansion cannot finish within one worker or activity lifetime —
-// without it, such a sync re-runs the load and expansion phases on every resume
-// and can fail to converge. Note the two failure modes trade off directly: the
-// tenants large enough to need cross-restart progress are the ones whose graph
-// is expensive enough to encode that checkpointing may OOM.
-func WithEntitlementGraphInCheckpoints(enabled bool) SyncOpt {
-	return func(s *syncer) {
-		s.cfg.checkpointEntitlementGraph = enabled
 	}
 }
 

--- a/pkg/sync/testdata/tokens/README.md
+++ b/pkg/sync/testdata/tokens/README.md
@@ -10,14 +10,13 @@ Two kinds of file live here:
 - **Recorded output** — built as a `state` through the package API and
   recorded from `Marshal()`. To reproduce one, construct the same state in
   a scratch test in `package sync` and log `Marshal()`; the fixture is that
-  line verbatim. `v1_inline_graph.json` is the one recorded under a
-  non-default option: it comes from the opt-in inline-graph writer
-  (`WithEntitlementGraphInCheckpoints`), not the default one.
+  line verbatim.
 - **Hand-authored input** — bytes no current writer can produce, so they
   are edited by hand; the partner file is recorded from `Marshal()`. These
   are every `v0_*.json`, `v3_future_version.json` (a version this SDK does
-  not recognize) and `v1_unknown_op.json` (a newer writer's operation
-  string).
+  not recognize), `v1_unknown_op.json` (a newer writer's operation string)
+  and `v1_inline_graph.json` (an SDK that still serialized the graph into
+  the token, which no writer has done since CXE-1376).
 
 There is deliberately no `-update` flag. These bytes are a compatibility
 surface rather than golden output: rewriting them from the current
@@ -47,8 +46,8 @@ refactor.
 | `v1_facts_all.json` | All five facts together. |
 | `v1_run_stats.json` | `step_durations_ms`, `connector_call_stats` (recorded and merged), `session_store_stats` (including `errors`/`timeouts`), a fully populated `ingest_quality`. |
 | `v1_compaction.json` | The `compaction` provenance block written by `BuildCompactedToken`, with partial timings folded into the top-level stat maps. |
-| `v1_inline_graph.json` | An inline `entitlement_graph` (4 nodes, 3 edges, one expanded, one shallow, one with a nil resource-type filter) travelling with a live `grant-expansion` page token. Written by the opt-in inline-graph writer. |
-| `v1_inline_graph.dropped.json` | The same token read back by the default writer: graph dropped, `grant-expansion` page token blanked. |
+| `v1_inline_graph.json` | An inline `entitlement_graph` (4 nodes, 3 edges, one expanded, one shallow, one with a nil resource-type filter) travelling with a live `grant-expansion` page token. Hand-authored: no writer has produced this shape since CXE-1376 removed the inline-graph writer. |
+| `v1_inline_graph.dropped.json` | The same token re-encoded by the current writer: graph dropped, `grant-expansion` page token blanked. |
 | `v0_current_action.json` → `.expected.json` | V0 with `current_action` present: the current action is appended last and gets the highest id. |
 | `v0_no_current_action.json` → `.expected.json` | V0 with `current_action` absent, carrying the three skip/fetch facts and a nonzero `completed_actions_count`. |
 | `v0_empty_object.json` → `.expected.json` | `{}` — no `version`, so the V1 parse is rejected and the V0 parser produces an empty V1 token. |

--- a/pkg/sync/token_golden_adapter_test.go
+++ b/pkg/sync/token_golden_adapter_test.go
@@ -5,12 +5,9 @@ package sync //nolint:revive,nolintlint // we can't change the package name for 
 // names the codec's entry points, so reorganizing the codec touches it and
 // not the bytes or the expectations.
 
-// goldenDecodeEncode decodes a token and re-encodes it. inlineGraph selects
-// the writer option that serializes the entitlement graph into the token;
-// it is a process-level setting, not a token field, so the caller supplies
-// it rather than the input carrying it.
-func goldenDecodeEncode(input string, inlineGraph bool) (string, error) {
-	st := newState(withCheckpointEntitlementGraph(inlineGraph))
+// goldenDecodeEncode decodes a token and re-encodes it.
+func goldenDecodeEncode(input string) (string, error) {
+	st := newState()
 	if err := st.Unmarshal(input); err != nil {
 		return "", err
 	}
@@ -19,8 +16,8 @@ func goldenDecodeEncode(input string, inlineGraph bool) (string, error) {
 
 // goldenEncodeTwice decodes a token once and encodes the decoded value
 // twice.
-func goldenEncodeTwice(input string, inlineGraph bool) (string, string, error) {
-	st := newState(withCheckpointEntitlementGraph(inlineGraph))
+func goldenEncodeTwice(input string) (string, string, error) {
+	st := newState()
 	if err := st.Unmarshal(input); err != nil {
 		return "", "", err
 	}

--- a/pkg/sync/token_golden_test.go
+++ b/pkg/sync/token_golden_test.go
@@ -33,9 +33,6 @@ type goldenTokenCase struct {
 	// expected is the fixture the input must re-encode to. Empty means the
 	// input re-encodes to its own bytes.
 	expected string
-	// inlineGraph selects the writer option that serializes the entitlement
-	// graph into the token.
-	inlineGraph bool
 	// needsExpansion is what NeedsExpansion(input) returns.
 	needsExpansion bool
 	// graph is what GraphFromToken(input) returns; nil expects nil.
@@ -77,12 +74,6 @@ func goldenTokenCases() []goldenTokenCase {
 					"entitlements": {Output: 40},
 				},
 			},
-		},
-		{
-			file:           "v1_inline_graph.json",
-			inlineGraph:    true,
-			needsExpansion: true,
-			graph:          &goldenGraph{nodes: 4, edges: 3, nextNodeID: 4, nextEdgeID: 3, depth: 2, loaded: true},
 		},
 		{
 			file:           "v1_inline_graph.json",
@@ -144,7 +135,7 @@ func TestGoldenTokenRoundTrip(t *testing.T) {
 			// leaves the live state alone: blanking the expansion page token
 			// in place would still give two equal encodings.
 			// TestSyncerTokenOmitsEntitlementGraph asserts that.
-			first, second, err := goldenEncodeTwice(input, tc.inlineGraph)
+			first, second, err := goldenEncodeTwice(input)
 			require.NoError(t, err)
 			require.Equal(t, first, second, "two encodings of one decoded token differ")
 			require.Equal(t, want, first)
@@ -154,7 +145,7 @@ func TestGoldenTokenRoundTrip(t *testing.T) {
 				// checkpoint after the resume carries. If they did not
 				// re-encode to themselves the first checkpoint after a
 				// resume would differ from the second.
-				again, err := goldenDecodeEncode(want, tc.inlineGraph)
+				again, err := goldenDecodeEncode(want)
 				require.NoError(t, err)
 				require.Equal(t, want, again)
 			}

--- a/pkg/synccompactor/compactor.go
+++ b/pkg/synccompactor/compactor.go
@@ -1321,8 +1321,8 @@ func (c *Compactor) expandGrants(ctx context.Context, newSyncId string, compacti
 	// opted-in compactions preserve a fresh graph (so the incremental chain
 	// heals after a fallback); otherwise drop any sidecar inherited from a
 	// fold-copied base. Pebble-only: incremental expansion declines on other
-	// engines, and without a sidecar the preserved graph would only bloat
-	// the final sync token.
+	// engines, and without a sidecar a preserved graph has nowhere to go:
+	// no writer puts a graph in a sync token.
 	if c.incrementalExpansion && c.resolvedEngine() == c1zstore.EnginePebble {
 		syncOpts = append(syncOpts, sync.WithPreserveEntitlementGraph())
 	} else if gs, ok := c.compactedC1z.(sync.EntitlementGraphStore); ok {

--- a/pkg/synccompactor/incremental_expansion_test.go
+++ b/pkg/synccompactor/incremental_expansion_test.go
@@ -897,11 +897,10 @@ func TestCompactor_IncrementalDegradesGracefullyOnSQLite(t *testing.T) {
 	hasGrant(t, grants, "ent-c|user|sam")
 	hasGrant(t, grants, "ent-c|user|mandy")
 
-	// SQLite has no graph sidecar, so a preserved graph could never be read
-	// back — the only place it could land is the final sync token, as
-	// unreadable bloat. Pin that the final token carries no graph (enforced
-	// twice over: graph preservation is Pebble-gated in expandGrants, and
-	// state.Marshal drops the graph from tokens by default).
+	// SQLite has no graph sidecar, so a preserved graph would have nowhere to
+	// go. Pin that the final token carries no graph (enforced twice over:
+	// graph preservation is Pebble-gated in expandGrants, and state.Marshal
+	// drops the graph from every token it writes).
 	store, err := dotc1z.NewStore(ctx, out.FilePath, dotc1z.WithReadOnly(true), dotc1z.WithTmpDir(t.TempDir()))
 	require.NoError(t, err)
 	defer store.Close(ctx)


### PR DESCRIPTION
Deletes `WithEntitlementGraphInCheckpoints` and the inline-graph checkpoint
writer behind it. `state.Marshal` now drops the entitlement graph and blanks the
expansion page token unconditionally, instead of doing so only when the option
was unset.

## Why this is safe

The option had no callers. A sweep of 65 ConductorOne repos under `~/work` plus
the `c1` monorepo found zero call sites in first-party code, in the current trees
or in `git log -S` history — every text hit is vendored SDK source. It was also
never reachable except by a direct Go call: nothing in `pkg/cli`, `pkg/config`,
`pkg/field`, `pkg/connectorrunner`, or `pkg/tasks` ever plumbed it to a flag or
config field, so no connector could have enabled it through config. Inside the
SDK the only invocation was `TestWithEntitlementGraphInCheckpointsReachesState`,
which this change removes.

It is a public API in a v0.x module, released in `v0.23.0` through `v0.29.0`
(2026-08-11 to 2026-09-04), so a third-party caller cannot be ruled out. It is
deleted rather than kept as a deprecated no-op deliberately: the behavior is
intentionally unavailable rather than relocated, so there is no replacement call
to migrate to, and a no-op would leave a caller believing they still have an OOM
remedy. A compile error is the honest signal and the fix is deleting one line.

## Reader compatibility is unchanged

Only the writer is gone. Tokens written by pre-omission SDKs still decode with
the graph restored and pagination preserved. The reader tests that used to build
those bytes by enabling the option now hand-craft them through a
`marshalLegacyInlineGraphToken` helper, so `TestSyncerTokenLegacyInlineGraphStillDecodes`,
`TestGraphFromToken`, and the graph compatibility matrix keep their coverage. The
golden token corpus added in #1129 pins the wire format on bytes across this
change.

## Accepted risk

The option was introduced as a break-glass knob for a tenant whose grant
expansion cannot finish within one worker or activity lifetime, on the theory
that checkpointing the graph would let expansion resume mid-run. On Pebble it
never did. `RunSingleStep` routes to `RunTopologicalMergeProjection` whenever the
store yields principal-sorted grants, which is the Pebble adapter;
`driveTopologicalLayer` never consults `edge.IsExpanded`, and
`MarkExpansionComplete` flips every edge at once only after the full projection
returns clean. A Pebble worker that dies at 90% of the projection comes back with
every edge unexpanded whether or not the graph was in the token. That has been
true since #965 landed the projection on 2026-06-16, six weeks before the option
was written.

Mid-expansion resume only ever existed on the source-batched expander that
SQLite and the in-memory doubles use, where `RunSingleStep` retires one queued
`graph.Actions` entry per call and marks that action's edges expanded as it goes.
So the exposure is writable syncs over not-yet-converted v1 files, which
`selectStoreDriver` deliberately keeps on SQLite when opened without an explicit
engine. That exposure already exists on `main`: #1019 made graph omission the
default on 2026-08-10 and nothing has set the option since, so no sync has been
getting inline-graph checkpoints for a month. This change deletes an unused
remedy rather than changing behavior.

The intended path for such a tenant is conversion to Pebble via an explicit
`WithEngine(EnginePebble)`, which makes expansion fast enough that resume stops
mattering. Persisting the whole graph into every checkpoint is what caused the
OOM that #1019 fixed.

## Ride-alongs

- Rewrote two comments in `pkg/sync/syncer.go` that claimed
  `preserveEntitlementGraph` falls back to inline token storage when the store
  lacks the sidecar capabilities. There was never such a fallback in code — the
  claim was only reachable through the option this change deletes.
- Corrected two comments in `pkg/synccompactor` for the same reason: a preserved
  graph without a sidecar has nowhere to go rather than bloating the final token,
  and `state.Marshal` drops the graph from every token rather than by default.
- Removed `stateOpt` and `newState`'s variadic parameter, which had no remaining
  implementations.