### PR TITLE
CXP-1085 uhttp: classify OAuth2 token-exchange failures

### DIFF
--- a/pkg/uhttp/authcredentials.go
+++ b/pkg/uhttp/authcredentials.go
@@ -105,7 +105,7 @@ func (o *OAuth2ClientCredentials) GetClient(ctx context.Context, options ...Opti
 		return nil, err
 	}
 	ctx = context.WithValue(ctx, oauth2.HTTPClient, httpClient)
-	ts := o.cfg.TokenSource(ctx)
+	ts := NewClassifyingTokenSource(o.cfg.TokenSource(ctx))
 	httpClient = oauth2.NewClient(ctx, ts)
 
 	return httpClient, nil
@@ -141,7 +141,7 @@ func (o *OAuth2JWT) GetClient(ctx context.Context, options ...Option) (*http.Cli
 	}
 
 	ctx = context.WithValue(ctx, oauth2.HTTPClient, httpClient)
-	ts := jwt.TokenSource(ctx)
+	ts := NewClassifyingTokenSource(jwt.TokenSource(ctx))
 	httpClient = oauth2.NewClient(ctx, ts)
 
 	return httpClient, nil
@@ -194,7 +194,10 @@ func (o *OAuth2RefreshToken) GetClient(ctx context.Context, options ...Option) (
 		RefreshToken: o.refreshToken,
 		TokenType:    "Bearer",
 	}
-	httpClient = o.cfg.Client(ctx, token)
+	// Config.Client is Config.TokenSource plus oauth2.NewClient, spelled out
+	// here so the refresh goes through NewClassifyingTokenSource.
+	ts := NewClassifyingTokenSource(o.cfg.TokenSource(ctx, token))
+	httpClient = oauth2.NewClient(ctx, ts)
 
 	return httpClient, nil
 }

--- a/pkg/uhttp/errors.go
+++ b/pkg/uhttp/errors.go
@@ -41,16 +41,16 @@ func wrapTransientNetworkError(err error) error {
 		return WrapErrors(codes.Unavailable, "connection closed before response", err)
 	}
 	if isConnectionReset(err) {
-		return WrapErrors(codes.Unavailable, "connection reset", err)
+		return wrapSocketClass(socketReset, err)
 	}
 	if isConnectionRefused(err) {
-		return WrapErrors(codes.Unavailable, "connection refused", err)
+		return wrapSocketClass(socketRefused, err)
 	}
 	if isBrokenPipe(err) {
-		return WrapErrors(codes.Unavailable, "broken pipe", err)
+		return wrapSocketClass(socketBrokenPipe, err)
 	}
 	if isNetworkUnreachable(err) {
-		return WrapErrors(codes.Unavailable, "network unreachable", err)
+		return wrapSocketClass(socketNetworkUnreachable, err)
 	}
 
 	var dnsErr *net.DNSError
@@ -97,6 +97,59 @@ func wrapTransientNetworkError(err error) error {
 	}
 
 	return err
+}
+
+// socketClass groups the socket failures the platform predicates in
+// errors_other.go and errors_windows.go match. Each platform lists the
+// errnos it spells a class with in transientSocketConditions, so the
+// predicates, the messages wrapTransientNetworkError attaches, and the
+// text-only table in oauth2.go all derive from one list and cannot drift
+// apart.
+type socketClass int
+
+const (
+	socketReset socketClass = iota
+	socketRefused
+	socketBrokenPipe
+	socketNetworkUnreachable
+	socketTimeout
+)
+
+// socketCondition is one platform spelling of a socketClass.
+type socketCondition struct {
+	err   error
+	class socketClass
+}
+
+// socketClassifications is the classification each class receives.
+// socketTimeout's message is reached only from oauth2.go's text-only table:
+// on the typed path a timeout is caught by the net.Error branch below (or by
+// isSocketTimeout on Windows), which keeps the underlying error in the
+// message.
+var socketClassifications = map[socketClass]struct {
+	code codes.Code
+	msg  string
+}{
+	socketReset:              {code: codes.Unavailable, msg: "connection reset"},
+	socketRefused:            {code: codes.Unavailable, msg: "connection refused"},
+	socketBrokenPipe:         {code: codes.Unavailable, msg: "broken pipe"},
+	socketNetworkUnreachable: {code: codes.Unavailable, msg: "network unreachable"},
+	socketTimeout:            {code: codes.DeadlineExceeded, msg: "network timeout"},
+}
+
+// hasSocketClass reports whether err is any platform spelling of class.
+func hasSocketClass(err error, class socketClass) bool {
+	for _, condition := range transientSocketConditions {
+		if condition.class == class && errors.Is(err, condition.err) {
+			return true
+		}
+	}
+	return false
+}
+
+func wrapSocketClass(class socketClass, err error) error {
+	classification := socketClassifications[class]
+	return WrapErrors(classification.code, classification.msg, err)
 }
 
 func isHTTP2ClientConnectionLost(err error) bool {

--- a/pkg/uhttp/errors.go
+++ b/pkg/uhttp/errors.go
@@ -13,8 +13,6 @@ import (
 	"golang.org/x/oauth2"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
-	"github.com/conductorone/baton-sdk/pkg/ratelimit"
 )
 
 // wrapTransientNetworkError mirrors Baton HTTP retry classification for callers
@@ -24,26 +22,13 @@ func wrapTransientNetworkError(err error) error {
 		return nil
 	}
 
-	// A transient token-endpoint status (429/5xx) stays retryable even if
-	// the body also carries a recognized RFC 6749 error param; otherwise
-	// the error param takes priority over the HTTP status, since some
-	// servers report it on a 200 and 400 is the spec default for
-	// invalid_client/invalid_grant, both of which GrpcCodeFromHTTPStatus
-	// alone would misclassify. This branch is total once errors.As matches,
-	// so a RetrieveError is never run through the network-error checks below.
+	// A rejected token request is classified in oauth2.go, from the RFC 6749
+	// error param rather than the HTTP status alone. This branch is total
+	// once errors.As matches, so a RetrieveError is never run through the
+	// network-error checks below.
 	var retrieveErr *oauth2.RetrieveError
 	if errors.As(err, &retrieveErr) {
-		if retrieveErr.Response != nil && isTransientHTTPStatus(retrieveErr.Response.StatusCode) {
-			return wrapTransientOAuthTokenError(retrieveErr, err)
-		}
-		if code, ok := oauthTokenErrorCode(retrieveErr.ErrorCode); ok {
-			return WrapErrors(code, oauthTokenErrorMessage(retrieveErr), err)
-		}
-		code := codes.Unknown
-		if retrieveErr.Response != nil {
-			code = GrpcCodeFromHTTPStatus(retrieveErr.Response.StatusCode)
-		}
-		return WrapErrors(code, oauthTokenErrorMessage(retrieveErr), err)
+		return classifyOAuth2RetrieveError(retrieveErr, err)
 	}
 
 	if errors.Is(err, io.ErrUnexpectedEOF) {
@@ -112,69 +97,6 @@ func wrapTransientNetworkError(err error) error {
 	}
 
 	return err
-}
-
-// isTransientHTTPStatus reports whether GrpcCodeFromHTTPStatus maps
-// statusCode to a code retry.Retryer.ShouldWaitAndRetry treats as retryable
-// (Unavailable or DeadlineExceeded), so a transient token-endpoint failure
-// stays retryable regardless of what error param the body also carries.
-func isTransientHTTPStatus(statusCode int) bool {
-	switch GrpcCodeFromHTTPStatus(statusCode) {
-	case codes.Unavailable, codes.DeadlineExceeded:
-		return true
-	default:
-		return false
-	}
-}
-
-// wrapTransientOAuthTokenError mirrors WrapErrorsWithRateLimitInfo's detail
-// attachment (retry.Retryer reads it for rate-limit-aware backoff), while
-// keeping ErrorDescription in the message the way oauthTokenErrorMessage
-// does elsewhere in this file.
-func wrapTransientOAuthTokenError(retrieveErr *oauth2.RetrieveError, err error) error {
-	msg := retrieveErr.Response.Status
-	if retrieveErr.ErrorDescription != "" {
-		msg = fmt.Sprintf("%s: %s", msg, retrieveErr.ErrorDescription)
-	}
-	st := status.New(GrpcCodeFromHTTPStatus(retrieveErr.Response.StatusCode), msg)
-	if description, rlErr := ratelimit.ExtractRateLimitData(retrieveErr.Response.StatusCode, &retrieveErr.Response.Header); rlErr == nil {
-		if withDetails, detailsErr := st.WithDetails(description); detailsErr == nil {
-			st = withDetails
-		}
-	}
-	return errors.Join(st.Err(), err)
-}
-
-// oauthTokenErrorCode maps an RFC 6749 §5.2 token-error "error" parameter to
-// a grpc code. ok is false when errCode is empty or unrecognized, signaling
-// the caller to fall back to the HTTP status.
-func oauthTokenErrorCode(errCode string) (codes.Code, bool) {
-	switch errCode {
-	case "invalid_client", "invalid_grant":
-		return codes.Unauthenticated, true
-	case "unauthorized_client", "access_denied":
-		return codes.PermissionDenied, true
-	case "invalid_scope", "invalid_request", "unsupported_grant_type", "unsupported_response_type":
-		return codes.InvalidArgument, true
-	default:
-		return codes.Unknown, false
-	}
-}
-
-// oauthTokenErrorMessage prefers the RFC 6749 error/error_description pair
-// the token endpoint sent, since that survives even when the HTTP status
-// alone would be misleading (e.g. a 200 response carrying an error body).
-func oauthTokenErrorMessage(retrieveErr *oauth2.RetrieveError) string {
-	switch {
-	case retrieveErr.ErrorCode != "" && retrieveErr.ErrorDescription != "":
-		return fmt.Sprintf("%s: %s", retrieveErr.ErrorCode, retrieveErr.ErrorDescription)
-	case retrieveErr.ErrorCode != "":
-		return retrieveErr.ErrorCode
-	case retrieveErr.Response != nil:
-		return retrieveErr.Response.Status
-	default:
-		return "oauth2 token request failed"
-	}
 }
 
 func isHTTP2ClientConnectionLost(err error) bool {

--- a/pkg/uhttp/errors_other.go
+++ b/pkg/uhttp/errors_other.go
@@ -3,36 +3,44 @@
 package uhttp
 
 import (
-	"errors"
 	"syscall"
 )
 
-// The socket-failure predicates below are split per platform because Winsock
+// The socket-failure spellings below are split per platform because Winsock
 // reports these conditions with WSAE* codes that are distinct syscall.Errno
 // values from the POSIX names, and syscall.Errno.Is does not bridge the two.
 // See errors_windows.go for the Winsock spellings.
+var transientSocketConditions = []socketCondition{
+	{err: syscall.ECONNRESET, class: socketReset},
+	{err: syscall.ECONNABORTED, class: socketReset},
+	{err: syscall.ECONNREFUSED, class: socketRefused},
+	{err: syscall.EPIPE, class: socketBrokenPipe},
+	{err: syscall.EHOSTUNREACH, class: socketNetworkUnreachable},
+	{err: syscall.ENETUNREACH, class: socketNetworkUnreachable},
+	{err: syscall.ENETDOWN, class: socketNetworkUnreachable},
+	{err: syscall.ETIMEDOUT, class: socketTimeout},
+}
 
 func isConnectionReset(err error) bool {
-	return errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.ECONNABORTED)
+	return hasSocketClass(err, socketReset)
 }
 
 func isConnectionRefused(err error) bool {
-	return errors.Is(err, syscall.ECONNREFUSED)
+	return hasSocketClass(err, socketRefused)
 }
 
 func isBrokenPipe(err error) bool {
-	return errors.Is(err, syscall.EPIPE)
+	return hasSocketClass(err, socketBrokenPipe)
 }
 
 func isNetworkUnreachable(err error) bool {
-	return errors.Is(err, syscall.EHOSTUNREACH) ||
-		errors.Is(err, syscall.ENETUNREACH) ||
-		errors.Is(err, syscall.ENETDOWN)
+	return hasSocketClass(err, socketNetworkUnreachable)
 }
 
 // isSocketTimeout is always false here: syscall.Errno.Timeout() already reports
 // true for ETIMEDOUT, so the net.Error timeout branch in
-// wrapTransientNetworkError catches it.
+// wrapTransientNetworkError catches it. ETIMEDOUT is still listed above so
+// oauth2.go's text-only classifier knows the spelling this platform prints.
 func isSocketTimeout(error) bool {
 	return false
 }

--- a/pkg/uhttp/errors_other_test.go
+++ b/pkg/uhttp/errors_other_test.go
@@ -1,0 +1,71 @@
+//go:build !windows
+
+package uhttp
+
+import (
+	"errors"
+	"net"
+	"net/url"
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// transientSocketConditions is the single list both classifiers read, which
+// means deleting an entry removes a condition from both of them at once and
+// no agreement test can notice. This is the floor: the POSIX spellings
+// production has produced, each asserted to still classify. Its Windows
+// counterpart is TestWrapTransientNetworkError_Winsock.
+func TestTransientSocketConditions_POSIXSpellings(t *testing.T) {
+	tests := []struct {
+		errno    syscall.Errno
+		op       string
+		wantCode codes.Code
+		wantMsg  string
+	}{
+		{errno: syscall.ECONNRESET, op: "read", wantCode: codes.Unavailable, wantMsg: "connection reset"},
+		{errno: syscall.ECONNABORTED, op: "read", wantCode: codes.Unavailable, wantMsg: "connection reset"},
+		{errno: syscall.ECONNREFUSED, op: "dial", wantCode: codes.Unavailable, wantMsg: "connection refused"},
+		{errno: syscall.EPIPE, op: "write", wantCode: codes.Unavailable, wantMsg: "broken pipe"},
+		{errno: syscall.EHOSTUNREACH, op: "dial", wantCode: codes.Unavailable, wantMsg: "network unreachable"},
+		{errno: syscall.ENETUNREACH, op: "dial", wantCode: codes.Unavailable, wantMsg: "network unreachable"},
+		{errno: syscall.ENETDOWN, op: "dial", wantCode: codes.Unavailable, wantMsg: "network unreachable"},
+		// ETIMEDOUT reaches DeadlineExceeded through the url.Error timeout
+		// branch rather than a predicate, since Errno.Timeout() reports true
+		// for it, so its message is "request timeout" and not the
+		// socketTimeout class message. Windows differs: Errno.Timeout() does
+		// not recognize WSAETIMEDOUT, so that spelling falls through to
+		// isSocketTimeout and reports "network timeout".
+		{errno: syscall.ETIMEDOUT, op: "dial", wantCode: codes.DeadlineExceeded, wantMsg: "request timeout"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.errno.Error(), func(t *testing.T) {
+			present := false
+			for _, condition := range transientSocketConditions {
+				if errors.Is(tt.errno, condition.err) {
+					present = true
+					break
+				}
+			}
+			require.True(t, present, "%v is no longer on the shared condition list", tt.errno)
+
+			err := &url.Error{Op: "Get", URL: "https://example.com", Err: &net.OpError{
+				Op:  tt.op,
+				Net: "tcp",
+				Err: os.NewSyscallError(tt.op, tt.errno),
+			}}
+
+			got := wrapTransientNetworkError(err)
+			st, ok := status.FromError(got)
+			require.True(t, ok, "got %v", got)
+			require.Equal(t, tt.wantCode, st.Code())
+			require.Contains(t, st.Message(), tt.wantMsg)
+			require.ErrorIs(t, got, err)
+		})
+	}
+}

--- a/pkg/uhttp/errors_windows.go
+++ b/pkg/uhttp/errors_windows.go
@@ -3,7 +3,6 @@
 package uhttp
 
 import (
-	"errors"
 	"syscall"
 
 	"golang.org/x/sys/windows"
@@ -13,42 +12,51 @@ import (
 // syscall.Errno values from the POSIX names of the same conditions.
 // syscall.Errno.Is on Windows only bridges the permission/exist/not-exist/
 // unsupported families, so matching the POSIX names alone silently fails to
-// classify any real socket error on Windows. Each predicate therefore accepts
-// both spellings.
+// classify any real socket error on Windows. Both spellings are listed here,
+// which is also how oauth2.go's text-only classifier learns the Winsock
+// message strings.
+//
+// WSAECONNABORTED covers teardowns POSIX reports as ECONNRESET or EPIPE, so it
+// belongs to the reset class rather than being a condition of its own, and
+// WSAESHUTDOWN ("cannot send after socket shutdown") is the Winsock
+// counterpart of writing to a pipe the peer already closed.
+var transientSocketConditions = []socketCondition{
+	{err: syscall.ECONNRESET, class: socketReset},
+	{err: windows.WSAECONNRESET, class: socketReset},
+	{err: windows.WSAECONNABORTED, class: socketReset},
+	{err: syscall.ECONNREFUSED, class: socketRefused},
+	{err: windows.WSAECONNREFUSED, class: socketRefused},
+	{err: syscall.EPIPE, class: socketBrokenPipe},
+	{err: windows.WSAESHUTDOWN, class: socketBrokenPipe},
+	{err: syscall.EHOSTUNREACH, class: socketNetworkUnreachable},
+	{err: syscall.ENETUNREACH, class: socketNetworkUnreachable},
+	{err: syscall.ENETDOWN, class: socketNetworkUnreachable},
+	{err: windows.WSAEHOSTUNREACH, class: socketNetworkUnreachable},
+	{err: windows.WSAENETUNREACH, class: socketNetworkUnreachable},
+	{err: windows.WSAENETDOWN, class: socketNetworkUnreachable},
+	{err: syscall.ETIMEDOUT, class: socketTimeout},
+	{err: windows.WSAETIMEDOUT, class: socketTimeout},
+}
 
 func isConnectionReset(err error) bool {
-	// Windows reports as WSAECONNABORTED some teardowns that POSIX reports as
-	// ECONNRESET or EPIPE, so it belongs with the reset class rather than
-	// being a separate condition.
-	return errors.Is(err, syscall.ECONNRESET) ||
-		errors.Is(err, windows.WSAECONNRESET) ||
-		errors.Is(err, windows.WSAECONNABORTED)
+	return hasSocketClass(err, socketReset)
 }
 
 func isConnectionRefused(err error) bool {
-	return errors.Is(err, syscall.ECONNREFUSED) ||
-		errors.Is(err, windows.WSAECONNREFUSED)
+	return hasSocketClass(err, socketRefused)
 }
 
 func isBrokenPipe(err error) bool {
-	// WSAESHUTDOWN ("cannot send after socket shutdown") is the Winsock
-	// counterpart of writing to a pipe the peer already closed.
-	return errors.Is(err, syscall.EPIPE) ||
-		errors.Is(err, windows.WSAESHUTDOWN)
+	return hasSocketClass(err, socketBrokenPipe)
 }
 
 func isNetworkUnreachable(err error) bool {
-	return errors.Is(err, syscall.EHOSTUNREACH) ||
-		errors.Is(err, syscall.ENETUNREACH) ||
-		errors.Is(err, syscall.ENETDOWN) ||
-		errors.Is(err, windows.WSAEHOSTUNREACH) ||
-		errors.Is(err, windows.WSAENETUNREACH) ||
-		errors.Is(err, windows.WSAENETDOWN)
+	return hasSocketClass(err, socketNetworkUnreachable)
 }
 
 // isSocketTimeout restores the parity that net.Error.Timeout() misses on
 // Windows: syscall.Errno.Timeout() recognizes only the POSIX ETIMEDOUT value,
 // so a WSAETIMEDOUT would otherwise fall through unclassified.
 func isSocketTimeout(err error) bool {
-	return errors.Is(err, windows.WSAETIMEDOUT)
+	return hasSocketClass(err, socketTimeout)
 }

--- a/pkg/uhttp/oauth2.go
+++ b/pkg/uhttp/oauth2.go
@@ -1,0 +1,363 @@
+package uhttp
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"mime"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"golang.org/x/oauth2"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/conductorone/baton-sdk/pkg/ratelimit"
+)
+
+// oauth2FetchTokenPrefix is the text golang.org/x/oauth2 puts on a token
+// request that failed before a token could be parsed out of the response.
+// It gates classifyFlattenedOAuth2TokenError, the one classifier here that
+// reads message text instead of error identity.
+const oauth2FetchTokenPrefix = "oauth2: cannot fetch token" //nolint:gosec // G101: a message prefix, not a credential
+
+// maxRecoveredDescription bounds an error_description recovered from a
+// response body before it becomes part of a grpc status message. x/oauth2
+// caps the body it reads at 1 MiB, and that whole body can be one JSON
+// string field.
+const maxRecoveredDescription = 256
+
+// ClassifyOAuth2TokenError attaches a grpc status to a golang.org/x/oauth2
+// token-exchange failure, so retry.Retryer can act on it: a token endpoint
+// that answered 500 or timed out is Unavailable/DeadlineExceeded (retryable),
+// while a rejected credential stays Unauthenticated or PermissionDenied
+// (terminal). Without it every token failure reaches the syncer as
+// codes.Unknown, which retry.Retryer treats as terminal, so a sub-second
+// token-endpoint blip discards a whole sync.
+//
+// Connectors that build their own oauth2.TokenSource call this directly or
+// go through NewClassifyingTokenSource; the AuthCredentials helpers in
+// authcredentials.go already do.
+func ClassifyOAuth2TokenError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	// An error that already carries a status was classified by a producer
+	// closer to the failure, usually Transport.RoundTrip in this package.
+	// status.Code reads the outermost status, so re-wrapping here would
+	// bury the code the retryer needs behind this one.
+	if status.Code(err) != codes.Unknown {
+		return err
+	}
+
+	var retrieveErr *oauth2.RetrieveError
+	if errors.As(err, &retrieveErr) {
+		return classifyOAuth2RetrieveError(retrieveErr, err)
+	}
+
+	if classified := classifyFlattenedOAuth2TokenError(err); classified != nil {
+		return classified
+	}
+
+	return wrapTransientNetworkError(err)
+}
+
+// NewClassifyingTokenSource returns a TokenSource that runs every error from
+// inner through ClassifyOAuth2TokenError. Wrap the outermost source, the one
+// clientcredentials.Config.TokenSource / jwt.Config.TokenSource /
+// oauth2.Config.TokenSource return, so the reuse-and-refresh caching those
+// build stays in place and only a real token fetch is classified.
+func NewClassifyingTokenSource(inner oauth2.TokenSource) oauth2.TokenSource {
+	if inner == nil {
+		return nil
+	}
+	return &classifyingTokenSource{inner: inner}
+}
+
+type classifyingTokenSource struct {
+	inner oauth2.TokenSource
+}
+
+var _ oauth2.TokenSource = (*classifyingTokenSource)(nil)
+
+func (c *classifyingTokenSource) Token() (*oauth2.Token, error) {
+	token, err := c.inner.Token()
+	if err != nil {
+		return nil, ClassifyOAuth2TokenError(err)
+	}
+	return token, nil
+}
+
+// classifyOAuth2RetrieveError maps a token endpoint's rejection to a grpc
+// code. It is reached from ClassifyOAuth2TokenError, which x/oauth2's token
+// sources feed, and from wrapTransientNetworkError, for the callers that
+// drive a token endpoint through this package's transport directly.
+func classifyOAuth2RetrieveError(retrieveErr *oauth2.RetrieveError, err error) error {
+	tokenErr := oauth2TokenErrorFrom(retrieveErr)
+
+	// A transient token-endpoint status (429/5xx) stays retryable even if
+	// the body also carries a recognized RFC 6749 error param; otherwise
+	// the error param takes priority over the HTTP status, since some
+	// servers report it on a 200 and 400 is the spec default for
+	// invalid_client/invalid_grant, both of which GrpcCodeFromHTTPStatus
+	// alone would misclassify.
+	if tokenErr.resp != nil && isTransientHTTPStatus(tokenErr.resp.StatusCode) {
+		return wrapTransientOAuth2TokenError(tokenErr, err)
+	}
+	if code, ok := oauth2TokenErrorCode(tokenErr.code); ok {
+		return WrapErrors(code, tokenErr.message(), err)
+	}
+	code := codes.Unknown
+	if tokenErr.resp != nil {
+		code = GrpcCodeFromHTTPStatus(tokenErr.resp.StatusCode)
+	}
+	return WrapErrors(code, tokenErr.message(), err)
+}
+
+// oauth2TokenError is the RFC 6749 §5.2 view of a rejected token request:
+// the error/error_description pair, plus the response that carried them.
+// The pair is not always on the *oauth2.RetrieveError — jwt.Config's token
+// source builds that error from the response alone (jwt/jwt.go:143 in
+// x/oauth2 v0.36.0) and leaves both fields empty — so oauth2TokenErrorFrom
+// recovers it from the body.
+type oauth2TokenError struct {
+	resp        *http.Response
+	code        string
+	description string
+}
+
+func oauth2TokenErrorFrom(retrieveErr *oauth2.RetrieveError) oauth2TokenError {
+	tokenErr := oauth2TokenError{
+		resp:        retrieveErr.Response,
+		code:        retrieveErr.ErrorCode,
+		description: retrieveErr.ErrorDescription,
+	}
+	if tokenErr.code != "" {
+		return tokenErr
+	}
+
+	code, description := oauth2ErrorParamsFromBody(retrieveErr.Response, retrieveErr.Body)
+	tokenErr.code = code
+	if tokenErr.description == "" {
+		tokenErr.description = description
+	}
+	return tokenErr
+}
+
+// message prefers the RFC 6749 error/error_description pair the token
+// endpoint sent, since that survives even when the HTTP status alone would
+// be misleading (e.g. a 200 response carrying an error body).
+func (e oauth2TokenError) message() string {
+	switch {
+	case e.code != "" && e.description != "":
+		return fmt.Sprintf("%s: %s", e.code, e.description)
+	case e.code != "":
+		return e.code
+	case e.resp != nil && e.description != "":
+		return fmt.Sprintf("%s: %s", e.resp.Status, e.description)
+	case e.resp != nil:
+		return e.resp.Status
+	case e.description != "":
+		return e.description
+	default:
+		return "oauth2 token request failed"
+	}
+}
+
+// wrapTransientOAuth2TokenError mirrors WrapErrorsWithRateLimitInfo's detail
+// attachment (retry.Retryer reads it for rate-limit-aware backoff), while
+// keeping the description in the message the way oauth2TokenError.message
+// does elsewhere in this file.
+func wrapTransientOAuth2TokenError(tokenErr oauth2TokenError, err error) error {
+	msg := tokenErr.resp.Status
+	if tokenErr.description != "" {
+		msg = fmt.Sprintf("%s: %s", msg, tokenErr.description)
+	}
+	st := status.New(GrpcCodeFromHTTPStatus(tokenErr.resp.StatusCode), msg)
+	if description, rlErr := ratelimit.ExtractRateLimitData(tokenErr.resp.StatusCode, &tokenErr.resp.Header); rlErr == nil {
+		if withDetails, detailsErr := st.WithDetails(description); detailsErr == nil {
+			st = withDetails
+		}
+	}
+	return errors.Join(st.Err(), err)
+}
+
+// isTransientHTTPStatus reports whether GrpcCodeFromHTTPStatus maps
+// statusCode to a code retry.Retryer.ShouldWaitAndRetry treats as retryable
+// (Unavailable or DeadlineExceeded), so a transient token-endpoint failure
+// stays retryable regardless of what error param the body also carries.
+func isTransientHTTPStatus(statusCode int) bool {
+	switch GrpcCodeFromHTTPStatus(statusCode) {
+	case codes.Unavailable, codes.DeadlineExceeded:
+		return true
+	default:
+		return false
+	}
+}
+
+// oauth2TokenErrorCode maps an RFC 6749 token-error "error" parameter to a
+// grpc code. ok is false when errCode is empty or unrecognized, signaling
+// the caller to fall back to the HTTP status.
+func oauth2TokenErrorCode(errCode string) (codes.Code, bool) {
+	switch errCode {
+	case "invalid_client", "invalid_grant":
+		return codes.Unauthenticated, true
+	case "unauthorized_client", "access_denied":
+		return codes.PermissionDenied, true
+	case "invalid_scope", "invalid_request", "unsupported_grant_type", "unsupported_response_type":
+		return codes.InvalidArgument, true
+	// RFC 6749 §4.1.2.1 defines these two as transient by construction, so
+	// they are retryable whatever status the endpoint pairs them with.
+	case "server_error", "temporarily_unavailable":
+		return codes.Unavailable, true
+	default:
+		return codes.Unknown, false
+	}
+}
+
+// oauth2ErrorParamsFromBody recovers the RFC 6749 error/error_description
+// pair from the response body, for the token sources that leave those fields
+// unset on *oauth2.RetrieveError.
+func oauth2ErrorParamsFromBody(resp *http.Response, body []byte) (string, string) {
+	if len(body) == 0 {
+		return "", ""
+	}
+
+	contentType := ""
+	if resp != nil {
+		contentType, _, _ = mime.ParseMediaType(resp.Header.Get(ContentType))
+	}
+
+	switch contentType {
+	// Mirrors x/oauth2's own content-type handling: some token endpoints
+	// answer with a query string rather than JSON.
+	case "application/x-www-form-urlencoded", "text/plain":
+		vals, err := url.ParseQuery(string(body))
+		if err != nil {
+			return "", ""
+		}
+		return vals.Get("error"), truncateDescription(vals.Get("error_description"))
+	default:
+		return oauth2ErrorParamsFromJSONBody(body)
+	}
+}
+
+func oauth2ErrorParamsFromJSONBody(body []byte) (string, string) {
+	var parsed struct {
+		Error            json.RawMessage `json:"error"`
+		ErrorDescription string          `json:"error_description"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return "", ""
+	}
+	description := parsed.ErrorDescription
+	if len(parsed.Error) == 0 {
+		return "", truncateDescription(description)
+	}
+
+	var errCode string
+	if err := json.Unmarshal(parsed.Error, &errCode); err == nil {
+		return errCode, truncateDescription(description)
+	}
+
+	// RFC 6749 §5.2 defines "error" as a string. An endpoint that answers
+	// with anything else carries no error param this can act on, so the
+	// code stays empty and classification falls back to the HTTP status.
+	// The body becomes the description instead, bounded: it is the only
+	// detail such an endpoint gave, and no shape can be assumed of it.
+	// (Google's token endpoint nests a code/message/status object there.)
+	if description == "" {
+		description = strings.TrimSpace(string(body))
+	}
+	return "", truncateDescription(description)
+}
+
+func truncateDescription(description string) string {
+	if len(description) <= maxRecoveredDescription {
+		return description
+	}
+	runes := []rune(description)
+	if len(runes) <= maxRecoveredDescription {
+		return description
+	}
+	return string(runes[:maxRecoveredDescription]) + "..."
+}
+
+// grpcStatusInText matches what status.Err().Error() prints, which is all
+// that is left of a classified error once x/oauth2 flattens it with %v.
+var grpcStatusInText = regexp.MustCompile(`rpc error: code = ([A-Za-z]+) desc = ([^\n]*)`)
+
+// grpcCodeByName inverts codes.Code.String(), for reading a code back out of
+// flattened status text. codes.Unauthenticated is the highest code defined.
+var grpcCodeByName = func() map[string]codes.Code {
+	byName := make(map[string]codes.Code, codes.Unauthenticated+1)
+	for code := codes.OK; code <= codes.Unauthenticated; code++ {
+		byName[code.String()] = code
+	}
+	return byName
+}()
+
+// flattenedTokenFailures classifies the token-request failures that reach a
+// caller as text only. Each entry restates a condition
+// wrapTransientNetworkError classifies from error identity, and the codes
+// have to agree with it: the same failure takes either path depending on
+// whether the caller installed this package's transport under
+// oauth2.HTTPClient. TestFlattenedAndTypedClassificationAgree asserts that.
+//
+// Order matters. "no such host" comes before the timeout entries because a
+// resolver failure text can carry both, and EOF comes last because
+// "unexpected EOF" contains it.
+var flattenedTokenFailures = []struct {
+	substr string
+	code   codes.Code
+	msg    string
+}{
+	{substr: "no such host", code: codes.InvalidArgument, msg: "dns lookup failed: NXDOMAIN"},
+	{substr: "server misbehaving", code: codes.Unavailable, msg: "temporary dns lookup failure"},
+	{substr: "context deadline exceeded", code: codes.DeadlineExceeded, msg: "request timeout"},
+	{substr: "Client.Timeout exceeded", code: codes.DeadlineExceeded, msg: "request timeout"},
+	{substr: "TLS handshake timeout", code: codes.DeadlineExceeded, msg: "request timeout"},
+	{substr: "i/o timeout", code: codes.DeadlineExceeded, msg: "request timeout"},
+	{substr: "connection reset by peer", code: codes.Unavailable, msg: "connection reset"},
+	{substr: "connection refused", code: codes.Unavailable, msg: "connection refused"},
+	{substr: "broken pipe", code: codes.Unavailable, msg: "broken pipe"},
+	{substr: "network is unreachable", code: codes.Unavailable, msg: "network unreachable"},
+	{substr: "no route to host", code: codes.Unavailable, msg: "network unreachable"},
+	{substr: "http2: client connection lost", code: codes.Unavailable, msg: "http2 client connection lost"},
+	{substr: "EOF", code: codes.Unavailable, msg: "connection closed before response"},
+}
+
+// classifyFlattenedOAuth2TokenError classifies a token failure whose error
+// identity x/oauth2 destroyed. jwt/jwt.go:135, :140 and :154 (x/oauth2
+// v0.36.0) wrap the transport failure with %v, not %w, so the status this
+// package's transport attached, and the *url.Error and syscall errno under
+// it, are gone by the time any caller sees the error — errors.As and
+// status.Code cannot recover them, and no dependency bump fixes it. Text is
+// the only evidence left, so this is the one classifier here that reads it,
+// gated on the prefix x/oauth2 puts on exactly these failures. It returns
+// nil when the text carries nothing it can act on.
+func classifyFlattenedOAuth2TokenError(err error) error {
+	msg := err.Error()
+	if !strings.Contains(msg, oauth2FetchTokenPrefix) {
+		return nil
+	}
+
+	// A status this package's transport attached survives flattening as
+	// text, and it is a better answer than any substring match: it was
+	// decided from the typed error.
+	if match := grpcStatusInText.FindStringSubmatch(msg); match != nil {
+		if code, ok := grpcCodeByName[match[1]]; ok && code != codes.OK && code != codes.Unknown {
+			return WrapErrors(code, fmt.Sprintf("%s: %s", oauth2FetchTokenPrefix, match[2]), err)
+		}
+	}
+
+	for _, failure := range flattenedTokenFailures {
+		if strings.Contains(msg, failure.substr) {
+			return WrapErrors(failure.code, fmt.Sprintf("%s: %s", oauth2FetchTokenPrefix, failure.msg), err)
+		}
+	}
+	return nil
+}

--- a/pkg/uhttp/oauth2.go
+++ b/pkg/uhttp/oauth2.go
@@ -23,11 +23,13 @@ import (
 // reads message text instead of error identity.
 const oauth2FetchTokenPrefix = "oauth2: cannot fetch token" //nolint:gosec // G101: a message prefix, not a credential
 
-// maxRecoveredDescription bounds an error_description recovered from a
-// response body before it becomes part of a grpc status message. x/oauth2
-// caps the body it reads at 1 MiB, and that whole body can be one JSON
-// string field.
-const maxRecoveredDescription = 256
+// maxErrorParamLength bounds an RFC 6749 error param before it becomes part
+// of a grpc status message. It applies whether the param came off the
+// *oauth2.RetrieveError or out of the body: x/oauth2 populates
+// ErrorDescription from up to 1 MiB of response body on the
+// clientcredentials and oauth2.Config paths, and that whole body can be one
+// JSON string field.
+const maxErrorParamLength = 256
 
 // ClassifyOAuth2TokenError attaches a grpc status to a golang.org/x/oauth2
 // token-exchange failure, so retry.Retryer can act on it: a token endpoint
@@ -135,15 +137,18 @@ func oauth2TokenErrorFrom(retrieveErr *oauth2.RetrieveError) oauth2TokenError {
 		code:        retrieveErr.ErrorCode,
 		description: retrieveErr.ErrorDescription,
 	}
-	if tokenErr.code != "" {
-		return tokenErr
+	if tokenErr.code == "" {
+		code, description := oauth2ErrorParamsFromBody(retrieveErr.Response, retrieveErr.Body)
+		tokenErr.code = code
+		if tokenErr.description == "" {
+			tokenErr.description = description
+		}
 	}
 
-	code, description := oauth2ErrorParamsFromBody(retrieveErr.Response, retrieveErr.Body)
-	tokenErr.code = code
-	if tokenErr.description == "" {
-		tokenErr.description = description
-	}
+	// Bound both params here rather than at each source, so nothing reaches
+	// message() or wrapTransientOAuth2TokenError unbounded.
+	tokenErr.code = truncateErrorParam(tokenErr.code)
+	tokenErr.description = truncateErrorParam(tokenErr.description)
 	return tokenErr
 }
 
@@ -239,7 +244,7 @@ func oauth2ErrorParamsFromBody(resp *http.Response, body []byte) (string, string
 		if err != nil {
 			return "", ""
 		}
-		return vals.Get("error"), truncateDescription(vals.Get("error_description"))
+		return vals.Get("error"), vals.Get("error_description")
 	default:
 		return oauth2ErrorParamsFromJSONBody(body)
 	}
@@ -255,12 +260,12 @@ func oauth2ErrorParamsFromJSONBody(body []byte) (string, string) {
 	}
 	description := parsed.ErrorDescription
 	if len(parsed.Error) == 0 {
-		return "", truncateDescription(description)
+		return "", description
 	}
 
 	var errCode string
 	if err := json.Unmarshal(parsed.Error, &errCode); err == nil {
-		return errCode, truncateDescription(description)
+		return errCode, description
 	}
 
 	// RFC 6749 §5.2 defines "error" as a string. An endpoint that answers
@@ -272,18 +277,18 @@ func oauth2ErrorParamsFromJSONBody(body []byte) (string, string) {
 	if description == "" {
 		description = strings.TrimSpace(string(body))
 	}
-	return "", truncateDescription(description)
+	return "", description
 }
 
-func truncateDescription(description string) string {
-	if len(description) <= maxRecoveredDescription {
-		return description
+func truncateErrorParam(param string) string {
+	if len(param) <= maxErrorParamLength {
+		return param
 	}
-	runes := []rune(description)
-	if len(runes) <= maxRecoveredDescription {
-		return description
+	runes := []rune(param)
+	if len(runes) <= maxErrorParamLength {
+		return param
 	}
-	return string(runes[:maxRecoveredDescription]) + "..."
+	return string(runes[:maxErrorParamLength]) + "..."
 }
 
 // grpcStatusInText matches what status.Err().Error() prints, which is all
@@ -300,34 +305,50 @@ var grpcCodeByName = func() map[string]codes.Code {
 	return byName
 }()
 
+type flattenedTokenFailure struct {
+	substr string
+	code   codes.Code
+	msg    string
+}
+
 // flattenedTokenFailures classifies the token-request failures that reach a
-// caller as text only. Each entry restates a condition
-// wrapTransientNetworkError classifies from error identity, and the codes
-// have to agree with it: the same failure takes either path depending on
-// whether the caller installed this package's transport under
-// oauth2.HTTPClient. TestFlattenedAndTypedClassificationAgree asserts that.
+// caller as text only. Its socket entries are built from
+// transientSocketConditions, the same per-platform list the predicates in
+// errors_other.go and errors_windows.go match on, with each errno's own
+// Error() string as the text the OS wrote into the flattened message. So the
+// two classifiers cannot disagree about a socket failure, and the Winsock
+// spellings are covered on Windows without being transcribed by hand.
+// TestFlattenedAndTypedClassificationAgree walks that list and requires both
+// paths to land on one code.
 //
 // Order matters. "no such host" comes before the timeout entries because a
 // resolver failure text can carry both, and EOF comes last because
 // "unexpected EOF" contains it.
-var flattenedTokenFailures = []struct {
-	substr string
-	code   codes.Code
-	msg    string
-}{
-	{substr: "no such host", code: codes.InvalidArgument, msg: "dns lookup failed: NXDOMAIN"},
-	{substr: "server misbehaving", code: codes.Unavailable, msg: "temporary dns lookup failure"},
-	{substr: "context deadline exceeded", code: codes.DeadlineExceeded, msg: "request timeout"},
-	{substr: "Client.Timeout exceeded", code: codes.DeadlineExceeded, msg: "request timeout"},
-	{substr: "TLS handshake timeout", code: codes.DeadlineExceeded, msg: "request timeout"},
-	{substr: "i/o timeout", code: codes.DeadlineExceeded, msg: "request timeout"},
-	{substr: "connection reset by peer", code: codes.Unavailable, msg: "connection reset"},
-	{substr: "connection refused", code: codes.Unavailable, msg: "connection refused"},
-	{substr: "broken pipe", code: codes.Unavailable, msg: "broken pipe"},
-	{substr: "network is unreachable", code: codes.Unavailable, msg: "network unreachable"},
-	{substr: "no route to host", code: codes.Unavailable, msg: "network unreachable"},
-	{substr: "http2: client connection lost", code: codes.Unavailable, msg: "http2 client connection lost"},
-	{substr: "EOF", code: codes.Unavailable, msg: "connection closed before response"},
+var flattenedTokenFailures = buildFlattenedTokenFailures()
+
+func buildFlattenedTokenFailures() []flattenedTokenFailure {
+	failures := []flattenedTokenFailure{
+		{substr: "no such host", code: codes.InvalidArgument, msg: "dns lookup failed: NXDOMAIN"},
+		{substr: "server misbehaving", code: codes.Unavailable, msg: "temporary dns lookup failure"},
+		{substr: "context deadline exceeded", code: codes.DeadlineExceeded, msg: "request timeout"},
+		{substr: "Client.Timeout exceeded", code: codes.DeadlineExceeded, msg: "request timeout"},
+		{substr: "TLS handshake timeout", code: codes.DeadlineExceeded, msg: "request timeout"},
+		{substr: "i/o timeout", code: codes.DeadlineExceeded, msg: "request timeout"},
+	}
+
+	for _, condition := range transientSocketConditions {
+		classification := socketClassifications[condition.class]
+		failures = append(failures, flattenedTokenFailure{
+			substr: condition.err.Error(),
+			code:   classification.code,
+			msg:    classification.msg,
+		})
+	}
+
+	return append(failures,
+		flattenedTokenFailure{substr: "http2: client connection lost", code: codes.Unavailable, msg: "http2 client connection lost"},
+		flattenedTokenFailure{substr: "EOF", code: codes.Unavailable, msg: "connection closed before response"},
+	)
 }
 
 // classifyFlattenedOAuth2TokenError classifies a token failure whose error

--- a/pkg/uhttp/oauth2_test.go
+++ b/pkg/uhttp/oauth2_test.go
@@ -332,44 +332,105 @@ func TestClassifyOAuth2TokenError_IsStableUnderReclassification(t *testing.T) {
 	}
 }
 
-// Every entry in flattenedTokenFailures restates a condition
-// wrapTransientNetworkError classifies from error identity. The pair has to
-// agree: which path a failure takes depends only on whether the caller
-// installed this package's transport under oauth2.HTTPClient.
+// The two classifiers over this domain have to agree on every socket
+// condition the platform predicates know, not only on the ones a test author
+// thought of: which path a failure takes depends solely on whether the caller
+// installed this package's transport under oauth2.HTTPClient. Walking
+// transientSocketConditions closes that over the platform's own list, so a
+// new errno cannot be added to it without both paths being checked, and the
+// Winsock spellings are covered when this runs on Windows.
 func TestFlattenedAndTypedClassificationAgree(t *testing.T) {
 	flatten := func(err error) error {
 		//nolint:errorlint // reproduces x/oauth2's %v flattening; %w would defeat the test
 		return fmt.Errorf("oauth2: cannot fetch token: %v", err)
 	}
-	dialFailure := func(inner error) error {
-		return &url.Error{Op: "Post", URL: "https://example.com/token", Err: &net.OpError{Op: "dial", Net: "tcp", Err: inner}}
-	}
-	readFailure := func(inner error) error {
-		return &url.Error{Op: "Post", URL: "https://example.com/token", Err: &net.OpError{Op: "read", Net: "tcp", Err: inner}}
+	socketFailure := func(inner error) error {
+		return &url.Error{Op: "Post", URL: "https://example.com/token", Err: &net.OpError{
+			Op:  "dial",
+			Net: "tcp",
+			Err: os.NewSyscallError("connect", inner),
+		}}
 	}
 
-	tests := []struct {
+	require.NotEmpty(t, transientSocketConditions)
+	classesPresent := map[socketClass]bool{}
+	for _, condition := range transientSocketConditions {
+		classesPresent[condition.class] = true
+	}
+	for class := range socketClassifications {
+		require.True(t, classesPresent[class],
+			"class %d has no spelling on this platform, so neither classifier can reach it", class)
+	}
+
+	for _, condition := range transientSocketConditions {
+		t.Run(condition.err.Error(), func(t *testing.T) {
+			typed := socketFailure(condition.err)
+
+			typedCode := status.Code(wrapTransientNetworkError(typed))
+			require.Equal(t, socketClassifications[condition.class].code, typedCode,
+				"the platform predicates and the shared condition list disagree")
+
+			require.Equal(t, typedCode, status.Code(ClassifyOAuth2TokenError(flatten(typed))),
+				"same failure, one code, whichever path it takes")
+		})
+	}
+
+	// The conditions that are not socket errnos, and so are not on the
+	// shared list, still have to agree.
+	dnsFailure := func(dnsErr *net.DNSError) error {
+		return &url.Error{Op: "Post", URL: "https://example.com/token", Err: &net.OpError{Op: "dial", Net: "tcp", Err: dnsErr}}
+	}
+	others := []struct {
 		name  string
 		typed error
 	}{
-		{name: "connection reset", typed: readFailure(os.NewSyscallError("read", syscall.ECONNRESET))},
-		{name: "connection refused", typed: dialFailure(os.NewSyscallError("connect", syscall.ECONNREFUSED))},
-		{name: "broken pipe", typed: readFailure(os.NewSyscallError("write", syscall.EPIPE))},
-		{name: "network unreachable", typed: dialFailure(os.NewSyscallError("connect", syscall.ENETUNREACH))},
-		{name: "NXDOMAIN", typed: dialFailure(&net.DNSError{Err: "no such host", Name: "example.invalid", IsNotFound: true})},
-		{name: "temporary dns failure", typed: dialFailure(&net.DNSError{Err: "server misbehaving", Name: "example.com", IsTemporary: true})},
+		{name: "NXDOMAIN", typed: dnsFailure(&net.DNSError{Err: "no such host", Name: "example.invalid", IsNotFound: true})},
+		{name: "temporary dns failure", typed: dnsFailure(&net.DNSError{Err: "server misbehaving", Name: "example.com", IsTemporary: true})},
 		{name: "context deadline exceeded", typed: context.DeadlineExceeded},
 	}
-
-	for _, tt := range tests {
+	for _, tt := range others {
 		t.Run(tt.name, func(t *testing.T) {
 			typedCode := status.Code(wrapTransientNetworkError(tt.typed))
 			require.NotEqual(t, codes.Unknown, typedCode, "the typed classifier must have an answer for this case")
-
-			flattenedCode := status.Code(ClassifyOAuth2TokenError(flatten(tt.typed)))
-			require.Equal(t, typedCode, flattenedCode,
-				"flattened text classified as %s, typed error as %s", flattenedCode, typedCode)
+			require.Equal(t, typedCode, status.Code(ClassifyOAuth2TokenError(flatten(tt.typed))))
 		})
+	}
+}
+
+// ETIMEDOUT is the one condition whose typed classification does not come off
+// the shared list — net.Error.Timeout() answers it before any predicate runs
+// (isSocketTimeout on Windows) — so dropping it from the list would leave the
+// flattened path silently unclassified again, which is the gap this table was
+// widened to close. The text comes from syscall rather than from the list, so
+// this fails if the entry goes away.
+func TestClassifyOAuth2TokenError_FlattenedConnectTimeout(t *testing.T) {
+	typed := &url.Error{Op: "Post", URL: "https://example.com/token", Err: &net.OpError{
+		Op:  "dial",
+		Net: "tcp",
+		Err: os.NewSyscallError("connect", syscall.ETIMEDOUT),
+	}}
+	//nolint:errorlint // reproduces x/oauth2's %v flattening; %w would defeat the test
+	flattened := fmt.Errorf("oauth2: cannot fetch token: %v", typed)
+
+	require.Contains(t, flattened.Error(), syscall.ETIMEDOUT.Error())
+	require.Equal(t, codes.DeadlineExceeded, status.Code(ClassifyOAuth2TokenError(flattened)))
+	require.True(t, newTestRetryer(t).ShouldWaitAndRetry(t.Context(), ClassifyOAuth2TokenError(flattened)),
+		"a token fetch whose TCP connect timed out must be retryable")
+}
+
+// The table is scanned in order and the first match wins, so an entry whose
+// text contains an earlier entry's text can never be reached. Substring
+// overlap is only safe when both land on the same code.
+func TestFlattenedTokenFailures_OrderIsUnambiguous(t *testing.T) {
+	for i, earlier := range flattenedTokenFailures {
+		for j, later := range flattenedTokenFailures {
+			if i >= j || earlier.code == later.code {
+				continue
+			}
+			require.False(t, strings.Contains(later.substr, earlier.substr),
+				"%q (%s) is shadowed by the earlier %q (%s); reorder or split them",
+				later.substr, later.code, earlier.substr, earlier.code)
+		}
 	}
 }
 
@@ -390,10 +451,56 @@ func TestClassifyOAuth2TokenError_TruncatesRecoveredDescription(t *testing.T) {
 	require.True(t, utf8.ValidString(msg), "truncation split a rune: %q", msg)
 }
 
+// x/oauth2 populates ErrorDescription itself on the clientcredentials and
+// oauth2.Config paths, from up to 1 MiB of body, so the bound has to cover
+// the params that arrive on the error and not only what is parsed out of a
+// body. Both the terminal and the transient path build the message.
+func TestClassifyOAuth2TokenError_TruncatesParamsFromTheError(t *testing.T) {
+	tests := []struct {
+		name  string
+		err   error
+		found string
+	}{
+		{
+			name: "terminal path",
+			err: &url.Error{Op: "Post", URL: "https://example.com/oauth/token", Err: &oauth2.RetrieveError{
+				Response:         &http.Response{StatusCode: http.StatusBadRequest, Status: "400 Bad Request"},
+				ErrorCode:        "invalid_grant",
+				ErrorDescription: strings.Repeat("y", 5000),
+			}},
+			found: "invalid_grant",
+		},
+		{
+			name: "transient path",
+			err: &url.Error{Op: "Post", URL: "https://example.com/oauth/token", Err: &oauth2.RetrieveError{
+				Response:         &http.Response{StatusCode: http.StatusServiceUnavailable, Status: "503 Service Unavailable"},
+				ErrorDescription: strings.Repeat("z", 5000),
+			}},
+			found: "503 Service Unavailable",
+		},
+		{
+			name: "error code itself",
+			err: &url.Error{Op: "Post", URL: "https://example.com/oauth/token", Err: &oauth2.RetrieveError{
+				Response:  &http.Response{StatusCode: http.StatusBadRequest, Status: "400 Bad Request"},
+				ErrorCode: strings.Repeat("w", 5000),
+			}},
+			found: "www",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := statusMessage(t, ClassifyOAuth2TokenError(tt.err))
+			require.Less(t, len(msg), 512, "message was not truncated: %d bytes", len(msg))
+			require.Contains(t, msg, tt.found)
+		})
+	}
+}
+
 // The bound is on runes, so a description that is long in bytes but short in
 // characters survives whole.
 func TestClassifyOAuth2TokenError_KeepsMultibyteDescriptionUnderTheBound(t *testing.T) {
-	description := strings.Repeat("é", maxRecoveredDescription-1)
+	description := strings.Repeat("é", maxErrorParamLength-1)
 	body, err := json.Marshal(map[string]string{"error": "invalid_grant", "error_description": description})
 	require.NoError(t, err)
 

--- a/pkg/uhttp/oauth2_test.go
+++ b/pkg/uhttp/oauth2_test.go
@@ -1,0 +1,650 @@
+package uhttp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+	"golang.org/x/oauth2/jwt"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/retry"
+)
+
+// statusMessage reads the message off the status attached to err. It is not
+// status.Convert(err).Message(): grpc replaces that message with the whole
+// wrapped error text (status.go:123) when the status is wrapped, which hides
+// what the classifier actually chose.
+func statusMessage(t *testing.T, err error) string {
+	t.Helper()
+	var withStatus interface{ GRPCStatus() *status.Status }
+	require.True(t, errors.As(err, &withStatus), "no status attached to %v", err)
+	return withStatus.GRPCStatus().Message()
+}
+
+func newTestRetryer(t *testing.T) *retry.Retryer {
+	t.Helper()
+	return retry.NewRetryer(t.Context(), retry.RetryConfig{
+		MaxAttempts:  3,
+		InitialDelay: time.Millisecond,
+		MaxDelay:     time.Millisecond,
+	})
+}
+
+// jsonTokenFailure builds the error x/oauth2's jwt token source produces: a
+// *oauth2.RetrieveError carrying the body and response only, with the RFC
+// 6749 params left empty.
+func jsonTokenFailure(statusCode int, body string) error {
+	header := http.Header{}
+	header.Set(ContentType, "application/json")
+	return &url.Error{
+		Op:  "Post",
+		URL: "https://example.com/oauth/token",
+		Err: &oauth2.RetrieveError{
+			Response: &http.Response{
+				StatusCode: statusCode,
+				Status:     fmt.Sprintf("%d %s", statusCode, http.StatusText(statusCode)),
+				Header:     header,
+			},
+			Body: []byte(body),
+		},
+	}
+}
+
+func TestClassifyOAuth2TokenError(t *testing.T) {
+	formHeader := http.Header{}
+	formHeader.Set(ContentType, "application/x-www-form-urlencoded")
+
+	tests := []struct {
+		name     string
+		err      error
+		wantCode codes.Code
+		wantMsg  string
+		// wantUnchanged marks the cases with nothing actionable in them,
+		// which must come back as they went in rather than wearing a
+		// codes.Unknown status they did not have before.
+		wantUnchanged bool
+	}{
+		{
+			// The GCP case from CXP-890: the endpoint answered 500 and the
+			// body carries a non-RFC error param, so the status decides.
+			name:     "500 with a JSON error param is retryable",
+			err:      jsonTokenFailure(http.StatusInternalServerError, `{"error":"internal_failure"}`),
+			wantCode: codes.Unavailable,
+			wantMsg:  "500 Internal Server Error",
+		},
+		{
+			name:     "503 with an unparseable body falls back to the status",
+			err:      jsonTokenFailure(http.StatusServiceUnavailable, "<html>upstream connect error</html>"),
+			wantCode: codes.Unavailable,
+			wantMsg:  "503 Service Unavailable",
+		},
+		{
+			// A non-string "error" member is not an RFC 6749 error param,
+			// so the status decides and the body is kept as the detail.
+			// This is the shape Google's token endpoint answers with.
+			name:     "non-string error member on a 500 is retryable",
+			err:      jsonTokenFailure(http.StatusInternalServerError, `{"error":{"code":500,"message":"Internal error encountered.","status":"INTERNAL"}}`),
+			wantCode: codes.Unavailable,
+			wantMsg:  `500 Internal Server Error: {"error":{"code":500,"message":"Internal error encountered.","status":"INTERNAL"}}`,
+		},
+		{
+			name:     "non-string error member on a 400 stays terminal",
+			err:      jsonTokenFailure(http.StatusBadRequest, `{"error":{"code":400,"message":"Invalid grant: account not found"}}`),
+			wantCode: codes.InvalidArgument,
+			wantMsg:  `400 Bad Request: {"error":{"code":400,"message":"Invalid grant: account not found"}}`,
+		},
+		{
+			name:     "error_description wins over the body of a non-string error member",
+			err:      jsonTokenFailure(http.StatusBadRequest, `{"error":["invalid_grant"],"error_description":"account not found"}`),
+			wantCode: codes.InvalidArgument,
+			wantMsg:  "400 Bad Request: account not found",
+		},
+		{
+			name:     "invalid_grant recovered from the body is Unauthenticated",
+			err:      jsonTokenFailure(http.StatusBadRequest, `{"error":"invalid_grant","error_description":"Invalid JWT Signature."}`),
+			wantCode: codes.Unauthenticated,
+			wantMsg:  "invalid_grant: Invalid JWT Signature.",
+		},
+		{
+			name:     "invalid_client recovered from the body is Unauthenticated",
+			err:      jsonTokenFailure(http.StatusUnauthorized, `{"error":"invalid_client"}`),
+			wantCode: codes.Unauthenticated,
+			wantMsg:  "invalid_client",
+		},
+		{
+			name:     "unauthorized_client recovered from the body is PermissionDenied",
+			err:      jsonTokenFailure(http.StatusBadRequest, `{"error":"unauthorized_client"}`),
+			wantCode: codes.PermissionDenied,
+			wantMsg:  "unauthorized_client",
+		},
+		{
+			// An error param on a 200 is why the body is read at all: the
+			// status alone would call this a success.
+			name:     "error param recovered from a 200 body still classifies",
+			err:      jsonTokenFailure(http.StatusOK, `{"error":"invalid_grant"}`),
+			wantCode: codes.Unauthenticated,
+			wantMsg:  "invalid_grant",
+		},
+		{
+			name:     "server_error is transient whatever status carries it",
+			err:      jsonTokenFailure(http.StatusBadRequest, `{"error":"server_error"}`),
+			wantCode: codes.Unavailable,
+			wantMsg:  "server_error",
+		},
+		{
+			name:     "temporarily_unavailable is transient whatever status carries it",
+			err:      jsonTokenFailure(http.StatusBadRequest, `{"error":"temporarily_unavailable"}`),
+			wantCode: codes.Unavailable,
+			wantMsg:  "temporarily_unavailable",
+		},
+		{
+			name: "form-encoded body params are recovered too",
+			err: &url.Error{Op: "Post", URL: "https://example.com/oauth/token", Err: &oauth2.RetrieveError{
+				Response: &http.Response{StatusCode: http.StatusBadRequest, Status: "400 Bad Request", Header: formHeader},
+				Body:     []byte("error=invalid_grant&error_description=expired+refresh+token"),
+			}},
+			wantCode: codes.Unauthenticated,
+			wantMsg:  "invalid_grant: expired refresh token",
+		},
+		{
+			// The params on the error win over the body: x/oauth2 already
+			// parsed them for the paths that populate them.
+			name: "populated RFC params take precedence over the body",
+			err: &url.Error{Op: "Post", URL: "https://example.com/oauth/token", Err: &oauth2.RetrieveError{
+				Response:  &http.Response{StatusCode: http.StatusBadRequest, Status: "400 Bad Request"},
+				ErrorCode: "invalid_scope",
+				Body:      []byte(`{"error":"invalid_grant"}`),
+			}},
+			wantCode: codes.InvalidArgument,
+			wantMsg:  "invalid_scope",
+		},
+		{
+			name:     "empty body with no params falls back to the status",
+			err:      jsonTokenFailure(http.StatusForbidden, ""),
+			wantCode: codes.PermissionDenied,
+			wantMsg:  "403 Forbidden",
+		},
+		{
+			name:     "a body carrying only a description keeps it alongside the status",
+			err:      jsonTokenFailure(http.StatusBadRequest, `{"error_description":"missing assertion"}`),
+			wantCode: codes.InvalidArgument,
+			wantMsg:  "400 Bad Request: missing assertion",
+		},
+		{
+			// jwt.Config's token source builds this shape whenever the
+			// response itself could not be read, so Response is nil while
+			// the body it did read is not.
+			name: "no response at all still yields the body description",
+			err: &url.Error{Op: "Post", URL: "https://example.com/oauth/token", Err: &oauth2.RetrieveError{
+				Body: []byte(`{"error_description":"no response"}`),
+			}},
+			wantCode: codes.Unknown,
+			wantMsg:  "no response",
+		},
+		{
+			name: "unparseable form body falls back to the status",
+			err: &url.Error{Op: "Post", URL: "https://example.com/oauth/token", Err: &oauth2.RetrieveError{
+				Response: &http.Response{StatusCode: http.StatusBadRequest, Status: "400 Bad Request", Header: formHeader},
+				Body:     []byte("error=%zz"),
+			}},
+			wantCode: codes.InvalidArgument,
+			wantMsg:  "400 Bad Request",
+		},
+		{
+			name:     "flattened timeout is DeadlineExceeded",
+			err:      fmt.Errorf(`oauth2: cannot fetch token: Post "https://oauth2.googleapis.com/token": context deadline exceeded`),
+			wantCode: codes.DeadlineExceeded,
+			wantMsg:  "request timeout",
+		},
+		{
+			name:     "flattened client timeout is DeadlineExceeded",
+			err:      fmt.Errorf(`oauth2: cannot fetch token: Post "https://example.com/token": context deadline exceeded (Client.Timeout exceeded while awaiting headers)`),
+			wantCode: codes.DeadlineExceeded,
+			wantMsg:  "request timeout",
+		},
+		{
+			name:     "flattened connection reset is Unavailable",
+			err:      fmt.Errorf(`oauth2: cannot fetch token: Post "https://example.com/token": read tcp 10.0.0.1:52000->10.0.0.2:443: read: connection reset by peer`),
+			wantCode: codes.Unavailable,
+			wantMsg:  "connection reset",
+		},
+		{
+			name:     "flattened EOF is Unavailable",
+			err:      fmt.Errorf(`oauth2: cannot fetch token: Post "https://example.com/token": EOF`),
+			wantCode: codes.Unavailable,
+			wantMsg:  "connection closed before response",
+		},
+		{
+			// NXDOMAIN is terminal here for the same reason it is terminal
+			// in wrapTransientNetworkError: a hostname that does not
+			// resolve is a misconfiguration.
+			name:     "flattened NXDOMAIN stays terminal",
+			err:      fmt.Errorf(`oauth2: cannot fetch token: Post "https://example.invalid/token": dial tcp: lookup example.invalid: no such host`),
+			wantCode: codes.InvalidArgument,
+			wantMsg:  "NXDOMAIN",
+		},
+		{
+			// A status this package's transport attached is recovered from
+			// the flattened text rather than re-derived from substrings.
+			name:     "flattened grpc status is recovered",
+			err:      fmt.Errorf("oauth2: cannot fetch token: Post \"https://example.com/token\": rpc error: code = Unavailable desc = http2 client connection lost\nsomething else"),
+			wantCode: codes.Unavailable,
+			wantMsg:  "http2 client connection lost",
+		},
+		{
+			// Recovering the code faithfully includes the terminal ones:
+			// the transport decided this from the typed error.
+			name:     "flattened terminal grpc status is recovered, not upgraded",
+			err:      fmt.Errorf(`oauth2: cannot fetch token: Post "https://example.invalid/token": rpc error: code = InvalidArgument desc = dns lookup failed: NXDOMAIN`),
+			wantCode: codes.InvalidArgument,
+			wantMsg:  "NXDOMAIN",
+		},
+		{
+			// Nothing actionable in the text: staying Unknown is the
+			// conservative answer, not a retry.
+			name:          "flattened malformed response body stays Unknown",
+			err:           fmt.Errorf(`oauth2: cannot fetch token: invalid character '<' looking for beginning of value`),
+			wantCode:      codes.Unknown,
+			wantMsg:       "cannot fetch token",
+			wantUnchanged: true,
+		},
+		{
+			// A network failure that reached the caller with its identity
+			// intact is classified by the network rules, not by text.
+			name: "typed network error is classified by identity",
+			err: &url.Error{Op: "Post", URL: "https://example.com/token", Err: &net.OpError{
+				Op:  "read",
+				Net: "tcp",
+				Err: os.NewSyscallError("read", syscall.ECONNRESET),
+			}},
+			wantCode: codes.Unavailable,
+			wantMsg:  "connection reset",
+		},
+		{
+			name:          "unrelated error is left alone",
+			err:           fmt.Errorf("creating JWT config failed: bad key"),
+			wantCode:      codes.Unknown,
+			wantMsg:       "creating JWT config failed",
+			wantUnchanged: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ClassifyOAuth2TokenError(tt.err)
+			require.Equal(t, tt.wantCode, status.Code(got), "got %v", got)
+			require.ErrorIs(t, got, tt.err, "classification must preserve the original error for errors.Is/As")
+
+			if tt.wantUnchanged {
+				require.Equal(t, tt.err, got)
+				require.Contains(t, got.Error(), tt.wantMsg)
+				return
+			}
+			require.Contains(t, statusMessage(t, got), tt.wantMsg)
+		})
+	}
+}
+
+func TestClassifyOAuth2TokenError_Nil(t *testing.T) {
+	require.NoError(t, ClassifyOAuth2TokenError(nil))
+}
+
+// A caller closer to the failure already classified it; re-wrapping would
+// bury that code behind this one, since status.Code reads the outermost.
+func TestClassifyOAuth2TokenError_KeepsAnExistingStatus(t *testing.T) {
+	classified := WrapErrors(codes.DeadlineExceeded, "request timeout", fmt.Errorf("oauth2: cannot fetch token: boom"))
+	require.Equal(t, classified, ClassifyOAuth2TokenError(classified))
+}
+
+// The two classifiers over this domain — ClassifyOAuth2TokenError above the
+// token source and wrapTransientNetworkError inside the transport — meet
+// whenever a connector wraps a token-backed client in BaseHttpClient, so
+// either order has to settle on one code.
+func TestClassifyOAuth2TokenError_IsStableUnderReclassification(t *testing.T) {
+	for _, err := range []error{
+		jsonTokenFailure(http.StatusInternalServerError, `{"error":"internal_failure"}`),
+		jsonTokenFailure(http.StatusBadRequest, `{"error":"invalid_grant"}`),
+		fmt.Errorf(`oauth2: cannot fetch token: Post "https://example.com/token": context deadline exceeded`),
+	} {
+		classified := ClassifyOAuth2TokenError(err)
+		want := status.Code(classified)
+
+		require.Equal(t, want, status.Code(ClassifyOAuth2TokenError(classified)))
+		require.Equal(t, want, status.Code(wrapTransientNetworkError(classified)))
+		require.Equal(t, want, status.Code(ClassifyOAuth2TokenError(wrapTransientNetworkError(err))))
+	}
+}
+
+// Every entry in flattenedTokenFailures restates a condition
+// wrapTransientNetworkError classifies from error identity. The pair has to
+// agree: which path a failure takes depends only on whether the caller
+// installed this package's transport under oauth2.HTTPClient.
+func TestFlattenedAndTypedClassificationAgree(t *testing.T) {
+	flatten := func(err error) error {
+		//nolint:errorlint // reproduces x/oauth2's %v flattening; %w would defeat the test
+		return fmt.Errorf("oauth2: cannot fetch token: %v", err)
+	}
+	dialFailure := func(inner error) error {
+		return &url.Error{Op: "Post", URL: "https://example.com/token", Err: &net.OpError{Op: "dial", Net: "tcp", Err: inner}}
+	}
+	readFailure := func(inner error) error {
+		return &url.Error{Op: "Post", URL: "https://example.com/token", Err: &net.OpError{Op: "read", Net: "tcp", Err: inner}}
+	}
+
+	tests := []struct {
+		name  string
+		typed error
+	}{
+		{name: "connection reset", typed: readFailure(os.NewSyscallError("read", syscall.ECONNRESET))},
+		{name: "connection refused", typed: dialFailure(os.NewSyscallError("connect", syscall.ECONNREFUSED))},
+		{name: "broken pipe", typed: readFailure(os.NewSyscallError("write", syscall.EPIPE))},
+		{name: "network unreachable", typed: dialFailure(os.NewSyscallError("connect", syscall.ENETUNREACH))},
+		{name: "NXDOMAIN", typed: dialFailure(&net.DNSError{Err: "no such host", Name: "example.invalid", IsNotFound: true})},
+		{name: "temporary dns failure", typed: dialFailure(&net.DNSError{Err: "server misbehaving", Name: "example.com", IsTemporary: true})},
+		{name: "context deadline exceeded", typed: context.DeadlineExceeded},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			typedCode := status.Code(wrapTransientNetworkError(tt.typed))
+			require.NotEqual(t, codes.Unknown, typedCode, "the typed classifier must have an answer for this case")
+
+			flattenedCode := status.Code(ClassifyOAuth2TokenError(flatten(tt.typed)))
+			require.Equal(t, typedCode, flattenedCode,
+				"flattened text classified as %s, typed error as %s", flattenedCode, typedCode)
+		})
+	}
+}
+
+// A recovered description reaches a grpc status message and from there the
+// logs, and x/oauth2 only caps the body it reads at 1 MiB.
+func TestClassifyOAuth2TokenError_TruncatesRecoveredDescription(t *testing.T) {
+	body, err := json.Marshal(map[string]string{
+		"error":             "invalid_grant",
+		"error_description": strings.Repeat("x", 4096),
+	})
+	require.NoError(t, err)
+
+	got := ClassifyOAuth2TokenError(jsonTokenFailure(http.StatusBadRequest, string(body)))
+	require.Equal(t, codes.Unauthenticated, status.Code(got))
+	msg := statusMessage(t, got)
+	require.Less(t, len(msg), 512, "message %q was not truncated", msg)
+	require.Contains(t, msg, "invalid_grant")
+	require.True(t, utf8.ValidString(msg), "truncation split a rune: %q", msg)
+}
+
+// The bound is on runes, so a description that is long in bytes but short in
+// characters survives whole.
+func TestClassifyOAuth2TokenError_KeepsMultibyteDescriptionUnderTheBound(t *testing.T) {
+	description := strings.Repeat("é", maxRecoveredDescription-1)
+	body, err := json.Marshal(map[string]string{"error": "invalid_grant", "error_description": description})
+	require.NoError(t, err)
+
+	got := ClassifyOAuth2TokenError(jsonTokenFailure(http.StatusBadRequest, string(body)))
+	require.Equal(t, "invalid_grant: "+description, statusMessage(t, got))
+}
+
+func TestClassifyOAuth2TokenError_AttachesRateLimitDetails(t *testing.T) {
+	header := http.Header{}
+	header.Set(ContentType, "application/json")
+	header.Set("Retry-After", "120")
+	got := ClassifyOAuth2TokenError(&url.Error{Op: "Post", URL: "https://example.com/token", Err: &oauth2.RetrieveError{
+		Response: &http.Response{StatusCode: http.StatusTooManyRequests, Status: "429 Too Many Requests", Header: header},
+		Body:     []byte(`{"error":"rate_limit_exceeded","error_description":"slow down"}`),
+	}})
+
+	require.Equal(t, codes.Unavailable, status.Code(got))
+	var found *v2.RateLimitDescription
+	var withStatus interface{ GRPCStatus() *status.Status }
+	require.True(t, errors.As(got, &withStatus))
+	for _, detail := range withStatus.GRPCStatus().Details() {
+		if rl, ok := detail.(*v2.RateLimitDescription); ok {
+			found = rl
+		}
+	}
+	require.NotNil(t, found, "expected a RateLimitDescription detail from the Retry-After header")
+	require.Contains(t, statusMessage(t, got), "slow down")
+}
+
+// The retryer is the consumer this classification exists for, and the
+// anti-goal matters as much as the goal: a rejected credential must not spin
+// in a retryer that has no attempt limit at its default settings.
+func TestClassifyOAuth2TokenError_RetryerAgreement(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		wantRetry bool
+	}{
+		{name: "500 token endpoint", err: jsonTokenFailure(http.StatusInternalServerError, `{"error":"internal_failure"}`), wantRetry: true},
+		{name: "429 token endpoint", err: jsonTokenFailure(http.StatusTooManyRequests, ""), wantRetry: true},
+		{name: "flattened timeout", err: fmt.Errorf(`oauth2: cannot fetch token: Post "https://example.com/token": context deadline exceeded`), wantRetry: true},
+		{name: "invalid_grant", err: jsonTokenFailure(http.StatusBadRequest, `{"error":"invalid_grant"}`), wantRetry: false},
+		{name: "invalid_client", err: jsonTokenFailure(http.StatusUnauthorized, `{"error":"invalid_client"}`), wantRetry: false},
+		{name: "unauthorized_client", err: jsonTokenFailure(http.StatusForbidden, `{"error":"unauthorized_client"}`), wantRetry: false},
+		{name: "invalid_scope", err: jsonTokenFailure(http.StatusBadRequest, `{"error":"invalid_scope"}`), wantRetry: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ClassifyOAuth2TokenError(tt.err)
+			require.Equal(t, tt.wantRetry, newTestRetryer(t).ShouldWaitAndRetry(t.Context(), got), "classified as %v", got)
+		})
+	}
+}
+
+func TestNewClassifyingTokenSource_NilInner(t *testing.T) {
+	require.Nil(t, NewClassifyingTokenSource(nil))
+}
+
+func TestNewClassifyingTokenSource_PassesTokensThrough(t *testing.T) {
+	want := &oauth2.Token{AccessToken: "test-access-token"}
+	got, err := NewClassifyingTokenSource(oauth2.StaticTokenSource(want)).Token()
+	require.NoError(t, err)
+	require.Equal(t, want.AccessToken, got.AccessToken)
+}
+
+// tokenServer answers every request with the given status and body.
+func tokenServer(t *testing.T, statusCode int, body string) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(ContentType, "application/json")
+		w.WriteHeader(statusCode)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func testJWTConfig(tokenURL string) *jwt.Config {
+	return &jwt.Config{
+		Email:      "test-email",
+		TokenURL:   tokenURL,
+		PrivateKey: getDummyPrivateKey(),
+		Subject:    "test-subject",
+	}
+}
+
+// The premise of classifyFlattenedOAuth2TokenError: x/oauth2's jwt token
+// source wraps a transport failure with %v (jwt/jwt.go:135, :140, :154 in
+// v0.36.0), so the *url.Error and any status attached below it are gone
+// before a caller sees the error. If a later x/oauth2 stops flattening,
+// this test fails and the text-matching fallback can be dropped.
+func TestXOauth2JWT_FlattensTransportErrors(t *testing.T) {
+	released := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-released
+	}))
+	defer server.Close()
+	defer close(released)
+
+	ctx := context.WithValue(t.Context(), oauth2.HTTPClient, &http.Client{Timeout: 100 * time.Millisecond})
+	_, rawErr := testJWTConfig(server.URL).TokenSource(ctx).Token()
+	require.Error(t, rawErr)
+
+	var urlErr *url.Error
+	require.False(t, errors.As(rawErr, &urlErr),
+		"x/oauth2 no longer flattens the transport error; the text fallback can go: %v", rawErr)
+	require.Equal(t, codes.Unknown, status.Code(rawErr), "premise: the error carries no status of its own")
+	require.Contains(t, rawErr.Error(), oauth2FetchTokenPrefix)
+
+	require.Equal(t, codes.DeadlineExceeded, status.Code(ClassifyOAuth2TokenError(rawErr)),
+		"a token endpoint that timed out must be retryable")
+}
+
+// The second premise: jwt.Config's token source builds *oauth2.RetrieveError
+// from the response alone (jwt/jwt.go:143), so the RFC 6749 params are only
+// in the body. This is the GCP shape from CXP-890.
+func TestXOauth2JWT_LeavesRFCParamsEmpty(t *testing.T) {
+	server := tokenServer(t, http.StatusBadRequest, `{"error":"invalid_grant","error_description":"Invalid JWT Signature."}`)
+
+	_, rawErr := testJWTConfig(server.URL).TokenSource(t.Context()).Token()
+	require.Error(t, rawErr)
+
+	var retrieveErr *oauth2.RetrieveError
+	require.True(t, errors.As(rawErr, &retrieveErr))
+	require.Empty(t, retrieveErr.ErrorCode, "premise: the RFC 6749 params are not parsed on this path")
+	require.NotEmpty(t, retrieveErr.Body)
+
+	got := ClassifyOAuth2TokenError(rawErr)
+	require.Equal(t, codes.Unauthenticated, status.Code(got))
+	require.Contains(t, statusMessage(t, got), "invalid_grant")
+	require.False(t, newTestRetryer(t).ShouldWaitAndRetry(t.Context(), got),
+		"a rejected credential must not be retried")
+}
+
+// A 500 from the token endpoint, end to end through the jwt token source:
+// the case that discarded whole syncs.
+func TestXOauth2JWT_TransientStatusIsRetryable(t *testing.T) {
+	server := tokenServer(t, http.StatusInternalServerError, `{"error":"internal_failure"}`)
+
+	_, rawErr := testJWTConfig(server.URL).TokenSource(t.Context()).Token()
+	require.Error(t, rawErr)
+	require.Equal(t, codes.Unknown, status.Code(rawErr), "premise: unclassified, so the retryer would give up")
+
+	got := ClassifyOAuth2TokenError(rawErr)
+	require.Equal(t, codes.Unavailable, status.Code(got))
+	require.True(t, newTestRetryer(t).ShouldWaitAndRetry(t.Context(), got))
+}
+
+func TestOAuth2ClientCredentials_GetClientClassifiesTokenFailure(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		wantCode   codes.Code
+	}{
+		{name: "500 is retryable", statusCode: http.StatusInternalServerError, body: `{"error":"internal_failure"}`, wantCode: codes.Unavailable},
+		{name: "invalid_client is terminal", statusCode: http.StatusUnauthorized, body: `{"error":"invalid_client"}`, wantCode: codes.Unauthenticated},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := tokenServer(t, tt.statusCode, tt.body)
+			creds := &OAuth2ClientCredentials{cfg: &clientcredentials.Config{
+				ClientID:     "client-id",
+				ClientSecret: "client-secret",
+				TokenURL:     server.URL,
+			}}
+
+			client, err := creds.GetClient(t.Context())
+			require.NoError(t, err)
+
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://example.com/api", nil)
+			require.NoError(t, err)
+			resp, err := client.Do(req) //nolint:bodyclose // the token exchange fails before a response exists
+			require.Nil(t, resp)
+			require.Equal(t, tt.wantCode, status.Code(err), "got %v", err)
+		})
+	}
+}
+
+func TestOAuth2JWT_GetClientClassifiesTokenFailure(t *testing.T) {
+	server := tokenServer(t, http.StatusInternalServerError, `{"error":"internal_failure"}`)
+	creds := &OAuth2JWT{
+		Credentials: []byte("test-credentials"),
+		CreateJWTConfig: func(credentials []byte, scopes ...string) (*jwt.Config, error) {
+			return testJWTConfig(server.URL), nil
+		},
+	}
+
+	client, err := creds.GetClient(t.Context())
+	require.NoError(t, err)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://example.com/api", nil)
+	require.NoError(t, err)
+	resp, err := client.Do(req) //nolint:bodyclose // the token exchange fails before a response exists
+	require.Nil(t, resp)
+	require.Equal(t, codes.Unavailable, status.Code(err), "got %v", err)
+}
+
+// An empty access token is what forces this helper to refresh on the first
+// request; a stored token with no expiry never refreshes at all.
+func TestOAuth2RefreshToken_GetClientClassifiesRefreshFailure(t *testing.T) {
+	server := tokenServer(t, http.StatusBadRequest, `{"error":"invalid_grant","error_description":"Token has been expired or revoked."}`)
+	creds := NewOAuth2RefreshToken("client-id", "client-secret", "https://example.com/callback", server.URL, "", "refresh-token", nil)
+
+	client, err := creds.GetClient(t.Context())
+	require.NoError(t, err)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://example.com/api", nil)
+	require.NoError(t, err)
+	resp, err := client.Do(req) //nolint:bodyclose // the token exchange fails before a response exists
+	require.Nil(t, resp)
+	require.Equal(t, codes.Unauthenticated, status.Code(err), "got %v", err)
+	require.False(t, newTestRetryer(t).ShouldWaitAndRetry(t.Context(), err))
+}
+
+// What a connector can still match on after the helpers classify a token
+// failure. The status is added by joining, never by replacing, so both the
+// error identity and the text x/oauth2 produced survive: existing
+// errors.As/errors.Is checks and message matches in connectors keep working.
+func TestOAuth2JWT_GetClientPreservesErrorIdentity(t *testing.T) {
+	server := tokenServer(t, http.StatusBadRequest, `{"error":"invalid_grant","error_description":"Invalid JWT Signature."}`)
+	creds := &OAuth2JWT{
+		Credentials: []byte("test-credentials"),
+		CreateJWTConfig: func(credentials []byte, scopes ...string) (*jwt.Config, error) {
+			return testJWTConfig(server.URL), nil
+		},
+	}
+
+	client, err := creds.GetClient(t.Context())
+	require.NoError(t, err)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://example.com/api", nil)
+	require.NoError(t, err)
+	_, doErr := client.Do(req) //nolint:bodyclose // the token exchange fails before a response exists
+	require.Error(t, doErr)
+
+	require.Equal(t, codes.Unauthenticated, status.Code(doErr))
+
+	var retrieveErr *oauth2.RetrieveError
+	require.True(t, errors.As(doErr, &retrieveErr), "*oauth2.RetrieveError must still be reachable: %v", doErr)
+	require.Equal(t, http.StatusBadRequest, retrieveErr.Response.StatusCode)
+
+	require.Contains(t, doErr.Error(), oauth2FetchTokenPrefix, "x/oauth2's own text must survive")
+	require.Contains(t, doErr.Error(), "invalid_grant", "the response body must survive")
+
+	// The token source stays an oauth2.TokenSource on an oauth2.Transport,
+	// which is the shape connectors reach through when they inspect it.
+	oauthTransport, ok := client.Transport.(*oauth2.Transport)
+	require.True(t, ok)
+	_, tokenErr := oauthTransport.Source.Token()
+	require.Equal(t, codes.Unauthenticated, status.Code(tokenErr))
+}


### PR DESCRIPTION
Classifies `golang.org/x/oauth2` token-exchange failures so `retry.Retryer` can
act on them: a token endpoint that answered 500 or timed out is now
`Unavailable`/`DeadlineExceeded` and gets backed off through, while a rejected
credential stays `Unauthenticated`/`PermissionDenied` and still fails fast.

Fixes [CXP-1085](https://linear.app/ductone/issue/CXP-1085), which surfaced
under [CXP-890](https://linear.app/ductone/issue/CXP-890).

## Why

Token failures reached the syncer as `codes.Unknown`, which `retry.Retryer`
treats as terminal — `pkg/retry/retry.go:61` waits only on `Unavailable` and
`DeadlineExceeded`. The sync action aborted and `IsSyncPreservable` discarded the
artifact, so a sub-second blip at `oauth2.googleapis.com/token` cost hours of
completed grant walking. GCP re-exchanges a service-account JWT roughly hourly,
so longer syncs failed more often.

The classification already existed and was unreachable. `wrapTransientNetworkError`'s
`*oauth2.RetrieveError` branch (added in #1106) only ran from `Transport.RoundTrip`
and `wrapper.Do` — and a non-2xx from a token endpoint is a *successful*
RoundTrip, so x/oauth2 builds the `RetrieveError` above the transport, where that
branch never sees it. This is not GCP-specific: every helper in
`pkg/uhttp/authcredentials.go` had the same gap.

## What changed

- `pkg/uhttp/oauth2.go` (new) exports `ClassifyOAuth2TokenError` and
  `NewClassifyingTokenSource`, for connectors that build their own `jwt.Config`
  rather than going through the SDK helpers (baton-google-cloud-platform does).
- `OAuth2ClientCredentials`, `OAuth2JWT` and `OAuth2RefreshToken` now build their
  token source through the wrapper. `OAuth2RefreshToken` spells out
  `cfg.TokenSource` + `oauth2.NewClient`, which is what `cfg.Client` does.
- `errors.go`'s `RetrieveError` branch delegates to the same function, so the
  transport path and the token-source path share one implementation.

Two x/oauth2 behaviors had to be worked around, both pinned by tests that drive a
real `jwt.Config` against `httptest` — if a future bump fixes either, the test
fails rather than leaving dead code:

1. **The RFC 6749 params are empty.** `jwt.Config`'s token source builds
   `RetrieveError` from the response alone (`jwt/jwt.go:143`), so `error` and
   `error_description` are recovered from the body, JSON or form-encoded. RFC 6749
   §5.2 defines `error` as a string; a body that puts something else there
   (Google's endpoint nests a `code`/`message`/`status` object) carries no param to
   act on, so the code falls back to the HTTP status and the bounded body becomes
   the description. Nothing keys on a vendor's field names.
2. **`%v` flattening.** `jwt/jwt.go:135`, `:140` and `:154` wrap transport failures
   with `%v`, not `%w`, destroying the status the uhttp transport attached before
   any caller sees it; `errors.As` cannot recover it and no dependency bump fixes
   it. `classifyFlattenedOAuth2TokenError` therefore reads message text, gated on
   the `oauth2: cannot fetch token` prefix. It first recovers a grpc status out of
   the flattened text — that code was decided from the typed error — then falls
   back to a substring table whose codes must agree with
   `wrapTransientNetworkError`'s, asserted case by case, since the same failure
   takes either path depending only on whether the caller installed this package's
   transport under `oauth2.HTTPClient`. `pkg/lambda/grpc/util.go:178` already
   classifies serialized errors this way for the same reason.

`pkg/retry`'s retryable set is untouched, per the CXE-1113 anti-goal: that retryer
has no attempt limit at its defaults, so a disabled credential must fail fast
rather than spin for hours.

## Effect on existing connectors

Nothing breaks at compile time — the exported surface only grew — and nothing
breaks in error matching, because the status is attached by `errors.Join` rather
than substitution. `errors.As` still recovers `*oauth2.RetrieveError`, and
`err.Error()` still carries x/oauth2's own text and the response body, so
existing `errors.Is`/`errors.As` checks and message matches keep working.
`TestOAuth2JWT_GetClientPreservesErrorIdentity` pins that end to end.

Three behavior changes worth a reviewer's attention:

- **`IsSyncPreservable` (`pkg/sync/syncer.go:91`) now returns true for these
  errors where it returned false.** An unclassified error fails its
  `status.FromError` check, while `Unavailable`, `Unauthenticated` and
  `PermissionDenied` are all in its preserve list — so a partial artifact
  survives a token failure instead of being discarded. That is the direction
  CXP-890 wants, and it is a retention change, called out here rather than left
  to be discovered. The `InvalidArgument` cases (`invalid_scope`,
  `invalid_request`, NXDOMAIN) still discard, as before.
- **`server_error` and `temporarily_unavailable` flip from terminal to
  retryable.** RFC 6749 §4.1.2.1 defines both as transient; a 400 carrying one
  previously landed on `InvalidArgument`.
- **A permanently failing token endpoint now backs off instead of failing
  fast**, bounded by the caller's `RetryConfig` and run duration. Same exposure
  any upstream 503 already has.

## Testing

`go test ./pkg/...` passes; `golangci-lint run pkg/uhttp/...` is clean (the six
findings the repo-wide run reports are pre-existing on `main`, in packages this
PR does not touch). Tests cover the cross product of source shape (typed
`RetrieveError`, `%v`-flattened text, raw transport error), param location (on
the error, JSON body, form body, absent, non-string) and disposition, each
asserted against `retry.Retryer` rather than the grpc code alone. Every branch in
`oauth2.go` is covered. Ten planted mutants were each caught: dropped body
recovery, dropped flattened fallback, dropped grpc status recovery, `server_error`
made terminal, dropped truncation, dropped existing-status guard, non-string
`error` member used as a code, NXDOMAIN made retryable, dropped body snippet, and
lost `error_description` precedence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
