### PR TITLE
Seamless Docs and Fewer Comments

### DIFF
--- a/.claude/skills/ci-review.md
+++ b/.claude/skills/ci-review.md
@@ -152,3 +152,10 @@ Shared SDK convenience APIs become long-term commitments. If a helper is only ne
 caller, check whether it belongs in that caller instead of the SDK. Prefer narrow additions
 that preserve existing contracts over broad abstractions that create new obligations for all
 downstreams.
+
+## Code Comments
+
+Review code comments per `docs/COMMENTS.md`, "Reviewing". The first question about any
+comment is whether it should exist; if not, the finding is delete, not reword. A comment
+finding blocks only when the comment is false in a way that would lead a reader to write
+wrong code. Deleting a comment that would not pass that page needs no justification.

--- a/.claude/skills/ci-review.md
+++ b/.claude/skills/ci-review.md
@@ -153,9 +153,16 @@ caller, check whether it belongs in that caller instead of the SDK. Prefer narro
 that preserve existing contracts over broad abstractions that create new obligations for all
 downstreams.
 
-## Code Comments
+## Review Budget And Wording Findings
 
-Review code comments per `docs/COMMENTS.md`, "Reviewing". The first question about any
-comment is whether it should exist; if not, the finding is delete, not reword. A comment
-finding blocks only when the comment is false in a way that would lead a reader to write
-wrong code. Deleting a comment that would not pass that page needs no justification.
+These constrain what you emit; they apply to every finding, code or prose.
+
+- A non-blocking wording finding is unsaid unless the wording would change what a reader
+  does. Still-imprecise is not a finding.
+- One round per location by default. If you already commented on a line and the fix is
+  still imprecise, propose the exact replacement text or say nothing. A second thread is
+  for a fix that introduced something new that would mislead a reader.
+- Code comments: review per `docs/COMMENTS.md`, "Reviewing". The first question is whether
+  the comment should exist; if not, the finding is delete, not reword. A comment finding
+  blocks only when the comment is false in a way that would lead a reader to write wrong
+  code. Deleting a comment that would not pass that page needs no justification.

--- a/.claude/skills/ci-review.md
+++ b/.claude/skills/ci-review.md
@@ -155,7 +155,7 @@ downstreams.
 
 ## Review Budget And Wording Findings
 
-These constrain what you emit; they apply to every finding, code or prose.
+These constrain what you emit. They apply to every finding, whatever it is about.
 
 - A non-blocking wording finding is unsaid unless the wording would change what a reader
   does. Still-imprecise is not a finding.

--- a/.claude/skills/ci-review.md
+++ b/.claude/skills/ci-review.md
@@ -57,7 +57,7 @@ review; a single-shot CI review is advisory sampling, not coverage. Specifically
   absence / error-path, per `docs/BUG_CATCHING.md` §2).
 - Name the instrument that would give real coverage — differential oracle against
   full recomputation, two-artifact cross-version harness, `-race` plus seeded soak,
-  fault injection at the seam, or a permutation table as a table-driven test — and
+  fault injection at a hook, or a permutation table as a table-driven test — and
   state whether the PR already contains it.
 - A HIGH-risk PR that names no instrument and no permutation table is itself a
   finding: request the full pass-set review per `docs/BUG_CATCHING.md` §6 before

--- a/.cursor/rules/comments.mdc
+++ b/.cursor/rules/comments.mdc
@@ -1,0 +1,11 @@
+---
+description: Follow docs/COMMENTS.md when writing or reviewing code comments
+alwaysApply: true
+---
+
+# Comments
+
+For any code comment you write, edit, or review, follow `docs/COMMENTS.md`.
+The prior is that a comment is worse than nothing most of the time. A
+typical change adds zero. In review, the first question is whether the
+comment should exist; if not, the finding is delete, not reword.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,9 @@ to code edits.
 
 Project overview, build commands, and architecture live in `CLAUDE.md`.
 Review and verification live in `docs/REVIEW_CHECKLIST.md` and
-`docs/BUG_CATCHING.md`.
+`docs/BUG_CATCHING.md`. When to write a code comment, and what it may say,
+lives in `docs/COMMENTS.md`. A comment is worse than nothing until it
+proves otherwise; put intent in names, types, and tests first.
 
 ## Diction
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Follow `AGENTS.md` for all writing: comments, docs, commits, PRs, review
 notes, and conversation with humans. Name the function, type, hook, or
-check. State the fact with essential framing.
+check. State the fact with essential framing. For whether a code comment
+should exist at all, follow `docs/COMMENTS.md`.
 
 ## Project Overview
 

--- a/docs/BUG_CATCHING.md
+++ b/docs/BUG_CATCHING.md
@@ -44,10 +44,10 @@ Corollaries:
   different implementations, failure modes, and consistency behavior per environment
   (`pkg/session`: client/server split, memory and noop variants).
 - **A contract is only as strong as its consumers.** SDK error codes, checkpoint
-  semantics, and preservability classifications are load-bearing for the c1 host,
+  semantics, and preservability classifications are required by the c1 host,
   which can silently neutralize them (timeout effort: a host-side rewrap stripped
   the status that made timeouts retryable). Review a changed contract *at its
-  consumers*, and put the contract test on the consumer side of the seam — the two
+  consumers*, and put the contract test on the consumer side of the boundary — the two
   highest-impact bugs of that effort were invisible from inside either repo alone.
 - **SQLite is deprecated** — major bug fixes only. Pebble is the target engine. New
   features may be Pebble-only *by design*, with graceful degradation (feature cleanly
@@ -222,7 +222,7 @@ step-up criteria:
   leaving every dependent criterion evidence incomplete. Keep the ledger in
   Markdown or generated test cases; build a framework only when repetition or
   drift justifies it.
-- Test each obligation at the layer that owns it and across the seam that
+- Test each obligation at the layer that owns it and across the boundary that
   could lose it — typed/raw mutation, engine operation, public capability,
   close/reopen artifact — without duplicating identical pure logic at every
   layer. A schema-only stage closes schema obligations (lint, compatibility,
@@ -286,7 +286,7 @@ representative violation. A red test may indicate a product defect, an invalid
 premise, an incorrect oracle, or unresolved boundary ownership — classify which
 before changing production code. Concretely: a rejection test asserts the expected
 error class and must not pass on an unexpected setup error; a fault test asserts
-the seam actually fired; a forbidden-mutation test seeds non-empty target state
+the hook actually fired; a forbidden-mutation test seeds non-empty target state
 and compares complete before/after snapshots (an empty destination cannot detect
 clear-before-validation; key counts cannot detect value mutation). Assert
 postconditions at the plan's stated strength: a digest is not replaced by a key
@@ -306,7 +306,7 @@ cancellation/retry where supported. Derive the commit sites from the
 implementation: every loop that commits is its own cut, not only the headline
 one, and each site owes §5.12's six answers (sync-replay: replacement ran a
 destructive clear loop before its copy loop, with the same dirty/cache/fast-path
-obligations and no seam). Equivalent repeated chunks may share one
+obligations and no hook). Equivalent repeated chunks may share one
 representative cut; distinct commit sites may not.
 
 Four classes review is structurally blind to, and where to send them:
@@ -334,7 +334,7 @@ Four classes review is structurally blind to, and where to send them:
 - **Error-path properties** — code that runs only when the environment fails.
   Review reads it; nothing executes it, because ordinary tests run over an
   implicitly cooperative environment (disks persist, RPCs return, deadlines never
-  fire). Instrument: fault injection at a seam, with a stated recovery contract as
+  fire). Instrument: fault injection at a hook, with a stated recovery contract as
   the oracle (§5.10; house example: the engine errorfs sweep — every write/fsync
   failure in the EndSync window must reopen as resumable-unfinished or
   finished-and-complete, exhaustively).
@@ -354,7 +354,7 @@ Recognition criterion — all three must hold:
    defined against something no run exhibits (what the store *would* contain
    uninterrupted). The oracle must be constructed.
 
-House example: the parallel scheduler + checkpoint/resume seam (5 adversarial rounds
+House example: the parallel scheduler + checkpoint/resume boundary (5 adversarial rounds
 did not converge on it; from first principles, should not have). For such
 subsystems, the only conversion of effort into confidence is **verification as a
 design deliverable**:
@@ -362,7 +362,7 @@ design deliverable**:
 1. **State the contract as explicit properties** — exactly-once execution, dedup
    soundness, termination, transition atomicity, bounded memory, crash-cut
    consistency. If the property list can't be written, the design is not done.
-2. **Construct the oracle** — the load-bearing step for silent failures:
+2. **Construct the oracle** — the required step for silent failures:
    *self-equivalence* (an interrupted-and-resumed run must produce the same sealed
    store as an uninterrupted one); *derived ground truth* (a deterministic topology
    makes the expected store computable); *contract audit* (record the operation
@@ -469,7 +469,7 @@ should ask for the table, not read the if-branches and try to reconstruct it.
   table-driven test — the expected value *is* the outcome, and excluded cells
   are skipped rows with a reason string, so the table cannot drift from behavior.
   Cells that require an artifact this repo cannot execute (an older SDK's
-  behavior) become a comment on the seam itself — where the next editor of the
+  behavior) become a comment on the boundary itself — where the next editor of the
   format will be looking — and migrate to the two-artifact harness when it
   exists. The PR description only *points* at both: nobody rereads a merged PR,
   and the table is needed by whoever touches the format next.
@@ -500,17 +500,17 @@ store state before falling back). Additionally:
 - Watch for silent degradation: a fallback that always fires is a dead feature with
   green tests.
 - A declared error category no test can *cause* is dead code with a taxonomy:
-  fault-inject each category at its producing seam and assert the recovery
+  fault-inject each category at the site that produces it and assert the recovery
   obligation is actually discharged (§5.10).
 
 ### Pass 5: Invariant & verification gating
 
 Any code that writes rows is an ingestion path and must pass through the invariant
-seam (`RunIngestInvariants` + verification marker). New write paths that bypass the
+pass (`RunIngestInvariants` + verification marker). New write paths that bypass the
 syncer are guilty until proven registered. Artifacts must satisfy their
 self-description: sidecar sync IDs match the sync-run record, verification markers
-current, graphs marked expanded, format versions valid. (This pass polices the
-seam; §5.9 is the design principle for why the seam exists and where it must sit.)
+current, graphs marked expanded, format versions valid. (This pass polices that
+funnel; §5.9 is why it exists and where it must sit.)
 
 ### Pass 6: Performance
 
@@ -571,9 +571,9 @@ validation: premise proven, oracle shown to fail on a planted violation.)
      where they enter. Direct logging of secrets is ordinary review's job; the type is
      for the *indirect* flow — a third-party parse error echoing secret-bearing input
      into a wrapped error that lands in a durable artifact (log, token, checkpoint).
-     At seams that wrap third-party errors around secret input, add one
+     Where third-party errors wrap secret input, add one
      `NotContains(err.Error(), secret)` test — upstream error content is not ours to
-     control (age branch tests exactly this seam).
+     control (age branch tests exactly this wrap).
 2. **Fuzzing / property tests with an oracle.** This repo is rich in free oracles:
    incremental vs. full recomputation, marshal/unmarshal round-trips (including
    converters — #997 dropped a field in toPebble), retry-twice-converges idempotency.
@@ -592,13 +592,13 @@ validation: premise proven, oracle shown to fail on a planted violation.)
      External existence proof: Amazon S3's ShardStore validated an LSM storage
      node exactly this way, run by ordinary engineers, not specialists.
 3. **One validator over many point tests, when production owns the invariant.** A
-   validator needs a stable production seam and an actual caller; do not add an
+   validator needs a stable production call path and an actual caller; do not add an
    unused runtime validator to a schema-only stage. An artifact fsck — sealed-c1z
    self-description checked at the end of every producing test — retires a bug
    *category*. Include a leak check: every key/record in a store is owned by the live
    sync or explicitly allowlisted. Cheap variant: run the suite once with the noop
    session store; any failure is a source-of-truth violation hiding in the cache
-   layer. When no production seam exists yet, use a test-only oracle or defer the
+   layer. When no production call path exists yet, use a test-only oracle or defer the
    runtime obligation to the stage that introduces its owner.
    - **Ride-along variant when the test fixture owns the invariant**: bind the
      checker to a shared fixture or choke point so every existing test evaluates
@@ -676,7 +676,7 @@ Wherever behavior branches on the class or identity of a value — an error's
 retryability, a cursor's identity, a record's kind, a store's capability — that
 classification must be **explicit** (a dedicated field, never an in-band magic
 value), **total** (closed over every producer of the domain, including implicit
-ones), **preserved across seams** (wraps, RPC hops, and serialization must not strip
+ones), **preserved across boundaries** (wraps, RPC hops, and serialization must not strip
 the status/sentinel identity downstream classifiers act on), and **coherent** (two
 classifiers over one domain state their intended relationship, asserted in a test).
 
@@ -689,7 +689,7 @@ classifiers over one domain state their intended relationship, asserted in a tes
 - Preserved: a host-side wrapper string-matched `err.Error()` and returned a fresh
   error, stripping the gRPC status — retryable lambda timeouts became
   non-retryable, discarding hours of checkpoint progress ~1,100×/fortnight (timeout
-  effort; visible only by tracing the value across the repo seam).
+  effort; visible only by tracing the value across the repo boundary).
   `strings.Contains(err.Error(), ...)` gates are findings by default; a rewrap
   preserves status/sentinels or explicitly declares the downgrade, enforced by a
   consumer-side test.
@@ -755,7 +755,7 @@ only when wire compatibility alone cannot preserve meaning.
   the contract to "call this" — greppable, and it cannot drift. Do not create that
   owner speculatively in a schema-only stage. (Age branch: `key_ids =
   hex(sha256(recipient))` lives in a proto comment while the consumer imports this
-  repo.) Prose remains appropriate for staged contracts and seams where code cannot
+  repo.) Prose remains appropriate for staged contracts and boundaries where code cannot
   be shared.
 
 ### 5.6 Distribution invalidates local intuitions
@@ -810,7 +810,7 @@ common thread: each of these fails by *nothing happening*.
   investigation). Every flag carries graduation-or-delete, and each long-lived flag
   doubles Pass 3's state space.
 - Deprecated-engine rot cuts both ways: SQLite fallback paths decay untested but
-  stay load-bearing until removal ships. Touching a dual-engine seam: verify the
+  stay required until removal ships. Touching a dual-engine path: verify the
   SQLite path or explicitly gate it off. The capability interfaces and
   degrade-to-token dualities are the removal-day cleanup checklist.
 - In exported library API the transition may be *unfinishable*: deprecated symbols
@@ -821,7 +821,7 @@ common thread: each of these fails by *nothing happening*.
   permanent.)
 - Branch aging: a conflict-free rebase can be semantically stale — review the
   *rebased* semantics against current main (the incremental branch predated the
-  invariant seam entirely).
+  invariant pass entirely).
 
 ### 5.9 An obligation owned by every path is owned by none — localize it
 
@@ -837,13 +837,13 @@ escalating fixes, both used in this repo:
   obligation once on the shared path (Phase 2, #1016 — the rawdb choke point: a new
   path has no way in except through it).
 - **Re-derive the obligation from state, not events**: redefine it as a function of
-  the *resulting* state, evaluated once at a terminal seam, making it independent of
+  the *resulting* state, evaluated once at a terminal check, making it independent of
   how the state arrived (Phase 3, #1017 — ingest invariants: "each side effect is
   defined as a function of the store and evaluated after every writer has
   finished"). Stronger than the funnel: it severs the event coupling instead of
   centralizing it.
 
-The caveat that bit anyway: **the seam must sit at the true convergence point.**
+The caveat that bit anyway: **the check must sit at the true convergence point.**
 Phase 3 attached evaluation to the syncer, but the syncer is a client of the store,
 not its funnel — the compactor's resume-and-write path bypassed the syncer while
 still reaching the sealed artifact (incremental branch). The point nothing can avoid
@@ -879,12 +879,12 @@ errorfs sweep (#1015; `pkg/dotc1z/engine/pebble/errorfs_sweep_test.go`).
   monotonic clock, so `IdleConnTimeout` never sees the gap while proxies time
   pooled connections out on the wall clock (#1005 — the fix measures the gap in
   wall-clock time, and its tests count connections to prove the pool was dropped).
-- **Seams are a design requirement.** Injection reaches only what flows through an
+- **Injection points are a design requirement.** Injection reaches only what flows through an
   interface (pebble vfs, session store, connector RPCs, contexts/clocks). Raw
   `os.*` IO is outside every fault domain — the sweep's own stated exclusion (the
   v3 envelope save) is an untested error path by construction. State exclusions
   explicitly; each one is a finding-in-waiting, and new IO should route through an
-  injectable seam rather than enlarge the exclusion list.
+  injectable hook rather than enlarge the exclusion list.
 - **Completeness must be provable.** The sweep arms at EndSync and raises k until
   an armed run completes without injecting anything — positive evidence the window
   was covered end-to-end. Prefer that shape over "we injected some faults."
@@ -892,10 +892,10 @@ errorfs sweep (#1015; `pkg/dotc1z/engine/pebble/errorfs_sweep_test.go`).
   known contract violation and watch the harness fail. A sweep that has never
   caught a planted bug is itself unverified code.
 - **Enumerate injection points mechanically, not from memory.** A hand-maintained
-  seam registry drifts exactly like §5.4's convention registries: the next commit
-  loop ships without a seam and its error path is dead code again. Prefer a
+  hook registry drifts exactly like §5.4's convention registries: the next commit
+  loop ships without a hook and its error path is dead code again. Prefer a
   meta-test that derives the commit/write call sites from the code (AST scan or
-  choke-point registration) and fails when one lacks a registered seam and a
+  choke-point registration) and fails when one lacks a registered hook and a
   failure-obligation test — the house idiom is `seamFailureCases` +
   `TestSeamsArmedOnlyInTests` in the pebble engine; SQLite's
   OOM-injection-at-every-allocation is the fully generalized form.
@@ -941,10 +941,10 @@ principles above concentrate, so audit each site against all six at once
 rather than rediscovering them one bug at a time. Every commit call site owes:
 
 1. **An executable failure.** Some instrument forces THIS commit to fail and
-   observes the aftermath. Each distinct commit loop is its own cut — a seam
+   observes the aftermath. Each distinct commit loop is its own cut — a hook
    on a sibling loop proves nothing here (§5.10; enforced mechanically by the
    pebble engine's commit-point registry meta-test, which fails when a commit
-   site ships without a seam route or a written exclusion).
+   site ships without a hook route or a written exclusion).
 2. **Failure re-converges derived state.** The batch is atomic; the flags,
    proofs, markers, and caches ABOUT the keyspace are not. A failed commit
    must invalidate every proof it may have falsified (§5.11).
@@ -966,7 +966,7 @@ rather than rediscovering them one bug at a time. Every commit call site owes:
    because a named downstream fence (checkpoint, envelope save, WAL sync
    point) fsyncs before anything depends on the write. This is the one
    obligation on this list with no mechanical check — the justification lives
-   in comments at each site, and the in-process error seams are only a proxy
+   in comments at each site, and the in-process error hooks are only a proxy
    for the real event (a crash between the halves of an ordering contract),
    which the errorfs sweep and crash-reopen tests carry for the paths they
    visit.
@@ -1057,7 +1057,7 @@ rather than rediscovering them one bug at a time. Every commit call site owes:
   - Pass 7 (concurrency): §1 + Pass 7 + §5.6
   - Fix-time agent: §4 + this section's failing-test-first and recurrence rules
   - Orchestrator (you): the whole document, read once.
-  A consequence: mild redundancy across sections is load-bearing — sliced readers
+  A consequence: mild redundancy across sections is required — sliced readers
   never see the other copies. Do not deduplicate it away.
 - Check merge-base age first; review what the change means on *current* main. Also
   confirm `git log base..head` contains exactly the intended commits before spending
@@ -1075,7 +1075,7 @@ rather than rediscovering them one bug at a time. Every commit call site owes:
   Schema, documentation, generation, and build defects may instead use the
   corresponding lint, compatibility check, static reproducer, or generated diff;
   record why a runtime regression test is not the right instrument. (Empirically
-  load-bearing on the fan-out branch: fix rounds stopped regressing when test-first
+  required on the fan-out branch: fix rounds stopped regressing when test-first
   became mandatory for its runtime bugs.)
 - Contracts check on any exported API touched: doc comments match actual behavior;
   functions whose names promise purity (Marshal, Get, Read) don't mutate arguments.
@@ -1117,7 +1117,7 @@ Evidence bullets cite recurring efforts by shorthand. PR numbers resolve with
   cross-version checkpoint resume that silently sealed an incomplete sync.
 - **Timeout effort** — lambda-timeout preservability work spanning this repo and
   the c1 host: retryable-timeout classification, preservable sync state, and the
-  host-side rewrap that stripped gRPC status. Source of the cross-repo seam
+  host-side rewrap that stripped gRPC status. Source of the cross-repo boundary
   evidence; its contract tests live on the consumer side.
 - **Sync-replay effort** — multi-model implementation-blind plan synthesis broadened
   the coverage model before freeze; repeated implementation review still supplied

--- a/docs/BUG_CATCHING.md
+++ b/docs/BUG_CATCHING.md
@@ -362,7 +362,8 @@ design deliverable**:
 1. **State the contract as explicit properties** — exactly-once execution, dedup
    soundness, termination, transition atomicity, bounded memory, crash-cut
    consistency. If the property list can't be written, the design is not done.
-2. **Construct the oracle** — the required step for silent failures:
+2. **Construct the oracle** — without it a silent failure has nothing to fail
+   against:
    *self-equivalence* (an interrupted-and-resumed run must produce the same sealed
    store as an uninterrupted one); *derived ground truth* (a deterministic topology
    makes the expected store computable); *contract audit* (record the operation
@@ -506,7 +507,7 @@ store state before falling back). Additionally:
 ### Pass 5: Invariant & verification gating
 
 Any code that writes rows is an ingestion path and must pass through the invariant
-pass (`RunIngestInvariants` + verification marker). New write paths that bypass the
+gate (`RunIngestInvariants` + verification marker). New write paths that bypass the
 syncer are guilty until proven registered. Artifacts must satisfy their
 self-description: sidecar sync IDs match the sync-run record, verification markers
 current, graphs marked expanded, format versions valid. (This pass polices that
@@ -821,7 +822,7 @@ common thread: each of these fails by *nothing happening*.
   permanent.)
 - Branch aging: a conflict-free rebase can be semantically stale — review the
   *rebased* semantics against current main (the incremental branch predated the
-  invariant pass entirely).
+  invariant gate entirely).
 
 ### 5.9 An obligation owned by every path is owned by none — localize it
 

--- a/docs/BUG_CATCHING.md
+++ b/docs/BUG_CATCHING.md
@@ -507,11 +507,11 @@ store state before falling back). Additionally:
 ### Pass 5: Invariant & verification gating
 
 Any code that writes rows is an ingestion path and must pass through the invariant
-gate (`RunIngestInvariants` + verification marker). New write paths that bypass the
-syncer are guilty until proven registered. Artifacts must satisfy their
-self-description: sidecar sync IDs match the sync-run record, verification markers
-current, graphs marked expanded, format versions valid. (This pass polices that
-funnel; §5.9 is why it exists and where it must sit.)
+gate (`RunIngestInvariants` + verification marker; the code calls this the invariant
+pass). New write paths that bypass the syncer are guilty until proven registered.
+Artifacts must satisfy their self-description: sidecar sync IDs match the sync-run
+record, verification markers current, graphs marked expanded, format versions valid.
+(This review pass polices that gate; §5.9 is why it exists and where it must sit.)
 
 ### Pass 6: Performance
 

--- a/docs/CHAOS_CONNECTOR.md
+++ b/docs/CHAOS_CONNECTOR.md
@@ -343,7 +343,7 @@ The first implementation does not claim:
 - malformed wire bytes, trailers, or connection resets;
 - combined connector and filesystem schedules other than the named
   lost-entitlement-response/first-subsequent-write case;
-- raw `os.*` calls outside existing injectable seams;
+- raw `os.*` calls outside existing injectable hooks;
 - closure over generated or seeded schedules;
 - deletion of disappeared external resource-type rows: resource types do not
   yet carry store-owned provenance, and deleting by a shared public type ID

--- a/docs/COMMENTS.md
+++ b/docs/COMMENTS.md
@@ -47,9 +47,9 @@ front of you.
 
 1. A contract the name and signature do not carry. Ask first whether they
    should: a constructor that fails on an existing file is better named
-   `CreateStore` than commented. Sometimes the answer is no; a signature can
+   `CreateLedger` than commented. Sometimes the answer is no; a signature can
    be made to carry anything and most of it is not worth it. Then the
-   sentence is the right call. `// NewStore returns a new Store.` is never
+   sentence is the right call. `// NewLedger returns a new Ledger.` is never
    this and is deleted. Exported is not a reason.
 2. Why this and not the obvious alternative: an external system's behavior,
    a spec clause, an ordering dependency, a past incident. Name the source.
@@ -62,7 +62,7 @@ front of you.
 4. Code that looks wrong and is not. State what breaks if it is "fixed".
 5. Which of several variants is the way forward. On the preferred one: use
    this; the others remain for X and go away after Y. On the others:
-   `// Deprecated: use NewStore.` (`staticcheck` SA1019 flags callers.) The
+   `// Deprecated: use NewLedger.` (`staticcheck` SA1019 flags callers.) The
    duplication is the defect; the comment holds the line.
 6. A TODO that says what would make it done: a ticket, a condition, a
    version. `// TODO(BATON-123): ...`.
@@ -103,9 +103,8 @@ front of you.
 
 One line by default. A paragraph for a protocol, a cross-function
 invariant, or a non-obvious algorithm. Full sentences, present tense, period
-at the end (`godot`). A date belongs
-when the fact has one: "the upstream API changed this in 2025-03" is a fact,
-"added 2025-03" is not.
+at the end (`godot`). A date belongs when the fact has one: "the upstream
+API changed this in 2025-03" is a fact, "added 2025-03" is not.
 
 ## Existing comments
 
@@ -149,17 +148,17 @@ and say so.
 ## Examples
 
 ```go
-// NewStore returns a new Store.
-func NewStore(path string) (*Store, error) {
+// NewLedger returns a new Ledger.
+func NewLedger(path string) (*Ledger, error) {
 ```
 
 Delete. If it fails on an existing file, the name carries that, and what
 remains is the part the name cannot:
 
 ```go
-// CreateStore returns ErrExists if path is already present. Use this over
-// OpenOrCreateStore, which is deprecated.
-func CreateStore(path string) (*Store, error) {
+// CreateLedger returns ErrExists if path is already present. Use this over
+// OpenOrCreateLedger, which is deprecated.
+func CreateLedger(path string) (*Ledger, error) {
 ```
 
 ```go

--- a/docs/COMMENTS.md
+++ b/docs/COMMENTS.md
@@ -1,0 +1,196 @@
+# Comments
+
+For agents writing or reviewing code comments in this repository. Diction
+per `AGENTS.md`.
+
+## Principles
+
+Exercise judgment, not procedure. Our a priori estimate is that a comment
+is worse than nothing most of the time. Everything below is what usually
+follows from that prior; none of it is a rule that overrides the case in
+front of you.
+
+- The code is the authoritative description of what the code does and what
+  it is intended to do: names, types, structure, and to a lesser extent
+  tests.
+- A comment earns its keep by stating something that is true that the code 
+  does not express that the reader ought to know.
+- A comment is a very strong signal that something the reader ought to know 
+  is not expressed by the code. That is chiefly a flaw in the code, not the
+  comment. Ask whether the code could carry it (a name, a function, a type,
+  a test) and whether that change is worth making. Often it is. Sometimes
+  it is too much effort, too disruptive, or touches an API you do not own.
+  Ideally, only write a comment when you want to make such a signal to the
+  reader.
+- Our target audience is _not current us and not the reviewer_. Our
+  audience is future us: someone opening the file tomorrow or months from
+  now without today's context. Comments are an ongoing maintenance burden
+  and often lead future us in the wrong direction or waste our time
+  verifying correctness.
+- Comments are often wrong *when written*. Review rounds spent on their
+  wording are entirely wasted. A comment that does not exist cannot be
+  wrong.
+- A typical change adds zero comments (or may even net remove some at this
+  point).
+- A comment is judged in context, not alone. Every comment can pass on its
+  own while the file has three times too many; comments compete for
+  attention. A fact has one owner, usually the definition, possibly in
+  another file; the same fact at the helper and at every call site is one
+  comment and the rest are deletions. Before adding one, read what is
+  already there, here and at the definition of whatever you are calling.
+- Most code affects correctness, not performance; the clearer version is
+  often the better one. In code that exists for performance (grant
+  expansion, compaction, et al), the comment explaining its shape is a good
+  comment. A comment describing a novel algorithm is fine.
+
+## Good comments
+
+1. A contract the name and signature do not carry. Ask first whether they
+   should: a constructor that fails on an existing file is better named
+   `CreateStore` than commented. Sometimes the answer is no; a signature can
+   be made to carry anything and most of it is not worth it. Then the
+   sentence is the right call. `// NewStore returns a new Store.` is never
+   this and is deleted. Exported is not a reason.
+2. Why this and not the obvious alternative: an external system's behavior,
+   a spec clause, an ordering dependency, a past incident. Name the source.
+   The alternative has to be one a competent reader would reach for, and
+   choosing it has to make a material difference: a bug, a broken resume, a
+   changed contract. If only you considered it, it is a reasoning trace. If
+   it would have worked too, it is a preference.
+3. An invariant the code cannot carry, after you have decided a type or a
+   test is not worth it here. `// Caller holds mu.`
+4. Code that looks wrong and is not. State what breaks if it is "fixed".
+5. Which of several variants is the way forward. On the preferred one: use
+   this; the others remain for X and go away after Y. On the others:
+   `// Deprecated: use NewStore.` (`staticcheck` SA1019 flags callers.) The
+   duplication is the defect; the comment holds the line.
+6. A TODO that says what would make it done: a ticket, a condition, a
+   version. `// TODO(BATON-123): ...`.
+
+## Not comments
+
+- Restates the code or the name.
+- Narrates steps. Extract and name the function.
+- Describes the change: "now handles", "previously", "moved from". Commit
+  message.
+- Addresses the reviewer: "safe because", "this is intentional". PR
+  description, or state the invariant and drop the reassurance.
+- Hedges: "should work", "probably". A limitation stated as fact with its
+  condition, or nothing.
+- Reasoning trace: "here we", "note that", "we need to".
+- Repeats a fact stated at its owner: the definition, the type, the
+  package doc. A call site restating what the callee's doc says, in this
+  file or another. Once, at the owner. A pointer to it at most.
+- Two comments justifying opposite decisions. That is one inconsistency in
+  the code, not two facts about it.
+- Commented-out code.
+- Test-body narration. The name and assertion are the documentation. A test
+  comment states what the test would miss if removed, when the name does
+  not.
+
+## Where it goes instead
+
+| To record | Put it in |
+| --- | --- |
+| What the code does | Identifiers and tests |
+| Why this change | Commit message |
+| Why this approach over others | PR description, or `docs/rfcs/` |
+| What broke and how it was found | The ticket; a comment only if the code must stay odd because of it |
+| How a subsystem works | `docs/` or the package doc |
+| Who and when | `git blame` |
+
+## Form
+
+One line by default. A paragraph for a protocol, a cross-function
+invariant, or a non-obvious algorithm. Full sentences, present tense, period
+at the end (`godot`). Doc comments start with the identifier. A date belongs
+when the fact has one: "the upstream API changed this in 2025-03" is a fact,
+"added 2025-03" is not.
+
+## Existing comments
+
+Leave comments you did not need to touch. A stale comment inside lines you
+are changing gets fixed or deleted. Do not sweep a file for comment quality
+in an unrelated change.
+
+Before finishing a change, reread every comment you added against this
+page.
+
+## Reviewing
+
+- First question: should this comment exist. If not, the finding is
+  "delete", not "reword". No thread on the wording of a comment that should
+  not exist.
+- A comment that does exist is a signal about the code. Ask whether the
+  finding is "the code should carry this" (a rename, a type, a split)
+  before anything about the comment itself.
+- Do not request a comment where a rename or a split would do. Request the
+  rename, if sensible.
+- Do not request a comment that explains the diff.
+- Deleting a comment that would not pass this page needs no justification;
+  do not ask for it back. Deleting one that carried an important contract, an
+  invariant, or a `Deprecated` marker is a change to that thing and is
+  reviewed as one.
+- A comment finding blocks merge when the comment is false in a way that
+  would lead a reader to write wrong code: a misstated invariant, a wrong
+  contract, a `Deprecated` pointing at the wrong variant. Exported or not;
+  route by consequence as in `docs/REVIEW_CHECKLIST.md`. Everything else is
+  unsaid unless it would change what a reader does; then it is
+  non-blocking.
+- One round per code comment. If the reworded version is still imprecise,
+  propose the exact text or drop it. Do not open a second thread on it.
+
+## Fixing review findings
+
+"This comment is imprecise" is not an instruction to reword. Ask whether the
+comment should exist. Most that draw wording findings should not. Delete
+and say so.
+
+## Examples
+
+```go
+// NewStore returns a new Store.
+func NewStore(path string) (*Store, error) {
+```
+
+Delete. If it fails on an existing file, the name carries that, and what
+remains is the part the name cannot:
+
+```go
+// CreateStore returns ErrExists if path is already present. Use this over
+// NewC1ZFile, which remains for opening existing files and is removed in
+// the next major.
+func CreateStore(path string) (*Store, error) {
+```
+
+```go
+// ids must be sorted before calling merge.
+func merge(ids []string) {
+```
+
+The comment is asking for `func merge(ids sortedIDs)`. Internal with a few
+callers: make the type. Public API with external callers: the sentence may be
+the right call; it reads `// ids is sorted; merge relies on it.`
+
+```go
+// Safe: we validated len(ids) > 0 above.
+first := ids[0]
+```
+
+Delete. If the validation is far away: `// ids is non-empty; validated in
+parseArgs.`
+
+```go
+// Now also handles the case where the grant has no principal.
+if g.Principal == nil {
+```
+
+Delete. Commit message.
+
+```go
+// Grants are written before entitlements so that a crash between the two
+// leaves a resumable state; resume treats a grant with no entitlement as
+// pending, never the reverse. See resumeState.
+```
+
+Keep.

--- a/docs/COMMENTS.md
+++ b/docs/COMMENTS.md
@@ -136,8 +136,10 @@ page.
   route by consequence as in `docs/REVIEW_CHECKLIST.md`. Everything else is
   unsaid unless it would change what a reader does; then it is
   non-blocking.
-- One round per code comment. If the reworded version is still imprecise,
-  propose the exact text or drop it. Do not open a second thread on it.
+- One round per code comment by default. If the reworded version is still
+  imprecise, propose the exact text or drop it. A second thread is for a fix
+  that introduced something new that would mislead a reader, not for
+  wording that is still not quite right.
 
 ## Fixing review findings
 

--- a/docs/COMMENTS.md
+++ b/docs/COMMENTS.md
@@ -103,7 +103,7 @@ front of you.
 
 One line by default. A paragraph for a protocol, a cross-function
 invariant, or a non-obvious algorithm. Full sentences, present tense, period
-at the end (`godot`). Doc comments start with the identifier. A date belongs
+at the end (`godot`). A date belongs
 when the fact has one: "the upstream API changed this in 2025-03" is a fact,
 "added 2025-03" is not.
 
@@ -158,8 +158,7 @@ remains is the part the name cannot:
 
 ```go
 // CreateStore returns ErrExists if path is already present. Use this over
-// NewC1ZFile, which remains for opening existing files and is removed in
-// the next major.
+// OpenOrCreateStore, which is deprecated.
 func CreateStore(path string) (*Store, error) {
 ```
 
@@ -170,7 +169,7 @@ func merge(ids []string) {
 
 The comment is asking for `func merge(ids sortedIDs)`. Internal with a few
 callers: make the type. Public API with external callers: the sentence may be
-the right call; it reads `// ids is sorted; merge relies on it.`
+the right call; it reads `// merge requires ids sorted.`
 
 ```go
 // Safe: we validated len(ids) > 0 above.

--- a/docs/REVIEW_CHECKLIST.md
+++ b/docs/REVIEW_CHECKLIST.md
@@ -61,7 +61,7 @@ Hard rules along the way:
 4. Error handling, classification & budgets — every error in a declared
    category, every category's recovery obligation discharged and injectable.
 5. Invariant & verification gating — every write path passes the invariant
-   pass; bypasses are guilty until proven registered.
+   gate; bypasses are guilty until proven registered.
 6. Performance — per-iteration cost at whale scale, failure-path cost,
    cost-contract deliverable on hot paths.
 7. Concurrency — TOCTOU, duplicate writers, goroutine lifecycle; data races

--- a/docs/REVIEW_CHECKLIST.md
+++ b/docs/REVIEW_CHECKLIST.md
@@ -121,8 +121,8 @@ on `*syncer` and every value a new field. Reject on these, not on taste.
     `w.(engineAccessor)` assertion. The question is "is this a Pebble file",
     not "does this store implement operation X", and its answer does not
     select a fallback path the way a nil `storeCaps` field does.
-- Test seams live in `syncTestHooks` (`hooks.go`) and nowhere else, reached as
-  `s.testHooks.x`. A seam stays nil in production and no production path may
+- Test hooks live in `syncTestHooks` (`hooks.go`) and nowhere else, reached as
+  `s.testHooks.x`. A hook stays nil in production and no production path may
   set one. The struct name carries the "test" marking, so its fields do not:
   apart from the `syncer.testHooks` anchor itself, any `test`-prefixed field
   in `pkg/sync` is by itself the finding.

--- a/docs/REVIEW_CHECKLIST.md
+++ b/docs/REVIEW_CHECKLIST.md
@@ -61,7 +61,7 @@ Hard rules along the way:
 4. Error handling, classification & budgets — every error in a declared
    category, every category's recovery obligation discharged and injectable.
 5. Invariant & verification gating — every write path passes the invariant
-   seam; bypasses are guilty until proven registered.
+   pass; bypasses are guilty until proven registered.
 6. Performance — per-iteration cost at whale scale, failure-path cost,
    cost-contract deliverable on hot paths.
 7. Concurrency — TOCTOU, duplicate writers, goroutine lifecycle; data races
@@ -72,7 +72,7 @@ Hard rules along the way:
 1. Type system / API shape — make the invalid state unrepresentable.
 2. Fuzzing / property tests with an oracle — including the stateful executable
    reference model for lifecycle interleavings.
-3. One validator over many point tests — production seam, ride-along fixture
+3. One validator over many point tests — production check, ride-along fixture
    checker, or positive-evidence ledger.
 4. Integration tests over the real store lifecycle (resume, seal, fold,
    reuse), not mocks.


### PR DESCRIPTION
Update our own docs to be in line with our own diction requirements, and tell agents to stop writing so many comments.